### PR TITLE
Enhance SKILL.md and discovery-guide.md for trader recommendations

### DIFF
--- a/senpi-getting-started-guide/SKILL.md
+++ b/senpi-getting-started-guide/SKILL.md
@@ -117,7 +117,7 @@ Wait for user confirmation before proceeding.
 
 ### Step 2: Discovery
 
-Use MCP **`discovery_get_top_traders`** to fetch top traders. Optionally use **`discovery_get_trader_state`** or **`discovery_get_trader_history`** for detail. Show a short table of top traders (e.g. by PnL, win rate) and **recommend one trader** to mirror for the first trade.
+Use MCP **`discovery_get_top_traders`** to fetch top traders. **Only present as options traders that currently have open positions** — filter out or verify with **`discovery_get_trader_state`** (or equivalent) so you do not offer traders with no open positions. Optionally use **`discovery_get_trader_history`** for extra detail. Show a short table of top traders with open positions (e.g. by PnL, win rate) and **recommend one trader** to mirror for the first trade.
 
 See [references/discovery-guide.md](references/discovery-guide.md) for display template and state update (`firstTrade.step: "DISCOVERY"`, `recommendedTraderId`, `recommendedTraderName`).
 

--- a/senpi-getting-started-guide/references/discovery-guide.md
+++ b/senpi-getting-started-guide/references/discovery-guide.md
@@ -1,59 +1,64 @@
 # Discovery Guide Reference
 
-Use this when running **Step 2: Discovery** of the first-trade tutorial. **Show the user only user-friendly copy;** do not mention state, step names, or MCP/tool names.
+Use this when running **Step 2: Discovery** of the first-trade tutorial. This step is about **finding top traders and recommending one to mirror** (not opening individual asset/direction positions). Use **`discovery_get_top_traders`**; optionally **`discovery_get_trader_state`** or **`discovery_get_trader_history`** to confirm a trader has open positions. **Only present as options traders that currently have open positions** — do not offer traders with no open positions. **Show the user only user-friendly copy;** do not mention state, step names, or MCP/tool names.
 
 ---
 
 ## MCP Usage
 
-- Use MCP tools to fetch top traders and their current positions (e.g. discovery-related tools).
-- Prefer liquid assets (ETH, BTC, SOL) for the first trade so entry/exit are smooth.
+- **`discovery_get_top_traders`** — Fetch top traders (e.g. by PnL, win rate, or consistency).
+- **Filter to traders with open positions** — Only show options for traders that **currently have open positions**. Use **`discovery_get_trader_state`** (or equivalent) to confirm open positions before including a trader in the list. Do not offer traders with no open positions.
+- Optionally **`discovery_get_trader_history`** — Get extra detail for a specific trader before recommending.
+- Prefer traders whose positions are in liquid assets (ETH, BTC, SOL) so the mirror strategy has smooth entry/exit.
 
 ---
 
 ## What to Look For
 
-- **Conviction** — Multiple top traders in the same direction on the same asset
-- **Liquid assets** — ETH, BTC, SOL preferred for first trade
-- **Recent entries** — Positions opened in the last few hours
+- **Open positions** — Only include traders that **currently have open positions** (so the mirror strategy has something to copy).
+- **Strong performance** — Among those, prefer top traders by PnL, win rate, or consistency.
+- **Liquid assets** — Traders with positions in ETH, BTC, SOL are better for a first mirror strategy.
+- **Recent activity** — Traders with recent activity so the mirror has clear positions to follow.
 
 ---
 
 ## Display Template
 
-After fetching data, show the user something like:
+After fetching with **`discovery_get_top_traders`** and **filtering to traders with open positions**, show the user something like:
 
-> 🔍 **Scanning smart money activity...**
+> 🔍 **Scanning top traders...**
 >
-> Here's what top traders are doing right now:
+> Here are some of the best performers **with open positions** right now:
 >
-> **Top Opportunities:**
+> **Top Traders:**
 >
-> | Asset | Direction | # Traders | Avg Entry | Conviction |
-> |-------|-----------|-----------|-----------|------------|
-> | ETH   | LONG      | 3         | $3,180    | 🟢 High    |
-> | SOL   | LONG      | 2         | $142      | 🟡 Medium  |
-> | BTC   | SHORT     | 1         | $67,500   | 🟡 Medium  |
+> | Rank | Trader | PnL (7d) | Win Rate | Open Positions |
+> |------|--------|----------|----------|----------------|
+> | 1    | 0xABC… | +$2,450  | 68%      | ETH LONG, BTC SHORT |
+> | 2    | 0xDEF… | +$1,890  | 62%      | SOL LONG |
+> | 3    | 0x123… | +$1,200  | 58%      | ETH SHORT |
 >
-> 💡 **Recommendation:** I suggest **ETH LONG** for your first trade:
-> - Most liquid market (easy to enter/exit)
-> - Strong conviction (3 top traders agree)
-> - Moderate volatility (good for learning)
+> 💡 **Recommendation:** For your first trade I suggest **mirroring the #1 trader** (0xABC…):
+> - Strong recent PnL and win rate
+> - Liquid markets (ETH, BTC) for easy entry/exit
+> - Good for learning how copy trading works
 >
-> Want to open an **ETH LONG** position? Say **"yes"** or tell me a different asset.
+> Want to create a **$100 mirror strategy** copying this trader? Say **"confirm"** to proceed, or tell me if you’d prefer a different trader.
+
+Store the **chosen trader’s identifier** (e.g. address or id from the API) for use in **`strategy_create`** in the next step. **Minimum budget for the first strategy is $100** — do not suggest $50 or less.
 
 ---
 
 ## State Update
 
-After discovery, update `firstTrade` in state:
+After discovery, update `firstTrade` in state with the **recommended trader** (for use in strategy_create):
 
 ```json
 "firstTrade": {
   "step": "DISCOVERY",
-  "recommendedAsset": "ETH",
-  "recommendedDirection": "LONG"
+  "recommendedTraderId": "<trader id or address from discovery_get_top_traders>",
+  "recommendedTraderName": "<optional display name or truncated address>"
 }
 ```
 
-Preserve other existing fields in `state.json` when merging.
+Preserve other existing fields in `state.json` when merging. Do **not** use `recommendedAsset` or `recommendedDirection` — this flow mirrors a **trader**, not a single asset/direction position.


### PR DESCRIPTION
- Update the discovery process to only present traders with open positions, ensuring users receive relevant options for mirroring.
- Revise user-facing instructions to clarify the focus on recommending top traders based on performance metrics like PnL and win rate.
- Improve the display template to emphasize traders with open positions and provide a user-friendly recommendation format.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust the first-trade discovery instructions and state fields; no runtime logic or security-sensitive code is modified.
> 
> **Overview**
> Tightens the Step 2 *Discovery* guidance to **only recommend traders who currently have open positions**, using `discovery_get_trader_state` (or equivalent) to verify and filtering out inactive traders.
> 
> Updates the user-facing discovery template and state expectations to focus on **mirroring a recommended trader** (table of traders + store `recommendedTraderId`/`recommendedTraderName`), explicitly removing the prior asset/direction-style recommendation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2da23df851abb85a8824d196113a07687b4d4ffe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->