### PR TITLE
Refine SKILL.md and next-steps documentation for strategy creation an…

### DIFF
--- a/senpi-getting-started-guide/SKILL.md
+++ b/senpi-getting-started-guide/SKILL.md
@@ -133,31 +133,27 @@ See [references/strategy-management.md](references/strategy-management.md) for t
 
 ### Step 4: Create Strategy
 
-On user confirmation, call MCP **`strategy_create`** with the chosen trader (from Step 2) and budget (**minimum $100**). On success, tell the user in plain language that their strategy is set up (e.g. "Your strategy is created and running."). Optionally mention budget and the trader they’re mirroring. Do not show strategy status or raw IDs. Offer: "how's my strategy?", "close my strategy", or "show my positions".
+On user confirmation, call MCP **`strategy_create`** with the chosen trader (from Step 2) and budget (**minimum $100**). On success, **show the celebration** (see [references/next-steps.md](references/next-steps.md) — "Celebrate (After First Strategy Created)"): congratulate the user for opening their first strategy, then offer "how's my strategy?", "close my strategy", or "show my positions". Do not show strategy status or raw IDs.
 
-Update state per [references/strategy-management.md](references/strategy-management.md) (`firstTrade.step: "STRATEGY_CREATED"`, `tradeDetails` with `strategyId`, `mirroredTraderId`). On failure, see [references/error-handling.md](references/error-handling.md).
+Update state per [references/strategy-management.md](references/strategy-management.md): set `firstTrade.step: "STRATEGY_CREATED"`, `tradeDetails` (strategyId, mirroredTraderId, etc.), **and** set `firstTrade.completed: true`, `firstTrade.step: "COMPLETE"`, `firstTrade.completedAt`. On failure, see [references/error-handling.md](references/error-handling.md).
 
 ---
 
 ### Step 5: Monitor Strategy
 
-When user asks "how's my strategy?" or similar, fetch data via MCP: **`strategy_get`**, **`strategy_get_clearinghouse_state`**, or **`execution_get_open_position_details`** for open positions. Show strategy value, open positions (if any), unrealized PnL, ROE. Offer: Hold, Close strategy, or Add protection.
-
-**If the user only monitors (never closes):** After they have checked their strategy at least once, still congratulate them for completing the first-trade flow — they discovered, created, and monitored. Show a short celebration and next steps (see [references/next-steps.md](references/next-steps.md)), set state to `READY` and `firstTrade.completed`, `firstTrade.step: "COMPLETE"`, `completedAt`. They should feel accomplished either way.
+When user asks "how's my strategy?" or similar, fetch data via MCP: **`strategy_get`**, **`strategy_get_clearinghouse_state`**, or **`execution_get_open_position_details`** for open positions. Show strategy value, open positions (if any), unrealized PnL, ROE. Offer: Hold, Close strategy, or Add protection. Do **not** show a separate congratulations here — that was already shown when they created their first strategy (Step 4).
 
 ---
 
 ### Step 6: Close Strategy
 
-When user says "close", "exit", "close my strategy", "take profit", etc., call MCP **`strategy_close`** with the strategy ID from state. Tell the user the strategy is closed and show **realized PnL, duration, and fees** in plain language. Do not mention strategy status or internal codes. Update state (STRATEGY_CLOSE, tradeDetails). See [references/strategy-management.md](references/strategy-management.md).
+When user says "close", "exit", "close my strategy", "take profit", etc., call MCP **`strategy_close`** with the strategy ID from state. Tell the user the strategy is closed and show **realized PnL, duration, and fees** in plain language. Show the "After Close" result and next steps from [references/next-steps.md](references/next-steps.md) (no separate congratulations — already shown when they created the strategy). Do not mention strategy status or internal codes. Update state (STRATEGY_CLOSE, tradeDetails with closedAt, pnl, etc.). See [references/strategy-management.md](references/strategy-management.md).
 
 ---
 
-### Step 7: Celebrate & Next Steps
+### Step 7: After Close — Result & Next Steps
 
-Show celebration (profit or loss, or after monitor-only) and suggest next skills and quick commands. Set state to `READY` and `firstTrade.completed`, `firstTrade.step: "COMPLETE"`, `completedAt`.
-
-Full copy and state shape: [references/next-steps.md](references/next-steps.md) and [references/strategy-management.md](references/strategy-management.md).
+When the user has closed their strategy (Step 6), the result and next steps are shown there. No separate celebration step — state was already set to `READY` and `firstTrade.completed` when they created their first strategy (Step 4). Full "After Close" copy: [references/next-steps.md](references/next-steps.md). State shape: [references/strategy-management.md](references/strategy-management.md).
 
 ---
 
@@ -172,7 +168,7 @@ If the user returns mid-tutorial, read firstTrade.step from state and resume fro
 - **[references/error-handling.md](references/error-handling.md)** — Insufficient balance, strategy_create failed, strategy_close failed, recovery
 - **[references/discovery-guide.md](references/discovery-guide.md)** — discovery_get_top_strategies, recommend a trader to mirror, display template
 - **[references/strategy-management.md](references/strategy-management.md)** — Strategy sizing, strategy_create/strategy_close flow, state updates for firstTrade
-- **[references/next-steps.md](references/next-steps.md)** — Celebration copy, skip tutorial, resume handling
+- **[references/next-steps.md](references/next-steps.md)** — Celebration (after first strategy created), after close, skip tutorial, resume handling
 
 ---
 

--- a/senpi-getting-started-guide/references/next-steps.md
+++ b/senpi-getting-started-guide/references/next-steps.md
@@ -1,66 +1,60 @@
 # Next Steps Reference
 
-Use this for **celebration** (after close or after monitor-only), **skip tutorial**, and **resume** handling in the first-trade guide.
+Use this for **celebration** (after first strategy is created), **after close** (result + next steps), **skip tutorial**, and **resume** handling in the first-trade guide.
 
 ---
 
-## Celebrate (After Close)
+## Celebrate (After First Strategy Created)
 
-**If profitable:**
+**Right after** the user's first strategy is successfully created (Step 4), congratulate them and show next steps:
 
-> 🎊 **CONGRATULATIONS ON YOUR FIRST TRADE!**
+> 🎉 **You opened your first strategy!**
 >
-> ```
->  ╔═══════════════════════════════════════╗
->  ║   🏆  FIRST STRATEGY COMPLETE  🏆    ║
->  ║      You made: +$X.XX (+X.XX%)       ║
->  ╚═══════════════════════════════════════╝
-> ```
+> You discovered top traders, picked one to mirror, and created a strategy — nice work!
 >
-> **What you learned:** Discovery, mirroring a top trader, creating a strategy, monitoring, and closing.
+> Your strategy is running. You can:
+> - Ask **"how's my strategy?"** to see value and positions
+> - Say **"close my strategy"** anytime to close and return funds to your wallet
 >
-> **Your trading journey begins!** Explore next:
->
-> | Skill | What it does | Command |
-> |-------|--------------|---------|
-> | 🛡️ **DSL** | Auto stop-loss protection | `npx skills add Senpi-ai/senpi-skills/dsl-dynamic-stop-loss` |
-> | 🐺 **WOLF** | Fully autonomous trading | `npx skills add Senpi-ai/senpi-skills/wolf-strategy` |
-> | 📊 **Scanner** | Find best setups | `npx skills add Senpi-ai/senpi-skills/opportunity-scanner` |
-> | 🐋 **Whale Index** | Copy top traders | `npx skills add Senpi-ai/senpi-skills/whale-index` |
->
-> **Quick commands:** "find opportunities", "show my portfolio", "open BTC short $100"
-
-**If loss:**
-
-> 📊 **FIRST STRATEGY COMPLETE**
->
-> Strategy Result: -$X.XX (-X.X%)
->
-> **That's okay!** You kept size small, learned the mirror flow, and closed when you wanted.
->
-> **Pro tip:** Install **DSL** for automatic protection: `npx skills add Senpi-ai/senpi-skills/dsl-dynamic-stop-loss`
->
-> Explore: DSL, Scanner, WOLF, Whale Index. Say "find opportunities" to discover more traders.
-
-Then update state to `READY` and set `firstTrade.completed`, `firstTrade.step: "COMPLETE"`, `firstTrade.completedAt`. See [references/strategy-management.md](references/strategy-management.md) for the full state shape (strategy flow).
-
----
-
-## Celebrate (After Monitor — No Close)
-
-If the user completed discovery and created a strategy but only monitored (e.g. asked "how's my strategy?" one or more times) and did not close, still congratulate them so they feel accomplished:
-
-> 🎉 **You've completed your first trade flow!**
->
-> You discovered top traders, created a mirror strategy, and checked how it's doing. Nice work!
->
-> Your strategy is still running. You can say **"close my strategy"** anytime to close it and bring funds back to your wallet, or keep it open and check back with "how's my strategy?"
->
-> **What you learned:** Discovery, mirroring a trader, creating a strategy, and monitoring.
+> **What you learned:** Discovery, mirroring a top trader, and creating a strategy.
 >
 > **Next:** Try "show my portfolio", "find opportunities", or install more skills — e.g. **Whale Index** to auto-mirror top traders, or **DSL** for protection.
 
-Then update state to `READY`, `firstTrade.completed`, `firstTrade.step: "COMPLETE"`, `firstTrade.completedAt`. Preserve existing `tradeDetails` (strategyId, etc.); no need for PnL if they didn't close.
+Then update state to `READY` and set `firstTrade.completed: true`, `firstTrade.step: "COMPLETE"`, `firstTrade.completedAt` (ISO 8601). Preserve `tradeDetails` (strategyId, mirroredTraderId, budgetUsd, etc.). See [references/strategy-management.md](references/strategy-management.md) for the full state shape.
+
+---
+
+## After Close (Result + Next Steps)
+
+When the user closes their first strategy, show the result and suggest next steps. **Do not repeat the main congratulations** — that was already shown when they opened their first strategy.
+
+**If profitable:**
+
+> 📊 **Strategy closed**
+>
+> Result: +$X.XX (+X.XX%)
+>
+> **Next:** Explore more skills (DSL, Scanner, WOLF, Whale Index) or say "find opportunities" to discover more strategies.
+
+**If loss:**
+
+> 📊 **Strategy closed**
+>
+> Result: -$X.XX (-X.X%). You kept size small and closed when you wanted.
+>
+> **Pro tip:** Install **DSL** for automatic protection. Say "find opportunities" to discover more.
+
+Update state: set `firstTrade.step: "STRATEGY_CLOSE"`, add `tradeDetails.closedAt`, `tradeDetails.pnl`, `tradeDetails.pnlPercent`, `tradeDetails.duration`. State remains `READY` with `firstTrade.completed: true` (already set when they created the strategy).
+
+---
+
+## After Monitor (No Close)
+
+If the user only monitors (e.g. asks "how's my strategy?" one or more times) and does not close: do **not** show a separate congratulations (already shown when they created the strategy). Show strategy value and positions, then offer:
+
+> Your strategy is still running. Say **"close my strategy"** anytime to close, or ask **"how's my strategy?"** to check again.
+
+No state change — `firstTrade.completed` and `step: "COMPLETE"` were already set when they created the strategy.
 
 ---
 
@@ -115,10 +109,10 @@ case $STEP in
     # User saw top traders — ask if ready to create strategy with recommended trader
     ;;
   "STRATEGY_CREATED")
-    # Strategy is active — show value/positions and offer to close or congratulate (monitor-only completion)
+    # Strategy is active — show value/positions and offer to close or keep monitoring
     ;;
   "STRATEGY_CLOSE")
-    # Just closed — show celebration
+    # Just closed — show result (PnL) and next steps
     ;;
 esac
 ```

--- a/senpi-getting-started-guide/references/strategy-management.md
+++ b/senpi-getting-started-guide/references/strategy-management.md
@@ -95,7 +95,7 @@ Preserve all other `firstTrade` and top-level fields when merging.
 
 ## Transition to READY
 
-After celebration (see [references/next-steps.md](next-steps.md)), set state to `READY` and mark first trade complete:
+After the user creates their first strategy (Step 4), show the celebration (see [references/next-steps.md](next-steps.md) — "Celebrate (After First Strategy Created)") and set state to `READY` and mark first trade complete:
 
 ```json
 "state": "READY",


### PR DESCRIPTION
…d closure

- Update the celebration messaging to occur immediately after the user's first strategy is created, emphasizing their achievement.
- Clarify that no separate congratulations should be shown when the strategy is closed, as the initial celebration suffices.
- Adjust state management instructions to ensure consistency in marking the first trade as complete and updating relevant details upon strategy closure.
- Enhance the next-steps reference to reflect the new flow and user experience during strategy management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that adjust tutorial messaging/state instructions without altering runtime code. Main risk is behavioral inconsistency if other guides/implementations still assume completion happens on close/monitor.
> 
> **Overview**
> Moves the first-trade **celebration/completion moment** to immediately after `strategy_create` succeeds (Step 4), and updates the guidance to mark `firstTrade` as completed/`COMPLETE` at that point (including `completedAt`).
> 
> Reworks later steps to avoid repeat congratulations: monitoring now shows status only, closing now shows an *After Close* result + next steps, and the standalone Step 7 celebration is removed/renamed. Updates `references/next-steps.md` and `references/strategy-management.md` to match the new messaging, resume notes, and state-update expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c8e4cda6878c1faf40d17cd540b2b2614301a06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->