### PR TITLE
Update SKILL.md and discovery-guide.md to reflect changes in trader d…

### DIFF
--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -116,7 +116,7 @@ npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-getting-st
 
 If the guide skill is not yet available, suggest these first actions instead:
 - "Check your portfolio" (uses `account_get_portfolio` tool)
-- "Discover top traders" (uses `discovery_get_top_traders` tool)
+- "Discover top traders" (uses `discovery_get_top_strategies` tool)
 - "View market data" (uses `market_get_prices` tool)
 
 ---

--- a/senpi-getting-started-guide/SKILL.md
+++ b/senpi-getting-started-guide/SKILL.md
@@ -117,7 +117,7 @@ Wait for user confirmation before proceeding.
 
 ### Step 2: Discovery
 
-Use MCP **`discovery_get_top_traders`** to fetch top traders. **Only present as options traders that currently have open positions** — filter out or verify with **`discovery_get_trader_state`** (or equivalent) so you do not offer traders with no open positions. Optionally use **`discovery_get_trader_history`** for extra detail. Show a short table of top traders with open positions (e.g. by PnL, win rate) and **recommend one trader** to mirror for the first trade.
+Use MCP **`discovery_get_top_strategies`** to fetch top traders. **Only present as options traders that currently have open positions** — filter out or verify with **`discovery_get_trader_state`** (or equivalent) so you do not offer traders with no open positions. Optionally use **`discovery_get_trader_history`** for extra detail. Show a short table of top traders with open positions (e.g. by PnL, win rate) and **recommend one trader** to mirror for the first trade.
 
 See [references/discovery-guide.md](references/discovery-guide.md) for display template and state update (`firstTrade.step: "DISCOVERY"`, `recommendedTraderId`, `recommendedTraderName`).
 
@@ -170,7 +170,7 @@ If the user returns mid-tutorial, read firstTrade.step from state and resume fro
 ## Reference Files
 
 - **[references/error-handling.md](references/error-handling.md)** — Insufficient balance, strategy_create failed, strategy_close failed, recovery
-- **[references/discovery-guide.md](references/discovery-guide.md)** — discovery_get_top_traders, recommend a trader to mirror, display template
+- **[references/discovery-guide.md](references/discovery-guide.md)** — discovery_get_top_strategies, recommend a trader to mirror, display template
 - **[references/strategy-management.md](references/strategy-management.md)** — Strategy sizing, strategy_create/strategy_close flow, state updates for firstTrade
 - **[references/next-steps.md](references/next-steps.md)** — Celebration copy, skip tutorial, resume handling
 

--- a/senpi-getting-started-guide/references/discovery-guide.md
+++ b/senpi-getting-started-guide/references/discovery-guide.md
@@ -1,12 +1,12 @@
 # Discovery Guide Reference
 
-Use this when running **Step 2: Discovery** of the first-trade tutorial. This step is about **finding top traders and recommending one to mirror** (not opening individual asset/direction positions). Use **`discovery_get_top_traders`**; optionally **`discovery_get_trader_state`** or **`discovery_get_trader_history`** to confirm a trader has open positions. **Only present as options traders that currently have open positions** — do not offer traders with no open positions. **Show the user only user-friendly copy;** do not mention state, step names, or MCP/tool names.
+Use this when running **Step 2: Discovery** of the first-trade tutorial. This step is about **finding top traders and recommending one to mirror** (not opening individual asset/direction positions). Use **`discovery_get_top_strategies`**; optionally **`discovery_get_trader_state`** or **`discovery_get_trader_history`** to confirm a trader has open positions. **Only present as options traders that currently have open positions** — do not offer traders with no open positions. **Show the user only user-friendly copy;** do not mention state, step names, or MCP/tool names.
 
 ---
 
 ## MCP Usage
 
-- **`discovery_get_top_traders`** — Fetch top traders (e.g. by PnL, win rate, or consistency).
+- **`discovery_get_top_strategies`** — Fetch top strategies (e.g. by PnL, win rate, or consistency).
 - **Filter to traders with open positions** — Only show options for traders that **currently have open positions**. Use **`discovery_get_trader_state`** (or equivalent) to confirm open positions before including a trader in the list. Do not offer traders with no open positions.
 - Optionally **`discovery_get_trader_history`** — Get extra detail for a specific trader before recommending.
 - Prefer traders whose positions are in liquid assets (ETH, BTC, SOL) so the mirror strategy has smooth entry/exit.
@@ -24,7 +24,7 @@ Use this when running **Step 2: Discovery** of the first-trade tutorial. This st
 
 ## Display Template
 
-After fetching with **`discovery_get_top_traders`** and **filtering to traders with open positions**, show the user something like:
+After fetching with **`discovery_get_top_strategies`** and **filtering to traders with open positions**, show the user something like:
 
 > 🔍 **Scanning top traders...**
 >
@@ -56,7 +56,7 @@ After discovery, update `firstTrade` in state with the **recommended trader** (f
 ```json
 "firstTrade": {
   "step": "DISCOVERY",
-  "recommendedTraderId": "<trader id or address from discovery_get_top_traders>",
+  "recommendedTraderId": "<trader id or address from discovery_get_top_strategies>",
   "recommendedTraderName": "<optional display name or truncated address>"
 }
 ```


### PR DESCRIPTION
…iscovery process

- Replace references to `discovery_get_top_traders` with `discovery_get_top_strategies` to align with the updated strategy for recommending traders.
- Ensure user instructions and reference materials consistently reflect the new focus on top strategies rather than individual traders.
- Maintain clarity in user-facing documentation to enhance the overall user experience during the discovery phase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that change which MCP tool name is referenced during discovery; low risk aside from potential confusion if the backend/tooling doesn’t match the new name.
> 
> **Overview**
> Updates onboarding and first-trade documentation to use `discovery_get_top_strategies` (instead of `discovery_get_top_traders`) for the discovery step and “discover top traders” suggestion.
> 
> Aligns the discovery reference guide/template and the state-update example (`recommendedTraderId`) to point at results from `discovery_get_top_strategies`, and updates related cross-references accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 580aea4160066176738482cb525c5c32dad711f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->