### PR TITLE
feat: add explicit Senpi capabilities + skills summary flow in entrypoint

### DIFF
--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 compatibility: "Node.js, shell, Python 3, OpenClaw (optional — Step 5 cron)"
 metadata:
   author: Senpi
-  version: "1.2.0"
+  version: "1.2.1"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -223,6 +223,29 @@ If the user asks to turn notifications off or back on, follow the procedure in
 
 ## Responding to Questions
 
+### "What is Senpi?" / "Summarize Senpi" / "Summarize skills and capabilities" / "How do I install skills?" / "What's new?"
+
+Use [references/about-senpi.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/about-senpi.md)
+as the single source for the summary. This is **explicit-ask only** — do not
+auto-insert this summary into normal onboarding steps.
+
+Default response order (keep compact and actionable):
+1. **What Senpi is** (short definition)
+2. **Core platform capabilities** (what users/agents can do)
+3. **Skills snapshot** (compact, grouped/high-signal list)
+4. **Install guidance** (what can be installed now; offer to perform installs for them)
+5. **What's new** (only from queued startup `UPDATE_OUTPUT`, if present)
+
+For "what's new", do not run a forced live check. Reuse startup-queued updates
+handled via
+[references/skill-update-checker.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-update-checker.md).
+If there are no queued updates, return a neutral status and offer to run:
+- a global skill update
+- a fresh live skill catalog fetch
+
+Do not tell users to run CLI commands themselves. Execute commands on the user's
+behalf whenever they ask to install, update, or refresh.
+
 ### "What skills should I install?" / "What should I use for [goal]?"
 
 Consult
@@ -238,5 +261,5 @@ for the goal-to-skill mapping, budget guidance, and install commands.
 | `scripts/check-skill-updates.py` | Daily background checker (run via cron with `--cron`). Reads Vercel skills CLI lock file, compares GitHub tree SHAs, writes version bumps / new skills to pending file |
 | `references/skill-update-checker.md` | Startup output handling + turn notifications on/off + cron management |
 | `references/skill-recommendations.md` | Goal-to-skill mapping table, budget guidance, install commands |
-| `references/about-senpi.md` | Senpi platform overview (what it is, what agents can do, core loop) |
+| `references/about-senpi.md` | Senpi summary source: what Senpi is, capabilities, compact skill map, install flow, and what's-new guidance |
 | `references/error-handling.md` | Recovery steps for `npx` command failures |

--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 compatibility: "Node.js, shell, Python 3, OpenClaw (optional — Step 5 cron)"
 metadata:
   author: Senpi
-  version: "1.2.1"
+  version: "1.2.2"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -225,26 +225,12 @@ If the user asks to turn notifications off or back on, follow the procedure in
 
 ### "What is Senpi?" / "Summarize Senpi" / "Summarize skills and capabilities" / "How do I install skills?" / "What's new?"
 
-Use [references/about-senpi.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/about-senpi.md)
-as the single source for the summary. This is **explicit-ask only** — do not
-auto-insert this summary into normal onboarding steps.
+This is **explicit-ask only** — do not auto-insert this summary into normal
+onboarding steps.
 
-Default response order (keep compact and actionable):
-1. **What Senpi is** (short definition)
-2. **Core platform capabilities** (what users/agents can do)
-3. **Skills snapshot** (compact, grouped/high-signal list)
-4. **Install guidance** (what can be installed now; offer to perform installs for them)
-5. **What's new** (only from queued startup `UPDATE_OUTPUT`, if present)
-
-For "what's new", do not run a forced live check. Reuse startup-queued updates
-handled via
-[references/skill-update-checker.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-update-checker.md).
-If there are no queued updates, return a neutral status and offer to run:
-- a global skill update
-- a fresh live skill catalog fetch
-
-Do not tell users to run CLI commands themselves. Execute commands on the user's
-behalf whenever they ask to install, update, or refresh.
+When asked, load and follow
+[references/about-senpi.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/about-senpi.md)
+(`Summary Response Contract` section) for order, depth, and command behavior.
 
 ### "What skills should I install?" / "What should I use for [goal]?"
 

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -1,19 +1,55 @@
 # About Senpi
 
-Senpi is a trading platform on Hyperliquid — a high-performance perpetual futures DEX.
+Senpi is an agent-first trading platform on Hyperliquid that lets users discover
+opportunities, automate strategies, and manage risk from one MCP-connected workflow.
 
-## What Agents Can Do
+## Core Capabilities
 
-- Discover profitable traders (Hyperfeed + Discovery)
-- Mirror top traders or run custom strategies with full position control
-- Trade 200+ crypto perps, plus equities, metals, and indices via XYZ DEX
+- Discover high-performing traders and market opportunities (Discovery + market tools)
+- Copy top traders or run autonomous/custom strategy workflows
+- Apply risk controls such as dynamic stop-loss and budget-aware orchestration
+- Trade broad markets through Senpi's Hyperliquid-based stack (crypto perps and more)
 
-## Core Loop
+## Compact Skill Snapshot
 
-Spot what's profiting -> validate with data -> trade or copy.
+### Protect Positions
+- `dsl-dynamic-stop-loss`: two-phase trailing stop-loss with tiered locking
+- `dsl-tight`: tighter DSL defaults for faster profit protection
+
+### Find Opportunities
+- `opportunity-scanner`: market-wide scoring and setup discovery
+- `emerging-movers`: smart-money rotation detection
+
+### Trade Autonomously or Copy
+- `wolf-strategy`: full autonomous trading stack
+- `autonomous-trading`: orchestrates DSL + scanner + movers
+- `whale-index`: mirrors top-performing traders
+- `wolf-howl`: nightly review and self-improvement loop (requires `wolf-strategy`)
+
+## Install Skills
+
+When users pick a skill, install it on their behalf with the skills CLI.
+Do not ask them to run terminal commands themselves.
+
+Default install action (agent-side):
+- Run: `npx skills add https://github.com/Senpi-ai/senpi-skills --skill <skill-name> -g -y`
+- Then report what was installed and suggest the immediate next action.
+
+For catalog refreshes, run the live list command agent-side and summarize results
+instead of pasting raw output.
+
+## What's New
+
+Use queued updates from the entrypoint startup pending file
+(`$SENPI_STATE_DIR/pending-skill-updates.json` when present). Do not force a
+live check in summary responses.
+
+If no updates are queued, return a neutral status and suggest:
+- the agent can apply installed skill updates now
+- the agent can fetch a fresh catalog now
 
 ## Platform Reference
 
-After the MCP server is active, call
-`read_senpi_guide(uri="senpi://guides/senpi-overview")` for the full platform
-reference (wallets, strategies, tool categories, fees, workflows).
+After MCP is active, call
+`read_senpi_guide(uri="senpi://guides/senpi-overview")` for full platform details
+(wallets, strategies, tool categories, fees, workflows).

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -3,6 +3,30 @@
 Senpi is an agent-first trading platform on Hyperliquid that lets users discover
 opportunities, automate strategies, and manage risk from one MCP-connected workflow.
 
+## Summary Response Contract
+
+Use this section only for explicit summary questions such as:
+- "What is Senpi?"
+- "Summarize Senpi"
+- "Summarize skills/capabilities"
+- "How do I install skills?"
+- "What's new?"
+
+Do not auto-insert this summary during normal onboarding.
+
+Default response order (compact + actionable):
+1. What Senpi is (one short definition)
+2. Core capabilities
+3. Compact skill snapshot
+4. Install guidance
+5. What's new
+
+Behavior rules:
+- Use queued startup `UPDATE_OUTPUT` for "what's new" when available.
+- Do not force a live update check in summary responses.
+- If no updates are queued, return neutral status and offer to run update/catalog refresh.
+- Do not tell users to run CLI commands themselves; run install/update/list actions on their behalf.
+
 ## Core Capabilities
 
 - Discover high-performing traders and market opportunities (Discovery + market tools)


### PR DESCRIPTION
## Summary
- add explicit Senpi summary response mode to senpi-entrypoint/SKILL.md
- define fixed response order: what Senpi is, capabilities, skills snapshot, install guidance, and what's new
- enforce explicit-ask-only behavior and agent-runs-commands guidance
- revamp senpi-entrypoint/references/about-senpi.md as the single summary source

## Scope
- only updates senpi-entrypoint/SKILL.md and senpi-entrypoint/references/about-senpi.md

## Notes
- no script changes
- no CLI/interface breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts agent guidance for when/how to answer Senpi capability summary questions, without modifying scripts or runtime logic.
> 
> **Overview**
> Introduces an **explicit-ask-only** flow in `SKILL.md` for questions like *"What is Senpi?"* / *"What's new?"*, instructing agents to load and follow `references/about-senpi.md` instead of mixing summaries into onboarding.
> 
> Revamps `references/about-senpi.md` into a single source of truth with a `Summary Response Contract` (fixed response order + behavior rules), a compact capabilities/skill snapshot, agent-run install guidance, and *what’s-new* handling via queued `UPDATE_OUTPUT`. Also bumps the entrypoint version to `1.2.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b56e2b00abb36b8610b899b4a226feb9cc602344. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->