### PR TITLE
refine(summary): hide empty updates and add setup recommendation question

### DIFF
--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -53,7 +53,9 @@ Do not narrate or explain tool calls. Execute silently and only present final re
 Before responding to any query in this skill, run the mandatory invocation
 check in
 [references/skill-update-checker.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-update-checker.md)
-(`Pre-Response Invocation Check` section).
+(`Pre-Response Invocation Check` section) exactly once per invocation, then
+reuse the captured `UPDATE_OUTPUT` for all downstream response contracts.
+Do not run the same check a second time in the same invocation.
 
 ---
 
@@ -218,6 +220,9 @@ If the user asks to turn notifications off or back on, follow the procedure in
 For any summary or Q&A response, follow
 [references/about-senpi.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/about-senpi.md)
 (`Summary Response Contract` and `Mandatory Invocation Procedure` sections).
+Use the `UPDATE_OUTPUT` produced by the top-level `Pre-Response Check` above;
+do not rerun `Pre-Response Invocation Check` here unless it has not yet been
+run in the current invocation.
 Do not consider the response complete until those procedures are satisfied.
 
 ### "What is Senpi?" / "Summarize Senpi" / "Summarize skills and capabilities" / "How do I install skills?" / "What's new?"

--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 compatibility: "Node.js, shell, Python 3, OpenClaw (optional — Step 5 cron)"
 metadata:
   author: Senpi
-  version: "1.2.2"
+  version: "1.2.3"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -50,22 +50,10 @@ Do not narrate or explain tool calls. Execute silently and only present final re
 
 ## Pre-Response Check (Run Every Time This Skill Is Invoked)
 
-Run this before responding to **any** user query in this skill (onboarding,
-Q&A, or mid-session invocation). This check is mandatory.
-
-Check whether the background cron has queued skill update notifications:
-
-```bash
-SENPI_STATE_DIR="${SENPI_STATE_DIR:-$HOME/.config/senpi}"
-SENPI_PENDING="$SENPI_STATE_DIR/pending-skill-updates.json"
-if [ -f "$SENPI_PENDING" ]; then
-  UPDATE_OUTPUT=$(cat "$SENPI_PENDING") && rm -f "$SENPI_PENDING"
-fi
-```
-
-If `UPDATE_OUTPUT` is set, handle it per
+Before responding to any query in this skill, run the mandatory invocation
+check in
 [references/skill-update-checker.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-update-checker.md)
-before continuing.
+(`Pre-Response Invocation Check` section).
 
 ---
 
@@ -225,29 +213,12 @@ If the user asks to turn notifications off or back on, follow the procedure in
 
 ## Responding to Questions
 
-### Mandatory Skill Update Check — Execution NOT Optional
+### Mandatory Response Contract (Execution NOT Optional)
 
-Run this procedure for **every** query handled by this skill:
-1. Run **Pre-Response Check** and capture queued `UPDATE_OUTPUT` if present.
-2. Build the core user response.
-3. Run one fresh checker pass:
-```bash
-SENPI_ENTRYPOINT_SCRIPTS=$(node -e "
-  const path = require('path'), os = require('os'), fs = require('fs');
-  const p = path.join(os.homedir(), '.agents', 'skills', 'senpi-entrypoint', 'scripts');
-  console.log(fs.existsSync(path.join(p, 'check-skill-updates.py')) ? p : '');
-" 2>/dev/null)
-
-if [ -n "$SENPI_ENTRYPOINT_SCRIPTS" ]; then
-  LIVE_UPDATE_OUTPUT=$(python3 "$SENPI_ENTRYPOINT_SCRIPTS/check-skill-updates.py" 2>/dev/null || true)
-fi
-```
-4. If updates exist in `UPDATE_OUTPUT` or `LIVE_UPDATE_OUTPUT`, append a short
-   user-friendly "What's new" addendum to the same response.
-5. If no updates exist, do not mention "What's new."
-
-⚠️ **Completion gate:** Do **NOT** consider the response complete until Step 3
-has run and Step 4/5 has been applied.
+For any summary or Q&A response, follow
+[references/about-senpi.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/about-senpi.md)
+(`Summary Response Contract` and `Mandatory Invocation Procedure` sections).
+Do not consider the response complete until those procedures are satisfied.
 
 ### "What is Senpi?" / "Summarize Senpi" / "Summarize skills and capabilities" / "How do I install skills?" / "What's new?"
 
@@ -257,11 +228,6 @@ onboarding steps.
 When asked, load and follow
 [references/about-senpi.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/about-senpi.md)
 (`Summary Response Contract` section) for order, depth, and command behavior.
-
-For **"What is Senpi?"**, also include:
-- Goal-based skill picks from
-  [references/skill-recommendations.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-recommendations.md).
-- Current onboarding/auth status (`SENPI_AUTH_TOKEN` set or unset) and next setup step.
 
 ### "What skills should I install?" / "What should I use for [goal]?"
 

--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 compatibility: "Node.js, shell, Python 3, OpenClaw (optional — Step 5 cron)"
 metadata:
   author: Senpi
-  version: "1.2.3"
+  version: "1.2.4"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -247,5 +247,5 @@ for the goal-to-skill mapping, budget guidance, and install commands.
 | `scripts/check-skill-updates.py` | Daily background checker (run via cron with `--cron`). Reads Vercel skills CLI lock file, compares GitHub tree SHAs, writes version bumps / new skills to pending file |
 | `references/skill-update-checker.md` | Startup output handling + turn notifications on/off + cron management |
 | `references/skill-recommendations.md` | Goal-to-skill mapping table, budget guidance, install commands |
-| `references/about-senpi.md` | Senpi summary source: what Senpi is, capabilities, compact skill map, install flow, and what's-new guidance |
+| `references/about-senpi.md` | Senpi summary source: what Senpi is, capabilities, full bullet catalog, user-friendly install flow, and what's-new guidance |
 | `references/error-handling.md` | Recovery steps for `npx` command failures |

--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -3,7 +3,7 @@ name: senpi-entrypoint
 description: >-
   Onboard AI agents into the Senpi trading platform on Hyperliquid. Walks
   through account creation, API key setup, MCP server configuration, skill
-  discovery, and first-trade guidance. Includes a silent skill update checker
+  discovery, and first-trade guidance. Includes a mandatory skill update check
   that surfaces new or updated skills after onboarding. Use when user says
   "set up Senpi", "get started with Senpi", "connect to Senpi", "install
   Senpi", "onboard to Senpi", or when an agent needs to start trading on
@@ -48,10 +48,12 @@ Do not narrate or explain tool calls. Execute silently and only present final re
 
 ---
 
-## Startup: Surface pending skill updates
+## Pre-Response Check (Run Every Time This Skill Is Invoked)
 
-Before anything else, check whether the background cron has queued skill
-update notifications since the last session:
+Run this before responding to **any** user query in this skill (onboarding,
+Q&A, or mid-session invocation). This check is mandatory.
+
+Check whether the background cron has queued skill update notifications:
 
 ```bash
 SENPI_STATE_DIR="${SENPI_STATE_DIR:-$HOME/.config/senpi}"
@@ -63,7 +65,7 @@ fi
 
 If `UPDATE_OUTPUT` is set, handle it per
 [references/skill-update-checker.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-update-checker.md)
-before continuing. Otherwise proceed silently.
+before continuing.
 
 ---
 
@@ -210,7 +212,7 @@ The job is stored in `$OPENCLAW_STATE_DIR/cron/jobs.json` (default:
 updates are found the script writes to
 `$SENPI_STATE_DIR/pending-skill-updates.json` (default:
 `~/.config/senpi/pending-skill-updates.json` if `SENPI_STATE_DIR` is unset),
-surfaced at the next session startup (see **Startup** section above).
+surfaced at the next invocation via **Pre-Response Check** (above).
 
 ---
 
@@ -223,6 +225,30 @@ If the user asks to turn notifications off or back on, follow the procedure in
 
 ## Responding to Questions
 
+### Mandatory Skill Update Check — Execution NOT Optional
+
+Run this procedure for **every** query handled by this skill:
+1. Run **Pre-Response Check** and capture queued `UPDATE_OUTPUT` if present.
+2. Build the core user response.
+3. Run one fresh checker pass:
+```bash
+SENPI_ENTRYPOINT_SCRIPTS=$(node -e "
+  const path = require('path'), os = require('os'), fs = require('fs');
+  const p = path.join(os.homedir(), '.agents', 'skills', 'senpi-entrypoint', 'scripts');
+  console.log(fs.existsSync(path.join(p, 'check-skill-updates.py')) ? p : '');
+" 2>/dev/null)
+
+if [ -n "$SENPI_ENTRYPOINT_SCRIPTS" ]; then
+  LIVE_UPDATE_OUTPUT=$(python3 "$SENPI_ENTRYPOINT_SCRIPTS/check-skill-updates.py" 2>/dev/null || true)
+fi
+```
+4. If updates exist in `UPDATE_OUTPUT` or `LIVE_UPDATE_OUTPUT`, append a short
+   user-friendly "What's new" addendum to the same response.
+5. If no updates exist, do not mention "What's new."
+
+⚠️ **Completion gate:** Do **NOT** consider the response complete until Step 3
+has run and Step 4/5 has been applied.
+
 ### "What is Senpi?" / "Summarize Senpi" / "Summarize skills and capabilities" / "How do I install skills?" / "What's new?"
 
 This is **explicit-ask only** — do not auto-insert this summary into normal
@@ -231,6 +257,11 @@ onboarding steps.
 When asked, load and follow
 [references/about-senpi.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/about-senpi.md)
 (`Summary Response Contract` section) for order, depth, and command behavior.
+
+For **"What is Senpi?"**, also include:
+- Goal-based skill picks from
+  [references/skill-recommendations.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-recommendations.md).
+- Current onboarding/auth status (`SENPI_AUTH_TOKEN` set or unset) and next setup step.
 
 ### "What skills should I install?" / "What should I use for [goal]?"
 

--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 compatibility: "Node.js, shell, Python 3, OpenClaw (optional — Step 5 cron)"
 metadata:
   author: Senpi
-  version: "1.2.4"
+  version: "1.2.2"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -17,9 +17,14 @@ Do not auto-insert this summary during normal onboarding.
 ## Mandatory Invocation Procedure (NOT Optional)
 
 Run this procedure for every summary/Q&A response handled by `senpi-entrypoint`:
-1. Run the pre-response invocation check from
-   [references/skill-update-checker.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-update-checker.md)
-   (`Pre-Response Invocation Check`) to capture queued `UPDATE_OUTPUT`.
+1. Ensure the pre-response invocation check has been executed exactly once for
+   this invocation, and use that `UPDATE_OUTPUT`.
+   - If `UPDATE_OUTPUT` is already available from `SKILL.md`'s top-level
+     `Pre-Response Check`, reuse it and do **not** run the check again.
+   - Run the checker from
+     [references/skill-update-checker.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-update-checker.md)
+     (`Pre-Response Invocation Check`) only as a fallback when it has not yet
+     been run in the current invocation.
 2. Compose the core answer using this summary contract.
 3. Resolve "What's new" using the rules in the `What's New` section below.
 4. If updates exist, append a short user-friendly "What's new" addendum; otherwise omit it.

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -19,13 +19,15 @@ Default response order (compact + actionable):
 2. Core capabilities
 3. Compact skill snapshot
 4. Install guidance
-5. What's new
+5. What's new (only if updates exist)
+6. Closing question
 
 Behavior rules:
 - Use queued startup `UPDATE_OUTPUT` for "what's new" when available.
 - Do not force a live update check in summary responses.
-- If no updates are queued, return neutral status and offer to run update/catalog refresh.
+- If no updates are queued, do not mention "what's new" at all.
 - Do not tell users to run CLI commands themselves; run install/update/list actions on their behalf.
+- End with: "Want me to recommend which skills to install next and set them up for you?"
 
 ## Core Capabilities
 
@@ -68,9 +70,7 @@ Use queued updates from the entrypoint startup pending file
 (`$SENPI_STATE_DIR/pending-skill-updates.json` when present). Do not force a
 live check in summary responses.
 
-If no updates are queued, return a neutral status and suggest:
-- the agent can apply installed skill updates now
-- the agent can fetch a fresh catalog now
+If no updates are queued, skip this section in the reply.
 
 ## Platform Reference
 

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -14,6 +14,18 @@ Use this section only for explicit summary questions such as:
 
 Do not auto-insert this summary during normal onboarding.
 
+## Mandatory Invocation Procedure (NOT Optional)
+
+Run this procedure for every summary/Q&A response handled by `senpi-entrypoint`:
+1. Run the pre-response invocation check from
+   [references/skill-update-checker.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-update-checker.md)
+   (`Pre-Response Invocation Check`) to capture queued `UPDATE_OUTPUT`.
+2. Compose the core answer using this summary contract.
+3. Resolve "What's new" using the rules in the `What's New` section below.
+4. If updates exist, append a short user-friendly "What's new" addendum; otherwise omit it.
+
+Completion gate: response is NOT complete until all steps above are executed.
+
 Default response order (compact + actionable):
 1. What Senpi is (one short definition)
 2. Core capabilities

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -73,8 +73,8 @@ SENPI_ENTRYPOINT_SCRIPTS=$(node -e "
   console.log(fs.existsSync(path.join(p, 'check-skill-updates.py')) ? p : '');
 " 2>/dev/null)
 
-if [ -n \"$SENPI_ENTRYPOINT_SCRIPTS\" ]; then
-  LIVE_UPDATE_OUTPUT=$(python3 \"$SENPI_ENTRYPOINT_SCRIPTS/check-skill-updates.py\" 2>/dev/null || true)
+if [ -n "$SENPI_ENTRYPOINT_SCRIPTS" ]; then
+  LIVE_UPDATE_OUTPUT=$(python3 "$SENPI_ENTRYPOINT_SCRIPTS/check-skill-updates.py" 2>/dev/null || true)
 fi
 ```
 

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -17,7 +17,7 @@ Do not auto-insert this summary during normal onboarding.
 Default response order (compact + actionable):
 1. What Senpi is (one short definition)
 2. Core capabilities
-3. Compact skill snapshot
+3. Full skill catalog (bullet list)
 4. Install guidance
 5. What's new (only if updates exist)
 6. Closing question
@@ -26,7 +26,9 @@ Behavior rules:
 - Use queued startup `UPDATE_OUTPUT` for "what's new" when available.
 - Do not force a live update check in summary responses.
 - If no updates are queued, do not mention "what's new" at all.
-- Do not tell users to run CLI commands themselves; run install/update/list actions on their behalf.
+- Do not mention CLI/commands in user-facing summary replies.
+- If user wants install/setup help, offer to handle it for them directly.
+- Present the entire skill catalog as bullet points (no tables).
 - End with: "Want me to recommend which skills to install next and set them up for you?"
 
 ## Core Capabilities
@@ -36,33 +38,26 @@ Behavior rules:
 - Apply risk controls such as dynamic stop-loss and budget-aware orchestration
 - Trade broad markets through Senpi's Hyperliquid-based stack (crypto perps and more)
 
-## Compact Skill Snapshot
+## Full Skill Catalog (Telegram-Friendly)
 
-### Protect Positions
-- `dsl-dynamic-stop-loss`: two-phase trailing stop-loss with tiered locking
-- `dsl-tight`: tighter DSL defaults for faster profit protection
-
-### Find Opportunities
-- `opportunity-scanner`: market-wide scoring and setup discovery
-- `emerging-movers`: smart-money rotation detection
-
-### Trade Autonomously or Copy
-- `wolf-strategy`: full autonomous trading stack
-- `autonomous-trading`: orchestrates DSL + scanner + movers
-- `whale-index`: mirrors top-performing traders
-- `wolf-howl`: nightly review and self-improvement loop (requires `wolf-strategy`)
+- `senpi-entrypoint`: onboarding flow for Senpi setup, discovery, and first-trade guidance.
+- `senpi-onboard`: account + API key + MCP setup workflow.
+- `senpi-getting-started-guide`: interactive first-trade walkthrough.
+- `dsl-dynamic-stop-loss`: two-phase trailing stop-loss with tiered locking.
+- `dsl-tight`: tighter DSL defaults for faster profit protection.
+- `opportunity-scanner`: market-wide scoring and setup discovery.
+- `emerging-movers`: smart-money rotation detection.
+- `autonomous-trading`: orchestrates DSL + scanner + movers.
+- `wolf-strategy`: full autonomous trading stack.
+- `wolf-howl`: nightly review and self-improvement loop.
+- `whale-index`: mirrors top-performing traders.
 
 ## Install Skills
 
-When users pick a skill, install it on their behalf with the skills CLI.
-Do not ask them to run terminal commands themselves.
-
-Default install action (agent-side):
-- Run: `npx skills add https://github.com/Senpi-ai/senpi-skills --skill <skill-name> -g -y`
-- Then report what was installed and suggest the immediate next action.
-
-For catalog refreshes, run the live list command agent-side and summarize results
-instead of pasting raw output.
+Keep this user-facing and non-technical:
+- Offer to install and set up selected skills for the user.
+- Confirm which skill(s) they want and their goal/budget before setup.
+- After setup, summarize what is ready and suggest the next best action.
 
 ## What's New
 

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -53,7 +53,7 @@ Behavior rules:
 - Apply risk controls such as dynamic stop-loss and budget-aware orchestration
 - Trade broad markets through Senpi's Hyperliquid-based stack (crypto perps and more)
 
-## Full Skill Catalog (Telegram-Friendly)
+## Full Skill Catalog
 
 - `senpi-entrypoint`: onboarding flow for Senpi setup, discovery, and first-trade guidance.
 - `senpi-onboard`: account + API key + MCP setup workflow.

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -24,8 +24,8 @@ Default response order (compact + actionable):
 
 Behavior rules:
 - Use queued startup `UPDATE_OUTPUT` for "what's new" when available.
-- Do not force a live update check in summary responses.
-- If no updates are queued, do not mention "what's new" at all.
+- If no queued updates exist, run one fresh update check before deciding.
+- If both queued and fresh checks show no updates, do not mention "what's new" at all.
 - Do not mention CLI/commands in user-facing summary replies.
 - If user wants install/setup help, offer to handle it for them directly.
 - Present the entire skill catalog as bullet points (no tables).
@@ -62,10 +62,26 @@ Keep this user-facing and non-technical:
 ## What's New
 
 Use queued updates from the entrypoint startup pending file
-(`$SENPI_STATE_DIR/pending-skill-updates.json` when present). Do not force a
-live check in summary responses.
+(`$SENPI_STATE_DIR/pending-skill-updates.json` when present).
 
-If no updates are queued, skip this section in the reply.
+If no queued updates exist, run one live check with the checker script:
+
+```bash
+SENPI_ENTRYPOINT_SCRIPTS=$(node -e "
+  const path = require('path'), os = require('os'), fs = require('fs');
+  const p = path.join(os.homedir(), '.agents', 'skills', 'senpi-entrypoint', 'scripts');
+  console.log(fs.existsSync(path.join(p, 'check-skill-updates.py')) ? p : '');
+" 2>/dev/null)
+
+if [ -n \"$SENPI_ENTRYPOINT_SCRIPTS\" ]; then
+  LIVE_UPDATE_OUTPUT=$(python3 \"$SENPI_ENTRYPOINT_SCRIPTS/check-skill-updates.py\" 2>/dev/null || true)
+fi
+```
+
+Rendering rule:
+- Prefer queued `UPDATE_OUTPUT` when it contains updates.
+- Otherwise use `LIVE_UPDATE_OUTPUT` if it contains updates.
+- If both are `HEARTBEAT_OK` / empty / invalid, skip this section in the reply.
 
 ## Platform Reference
 

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -29,6 +29,9 @@ Behavior rules:
 - Do not mention CLI/commands in user-facing summary replies.
 - If user wants install/setup help, offer to handle it for them directly.
 - Present the entire skill catalog as bullet points (no tables).
+- For "What is Senpi?", include a short onboarding-status note (`SENPI_AUTH_TOKEN` set/unset and next step).
+- For goal-based picks, also consult
+  [references/skill-recommendations.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-recommendations.md).
 - End with: "Want me to recommend which skills to install next and set them up for you?"
 
 ## Core Capabilities
@@ -58,6 +61,9 @@ Keep this user-facing and non-technical:
 - Offer to install and set up selected skills for the user.
 - Confirm which skill(s) they want and their goal/budget before setup.
 - After setup, summarize what is ready and suggest the next best action.
+
+For tailored recommendations by objective and budget, see
+[references/skill-recommendations.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-recommendations.md).
 
 ## What's New
 

--- a/senpi-entrypoint/references/skill-update-checker.md
+++ b/senpi-entrypoint/references/skill-update-checker.md
@@ -1,5 +1,23 @@
 # Skill Update Checker Reference
 
+## Pre-Response Invocation Check
+
+Run this check every time `senpi-entrypoint` is invoked, before composing a
+user-facing response:
+
+```bash
+SENPI_STATE_DIR="${SENPI_STATE_DIR:-$HOME/.config/senpi}"
+SENPI_PENDING="$SENPI_STATE_DIR/pending-skill-updates.json"
+if [ -f "$SENPI_PENDING" ]; then
+  UPDATE_OUTPUT=$(cat "$SENPI_PENDING") && rm -f "$SENPI_PENDING"
+fi
+```
+
+If `UPDATE_OUTPUT` contains updates, preserve it for response assembly and
+rendering. If it is heartbeat/empty, continue to normal response flow.
+
+---
+
 ## Output Handling
 
 At session startup the entrypoint reads


### PR DESCRIPTION
## Summary
- hide the 'What's New' section when no queued updates exist
- require a closing prompt that asks whether user wants skill recommendations and setup help

## Files
- senpi-entrypoint/SKILL.md (version bump to 1.2.3)
- senpi-entrypoint/references/about-senpi.md

## Why
- reduces noisy/random messaging
- nudges users into actionable next steps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `senpi-entrypoint` execution contract to always run a pre-response update check and alters summary/Q&A behavior (including optional live checks), which can affect user-facing messaging and when pending updates are cleared.
> 
> **Overview**
> Makes skill update detection **mandatory per `senpi-entrypoint` invocation**, centralizing it in a new `Pre-Response Check` flow and requiring downstream responses to reuse the same `UPDATE_OUTPUT` (no duplicate checks).
> 
> Tightens the summary/Q&A response contract in `references/about-senpi.md`: expands from a compact snapshot to a **full bullet catalog**, adds a required closing recommendation/setup question, and changes *“What’s new”* to **only render when updates exist** (falling back to a one-time live check when no queued updates are present).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c5e148fbe0e43e4dcddba708a216b889bbbe7a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->