### PR TITLE
DSL - SL run on hyperliquid

### DIFF
--- a/dsl-dynamic-stop-loss/SKILL.md
+++ b/dsl-dynamic-stop-loss/SKILL.md
@@ -32,7 +32,7 @@ metadata:
 
 ---
 
-Automated trailing stop loss for leveraged perp positions on Hyperliquid (main and xyz dex). Monitors price via cron, ratchets profit floors upward through configurable tiers, and **auto-closes positions on breach** — no agent intervention required for the critical path. v5 adds strategy-scoped state paths and delete-on-close cleanup.
+Automated trailing stop loss for leveraged perp positions on Hyperliquid (main and xyz dex). Monitors price via cron, ratchets profit floors upward through configurable tiers, and **syncs the stop loss to Hyperliquid** via Senpi `edit_position` so that **Hyperliquid executes the SL** when price hits — reducing loss exposure versus a 3-minute cron-only close. Breach detection, tier upgrades, and retraction logic still run in the cron; cancellation and setup of the SL happen via Senpi API; the new SL order ID is stored in state and status can be checked via `strategy_get_open_orders`. On breach the script may still call `close_position` as a backup. v5 adds strategy-scoped state paths and delete-on-close cleanup.
 
 ## Self-Contained Design
 
@@ -42,12 +42,13 @@ Script handles:              Agent handles:
 ✅ Reconcile state vs positions (delete orphan state files)   🧹 On strategy_inactive: remove cron, run cleanup
 ✅ Price monitoring           📊 Portfolio reporting
 ✅ High water + tier upgrades  🔄 Retry awareness (pendingClose alerts)
-✅ Breach + close (mcporter)  ⏰ One cron per strategy when user sets up DSL
+✅ Sync SL via edit_position (Senpi MCP); HL executes SL when price hits  ⏰ One cron per strategy when user sets up DSL
+✅ Breach + close_position backup (mcporter)  📋 sl_synced / sl_order_id in output
 ✅ State delete on close
 ✅ Error handling (fetch failures)
 ```
 
-The script closes positions directly via `mcporter`. If the agent is slow, busy, or restarting, the position still gets closed on the next cron tick.
+The script syncs the current effective floor to Hyperliquid as a native stop-loss order via Senpi `edit_position`. When price hits that level, Hyperliquid closes the position without waiting for the next cron tick. If the agent is slow or the SL did not fire yet, the script still attempts `close_position` on breach as a backup.
 
 ## How It Works
 
@@ -133,8 +134,10 @@ For LONGs, "best" = maximum. For SHORTs, "best" = minimum.
 │ 4. For each active position that has a state file:                        │
 │    • Fetch price via MCP (market_get_prices / allMids)                     │
 │    • Update high water, tier upgrades (ROE-based), effective floor         │
+│    • Sync SL: if no slOrderId or floor changed → edit_position(floor);    │
+│      store slOrderId (from response or strategy_get_open_orders)          │
 │    • Detect breaches (with decay modes)                                   │
-│    • ON BREACH: close via mcporter w/retry; delete state file on success  │
+│    • ON BREACH: close_position via mcporter (backup); delete state on ok  │
 │    • Print one JSON line per position (ndjson)                            │
 ├──────────────────────────────────────────────────────────────────────────┤
 │ Agent reads output (one line per position, or one strategy-level line):  │
@@ -153,8 +156,9 @@ For LONGs, "best" = maximum. For SHORTs, "best" = minimum.
 | `scripts/dsl-v5.py` | Strategy-scoped DSL: MCP clearinghouse + reconcile state, then per-position monitor/close, outputs ndjson |
 | `scripts/dsl-cleanup.py` | Strategy-level cleanup — deletes strategy dir when all positions closed |
 | State file (JSON) | Per-position config + runtime state; path: `{DSL_STATE_DIR}/{strategyId}/{asset}.json` |
+| [references/migration.md](references/migration.md) | Upgrading from cron-only DSL to Hyperliquid SL flow |
 
-Use `DSL_STATE_DIR` + `DSL_STRATEGY_ID` only for cron (no per-position env). See [references/state-schema.md](references/state-schema.md) for path conventions. Cleanup: [references/cleanup.md](references/cleanup.md).
+Use `DSL_STATE_DIR` + `DSL_STRATEGY_ID` only for cron (no per-position env). See [references/state-schema.md](references/state-schema.md) for path conventions. Cleanup: [references/cleanup.md](references/cleanup.md). Upgrading from cron-only DSL: [references/migration.md](references/migration.md).
 
 ## State File Schema
 
@@ -222,6 +226,7 @@ Key fields for agent decision-making:
 | `status: "error"` | Log; alert if `consecutive_failures >= 3` |
 | `breached: true` | Alert "⚠️ BREACH X/X" |
 | `distance_to_next_tier_pct < 2` | Optionally notify approaching next tier |
+| `sl_initial_sync: true` | Optional: notify user that trailing stop is now synced to Hyperliquid for this position (e.g. after upgrade) |
 
 ## Cron Setup
 
@@ -256,11 +261,12 @@ No `DSL_ASSET` — the script discovers positions from MCP clearinghouse and sta
 
 ### When a Position Closes
 
-1. ✅ Script closes position via `senpi:close_position` (coin with `xyz:` prefix as-is; with retry)
-2. ✅ Script deletes the state file (no archive)
-3. 🤖 **Agent:** On `closed=true` in script output — alert user. No need to disable a “position cron” (cron is per strategy and keeps running).
-4. 🤖 **Agent:** On `status: "strategy_inactive"` — remove the cron for that strategy and run strategy cleanup so the strategy directory is removed — see [references/cleanup.md](references/cleanup.md).
-5. 🤖 **Agent:** When the strategy has no state files left (e.g. all positions closed), the next run will output strategy_inactive; then agent removes cron and runs cleanup.
+1. ✅ **Hyperliquid** may close the position when price hits the synced SL (no cron delay). The script reconciles: on the next run the coin is no longer in clearinghouse, so the state file is deleted.
+2. ✅ On breach the script may close via `senpi:close_position` (backup; coin with `xyz:` prefix as-is; with retry)
+3. ✅ Script deletes the state file when position is closed (no archive)
+4. 🤖 **Agent:** On `closed=true` in script output — alert user. No need to disable a “position cron” (cron is per strategy and keeps running).
+5. 🤖 **Agent:** On `status: "strategy_inactive"` — remove the cron for that strategy and run strategy cleanup so the strategy directory is removed — see [references/cleanup.md](references/cleanup.md).
+6. 🤖 **Agent:** When the strategy has no state files left (e.g. all positions closed), the next run will output strategy_inactive; then agent removes cron and runs cleanup.
 
 If close fails, script sets `pendingClose: true` and retries on the next cron tick.
 
@@ -273,7 +279,9 @@ See [references/customization.md](references/customization.md) for conservative/
 - **Strategy active**: `senpi:strategy_get` via mcporter (by `strategy_id`); status must be ACTIVE or PAUSED for DSL to run
 - **Positions**: `senpi:strategy_get_clearinghouse_state` via mcporter (by strategy wallet from strategy_get)
 - **Price**: `senpi:market_get_prices` or `senpi:allMids` via mcporter (main + xyz dex)
-- **Close position**: `senpi:close_position` via mcporter (pass `coin` with `xyz:` prefix for xyz assets)
+- **Sync stop loss**: `senpi:edit_position` via mcporter (`strategyWalletAddress`, `coin`, `stopLoss: { price, orderType: "LIMIT" }`); cancels previous SL and sets new SL on Hyperliquid
+- **SL order status**: `senpi:strategy_get_open_orders` via mcporter (`strategy_wallet`, `dex`) to resolve or verify SL order ID
+- **Close position**: `senpi:close_position` via mcporter (backup on breach; pass `coin` with `xyz:` prefix for xyz assets)
 
 > ⚠️ **Do NOT use `strategy_close_strategy`** to close individual positions. That closes the **entire strategy** (irreversible). Use `close_position`.
 

--- a/dsl-dynamic-stop-loss/references/migration.md
+++ b/dsl-dynamic-stop-loss/references/migration.md
@@ -1,0 +1,40 @@
+# Upgrading / Migration (Hyperliquid SL flow)
+
+See the main skill: [SKILL.md](../SKILL.md).
+
+This document describes how to move from an earlier DSL version (cron-only breach detection and `close_position` on breach) to the current flow where the stop loss is synced to Hyperliquid via Senpi `edit_position` and Hyperliquid executes the SL when price hits.
+
+## Summary
+
+- **No separate migration script or manual state edits.** The main script ([scripts/dsl-v5.py](../scripts/dsl-v5.py)) performs migration on the first run after the update by syncing each position’s SL to Hyperliquid and backfilling state.
+- **Crons and state paths are unchanged.** Same env vars, same schedule, same state file paths.
+
+## Crons
+
+No change. The same per-strategy cron (same schedule, same env `DSL_STATE_DIR`, `DSL_STRATEGY_ID`) keeps running the updated script. Do not remove or recreate crons unless you are changing schedule or strategy.
+
+## State files
+
+No manual migration. Existing state files do not have `slOrderId`, `lastSyncedFloorPrice`, or `slOrderIdUpdatedAt`. On the **first run** after the update:
+
+1. For each position the script sees that `slOrderId` is missing.
+2. It calls `edit_position` to place the current effective floor as a stop loss on Hyperliquid.
+3. It writes `slOrderId`, `lastSyncedFloorPrice`, and `slOrderIdUpdatedAt` into the state file.
+
+From that run onward, the position is protected by Hyperliquid’s native SL and the script only updates the SL when the floor changes. The script output may include `sl_initial_sync: true` for positions that were migrated this run (see [output-schema.md](output-schema.md)).
+
+## Migrate immediately (optional)
+
+To sync SL to Hyperliquid without waiting for the next cron tick, run the same command the cron uses **once per strategy**, e.g.:
+
+```bash
+DSL_STATE_DIR=/data/workspace/dsl DSL_STRATEGY_ID=<strategy-uuid> python3 scripts/dsl-v5.py
+```
+
+That run will perform the initial sync for all positions of that strategy and backfill state. The agent may see `sl_initial_sync: true` in the output for those positions.
+
+## Best practices
+
+- **Single source of truth:** State is migrated by the same script that runs on schedule; no second migration script to keep in sync.
+- **Idempotent:** Running the script multiple times is safe; it only syncs when `slOrderId` is missing or the effective floor has changed.
+- **Agent visibility:** Use `sl_initial_sync: true` in the output to optionally notify the user that a position was just moved to the Hyperliquid SL flow (see [output-schema.md](output-schema.md) Agent Response Logic).

--- a/dsl-dynamic-stop-loss/references/output-schema.md
+++ b/dsl-dynamic-stop-loss/references/output-schema.md
@@ -32,7 +32,10 @@ The script prints a single JSON line to stdout on each run. The agent reads this
   "elapsed_minutes": 13,
   "distance_to_next_tier_pct": 6.54,
   "pending_close": false,
-  "consecutive_failures": 0
+  "consecutive_failures": 0,
+  "sl_synced": false,
+  "sl_initial_sync": false,
+  "sl_order_id": 12345678
 }
 ```
 
@@ -82,6 +85,14 @@ The script prints a single JSON line to stdout on each run. The agent reads this
 | `pending_close` | bool | True if close was attempted and failed |
 | `consecutive_failures` | int | Number of consecutive price fetch failures |
 
+### v5 Hyperliquid SL Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sl_synced` | bool | True if the SL was synced to Hyperliquid this tick (via `edit_position`) |
+| `sl_initial_sync` | bool | True if this tick was the first sync for this position (e.g. after upgrading to the Hyperliquid SL flow); state now has `slOrderId` and the position is protected by HL native SL |
+| `sl_order_id` | int/null | Hyperliquid order ID of the current SL for this position; null if not yet set or unavailable |
+
 ## Agent Response Logic
 
 ```
@@ -104,6 +115,9 @@ if breached == true (but not closing yet):
 
 if distance_to_next_tier_pct < 2:
   → optionally notify "approaching next tier lock"
+
+if sl_initial_sync == true:
+  → optionally notify user "Trailing stop is now synced to Hyperliquid for this position; it will close at the stop level even between cron runs."
 
 otherwise:
   → silent (HEARTBEAT_OK)

--- a/dsl-dynamic-stop-loss/references/state-schema.md
+++ b/dsl-dynamic-stop-loss/references/state-schema.md
@@ -110,6 +110,19 @@ Complete JSON schema for DSL v4/v5 state files. One state file per position. v5 
 | `lastCheck` | `null` | Last check timestamp — set by script |
 | `lastPrice` | `null` | Last fetched price — set by script |
 
+## v5 Hyperliquid SL Fields (optional)
+
+When the script syncs the dynamic stop loss to Hyperliquid via Senpi `edit_position`, it stores and updates these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slOrderId` | number \| null | Hyperliquid order ID of the current SL for this position. Set after a successful `edit_position` (or resolved via `strategy_get_open_orders`). |
+| `lastSyncedFloorPrice` | number \| null | The effective floor price at which the current SL was last placed on Hyperliquid. Used to detect when the floor has changed and a new SL must be set. |
+| `slOrderIdUpdatedAt` | string \| null | ISO 8601 timestamp when the SL was last synced (for debugging/audit). |
+| `lastSlSyncError` | string \| null | Set by script when `edit_position` or SL order resolution fails; next sync will retry. |
+
+Path and file naming stay the same; these fields are optional and backfilled by the script when syncing.
+
 ## v5 Path Conventions
 
 State files are stored under a directory per strategy. Required env vars:

--- a/dsl-dynamic-stop-loss/scripts/dsl-v5.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-v5.py
@@ -428,6 +428,139 @@ def update_breach_count(state: dict, breached: bool, decay_mode: str) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Edit position (sync SL) and open orders (MCP)
+# ---------------------------------------------------------------------------
+
+def _mcp_edit_position(
+    wallet: str, coin: str, stop_loss_price: float, order_type: str = "LIMIT"
+) -> tuple[bool, str | None, int | None]:
+    """Call senpi edit_position to set/update SL at price. Returns (success, error_message, sl_order_id_from_response).
+    sl_order_id_from_response is None if API does not return it (use strategy_get_open_orders to resolve).
+    """
+    args = {
+        "strategyWalletAddress": wallet,
+        "coin": coin,
+        "stopLoss": {"price": round(stop_loss_price, 4), "orderType": order_type},
+    }
+    try:
+        r = subprocess.run(
+            ["mcporter", "call", "senpi", "edit_position", "--args", json.dumps(args)],
+            capture_output=True, text=True, timeout=30,
+        )
+        raw = _unwrap_mcporter_response(r.stdout) if r.stdout else None
+        if r.returncode != 0:
+            return False, (r.stderr or r.stdout or "non-zero exit"), None
+        if not raw or not isinstance(raw, dict):
+            return False, "edit_position: invalid or empty response", None
+        if raw.get("success") is False:
+            err = raw.get("error", {})
+            msg = err.get("message", err.get("description", str(err))) if isinstance(err, dict) else str(err)
+            return False, msg, None
+        # MCP EditPosition returns data.ordersUpdated.stopLoss.orderId (or data = raw when unwrapped)
+        data = raw.get("data") or raw
+        oid = None
+        if isinstance(data, dict):
+            ou = data.get("ordersUpdated") or data.get("orders_updated")
+            if isinstance(ou, dict):
+                sl = ou.get("stopLoss") or ou.get("stop_loss")
+                if isinstance(sl, dict):
+                    oid = sl.get("orderId") or sl.get("order_id")
+            if oid is None:
+                oid = data.get("stopLossOrderId") or data.get("stop_loss_order_id")
+            if oid is not None:
+                try:
+                    oid = int(oid)
+                except (TypeError, ValueError):
+                    oid = None
+        return True, None, oid
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        return False, str(e), None
+
+
+def _mcp_strategy_get_open_orders(wallet: str, dex: str = "") -> tuple[list[dict], str | None]:
+    """Call senpi strategy_get_open_orders. Returns (list of orders with oid, coin, triggerPx, etc.), error.
+    dex must match the position's dex (same as for market price): '' for main, 'xyz' for xyz assets."""
+    args = {"strategy_wallet": wallet, "dex": dex}
+    try:
+        r = subprocess.run(
+            ["mcporter", "call", "senpi", "strategy_get_open_orders", "--args", json.dumps(args)],
+            capture_output=True, text=True, timeout=20,
+        )
+        if r.returncode != 0:
+            return [], (r.stderr or r.stdout or "non-zero exit")
+        raw = _unwrap_mcporter_response(r.stdout) if r.stdout else None
+        if not raw or not isinstance(raw, dict):
+            return [], "strategy_get_open_orders: invalid or empty response"
+        data = raw.get("data") or raw
+        orders = data.get("orders") if isinstance(data, dict) else None
+        if not isinstance(orders, list):
+            return [], None
+        return orders, None
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        return [], str(e)
+
+
+def _resolve_sl_order_id_after_edit(
+    wallet: str, dex: str, coin: str, trigger_price: float, orders: list[dict]
+) -> int | None:
+    """From strategy_get_open_orders list, find the SL order for this coin matching trigger_price. Return oid or None."""
+    for o in orders:
+        if not isinstance(o, dict):
+            continue
+        o_coin = o.get("coin")
+        if o_coin != coin:
+            continue
+        if not o.get("isTrigger", False) and not o.get("isPositionTpsl", False):
+            continue
+        try:
+            tp = float(o.get("triggerPx", 0))
+        except (TypeError, ValueError):
+            continue
+        if abs(tp - trigger_price) < 1e-6:
+            oid = o.get("oid")
+            if oid is not None:
+                try:
+                    return int(oid)
+                except (TypeError, ValueError):
+                    pass
+    return None
+
+
+def sync_sl_to_hyperliquid(
+    state: dict,
+    effective_floor: float,
+    now: str,
+    dex: str,
+) -> tuple[bool, bool, str | None]:
+    """Set or update SL on Hyperliquid at effective_floor via edit_position. Resolve slOrderId via open orders if needed.
+    Mutates state: slOrderId, lastSyncedFloorPrice, slOrderIdUpdatedAt.
+    Returns (success, sl_synced_this_tick, error_message)."""
+    wallet = state.get("wallet", "")
+    coin = state["asset"]
+    if not wallet:
+        return False, False, "no wallet in state"
+
+    success, err, oid_from_api = _mcp_edit_position(
+        wallet, coin, effective_floor, order_type="LIMIT"
+    )
+    if not success:
+        return False, False, err
+
+    oid = oid_from_api
+    if oid is None:
+        orders, orders_err = _mcp_strategy_get_open_orders(wallet, dex)
+        if orders_err:
+            return False, False, f"edit_ok_but_resolve_failed: {orders_err}"
+        oid = _resolve_sl_order_id_after_edit(wallet, dex, coin, effective_floor, orders)
+
+    state["lastSyncedFloorPrice"] = round(effective_floor, 4)
+    state["slOrderIdUpdatedAt"] = now
+    if oid is not None:
+        state["slOrderId"] = oid
+    return True, True, None
+
+
+# ---------------------------------------------------------------------------
 # Close position (MCP)
 # ---------------------------------------------------------------------------
 
@@ -531,6 +664,8 @@ def build_output(
     closed: bool,
     close_result: str | None,
     now: str,
+    sl_synced: bool = False,
+    sl_initial_sync: bool = False,
 ) -> dict:
     """Build the single JSON object printed to stdout."""
     is_long = direction == "LONG"
@@ -597,6 +732,9 @@ def build_output(
         "distance_to_next_tier_pct": distance_to_next_tier,
         "pending_close": state.get("pendingClose", False),
         "consecutive_failures": state.get("consecutiveFetchFailures", 0),
+        "sl_synced": sl_synced,
+        "sl_initial_sync": sl_initial_sync,
+        "sl_order_id": state.get("slOrderId"),
     }
 
 
@@ -680,6 +818,29 @@ def process_one_position(state_file: str, strategy_id: str, now: str) -> None:
     )
     state["floorPrice"] = round(effective_floor, 4)
 
+    # Optional: if we have slOrderId, verify it still exists on HL; if not, re-sync (SL cancelled externally)
+    last_synced = state.get("lastSyncedFloorPrice")
+    if state.get("slOrderId") is not None and last_synced is not None:
+        orders, _ = _mcp_strategy_get_open_orders(state.get("wallet", ""), dex)
+        oids_for_coin = [o.get("oid") for o in orders if isinstance(o, dict) and o.get("coin") == asset]
+        if state["slOrderId"] not in oids_for_coin:
+            state["lastSyncedFloorPrice"] = None  # force sync below
+
+    had_sl_order_before = state.get("slOrderId") is not None
+    # Sync SL to Hyperliquid: initial (no slOrderId) or floor changed
+    need_sync = (
+        state.get("slOrderId") is None
+        or state.get("lastSyncedFloorPrice") is None
+        or abs((state.get("lastSyncedFloorPrice") or 0) - effective_floor) > 1e-9
+    )
+    sl_synced_this_tick = False
+    if need_sync:
+        sync_ok, sl_synced_this_tick, sync_err = sync_sl_to_hyperliquid(state, effective_floor, now, dex)
+        if not sync_ok and sync_err:
+            # Log but continue; backup close on breach still available
+            state["lastSlSyncError"] = sync_err
+    sl_initial_sync = sl_synced_this_tick and not had_sl_order_before
+
     breached = price <= effective_floor if is_long else price >= effective_floor
     breach_count = update_breach_count(state, breached, state.get("breachDecay", "hard"))
     force_close = state.get("pendingClose", False)
@@ -717,6 +878,8 @@ def process_one_position(state_file: str, strategy_id: str, now: str) -> None:
         closed=closed,
         close_result=close_result,
         now=now,
+        sl_synced=sl_synced_this_tick,
+        sl_initial_sync=sl_initial_sync,
     )
     out["strategy_id"] = strategy_id
     print(json.dumps(out))

--- a/dsl-dynamic-stop-loss/scripts/dsl-v5.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-v5.py
@@ -551,7 +551,8 @@ def sync_sl_to_hyperliquid(
         orders, orders_err = _mcp_strategy_get_open_orders(wallet, dex)
         if orders_err:
             return False, False, f"edit_ok_but_resolve_failed: {orders_err}"
-        oid = _resolve_sl_order_id_after_edit(wallet, dex, coin, effective_floor, orders)
+        # Use rounded price to match what was sent to Hyperliquid (round(..., 4))
+        oid = _resolve_sl_order_id_after_edit(wallet, dex, coin, round(effective_floor, 4), orders)
 
     state["lastSyncedFloorPrice"] = round(effective_floor, 4)
     state["slOrderIdUpdatedAt"] = now
@@ -822,16 +823,25 @@ def process_one_position(state_file: str, strategy_id: str, now: str) -> None:
     last_synced = state.get("lastSyncedFloorPrice")
     if state.get("slOrderId") is not None and last_synced is not None:
         orders, _ = _mcp_strategy_get_open_orders(state.get("wallet", ""), dex)
-        oids_for_coin = [o.get("oid") for o in orders if isinstance(o, dict) and o.get("coin") == asset]
+        oids_for_coin = []
+        for o in orders:
+            if not isinstance(o, dict) or o.get("coin") != asset:
+                continue
+            oid = o.get("oid")
+            if oid is not None:
+                try:
+                    oids_for_coin.append(int(oid))
+                except (TypeError, ValueError):
+                    pass  # ignore non-int OIDs
         if state["slOrderId"] not in oids_for_coin:
             state["lastSyncedFloorPrice"] = None  # force sync below
 
     had_sl_order_before = state.get("slOrderId") is not None
-    # Sync SL to Hyperliquid: initial (no slOrderId) or floor changed
+    effective_floor_rounded = round(effective_floor, 4)
+    # Sync SL to Hyperliquid: never synced or floor changed (compare rounded to match stored lastSyncedFloorPrice)
     need_sync = (
-        state.get("slOrderId") is None
-        or state.get("lastSyncedFloorPrice") is None
-        or abs((state.get("lastSyncedFloorPrice") or 0) - effective_floor) > 1e-9
+        state.get("lastSyncedFloorPrice") is None
+        or abs((state.get("lastSyncedFloorPrice") or 0) - effective_floor_rounded) > 1e-9
     )
     sl_synced_this_tick = False
     if need_sync:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes position-protection and order-management behavior by placing/updating native Hyperliquid stop-loss orders via new MCP calls, with potential impact on live trading if the sync or order-ID resolution logic is wrong.
> 
> **Overview**
> **DSL v5 now syncs its computed trailing floor to Hyperliquid as a native stop-loss order** via Senpi `edit_position`, so positions can close immediately on stop hits instead of waiting for the next cron tick.
> 
> `scripts/dsl-v5.py` adds SL sync + reconciliation logic (place/update when missing or floor changes, resolve `slOrderId` via `strategy_get_open_orders`, and re-sync if the stored order disappears) while keeping the existing cron-based breach detection and `close_position` as a backup.
> 
> Docs and schemas are updated to reflect the new flow: new state fields (`slOrderId`, `lastSyncedFloorPrice`, timestamps/errors), new output fields (`sl_synced`, `sl_initial_sync`, `sl_order_id`), and a new `references/migration.md` describing automatic first-run backfill/migration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca208a6d5c6e6b202d686b278cfa327cb767df67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->