### PR TITLE
Update SKILL.md and discovery-guide.md to standardize trader discover…

### DIFF
--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -116,7 +116,7 @@ npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-getting-st
 
 If the guide skill is not yet available, suggest these first actions instead:
 - "Check your portfolio" (uses `account_get_portfolio` tool)
-- "Discover top traders" (uses `discovery_get_top_strategies` tool)
+- "Discover top traders" (uses `discovery_get_top_traders` tool)
 - "View market data" (uses `market_get_prices` tool)
 
 ---

--- a/senpi-getting-started-guide/SKILL.md
+++ b/senpi-getting-started-guide/SKILL.md
@@ -107,7 +107,14 @@ If onboarding is not complete (state FRESH or ONBOARDING), tell the user only: "
 
 ### Step 1: Introduction
 
-Display the trade cycle: **Discover top traders** → **Create a strategy** (mirror a chosen trader) → **Monitor** → **Close strategy**. Recommend a **$100 minimum** budget for the first strategy and include a short risk disclaimer. Ask user to say **"yes"** to continue or **"skip"** if experienced.
+Display the trade cycle. **When showing the 4-step list to the user, use this exact wording:**
+
+> 1️⃣ **Discover** — Find top-performing traders on Hyperliquid  
+> 2️⃣ **Create a strategy** — Mirror a chosen trader's positions ($100 budget)  
+> 3️⃣ **Monitor** — Watch how the strategy performs  
+> 4️⃣ **Close** — Exit when you're ready  
+
+Recommend a **$100 minimum** budget for the first strategy and include a short risk disclaimer. Ask user to say **"yes"** to continue or **"skip"** if experienced.
 
 Update state: set `firstTrade.step` to `INTRODUCTION`, `firstTrade.started` true, `startedAt` (ISO 8601). Preserve existing fields in `state.json`.
 
@@ -117,7 +124,7 @@ Wait for user confirmation before proceeding.
 
 ### Step 2: Discovery
 
-Use MCP **`discovery_get_top_strategies`** to fetch top traders. **Only present as options traders that currently have open positions** — filter out or verify with **`discovery_get_trader_state`** (or equivalent) so you do not offer traders with no open positions. Optionally use **`discovery_get_trader_history`** for extra detail. Show a short table of top traders with open positions (e.g. by PnL, win rate) and **recommend one trader** to mirror for the first trade.
+Use MCP **`discovery_get_top_traders`** to fetch top traders. Optionally use **`discovery_get_trader_state`** or **`discovery_get_trader_history`** for extra detail. Show a short table of top traders (e.g. by PnL, win rate) and **recommend one trader** to mirror for the first trade.
 
 See [references/discovery-guide.md](references/discovery-guide.md) for display template and state update (`firstTrade.step: "DISCOVERY"`, `recommendedTraderId`, `recommendedTraderName`).
 
@@ -166,7 +173,7 @@ If the user returns mid-tutorial, read firstTrade.step from state and resume fro
 ## Reference Files
 
 - **[references/error-handling.md](references/error-handling.md)** — Insufficient balance, strategy_create failed, strategy_close failed, recovery
-- **[references/discovery-guide.md](references/discovery-guide.md)** — discovery_get_top_strategies, recommend a trader to mirror, display template
+- **[references/discovery-guide.md](references/discovery-guide.md)** — discovery_get_top_traders, recommend a trader to mirror, display template
 - **[references/strategy-management.md](references/strategy-management.md)** — Strategy sizing, strategy_create/strategy_close flow, state updates for firstTrade
 - **[references/next-steps.md](references/next-steps.md)** — Celebration (after first strategy created), after close, skip tutorial, resume handling
 

--- a/senpi-getting-started-guide/references/discovery-guide.md
+++ b/senpi-getting-started-guide/references/discovery-guide.md
@@ -1,22 +1,20 @@
 # Discovery Guide Reference
 
-Use this when running **Step 2: Discovery** of the first-trade tutorial. This step is about **finding top traders and recommending one to mirror** (not opening individual asset/direction positions). Use **`discovery_get_top_strategies`**; optionally **`discovery_get_trader_state`** or **`discovery_get_trader_history`** to confirm a trader has open positions. **Only present as options traders that currently have open positions** — do not offer traders with no open positions. **Show the user only user-friendly copy;** do not mention state, step names, or MCP/tool names.
+Use this when running **Step 2: Discovery** of the first-trade tutorial. This step is about **finding top traders and recommending one to mirror** (not opening individual asset/direction positions). Use **`discovery_get_top_traders`**; optionally **`discovery_get_trader_state`** or **`discovery_get_trader_history`** for extra detail. **Show the user only user-friendly copy;** do not mention state, step names, or MCP/tool names.
 
 ---
 
 ## MCP Usage
 
-- **`discovery_get_top_strategies`** — Fetch top strategies (e.g. by PnL, win rate, or consistency).
-- **Filter to traders with open positions** — Only show options for traders that **currently have open positions**. Use **`discovery_get_trader_state`** (or equivalent) to confirm open positions before including a trader in the list. Do not offer traders with no open positions.
-- Optionally **`discovery_get_trader_history`** — Get extra detail for a specific trader before recommending.
+- **`discovery_get_top_traders`** — Fetch top traders (e.g. by PnL, win rate, or consistency).
+- Optionally **`discovery_get_trader_state`** or **`discovery_get_trader_history`** — Get extra detail for a specific trader before recommending.
 - Prefer traders whose positions are in liquid assets (ETH, BTC, SOL) so the mirror strategy has smooth entry/exit.
 
 ---
 
 ## What to Look For
 
-- **Open positions** — Only include traders that **currently have open positions** (so the mirror strategy has something to copy).
-- **Strong performance** — Among those, prefer top traders by PnL, win rate, or consistency.
+- **Strong performance** — Prefer top traders by PnL, win rate, or consistency.
 - **Liquid assets** — Traders with positions in ETH, BTC, SOL are better for a first mirror strategy.
 - **Recent activity** — Traders with recent activity so the mirror has clear positions to follow.
 
@@ -24,11 +22,11 @@ Use this when running **Step 2: Discovery** of the first-trade tutorial. This st
 
 ## Display Template
 
-After fetching with **`discovery_get_top_strategies`** and **filtering to traders with open positions**, show the user something like:
+After fetching with **`discovery_get_top_traders`**, show the user something like:
 
 > 🔍 **Scanning top traders...**
 >
-> Here are some of the best performers **with open positions** right now:
+> Here are some of the best performers right now:
 >
 > **Top Traders:**
 >
@@ -56,7 +54,7 @@ After discovery, update `firstTrade` in state with the **recommended trader** (f
 ```json
 "firstTrade": {
   "step": "DISCOVERY",
-  "recommendedTraderId": "<trader id or address from discovery_get_top_strategies>",
+  "recommendedTraderId": "<trader id or address from discovery_get_top_traders>",
   "recommendedTraderName": "<optional display name or truncated address>"
 }
 ```


### PR DESCRIPTION
…y terminology

- Replace instances of `discovery_get_top_strategies` with `discovery_get_top_traders` to ensure consistency in documentation.
- Revise user instructions to clarify the process of finding and recommending top traders based on performance metrics.
- Enhance the display template and user-facing copy for improved clarity during the discovery phase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update tool naming and user-facing copy; low risk aside from potential confusion if the referenced MCP tool name diverges from the implementation.
> 
> **Overview**
> Standardizes trader-discovery documentation to use `discovery_get_top_traders` (replacing `discovery_get_top_strategies`) across the entrypoint and the getting-started guide, including the referenced discovery guide.
> 
> Tightens the getting-started tutorial’s user-facing copy by specifying exact wording for the 4-step trade-cycle list and updating the discovery display/state-update templates to align with the new tool naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5edcdc5efb5ab4c9b50a553329930466343c2f3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->