### PR TITLE
WOLF v6: multi-strategy support and opportunity scanner fix

### DIFF
--- a/wolf-strategy/README.md
+++ b/wolf-strategy/README.md
@@ -1,50 +1,52 @@
-# WOLF Strategy v4.0
+# WOLF Strategy v6.0
 
-Fully autonomous trading strategy for Hyperliquid perps. The WOLF hunts for its human — scans, enters, exits, and rotates positions without asking permission.
+Fully autonomous multi-strategy trading for Hyperliquid perps. The WOLF hunts for its human — scans, enters, exits, and rotates positions without asking permission. Manages multiple strategies simultaneously, each with independent wallets, budgets, slots, and DSL configs.
 
 **Proven:** +$2,000 realized in 24h, 25+ trades, 65% win rate on $6.5k budget.
 
 ## What's Included
 
-This is a complete, self-contained skill with all scripts bundled:
-
 | File | Purpose |
 |------|---------|
-| `SKILL.md` | Strategy instructions, rules, and architecture |
-| `scripts/wolf-setup.py` | **Setup wizard** — agent passes wallet/strategy/chat ID, only asks user for **budget** |
-| `scripts/emerging-movers.py` | Emerging Movers v3.1 — primary entry signal (60s scans) |
-| `scripts/dsl-v4.py` | DSL v4 trailing stop engine (4-tier at 5/10/15/20% ROE) |
-| `scripts/opportunity-scan.py` | Opportunity Scanner v5 — 3-stage funnel, 4-pillar scoring |
-| `scripts/sm-flip-check.py` | SM conviction flip detector |
-| `scripts/wolf-monitor.py` | Watchdog — margin buffer + position health |
-| `scripts/job-health-check.py` | Orphan DSL / stale cron detector |
-| `references/cron-templates.md` | Exact cron MANDATE templates that make the agent ACT |
-| `references/state-schema.md` | DSL state file + strategy config schemas with all gotchas |
+| `SKILL.md` | Strategy instructions, rules, multi-strategy architecture |
+| `scripts/wolf_config.py` | **Shared config loader** — all scripts import this |
+| `scripts/wolf-setup.py` | **Setup wizard** — adds strategy to multi-strategy registry |
+| `scripts/emerging-movers.py` | Emerging Movers v4 — primary entry signal (90s scans, FIRST_JUMP priority) |
+| `scripts/dsl-combined.py` | DSL v4 combined runner — trailing stops for all positions, all strategies |
+| `scripts/dsl-v4.py` | DSL v4 single-position engine (legacy, still works) |
+| `scripts/opportunity-scan-v6.py` | **Opportunity Scanner v6** — BTC macro, hourly trend, disqualifiers, parallel fetches |
+| `scripts/opportunity-scan.py` | Opportunity Scanner v5 (legacy, replaced by v6) |
+| `scripts/sm-flip-check.py` | SM conviction flip detector (multi-strategy) |
+| `scripts/wolf-monitor.py` | Watchdog — per-strategy margin buffer + position health |
+| `scripts/job-health-check.py` | Per-strategy orphan DSL / state validation |
+| `references/cron-templates.md` | Cron MANDATE templates with multi-strategy signal routing |
+| `references/state-schema.md` | Registry schema, DSL state schema, scanner config |
 | `references/learnings.md` | Proven results, known bugs, trading discipline rules |
 
-## What's New in v4
+## What's New in v6
 
-- **All 7 Python scripts bundled** — no separate skill dependencies needed
-- **Setup wizard** (`wolf-setup.py`) — asks budget, wallet, strategy ID, Telegram chat ID → calculates everything
-- **Cron MANDATE templates** — the exact systemEvent payloads that make the agent act autonomously, not just report
-- **Correct OpenClaw cron format** — systemEvent crons, not the broken `senpi.cron_create`
-- **Tighter DSL tiers** — 4 tiers at 5/10/15/20% ROE (locks profit earlier than old 6-tier)
-- **Entry filters fixed** — 10+ traders (not 30+), conviction gate removed (rank climb is the signal)
-- **XYZ equities support** — isolated margin, `xyz:` prefix, trader count exempt
-- **Oversold decline rule** — skip shorts when RSI < 30 + extended 24h move
-- **Auto-delever** — scales slots down if account value drops below threshold
-- **Token optimization** — skips redundant checks when data < 3 min old
+- **Multi-strategy support** — manage 2+ strategies with independent wallets, budgets, slots, DSL configs
+- **Strategy registry** (`wolf-strategies.json`) replaces single `wolf-strategy.json`
+- **Per-strategy state dirs** — `state/{strategyKey}/dsl-{ASSET}.json` prevents collision when same asset traded in multiple strategies
+- **Signal routing** — signals route to best-fit strategy based on available slots and risk profile
+- **Opportunity Scanner v6** — fixed with BTC macro context, hourly trend filter, 6 hard disqualifiers, parallel candle fetches, cross-scan momentum
+- **One set of crons** — scripts iterate all strategies internally, no per-strategy crons needed
+- **Shared config loader** (`wolf_config.py`) — all scripts use same module for config, paths, legacy migration
+- **Backward compatible** — auto-migrates legacy `wolf-strategy.json` and old state files on first run
 
 ## Quick Start
 
 1. Download all files (or clone this folder)
 2. Send `SKILL.md` to your Senpi agent: **"Here are some new superpowers"**
 3. Tell the agent your **budget** — it handles everything else
+4. To add a second strategy, run `wolf-setup.py` again with a different wallet/budget
 
 ## Changelog
 
 | Version | Date | Changes |
 |---------|------|---------|
+| v6.0 | 2026-02-24 | Multi-strategy support, strategy registry, opportunity scanner v6 rewrite, per-strategy state dirs, signal routing, shared config loader |
+| v5.0 | 2026-02-24 | FIRST_JUMP signal priority, combined DSL runner, 90s scanner interval, Phase 1 auto-cut, 7x min leverage |
 | v4.0 | 2026-02-24 | Complete rewrite — all scripts bundled, setup wizard, cron mandates, tighter DSL tiers, entry filters fixed |
 | v3.1 | 2026-02-23 | Budget-scaled parameters, autonomy rules, aggressive rotation |
 | v3.0 | 2026-02-23 | Initial release. 2-slot, IMMEDIATE_MOVER entries, +$750 proven |

--- a/wolf-strategy/scripts/job-health-check.py
+++ b/wolf-strategy/scripts/job-health-check.py
@@ -1,123 +1,179 @@
 #!/usr/bin/env python3
 """
-WOLF Job Health Check — Meta-watchdog
-Verifies:
-1. All active positions have a running DSL cron
-2. All DSL crons point to positions that still exist
-3. No cron has been stuck (lastRunAtMs too old vs schedule)
-4. DSL state files match actual wallet positions
-5. SM flip check isn't reporting stale positions
+WOLF Job Health Check v2 — Multi-strategy meta-watchdog
+Verifies per-strategy:
+1. All active positions have a DSL state file
+2. No orphan DSL state files (active but no matching position)
+3. DSL state files are fresh (checked within 10 min)
+4. Direction matches between state and wallet position
+5. State files have correct strategyKey
 
-Outputs JSON with issues[] array.
+Outputs JSON with per-strategy issues[] array.
 """
 
 import json, subprocess, sys, os, glob
 from datetime import datetime, timezone
 
-WALLET = "0x7df5eaec3ca1d22196ffeed03294d1a5bb32ff6d"
-STATE_DIR = "/data/workspace"
-STATE_PATTERN = "dsl-state-WOLF-*.json"
+# Add scripts dir to path for wolf_config import
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from wolf_config import load_all_strategies, state_dir, dsl_state_glob
+
 
 def run_cmd(args, timeout=30):
     r = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
     return r.stdout.strip()
 
-def get_wallet_positions():
-    """Get actual positions from clearinghouse."""
-    raw = run_cmd(["mcporter", "call", "senpi", "strategy_get_clearinghouse_state",
-                   f"strategy_wallet={WALLET}"])
-    data = json.loads(raw).get("data", {})
-    positions = {}
-    for section in ["main", "crypto"]:
-        if section in data and "assetPositions" in data[section]:
-            for p in data[section]["assetPositions"]:
-                pos = p.get("position", {})
-                coin = pos.get("coin")
-                if coin:
-                    szi = float(pos.get("szi", 0))
+
+def get_wallet_positions(wallet):
+    """Get actual positions from clearinghouse for a specific wallet."""
+    try:
+        raw = run_cmd(["mcporter", "call", "senpi", "strategy_get_clearinghouse_state",
+                       f"strategy_wallet={wallet}"])
+        data = json.loads(raw).get("data", {})
+        positions = {}
+        for section in ["main", "crypto"]:
+            if section in data and "assetPositions" in data[section]:
+                for p in data[section]["assetPositions"]:
+                    pos = p.get("position", {})
+                    coin = pos.get("coin")
+                    if coin:
+                        szi = float(pos.get("szi", 0))
+                        if szi != 0:
+                            positions[coin] = {
+                                "direction": "SHORT" if szi < 0 else "LONG",
+                                "size": abs(szi),
+                                "entryPx": pos.get("entryPx"),
+                                "unrealizedPnl": pos.get("unrealizedPnl"),
+                                "returnOnEquity": pos.get("returnOnEquity"),
+                            }
+        return positions
+    except Exception as e:
+        return {"_error": str(e)}
+
+
+def get_xyz_positions(wallet):
+    """Get XYZ positions from clearinghouse."""
+    try:
+        raw = run_cmd(["mcporter", "call", "senpi", "strategy_get_clearinghouse_state",
+                       f"strategy_wallet={wallet}", "dex=xyz"])
+        data = json.loads(raw).get("data", {})
+        positions = {}
+        xyz = data.get("xyz", {})
+        for p in xyz.get("assetPositions", []):
+            pos = p.get("position", {})
+            coin = pos.get("coin")
+            if coin:
+                szi = float(pos.get("szi", 0))
+                if szi != 0:
                     positions[coin] = {
                         "direction": "SHORT" if szi < 0 else "LONG",
                         "size": abs(szi),
                         "entryPx": pos.get("entryPx"),
-                        "unrealizedPnl": pos.get("unrealizedPnl"),
-                        "returnOnEquity": pos.get("returnOnEquity"),
                     }
-    return positions
+        return positions
+    except Exception:
+        return {}
 
-def get_active_dsl_states():
-    """Read all DSL state files."""
+
+def get_active_dsl_states(strategy_key):
+    """Read all DSL state files for a specific strategy."""
     states = {}
-    for f in sorted(glob.glob(os.path.join(STATE_DIR, STATE_PATTERN))):
+    for f in sorted(glob.glob(dsl_state_glob(strategy_key))):
         try:
             with open(f) as fh:
                 state = json.load(fh)
-            asset = state.get("asset", os.path.basename(f).replace("dsl-state-WOLF-", "").replace(".json", ""))
+            # Extract asset from filename: dsl-HYPE.json -> HYPE
+            asset = os.path.basename(f).replace("dsl-", "").replace(".json", "")
             states[asset] = {
                 "active": state.get("active", False),
                 "pendingClose": state.get("pendingClose", False),
                 "file": f,
                 "direction": state.get("direction"),
                 "lastCheck": state.get("lastCheck"),
+                "strategyKey": state.get("strategyKey", strategy_key),
             }
-        except:
+        except (json.JSONDecodeError, IOError):
             continue
     return states
 
-def get_cron_jobs():
-    """List all enabled cron jobs via gateway."""
-    # We'll parse from a file written by the caller, or just check state files
-    # For now, return DSL-related info from state files
-    return {}
 
-def main():
+def check_strategy(strategy_key, cfg):
+    """Run health checks for a single strategy."""
     issues = []
-    warnings = []
     now = datetime.now(timezone.utc)
-    
-    # 1. Get actual positions
-    try:
-        positions = get_wallet_positions()
-    except Exception as e:
-        print(json.dumps({"status": "error", "error": f"Failed to fetch positions: {e}"}))
-        sys.exit(1)
-    
-    # 2. Get DSL states
-    dsl_states = get_active_dsl_states()
-    
-    # 3. Check: every position has an active DSL state
-    for coin, pos in positions.items():
+    wallet = cfg.get("wallet", "")
+
+    if not wallet:
+        issues.append({
+            "level": "CRITICAL",
+            "type": "NO_WALLET",
+            "strategyKey": strategy_key,
+            "message": f"Strategy {strategy_key}: no wallet configured"
+        })
+        return issues, [], []
+
+    # Get actual positions
+    positions = get_wallet_positions(wallet)
+    if "_error" in positions:
+        issues.append({
+            "level": "WARNING",
+            "type": "FETCH_ERROR",
+            "strategyKey": strategy_key,
+            "message": f"Strategy {strategy_key}: failed to fetch positions: {positions['_error']}"
+        })
+        positions = {}
+
+    # Get XYZ positions if configured
+    xyz_wallet = cfg.get("xyzWallet")
+    xyz_positions = {}
+    if xyz_wallet:
+        xyz_positions = get_xyz_positions(xyz_wallet)
+
+    # Merge positions (XYZ coins might have xyz: prefix)
+    all_positions = dict(positions)
+    for coin, pos in xyz_positions.items():
+        all_positions[coin] = pos
+
+    # Get DSL states for this strategy
+    dsl_states = get_active_dsl_states(strategy_key)
+
+    # Check: every position has an active DSL state
+    for coin, pos in all_positions.items():
         asset_key = coin
+        # Check with and without xyz: prefix
         if asset_key not in dsl_states:
-            # Check with xyz: prefix too
-            xyz_key = f"xyz:{coin}"
-            if xyz_key not in dsl_states:
+            clean_key = coin.replace("xyz:", "")
+            if clean_key in dsl_states:
+                asset_key = clean_key
+            else:
                 issues.append({
                     "level": "CRITICAL",
                     "type": "NO_DSL",
+                    "strategyKey": strategy_key,
                     "asset": coin,
-                    "message": f"{coin} {pos['direction']} has NO DSL state file — unprotected position"
+                    "message": f"[{strategy_key}] {coin} {pos['direction']} has NO DSL state file -- unprotected position"
                 })
                 continue
-            else:
-                asset_key = xyz_key
-        
+
         dsl = dsl_states[asset_key]
         if not dsl["active"] and not dsl["pendingClose"]:
             issues.append({
-                "level": "CRITICAL", 
+                "level": "CRITICAL",
                 "type": "DSL_INACTIVE",
+                "strategyKey": strategy_key,
                 "asset": coin,
-                "message": f"{coin} has DSL state file but active=false — unprotected position"
+                "message": f"[{strategy_key}] {coin} has DSL state file but active=false -- unprotected position"
             })
         elif dsl["direction"] != pos["direction"]:
             issues.append({
                 "level": "CRITICAL",
                 "type": "DIRECTION_MISMATCH",
+                "strategyKey": strategy_key,
                 "asset": coin,
-                "message": f"{coin} position is {pos['direction']} but DSL is {dsl['direction']}"
+                "message": f"[{strategy_key}] {coin} position is {pos['direction']} but DSL is {dsl['direction']}"
             })
-        
-        # Check DSL freshness (last check should be within 10 min)
+
+        # Check DSL freshness
         if dsl.get("lastCheck"):
             try:
                 last = datetime.fromisoformat(dsl["lastCheck"].replace("Z", "+00:00"))
@@ -126,36 +182,66 @@ def main():
                     issues.append({
                         "level": "WARNING",
                         "type": "DSL_STALE",
+                        "strategyKey": strategy_key,
                         "asset": coin,
-                        "message": f"{coin} DSL last checked {round(age_min)}min ago — cron may not be firing"
+                        "message": f"[{strategy_key}] {coin} DSL last checked {round(age_min)}min ago -- cron may not be firing"
                     })
-            except:
+            except (ValueError, TypeError):
                 pass
-    
-    # 4. Check: no active DSL states for positions that don't exist (orphans)
+
+    # Check: no orphan DSL states (active but no matching position)
     for asset, dsl in dsl_states.items():
         if dsl["active"]:
             clean_asset = asset.replace("xyz:", "")
-            if clean_asset not in positions and asset not in positions:
-                issues.append({
-                    "level": "WARNING",
-                    "type": "ORPHAN_DSL",
-                    "asset": asset,
-                    "message": f"{asset} DSL state is active but no matching position — should deactivate"
-                })
-    
-    # 5. Summary
+            if clean_asset not in all_positions and asset not in all_positions:
+                # Also check xyz:-prefixed version
+                xyz_asset = f"xyz:{asset}"
+                if xyz_asset not in all_positions:
+                    issues.append({
+                        "level": "WARNING",
+                        "type": "ORPHAN_DSL",
+                        "strategyKey": strategy_key,
+                        "asset": asset,
+                        "message": f"[{strategy_key}] {asset} DSL state is active but no matching position -- should deactivate"
+                    })
+
+    return issues, list(all_positions.keys()), [a for a, d in dsl_states.items() if d["active"]]
+
+
+def main():
+    now = datetime.now(timezone.utc)
+    strategies = load_all_strategies()
+
+    if not strategies:
+        print(json.dumps({"status": "ok", "time": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                          "strategies": 0, "issues": [], "message": "No enabled strategies"}))
+        sys.exit(0)
+
+    all_issues = []
+    strategy_results = {}
+
+    for key, cfg in strategies.items():
+        issues, positions, active_dsl = check_strategy(key, cfg)
+        all_issues.extend(issues)
+        strategy_results[key] = {
+            "positions": positions,
+            "active_dsl": active_dsl,
+            "issues": issues,
+            "issue_count": len(issues),
+            "critical_count": sum(1 for i in issues if i["level"] == "CRITICAL"),
+        }
+
     result = {
-        "status": "ok" if not any(i["level"] == "CRITICAL" for i in issues) else "critical",
+        "status": "ok" if not any(i["level"] == "CRITICAL" for i in all_issues) else "critical",
         "time": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "positions": list(positions.keys()),
-        "active_dsl": [a for a, d in dsl_states.items() if d["active"]],
-        "issues": issues,
-        "issue_count": len(issues),
-        "critical_count": sum(1 for i in issues if i["level"] == "CRITICAL"),
+        "strategies": strategy_results,
+        "issues": all_issues,
+        "issue_count": len(all_issues),
+        "critical_count": sum(1 for i in all_issues if i["level"] == "CRITICAL"),
     }
-    
+
     print(json.dumps(result, indent=2))
+
 
 if __name__ == "__main__":
     main()

--- a/wolf-strategy/scripts/opportunity-scan-v6.py
+++ b/wolf-strategy/scripts/opportunity-scan-v6.py
@@ -1,0 +1,1012 @@
+#!/usr/bin/env python3
+"""
+Opportunity Scanner v6 — Fixed, multi-strategy aware, all v5 features.
+
+Fixes from v5:
+  - Stage 0: BTC macro context (prevents alt longs during BTC crash)
+  - Parallel candle fetches via ThreadPoolExecutor (~20s vs ~60s)
+  - classify_hourly_trend() — the #1 missing filter (the "$346 lesson")
+  - Hard disqualifiers that skip assets entirely (not just penalize)
+  - Cross-scan momentum (scoreDelta, scanStreak) via scan-history.json
+  - Configurable thresholds via scanner-config.json
+  - Per-TF error recovery (one failed fetch doesn't kill the asset)
+  - Structured error output (every code path outputs valid JSON)
+  - Multi-strategy position awareness (checks ALL strategies' DSL states)
+  - First scan produces baseline results immediately (no cold start)
+
+3-stage funnel, 4-pillar scoring. Scans all Hyperliquid perps.
+"""
+
+import json, sys, subprocess, time, os
+from datetime import datetime, timezone
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+# Add scripts dir to path for wolf_config import
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from wolf_config import get_all_active_positions, WORKSPACE, atomic_write
+
+# --- Config ---
+HISTORY_DIR = os.path.join(WORKSPACE, "history")
+SCAN_HISTORY_FILE = os.path.join(HISTORY_DIR, "scan-history.json")
+SCANNER_CONFIG_FILE = os.path.join(HISTORY_DIR, "scanner-config.json")
+
+DEFAULT_CONFIG = {
+    "topNDeep": 15,
+    "minVolume24h": 500_000,
+    "maxWorkers": 8,
+    "pillarWeights": {
+        "smartMoney": 0.25,
+        "marketStructure": 0.25,
+        "technicals": 0.25,
+        "funding": 0.25
+    },
+    "macroModifiers": {
+        "strong_downLong": -30,
+        "strong_downShort": 15,
+        "downLong": -15,
+        "downShort": 8,
+        "neutralLong": 0,
+        "neutralShort": 0,
+        "upLong": 8,
+        "upShort": -15,
+        "strong_upLong": 15,
+        "strong_upShort": -30
+    },
+    "disqualifyThresholds": {
+        "counterTrendStrength": 50,
+        "extremeRsiLow": 20,
+        "extremeRsiHigh": 80,
+        "volumeDeadThreshold": 0.5,
+        "heavyFundingAnnualized": 50,
+        "btcHeadwindPoints": 30
+    }
+}
+
+
+def load_config():
+    """Load scanner config with fallback to defaults."""
+    try:
+        with open(SCANNER_CONFIG_FILE) as f:
+            user = json.load(f)
+        merged = dict(DEFAULT_CONFIG)
+        merged.update(user)
+        return merged
+    except (FileNotFoundError, json.JSONDecodeError):
+        return dict(DEFAULT_CONFIG)
+
+
+def log(level, msg):
+    print(f"[{level.upper()}] {msg}", file=sys.stderr)
+
+
+# --- Helpers ---
+
+def fetch_json(payload):
+    """Fetch from Hyperliquid info API."""
+    try:
+        r = subprocess.run(
+            ["curl", "-s", "https://api.hyperliquid.xyz/info",
+             "-H", "Content-Type: application/json",
+             "-d", json.dumps(payload)],
+            capture_output=True, text=True, timeout=30
+        )
+        return json.loads(r.stdout)
+    except Exception as e:
+        log("warn", f"fetch_json failed: {e}")
+        return None
+
+
+def fetch_candles(coin, interval, hours):
+    """Fetch candle data for a coin at given interval and lookback hours."""
+    now_ms = int(time.time() * 1000)
+    start = now_ms - (hours * 3600 * 1000)
+    return fetch_json({
+        "type": "candleSnapshot",
+        "req": {"coin": coin, "interval": interval, "startTime": start, "endTime": now_ms}
+    })
+
+
+def fetch_mcporter(tool, args=""):
+    """Call mcporter tool, return parsed JSON."""
+    import tempfile
+    tmp = tempfile.mktemp(suffix=".json")
+    cmd = f"mcporter call senpi.{tool} --output json {args} > {tmp} 2>/dev/null"
+    try:
+        subprocess.run(cmd, shell=True, timeout=60)
+        with open(tmp) as f:
+            data = json.load(f)
+        return data
+    except Exception as e:
+        log("warn", f"mcporter call failed: {e}")
+        return {}
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def calc_rsi(closes, period=14):
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        delta = closes[i] - closes[i-1]
+        gains.append(max(0, delta))
+        losses.append(max(0, -delta))
+    avg_gain = sum(gains[:period]) / period
+    avg_loss = sum(losses[:period]) / period
+    for i in range(period, len(gains)):
+        avg_gain = (avg_gain * (period - 1) + gains[i]) / period
+        avg_loss = (avg_loss * (period - 1) + losses[i]) / period
+    if avg_loss == 0:
+        return 100.0
+    rs = avg_gain / avg_loss
+    return round(100 - (100 / (1 + rs)), 1)
+
+
+def calc_ema(values, period):
+    if not values:
+        return []
+    ema = [values[0]]
+    k = 2 / (period + 1)
+    for v in values[1:]:
+        ema.append(v * k + ema[-1] * (1 - k))
+    return ema
+
+
+def price_change(candles, hours_back):
+    """Calculate price change over the last N hours from candle data."""
+    if not candles or len(candles) < 2:
+        return 0
+    current = float(candles[-1]["c"])
+    idx = max(0, len(candles) - hours_back)
+    ref = float(candles[idx]["o"])
+    return round((current - ref) / ref * 100, 2) if ref else 0
+
+
+def volume_ratio(candles, recent_n=4):
+    if len(candles) < 6:
+        return 1.0
+    recent = candles[-recent_n:]
+    prior = candles[:-recent_n]
+    if not prior:
+        return 1.0
+    recent_avg = sum(float(c["v"]) for c in recent) / len(recent)
+    prior_avg = sum(float(c["v"]) for c in prior) / len(prior)
+    if prior_avg == 0:
+        return 1.0
+    return round(recent_avg / prior_avg, 2)
+
+
+def find_swing_levels(candles, lookback=5):
+    highs = [float(c["h"]) for c in candles]
+    lows = [float(c["l"]) for c in candles]
+    swing_highs = []
+    swing_lows = []
+    for i in range(lookback, len(candles) - lookback):
+        if highs[i] == max(highs[i-lookback:i+lookback+1]):
+            swing_highs.append(highs[i])
+        if lows[i] == min(lows[i-lookback:i+lookback+1]):
+            swing_lows.append(lows[i])
+    return swing_highs[-3:] if swing_highs else [], swing_lows[-3:] if swing_lows else []
+
+
+def detect_patterns(candles):
+    if len(candles) < 3:
+        return []
+    patterns = []
+    c1, c2, c3 = candles[-3], candles[-2], candles[-1]
+
+    def body(c): return abs(float(c["c"]) - float(c["o"]))
+    def full_range(c): return float(c["h"]) - float(c["l"])
+    def is_bullish(c): return float(c["c"]) > float(c["o"])
+    def upper_wick(c): return float(c["h"]) - max(float(c["c"]), float(c["o"]))
+    def lower_wick(c): return min(float(c["c"]), float(c["o"])) - float(c["l"])
+
+    fr3, b3 = full_range(c3), body(c3)
+    if fr3 > 0:
+        if lower_wick(c3) > b3 * 2 and upper_wick(c3) < b3 * 0.5:
+            patterns.append("hammer" if is_bullish(c3) else "inverted_hammer")
+        if upper_wick(c3) > b3 * 2 and lower_wick(c3) < b3 * 0.5:
+            patterns.append("shooting_star")
+        if b3 < fr3 * 0.1:
+            patterns.append("doji")
+
+    if not is_bullish(c2) and is_bullish(c3):
+        if float(c3["c"]) > float(c2["o"]) and float(c3["o"]) < float(c2["c"]):
+            patterns.append("bullish_engulfing")
+    if is_bullish(c2) and not is_bullish(c3):
+        if float(c3["c"]) < float(c2["o"]) and float(c3["o"]) > float(c2["c"]):
+            patterns.append("bearish_engulfing")
+    if is_bullish(c1) and is_bullish(c2) and is_bullish(c3):
+        if float(c3["c"]) > float(c2["c"]) > float(c1["c"]):
+            patterns.append("three_soldiers")
+    if not is_bullish(c1) and not is_bullish(c2) and not is_bullish(c3):
+        if float(c3["c"]) < float(c2["c"]) < float(c1["c"]):
+            patterns.append("three_crows")
+
+    return patterns
+
+
+# --- Stage 0: BTC Macro Context (NEW) ---
+
+def fetch_btc_macro(config):
+    """Analyze BTC 4h+1h trend for macro context."""
+    try:
+        candles_4h = fetch_candles("BTC", "4h", hours=168)
+        candles_1h = fetch_candles("BTC", "1h", hours=24)
+        if not candles_4h or not candles_1h:
+            return {"trend": "neutral", "strength": 50, "chg1h": 0,
+                    "modifier": {"LONG": 0, "SHORT": 0}, "error": "candle_fetch_failed"}
+
+        closes_4h = [float(c["c"]) for c in candles_4h]
+        ema5 = calc_ema(closes_4h, 5)
+        ema13 = calc_ema(closes_4h, 13)
+        if not ema5 or not ema13:
+            return {"trend": "neutral", "strength": 50, "chg1h": 0,
+                    "modifier": {"LONG": 0, "SHORT": 0}}
+
+        diff = (ema5[-1] - ema13[-1]) / ema13[-1] * 100
+        chg_1h = price_change(candles_1h, 1)
+
+        if diff < -1.5 and chg_1h < -1:
+            trend = "strong_down"
+        elif diff < -0.5:
+            trend = "down"
+        elif diff > 1.5 and chg_1h > 1:
+            trend = "strong_up"
+        elif diff > 0.5:
+            trend = "up"
+        else:
+            trend = "neutral"
+
+        mods = config.get("macroModifiers", DEFAULT_CONFIG["macroModifiers"])
+        return {
+            "trend": trend,
+            "strength": round(abs(diff) * 10),
+            "chg1h": round(chg_1h, 2),
+            "modifier": {
+                "LONG": mods.get(f"{trend}Long", 0),
+                "SHORT": mods.get(f"{trend}Short", 0)
+            }
+        }
+    except Exception as e:
+        log("warn", f"BTC macro failed: {e}")
+        return {"trend": "neutral", "strength": 50, "chg1h": 0,
+                "modifier": {"LONG": 0, "SHORT": 0}, "error": str(e)}
+
+
+# --- classify_hourly_trend() — THE #1 MISSING FILTER ---
+
+def classify_hourly_trend(candles_1h):
+    """Analyze swing highs/lows in 1h data to determine trend.
+
+    Returns "UP", "DOWN", or "NEUTRAL".
+    Counter-trend on hourly = hard skip. This was the "$346 lesson."
+    """
+    if not candles_1h or len(candles_1h) < 6:
+        return "NEUTRAL"
+
+    highs = [float(c["h"]) for c in candles_1h]
+    lows = [float(c["l"]) for c in candles_1h]
+    closes = [float(c["c"]) for c in candles_1h]
+
+    # Find swing points (lookback=2 for 1h timeframe)
+    swing_highs = []
+    swing_lows = []
+    lb = 2
+    for i in range(lb, len(candles_1h) - lb):
+        if highs[i] == max(highs[i-lb:i+lb+1]):
+            swing_highs.append((i, highs[i]))
+        if lows[i] == min(lows[i-lb:i+lb+1]):
+            swing_lows.append((i, lows[i]))
+
+    if len(swing_highs) < 2 or len(swing_lows) < 2:
+        # Not enough structure, use EMA
+        ema8 = calc_ema(closes, 8)
+        ema21 = calc_ema(closes, 21)
+        if ema8 and ema21:
+            if ema8[-1] > ema21[-1] and closes[-1] > ema8[-1]:
+                return "UP"
+            elif ema8[-1] < ema21[-1] and closes[-1] < ema8[-1]:
+                return "DOWN"
+        return "NEUTRAL"
+
+    # Check last 2 swing highs and lows
+    last_highs = [h[1] for h in swing_highs[-2:]]
+    last_lows = [l[1] for l in swing_lows[-2:]]
+
+    higher_highs = last_highs[-1] > last_highs[-2]
+    higher_lows = last_lows[-1] > last_lows[-2]
+    lower_highs = last_highs[-1] < last_highs[-2]
+    lower_lows = last_lows[-1] < last_lows[-2]
+
+    if higher_highs and higher_lows:
+        return "UP"
+    elif lower_highs and lower_lows:
+        return "DOWN"
+    else:
+        return "NEUTRAL"
+
+
+# --- 4h Trend Analysis ---
+
+def analyze_trend(candles_4h):
+    if len(candles_4h) < 5:
+        return "neutral", 0
+    closes = [float(c["c"]) for c in candles_4h]
+    ema_fast = calc_ema(closes, 5)
+    ema_slow = calc_ema(closes, 13)
+    if not ema_fast or not ema_slow:
+        return "neutral", 0
+    fast_now = ema_fast[-1]
+    slow_now = ema_slow[-1]
+    price_now = closes[-1]
+
+    if fast_now > slow_now and price_now > fast_now:
+        trend, strength = "strong_up", min(100, int((fast_now - slow_now) / slow_now * 1000))
+    elif fast_now > slow_now:
+        trend, strength = "up", min(70, int((fast_now - slow_now) / slow_now * 500))
+    elif fast_now < slow_now and price_now < fast_now:
+        trend, strength = "strong_down", min(100, int((slow_now - fast_now) / slow_now * 1000))
+    elif fast_now < slow_now:
+        trend, strength = "down", min(70, int((slow_now - fast_now) / slow_now * 500))
+    else:
+        trend, strength = "neutral", 0
+
+    if len(ema_fast) >= 3 and len(ema_slow) >= 3:
+        gap_now = abs(ema_fast[-1] - ema_slow[-1])
+        gap_prev = abs(ema_fast[-3] - ema_slow[-3])
+        if gap_now > gap_prev:
+            strength = min(100, strength + 15)
+
+    return trend, strength
+
+
+# --- Hard Disqualifiers (NEW) ---
+
+def check_disqualifiers(direction, hourly_trend, rsi1h, trend_4h, trend_strength,
+                         vol_ratio_1h, vol_ratio_15m, funding_rate, btc_macro, config):
+    """Six conditions that SKIP an asset entirely (not just penalize).
+    Returns (disqualified: bool, reason: str or None).
+    """
+    thresholds = config.get("disqualifyThresholds", DEFAULT_CONFIG["disqualifyThresholds"])
+
+    # 1. Counter-trend on hourly
+    if direction == "LONG" and hourly_trend == "DOWN":
+        return True, "Counter-trend: hourly structure is DOWN for LONG"
+    if direction == "SHORT" and hourly_trend == "UP":
+        return True, "Counter-trend: hourly structure is UP for SHORT"
+
+    # 2. Extreme RSI
+    if direction == "SHORT" and rsi1h < thresholds["extremeRsiLow"]:
+        return True, f"Extreme RSI {rsi1h} < {thresholds['extremeRsiLow']} for SHORT (oversold bounce risk)"
+    if direction == "LONG" and rsi1h > thresholds["extremeRsiHigh"]:
+        return True, f"Extreme RSI {rsi1h} > {thresholds['extremeRsiHigh']} for LONG (overbought reversal risk)"
+
+    # 3. Counter-trend on 4h with strength > threshold
+    if direction == "LONG" and trend_4h in ("strong_down", "down") and trend_strength > thresholds["counterTrendStrength"]:
+        return True, f"Counter-trend: 4h {trend_4h} with strength {trend_strength} > {thresholds['counterTrendStrength']}"
+    if direction == "SHORT" and trend_4h in ("strong_up", "up") and trend_strength > thresholds["counterTrendStrength"]:
+        return True, f"Counter-trend: 4h {trend_4h} with strength {trend_strength} > {thresholds['counterTrendStrength']}"
+
+    # 4. Volume dying on both timeframes
+    if vol_ratio_1h < thresholds["volumeDeadThreshold"] and vol_ratio_15m < thresholds["volumeDeadThreshold"]:
+        return True, f"Volume dying: 1h={vol_ratio_1h}x, 15m={vol_ratio_15m}x (both < {thresholds['volumeDeadThreshold']})"
+
+    # 5. Heavy unfavorable funding
+    ann_rate = abs(funding_rate * 24 * 365 * 100)
+    favorable = (direction == "LONG" and funding_rate <= 0) or (direction == "SHORT" and funding_rate >= 0)
+    if not favorable and ann_rate > thresholds["heavyFundingAnnualized"]:
+        return True, f"Heavy unfavorable funding: {ann_rate:.0f}% annualized against {direction}"
+
+    # 6. BTC macro headwind
+    btc_mod = btc_macro.get("modifier", {}).get(direction, 0)
+    if btc_mod < -thresholds["btcHeadwindPoints"]:
+        return True, f"BTC macro headwind: {btc_mod} points for {direction} (BTC trend: {btc_macro.get('trend')})"
+
+    return False, None
+
+
+# --- Scoring functions (each returns 0-100) ---
+
+def score_smart_money(asset_data):
+    if not asset_data:
+        return 0, "LONG", {}
+    pnl_pct = abs(asset_data.get("pnlContributionPct", 0))
+    traders = asset_data.get("traderCount", 0)
+    accel = asset_data.get("contributionChange4h", 0)
+    direction = asset_data.get("dominantDirection", "LONG")
+
+    score = 0
+    if pnl_pct > 15: score += 50
+    elif pnl_pct > 5: score += 35
+    elif pnl_pct > 1: score += 20
+    elif pnl_pct > 0.3: score += 10
+
+    if traders > 300: score += 25
+    elif traders > 100: score += 18
+    elif traders > 30: score += 10
+    elif traders > 10: score += 5
+
+    if abs(accel) > 10: score += 20
+    elif abs(accel) > 3: score += 12
+    elif abs(accel) > 1: score += 6
+
+    avg_at_peak = asset_data.get("avgAtPeak", 50)
+    near_peak_pct = asset_data.get("nearPeakPct", 0)
+    if avg_at_peak > 85: score += 15
+    elif avg_at_peak > 70: score += 8
+    elif avg_at_peak < 50: score -= 10
+    if near_peak_pct > 50: score += 10
+
+    details = {
+        "pnlPct": round(pnl_pct, 1), "traders": traders,
+        "accel": round(accel, 1), "direction": direction,
+        "avgAtPeak": avg_at_peak, "nearPeakPct": near_peak_pct
+    }
+    return min(100, round(score)), direction, details
+
+
+def score_market_structure(meta):
+    vol24h = meta.get("volume24h", 0)
+    oi = meta.get("openInterest", 0)
+    prev_day_vol = meta.get("prevDayVolume", vol24h)
+    score = 0
+
+    if vol24h > 50_000_000: score += 30
+    elif vol24h > 10_000_000: score += 20
+    elif vol24h > 1_000_000: score += 10
+
+    if prev_day_vol > 0:
+        vol_change = vol24h / prev_day_vol
+        if vol_change > 2.0: score += 30
+        elif vol_change > 1.3: score += 20
+        elif vol_change > 1.0: score += 10
+
+    if oi > 10_000_000: score += 20
+    elif oi > 1_000_000: score += 10
+
+    if vol24h > 0:
+        oi_vol = oi / vol24h
+        if 0.3 < oi_vol < 3.0: score += 20
+
+    details = {
+        "vol24h": round(vol24h), "oi": round(oi),
+        "volTrend": round(vol24h / prev_day_vol, 2) if prev_day_vol > 0 else 1.0
+    }
+    return min(100, round(score)), details
+
+
+def score_technicals(tf_data, direction):
+    score = 0
+    rsi1h = tf_data.get("rsi1h", 50)
+    rsi15m = tf_data.get("rsi15m", 50)
+    vol1h = tf_data.get("volRatio1h", 1.0)
+    vol15m = tf_data.get("volRatio15m", 1.0)
+    trend = tf_data.get("trend4h", "neutral")
+    patterns15m = tf_data.get("patterns15m", [])
+    patterns1h = tf_data.get("patterns1h", [])
+    momentum15m = tf_data.get("momentum15m", 0)
+    divergence = tf_data.get("divergence")
+    chg4h = tf_data.get("chg4h", 0)
+
+    # 4H Trend alignment (0-20 pts)
+    if direction == "LONG":
+        if trend in ("strong_up", "up"): score += 20
+        elif trend == "neutral": score += 5
+        elif trend in ("strong_down", "down"): score -= 5
+    else:
+        if trend in ("strong_down", "down"): score += 20
+        elif trend == "neutral": score += 5
+        elif trend in ("strong_up", "up"): score -= 5
+
+    # 1H RSI (0-20 pts)
+    if direction == "LONG":
+        if rsi1h < 30: score += 20
+        elif rsi1h < 40: score += 15
+        elif rsi1h < 55: score += 8
+        elif rsi1h > 70: score -= 10
+    else:
+        if rsi1h > 70: score += 20
+        elif rsi1h > 60: score += 15
+        elif rsi1h > 45: score += 8
+        elif rsi1h < 30: score -= 10
+
+    # 15M RSI convergence (0-10 pts)
+    if direction == "LONG":
+        if rsi15m < 35 and rsi1h < 45: score += 10
+        elif rsi15m < 40: score += 5
+    else:
+        if rsi15m > 65 and rsi1h > 55: score += 10
+        elif rsi15m > 60: score += 5
+
+    # Volume confirmation (0-15 pts)
+    best_vol = max(vol1h, vol15m)
+    if best_vol > 2.0: score += 15
+    elif best_vol > 1.5: score += 10
+    elif best_vol > 1.2: score += 5
+    elif best_vol < 0.5: score -= 5
+
+    # 15M patterns (0-15 pts)
+    bullish_patterns = {"hammer", "bullish_engulfing", "three_soldiers", "doji"}
+    bearish_patterns = {"shooting_star", "bearish_engulfing", "three_crows", "doji"}
+    relevant = bullish_patterns if direction == "LONG" else bearish_patterns
+    found = set(patterns15m) & relevant
+    if found: score += min(15, len(found) * 8)
+    found_1h = set(patterns1h) & relevant
+    if found_1h: score += min(5, len(found_1h) * 3)
+
+    # Momentum alignment (0-10 pts)
+    if direction == "LONG" and momentum15m > 0.1: score += 10
+    elif direction == "LONG" and momentum15m < -0.3: score += 5
+    elif direction == "SHORT" and momentum15m < -0.1: score += 10
+    elif direction == "SHORT" and momentum15m > 0.3: score += 5
+
+    # 4h momentum (0-10 pts)
+    if direction == "LONG" and chg4h > 1: score += 10
+    elif direction == "LONG" and chg4h < -2: score += 7
+    elif direction == "SHORT" and chg4h < -1: score += 10
+    elif direction == "SHORT" and chg4h > 2: score += 7
+
+    # Volume-price divergence (0-10 pts)
+    if divergence == "bullish" and direction == "LONG": score += 10
+    elif divergence == "bearish" and direction == "SHORT": score += 10
+    elif divergence == "bullish" and direction == "SHORT": score -= 5
+    elif divergence == "bearish" and direction == "LONG": score -= 5
+
+    details = {
+        "rsi1h": rsi1h, "rsi15m": rsi15m,
+        "volRatio1h": vol1h, "volRatio15m": vol15m,
+        "trend4h": trend, "trendStrength": tf_data.get("trendStrength", 0),
+        "hourlyTrend": tf_data.get("hourlyTrend", "NEUTRAL"),
+        "patterns15m": patterns15m, "patterns1h": patterns1h,
+        "momentum15m": momentum15m, "divergence": divergence,
+        "chg1h": tf_data.get("chg1h", 0), "chg4h": chg4h,
+        "chg24h": tf_data.get("chg24h", 0),
+        "support": tf_data.get("support"), "resistance": tf_data.get("resistance"),
+    }
+    return max(0, min(100, round(score))), details
+
+
+def score_funding(funding_rate, direction):
+    score = 0
+    ann_rate = funding_rate * 24 * 365 * 100
+    favorable = (direction == "LONG" and funding_rate <= 0) or \
+                (direction == "SHORT" and funding_rate >= 0)
+
+    if abs(ann_rate) < 5: score += 40
+    elif abs(ann_rate) < 15: score += 25 if favorable else 15
+
+    if favorable:
+        if abs(ann_rate) > 50: score += 35
+        elif abs(ann_rate) > 15: score += 25
+        elif abs(ann_rate) > 5: score += 15
+    else:
+        if abs(ann_rate) > 50: score -= 20
+        elif abs(ann_rate) > 15: score -= 10
+
+    details = {
+        "rate": round(funding_rate * 100, 4),
+        "annualized": round(ann_rate, 1),
+        "favorable": favorable
+    }
+    return max(0, min(100, round(score))), details
+
+
+# --- Deep dive with parallel fetches ---
+
+def deep_dive_asset(name, direction, meta, btc_macro, config):
+    """Full multi-TF analysis for a single asset. Runs in thread pool."""
+    result = {"asset": name, "direction": direction, "error": None}
+    try:
+        # Fetch 3 timeframes (per-TF error recovery)
+        candles_4h = fetch_candles(name, "4h", hours=168) or []
+        candles_1h = fetch_candles(name, "1h", hours=24) or []
+        candles_15m = fetch_candles(name, "15m", hours=6) or []
+
+        if not candles_1h:
+            result["error"] = "no_1h_candles"
+            return result
+
+        closes_1h = [float(c["c"]) for c in candles_1h]
+        closes_15m = [float(c["c"]) for c in candles_15m] if candles_15m else []
+
+        # Hourly trend classification (THE #1 filter)
+        hourly_trend = classify_hourly_trend(candles_1h)
+
+        # 4h trend
+        trend_4h, trend_strength = analyze_trend(candles_4h) if candles_4h else ("neutral", 0)
+
+        # RSI
+        rsi1h = calc_rsi(closes_1h)
+        rsi15m = calc_rsi(closes_15m) if closes_15m else 50
+
+        # Volume
+        vol1h = volume_ratio(candles_1h, 4)
+        vol15m = volume_ratio(candles_15m, 4) if candles_15m else 1.0
+
+        # Swing levels
+        swing_highs, swing_lows = find_swing_levels(candles_1h, 3)
+
+        # Price changes
+        chg1h = price_change(candles_1h, 1)
+        chg4h = price_change(candles_1h, 4) if len(candles_1h) >= 4 else price_change(candles_1h, len(candles_1h))
+        chg24h = price_change(candles_1h, len(candles_1h))
+
+        # Patterns
+        patterns15m = detect_patterns(candles_15m) if candles_15m and len(candles_15m) >= 3 else []
+        patterns1h = detect_patterns(candles_1h)
+
+        # 15m momentum
+        momentum15m = 0
+        if candles_15m and len(candles_15m) >= 4:
+            recent_close = float(candles_15m[-1]["c"])
+            hour_ago_open = float(candles_15m[-4]["o"])
+            if hour_ago_open > 0:
+                momentum15m = round((recent_close - hour_ago_open) / hour_ago_open * 100, 3)
+
+        # Divergence
+        divergence = None
+        if candles_15m and len(candles_15m) >= 8:
+            recent_vol = sum(float(c["v"]) for c in candles_15m[-4:])
+            prior_vol = sum(float(c["v"]) for c in candles_15m[-8:-4])
+            recent_chg = float(candles_15m[-1]["c"]) - float(candles_15m[-4]["c"])
+            if prior_vol > 0:
+                vol_surge = recent_vol / prior_vol
+                if vol_surge > 1.5 and recent_chg < 0: divergence = "bullish"
+                elif vol_surge > 1.5 and recent_chg > 0: divergence = "bearish"
+
+        result["technicals"] = {
+            "hourlyTrend": hourly_trend,
+            "trend4h": trend_4h, "trendStrength": trend_strength,
+            "rsi1h": rsi1h, "rsi15m": rsi15m,
+            "volRatio1h": vol1h, "volRatio15m": vol15m,
+            "resistance": round(max(swing_highs), 4) if swing_highs else None,
+            "support": round(min(swing_lows), 4) if swing_lows else None,
+            "chg1h": chg1h, "chg4h": chg4h, "chg24h": chg24h,
+            "patterns15m": patterns15m, "patterns1h": patterns1h,
+            "momentum15m": momentum15m, "divergence": divergence,
+        }
+        result["candleCounts"] = {
+            "4h": len(candles_4h), "1h": len(candles_1h), "15m": len(candles_15m)
+        }
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
+
+
+# --- Cross-scan momentum ---
+
+def load_scan_history():
+    try:
+        with open(SCAN_HISTORY_FILE) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"scans": []}
+
+
+def save_scan_history(history):
+    os.makedirs(HISTORY_DIR, exist_ok=True)
+    atomic_write(SCAN_HISTORY_FILE, history)
+
+
+def compute_momentum(asset, score, scan_history):
+    """Compute scoreDelta and scanStreak from history."""
+    scans = scan_history.get("scans", [])
+    if not scans:
+        return {"scoreDelta": 0, "scanStreak": 1, "isBaseline": True}
+
+    last_scan = scans[-1].get("results", {})
+    prev_score = last_scan.get(asset, {}).get("finalScore", 0)
+    score_delta = score - prev_score if prev_score else 0
+
+    # Count consecutive appearances
+    streak = 0
+    for scan in reversed(scans):
+        if asset in scan.get("results", {}):
+            streak += 1
+        else:
+            break
+
+    return {"scoreDelta": score_delta, "scanStreak": streak + 1, "isBaseline": False}
+
+
+# ===============================================
+# MAIN
+# ===============================================
+
+def main():
+    try:
+        config = load_config()
+        TOP_N_DEEP = config["topNDeep"]
+        MIN_VOLUME_24H = config["minVolume24h"]
+        W = config["pillarWeights"]
+
+        scan_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # --- Stage 0: BTC Macro Context ---
+        log("info", "Stage 0: Fetching BTC macro context...")
+        btc_macro = fetch_btc_macro(config)
+        log("info", f"Stage 0: BTC trend={btc_macro['trend']}, strength={btc_macro['strength']}, mods={btc_macro['modifier']}")
+
+        # --- Stage 1: Bulk screen ---
+        log("info", "Stage 1: Fetching market structure for all assets...")
+        meta_raw = fetch_json({"type": "metaAndAssetCtxs"})
+        if not meta_raw or len(meta_raw) < 2:
+            print(json.dumps({"success": False, "error": "Failed to fetch metaAndAssetCtxs", "stage": "stage1"}))
+            sys.exit(1)
+
+        meta_info = meta_raw[0]["universe"]
+        meta_ctx = meta_raw[1]
+
+        assets = {}
+        for i, (info, ctx) in enumerate(zip(meta_info, meta_ctx)):
+            name = info["name"]
+            try:
+                funding = float(ctx.get("funding", 0))
+                vol24h = float(ctx.get("dayNtlVlm", 0))
+                oi = float(ctx.get("openInterest", 0))
+                mark = float(ctx.get("markPx", 0))
+            except (ValueError, TypeError):
+                continue
+            if vol24h < MIN_VOLUME_24H:
+                continue
+            assets[name] = {
+                "funding": funding, "volume24h": vol24h,
+                "openInterest": oi, "markPrice": mark,
+                "prevDayVolume": vol24h,
+            }
+
+        log("info", f"Stage 1: {len(assets)} assets pass volume filter (of {len(meta_info)} total)")
+
+        # --- Stage 2: Smart money overlay ---
+        log("info", "Stage 2: Fetching smart money data...")
+        sm_by_asset = {}
+        try:
+            momentum_raw = fetch_mcporter("leaderboard_get_markets")
+            markets_list = momentum_raw.get("data", {}).get("markets", {}).get("markets", [])
+            for item in markets_list:
+                name = item.get("token", "")
+                if name not in assets:
+                    continue
+                pnl = float(item.get("pct_of_top_traders_gain", 0)) * 100
+                accel = item.get("contribution_pct_change_4h")
+                entry = {
+                    "pnlContributionPct": pnl,
+                    "traderCount": int(item.get("trader_count", 0)),
+                    "contributionChange4h": float(accel) if accel is not None else 0.0,
+                    "dominantDirection": item.get("direction", "long").upper()
+                }
+                if name not in sm_by_asset or pnl > sm_by_asset[name]["pnlContributionPct"]:
+                    sm_by_asset[name] = entry
+
+            # Freshness data
+            try:
+                top_traders_raw = fetch_mcporter("leaderboard_get_top", "-p limit=100")
+                top_traders = top_traders_raw.get("data", {}).get("leaderboard", {}).get("data", [])
+                from collections import defaultdict
+                market_peaks = defaultdict(list)
+                for t in top_traders:
+                    upnl = t.get("unrealized_pnl", 0)
+                    ath = t.get("ath_delta", 0)
+                    ratio = upnl / ath if ath > 0 else 0
+                    for m in t.get("top_markets", []):
+                        market_peaks[m].append(ratio)
+                for name in sm_by_asset:
+                    if name in market_peaks:
+                        ratios = market_peaks[name]
+                        sm_by_asset[name]["avgAtPeak"] = round(sum(ratios) / len(ratios) * 100, 1)
+                        sm_by_asset[name]["nearPeakPct"] = round(sum(1 for r in ratios if r > 0.85) / len(ratios) * 100, 1)
+            except Exception as e:
+                log("warn", f"Stage 2b: Peak data failed ({e})")
+        except Exception as e:
+            log("warn", f"Stage 2: SM fetch failed ({e})")
+
+        log("info", f"Stage 2: Smart money data for {len(sm_by_asset)} assets")
+
+        # Quick score all assets and pick top N
+        quick_scores = []
+        for name, meta in assets.items():
+            sm = sm_by_asset.get(name, {})
+            sm_score, direction, _ = score_smart_money(sm)
+            if not sm:
+                direction = "LONG" if meta["funding"] < 0 else "SHORT"
+            ms_score, _ = score_market_structure(meta)
+            fund_score, _ = score_funding(meta["funding"], direction)
+            quick = (sm_score * W["smartMoney"] + ms_score * W["marketStructure"] + fund_score * W["funding"]) / (1 - W["technicals"])
+            quick_scores.append((name, quick, direction))
+
+        sm_top = sorted(sm_by_asset.items(), key=lambda x: x[1]["pnlContributionPct"], reverse=True)
+        forced_assets = set(name for name, _ in sm_top[:8] if name in assets)
+
+        quick_scores.sort(key=lambda x: x[1], reverse=True)
+        top_names = set()
+        top_assets = []
+        for item in quick_scores:
+            if len(top_assets) >= TOP_N_DEEP and item[0] not in forced_assets:
+                continue
+            if item[0] not in top_names:
+                top_assets.append(item)
+                top_names.add(item[0])
+            if len(top_names) >= TOP_N_DEEP + len(forced_assets):
+                break
+
+        log("info", f"Stage 2: Top {len(top_assets)} for deep analysis")
+
+        # --- Multi-strategy position awareness ---
+        active_positions = get_all_active_positions()
+
+        # --- Stage 3: Deep dive (PARALLEL) ---
+        log("info", "Stage 3: Parallel candle fetches for top assets...")
+        deep_results = {}
+        max_workers = config.get("maxWorkers", 8)
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {
+                executor.submit(deep_dive_asset, n, d, assets[n], btc_macro, config): (n, d)
+                for n, _, d in top_assets
+            }
+            for future in as_completed(futures):
+                name, direction = futures[future]
+                try:
+                    result = future.result(timeout=30)
+                    if result and not result.get("error"):
+                        deep_results[result["asset"]] = result
+                    elif result:
+                        log("warn", f"  {name}: {result.get('error')}")
+                except Exception as e:
+                    log("warn", f"  {name}: deep dive exception: {e}")
+
+        log("info", f"Stage 3: {len(deep_results)} assets deep-dived successfully")
+
+        # --- Full scoring + disqualification ---
+        results = []
+        disqualified = []
+        scan_history = load_scan_history()
+
+        for name, quick, direction in top_assets:
+            if name not in deep_results:
+                continue
+
+            dd = deep_results[name]
+            tf_data = dd.get("technicals", {})
+
+            # Check hard disqualifiers
+            dq, dq_reason = check_disqualifiers(
+                direction=direction,
+                hourly_trend=tf_data.get("hourlyTrend", "NEUTRAL"),
+                rsi1h=tf_data.get("rsi1h", 50),
+                trend_4h=tf_data.get("trend4h", "neutral"),
+                trend_strength=tf_data.get("trendStrength", 0),
+                vol_ratio_1h=tf_data.get("volRatio1h", 1.0),
+                vol_ratio_15m=tf_data.get("volRatio15m", 1.0),
+                funding_rate=assets[name]["funding"],
+                btc_macro=btc_macro,
+                config=config
+            )
+
+            # Full 4-pillar scoring (compute even if disqualified for transparency)
+            sm = sm_by_asset.get(name, {})
+            sm_score, _, sm_details = score_smart_money(sm)
+            ms_score, ms_details = score_market_structure(assets[name])
+            tech_score, tech_details = score_technicals(tf_data, direction)
+            fund_score, fund_details = score_funding(assets[name]["funding"], direction)
+
+            final = round(
+                sm_score * W["smartMoney"] * 4 +
+                ms_score * W["marketStructure"] * 4 +
+                tech_score * W["technicals"] * 4 +
+                fund_score * W["funding"] * 4
+            )
+
+            # Apply BTC macro modifier
+            macro_mod = btc_macro.get("modifier", {}).get(direction, 0)
+            final_with_macro = final + macro_mod
+
+            # Cross-scan momentum
+            momentum = compute_momentum(name, final_with_macro, scan_history)
+
+            # Position conflict check
+            conflict = name in active_positions
+            existing_positions = active_positions.get(name, [])
+
+            # Risk flags
+            risks = []
+            rsi1h = tech_details.get("rsi1h", 50)
+            if direction == "LONG" and rsi1h > 65: risks.append("overbought RSI")
+            elif direction == "SHORT" and rsi1h < 35: risks.append("oversold RSI")
+            best_vol = max(tech_details.get("volRatio1h", 1), tech_details.get("volRatio15m", 1))
+            if best_vol < 0.5: risks.append("volume dying")
+            elif best_vol < 0.7: risks.append("volume declining")
+            if not fund_details["favorable"]:
+                risks.append(f"funding against you ({fund_details['annualized']:+.1f}% ann)")
+            if abs(tech_details.get("chg24h", 0)) > 5:
+                risks.append("extended move, may revert")
+            trend = tech_details.get("trend4h", "neutral")
+            if direction == "LONG" and trend in ("strong_down", "down"):
+                risks.append("counter-trend (4h downtrend)")
+            elif direction == "SHORT" and trend in ("strong_up", "up"):
+                risks.append("counter-trend (4h uptrend)")
+
+            entry = {
+                "asset": name,
+                "direction": direction,
+                "finalScore": final_with_macro,
+                "rawScore": final,
+                "macroModifier": macro_mod,
+                "pillarScores": {
+                    "smartMoney": sm_score, "marketStructure": ms_score,
+                    "technicals": tech_score, "funding": fund_score
+                },
+                "smartMoney": sm_details,
+                "marketStructure": ms_details,
+                "technicals": tech_details,
+                "funding": fund_details,
+                "markPrice": assets[name]["markPrice"],
+                "risks": risks,
+                "conflict": conflict,
+                "existingPositions": existing_positions if conflict else None,
+                "momentum": momentum,
+            }
+
+            if dq:
+                entry["disqualified"] = True
+                entry["disqualifyReason"] = dq_reason
+                entry["wouldHaveScored"] = final_with_macro
+                disqualified.append(entry)
+            else:
+                entry["disqualified"] = False
+                results.append(entry)
+
+            log("info", f"  {name}: score={final_with_macro} (raw={final}, macro={macro_mod:+d})"
+                        f"{' [DQ: ' + dq_reason + ']' if dq else ''}"
+                        f"{' [CONFLICT]' if conflict else ''}")
+
+        # Sort by final score
+        results.sort(key=lambda x: x["finalScore"], reverse=True)
+
+        # Save scan history for cross-scan momentum
+        new_scan_entry = {
+            "time": scan_time,
+            "results": {r["asset"]: {"finalScore": r["finalScore"], "direction": r["direction"]}
+                        for r in results}
+        }
+        scan_history["scans"].append(new_scan_entry)
+        if len(scan_history["scans"]) > 20:
+            scan_history["scans"] = scan_history["scans"][-20:]
+        save_scan_history(scan_history)
+
+        # --- Output ---
+        output = {
+            "success": True,
+            "scanTime": scan_time,
+            "btcMacro": btc_macro,
+            "assetsScanned": len(meta_info),
+            "passedStage1": len(assets),
+            "passedStage2": len(top_assets),
+            "deepDived": len(deep_results),
+            "qualified": len(results),
+            "disqualifiedCount": len(disqualified),
+            "pillarWeights": W,
+            "opportunities": results[:15],
+            "disqualified": disqualified[:5],
+            "activePositions": {k: v for k, v in active_positions.items()},
+            "scanHistory": {
+                "totalScans": len(scan_history["scans"]),
+                "isFirstScan": len(scan_history["scans"]) <= 1,
+            }
+        }
+
+        print(json.dumps(output, indent=2))
+        log("info", f"Done. {len(results)} qualified, {len(disqualified)} disqualified.")
+
+    except Exception as e:
+        print(json.dumps({"success": False, "error": str(e), "stage": "unknown"}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/wolf-strategy/scripts/sm-flip-check.py
+++ b/wolf-strategy/scripts/sm-flip-check.py
@@ -1,36 +1,40 @@
 #!/usr/bin/env python3
 """
-Smart Money Flip Detector — Lightweight (1 API call)
-Checks if SM direction has flipped against any active AUTO positions.
-Runs every 5 min. Outputs JSON with alerts.
+Smart Money Flip Detector v2 — Multi-strategy
+Checks if SM direction has flipped against any active positions across ALL strategies.
+Runs every 5 min. Outputs JSON with alerts including strategyKey.
 
 Usage: python3 sm-flip-check.py
-Reads active DSL state files to know current positions.
+Reads active DSL state files from all strategy state dirs.
 """
 
 import json, subprocess, sys, os, glob
 from datetime import datetime, timezone
 
-AUTO_WALLET = "0x07a94ad0b01cc6d70c8c85afcc1b26e576b38857"
-STATE_DIR = "/data/workspace"
-STATE_PATTERN = "dsl-state-WOLF-*.json"
+# Add scripts dir to path for wolf_config import
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from wolf_config import load_all_strategies, dsl_state_glob
+
 
 def get_active_positions():
-    """Read all active AUTO DSL state files."""
+    """Read all active DSL state files across ALL strategies."""
     positions = []
-    for f in glob.glob(os.path.join(STATE_DIR, STATE_PATTERN)):
-        try:
-            with open(f) as fh:
-                state = json.load(fh)
-            if state.get("active"):
-                positions.append({
-                    "asset": state["asset"],
-                    "direction": state["direction"],
-                    "file": f
-                })
-        except:
-            continue
+    for key, cfg in load_all_strategies().items():
+        for f in glob.glob(dsl_state_glob(key)):
+            try:
+                with open(f) as fh:
+                    state = json.load(fh)
+                if state.get("active"):
+                    positions.append({
+                        "asset": state["asset"],
+                        "direction": state["direction"],
+                        "strategyKey": key,
+                        "file": f
+                    })
+            except (json.JSONDecodeError, IOError, KeyError):
+                continue
     return positions
+
 
 def get_sm_data():
     """Fetch smart money data via leaderboard_get_markets."""
@@ -40,12 +44,12 @@ def get_sm_data():
     )
     return json.loads(result.stdout)
 
+
 def analyze(positions, sm_data):
     """Check for SM flips against our positions."""
     alerts = []
-    
-    # Parse SM data — find per-asset dominant direction
-    # Structure: data.markets.markets[] (array of {token, direction, pct_of_top_traders_gain, trader_count, ...})
+
+    # Parse SM data
     raw = sm_data.get("data", sm_data.get("result", {}))
     if isinstance(raw, dict):
         inner = raw.get("markets", raw)
@@ -59,21 +63,20 @@ def analyze(positions, sm_data):
         markets = []
     if not isinstance(markets, list):
         return {"error": "unexpected SM data format", "raw_keys": str(type(markets))}
-    
-    # Build asset→SM map (keep dominant side by pnl%)
+
+    # Build asset->SM map
     sm_map = {}
     for m in markets:
         asset = m.get("token") or m.get("asset") or m.get("coin", "")
         if not asset:
             continue
-        pnl_pct = float(m.get("pct_of_top_traders_gain", m.get("pnlContribution", 0)) or 0) * 100  # convert to %
+        pnl_pct = float(m.get("pct_of_top_traders_gain", m.get("pnlContribution", 0)) or 0) * 100
         traders = int(m.get("trader_count", m.get("traderCount", 0)) or 0)
         direction = (m.get("direction") or "").upper()
-        
-        # Get freshness signals (may not be in this endpoint — default safe)
+
         avg_at_peak = float(m.get("avgAtPeak", 50) or 50)
         near_peak_pct = float(m.get("nearPeakPct", 0) or 0)
-        
+
         key = asset.upper()
         if key not in sm_map or abs(pnl_pct) > abs(sm_map[key].get("pnlPct", 0)):
             sm_map[key] = {
@@ -83,20 +86,19 @@ def analyze(positions, sm_data):
                 "avgAtPeak": avg_at_peak,
                 "nearPeakPct": near_peak_pct
             }
-    
+
     for pos in positions:
         asset = pos["asset"].upper()
         sm = sm_map.get(asset)
         if not sm:
             continue
-        
+
         my_dir = pos["direction"].upper()
         sm_dir = sm["direction"]
-        
-        # Check for flip
+
         flipped = (my_dir == "LONG" and sm_dir == "SHORT") or \
                   (my_dir == "SHORT" and sm_dir == "LONG")
-        
+
         # Conviction scoring
         conviction = 0
         if sm["pnlPct"] > 5: conviction += 2
@@ -106,7 +108,7 @@ def analyze(positions, sm_data):
         if sm["nearPeakPct"] > 50: conviction += 2
         elif sm["nearPeakPct"] > 20: conviction += 1
         if sm["avgAtPeak"] > 80: conviction += 1
-        
+
         alert_level = "none"
         if flipped and conviction >= 4:
             alert_level = "FLIP_NOW"
@@ -114,7 +116,7 @@ def analyze(positions, sm_data):
             alert_level = "FLIP_WARNING"
         elif flipped:
             alert_level = "WATCH"
-        
+
         alerts.append({
             "asset": asset,
             "myDirection": my_dir,
@@ -125,9 +127,10 @@ def analyze(positions, sm_data):
             "smPnlPct": sm["pnlPct"],
             "smTraders": sm["traders"],
             "avgAtPeak": sm["avgAtPeak"],
-            "nearPeakPct": sm["nearPeakPct"]
+            "nearPeakPct": sm["nearPeakPct"],
+            "strategyKey": pos["strategyKey"]
         })
-    
+
     return {
         "time": datetime.now(timezone.utc).isoformat(),
         "positions": len(positions),
@@ -135,12 +138,13 @@ def analyze(positions, sm_data):
         "hasFlipSignal": any(a["alertLevel"] in ("FLIP_NOW", "FLIP_WARNING") for a in alerts)
     }
 
+
 if __name__ == "__main__":
     positions = get_active_positions()
     if not positions:
         print(json.dumps({"time": datetime.now(timezone.utc).isoformat(), "positions": 0, "alerts": [], "hasFlipSignal": False}))
         sys.exit(0)
-    
+
     sm_data = get_sm_data()
     result = analyze(positions, sm_data)
     print(json.dumps(result))

--- a/wolf-strategy/scripts/wolf-setup.py
+++ b/wolf-strategy/scripts/wolf-setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-WOLF v4 Setup Wizard
-Sets up the WOLF autonomous trading strategy.
+WOLF v6 Setup Wizard
+Sets up a WOLF autonomous trading strategy and adds it to the multi-strategy registry.
 Calculates all parameters from budget, fetches max-leverage data,
 and outputs config + cron templates.
 
@@ -9,22 +9,53 @@ Usage:
   # Agent passes what it knows, only asks user for budget:
   python3 wolf-setup.py --wallet 0x... --strategy-id UUID --chat-id 12345 --budget 6500
 
+  # With optional XYZ wallet:
+  python3 wolf-setup.py --wallet 0x... --strategy-id UUID --chat-id 12345 --budget 6500 \
+      --xyz-wallet 0x... --xyz-strategy-id UUID
+
+  # With custom name and DSL preset:
+  python3 wolf-setup.py --wallet 0x... --strategy-id UUID --chat-id 12345 --budget 6500 \
+      --name "Aggressive Momentum" --dsl-preset aggressive
+
   # Interactive mode (prompts for everything):
   python3 wolf-setup.py
 """
 import json, subprocess, sys, os, math, argparse
 
-WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
-CONFIG_FILE = os.path.join(WORKSPACE, "wolf-strategy.json")
+WORKSPACE = os.environ.get("WOLF_WORKSPACE",
+    os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace"))
+REGISTRY_FILE = os.path.join(WORKSPACE, "wolf-strategies.json")
+LEGACY_CONFIG = os.path.join(WORKSPACE, "wolf-strategy.json")
 MAX_LEV_FILE = os.path.join(WORKSPACE, "max-leverage.json")
 SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 
-# Parse CLI args — agent passes what it already knows
-parser = argparse.ArgumentParser(description="WOLF v4 Setup")
+# DSL presets
+DSL_PRESETS = {
+    "aggressive": [
+        {"triggerPct": 5, "lockPct": 50, "breaches": 3},
+        {"triggerPct": 10, "lockPct": 65, "breaches": 2},
+        {"triggerPct": 15, "lockPct": 75, "breaches": 2},
+        {"triggerPct": 20, "lockPct": 85, "breaches": 1}
+    ],
+    "conservative": [
+        {"triggerPct": 3, "lockPct": 60, "breaches": 4},
+        {"triggerPct": 7, "lockPct": 75, "breaches": 3},
+        {"triggerPct": 12, "lockPct": 85, "breaches": 2},
+        {"triggerPct": 18, "lockPct": 90, "breaches": 1}
+    ]
+}
+
+# Parse CLI args
+parser = argparse.ArgumentParser(description="WOLF v6 Setup")
 parser.add_argument("--wallet", help="Strategy wallet address (0x...)")
 parser.add_argument("--strategy-id", help="Strategy ID (UUID)")
 parser.add_argument("--budget", type=float, help="Trading budget in USD (min $500)")
 parser.add_argument("--chat-id", type=int, help="Telegram chat ID")
+parser.add_argument("--xyz-wallet", help="XYZ DEX wallet address (optional)")
+parser.add_argument("--xyz-strategy-id", help="XYZ DEX strategy ID (optional)")
+parser.add_argument("--name", help="Human-readable strategy name (optional)")
+parser.add_argument("--dsl-preset", choices=["aggressive", "conservative"], default="aggressive",
+                    help="DSL tier preset (default: aggressive)")
 args = parser.parse_args()
 
 def ask(prompt, default=None, validator=None):
@@ -64,7 +95,7 @@ def validate_chat_id(v):
     return int(v)
 
 print("=" * 60)
-print("  WOLF v4 — Autonomous Trading Strategy Setup")
+print("  WOLF v6 -- Autonomous Trading Strategy Setup")
 print("=" * 60)
 print()
 
@@ -85,6 +116,11 @@ chat_id = args.chat_id or ask("Telegram chat ID (numeric)", validator=validate_c
 if args.chat_id:
     validate_chat_id(str(args.chat_id))
 
+strategy_name = args.name or f"Strategy {strategy_id[:8]}"
+xyz_wallet = args.xyz_wallet
+xyz_strategy_id = args.xyz_strategy_id
+dsl_preset = args.dsl_preset
+
 # Calculate parameters
 if budget < 3000:
     slots = 2
@@ -97,8 +133,8 @@ else:
 
 margin_per_slot = round(budget * 0.30, 2)
 margin_buffer = round(budget * (1 - 0.30 * slots), 2)
-daily_loss_limit = round(budget * -0.15, 2)
-drawdown_cap = round(budget * -0.30, 2)
+daily_loss_limit = round(budget * 0.15, 2)
+drawdown_cap = round(budget * 0.30, 2)
 
 if budget < 1000:
     default_leverage = 5
@@ -110,30 +146,77 @@ else:
     default_leverage = 10
 
 notional_per_slot = round(margin_per_slot * default_leverage, 2)
+auto_delever_threshold = round(budget * 0.80, 2)
 
-auto_delever_threshold = 6000 if slots == 3 else 3000
+# Build strategy key
+strategy_key = f"wolf-{strategy_id[:8]}"
 
-config = {
+# Build strategy entry
+strategy_entry = {
+    "name": strategy_name,
+    "wallet": wallet,
+    "strategyId": strategy_id,
+    "xyzWallet": xyz_wallet,
+    "xyzStrategyId": xyz_strategy_id,
     "budget": budget,
     "slots": slots,
     "marginPerSlot": margin_per_slot,
-    "marginBuffer": margin_buffer,
     "defaultLeverage": default_leverage,
-    "maxLeverage": 20,
-    "notionalPerSlot": notional_per_slot,
     "dailyLossLimit": daily_loss_limit,
-    "drawdownCap": drawdown_cap,
     "autoDeleverThreshold": auto_delever_threshold,
-    "wallet": wallet,
-    "strategyId": strategy_id,
-    "telegramChatId": chat_id,
-    "telegramTarget": f"telegram:{chat_id}",
+    "dsl": {
+        "preset": dsl_preset,
+        "tiers": DSL_PRESETS[dsl_preset]
+    },
+    "enabled": True
 }
 
-# Save config
-with open(CONFIG_FILE, "w") as f:
-    json.dump(config, f, indent=2)
-print(f"\n✅ Config saved to {CONFIG_FILE}")
+# Load or create registry
+if os.path.exists(REGISTRY_FILE):
+    with open(REGISTRY_FILE) as f:
+        registry = json.load(f)
+else:
+    registry = {
+        "version": 1,
+        "defaultStrategy": None,
+        "strategies": {},
+        "global": {
+            "telegramChatId": str(chat_id),
+            "workspace": WORKSPACE,
+            "notifications": {
+                "provider": "telegram",
+                "alertDedupeMinutes": 15
+            }
+        }
+    }
+
+# Add strategy to registry
+registry["strategies"][strategy_key] = strategy_entry
+
+# Set as default if it's the only one (or the first)
+if registry.get("defaultStrategy") is None or len(registry["strategies"]) == 1:
+    registry["defaultStrategy"] = strategy_key
+
+# Update global telegram if needed
+if not registry["global"].get("telegramChatId"):
+    registry["global"]["telegramChatId"] = str(chat_id)
+
+# Save registry atomically
+os.makedirs(WORKSPACE, exist_ok=True)
+tmp_file = REGISTRY_FILE + ".tmp"
+with open(tmp_file, "w") as f:
+    json.dump(registry, f, indent=2)
+os.replace(tmp_file, REGISTRY_FILE)
+print(f"\n  Registry saved to {REGISTRY_FILE}")
+
+# Create per-strategy state directory
+state_dir = os.path.join(WORKSPACE, "state", strategy_key)
+os.makedirs(state_dir, exist_ok=True)
+print(f"  State directory created: {state_dir}")
+
+# Create other shared directories
+for d in ["history", "memory", "logs"]:
+    os.makedirs(os.path.join(WORKSPACE, d), exist_ok=True)
 
 # Fetch max-leverage from Hyperliquid
 print("\nFetching max-leverage data from Hyperliquid...")
@@ -151,9 +234,9 @@ try:
         max_lev[name] = asset.get("maxLeverage", 50)
     with open(MAX_LEV_FILE, "w") as f:
         json.dump(max_lev, f, indent=2)
-    print(f"✅ Max leverage data saved ({len(max_lev)} assets) to {MAX_LEV_FILE}")
+    print(f"  Max leverage data saved ({len(max_lev)} assets) to {MAX_LEV_FILE}")
 except Exception as e:
-    print(f"⚠️  Failed to fetch max-leverage: {e}")
+    print(f"  Failed to fetch max-leverage: {e}")
     print("   You can manually fetch later.")
 
 # Build cron templates
@@ -162,121 +245,126 @@ margin_str = str(int(margin_per_slot))
 
 cron_templates = {
     "emerging_movers": {
-        "name": "WOLF Emerging Movers v3 (60s)",
-        "schedule": {"kind": "every", "everyMs": 60000},
+        "name": "WOLF Emerging Movers v5 (90s)",
+        "schedule": {"kind": "every", "everyMs": 90000},
         "sessionTarget": "main",
         "wakeMode": "now",
         "payload": {
             "kind": "systemEvent",
-            "text": f"WOLF v3 Scanner: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/emerging-movers.py`, parse JSON.\n\nMANDATE: Hunt runners before they peak. v3 IMMEDIATE signals + DSL.\n1. **IMMEDIATE_MOVER**: 10+ rank jump from #25+ in ONE scan → OPEN ${margin_str} margin, {default_leverage}x leverage, DSL on. Act on FIRST jump.\n2. **NEW_ENTRY_DEEP**: Appears in top 20 from nowhere → OPEN ${margin_str} margin, {default_leverage}x leverage, DSL on.\n3. **CONTRIB_EXPLOSION**: 3x+ contrib in one scan → OPEN ${margin_str} margin, {default_leverage}x leverage, DSL on.\n4. Wallet: {wallet} (strategy {strategy_id[:8]}). XYZ positions use leverageType ISOLATED on same wallet.\n5. Max {slots} positions. Alert user on Telegram ({tg}).\n6. Negative velocity or already-peaked signals = SKIP. Empty slot > mediocre position.\n7. **DEAD WEIGHT RULE**: If any open position has negative ROE AND SM conviction is against it (flipped, conv 1+) for 30+ minutes → CUT immediately and free the slot.\n8. **ROTATION RULE**: If slots are FULL and a new IMMEDIATE fires, compare it against current positions. Score: reason count + rank jump magnitude + contrib velocity. If new signal scores higher than weakest position's current momentum (ROE trend, SM conviction, contrib rank) → CUT weakest, OPEN new. Factors favoring rotation: new signal has 4+ reasons, weakest position is flat/negative ROE, weakest has low SM conviction (0-1). Factors favoring hold: current position is trending up with good ROE, SM conv 3+.\n9. If no actionable signals → HEARTBEAT_OK.\n10. **AUTO-DELEVER**: If account drops below ${auto_delever_threshold:,} → revert to max {slots - 1} positions, close weakest if {slots} open."
+            "text": f"WOLF v6 Scanner: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/emerging-movers.py`, parse JSON.\n\nMANDATE: Hunt runners before they peak. Multi-strategy aware.\n1. **FIRST_JUMP**: 10+ rank jump from #25+ AND wasn't in previous top 50 (or was >= #30) -> ENTER IMMEDIATELY.\n2. **CONTRIB_EXPLOSION**: 3x+ contrib spike -> ENTER. NEVER downgrade for erratic history.\n3. **IMMEDIATE_MOVER**: 10+ rank jump from #25+ in ONE scan -> ENTER if not downgraded.\n4. **NEW_ENTRY_DEEP**: Appears in top 20 from nowhere -> ENTER.\n5. **Signal routing**: Read wolf-strategies.json. For each signal, find the best-fit strategy: check available slots, existing positions, risk profile match. Route to the strategy with open slots that doesn't already hold the asset.\n6. Min 7x leverage (check max-leverage.json). Alert user on Telegram ({tg}).\n7. **DEAD WEIGHT RULE**: Negative ROE + SM conviction against it for 30+ min -> CUT immediately.\n8. **ROTATION RULE**: If target strategy slots FULL and FIRST_JUMP fires -> compare against weakest position in THAT strategy.\n9. If no actionable signals -> HEARTBEAT_OK.\n10. **AUTO-DELEVER**: Per-strategy threshold check."
         }
     },
-    "dsl_template": {
-        "name": "DSL {ASSET} 180s",
+    "dsl_combined": {
+        "name": "WOLF DSL Combined v6 (3min)",
         "schedule": {"kind": "every", "everyMs": 180000},
         "sessionTarget": "main",
         "wakeMode": "now",
         "payload": {
             "kind": "systemEvent",
-            "text": f"[DSL] Run DSL check for {{ASSET}}: `DSL_STATE_FILE=/data/workspace/dsl-state-WOLF-{{ASSET}}.json PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/dsl-v4.py`. Parse JSON output. If close_triggered=true, close {{ASSET}} (coin={{COIN}}, strategyWalletAddress={wallet}), alert user on Telegram ({tg}), deactivate state file, disable this cron. If active=false, HEARTBEAT_OK."
+            "text": f"WOLF DSL: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/dsl-combined.py`, parse JSON.\n\nThis checks ALL active positions across ALL strategies in one pass. Parse the `results` array.\nFOR EACH position in results:\n- If `closed: true` -> alert user on Telegram ({tg}) with asset, direction, strategyKey, close_reason, upnl.\n- If `tier_changed: true` -> note the tier upgrade.\n- If `phase1_autocut: true` and `closed: true` -> position cut for timeout. Alert user.\n- If `status: \"pending_close\"` -> close failed, will retry.\nIf `any_closed: true` -> check for new signals.\nIf all active with no alerts -> HEARTBEAT_OK."
         }
     },
     "sm_flip": {
-        "name": "WOLF SM Flip Detector (5min)",
+        "name": "WOLF SM Flip Detector v6 (5min)",
         "schedule": {"kind": "every", "everyMs": 300000},
         "sessionTarget": "main",
         "wakeMode": "now",
         "payload": {
             "kind": "systemEvent",
-            "text": f"WOLF SM Check (warning-only): Run `python3 {SCRIPTS_DIR}/sm-flip-check.py`, parse JSON. If any alert has conviction 4+ SHORT against our LONG (or vice versa) with 100+ traders → CUT the position (don't flip, just close and free the slot for runners). conviction 2-3 = note but don't act. If hasFlipSignal=false → HEARTBEAT_OK."
+            "text": f"WOLF SM Check: Run `python3 {SCRIPTS_DIR}/sm-flip-check.py`, parse JSON.\n\nMulti-strategy aware. If any alert has conviction 4+ in OPPOSITE direction with 100+ traders -> CUT the position (set DSL state active: false). The output includes strategyKey for each position.\nConviction 2-3 = note but don't act.\nAlert user on Telegram ({tg}) for any cuts.\nIf hasFlipSignal=false -> HEARTBEAT_OK."
         }
     },
     "watchdog": {
-        "name": "WOLF Watchdog (5min)",
+        "name": "WOLF Watchdog v6 (5min)",
         "schedule": {"kind": "every", "everyMs": 300000},
         "sessionTarget": "main",
         "wakeMode": "now",
         "payload": {
             "kind": "systemEvent",
-            "text": f"WOLF Watchdog: Run `PYTHONUNBUFFERED=1 timeout 45 python3 {SCRIPTS_DIR}/wolf-monitor.py`. Parse JSON output.\n\nKEY CHECKS:\n1. **Cross-margin buffer** (`crypto_liq_buffer_pct`): If <50% → WARNING to user. If <30% → CRITICAL, consider closing weakest position.\n2. **Position alerts**: Any alert with level=CRITICAL → immediate Telegram alert ({tg}). WARNING → alert if new (don't repeat same warning within 15min).\n3. **Rotation check**: Compare each position's ROE. If any position is -15%+ ROE AND emerging movers show a strong climber (top 10, 3+ reasons) we DON'T hold → suggest rotation to user.\n4. **XYZ isolated liq**: If liq_distance_pct < 15% → alert user.\n5. Save output to /data/workspace/watchdog-last.json for dedup.\n\nIf no alerts needed → HEARTBEAT_OK."
+            "text": f"WOLF Watchdog: Run `PYTHONUNBUFFERED=1 timeout 45 python3 {SCRIPTS_DIR}/wolf-monitor.py`. Parse JSON output.\n\nMulti-strategy: output has `strategies` dict keyed by strategy key. Per-strategy checks:\n1. Cross-margin buffer: <50% WARNING, <30% CRITICAL.\n2. Position alerts: CRITICAL -> immediate Telegram ({tg}). WARNING -> alert if new.\n3. Rotation check: -15%+ ROE AND strong climber we don't hold -> suggest rotation.\n4. XYZ isolated liq < 15% -> alert user.\n5. Per-strategy watchdog state saved in state/{{strategyKey}}/watchdog-last.json.\nIf no alerts -> HEARTBEAT_OK."
         }
     },
     "portfolio": {
-        "name": "WOLF Portfolio (15min)",
+        "name": "WOLF Portfolio v6 (15min)",
         "schedule": {"kind": "every", "everyMs": 900000},
         "sessionTarget": "main",
         "wakeMode": "now",
         "payload": {
             "kind": "systemEvent",
-            "text": f"WOLF portfolio update: Get clearinghouse state for wallet {wallet}. Send user a concise Telegram update ({tg}). Code block table format. Include account value and position summary."
+            "text": f"WOLF portfolio update: Read wolf-strategies.json for all enabled strategies. For each strategy, get clearinghouse state for its wallet. Send user a concise Telegram update ({tg}). Code block table format. Include per-strategy account value, positions (asset, direction, ROE, PnL, DSL tier), and slot usage."
         }
     },
     "health_check": {
-        "name": "WOLF Job Health Check (10min)",
+        "name": "WOLF Health Check v6 (10min)",
         "schedule": {"kind": "every", "everyMs": 600000},
         "sessionTarget": "main",
         "wakeMode": "now",
         "payload": {
             "kind": "systemEvent",
-            "text": f"WOLF Health Check: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/job-health-check.py`, parse JSON.\n\nIf any CRITICAL issues → fix immediately (deactivate orphan DSLs, create missing DSLs for unprotected positions, fix direction mismatches). Alert user on Telegram ({tg}) for critical issues.\nIf only WARNINGs → fix silently (deactivate orphans, note stale crons).\nIf no issues → HEARTBEAT_OK."
+            "text": f"WOLF Health Check: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/job-health-check.py`, parse JSON.\n\nMulti-strategy: validates per-strategy state dirs vs actual wallet positions.\nIf CRITICAL -> fix immediately (deactivate orphans, create missing DSLs, fix direction mismatches).\nAlert user on Telegram ({tg}) for critical issues.\nWARNINGs -> fix silently.\nNo issues -> HEARTBEAT_OK."
         }
     },
     "opportunity_scanner": {
-        "name": "WOLF Scanner (15min)",
+        "name": "WOLF Scanner v6 (15min)",
         "schedule": {"kind": "every", "everyMs": 900000},
         "sessionTarget": "main",
         "wakeMode": "now",
         "payload": {
             "kind": "systemEvent",
-            "text": f"WOLF scanner: Run `PYTHONUNBUFFERED=1 timeout 180 python3 {SCRIPTS_DIR}/opportunity-scan.py 2>/dev/null`. Read /data/workspace/wolf-strategy.json for rules. Wallet: {wallet} (strategy {strategy_id[:8]}). Max {slots} concurrent positions, ${margin_str} margin each, {default_leverage}x leverage. XYZ positions use leverageType ISOLATED on same wallet. Threshold 175+. Check existing positions before opening. If good opportunity → open position, create DSL state file (dsl-state-WOLF-{{ASSET}}.json), create DSL cron, alert user ({tg}). Otherwise HEARTBEAT_OK. AUTO-DELEVER: If account below ${auto_delever_threshold:,} → max {slots - 1} positions only."
+            "text": f"WOLF scanner: Run `PYTHONUNBUFFERED=1 timeout 180 python3 {SCRIPTS_DIR}/opportunity-scan-v6.py 2>/dev/null`. Parse JSON.\n\nMulti-strategy signal routing: For each scored opportunity (threshold 175+):\n1. Which strategies have empty slots?\n2. Does any strategy already hold this asset? (skip within strategy, allow cross-strategy)\n3. Which strategy's risk profile matches the signal?\n4. Route to best-fit -> open position on THAT wallet -> create DSL state in THAT strategy's state dir.\nAlert user ({tg}). Otherwise HEARTBEAT_OK."
         }
     }
 }
 
 print("\n" + "=" * 60)
-print("  WOLF v4 Configuration Summary")
+print("  WOLF v6 Configuration Summary")
 print("=" * 60)
 print(f"""
+  Strategy Key:     {strategy_key}
+  Strategy Name:    {strategy_name}
   Wallet:           {wallet}
   Strategy ID:      {strategy_id}
+  XYZ Wallet:       {xyz_wallet or 'None'}
   Budget:           ${budget:,.2f}
   Slots:            {slots}
   Margin/Slot:      ${margin_per_slot:,.2f}
   Default Leverage:  {default_leverage}x
   Notional/Slot:    ${notional_per_slot:,.2f}
-  Margin Buffer:    ${margin_buffer:,.2f}
   Daily Loss Limit: ${daily_loss_limit:,.2f}
-  Drawdown Cap:     ${drawdown_cap:,.2f}
-  Auto-Delever:     Below ${auto_delever_threshold:,}
+  Auto-Delever:     Below ${auto_delever_threshold:,.2f}
+  DSL Preset:       {dsl_preset}
   Telegram:         {tg}
 """)
 
-print("=" * 60)
+strategies_count = len(registry["strategies"])
+print(f"  Total strategies in registry: {strategies_count}")
+if strategies_count > 1:
+    print(f"  All strategies: {list(registry['strategies'].keys())}")
+
+print("\n" + "=" * 60)
 print("  Next Steps: Create 7 cron jobs")
 print("=" * 60)
 print("""
-Use OpenClaw cron to create each job. Example:
-
-  openclaw cron add --json '{
-    "name": "WOLF Emerging Movers v3 (60s)",
-    "schedule": { "kind": "every", "everyMs": 60000 },
-    "sessionTarget": "main",
-    "wakeMode": "now",
-    "payload": { "kind": "systemEvent", "text": "..." }
-  }'
-
-See references/cron-templates.md in the wolf-strategy skill
+Use OpenClaw cron to create each job. See references/cron-templates.md
 for the exact payload text for each of the 7 jobs.
 
-DSL crons are created per-position (when the agent opens a trade).
-You only need to create the other 6 at setup time.
+With multi-strategy, crons iterate all enabled strategies internally.
+You only need ONE set of crons regardless of strategy count.
 """)
 
 # Output full result as JSON for programmatic use
 result = {
-    "config": config,
+    "success": True,
+    "strategyKey": strategy_key,
+    "config": strategy_entry,
+    "registry": {
+        "strategiesCount": strategies_count,
+        "strategies": list(registry["strategies"].keys()),
+        "defaultStrategy": registry["defaultStrategy"]
+    },
     "cronTemplates": cron_templates,
     "maxLeverageFile": MAX_LEV_FILE,
-    "configFile": CONFIG_FILE,
+    "registryFile": REGISTRY_FILE,
+    "stateDir": state_dir,
 }
 print(json.dumps(result, indent=2))

--- a/wolf-strategy/scripts/wolf_config.py
+++ b/wolf-strategy/scripts/wolf_config.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+wolf_config.py — Multi-strategy config loader for WOLF v6
+
+Provides a single importable module every script uses to load strategy config,
+resolve state file paths, and handle legacy migration.
+
+Usage:
+    from wolf_config import load_strategy, load_all_strategies, dsl_state_path
+    cfg = load_strategy("wolf-abc123")   # Specific strategy
+    cfg = load_strategy()                # Default strategy
+    strategies = load_all_strategies()   # All enabled strategies
+    path = dsl_state_path("wolf-abc123", "HYPE")
+"""
+
+import json, os, sys, glob
+
+WORKSPACE = os.environ.get("WOLF_WORKSPACE",
+    os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace"))
+REGISTRY_FILE = os.path.join(WORKSPACE, "wolf-strategies.json")
+LEGACY_CONFIG = os.path.join(WORKSPACE, "wolf-strategy.json")
+LEGACY_STATE_PATTERN = os.path.join(WORKSPACE, "dsl-state-WOLF-*.json")
+
+
+def _fail(msg):
+    """Print error JSON and exit."""
+    print(json.dumps({"success": False, "error": msg}))
+    sys.exit(1)
+
+
+def _load_registry():
+    """Load the strategy registry, with auto-migration from legacy format."""
+    if os.path.exists(REGISTRY_FILE):
+        with open(REGISTRY_FILE) as f:
+            return json.load(f)
+
+    # Fallback: auto-migrate legacy single-strategy config
+    if os.path.exists(LEGACY_CONFIG):
+        with open(LEGACY_CONFIG) as f:
+            legacy = json.load(f)
+        sid = legacy.get("strategyId", "unknown")
+        key = f"wolf-{sid[:8]}" if sid != "unknown" else "wolf-default"
+
+        # Build strategy entry from legacy config
+        strategy = {
+            "name": "Default Strategy",
+            "wallet": legacy.get("wallet", ""),
+            "strategyId": legacy.get("strategyId", ""),
+            "xyzWallet": legacy.get("xyzWallet"),
+            "xyzStrategyId": legacy.get("xyzStrategyId"),
+            "budget": legacy.get("budget", 0),
+            "slots": legacy.get("slots", 2),
+            "marginPerSlot": legacy.get("marginPerSlot", 0),
+            "defaultLeverage": legacy.get("defaultLeverage", 10),
+            "dailyLossLimit": legacy.get("dailyLossLimit", 0),
+            "autoDeleverThreshold": legacy.get("autoDeleverThreshold", 0),
+            "dsl": {
+                "preset": "aggressive",
+                "tiers": [
+                    {"triggerPct": 5, "lockPct": 50, "breaches": 3},
+                    {"triggerPct": 10, "lockPct": 65, "breaches": 2},
+                    {"triggerPct": 15, "lockPct": 75, "breaches": 2},
+                    {"triggerPct": 20, "lockPct": 85, "breaches": 1}
+                ]
+            },
+            "enabled": True
+        }
+
+        registry = {
+            "version": 1,
+            "defaultStrategy": key,
+            "strategies": {key: strategy},
+            "global": {
+                "telegramChatId": str(legacy.get("telegramChatId", "")),
+                "workspace": WORKSPACE,
+                "notifications": {
+                    "provider": "telegram",
+                    "alertDedupeMinutes": 15
+                }
+            }
+        }
+
+        # Auto-migrate legacy state files to new directory structure
+        _migrate_legacy_state_files(key)
+
+        return registry
+
+    _fail("No config found. Run wolf-setup.py first.")
+
+
+def _migrate_legacy_state_files(strategy_key):
+    """Move old dsl-state-WOLF-*.json files into state/{strategy_key}/dsl-*.json."""
+    legacy_files = glob.glob(LEGACY_STATE_PATTERN)
+    if not legacy_files:
+        return
+
+    new_dir = os.path.join(WORKSPACE, "state", strategy_key)
+    os.makedirs(new_dir, exist_ok=True)
+
+    for old_path in legacy_files:
+        basename = os.path.basename(old_path)
+        # dsl-state-WOLF-HYPE.json → dsl-HYPE.json
+        asset = basename.replace("dsl-state-WOLF-", "").replace(".json", "")
+        new_path = os.path.join(new_dir, f"dsl-{asset}.json")
+
+        if os.path.exists(new_path):
+            continue  # don't overwrite already-migrated files
+
+        try:
+            with open(old_path) as f:
+                state = json.load(f)
+            # Add strategy context
+            state["strategyKey"] = strategy_key
+            if "version" not in state:
+                state["version"] = 2
+            atomic_write(new_path, state)
+        except (json.JSONDecodeError, IOError):
+            continue
+
+
+def load_strategy(strategy_key=None):
+    """Load a single strategy config.
+
+    Args:
+        strategy_key: Strategy key (e.g. "wolf-abc123"). If None, uses
+                      WOLF_STRATEGY env var or defaultStrategy from registry.
+
+    Returns:
+        Strategy config dict with injected _key, _global, _workspace, _state_dir.
+    """
+    reg = _load_registry()
+    if strategy_key is None:
+        strategy_key = os.environ.get("WOLF_STRATEGY", reg.get("defaultStrategy"))
+    if not strategy_key or strategy_key not in reg["strategies"]:
+        _fail(f"Strategy '{strategy_key}' not found. "
+              f"Available: {list(reg['strategies'].keys())}")
+    cfg = reg["strategies"][strategy_key].copy()
+    cfg["_key"] = strategy_key
+    cfg["_global"] = reg.get("global", {})
+    cfg["_workspace"] = reg.get("global", {}).get("workspace", WORKSPACE)
+    cfg["_state_dir"] = os.path.join(cfg["_workspace"], "state", strategy_key)
+    return cfg
+
+
+def load_all_strategies(enabled_only=True):
+    """Load all strategies from the registry.
+
+    Args:
+        enabled_only: If True (default), skip strategies with enabled=False.
+
+    Returns:
+        Dict of strategy_key → strategy config.
+    """
+    reg = _load_registry()
+    result = {}
+    for key, cfg in reg["strategies"].items():
+        if enabled_only and not cfg.get("enabled", True):
+            continue
+        entry = cfg.copy()
+        entry["_key"] = key
+        entry["_global"] = reg.get("global", {})
+        entry["_workspace"] = reg.get("global", {}).get("workspace", WORKSPACE)
+        entry["_state_dir"] = os.path.join(entry["_workspace"], "state", key)
+        result[key] = entry
+    return result
+
+
+def state_dir(strategy_key):
+    """Get (and create) the state directory for a strategy."""
+    d = os.path.join(WORKSPACE, "state", strategy_key)
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def dsl_state_path(strategy_key, asset):
+    """Get the DSL state file path for a strategy + asset."""
+    return os.path.join(state_dir(strategy_key), f"dsl-{asset}.json")
+
+
+def dsl_state_glob(strategy_key):
+    """Get the glob pattern for all DSL state files in a strategy."""
+    return os.path.join(state_dir(strategy_key), "dsl-*.json")
+
+
+def get_all_active_positions():
+    """Get all active positions across ALL strategies.
+
+    Returns:
+        Dict of asset → list of {strategyKey, direction, stateFile}.
+    """
+    positions = {}
+    for key, cfg in load_all_strategies().items():
+        for sf in glob.glob(dsl_state_glob(key)):
+            try:
+                with open(sf) as f:
+                    s = json.load(f)
+                if s.get("active"):
+                    asset = s["asset"]
+                    if asset not in positions:
+                        positions[asset] = []
+                    positions[asset].append({
+                        "strategyKey": key,
+                        "direction": s["direction"],
+                        "stateFile": sf
+                    })
+            except (json.JSONDecodeError, IOError, KeyError):
+                continue
+    return positions
+
+
+def atomic_write(path, data):
+    """Atomically write JSON data to a file."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)


### PR DESCRIPTION
Add multi-strategy architecture so WOLF manages multiple strategies simultaneously, each with independent wallets, budgets, slots, and DSL configs. Fix the opportunity scanner with BTC macro context, hourly trend filter, hard disqualifiers, parallel candle fetches, and cross-scan momentum.

New files:
- wolf_config.py: shared config loader with legacy auto-migration
- opportunity-scan-v6.py: rewritten scanner fixing all v5 reliability issues

Modified scripts to iterate all strategies via load_all_strategies(), use per-strategy state dirs (state/{key}/dsl-{ASSET}.json), and include strategyKey in all outputs. Removed hardcoded wallets from wolf-monitor and job-health-check. Updated all docs to reflect v6 architecture and removed "broken/optional" scanner language.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches autonomous trade management paths (DSL closes, monitoring, health checks) and changes on-disk config/state formats with migration, so misrouting or state-path bugs could impact live position handling across strategies.
> 
> **Overview**
> WOLF moves from a single-strategy config/state layout to a **multi-strategy registry** (`wolf-strategies.json`) with **per-strategy state directories** (`state/{strategyKey}/dsl-{ASSET}.json`), enabling multiple wallets/slots/DSL presets to run concurrently without state collisions.
> 
> Core runners (`dsl-combined.py`, `sm-flip-check.py`, `wolf-monitor.py`, `job-health-check.py`) are updated to **iterate all enabled strategies**, include `strategyKey` in outputs for routing/alerts, and stop relying on hardcoded wallets/legacy state paths; `wolf-setup.py` now appends strategies to the registry and creates required directories.
> 
> Adds `wolf_config.py` as a shared loader with **legacy auto-migration** from `wolf-strategy.json` and old `dsl-state-WOLF-*.json` files, and introduces `opportunity-scan-v6.py` (new scanner) with BTC macro context, hourly trend filter, hard disqualifiers, parallel candle fetches, and cross-scan momentum/history, while docs/cron templates are revised to reflect **one set of crons** and the new scanner/state schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81ddc2b8b58762a25e4a15972c1bc65d0d48307c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->