### PR TITLE
Made crons isolated & model tiering

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -67,11 +67,11 @@ Token burn is the single biggest operational cost. These patterns reduce it dram
 
 Classify each cron job by the reasoning it requires. The 3-tier approach maps directly to session type (see Section 2.6):
 
-| Tier | Use When | Tested Model IDs |
-|------|----------|-----------------|
+| Tier | Use When | Example Model IDs |
+|------|----------|-------------------|
 | **Primary** | Complex judgment, multi-strategy routing, entry decisions | Your configured model (runs on main session) |
-| **Mid** | Structured tasks, script output parsing, rule-based actions | `anthropic/claude-sonnet-4-20250514` |
-| **Budget** | Simple threshold checks, binary decisions | `anthropic/claude-haiku-4-5` |
+| **Mid** | Structured tasks, script output parsing, rule-based actions | `anthropic/claude-sonnet-4-20250514`, `openai/gpt-4o`, `google/gemini-2.0-flash` |
+| **Budget** | Simple threshold checks, binary decisions | `anthropic/claude-haiku-4-5`, `openai/gpt-4o-mini`, `google/gemini-2.0-flash-lite` |
 
 Most crons should be Mid or Budget. Only crons requiring accumulated context or complex judgment need Primary.
 
@@ -685,7 +685,7 @@ Crons use one of two formats depending on session type (see Section 2.6):
   "sessionTarget": "isolated",
   "payload": {
     "kind": "agentTurn",
-    "model": "anthropic/claude-haiku-4-5",
+    "model": "<Mid or Budget tier model ID>",
     "message": "..."
   }
 }

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -65,14 +65,20 @@ Token burn is the single biggest operational cost. These patterns reduce it dram
 
 ### 2.1 Model Tiering
 
-Classify each cron job by the reasoning it requires:
+Classify each cron job by the reasoning it requires. The 3-tier approach maps directly to session type (see Section 2.6):
 
-| Tier | Use When | Model Examples |
-|------|----------|---------------|
-| **Tier 1** (fast/cheap) | Binary/threshold checks, status parsing, health validation | claude-haiku-4-5, gpt-4o-mini, gemini-flash |
-| **Tier 2** (capable) | Judgment calls, signal routing, multi-factor scoring | anthropic/claude-sonnet-4-20250514, anthropic/claude-opus-4-20250514, gpt-4o, gemini-pro |
+| Tier | Use When | Tested Model IDs |
+|------|----------|-----------------|
+| **Primary** | Complex judgment, multi-strategy routing, entry decisions | Your configured model (runs on main session) |
+| **Mid** | Structured tasks, script output parsing, rule-based actions | `anthropic/claude-sonnet-4-20250514` |
+| **Budget** | Simple threshold checks, binary decisions | `anthropic/claude-haiku-4-5` |
 
-Document the tier for each cron in your `cron-templates.md`. Most crons should be Tier 1.
+Most crons should be Mid or Budget. Only crons requiring accumulated context or complex judgment need Primary.
+
+- **Primary** crons run on the main session and share context (position history, routing decisions).
+- **Mid / Budget** crons run on isolated sessions with the model specified in the cron payload.
+
+Document the tier and session type for each cron in your `cron-templates.md`.
 
 ### 2.2 Heartbeat Early Exit
 
@@ -139,10 +145,27 @@ This prevents: config re-reads per action, multiple Telegram messages, context g
 
 ### 2.6 Context Isolation
 
+**Within a cron run:**
 - Read config files ONCE per cron run
 - Build a complete action plan before executing any tool calls
 - Send ONE consolidated notification per run, not one per signal
 - Skip redundant checks when data is fresh (e.g., < 3 min old)
+
+**Across cron runs — session isolation:**
+
+Crons run in one of two session types:
+
+| Session Type | When to Use | Behavior |
+|-------------|-------------|----------|
+| **Main** (`sessionTarget: "main"`) | Cron needs accumulated context — routing history, position knowledge, multi-step judgment | Shares context with other main-session crons. Uses the agent's configured Primary model. |
+| **Isolated** (`sessionTarget: "isolated"`) | Cron is self-contained — script output has everything the LLM needs to decide | Fresh session per run. No context pollution. Runs a cheaper Mid/Budget model specified in the payload. |
+
+**Default to isolated.** Most crons are self-contained: run script → parse JSON → act or HEARTBEAT_OK. Only promote to main session when the cron genuinely needs cross-run context (e.g., remembering which strategies were routed to previously).
+
+**Why this matters:**
+- Isolated crons don't pollute the main session's context window with repetitive heartbeats
+- Cheaper models (Mid/Budget) run on isolated sessions, reducing cost
+- Main session stays lean — only crons that need shared context contribute to it
 
 ---
 
@@ -605,7 +628,7 @@ elif orphan_detected and had_fetch_error:
     })
 ```
 
-**Why:** Tier 1 models are unreliable at multi-step remediation. Moving fix logic into the script makes it deterministic. The cron mandate just routes the `action` field to "alert" or "ignore."
+**Why:** Budget/Mid models are unreliable at multi-step remediation. Moving fix logic into the script makes it deterministic. The cron mandate just routes the `action` field to "alert" or "ignore."
 
 ### 6.4 Graceful Degradation
 
@@ -636,7 +659,9 @@ print(json.dumps({"alerts": alerts, "partial": True}))
 
 ### 7.1 Cron Template Format
 
-All crons use OpenClaw's `systemEvent` format:
+Crons use one of two formats depending on session type (see Section 2.6):
+
+**Main session** — `systemEvent` format (Primary model, shared context):
 
 ```json
 {
@@ -651,16 +676,43 @@ All crons use OpenClaw's `systemEvent` format:
 }
 ```
 
-### 7.2 Mandate Text Pattern — Explicit Rules for Lower-Tier Models
+**Isolated session** — `agentTurn` format (Mid/Budget model, fresh context):
 
-Cron mandates run on the cheapest model possible (Tier 1). These models **cannot make judgment calls** — they need deterministic, per-case rules. Never say "apply rules from SKILL.md" in a Tier 1 mandate.
+```json
+{
+  "name": "{Skill Name} — {Job Name}",
+  "schedule": { "kind": "every", "everyMs": 90000 },
+  "sessionTarget": "isolated",
+  "payload": {
+    "kind": "agentTurn",
+    "model": "anthropic/claude-haiku-4-5",
+    "message": "..."
+  }
+}
+```
+
+**Critical differences:**
+
+| | Main (systemEvent) | Isolated (agentTurn) |
+|---|---|---|
+| `sessionTarget` | `"main"` | `"isolated"` |
+| `wakeMode` | `"now"` (required) | Not used (omit it) |
+| `payload.kind` | `"systemEvent"` | `"agentTurn"` |
+| Mandate key | `"text"` | `"message"` |
+| Model | Agent's configured model | Specified in `payload.model` |
+
+> **Warning:** `systemEvent` uses `"text"`, `agentTurn` uses `"message"`. Using the wrong key silently fails — the cron fires but the LLM receives an empty prompt.
+
+### 7.2 Mandate Text Pattern — Explicit Rules for Budget/Mid Models
+
+Cron mandates typically run on Budget or Mid tier models. These models **cannot make judgment calls** — they need deterministic, per-case rules. Never say "apply rules from SKILL.md" in a Budget/Mid mandate.
 
 ```
-# BAD — vague, requires judgment (Tier 1 model will hallucinate)
+# BAD — vague, requires judgment (Budget model will hallucinate)
 "Parse JSON. Apply WOLF SM rules from SKILL.md for judgment calls.
 If hasFlipSignal=false → HEARTBEAT_OK."
 
-# GOOD — explicit per-case branching (Tier 1 model follows steps)
+# GOOD — explicit per-case branching (Budget model follows steps)
 "Parse JSON. For each alert in `alerts`:
 if `alertLevel == "FLIP_NOW"` → close that position, alert Telegram ({TELEGRAM}).
 Ignore alerts with `alertLevel` of WATCH or FLIP_WARNING (no action needed).
@@ -679,7 +731,7 @@ If `hasFlipSignal == false` or no FLIP_NOW alerts → HEARTBEAT_OK."
 If no issues → HEARTBEAT_OK."
 ```
 
-**Rule of thumb:** If the mandate says "judgment" or "apply rules," it's too vague for Tier 1. Rewrite with explicit `if/then` per output field.
+**Rule of thumb:** If the mandate says "judgment" or "apply rules," it's too vague for Budget/Mid. Rewrite with explicit `if/then` per output field.
 
 ### 7.3 One Set of Crons, Scripts Iterate Internally
 
@@ -713,6 +765,42 @@ If a config field name differs from what you'd expect, document it explicitly:
 - `stagnation.thresholdHours` is the correct key. Using `staleHours` will be silently ignored.
 - `phase2.retraceFromHW` is a percentage — use `5` for 5%.
 ```
+
+### 7.7 Slot Guard Pattern
+
+When a skill has resource limits (e.g., max concurrent positions, strategy slots, budget caps), the **script** must surface availability — the agent should never count state files or compute capacity itself.
+
+**Script surfaces availability in JSON output:**
+
+```python
+# In your script — count active state files and report
+active_states = [f for f in os.listdir(state_dir) if f.endswith(".json")]
+active_count = sum(1 for f in active_states if load_json(f).get("active"))
+max_slots = config.get("maxSlots", 5)
+
+output["strategySlots"] = {
+    "active": active_count,
+    "max": max_slots,
+    "available": max_slots - active_count,
+    "anySlotsAvailable": active_count < max_slots
+}
+```
+
+**Mandate includes a SLOT GUARD directive:**
+
+```
+SLOT GUARD (MANDATORY):
+Check `strategySlots.anySlotsAvailable` BEFORE opening any new position.
+If false → skip entry, log "no slots available", continue to next signal.
+Never open a position without confirming slot availability first.
+```
+
+**Key principles:**
+
+- **Script is the source of truth** — the script counts state files, computes capacity, and reports it. The agent reads the field and acts on it.
+- **Agent never globs state files** — if the agent is counting files to determine capacity, the script contract is broken. Fix the script.
+- **Pattern generalizes** — any resource limit (slots, budget remaining, rate limits, cooldowns) should be surfaced the same way: script computes, outputs a guard field, mandate enforces checking it.
+- **Guard is mandatory, not advisory** — the mandate must include explicit "MANDATORY" language. Budget/Mid models skip soft suggestions.
 
 ---
 
@@ -985,7 +1073,7 @@ Before shipping a new skill, verify:
 - [ ] Errors surfaced (not silently swallowed) — callers can distinguish "no data" from "call failed"
 - [ ] Error output is structured JSON, not tracebacks
 - [ ] Cron mandates are short, reference SKILL.md for detailed rules
-- [ ] Model tier (Tier 1 / Tier 2) documented per cron
+- [ ] Model tier (Primary / Mid / Budget) and session type (main / isolated) documented per cron
 - [ ] `HEARTBEAT_OK` early exit when nothing actionable
 - [ ] Default output is minimal; verbose behind env var
 - [ ] Config has deep merge, backward-compatible defaults
@@ -998,4 +1086,5 @@ Before shipping a new skill, verify:
 - [ ] Shared helpers for duplicated parsing logic (DRY)
 - [ ] `shlex.quote()` on all subprocess args; `tempfile.mkstemp` for temp files with `finally` cleanup
 - [ ] Prefixed identifiers (e.g., `xyz:BTC`) stripped before use in file paths
+- [ ] Resource limits (slots, capacity) surfaced in script output, not left to agent counting
 - [ ] Dead/legacy code deleted (git history is the reference)

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -107,13 +107,13 @@ To add a second strategy, run `wolf-setup.py` again with a different wallet/budg
 
 Configure per-cron in OpenClaw. Step down from your primary model for isolated crons to save ~60-70% on those runs.
 
-**Tested model IDs** (confirmed working on OpenClaw):
+**Example model IDs** (confirmed working on OpenClaw):
 
-| Tier | Role | Crons | Model ID |
-|------|------|-------|----------|
+| Tier | Role | Crons | Example Model IDs |
+|------|------|-------|--------------------|
 | **Primary** | Complex judgment, multi-strategy routing | Emerging Movers, Opportunity Scanner | Your configured model (runs on main session) |
-| **Mid** | Structured tasks, script output parsing | DSL Combined, Portfolio Update, Health Check | `anthropic/claude-sonnet-4-20250514` |
-| **Budget** | Simple threshold checks, binary decisions | SM Flip, Watchdog | `anthropic/claude-haiku-4-5` |
+| **Mid** | Structured tasks, script output parsing | DSL Combined, Portfolio Update, Health Check | `anthropic/claude-sonnet-4-20250514`, `openai/gpt-4o`, `google/gemini-2.0-flash` |
+| **Budget** | Simple threshold checks, binary decisions | SM Flip, Watchdog | `anthropic/claude-haiku-4-5`, `openai/gpt-4o-mini`, `google/gemini-2.0-flash-lite` |
 
 | Cron | Session | Model Tier | Reason |
 |------|---------|-----------|--------|
@@ -128,8 +128,9 @@ Configure per-cron in OpenClaw. Step down from your primary model for isolated c
 **Single-model option:** All 7 crons can run on one model. Simpler but costs more for the 5 isolated crons that do structured/binary work.
 
 **Model ID gotchas:**
-- The tested Mid/Budget IDs above are Anthropic models. If your primary is a different provider (OpenAI, Gemini, etc.), use single-model mode or substitute equivalent models from your provider at your own risk.
-- Agents are often not model-aware — they may suggest deprecated IDs (e.g. `claude-3-5-haiku-20241022`) or hallucinate model names. Always use the exact IDs listed above.
+- Pick one model per tier from your provider. The tier concept (Primary / Mid / Budget) matters more than the specific model — any provider's equivalent works.
+- Budget should be the cheapest model that can follow explicit if/then rules. Mid should handle structured JSON parsing reliably.
+- Agents are often not model-aware — they may suggest deprecated IDs (e.g. `claude-3-5-haiku-20241022`) or hallucinate model names. Always use the exact IDs from the table above.
 - If a cron fails to create or run due to an invalid model ID, fall back to your primary model for that cron. A working cron on the "wrong" tier is better than a broken cron.
 - When in doubt, use your primary model for all 7 crons (single-model option) and optimize tiers later.
 

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -105,13 +105,15 @@ To add a second strategy, run `wolf-setup.py` again with a different wallet/budg
 
 ### Model Selection Per Cron — 3-Tier Approach
 
-Configure per-cron in OpenClaw. The agent already knows its primary model — step down for isolated crons to save ~60-70% on those runs.
+Configure per-cron in OpenClaw. Step down from your primary model for isolated crons to save ~60-70% on those runs.
 
-| Tier | Role | Crons | How to pick |
-|------|------|-------|-------------|
+**Tested model IDs** (confirmed working on OpenClaw):
+
+| Tier | Role | Crons | Model ID |
+|------|------|-------|----------|
 | **Primary** | Complex judgment, multi-strategy routing | Emerging Movers, Opportunity Scanner | Your configured model (runs on main session) |
-| **Mid** | Structured tasks, script output parsing | DSL Combined, Portfolio Update, Health Check | One tier down from primary (e.g. primary=Opus→mid=Sonnet) |
-| **Budget** | Simple threshold checks, binary decisions | SM Flip, Watchdog | Cheapest from same provider (e.g. Haiku, gpt-4o-mini, gemini-flash) |
+| **Mid** | Structured tasks, script output parsing | DSL Combined, Portfolio Update, Health Check | `anthropic/claude-sonnet-4-20250514` |
+| **Budget** | Simple threshold checks, binary decisions | SM Flip, Watchdog | `anthropic/claude-haiku-4-5` |
 
 | Cron | Session | Model Tier | Reason |
 |------|---------|-----------|--------|
@@ -124,6 +126,12 @@ Configure per-cron in OpenClaw. The agent already knows its primary model — st
 | Watchdog | isolated | Budget | Threshold checks → alert |
 
 **Single-model option:** All 7 crons can run on one model. Simpler but costs more for the 5 isolated crons that do structured/binary work.
+
+**Model ID gotchas:**
+- The tested Mid/Budget IDs above are Anthropic models. If your primary is a different provider (OpenAI, Gemini, etc.), use single-model mode or substitute equivalent models from your provider at your own risk.
+- Agents are often not model-aware — they may suggest deprecated IDs (e.g. `claude-3-5-haiku-20241022`) or hallucinate model names. Always use the exact IDs listed above.
+- If a cron fails to create or run due to an invalid model ID, fall back to your primary model for that cron. A working cron on the "wrong" tier is better than a broken cron.
+- When in doubt, use your primary model for all 7 crons (single-model option) and optimize tiers later.
 
 ## Cron Setup
 

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -139,7 +139,7 @@ Configure per-cron in OpenClaw. Step down from your primary model for isolated c
 - **Main session** (`systemEvent`): Emerging Movers + Opportunity Scanner. These share the primary session context for accumulated routing knowledge.
 - **Isolated session** (`agentTurn`): DSL Combined, Portfolio, Health Check, SM Flip, Watchdog. Each runs in its own session — no context pollution, enables cheaper model tiers.
 
-Create each cron using the OpenClaw cron tool. The exact mandate text for each cron is in **`references/cron-templates.md`**. Read that file, replace the placeholders (only `{TELEGRAM}` and `{SCRIPTS}` in v6), and create all 7 crons.
+Create each cron using the OpenClaw cron tool. The exact mandate text for each cron is in **`references/cron-templates.md`**. Read that file, replace the placeholders (`{TELEGRAM}`, `{SCRIPTS}`, and `{WOLF}` in v6), and create all 7 crons.
 
 **v6 simplification:** No more per-wallet/per-strategy placeholders in cron mandates. Scripts read all strategy info from the registry.
 

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -89,37 +89,47 @@ To add a second strategy, run `wolf-setup.py` again with a different wallet/budg
 
 ## Architecture — 7 Cron Jobs
 
-| # | Job | Interval | Script | Purpose |
-|---|-----|----------|--------|---------|
-| 1 | Emerging Movers | **90s** | `scripts/emerging-movers.py` | Hunt FIRST_JUMP + IMMEDIATE_MOVER signals — primary entry trigger |
-| 2 | DSL Combined | **3min** | `scripts/dsl-combined.py` | Trailing stop exits for ALL open positions across ALL strategies |
-| 3 | SM Flip Detector | 5min | `scripts/sm-flip-check.py` | Cut positions where SM conviction collapses |
-| 4 | Watchdog | 5min | `scripts/wolf-monitor.py` | Per-strategy margin buffer, liq distances, rotation candidates |
-| 5 | Portfolio Update | 15min | (agent-driven) | Per-strategy PnL reporting to user |
-| 6 | Opportunity Scanner | 15min | `scripts/opportunity-scan-v6.py` | Deep-dive 4-pillar scoring with BTC macro, hourly trend, disqualifiers |
-| 7 | Health Check | 10min | `scripts/job-health-check.py` | Per-strategy orphan DSL detection, state validation |
+| # | Job | Interval | Session | Script | Purpose |
+|---|-----|----------|---------|--------|---------|
+| 1 | Emerging Movers | **90s** | **main** | `scripts/emerging-movers.py` | Hunt FIRST_JUMP + IMMEDIATE_MOVER signals — primary entry trigger |
+| 2 | DSL Combined | **3min** | isolated | `scripts/dsl-combined.py` | Trailing stop exits for ALL open positions across ALL strategies |
+| 3 | SM Flip Detector | 5min | isolated | `scripts/sm-flip-check.py` | Cut positions where SM conviction collapses |
+| 4 | Watchdog | 5min | isolated | `scripts/wolf-monitor.py` | Per-strategy margin buffer, liq distances, rotation candidates |
+| 5 | Portfolio Update | 15min | isolated | (agent-driven) | Per-strategy PnL reporting to user |
+| 6 | Opportunity Scanner | 15min | **main** | `scripts/opportunity-scan-v6.py` | Deep-dive 4-pillar scoring with BTC macro, hourly trend, disqualifiers |
+| 7 | Health Check | 10min | isolated | `scripts/job-health-check.py` | Per-strategy orphan DSL detection, state validation |
 
 **v6 change:** One set of crons for all strategies. Each script reads `wolf-strategies.json` and iterates all enabled strategies internally.
 
 **v6 change:** Opportunity Scanner v6 replaces the old scanner with BTC macro context, hourly trend filter, hard disqualifiers, parallel candle fetches, and cross-scan momentum tracking.
 
-### Model Selection Per Cron
+### Model Selection Per Cron — 3-Tier Approach
 
-Configure these tiers in OpenClaw per-cron settings. Tier 1 = fast/cheap (e.g. claude-haiku-4-5, gpt-4o-mini, gemini-flash). Tier 2 = capable (e.g. anthropic/claude-sonnet-4-20250514, opus, gpt-4o, gemini-pro).
+Configure per-cron in OpenClaw. The agent already knows its primary model — step down for isolated crons to save ~60-70% on those runs.
 
-| Cron | Model Tier | Reason |
-|------|-----------|--------|
-| Emerging Movers | **Tier 2 (capable)** | Multi-strategy routing judgment, entry decisions |
-| Opportunity Scanner | **Tier 2 (capable)** | Complex 4-pillar analysis, conflict resolution |
-| DSL Combined | Tier 1 (fast/cheap) | Binary: `status=="closed"` → alert, else HEARTBEAT_OK |
-| SM Flip Detector | Tier 1 (fast/cheap) | Binary: conviction≥4 + 100 traders → close |
-| Watchdog | Tier 1 (fast/cheap) | Threshold checks → alert |
-| Portfolio Update | Tier 1 (fast/cheap) | Text formatting, no decisions |
-| Health Check | Tier 1 (fast/cheap) | Rule-based file repair |
+| Tier | Role | Crons | How to pick |
+|------|------|-------|-------------|
+| **Primary** | Complex judgment, multi-strategy routing | Emerging Movers, Opportunity Scanner | Your configured model (runs on main session) |
+| **Mid** | Structured tasks, script output parsing | DSL Combined, Portfolio Update, Health Check | One tier down from primary (e.g. primary=Opus→mid=Sonnet) |
+| **Budget** | Simple threshold checks, binary decisions | SM Flip, Watchdog | Cheapest from same provider (e.g. Haiku, gpt-4o-mini, gemini-flash) |
+
+| Cron | Session | Model Tier | Reason |
+|------|---------|-----------|--------|
+| Emerging Movers | main | **Primary** | Multi-strategy routing judgment, entry decisions |
+| Opportunity Scanner | main | **Primary** | Complex 4-pillar analysis, conflict resolution |
+| DSL Combined | isolated | Mid | Script output parsing, rule-based close/alert |
+| Portfolio Update | isolated | Mid | Clearinghouse data formatting, no decisions |
+| Health Check | isolated | Mid | Rule-based file repair, action routing |
+| SM Flip Detector | isolated | Budget | Binary: conviction≥4 + 100 traders → close |
+| Watchdog | isolated | Budget | Threshold checks → alert |
+
+**Single-model option:** All 7 crons can run on one model. Simpler but costs more for the 5 isolated crons that do structured/binary work.
 
 ## Cron Setup
 
-**Critical:** Crons are **OpenClaw systemEvent crons**, NOT senpi crons. Each cron fires a systemEvent that wakes the agent with a MANDATE.
+**Critical:** Crons are **OpenClaw crons**, NOT senpi crons. WOLF uses two session types:
+- **Main session** (`systemEvent`): Emerging Movers + Opportunity Scanner. These share the primary session context for accumulated routing knowledge.
+- **Isolated session** (`agentTurn`): DSL Combined, Portfolio, Health Check, SM Flip, Watchdog. Each runs in its own session — no context pollution, enables cheaper model tiers.
 
 Create each cron using the OpenClaw cron tool. The exact mandate text for each cron is in **`references/cron-templates.md`**. Read that file, replace the placeholders (only `{TELEGRAM}` and `{SCRIPTS}` in v6), and create all 7 crons.
 
@@ -365,7 +375,7 @@ XYZ DEX assets (GOLD, SILVER, TSLA, AAPL, etc.) behave differently:
 
 ## Token Optimization & Context Management
 
-**Model tiers:** See table in "Architecture — 7 Cron Jobs" section. Configure fast/cheap (Tier 1) vs capable (Tier 2) models in OpenClaw per-cron settings.
+**Model tiers:** See "Model Selection Per Cron" table. Primary for main-session crons, Mid/Budget for isolated crons. Configure per-cron in OpenClaw.
 
 **Heartbeat policy:** If script output contains no actionable signals, output HEARTBEAT_OK immediately. Do not reason about what wasn't found.
 

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -140,7 +140,7 @@ Configure per-cron in OpenClaw. Step down from your primary model for isolated c
 - **Main session** (`systemEvent`): Emerging Movers + Opportunity Scanner. These share the primary session context for accumulated routing knowledge.
 - **Isolated session** (`agentTurn`): DSL Combined, Portfolio, Health Check, SM Flip, Watchdog. Each runs in its own session — no context pollution, enables cheaper model tiers.
 
-Create each cron using the OpenClaw cron tool. The exact mandate text for each cron is in **`references/cron-templates.md`**. Read that file, replace the placeholders (`{TELEGRAM}`, `{SCRIPTS}`, and `{WOLF}` in v6), and create all 7 crons.
+Create each cron using the OpenClaw cron tool. The exact mandate text for each cron is in **`references/cron-templates.md`**. Read that file, replace the placeholders (`{TELEGRAM}`, `{SCRIPTS}`, and `{WORKSPACE}` in v6), and create all 7 crons.
 
 **v6 simplification:** No more per-wallet/per-strategy placeholders in cron mandates. Scripts read all strategy info from the registry.
 

--- a/wolf-strategy/references/cron-templates.md
+++ b/wolf-strategy/references/cron-templates.md
@@ -57,7 +57,7 @@ Two cron formats depending on session type:
 Replace these placeholders in all templates:
 - `{TELEGRAM}` — telegram:CHAT_ID (e.g. telegram:5183731261)
 - `{SCRIPTS}` — path to scripts dir (e.g. /data/workspace/skills/wolf-strategy/scripts)
-- `{WOLF}` — path to wolf-strategy skill dir (e.g. /data/workspace/skills/wolf-strategy)
+- `{WORKSPACE}` — path to workspace root (e.g. /data/workspace)
 
 **Wallet/strategy-specific placeholders are gone in v6.** Scripts read wallets from `wolf-strategies.json`.
 
@@ -68,7 +68,7 @@ Replace these placeholders in all templates:
 ```
 WOLF Emerging Movers: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS}/emerging-movers.py`, parse JSON.
 SLOT GUARD (MANDATORY): Check `anySlotsAvailable` — if false, output HEARTBEAT_OK immediately. Do NOT open any position when all strategies show 0 available slots. Check `strategySlots` per strategy before routing.
-On FIRST_JUMP/CONTRIB_EXPLOSION/IMMEDIATE_MOVER/NEW_ENTRY_DEEP/DEEP_CLIMBER signals: use `strategySlots` to route to a strategy with available > 0 (skip strategies at capacity), open position on that wallet, create DSL state in {WOLF}/state/{strategyKey}/dsl-{ASSET}.json.
+On FIRST_JUMP/CONTRIB_EXPLOSION/IMMEDIATE_MOVER/NEW_ENTRY_DEEP/DEEP_CLIMBER signals: use `strategySlots` to route to a strategy with available > 0 (skip strategies at capacity), open position on that wallet, create DSL state in {WORKSPACE}/state/{strategyKey}/dsl-{ASSET}.json.
 Apply WOLF entry rules from SKILL.md (min 7x leverage, rank #25+ entry, no top-10 entries, rotation logic).
 Alert Telegram ({TELEGRAM}) for each entry. Else HEARTBEAT_OK.
 ```
@@ -89,7 +89,7 @@ If `any_closed: true` → note freed slot(s) for next Emerging Movers run. Else 
 
 ```
 WOLF SM Check: Run `python3 {SCRIPTS}/sm-flip-check.py`, parse JSON.
-For each alert in `alerts`: if `alertLevel == "FLIP_NOW"` → close that position on the wallet for `strategyKey` (set `active: false` in `{WOLF}/state/{strategyKey}/dsl-{ASSET}.json`), alert Telegram ({TELEGRAM}) with asset, direction, conviction, strategyKey.
+For each alert in `alerts`: if `alertLevel == "FLIP_NOW"` → close that position on the wallet for `strategyKey` (set `active: false` in `{WORKSPACE}/state/{strategyKey}/dsl-{ASSET}.json`), alert Telegram ({TELEGRAM}) with asset, direction, conviction, strategyKey.
 Ignore alerts with `alertLevel` of WATCH or FLIP_WARNING (no action needed).
 If `hasFlipSignal == false` or no FLIP_NOW alerts → HEARTBEAT_OK.
 ```
@@ -109,7 +109,7 @@ If no alerts → HEARTBEAT_OK.
 ## 5. Portfolio Update (every 15min) — isolated / agentTurn
 
 ```
-WOLF Portfolio: Read {WOLF}/wolf-strategies.json, get clearinghouse state per wallet, send Telegram ({TELEGRAM}).
+WOLF Portfolio: Read {WORKSPACE}/wolf-strategies.json, get clearinghouse state per wallet, send Telegram ({TELEGRAM}).
 Format: code-block table with per-strategy name/account value/positions (asset, direction, ROE, PnL, DSL tier)/slot usage + global totals.
 ```
 

--- a/wolf-strategy/references/cron-templates.md
+++ b/wolf-strategy/references/cron-templates.md
@@ -14,10 +14,10 @@ WOLF uses two session types and a 3-tier model approach. Configure per-cron in O
 | SM Flip Detector | 5min (12x/hr) | isolated | agentTurn | Budget (cheapest available) |
 | Watchdog | 5min (12x/hr) | isolated | agentTurn | Budget (cheapest available) |
 
-**3-tier model approach** (tested IDs for OpenClaw):
+**3-tier model approach** (configure per-cron in OpenClaw):
 - **Primary** — Your configured model. Complex judgment, multi-strategy routing, entry decisions.
-- **Mid** (`anthropic/claude-sonnet-4-20250514`) — Structured tasks, script output parsing, rule-based actions.
-- **Budget** (`anthropic/claude-haiku-4-5`) — Simple threshold checks, binary decisions.
+- **Mid** — Structured tasks, script output parsing, rule-based actions. Examples: `anthropic/claude-sonnet-4-20250514`, `openai/gpt-4o`, `google/gemini-2.0-flash`.
+- **Budget** — Simple threshold checks, binary decisions. Examples: `anthropic/claude-haiku-4-5`, `openai/gpt-4o-mini`, `google/gemini-2.0-flash-lite`.
 
 All 7 crons can also run on a single model if you prefer simplicity over cost savings.
 

--- a/wolf-strategy/scripts/sm-flip-check.py
+++ b/wolf-strategy/scripts/sm-flip-check.py
@@ -106,19 +106,20 @@ def analyze(positions, sm_data):
         elif flipped:
             alert_level = "WATCH"
 
-        alerts.append({
-            "asset": asset,
-            "myDirection": my_dir,
-            "smDirection": sm_dir,
-            "flipped": flipped,
-            "alertLevel": alert_level,
-            "conviction": conviction,
-            "smPnlPct": sm["pnlPct"],
-            "smTraders": sm["traders"],
-            "avgAtPeak": sm["avgAtPeak"],
-            "nearPeakPct": sm["nearPeakPct"],
-            "strategyKey": pos["strategyKey"]
-        })
+        if flipped:
+            alerts.append({
+                "asset": asset,
+                "myDirection": my_dir,
+                "smDirection": sm_dir,
+                "flipped": flipped,
+                "alertLevel": alert_level,
+                "conviction": conviction,
+                "smPnlPct": sm["pnlPct"],
+                "smTraders": sm["traders"],
+                "avgAtPeak": sm["avgAtPeak"],
+                "nearPeakPct": sm["nearPeakPct"],
+                "strategyKey": pos["strategyKey"]
+            })
 
     return {
         "time": datetime.now(timezone.utc).isoformat(),

--- a/wolf-strategy/scripts/wolf-setup.py
+++ b/wolf-strategy/scripts/wolf-setup.py
@@ -255,51 +255,46 @@ cron_templates = {
     "dsl_combined": {
         "name": "WOLF DSL Combined v6 (3min)",
         "schedule": {"kind": "every", "everyMs": 180000},
-        "sessionTarget": "main",
-        "wakeMode": "now",
+        "sessionTarget": "isolated",
         "payload": {
-            "kind": "systemEvent",
-            "text": f"WOLF DSL: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/dsl-combined.py`, parse JSON.\n\nThis checks ALL active positions across ALL strategies in one pass. Parse the `results` array.\nFOR EACH position in results:\n- If `closed: true` -> alert user on Telegram ({tg}) with asset, direction, strategyKey, close_reason, upnl.\n- If `tier_changed: true` -> note the tier upgrade.\n- If `phase1_autocut: true` and `closed: true` -> position cut for timeout. Alert user.\n- If `status: \"pending_close\"` -> close failed, will retry.\nIf `any_closed: true` -> check for new signals.\nIf all active with no alerts -> HEARTBEAT_OK."
+            "kind": "agentTurn",
+            "message": f"WOLF DSL: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/dsl-combined.py`, parse JSON.\n\nThis checks ALL active positions across ALL strategies in one pass. Parse the `results` array.\nFOR EACH position in results:\n- If `closed: true` -> alert user on Telegram ({tg}) with asset, direction, strategyKey, close_reason, upnl.\n- If `tier_changed: true` -> note the tier upgrade.\n- If `phase1_autocut: true` and `closed: true` -> position cut for timeout. Alert user.\n- If `status: \"pending_close\"` -> close failed, will retry.\nIf `any_closed: true` -> check for new signals.\nIf all active with no alerts -> HEARTBEAT_OK."
         }
     },
     "sm_flip": {
         "name": "WOLF SM Flip Detector v6 (5min)",
         "schedule": {"kind": "every", "everyMs": 300000},
-        "sessionTarget": "main",
-        "wakeMode": "now",
+        "sessionTarget": "isolated",
         "payload": {
-            "kind": "systemEvent",
-            "text": f"WOLF SM Check: Run `python3 {SCRIPTS_DIR}/sm-flip-check.py`, parse JSON.\n\nMulti-strategy aware. If any alert has conviction 4+ in OPPOSITE direction with 100+ traders -> CUT the position (set DSL state active: false). The output includes strategyKey for each position.\nConviction 2-3 = note but don't act.\nAlert user on Telegram ({tg}) for any cuts.\nIf hasFlipSignal=false -> HEARTBEAT_OK."
+            "kind": "agentTurn",
+            "message": f"WOLF SM Check: Run `python3 {SCRIPTS_DIR}/sm-flip-check.py`, parse JSON.\n\nMulti-strategy aware. If any alert has conviction 4+ in OPPOSITE direction with 100+ traders -> CUT the position (set DSL state active: false). The output includes strategyKey for each position.\nConviction 2-3 = note but don't act.\nAlert user on Telegram ({tg}) for any cuts.\nIf hasFlipSignal=false -> HEARTBEAT_OK."
         }
     },
     "watchdog": {
         "name": "WOLF Watchdog v6 (5min)",
         "schedule": {"kind": "every", "everyMs": 300000},
-        "sessionTarget": "main",
-        "wakeMode": "now",
+        "sessionTarget": "isolated",
         "payload": {
-            "kind": "systemEvent",
-            "text": f"WOLF Watchdog: Run `PYTHONUNBUFFERED=1 timeout 45 python3 {SCRIPTS_DIR}/wolf-monitor.py`. Parse JSON output.\n\nMulti-strategy: output has `strategies` dict keyed by strategy key. Per-strategy checks:\n1. Cross-margin buffer: <50% WARNING, <30% CRITICAL.\n2. Position alerts: CRITICAL -> immediate Telegram ({tg}). WARNING -> alert if new.\n3. Rotation check: -15%+ ROE AND strong climber we don't hold -> suggest rotation.\n4. XYZ isolated liq < 15% -> alert user.\n5. Per-strategy watchdog state saved in state/{{strategyKey}}/watchdog-last.json.\nIf no alerts -> HEARTBEAT_OK."
+            "kind": "agentTurn",
+            "message": f"WOLF Watchdog: Run `PYTHONUNBUFFERED=1 timeout 45 python3 {SCRIPTS_DIR}/wolf-monitor.py`. Parse JSON output.\n\nMulti-strategy: output has `strategies` dict keyed by strategy key. Per-strategy checks:\n1. Cross-margin buffer: <50% WARNING, <30% CRITICAL.\n2. Position alerts: CRITICAL -> immediate Telegram ({tg}). WARNING -> alert if new.\n3. Rotation check: -15%+ ROE AND strong climber we don't hold -> suggest rotation.\n4. XYZ isolated liq < 15% -> alert user.\n5. Per-strategy watchdog state saved in state/{{strategyKey}}/watchdog-last.json.\nIf no alerts -> HEARTBEAT_OK."
         }
     },
     "portfolio": {
         "name": "WOLF Portfolio v6 (15min)",
         "schedule": {"kind": "every", "everyMs": 900000},
-        "sessionTarget": "main",
-        "wakeMode": "now",
+        "sessionTarget": "isolated",
         "payload": {
-            "kind": "systemEvent",
-            "text": f"WOLF portfolio update: Read wolf-strategies.json for all enabled strategies. For each strategy, get clearinghouse state for its wallet. Send user a concise Telegram update ({tg}). Code block table format. Include per-strategy account value, positions (asset, direction, ROE, PnL, DSL tier), and slot usage."
+            "kind": "agentTurn",
+            "message": f"WOLF portfolio update: Read wolf-strategies.json for all enabled strategies. For each strategy, get clearinghouse state for its wallet. Send user a concise Telegram update ({tg}). Code block table format. Include per-strategy account value, positions (asset, direction, ROE, PnL, DSL tier), and slot usage."
         }
     },
     "health_check": {
         "name": "WOLF Health Check v6 (10min)",
         "schedule": {"kind": "every", "everyMs": 600000},
-        "sessionTarget": "main",
-        "wakeMode": "now",
+        "sessionTarget": "isolated",
         "payload": {
-            "kind": "systemEvent",
-            "text": f"WOLF Health Check: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/job-health-check.py`, parse JSON.\n\nMulti-strategy: validates per-strategy state dirs vs actual wallet positions.\nIf CRITICAL -> fix immediately (deactivate orphans, create missing DSLs, fix direction mismatches).\nAlert user on Telegram ({tg}) for critical issues.\nWARNINGs -> fix silently.\nNo issues -> HEARTBEAT_OK."
+            "kind": "agentTurn",
+            "message": f"WOLF Health Check: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/job-health-check.py`, parse JSON.\n\nMulti-strategy: validates per-strategy state dirs vs actual wallet positions.\nIf CRITICAL -> fix immediately (deactivate orphans, create missing DSLs, fix direction mismatches).\nAlert user on Telegram ({tg}) for critical issues.\nWARNINGs -> fix silently.\nNo issues -> HEARTBEAT_OK."
         }
     },
     "opportunity_scanner": {
@@ -347,6 +342,23 @@ for the exact payload text for each of the 7 jobs.
 
 With multi-strategy, crons iterate all enabled strategies internally.
 You only need ONE set of crons regardless of strategy count.
+
+  Session & Model Tier Recommendations:
+  ┌──────────────────────┬──────────┬──────────┬─────────────────────────┐
+  │ Cron                 │ Session  │ Payload  │ Model Tier              │
+  ├──────────────────────┼──────────┼──────────┼─────────────────────────┤
+  │ Emerging Movers      │ main     │ sysEvent │ Primary (your model)    │
+  │ Opportunity Scanner  │ main     │ sysEvent │ Primary (your model)    │
+  │ DSL Combined         │ isolated │ agentTrn │ Mid (one tier down)     │
+  │ Portfolio Update     │ isolated │ agentTrn │ Mid (one tier down)     │
+  │ Health Check         │ isolated │ agentTrn │ Mid (one tier down)     │
+  │ SM Flip Detector     │ isolated │ agentTrn │ Budget (cheapest)       │
+  │ Watchdog             │ isolated │ agentTrn │ Budget (cheapest)       │
+  └──────────────────────┴──────────┴──────────┴─────────────────────────┘
+
+  Main crons share your primary session context (systemEvent).
+  Isolated crons run in their own session (agentTurn) — no context pollution.
+  All 7 crons can also run on a single model if you prefer simplicity.
 """)
 
 # Output full result as JSON for programmatic use

--- a/wolf-strategy/scripts/wolf-setup.py
+++ b/wolf-strategy/scripts/wolf-setup.py
@@ -53,6 +53,10 @@ parser.add_argument("--chat-id", type=int, help="Telegram chat ID")
 parser.add_argument("--name", help="Human-readable strategy name (optional)")
 parser.add_argument("--dsl-preset", choices=["aggressive", "conservative"], default="aggressive",
                     help="DSL tier preset (default: aggressive)")
+parser.add_argument("--mid-model", default="anthropic/claude-sonnet-4-20250514",
+                    help="Model ID for Mid-tier isolated crons (DSL, Portfolio, Health)")
+parser.add_argument("--budget-model", default="anthropic/claude-haiku-4-5",
+                    help="Model ID for Budget-tier isolated crons (SM Flip, Watchdog)")
 args = parser.parse_args()
 
 def ask(prompt, default=None, validator=None):
@@ -115,6 +119,8 @@ if args.chat_id:
 
 strategy_name = args.name or f"Strategy {strategy_id[:8]}"
 dsl_preset = args.dsl_preset
+mid_model = args.mid_model
+budget_model = args.budget_model
 
 # Calculate parameters
 if budget < 3000:
@@ -258,7 +264,8 @@ cron_templates = {
         "sessionTarget": "isolated",
         "payload": {
             "kind": "agentTurn",
-            "message": f"WOLF DSL: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/dsl-combined.py`, parse JSON.\n\nThis checks ALL active positions across ALL strategies in one pass. Parse the `results` array.\nFOR EACH position in results:\n- If `closed: true` -> alert user on Telegram ({tg}) with asset, direction, strategyKey, close_reason, upnl.\n- If `tier_changed: true` -> note the tier upgrade.\n- If `phase1_autocut: true` and `closed: true` -> position cut for timeout. Alert user.\n- If `status: \"pending_close\"` -> close failed, will retry.\nIf `any_closed: true` -> check for new signals.\nIf all active with no alerts -> HEARTBEAT_OK."
+            "model": mid_model,
+            "message": f"WOLF DSL: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/dsl-combined.py`, parse JSON.\n\nFor each entry in `results`: if `status==\"closed\"` -> alert Telegram ({tg}) with asset, direction, strategyKey, close_reason, upnl. If `phase1_autocut: true` -> note timeout cut. If `status==\"pending_close\"` -> alert user (retry next run).\nIf `any_closed: true` -> note freed slot(s) for next Emerging Movers run. Else HEARTBEAT_OK."
         }
     },
     "sm_flip": {
@@ -267,7 +274,8 @@ cron_templates = {
         "sessionTarget": "isolated",
         "payload": {
             "kind": "agentTurn",
-            "message": f"WOLF SM Check: Run `python3 {SCRIPTS_DIR}/sm-flip-check.py`, parse JSON.\n\nMulti-strategy aware. If any alert has conviction 4+ in OPPOSITE direction with 100+ traders -> CUT the position (set DSL state active: false). The output includes strategyKey for each position.\nConviction 2-3 = note but don't act.\nAlert user on Telegram ({tg}) for any cuts.\nIf hasFlipSignal=false -> HEARTBEAT_OK."
+            "model": budget_model,
+            "message": f"WOLF SM Check: Run `python3 {SCRIPTS_DIR}/sm-flip-check.py`, parse JSON.\n\nFor each alert in `alerts`: if `alertLevel == \"FLIP_NOW\"` -> close that position on the wallet for `strategyKey` (set `active: false` in `{WORKSPACE}/state/{{{{strategyKey}}}}/dsl-{{{{ASSET}}}}.json`), alert Telegram ({tg}) with asset, direction, conviction, strategyKey.\nIgnore alerts with `alertLevel` of WATCH or FLIP_WARNING (no action needed).\nIf `hasFlipSignal == false` or no FLIP_NOW alerts -> HEARTBEAT_OK."
         }
     },
     "watchdog": {
@@ -276,7 +284,8 @@ cron_templates = {
         "sessionTarget": "isolated",
         "payload": {
             "kind": "agentTurn",
-            "message": f"WOLF Watchdog: Run `PYTHONUNBUFFERED=1 timeout 45 python3 {SCRIPTS_DIR}/wolf-monitor.py`. Parse JSON output.\n\nMulti-strategy: output has `strategies` dict keyed by strategy key. Per-strategy checks:\n1. Cross-margin buffer: <50% WARNING, <30% CRITICAL.\n2. Position alerts: CRITICAL -> immediate Telegram ({tg}). WARNING -> alert if new.\n3. Rotation check: -15%+ ROE AND strong climber we don't hold -> suggest rotation.\n4. XYZ isolated liq < 15% -> alert user.\n5. Per-strategy watchdog state saved in state/{{strategyKey}}/watchdog-last.json.\nIf no alerts -> HEARTBEAT_OK."
+            "model": budget_model,
+            "message": f"WOLF Watchdog: Run `PYTHONUNBUFFERED=1 timeout 45 python3 {SCRIPTS_DIR}/wolf-monitor.py`, parse JSON.\n\nCheck each strategy: crypto_liq_buffer_pct<50% -> WARNING (alert Telegram only); <30% -> CRITICAL (close the position with lowest ROE% in that strategy, then alert Telegram ({tg})). XYZ liq_distance_pct<15% -> alert Telegram.\nIf no alerts -> HEARTBEAT_OK."
         }
     },
     "portfolio": {
@@ -285,7 +294,8 @@ cron_templates = {
         "sessionTarget": "isolated",
         "payload": {
             "kind": "agentTurn",
-            "message": f"WOLF portfolio update: Read wolf-strategies.json for all enabled strategies. For each strategy, get clearinghouse state for its wallet. Send user a concise Telegram update ({tg}). Code block table format. Include per-strategy account value, positions (asset, direction, ROE, PnL, DSL tier), and slot usage."
+            "model": mid_model,
+            "message": f"WOLF Portfolio: Read {WORKSPACE}/wolf-strategies.json, get clearinghouse state per wallet, send Telegram ({tg}).\nFormat: code-block table with per-strategy name/account value/positions (asset, direction, ROE, PnL, DSL tier)/slot usage + global totals."
         }
     },
     "health_check": {
@@ -294,7 +304,8 @@ cron_templates = {
         "sessionTarget": "isolated",
         "payload": {
             "kind": "agentTurn",
-            "message": f"WOLF Health Check: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/job-health-check.py`, parse JSON.\n\nMulti-strategy: validates per-strategy state dirs vs actual wallet positions.\nIf CRITICAL -> fix immediately (deactivate orphans, create missing DSLs, fix direction mismatches).\nAlert user on Telegram ({tg}) for critical issues.\nWARNINGs -> fix silently.\nNo issues -> HEARTBEAT_OK."
+            "model": mid_model,
+            "message": f"WOLF Health Check: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/job-health-check.py`, parse JSON.\n\nThe script auto-fixes most issues (check the `action` field per issue):\n- auto_created -> DSL was missing, script created it. Alert Telegram ({tg}).\n- auto_deactivated -> Orphan DSL deactivated (position closed externally). No alert needed.\n- auto_replaced -> Direction mismatch fixed with fresh DSL. Alert Telegram ({tg}).\n- updated_state -> Size/entry/leverage reconciled to match on-chain. No alert needed.\n- skipped_fetch_error -> Orphan check skipped due to API error. No alert needed (transient).\n- alert_only -> Script could not auto-fix. Handle manually:\n  - NO_WALLET -> CRITICAL, needs manual config. Alert Telegram ({tg}).\n  - DSL_INACTIVE -> CRITICAL, set `active: true` in the DSL state file. Alert Telegram ({tg}).\nIf no issues -> HEARTBEAT_OK."
         }
     },
     "opportunity_scanner": {
@@ -336,7 +347,7 @@ if strategies_count > 1:
 print("\n" + "=" * 60)
 print("  Next Steps: Create 7 cron jobs")
 print("=" * 60)
-print("""
+print(f"""
 Use OpenClaw cron to create each job. See references/cron-templates.md
 for the exact payload text for each of the 7 jobs.
 
@@ -344,17 +355,17 @@ With multi-strategy, crons iterate all enabled strategies internally.
 You only need ONE set of crons regardless of strategy count.
 
   Session & Model Tier Recommendations:
-  ┌──────────────────────┬──────────┬──────────┬─────────────────────────┐
-  │ Cron                 │ Session  │ Payload  │ Model Tier              │
-  ├──────────────────────┼──────────┼──────────┼─────────────────────────┤
-  │ Emerging Movers      │ main     │ sysEvent │ Primary (your model)    │
-  │ Opportunity Scanner  │ main     │ sysEvent │ Primary (your model)    │
-  │ DSL Combined         │ isolated │ agentTrn │ Mid (one tier down)     │
-  │ Portfolio Update     │ isolated │ agentTrn │ Mid (one tier down)     │
-  │ Health Check         │ isolated │ agentTrn │ Mid (one tier down)     │
-  │ SM Flip Detector     │ isolated │ agentTrn │ Budget (cheapest)       │
-  │ Watchdog             │ isolated │ agentTrn │ Budget (cheapest)       │
-  └──────────────────────┴──────────┴──────────┴─────────────────────────┘
+  ┌──────────────────────┬──────────┬──────────┬─────────────────────────────────────────────┐
+  │ Cron                 │ Session  │ Payload  │ Model                                       │
+  ├──────────────────────┼──────────┼──────────┼─────────────────────────────────────────────┤
+  │ Emerging Movers      │ main     │ sysEvent │ Primary (your model)                        │
+  │ Opportunity Scanner  │ main     │ sysEvent │ Primary (your model)                        │
+  │ DSL Combined         │ isolated │ agentTrn │ Mid: {mid_model}  │
+  │ Portfolio Update     │ isolated │ agentTrn │ Mid: {mid_model}  │
+  │ Health Check         │ isolated │ agentTrn │ Mid: {mid_model}  │
+  │ SM Flip Detector     │ isolated │ agentTrn │ Budget: {budget_model}       │
+  │ Watchdog             │ isolated │ agentTrn │ Budget: {budget_model}       │
+  └──────────────────────┴──────────┴──────────┴─────────────────────────────────────────────┘
 
   Main crons share your primary session context (systemEvent).
   Isolated crons run in their own session (agentTurn) — no context pollution.

--- a/wolf-strategy/scripts/wolf-setup.py
+++ b/wolf-strategy/scripts/wolf-setup.py
@@ -275,7 +275,7 @@ cron_templates = {
         "payload": {
             "kind": "agentTurn",
             "model": budget_model,
-            "message": f"WOLF SM Check: Run `python3 {SCRIPTS_DIR}/sm-flip-check.py`, parse JSON.\n\nFor each alert in `alerts`: if `alertLevel == \"FLIP_NOW\"` -> close that position on the wallet for `strategyKey` (set `active: false` in `{WORKSPACE}/state/{{{{strategyKey}}}}/dsl-{{{{ASSET}}}}.json`), alert Telegram ({tg}) with asset, direction, conviction, strategyKey.\nIgnore alerts with `alertLevel` of WATCH or FLIP_WARNING (no action needed).\nIf `hasFlipSignal == false` or no FLIP_NOW alerts -> HEARTBEAT_OK."
+            "message": f"WOLF SM Check: Run `python3 {SCRIPTS_DIR}/sm-flip-check.py`, parse JSON.\n\nFor each alert in `alerts`: if `alertLevel == \"FLIP_NOW\"` -> close that position on the wallet for `strategyKey` (set `active: false` in `{WORKSPACE}/state/{{strategyKey}}/dsl-{{ASSET}}.json`), alert Telegram ({tg}) with asset, direction, conviction, strategyKey.\nIgnore alerts with `alertLevel` of WATCH or FLIP_WARNING (no action needed).\nIf `hasFlipSignal == false` or no FLIP_NOW alerts -> HEARTBEAT_OK."
         }
     },
     "watchdog": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how WOLF crons are executed (switching 5 jobs to `sessionTarget: "isolated"`/`agentTurn` with per-cron model IDs), so misconfigured payload fields or model IDs could cause silent no-op runs or different automation behavior. Script output/mandate contract changes (slot guard fields, flipped-only SM alerts) may also affect downstream routing decisions.
> 
> **Overview**
> Updates WOLF cron execution to a **2-session / 3-tier model** scheme: only the judgment-heavy crons run on the main session, while DSL/SM/watchdog/portfolio/health run in **isolated `agentTurn` sessions** with explicit Mid/Budget model IDs to reduce context bloat and cost.
> 
> Adds a **slot guard contract** by having `emerging-movers.py` and `opportunity-scan-v6.py` surface `strategySlots` + `anySlotsAvailable`, and updates cron templates/mandates (including `{WORKSPACE}` paths) to require checking these fields before opening new positions.
> 
> Refines automation details: `sm-flip-check.py` now only emits alerts when an SM direction flip occurs, and `wolf-setup.py` gains `--mid-model`/`--budget-model` flags and generates updated isolated-cron payloads. Documentation (`GUIDE.md`, `SKILL.md`, cron templates) is updated to reflect the new session/model and payload key differences (`text` vs `message`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70aa02b99e718fcac698d27446d0fbdd10c89090. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->