### PR TITLE
wolf dsl fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,65 @@
+# Python cache and compiled files
+__pycache__/
+*.py[cod]
+*.so
+*.egg
+*.egg-info/
+dist/
+build/
+.eggs/
+pip-wheel-metadata/
+*.pyo
+*.pyd
+.env
+.venv
+env/
+venv/
+ENV/
+*.env
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# VSCode & IDE
+.vscode/
+.idea/
+
+# MacOS
+.DS_Store
+
+# Log and test output
+*.log
+
+# Agent skills state/output
+*.state.json
+*.cache.json
+*.output.json
+*.tmp
+*.bak
+
+# Coverage and test
+htmlcov/
+.coverage
+.tox/
+.cache/
+.nox/
+.pytest_cache/
+
+# Agent data directories
+data/
+workspace/
+outputs/
+checkpoints/
+runs/
+
+# Misc
+*.swp
+*.swo
+
+# Node/npm for agent toolchains
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+.DS_Store

--- a/wolf-strategy/scripts/dsl-v4.py
+++ b/wolf-strategy/scripts/dsl-v4.py
@@ -43,6 +43,23 @@ stag_min_roe = stag_cfg.get("minROE", 8.0)          # minimum ROE% to trigger
 stag_stale_hours = stag_cfg.get("staleHours", 1.0)   # hours HW must be stale
 stag_range_pct = stag_cfg.get("priceRangePct", 1.0)  # max price movement % in window
 
+
+def _fetch_prices(dex=None):
+    """Fetch mid prices via Senpi MCP market_get_prices. Returns dict of asset->price (string)."""
+    try:
+        args = {} if dex is None or dex == "" else {"dex": dex}
+        r = subprocess.run(
+            ["mcporter", "call", "senpi", "market_get_prices", "--args", json.dumps(args)],
+            capture_output=True, text=True, timeout=15
+        )
+        data = json.loads(r.stdout)
+        inner = data.get("data", data.get("result", data))
+        prices = inner.get("prices") if isinstance(inner, dict) else data.get("prices")
+        return prices if isinstance(prices, dict) else {}
+    except Exception:
+        return {}
+
+
 # ─── Fetch price ───
 try:
     asset_name = state["asset"]
@@ -50,35 +67,18 @@ try:
     if not asset_name.startswith("xyz:") and is_xyz:
         asset_name = "xyz:" + asset_name
     if is_xyz:
-        # XYZ DEX uses a different endpoint
-        xyz_coin = asset_name  # e.g. "xyz:GOLD"
-        r = subprocess.run(
-            ["mcporter", "call", "senpi.strategy_get_clearinghouse_state",
-             f"strategy_wallet={state['wallet']}", "dex=xyz"],
-            capture_output=True, text=True, timeout=15
-        )
-        data = json.loads(r.stdout)
-        found = False
-        for pos in data.get("data", {}).get("xyz", {}).get("assetPositions", []):
-            if pos["position"]["coin"] == xyz_coin:
-                # Use mid between entry and current value to approximate price
-                # Actually get mark price from position value / size
-                pval = float(pos["position"]["positionValue"])
-                sz = abs(float(pos["position"]["szi"]))
-                price = pval / sz if sz > 0 else 0
-                found = True
-                break
-        if not found:
-            raise Exception(f"XYZ position {xyz_coin} not found in clearinghouse")
+        # XYZ DEX: use market mids from MCP (keys like xyz:XYZ100, xyz:TSLA)
+        prices = _fetch_prices(dex="xyz")
+        price_str = prices.get(asset_name) or prices.get(asset_name.replace("xyz:", "", 1))
+        if price_str is None:
+            raise Exception(f"XYZ asset {asset_name} not found in market_get_prices(dex=xyz)")
+        price = float(price_str)
     else:
-        r = subprocess.run(
-            ["curl", "-s", "https://api.hyperliquid.xyz/info",
-             "-H", "Content-Type: application/json",
-             "-d", '{"type":"allMids"}'],
-            capture_output=True, text=True, timeout=15
-        )
-        mids = json.loads(r.stdout)
-        price = float(mids[asset_name])
+        # Main DEX: use market mids from MCP
+        prices = _fetch_prices()
+        if asset_name not in prices:
+            raise Exception(f"Asset {asset_name} not found in market_get_prices")
+        price = float(prices[asset_name])
     state["consecutiveFetchFailures"] = 0
 except Exception as e:
     fails = state.get("consecutiveFetchFailures", 0) + 1

--- a/wolf-strategy/scripts/wolf_config.py
+++ b/wolf-strategy/scripts/wolf_config.py
@@ -215,3 +215,16 @@ def atomic_write(path, data):
     with open(tmp, "w") as f:
         json.dump(data, f, indent=2)
     os.replace(tmp, path)
+
+
+def parse_mcp_prices_response(data):
+    """Parse MCP market_get_prices response. Returns dict of asset->price (string) or {}.
+
+    Handles response shapes: { data: { prices }, result: { prices }, or root-level prices }.
+    If the MCP response shape changes, update this single place.
+    """
+    if not isinstance(data, dict):
+        return {}
+    inner = data.get("data", data.get("result", data))
+    prices = inner.get("prices") if isinstance(inner, dict) else data.get("prices")
+    return prices if isinstance(prices, dict) else {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates core price inputs for DSL close logic and monitoring by switching from direct Hyperliquid curl and XYZ clearinghouse-derived prices to `senpi market_get_prices`, which could change trigger behavior if the feed or symbol mapping differs.
> 
> **Overview**
> Switches all strategy scripts to a single pricing source: `senpi` MCP `market_get_prices` for both main DEX and `dex=xyz`, replacing the prior direct Hyperliquid `allMids` curl call and the XYZ clearinghouse-derived price calculation.
> 
> `dsl-combined.py`, `dsl-v4.py`, and `wolf-monitor.py` now batch-fetch mids once (including optional `dex` support) and parse responses via the new shared `wolf_config.parse_mcp_prices_response`, reducing per-wallet calls and centralizing response-shape handling. Adds a repo-wide `.gitignore` for common Python/IDE/test artifacts and workspace outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4100d9fc972845d91f1591d43f4ee87391ea160. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->