### PR TITLE
Update SKILL.md and error handling to enforce $100 minimum strategy b…

### DIFF
--- a/senpi-getting-started-guide/SKILL.md
+++ b/senpi-getting-started-guide/SKILL.md
@@ -23,6 +23,8 @@ Guide users through their first complete trade on Hyperliquid via Senpi. This sk
 
 **User-facing rule:** Never show the user internal details. Do **not** mention state names (e.g. UNFUNDED, READY, FRESH), file paths (e.g. state.json, ~/.config/senpi), step codes (e.g. STRATEGY_CREATED), or MCP/tool names. Use only plain, friendly language (e.g. "You're all set to start", "Fund your wallet to begin", "Your strategy is running").
 
+**Minimum strategy budget:** Use **$100** as the minimum when creating the first-trade mirror strategy. Do not suggest or use $50 or any amount below $100.
+
 ---
 
 ## Prerequisites
@@ -105,7 +107,7 @@ If onboarding is not complete (state FRESH or ONBOARDING), tell the user only: "
 
 ### Step 1: Introduction
 
-Display the trade cycle: **Discover top traders** → **Create a strategy** (mirror a chosen trader) → **Monitor** → **Close strategy**. Recommend a small budget (e.g. $50) for the first strategy and include a short risk disclaimer. Ask user to say **"yes"** to continue or **"skip"** if experienced.
+Display the trade cycle: **Discover top traders** → **Create a strategy** (mirror a chosen trader) → **Monitor** → **Close strategy**. Recommend a **$100 minimum** budget for the first strategy and include a short risk disclaimer. Ask user to say **"yes"** to continue or **"skip"** if experienced.
 
 Update state: set `firstTrade.step` to `INTRODUCTION`, `firstTrade.started` true, `startedAt` (ISO 8601). Preserve existing fields in `state.json`.
 
@@ -123,7 +125,7 @@ See [references/discovery-guide.md](references/discovery-guide.md) for display t
 
 ### Step 3: Strategy Sizing
 
-Before creating the strategy, explain: chosen trader, budget ($50), and that the strategy will mirror that trader's positions. Warn about risk and liquidation. Ask user to say **"confirm"** to create the strategy.
+Before creating the strategy, explain: chosen trader, budget (**$100 minimum**), and that the strategy will mirror that trader's positions. Warn about risk and liquidation. Ask user to say **"confirm"** to create the strategy.
 
 See [references/strategy-management.md](references/strategy-management.md) for the sizing table and wording.
 
@@ -131,7 +133,7 @@ See [references/strategy-management.md](references/strategy-management.md) for t
 
 ### Step 4: Create Strategy
 
-On user confirmation, call MCP **`strategy_create`** with the chosen trader (from Step 2) and budget (e.g. $50). On success, tell the user in plain language that their strategy is set up (e.g. "Your strategy is created and running."). Optionally mention budget and the trader they’re mirroring. Do not show strategy status or raw IDs. Offer: "how's my strategy?", "close my strategy", or "show my positions".
+On user confirmation, call MCP **`strategy_create`** with the chosen trader (from Step 2) and budget (**minimum $100**). On success, tell the user in plain language that their strategy is set up (e.g. "Your strategy is created and running."). Optionally mention budget and the trader they’re mirroring. Do not show strategy status or raw IDs. Offer: "how's my strategy?", "close my strategy", or "show my positions".
 
 Update state per [references/strategy-management.md](references/strategy-management.md) (`firstTrade.step: "STRATEGY_CREATED"`, `tradeDetails` with `strategyId`, `mirroredTraderId`). On failure, see [references/error-handling.md](references/error-handling.md).
 

--- a/senpi-getting-started-guide/references/error-handling.md
+++ b/senpi-getting-started-guide/references/error-handling.md
@@ -12,7 +12,7 @@ If the user tries to create a strategy but balance is less than the required amo
 
 > ⚠️ **Not enough balance**
 >
-> You need at least $50 to create this strategy.
+> You need at least **$100** to create this strategy.
 >
 > Current balance: $10.00
 >

--- a/senpi-getting-started-guide/references/strategy-management.md
+++ b/senpi-getting-started-guide/references/strategy-management.md
@@ -6,7 +6,7 @@ Use this for **strategy sizing**, **create**, **monitor**, and **close** steps o
 
 ## Strategy Sizing (Before Create)
 
-Explain the mirror strategy to the user with a table. Default first-trade: $50 budget, chosen trader from Step 2 (Discovery).
+Explain the mirror strategy to the user with a table. **Minimum first-trade budget: $100.** Chosen trader from Step 2 (Discovery).
 
 **Display:**
 
@@ -15,20 +15,20 @@ Explain the mirror strategy to the user with a table. Default first-trade: $50 b
 > | Parameter | Value | Explanation |
 > |-----------|-------|-------------|
 > | Mirrored trader | &lt;name or 0x…&gt; | Top trader from discovery |
-> | Budget | $50 | Amount allocated to this strategy |
+> | Budget | $100 (min) | Amount allocated to this strategy |
 > | Type | Mirror | Copies this trader's positions |
 >
 > **Risk:** Your strategy will open and manage positions in line with the chosen trader. PnL depends on market moves and trader behavior.
 >
 > ⚠️ **You can close the strategy anytime** with "close my strategy" — funds return to your wallet.
 >
-> Ready to create this strategy? Say **"confirm"** to execute.
+> Ready to create this strategy? Say **"confirm"** to execute. (Minimum budget: $100.)
 
 ---
 
 ## Create Strategy
 
-- Call MCP **`strategy_create`** with the chosen trader (use `recommendedTraderId` from state) and budget (e.g. $50). Pass the trader identifier and budget as required by the tool.
+- Call MCP **`strategy_create`** with the chosen trader (use `recommendedTraderId` from state) and budget (**minimum $100**). Pass the trader identifier and budget as required by the tool.
 - On success, tell the user in **plain language only** (e.g. "Your strategy is created and running."). Optionally mention budget and the trader they’re mirroring. Do not show strategy ID, status, or any internal codes. Offer: "how's my strategy?", "close my strategy", "show my positions".
 
 **State update after create:**
@@ -40,7 +40,7 @@ Explain the mirror strategy to the user with a table. Default first-trade: $50 b
   "tradeDetails": {
     "strategyId": "<id returned by strategy_create>",
     "mirroredTraderId": "<recommendedTraderId from DISCOVERY step>",
-    "budgetUsd": 50,
+    "budgetUsd": 100,
     "createdAt": "<ISO8601 UTC>"
   }
 }


### PR DESCRIPTION
…udget

- Set $100 as the minimum budget for creating the first-trade mirror strategy across relevant sections.
- Revise user prompts and error messages to reflect the updated budget requirement, ensuring clarity and consistency in user experience.
- Adjust strategy management documentation to align with the new budget guidelines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that tightens the first-trade budget constraint; main impact is user guidance/state examples now assume $100 minimum instead of $50.
> 
> **Overview**
> Sets a **$100 minimum** budget for the first-trade mirror strategy across the tutorial flow, updating the Introduction/Sizing/Create copy to stop suggesting $50 and to gate starting/creating on having at least $100.
> 
> Aligns reference docs and examples with the new requirement, including the insufficient-balance message and the `strategy-management.md` sizing table and `tradeDetails.budgetUsd` example value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f892a23f692356f2d2420bfacddba9483af6c96e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->