### PR TITLE
Tiger token optimization

### DIFF
--- a/tiger/README.md
+++ b/tiger/README.md
@@ -155,7 +155,7 @@ tiger-strategy/
 - atomic_write(), deep_merge(), mcporter_call() with 3-retry
 - Model tiering per cron (Tier 1/Tier 2)
 - HEARTBEAT_OK early exit pattern
-- Verbose mode via TIGER_VERBOSE=1
+- Full signal data always included (indicator values, factor breakdowns)
 - OpenClaw cron templates (systemEvent format)
 - State schema reference with full field documentation
 - Instance-scoped state (state/{instanceKey}/)

--- a/tiger/SKILL.md
+++ b/tiger/SKILL.md
@@ -12,7 +12,7 @@ compatibility: >-
   (configured with Senpi auth) and OpenClaw cron system.
 metadata:
   author: Jason & DanielM
-  version: "1.2.0"
+  version: "1.2.1"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/tiger/SKILL.md
+++ b/tiger/SKILL.md
@@ -75,6 +75,20 @@ metadata:
 
 ---
 
+## Lifecycle Walkthrough
+
+A compression breakout on HYPE, from signal to close:
+
+1. **Scanner fires** — Compression scanner (Cron 1) runs `compression-scanner.py`. Output: `{"signals": [{"asset": "HYPE", "direction": "LONG", "score": 0.72, "breakout": true, "risks": ["high_funding"]}], "strategySlots": {"available": 2, "anySlotsAvailable": true}}`.
+2. **Agent evaluates** — Score 0.72 exceeds NORMAL confluence threshold (0.40). Slots available. `breakout: true` and `direction` present (both required). Risk `high_funding` is noted but not blocking. Agent proceeds.
+3. **Agent enters** — Calls `create_position` with `coin: "HYPE"`, `direction: "LONG"`, `leverage: 10`, `marginAmount` from Half-Kelly sizing. Records position in `tiger-state.json`, creates `dsl-HYPE.json` with `active: true`, Phase 1 retrace at 0.015.
+4. **DSL monitors** — Cron 10 picks up `dsl-HYPE.json` every 30s. Position reaches 6% ROE → promotes to Tier 1 (locks 20% of high-water, retrace threshold 1.5%). Continues to 12% ROE → Tier 2 (locks 50%, retrace 1.2%).
+5. **Exit** — Price retraces 1.3% from high-water while in Tier 2. Two consecutive breaches → DSL auto-closes via `close_position`. Logs result to `trade-log.json`. Final ROE: ~8.5% after lock.
+
+If instead Risk Guardian (Cron 8) detects OI collapse > 25% during step 4, it closes the position directly and deactivates the DSL state file — DSL respects `active: false` on next tick.
+
+---
+
 ## 5 Signal Patterns
 
 ### 1. Compression Breakout (Primary)

--- a/tiger/SKILL.md
+++ b/tiger/SKILL.md
@@ -12,7 +12,7 @@ compatibility: >-
   (configured with Senpi auth) and OpenClaw cron system.
 metadata:
   author: Jason & DanielM
-  version: "1.2.1"
+  version: "1.2.2"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/tiger/SKILL.md
+++ b/tiger/SKILL.md
@@ -12,7 +12,7 @@ compatibility: >-
   (configured with Senpi auth) and OpenClaw cron system.
 metadata:
   author: Jason & DanielM
-  version: "1.2.2"
+  version: "1.2.3"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -241,6 +241,29 @@ All percentage values are whole numbers (5 = 5%).
 
 ---
 
+## Communication Discipline
+
+**Principle:** Only communicate actions and state changes. Never narrate routine operations.
+
+### When to communicate (valuable):
+- Trade ENTRY executed (scanner found actionable signal, position opened)
+- Trade EXIT executed (DSL, risk, or exit checker closed a position)
+- Aggression level CHANGED (goal engine shifted levels)
+- Risk event triggered (halt, drawdown breach, OI collapse)
+- ROAR made config adjustments
+- Target hit or deadline reached
+
+### When to stay silent (noise — output ONLY `HEARTBEAT_OK`):
+- Scanner ran, found 0 actionable signals
+- Scanner ran, slots full (SLOT GUARD triggered)
+- Scanner ran, system is halted
+- Goal engine ran, aggression unchanged
+- Any routine cycle with no state change
+
+**Rule:** When a cron produces no actionable result, output exactly `HEARTBEAT_OK` — no preamble, no summary of what was checked, no explanation of why nothing was found.
+
+---
+
 ## API Dependencies
 
 | Tool | Used By | Purpose |
@@ -297,7 +320,7 @@ See `references/cron-templates.md` for ready-to-use OpenClaw cron payloads.
 **Prescreener** (Cron 0): Runs `isolated` with `delivery.mode: "none"` and explicit model (`claude-haiku-4-5`). Writes prescreened.json — no trade actions.
 **Scanners** (Crons 1-5): Run in `main` session (`systemEvent`) so the agent can evaluate signals and execute `create_position`. Tier 1 analysis — the scripts produce JSON signals, the agent decides.
 **OI Tracker** (Cron 6): Runs `isolated` (`agentTurn`, `claude-haiku-4-5`). Data collection only — no trade actions.
-**Goal Engine** (Cron 7): Runs in `main` session (`systemEvent`). Tier 2 — recalculates aggression and sizing.
+**Goal Engine** (Cron 7): Runs `isolated` (`agentTurn`, `claude-sonnet-4-5`) with `delivery.mode: "announce"`. Tier 2 — recalculates aggression and sizing. Only announces when aggression changes, halts, or target is hit.
 **Risk Guardian / Exit Checker** (Crons 8-9): Run `isolated` (`agentTurn`, `claude-sonnet-4-5`). Scripts execute close actions directly and update state.
 **DSL** (Cron 10): Runs `isolated` (`agentTurn`, `claude-haiku-4-5`) — auto-closes positions on breach.
 **ROAR** (Cron 11): Runs `isolated` with `delivery.mode: "announce"` and explicit model (`claude-sonnet-4-5`). Tunes config — only announces when changes are made.

--- a/tiger/SKILL.md
+++ b/tiger/SKILL.md
@@ -281,9 +281,11 @@ See `references/cron-templates.md` for ready-to-use OpenClaw cron payloads.
 | 11 | ROAR Analyst | 8 hour | `roar-analyst.py` | Tier 2 |
 
 **Prescreener** (Cron 0): Runs `isolated` with `delivery.mode: "none"` and explicit model (`claude-haiku-4-5`). Writes prescreened.json — no trade actions.
-**Scanners** (Crons 1-6): Run in `main` session (`systemEvent`) so the agent can evaluate signals and execute `create_position`. Tier 1 analysis — the scripts produce JSON signals, the agent decides.
-**Decision-makers** (Crons 7-9): Run in `main` session (`systemEvent`). Tier 2 — goal engine, risk guardian, and exit checker execute directly (close_position) and update state.
-**DSL** (Cron 10): Runs in `main` session (`systemEvent`) — auto-closes positions on breach.
+**Scanners** (Crons 1-5): Run in `main` session (`systemEvent`) so the agent can evaluate signals and execute `create_position`. Tier 1 analysis — the scripts produce JSON signals, the agent decides.
+**OI Tracker** (Cron 6): Runs `isolated` (`agentTurn`, `claude-haiku-4-5`). Data collection only — no trade actions.
+**Goal Engine** (Cron 7): Runs in `main` session (`systemEvent`). Tier 2 — recalculates aggression and sizing.
+**Risk Guardian / Exit Checker** (Crons 8-9): Run `isolated` (`agentTurn`, `claude-sonnet-4-5`). Scripts execute close actions directly and update state.
+**DSL** (Cron 10): Runs `isolated` (`agentTurn`, `claude-haiku-4-5`) — auto-closes positions on breach.
 **ROAR** (Cron 11): Runs `isolated` with `delivery.mode: "announce"` and explicit model (`claude-sonnet-4-5`). Tunes config — only announces when changes are made.
 
 Scanners are staggered by 1-2 minutes to avoid mcporter rate limits (see cron-templates.md).

--- a/tiger/SKILL.md
+++ b/tiger/SKILL.md
@@ -12,7 +12,7 @@ compatibility: >-
   (configured with Senpi auth) and OpenClaw cron system.
 metadata:
   author: Jason & DanielM
-  version: "1.1.0"
+  version: "1.2.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/tiger/docs.md
+++ b/tiger/docs.md
@@ -59,7 +59,7 @@ TIGER is a fully automated trading system that takes a **budget**, **profit targ
 
 1. **Setup**: User runs `tiger-setup.py` with wallet, strategy ID, budget, target, deadline, and chat ID. This creates `tiger-config.json` and initializes state files.
 
-2. **Prescreening** (every 5m): Scores all ~230 Hyperliquid assets in a single API call. Ranks by a composite score (35% momentum + 20% funding rate + 15% OI ratio + 30% volume rank). Outputs top 30 candidates split into `group_a` (higher volatility) and `group_b`.
+2. **Prescreening** (every 5m): Scores all ~230 Hyperliquid assets in a single API call. Ranks by a composite score (35% momentum + 20% funding rate + 15% OI ratio + 30% volume rank). Outputs top 30 candidates split into `group_a` (higher volume) and `group_b` (lower volume).
 
 3. **Scanning** (5 scanners, staggered): Each scanner reads the prescreened candidates and evaluates them against pattern-specific confluence factors. Assets scoring above the aggression-adjusted confluence threshold produce actionable signals.
 
@@ -88,8 +88,7 @@ All scripts share state through JSON files in `state/{strategyId}/`, written ato
 tiger/
 ├── SKILL.md                          # Skill definition (agent-facing)
 ├── README.md                         # Quick start guide
-├── DOCUMENTATION.md                  # This file
-├── pending-enforcements.doc.md       # Design doc: advisory→deterministic enforcement
+├── docs.md                           # This file
 │
 ├── scripts/                          # 16 Python scripts
 │   ├── tiger_lib.py                  # Technical analysis library (pure stdlib)
@@ -116,19 +115,20 @@ tiger/
 │   ├── setup-guide.md                # Installation and tuning walkthrough
 │   └── cron-templates.md             # Ready-to-use OpenClaw cron payloads
 │
-├── tests/                            # 11 test files, 255 test functions
+├── tests/                            # 13 test files, 289 test functions
 │   ├── conftest.py                   # Shared fixtures and sample data
 │   ├── test_tiger_lib.py             # Technical analysis indicators
 │   ├── test_tiger_config.py          # Config loading, normalization, I/O
 │   ├── test_compression.py           # Compression scanner scoring
 │   ├── test_correlation.py           # BTC correlation lag detection
 │   ├── test_dsl_v4.py                # 2-phase trailing stop engine
+│   ├── test_goal_engine.py           # Goal engine clearinghouse guards
+│   ├── test_mcporter.py              # MCP I/O primitives, retry, envelope stripping
 │   ├── test_prescreener.py           # Asset prescreening pipeline
 │   ├── test_risk_guardian.py         # Risk limit enforcement
 │   ├── test_roar_analyst.py          # ROAR rules and scorecard
 │   ├── test_roar_config.py           # Bounds, protection, revert logic
-│   ├── test_tiger_exit.py            # Pattern-specific exit conditions
-│   └── (test_momentum, test_reversion — implicitly covered via integration)
+│   └── test_tiger_exit.py            # Pattern-specific exit conditions
 │
 └── state/                            # Runtime state (per strategy instance)
     └── {strategyId}/
@@ -177,30 +177,50 @@ Zero external dependencies. All indicators implemented with only `math` and `sta
 | `rsi(closes, period)` | Relative Strength Index |
 | `bollinger_bands(closes, period, num_std)` | Upper/mid/lower bands |
 | `bb_width(closes, period, num_std)` | Band width (squeeze detection) |
-| `bb_width_percentile(widths, current)` | Width percentile rank |
+| `bb_width_percentile(closes, period=20, lookback=100)` | Width percentile rank (computes widths internally) |
 | `atr(highs, lows, closes, period)` | Average True Range |
 | `volume_ratio(volumes, short, long)` | Short-term / long-term volume ratio |
 | `oi_change_pct(oi_series)` | Open Interest change percentage |
 | `detect_rsi_divergence(prices, rsi_values)` | Bullish/bearish divergence |
-| `confluence_score(factors, weights)` | Weighted factor summation (0-1) |
-| `kelly_fraction(win_rate, avg_win, avg_loss)` | Half-Kelly position sizing (capped 25%) |
+| `confluence_score(factors)` | Weighted factor summation (0-1), takes `Dict[str, Tuple[bool, float]]` |
+| `kelly_fraction(win_rate, avg_win, avg_loss, fraction=0.5)` | Half-Kelly position sizing (capped 25%) |
 | `required_daily_return(current, target, days)` | Compound daily rate needed |
 | `aggression_mode(daily_rate)` | Map rate → CONSERVATIVE/NORMAL/ELEVATED/ABORT |
 | `parse_candles(raw)` | Extract OHLCV arrays from Senpi candle format |
 
 #### tiger_config.py — Infrastructure
 
-| Component | Purpose |
-|-----------|---------|
-| `resolve_dependencies()` | Injectable dependency resolution (testable) |
-| `atomic_write(path, data)` | Crash-safe JSON writes via `os.replace()` |
-| `deep_merge(base, override)` | Recursive config merging with nested defaults |
-| `mcporter_call(tool, args)` | 3-attempt retry wrapper for Senpi MCP calls |
-| `AliasDict` | Transparent `snake_case` → `camelCase` key normalization |
-| `load_config()` | Read config with alias resolution |
-| `load_state() / save_state()` | State file I/O with atomic guarantees |
-| `get_active_positions()` | Parse clearinghouse for open positions |
-| `is_halted()` | Check safety halt flag |
+| Category | Component | Purpose |
+|----------|-----------|---------|
+| **Core** | `resolve_dependencies()` | Injectable dependency resolution (testable) |
+| | `build_runtime()` / `TigerRuntime` | Construct runtime with workspace paths and config location |
+| | `AliasDict` | Transparent `snake_case` → `camelCase` key normalization |
+| | `atomic_write(path, data)` | Crash-safe JSON writes via `os.replace()` |
+| | `deep_merge(base, override)` | Recursive config merging with nested defaults |
+| **Config** | `load_config()` | Read config with alias resolution |
+| | `save_config()` | Persist config to disk after normalizing |
+| **State** | `load_state() / save_state()` | State file I/O with atomic guarantees |
+| | `get_active_positions() / set_active_positions()` | Read/write active positions in state |
+| | `get_safety() / is_halted() / halt_reason()` | Safety substate and halt flag access |
+| | `set_halt_state()` | Set halt flag and reason in state |
+| | `load_dsl_state() / save_dsl_state()` | Per-position DSL trailing stop state |
+| | `load_oi_history() / append_oi_snapshot()` | OI history (last 288 per asset) |
+| | `log_trade() / load_trade_log()` | Trade log append and read |
+| | `load_btc_cache() / save_btc_cache()` | BTC price cache for correlation scanner |
+| | `load_prescreened_candidates()` | Load prescreened.json if fresh (<10min) |
+| | `get_disabled_patterns()` | Load ROAR-disabled patterns |
+| | `get_pattern_min_confluence()` | Resolve min confluence per pattern/aggression |
+| **MCP** | `mcporter_call(tool, args)` | 3-attempt retry wrapper for Senpi MCP calls |
+| | `mcporter_call_safe()` | Like mcporter_call but returns error dict |
+| | `get_all_instruments()` | Fetch all instruments with OI, funding, volume |
+| | `get_asset_candles()` | Fetch candle data for an asset |
+| | `get_prices()` / `get_sm_markets()` | Current prices / smart money markets |
+| | `get_portfolio()` / `get_clearinghouse()` | Portfolio and clearinghouse state |
+| | `create_position()` / `edit_position()` / `close_position()` | Position lifecycle MCP wrappers |
+| **Output** | `output()` / `output_heartbeat()` / `output_error()` | JSON output for cron communication |
+| **Utilities** | `now_utc()` / `hours_since()` | Time helpers |
+| | `days_remaining()` / `day_number()` | Deadline and day tracking |
+| | `shorten_address()` | Wallet address truncation |
 
 ### Cron Architecture
 
@@ -285,7 +305,7 @@ Advisory actions remain so because they require position-size computation that b
 
 **Window quality**: STRONG (lag > 0.7), MODERATE (0.5-0.7), CLOSING (0.4-0.5).
 
-**Optimization**: Scans 23 known high-corr alts first, then extends to 20 additional liquid assets only if no strong signals found. BTC price is cached to reduce API calls.
+**Optimization**: Scans 23 known high-corr alts first, plus 10 top-volume liquid assets. If no strong signals found, extends to 10 more assets. BTC price is cached to reduce API calls.
 
 **DSL tuning**: Tight Phase 1 retrace (0.015). Window closes fast — if the alt catches up, the edge is gone.
 
@@ -299,7 +319,7 @@ Advisory actions remain so because they require position-size computation that b
 | 2h price move | 0.15 | > 2.5% |
 | Volume surge | 0.20 | Ratio > 1.5x |
 | 4h trend aligned | 0.15 | Move matches 4h candle direction |
-| RSI not extreme | 0.10 | Between 30-70 |
+| RSI not extreme | 0.10 | Not overbought (≤78 for longs) or oversold (≥22 for shorts) |
 | SMA aligned | 0.10 | Price on correct side of SMA20 |
 | ATR healthy | 0.05 | > 1.5% |
 
@@ -352,7 +372,7 @@ Advisory actions remain so because they require position-size computation that b
 
 **Per-slot budget**: `current_balance * kelly_fraction`, subject to `maxSlots` (default: 3 concurrent positions).
 
-**Leverage**: Adaptive based on aggression. CONSERVATIVE 5-7x, NORMAL 7-10x, ELEVATED 10-15x, ABORT reduces (no new entries).
+**Leverage**: Adaptive based on required daily rate. <3% → 7x, <8% → 10x, <15% → 15x, ≥15% → maxLeverage. All capped by configured `maxLeverage`.
 
 ### Goal Engine & Aggression
 
@@ -376,7 +396,6 @@ Per-position state file. Combined runner checks all active positions every 30 se
 - Trailing floor: `high_water * (1 - retrace_threshold)` (LONG)
 - Absolute floor: `entry_price * (1 - phase1.retrace)` — never violated
 - 3 consecutive breaches → auto-close
-- Max duration: 90 minutes
 - Breach decay modes: "soft" (decay by 1 each check) or "hard" (reset to 0)
 
 **Phase 2** (tier 1+ activation at ROE ≥ 5%):
@@ -388,8 +407,6 @@ Per-position state file. Combined runner checks all active positions every 30 se
 | 3 | 20% | 70% | 1.0% | 2 |
 | 4 | 35% | 80% | 0.8% | 1 |
 
-**Stagnation take-profit**: ROE ≥ 8% with no new high-water for 1h → auto-close.
-
 ### Risk Management
 
 Enforced by `risk-guardian.py` every 5 minutes:
@@ -397,12 +414,15 @@ Enforced by `risk-guardian.py` every 5 minutes:
 | Rule | Limit | Default | Action |
 |------|-------|---------|--------|
 | Single trade loss | % of balance | 5% | CLOSE immediately |
-| Daily loss | % of day-start balance | 12% | HALT + CLOSE ALL |
+| Daily loss | % of day-start balance | 12% | HALT |
 | Drawdown from peak | % of peak balance | 20% | HALT |
 | OI collapse | OI drops >X% in 1h | 25% | CLOSE affected position |
 | OI drop | OI drops >X% in 1h | 10% | REDUCE (advisory) |
 | Funding reversal | Funding flips on FUNDING_ARB | Auto | CLOSE |
-| Deadline proximity | Final 24h | Auto | Tighten all stops to 90% lock |
+| Funding weak | Funding drops below 10% annualized | Auto | REDUCE (advisory) |
+| Deadline ≤0 days | Deadline reached | Auto | CLOSE ALL |
+| Deadline ≤12h | Imminent | Auto | Tighten all stops to 90% lock |
+| Deadline ≤24h | Approaching | Auto | Tighten all stops to 85% lock |
 | Max concurrent positions | Number of slots | 3 | Block new entries |
 
 ### Exit Checker — Pattern-Specific Rules
@@ -411,10 +431,10 @@ Enforced by `risk-guardian.py` every 5 minutes:
 |-----------|-----------|-----------|--------|
 | False breakout | Compression only | Re-enters BB range within 2 candles + ROE <3% | CLOSE |
 | Daily target hit | All patterns | Unrealized PnL ≥ daily target USD | CLOSE |
-| Trailing lock | All patterns | ROE below lock% of peak HWM | CLOSE |
+| Trailing lock | All patterns | HWM ROE >5% and ROE below lock% of peak HWM | CLOSE |
 | Conservative TP | All (CONSERVATIVE) | PnL > 50% daily target | PARTIAL_75 |
 | Stagnation | All patterns | ROE >3% but flat for 2+ hours | CLOSE |
-| Time stop | All patterns | Losing >30min + ROE <0% | CLOSE |
+| Time stop | All patterns | ROE < -2% pre-filter, then losing >30min + ROE <0% | CLOSE |
 | Deadline | All patterns | Days remaining ≤ 0 | CLOSE ALL |
 
 ### ROAR Meta-Optimizer
@@ -430,7 +450,7 @@ Runs every 8h (+ ad-hoc every 5th trade). Analyzes trade log, applies 6 rules:
 | 5 | No entries in 48h (5+ trades) | Lower threshold -0.02 |
 | 6 | Negative expectancy (20+ trades) | Disable pattern for 48h |
 
-**Protected keys** (never modified): budget, target, deadlineDays, maxSlots, maxLeverage, maxDrawdownPct, maxDailyLossPct, maxSingleLossPct, strategyWallet.
+**Protected keys** (never modified): budget, target, deadlineDays, startTime, strategyId, strategyWallet, telegramChatId, maxSlots, maxLeverage, maxDrawdownPct, maxDailyLossPct, maxSingleLossPct.
 
 **Safety net**: If both win rate AND avg PnL degraded since last adjustment, ROAR auto-reverts to the previous config snapshot.
 
@@ -443,6 +463,9 @@ Runs every 8h (+ ad-hoc every 5th trade). Analyzes trade log, applies 6 rules:
 | BTC correlation move % | 1.5 | 5.0 |
 | Funding annualized % | 15.0 | 60.0 |
 | DSL retrace (phase 1 & 2) | 0.008 | 0.03 |
+| Trailing lock % (CONSERVATIVE) | 0.60 | 0.95 |
+| Trailing lock % (NORMAL) | 0.40 | 0.80 |
+| Trailing lock % (ELEVATED) | 0.25 | 0.60 |
 
 ### Expected Performance
 
@@ -524,16 +547,18 @@ Runs every 8h (+ ad-hoc every 5th trade). Analyzes trade log, applies 6 rules:
 | File | Test Count | Component |
 |------|-----------|-----------|
 | `test_tiger_lib.py` | 65 | Technical analysis indicators |
+| `test_dsl_v4.py` | 38 | 2-phase trailing stop engine |
 | `test_roar_config.py` | 34 | ROAR bounds, protection, revert logic |
-| `test_dsl_v4.py` | 31 | 2-phase trailing stop engine |
-| `test_risk_guardian.py` | 29 | Risk limit enforcement |
+| `test_risk_guardian.py` | 32 | Risk limit enforcement |
 | `test_tiger_config.py` | 29 | Config loading, normalization, I/O |
 | `test_roar_analyst.py` | 19 | ROAR rules engine and scorecard |
-| `test_tiger_exit.py` | 15 | Pattern-specific exit conditions |
+| `test_tiger_exit.py` | 17 | Pattern-specific exit conditions |
+| `test_mcporter.py` | 14 | MCP I/O primitives, retry, envelope stripping |
 | `test_correlation.py` | 13 | BTC correlation lag detection |
 | `test_prescreener.py` | 12 | Asset prescreening pipeline |
-| `test_compression.py` | 8 | Compression scanner scoring |
-| **Total** | **255** | |
+| `test_compression.py` | 11 | Compression scanner scoring |
+| `test_goal_engine.py` | 4 | Goal engine clearinghouse guards |
+| **Total** | **288** | |
 
 ### Design Principle
 
@@ -579,7 +604,7 @@ State I/O:
 - Active positions: Empty portfolio handling
 - Pattern confluence: Override from config, aggression-level fallback
 
-#### test_dsl_v4.py (31 tests) — Trailing Stop Engine
+#### test_dsl_v4.py (38 tests) — Trailing Stop Engine
 
 Unit normalization:
 - `normalize_trigger_pct`: Whole number 5 → 0.05, whole number 100 → 1.0, already decimal passthrough, boundary at exactly 1, boundary just under 1, string input, zero, negative, valid number, invalid string, None, zero string
@@ -600,7 +625,7 @@ Phase 2 logic:
 General:
 - Inactive state returns inactive status, fetch failure counting
 
-#### test_risk_guardian.py (29 tests) — Risk Enforcement
+#### test_risk_guardian.py (32 tests) — Risk Enforcement
 
 Daily loss:
 - No breach (within limits), breach (exceeds limit), at exact limit (no breach)
@@ -668,7 +693,7 @@ Pattern disable:
 Config application:
 - Applies changes, skips protected keys, clamps to bounds, saves previous config snapshot
 
-#### test_tiger_exit.py (15 tests) — Pattern-Specific Exits
+#### test_tiger_exit.py (17 tests) — Pattern-Specific Exits
 
 - Daily target hit: Triggers when PnL exceeds target, no trigger below target
 - Trailing lock: Triggers when ROE below lock%, no trigger above lock, no trigger with insufficient HWM
@@ -709,7 +734,7 @@ Filtering:
 Output:
 - Writes to correct instance directory
 
-#### test_compression.py (8 tests) — BB Squeeze Detection
+#### test_compression.py (11 tests) — BB Squeeze Detection
 
 - Insufficient 1h candles, insufficient 4h candles
 - Fetch failure returns None
@@ -719,6 +744,16 @@ Output:
 - Disabled pattern triggers early exit
 - Active positions filtered (no duplicate signals)
 
+#### test_goal_engine.py (4 tests) — Goal Engine
+
+- Clearinghouse response guards and edge cases
+
+#### test_mcporter.py (14 tests) — MCP I/O Primitives
+
+- Retry logic and attempt counting
+- Envelope stripping from MCP responses
+- Error handling and safe call variants
+
 ### What Is NOT Tested
 
 For completeness, these components rely on integration rather than isolated unit tests:
@@ -726,7 +761,6 @@ For completeness, these components rely on integration rather than isolated unit
 - **Momentum scanner** and **reversion scanner**: Not individually unit-tested. Their logic is covered indirectly through `test_tiger_lib.py` (indicator correctness) and the shared scoring infrastructure tested in compression/correlation.
 - **Funding scanner**: Same coverage model as momentum/reversion — indicator math is tested via `tiger_lib`, pattern-specific logic follows the same structure as tested scanners.
 - **OI tracker**: Data collection script with minimal logic beyond API calls and file writes.
-- **Goal engine**: Aggression calculation is tested in `test_tiger_lib.py` (`aggression_mode`, `required_daily_return`, `kelly_fraction`). The script itself orchestrates these primitives.
 - **Setup wizard**: Interactive script, not suitable for automated testing.
 - **End-to-end integration**: No tests simulate a full scan → entry → management → exit lifecycle across multiple crons.
 - **MCP API calls**: All external calls go through `mcporter_call()` which is mocked in tests. No live API integration tests.

--- a/tiger/references/cron-templates.md
+++ b/tiger/references/cron-templates.md
@@ -52,7 +52,7 @@ Every 5 minutes. BB squeeze + OI breakout detection.
   "wakeMode": "now",
   "payload": {
     "kind": "systemEvent",
-    "text": "TIGER COMPRESSION SCANNER: Run `timeout 55 python3 {SCRIPTS}/compression-scanner.py`, parse JSON.\nIf actionable > 0 + slots available + not halted: evaluate top signal per SKILL.md.\nIf confluence ≥ threshold for current aggression: enter via create_position.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "text": "TIGER COMPRESSION SCANNER: Run `timeout 55 python3 {SCRIPTS}/compression-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + not halted: evaluate top signal per SKILL.md.\nIf confluence ≥ threshold for current aggression: enter via create_position.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
   }
 }
 ```
@@ -71,7 +71,7 @@ Every 3 minutes. BTC correlation lag detection.
   "wakeMode": "now",
   "payload": {
     "kind": "systemEvent",
-    "text": "TIGER CORRELATION SCANNER: Run `timeout 55 python3 {SCRIPTS}/correlation-scanner.py`, parse JSON.\nIf actionable > 0 + BTC move confirmed + lag ratio ≥ 0.5 + slots available:\nEnter via create_position. Notify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "text": "TIGER CORRELATION SCANNER: Run `timeout 55 python3 {SCRIPTS}/correlation-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + BTC move confirmed + lag ratio ≥ 0.5:\nEnter via create_position. Notify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
   }
 }
 ```
@@ -90,7 +90,7 @@ Every 5 minutes (offset 1 min from compression).
   "wakeMode": "now",
   "payload": {
     "kind": "systemEvent",
-    "text": "TIGER MOMENTUM SCANNER: Run `timeout 55 python3 {SCRIPTS}/momentum-scanner.py`, parse JSON.\nIf actionable > 0 + slots available: evaluate per SKILL.md momentum rules.\nUse tighter Phase 1 retrace (0.012) for DSL on momentum positions.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "text": "TIGER MOMENTUM SCANNER: Run `timeout 55 python3 {SCRIPTS}/momentum-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0: evaluate per SKILL.md momentum rules.\nUse tighter Phase 1 retrace (0.012) for DSL on momentum positions.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
   }
 }
 ```
@@ -109,7 +109,7 @@ Every 5 minutes (offset 2 min from compression).
   "wakeMode": "now",
   "payload": {
     "kind": "systemEvent",
-    "text": "TIGER REVERSION SCANNER: Run `timeout 55 python3 {SCRIPTS}/reversion-scanner.py`, parse JSON.\nIf actionable > 0 + 4h RSI extreme confirmed + slots available:\nEnter counter-trend per SKILL.md reversion rules.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "text": "TIGER REVERSION SCANNER: Run `timeout 55 python3 {SCRIPTS}/reversion-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + 4h RSI extreme confirmed:\nEnter counter-trend per SKILL.md reversion rules.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
   }
 }
 ```
@@ -128,7 +128,7 @@ Every 30 minutes.
   "wakeMode": "now",
   "payload": {
     "kind": "systemEvent",
-    "text": "TIGER FUNDING SCANNER: Run `timeout 55 python3 {SCRIPTS}/funding-scanner.py`, parse JSON.\nIf actionable > 0 + extreme funding confirmed + slots available:\nEnter opposite crowd per SKILL.md funding rules. Use wider DSL retrace (0.02+).\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "text": "TIGER FUNDING SCANNER: Run `timeout 55 python3 {SCRIPTS}/funding-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + extreme funding confirmed:\nEnter opposite crowd per SKILL.md funding rules. Use wider DSL retrace (0.02+).\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
   }
 }
 ```

--- a/tiger/references/cron-templates.md
+++ b/tiger/references/cron-templates.md
@@ -52,7 +52,7 @@ Every 5 minutes. BB squeeze + OI breakout detection.
   "wakeMode": "now",
   "payload": {
     "kind": "systemEvent",
-    "text": "TIGER COMPRESSION SCANNER: Run `timeout 55 python3 {SCRIPTS}/compression-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + not halted: evaluate top signal per SKILL.md.\nIf confluence ≥ threshold for current aggression: enter via create_position.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "text": "TIGER COMPRESSION SCANNER: Run `timeout 55 python3 {SCRIPTS}/compression-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + not halted: evaluate top signal per SKILL.md.\nIf confluence ≥ threshold for current aggression: enter via create_position.\nNotify Telegram ({TELEGRAM}).\nIf no entry: output ONLY HEARTBEAT_OK — no summary, no reasoning."
   }
 }
 ```
@@ -71,7 +71,7 @@ Every 3 minutes. BTC correlation lag detection.
   "wakeMode": "now",
   "payload": {
     "kind": "systemEvent",
-    "text": "TIGER CORRELATION SCANNER: Run `timeout 55 python3 {SCRIPTS}/correlation-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + BTC move confirmed + lag ratio ≥ 0.5:\nEnter via create_position. Notify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "text": "TIGER CORRELATION SCANNER: Run `timeout 55 python3 {SCRIPTS}/correlation-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + BTC move confirmed + lag ratio ≥ 0.5:\nEnter via create_position. Notify Telegram ({TELEGRAM}).\nIf no entry: output ONLY HEARTBEAT_OK — no summary, no reasoning."
   }
 }
 ```
@@ -90,7 +90,7 @@ Every 5 minutes (offset 1 min from compression).
   "wakeMode": "now",
   "payload": {
     "kind": "systemEvent",
-    "text": "TIGER MOMENTUM SCANNER: Run `timeout 55 python3 {SCRIPTS}/momentum-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0: evaluate per SKILL.md momentum rules.\nUse tighter Phase 1 retrace (0.012) for DSL on momentum positions.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "text": "TIGER MOMENTUM SCANNER: Run `timeout 55 python3 {SCRIPTS}/momentum-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0: evaluate per SKILL.md momentum rules.\nUse tighter Phase 1 retrace (0.012) for DSL on momentum positions.\nNotify Telegram ({TELEGRAM}).\nIf no entry: output ONLY HEARTBEAT_OK — no summary, no reasoning."
   }
 }
 ```
@@ -109,7 +109,7 @@ Every 5 minutes (offset 2 min from compression).
   "wakeMode": "now",
   "payload": {
     "kind": "systemEvent",
-    "text": "TIGER REVERSION SCANNER: Run `timeout 55 python3 {SCRIPTS}/reversion-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + 4h RSI extreme confirmed:\nEnter counter-trend per SKILL.md reversion rules.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "text": "TIGER REVERSION SCANNER: Run `timeout 55 python3 {SCRIPTS}/reversion-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + 4h RSI extreme confirmed:\nEnter counter-trend per SKILL.md reversion rules.\nNotify Telegram ({TELEGRAM}).\nIf no entry: output ONLY HEARTBEAT_OK — no summary, no reasoning."
   }
 }
 ```
@@ -128,7 +128,7 @@ Every 30 minutes.
   "wakeMode": "now",
   "payload": {
     "kind": "systemEvent",
-    "text": "TIGER FUNDING SCANNER: Run `timeout 55 python3 {SCRIPTS}/funding-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + extreme funding confirmed:\nEnter opposite crowd per SKILL.md funding rules. Use wider DSL retrace (0.02+).\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "text": "TIGER FUNDING SCANNER: Run `timeout 55 python3 {SCRIPTS}/funding-scanner.py`, parse JSON.\nSLOT GUARD (MANDATORY): If strategySlots.anySlotsAvailable is false → HEARTBEAT_OK, do NOT enter.\nIf actionable > 0 + extreme funding confirmed:\nEnter opposite crowd per SKILL.md funding rules. Use wider DSL retrace (0.02+).\nNotify Telegram ({TELEGRAM}).\nIf no entry: output ONLY HEARTBEAT_OK — no summary, no reasoning."
   }
 }
 ```
@@ -160,17 +160,24 @@ Every 5 minutes (offset 3 min). Data collection only.
 
 ## Cron 7: Goal Engine — Tier 2
 
-Every 1 hour. Requires judgment: evaluate aggression level.
+Every 1 hour. Isolated with announce — only delivers when aggression changes, halts, or target is hit.
 
 ```json
 {
   "name": "TIGER — Goal Engine",
   "schedule": { "kind": "every", "everyMs": 3600000 },
-  "sessionTarget": "main",
-  "wakeMode": "now",
+  "sessionTarget": "isolated",
+  "wakeMode": "next-heartbeat",
   "payload": {
-    "kind": "systemEvent",
-    "text": "TIGER GOAL ENGINE: Run `python3 {SCRIPTS}/goal-engine.py`, parse JSON.\nUpdate aggression level. If aggression changed → notify Telegram ({TELEGRAM}).\nIf ABORT → tighten all stops, stop new entries.\nElse HEARTBEAT_OK."
+    "kind": "agentTurn",
+    "message": "TIGER GOAL ENGINE: Run `python3 {SCRIPTS}/goal-engine.py`, parse JSON.\nIf aggression_changed is true OR halted is true OR TARGET_HIT is true → send ONE Telegram to {TELEGRAM} summarizing the change.\nElse HEARTBEAT_OK.",
+    "model": "anthropic/claude-sonnet-4-5-20250929"
+  },
+  "delivery": {
+    "mode": "announce",
+    "channel": "telegram",
+    "to": "{TELEGRAM}",
+    "bestEffort": true
   }
 }
 ```
@@ -299,7 +306,7 @@ Correlation (3min) and Funding (30min) run on their own cadence. DSL runs every 
 | 4 | tiger-reversion | 300000 (5m) | **main** | systemEvent | — | Tier 1 | Overextension fade |
 | 5 | tiger-funding | 1800000 (30m) | **main** | systemEvent | — | Tier 1 | Funding arb |
 | 6 | tiger-oi | 300000 (5m) | isolated | agentTurn | none | Tier 1 | Data collection |
-| 7 | tiger-goal | 3600000 (1h) | **main** | systemEvent | — | Tier 2 | Aggression |
+| 7 | tiger-goal | 3600000 (1h) | isolated | agentTurn | announce | Tier 2 | Aggression |
 | 8 | tiger-risk | 300000 (5m) | isolated | agentTurn | none | Tier 2 | Risk limits |
 | 9 | tiger-exit | 300000 (5m) | isolated | agentTurn | none | Tier 2 | Pattern exits |
 | 10 | tiger-dsl | 30000 (30s) | isolated | agentTurn | none | Tier 1 | Trailing stops |

--- a/tiger/references/cron-templates.md
+++ b/tiger/references/cron-templates.md
@@ -143,11 +143,15 @@ Every 5 minutes (offset 3 min). Data collection only.
 {
   "name": "TIGER — OI Tracker",
   "schedule": { "kind": "every", "everyMs": 300000 },
-  "sessionTarget": "main",
-  "wakeMode": "now",
+  "sessionTarget": "isolated",
+  "wakeMode": "next-heartbeat",
   "payload": {
-    "kind": "systemEvent",
-    "text": "TIGER OI TRACKER: Run `timeout 55 python3 {SCRIPTS}/oi-tracker.py`, parse JSON.\nData collection only — no trading actions.\nIf error → notify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "kind": "agentTurn",
+    "message": "TIGER OI TRACKER: Run `timeout 55 python3 {SCRIPTS}/oi-tracker.py`, parse JSON.\nData collection only — no trading actions.\nIf error → notify Telegram ({TELEGRAM}). Else HEARTBEAT_OK.",
+    "model": "anthropic/claude-haiku-4-5"
+  },
+  "delivery": {
+    "mode": "none"
   }
 }
 ```
@@ -181,11 +185,15 @@ Every 5 minutes (offset 4 min). Enforces all risk limits.
 {
   "name": "TIGER — Risk Guardian",
   "schedule": { "kind": "every", "everyMs": 300000 },
-  "sessionTarget": "main",
-  "wakeMode": "now",
+  "sessionTarget": "isolated",
+  "wakeMode": "next-heartbeat",
   "payload": {
-    "kind": "systemEvent",
-    "text": "TIGER RISK GUARDIAN: Run `python3 {SCRIPTS}/risk-guardian.py`, parse JSON.\n\nPROCESSING ORDER:\n1. Read state ONCE.\n2. Check daily loss, drawdown, single position limits per SKILL.md.\n3. Check OI collapse, funding reversal for FUNDING_ARB positions.\n4. Script executes close actions directly and sets halted when critical.\n5. Send ONE Telegram ({TELEGRAM}).\n\nElse HEARTBEAT_OK."
+    "kind": "agentTurn",
+    "message": "TIGER RISK GUARDIAN: Run `python3 {SCRIPTS}/risk-guardian.py`, parse JSON.\n\nPROCESSING ORDER:\n1. Read state ONCE.\n2. Check daily loss, drawdown, single position limits per SKILL.md.\n3. Check OI collapse, funding reversal for FUNDING_ARB positions.\n4. Script executes close actions directly and sets halted when critical.\n5. Send ONE Telegram ({TELEGRAM}).\n\nElse HEARTBEAT_OK.",
+    "model": "anthropic/claude-sonnet-4-5-20250929"
+  },
+  "delivery": {
+    "mode": "none"
   }
 }
 ```
@@ -200,11 +208,15 @@ Every 5 minutes (runs with risk guardian).
 {
   "name": "TIGER — Exit Checker",
   "schedule": { "kind": "every", "everyMs": 300000 },
-  "sessionTarget": "main",
-  "wakeMode": "now",
+  "sessionTarget": "isolated",
+  "wakeMode": "next-heartbeat",
   "payload": {
-    "kind": "systemEvent",
-    "text": "TIGER EXIT CHECKER: Run `python3 {SCRIPTS}/tiger-exit.py`, parse JSON.\nScript executes CLOSE exits directly; PARTIAL actions remain advisory.\nPattern-specific exits per SKILL.md. Deadline proximity: tighten stops in final 24h.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "kind": "agentTurn",
+    "message": "TIGER EXIT CHECKER: Run `python3 {SCRIPTS}/tiger-exit.py`, parse JSON.\nScript executes CLOSE exits directly; PARTIAL actions remain advisory.\nPattern-specific exits per SKILL.md. Deadline proximity: tighten stops in final 24h.\nNotify Telegram ({TELEGRAM}). Else HEARTBEAT_OK.",
+    "model": "anthropic/claude-sonnet-4-5-20250929"
+  },
+  "delivery": {
+    "mode": "none"
   }
 }
 ```
@@ -219,11 +231,15 @@ Every 30 seconds. Iterates all active DSL state files for the strategy instance.
 {
   "name": "TIGER — DSL Trailing Stops",
   "schedule": { "kind": "every", "everyMs": 30000 },
-  "sessionTarget": "main",
-  "wakeMode": "now",
+  "sessionTarget": "isolated",
+  "wakeMode": "next-heartbeat",
   "payload": {
-    "kind": "systemEvent",
-    "text": "TIGER DSL: Run `python3 {SCRIPTS}/dsl-v4.py`, parse JSON.\nWhen DSL_STATE_FILE is unset, dsl-v4 runs in combined mode across all dsl-*.json files.\nDSL is self-contained — auto-closes via close_position on breach.\nIf position closed → notify Telegram ({TELEGRAM}). Else HEARTBEAT_OK."
+    "kind": "agentTurn",
+    "message": "TIGER DSL: Run `python3 {SCRIPTS}/dsl-v4.py`, parse JSON.\nWhen DSL_STATE_FILE is unset, dsl-v4 runs in combined mode across all dsl-*.json files.\nDSL is self-contained — auto-closes via close_position on breach.\nIf position closed → notify Telegram ({TELEGRAM}). Else HEARTBEAT_OK.",
+    "model": "anthropic/claude-haiku-4-5"
+  },
+  "delivery": {
+    "mode": "none"
   }
 }
 ```
@@ -282,9 +298,9 @@ Correlation (3min) and Funding (30min) run on their own cadence. DSL runs every 
 | 3 | tiger-momentum | 300000 (5m) | **main** | systemEvent | — | Tier 1 | Price move + volume |
 | 4 | tiger-reversion | 300000 (5m) | **main** | systemEvent | — | Tier 1 | Overextension fade |
 | 5 | tiger-funding | 1800000 (30m) | **main** | systemEvent | — | Tier 1 | Funding arb |
-| 6 | tiger-oi | 300000 (5m) | **main** | systemEvent | — | Tier 1 | Data collection |
+| 6 | tiger-oi | 300000 (5m) | isolated | agentTurn | none | Tier 1 | Data collection |
 | 7 | tiger-goal | 3600000 (1h) | **main** | systemEvent | — | Tier 2 | Aggression |
-| 8 | tiger-risk | 300000 (5m) | **main** | systemEvent | — | Tier 2 | Risk limits |
-| 9 | tiger-exit | 300000 (5m) | **main** | systemEvent | — | Tier 2 | Pattern exits |
-| 10 | tiger-dsl | 30000 (30s) | **main** | systemEvent | — | Tier 1 | Trailing stops |
+| 8 | tiger-risk | 300000 (5m) | isolated | agentTurn | none | Tier 2 | Risk limits |
+| 9 | tiger-exit | 300000 (5m) | isolated | agentTurn | none | Tier 2 | Pattern exits |
+| 10 | tiger-dsl | 30000 (30s) | isolated | agentTurn | none | Tier 1 | Trailing stops |
 | 11 | tiger-roar | 28800000 (8h) | isolated | agentTurn | announce | Tier 2 | Meta-optimizer |

--- a/tiger/references/setup-guide.md
+++ b/tiger/references/setup-guide.md
@@ -11,7 +11,7 @@
 ### 1. Create workspace
 
 ```bash
-export TIGER_WORKSPACE="$HOME/tiger"
+export TIGER_WORKSPACE="$OPENCLAW_WORKSPACE_DIR/tiger"
 mkdir -p $TIGER_WORKSPACE/state/scan-history
 ```
 

--- a/tiger/scripts/compression-scanner.py
+++ b/tiger/scripts/compression-scanner.py
@@ -216,7 +216,11 @@ def main(deps=None):
         "action": "compression_scan",
         "scanned": len(candidates),
         "actionable": len(actionable),
-        "available_slots": available_slots,
+        "strategySlots": {
+            "available": available_slots,
+            "max": config["maxSlots"],
+            "anySlotsAvailable": available_slots > 0,
+        },
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
     }

--- a/tiger/scripts/compression-scanner.py
+++ b/tiger/scripts/compression-scanner.py
@@ -113,13 +113,13 @@ def scan_asset(asset: str, context: dict, config: dict, oi_hist: dict, get_asset
             "current_price": current_price,
             "max_leverage": context.get("max_leverage", 0),
         }
-        if os.environ.get("TIGER_VERBOSE") == "1":
-            result["bb_squeeze_percentile"] = round(squeeze_pctl, 1)
-            result["rsi"] = round(current_rsi, 1) if current_rsi else None
-            result["atr_pct"] = round(atr_pct, 2)
-            result["volume_ratio"] = round(vol_ratio, 2) if vol_ratio else None
-            result["oi_change_1h_pct"] = round(oi_change, 1) if oi_change else None
-            result["factors"] = {k: v[0] for k, v in factors.items()}
+        result["bb_squeeze_percentile"] = round(squeeze_pctl, 1)
+        result["rsi"] = round(current_rsi, 1) if current_rsi else None
+        result["atr_pct"] = round(atr_pct, 2)
+        result["volume_ratio"] = round(vol_ratio, 2) if vol_ratio else None
+        result["oi_change_1h_pct"] = round(oi_change, 1) if oi_change else None
+        result["funding_annualized_pct"] = round(funding_annualized, 1)
+        result["factors"] = {k: v[0] for k, v in factors.items()}
         return result
 
     return None

--- a/tiger/scripts/compression-scanner.py
+++ b/tiger/scripts/compression-scanner.py
@@ -212,19 +212,17 @@ def main(deps=None):
     # Check slot availability
     available_slots = config["maxSlots"] - len(active_coins)
 
+    if not actionable:
+        output({"success": True, "heartbeat": "HEARTBEAT_OK"})
+        return
+
     report = {
         "action": "compression_scan",
         "scanned": len(candidates),
-        "signals_found": len(signals),
         "actionable": len(actionable),
-        "watching": len(watching),
         "available_slots": available_slots,
-        "min_score": min_score,
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
-        "watching_list": watching[:5],
-        "all_signals": signals[:5],
-        "active_positions": list(active_coins)
     }
 
     output(report)

--- a/tiger/scripts/compression-scanner.py
+++ b/tiger/scripts/compression-scanner.py
@@ -23,12 +23,11 @@ def scan_asset(asset: str, context: dict, config: dict, oi_hist: dict, get_asset
     """Analyze a single asset for compression breakout potential."""
     # Fetch candles
     result = get_asset_candles_fn(asset, ["1h", "4h"])
-    if not result.get("success") and not result.get("data"):
+    if not result or result.get("error"):
         return None
 
-    data = result.get("data", result)
-    candles_1h = data.get("candles", {}).get("1h", [])
-    candles_4h = data.get("candles", {}).get("4h", [])
+    candles_1h = result.get("candles", {}).get("1h", [])
+    candles_4h = result.get("candles", {}).get("4h", [])
 
     if len(candles_1h) < 30 or len(candles_4h) < 25:
         return None

--- a/tiger/scripts/compression-scanner.py
+++ b/tiger/scripts/compression-scanner.py
@@ -105,26 +105,23 @@ def scan_asset(asset: str, context: dict, config: dict, oi_hist: dict, get_asset
 
     # Only report if in squeeze or breaking out
     if squeeze_pctl is not None and squeeze_pctl < 40:
-        return {
+        result = {
             "asset": asset,
             "pattern": "COMPRESSION_BREAKOUT",
             "score": round(score, 2),
             "direction": breakout_direction,
-            "bb_squeeze_percentile": round(squeeze_pctl, 1),
             "breakout": breakout_direction is not None,
             "current_price": current_price,
-            "upper_bb": round(upper_1h[-1], 4),
-            "lower_bb": round(lower_1h[-1], 4),
-            "rsi": round(current_rsi, 1) if current_rsi else None,
-            "atr_pct": round(atr_pct, 2),
-            "volume_ratio": round(vol_ratio, 2) if vol_ratio else None,
-            "oi": oi,
-            "oi_change_1h_pct": round(oi_change, 1) if oi_change else None,
-            "oi_price_divergence": oi_price_divergence,
-            "funding_annualized_pct": round(funding_annualized, 1),
             "max_leverage": context.get("max_leverage", 0),
-            "factors": {k: v[0] for k, v in factors.items()}
         }
+        if os.environ.get("TIGER_VERBOSE") == "1":
+            result["bb_squeeze_percentile"] = round(squeeze_pctl, 1)
+            result["rsi"] = round(current_rsi, 1) if current_rsi else None
+            result["atr_pct"] = round(atr_pct, 2)
+            result["volume_ratio"] = round(vol_ratio, 2) if vol_ratio else None
+            result["oi_change_1h_pct"] = round(oi_change, 1) if oi_change else None
+            result["factors"] = {k: v[0] for k, v in factors.items()}
+        return result
 
     return None
 

--- a/tiger/scripts/compression-scanner.py
+++ b/tiger/scripts/compression-scanner.py
@@ -208,7 +208,7 @@ def main(deps=None):
     # Check slot availability
     available_slots = config["maxSlots"] - len(active_coins)
 
-    if not actionable:
+    if not actionable and not watching:
         output({"success": True, "heartbeat": "HEARTBEAT_OK"})
         return
 
@@ -216,6 +216,7 @@ def main(deps=None):
         "action": "compression_scan",
         "scanned": len(candidates),
         "actionable": len(actionable),
+        "watching": len(watching),
         "strategySlots": {
             "available": available_slots,
             "max": config["maxSlots"],
@@ -223,6 +224,7 @@ def main(deps=None):
         },
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
+        "watching_list": watching[:3],
     }
 
     output(report)

--- a/tiger/scripts/correlation-scanner.py
+++ b/tiger/scripts/correlation-scanner.py
@@ -172,13 +172,12 @@ def check_alt_lag(
         "window_quality": window_quality,
         "max_leverage": max_lev,
     }
-    if os.environ.get("TIGER_VERBOSE") == "1":
-        result["alt_move_4h_pct"] = round(alt_move_4h, 2)
-        result["expected_catchup_pct"] = round(expected_catchup, 2)
-        result["volume_ratio"] = round(vol_r, 2) if vol_r else None
-        result["rsi"] = round(current_rsi, 1) if current_rsi else None
-        result["sm_aligned"] = sm_aligned
-        result["factors"] = {k: v[0] for k, v in factors.items()}
+    result["alt_move_4h_pct"] = round(alt_move_4h, 2)
+    result["expected_catchup_pct"] = round(expected_catchup, 2)
+    result["volume_ratio"] = round(vol_r, 2) if vol_r else None
+    result["rsi"] = round(current_rsi, 1) if current_rsi else None
+    result["sm_aligned"] = sm_aligned
+    result["factors"] = {k: v[0] for k, v in factors.items()}
     return result
 
 

--- a/tiger/scripts/correlation-scanner.py
+++ b/tiger/scripts/correlation-scanner.py
@@ -35,11 +35,10 @@ def check_btc_move(config: dict, state: dict, get_asset_candles_fn, now_fn=None)
     now_fn = now_fn or (lambda: datetime.now(timezone.utc).isoformat())
 
     result = get_asset_candles_fn("BTC", ["1h"])
-    if not result.get("success") and not result.get("data"):
+    if not result or result.get("error"):
         return {"triggered": False, "error": "Failed to fetch BTC data"}
 
-    data = result.get("data", result)
-    candles = data.get("candles", {}).get("1h", [])
+    candles = result.get("candles", {}).get("1h", [])
     if len(candles) < 5:
         return {"triggered": False, "error": "Insufficient BTC candle data"}
 
@@ -82,12 +81,11 @@ def check_alt_lag(
 ) -> dict:
     """Check if an alt is lagging behind BTC's move."""
     result = get_asset_candles_fn(asset, ["1h", "4h"])
-    if not result.get("success") and not result.get("data"):
+    if not result or result.get("error"):
         return None
 
-    data = result.get("data", result)
-    candles_1h = data.get("candles", {}).get("1h", [])
-    candles_4h = data.get("candles", {}).get("4h", [])
+    candles_1h = result.get("candles", {}).get("1h", [])
+    candles_4h = result.get("candles", {}).get("4h", [])
 
     if len(candles_1h) < 5 or len(candles_4h) < 20:
         return None

--- a/tiger/scripts/correlation-scanner.py
+++ b/tiger/scripts/correlation-scanner.py
@@ -335,19 +335,18 @@ def main(deps=None):
         config=config
     )
 
+    if not actionable:
+        output({"success": True, "heartbeat": "HEARTBEAT_OK"})
+        return
+
     output({
         "action": "correlation_scan",
-        "btc_triggered": True,
         "btc_direction": btc["direction"],
         "btc_move_4h_pct": btc["move_4h_pct"],
-        "btc_move_1h_pct": btc["move_1h_pct"],
-        "alts_scanned": len(unique_scan),
-        "lagging_found": len(signals),
         "actionable": len(actionable),
         "available_slots": config["maxSlots"] - len(active_coins),
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
-        "active_positions": list(active_coins)
     })
 
 

--- a/tiger/scripts/correlation-scanner.py
+++ b/tiger/scripts/correlation-scanner.py
@@ -164,25 +164,24 @@ def check_alt_lag(
 
     score = confluence_score(factors)
 
-    return {
+    result = {
         "asset": asset,
         "pattern": "CORRELATION_LAG",
         "score": round(score, 2),
         "direction": direction,
         "current_price": current_price,
-        "alt_move_4h_pct": round(alt_move_4h, 2),
-        "lag_pct": round(lag, 2),
         "lag_ratio": round(lag_ratio, 2),
         "window_quality": window_quality,
-        "expected_catchup_pct": round(expected_catchup, 2),
-        "volume_ratio": round(vol_r, 2) if vol_r else None,
-        "volume_quiet": low_volume,
-        "rsi": round(current_rsi, 1) if current_rsi else None,
-        "sm_aligned": sm_aligned,
-        "atr_pct": round(atr_pct, 2),
         "max_leverage": max_lev,
-        "factors": {k: v[0] for k, v in factors.items()}
     }
+    if os.environ.get("TIGER_VERBOSE") == "1":
+        result["alt_move_4h_pct"] = round(alt_move_4h, 2)
+        result["expected_catchup_pct"] = round(expected_catchup, 2)
+        result["volume_ratio"] = round(vol_r, 2) if vol_r else None
+        result["rsi"] = round(current_rsi, 1) if current_rsi else None
+        result["sm_aligned"] = sm_aligned
+        result["factors"] = {k: v[0] for k, v in factors.items()}
+    return result
 
 
 def main(deps=None):

--- a/tiger/scripts/correlation-scanner.py
+++ b/tiger/scripts/correlation-scanner.py
@@ -336,12 +336,17 @@ def main(deps=None):
         output({"success": True, "heartbeat": "HEARTBEAT_OK"})
         return
 
+    available_slots = config["maxSlots"] - len(active_coins)
     output({
         "action": "correlation_scan",
         "btc_direction": btc["direction"],
         "btc_move_4h_pct": btc["move_4h_pct"],
         "actionable": len(actionable),
-        "available_slots": config["maxSlots"] - len(active_coins),
+        "strategySlots": {
+            "available": available_slots,
+            "max": config["maxSlots"],
+            "anySlotsAvailable": available_slots > 0,
+        },
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
     })

--- a/tiger/scripts/dsl-v4.py
+++ b/tiger/scripts/dsl-v4.py
@@ -359,24 +359,37 @@ def main(deps=None, env=None):
     error_count = 0
     closed_count = 0
     pending_count = 0
+    active_count = 0
 
     for state_file in files:
         result, errored = _process_state_file(state_file, config, deps)
-        results.append(result)
         if errored:
             error_count += 1
         if result.get("closed"):
             closed_count += 1
         if result.get("status") == "pending_close":
             pending_count += 1
+        if result.get("status") == "active":
+            active_count += 1
+        # Only include results with meaningful state changes
+        if result.get("status") not in ("inactive",) and (
+            result.get("closed") or result.get("tier_changed") or
+            result.get("breached") or result.get("pending_close") or
+            result.get("status") == "error"
+        ):
+            results.append(result)
+
+    # Nothing actionable → heartbeat
+    if not results:
+        print(json.dumps({"success": True, "heartbeat": "HEARTBEAT_OK"}))
+        return
 
     print(json.dumps({
         "status": "ok" if error_count == 0 else "partial_error",
         "mode": "combined",
-        "processed": len(results),
-        "errors": error_count,
+        "processed": len(files),
+        "active": active_count,
         "closed": closed_count,
-        "pending_close": pending_count,
         "results": results,
         "time": _iso_now(),
     }))

--- a/tiger/scripts/dsl-v4.py
+++ b/tiger/scripts/dsl-v4.py
@@ -103,12 +103,12 @@ def _process_state_file(state_file, config, deps):
 
     try:
         prices_result = get_prices([asset] if asset else None)
-        if isinstance(prices_result, dict) and "prices" in prices_result:
+        if not prices_result or prices_result.get("error"):
+            raise RuntimeError(prices_result.get("error", "empty response") if prices_result else "no response")
+        if "prices" in prices_result:
             mids = prices_result["prices"]
-        elif isinstance(prices_result, dict):
-            mids = prices_result
         else:
-            mids = {}
+            mids = prices_result
         price = float(mids[asset])
         state["consecutiveFetchFailures"] = 0
     except Exception as e:

--- a/tiger/scripts/dsl-v4.py
+++ b/tiger/scripts/dsl-v4.py
@@ -103,11 +103,10 @@ def _process_state_file(state_file, config, deps):
 
     try:
         prices_result = get_prices([asset] if asset else None)
-        prices_data = prices_result.get("data", prices_result)
-        if isinstance(prices_data, dict) and "prices" in prices_data:
-            mids = prices_data["prices"]
-        elif isinstance(prices_data, dict):
-            mids = prices_data
+        if isinstance(prices_result, dict) and "prices" in prices_result:
+            mids = prices_result["prices"]
+        elif isinstance(prices_result, dict):
+            mids = prices_result
         else:
             mids = {}
         price = float(mids[asset])

--- a/tiger/scripts/dsl-v4.py
+++ b/tiger/scripts/dsl-v4.py
@@ -357,7 +357,6 @@ def main(deps=None, env=None):
     results = []
     error_count = 0
     closed_count = 0
-    pending_count = 0
     active_count = 0
 
     for state_file in files:
@@ -366,8 +365,6 @@ def main(deps=None, env=None):
             error_count += 1
         if result.get("closed"):
             closed_count += 1
-        if result.get("status") == "pending_close":
-            pending_count += 1
         if result.get("status") == "active":
             active_count += 1
         # Only include results with meaningful state changes

--- a/tiger/scripts/dsl-v4.py
+++ b/tiger/scripts/dsl-v4.py
@@ -371,10 +371,12 @@ def main(deps=None, env=None):
         if result.get("status") == "active":
             active_count += 1
         # Only include results with meaningful state changes
-        if result.get("status") not in ("inactive",) and (
-            result.get("closed") or result.get("tier_changed") or
-            result.get("breached") or result.get("pending_close") or
-            result.get("status") == "error"
+        if result.get("closed") or (
+            result.get("status") not in ("inactive",) and (
+                result.get("tier_changed") or
+                result.get("breached") or result.get("pending_close") or
+                result.get("status") == "error"
+            )
         ):
             results.append(result)
 

--- a/tiger/scripts/funding-scanner.py
+++ b/tiger/scripts/funding-scanner.py
@@ -118,13 +118,12 @@ def analyze_funding(asset: str, context: dict, config: dict, sm_data: dict, oi_h
         "leverage": leverage,
         "max_leverage": context.get("max_leverage", 0),
     }
-    if os.environ.get("TIGER_VERBOSE") == "1":
-        result["funding_rate_8h"] = round(funding_rate * 100, 4)
-        result["weekly_yield_pct_margin"] = round(weekly_funding_pct_margin, 1)
-        result["rsi"] = round(current_rsi, 1) if current_rsi else None
-        result["rsi_safe"] = rsi_safe
-        result["sm_aligned"] = sm_aligned
-        result["factors"] = {k: v[0] for k, v in factors.items()}
+    result["funding_rate_8h"] = round(funding_rate * 100, 4)
+    result["weekly_yield_pct_margin"] = round(weekly_funding_pct_margin, 1)
+    result["rsi"] = round(current_rsi, 1) if current_rsi else None
+    result["rsi_safe"] = rsi_safe
+    result["sm_aligned"] = sm_aligned
+    result["factors"] = {k: v[0] for k, v in factors.items()}
     return result
 
 

--- a/tiger/scripts/funding-scanner.py
+++ b/tiger/scripts/funding-scanner.py
@@ -108,26 +108,25 @@ def analyze_funding(asset: str, context: dict, config: dict, sm_data: dict, oi_h
 
     # Risk: if funding flips, you lose the yield AND might be counter-trend
     # Higher score = more confidence funding will persist
-    return {
+    result = {
         "asset": asset,
         "pattern": "FUNDING_ARB",
         "score": round(score, 2),
         "direction": direction,
         "current_price": current_price,
-        "funding_rate_8h": round(funding_rate * 100, 4),  # as %
         "funding_annualized_pct": round(funding_annualized, 1),
         "daily_yield_pct_margin": round(daily_funding_pct_margin, 2),
-        "weekly_yield_pct_margin": round(weekly_funding_pct_margin, 1),
         "leverage": leverage,
-        "trend_aligned": trend_aligned,
-        "sma_trend": sma_trend,
-        "rsi": round(current_rsi, 1) if current_rsi else None,
-        "rsi_safe": rsi_safe,
-        "oi_stable": oi_stable,
-        "sm_aligned": sm_aligned,
         "max_leverage": context.get("max_leverage", 0),
-        "factors": {k: v[0] for k, v in factors.items()}
     }
+    if os.environ.get("TIGER_VERBOSE") == "1":
+        result["funding_rate_8h"] = round(funding_rate * 100, 4)
+        result["weekly_yield_pct_margin"] = round(weekly_funding_pct_margin, 1)
+        result["rsi"] = round(current_rsi, 1) if current_rsi else None
+        result["rsi_safe"] = rsi_safe
+        result["sm_aligned"] = sm_aligned
+        result["factors"] = {k: v[0] for k, v in factors.items()}
+    return result
 
 
 def main(deps=None):

--- a/tiger/scripts/funding-scanner.py
+++ b/tiger/scripts/funding-scanner.py
@@ -210,21 +210,16 @@ def main(deps=None):
     min_score = get_pattern_min_confluence(config, state, pattern)
     actionable = [s for s in signals if s["score"] >= min_score]
 
+    if not actionable:
+        output({"success": True, "heartbeat": "HEARTBEAT_OK"})
+        return
+
     output({
         "action": "funding_scan",
-        "scanned": len(candidates),
-        "extreme_funding_assets": len(candidates),
-        "signals_found": len(signals),
         "actionable": len(actionable),
         "available_slots": config["maxSlots"] - len(active_coins),
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
-        "all_extreme_funding": [
-            {"asset": s["asset"], "funding_ann": s["funding_annualized_pct"],
-             "daily_yield": s["daily_yield_pct_margin"], "direction": s["direction"]}
-            for s in signals[:10]
-        ],
-        "active_positions": list(active_coins)
     })
 
 

--- a/tiger/scripts/funding-scanner.py
+++ b/tiger/scripts/funding-scanner.py
@@ -42,12 +42,11 @@ def analyze_funding(asset: str, context: dict, config: dict, sm_data: dict, oi_h
 
     # Fetch candles for technical alignment check
     result = get_asset_candles_fn(asset, ["1h", "4h"])
-    if not result.get("success") and not result.get("data"):
+    if not result or result.get("error"):
         return None
 
-    data = result.get("data", result)
-    candles_1h = data.get("candles", {}).get("1h", [])
-    candles_4h = data.get("candles", {}).get("4h", [])
+    candles_1h = result.get("candles", {}).get("1h", [])
+    candles_4h = result.get("candles", {}).get("4h", [])
 
     if len(candles_4h) < 25:
         return None

--- a/tiger/scripts/funding-scanner.py
+++ b/tiger/scripts/funding-scanner.py
@@ -212,10 +212,15 @@ def main(deps=None):
         output({"success": True, "heartbeat": "HEARTBEAT_OK"})
         return
 
+    available_slots = config["maxSlots"] - len(active_coins)
     output({
         "action": "funding_scan",
         "actionable": len(actionable),
-        "available_slots": config["maxSlots"] - len(active_coins),
+        "strategySlots": {
+            "available": available_slots,
+            "max": config["maxSlots"],
+            "anySlotsAvailable": available_slots > 0,
+        },
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
     })

--- a/tiger/scripts/goal-engine.py
+++ b/tiger/scripts/goal-engine.py
@@ -30,8 +30,8 @@ def recalculate_goal(config, state, deps):
 
     # Fetch current balance from clearinghouse
     ch = get_clearinghouse(wallet)
-    if ch.get("error"):
-        return {"error": f"Clearinghouse fetch failed: {ch['error']}"}
+    if not ch or ch.get("error"):
+        return {"error": f"Clearinghouse fetch failed: {ch.get('error', 'empty response') if ch else 'no response'}"}
 
     # Parse account value from clearinghouse
     margin_summary = ch.get("marginSummary", ch.get("crossMarginSummary", {}))

--- a/tiger/scripts/goal-engine.py
+++ b/tiger/scripts/goal-engine.py
@@ -33,9 +33,8 @@ def recalculate_goal(config, state, deps):
     if ch.get("error"):
         return {"error": f"Clearinghouse fetch failed: {ch['error']}"}
 
-    ch_data = ch.get("data", ch)
     # Parse account value from clearinghouse
-    margin_summary = ch_data.get("marginSummary", ch_data.get("crossMarginSummary", {}))
+    margin_summary = ch.get("marginSummary", ch.get("crossMarginSummary", {}))
     current_balance = float(margin_summary.get("accountValue", state.get("currentBalance", config["budget"])))
 
     # Update state

--- a/tiger/scripts/momentum-scanner.py
+++ b/tiger/scripts/momentum-scanner.py
@@ -199,17 +199,16 @@ def main(deps=None):
     actionable = [s for s in signals if s["score"] >= min_score and s.get("rsi_ok")]
     available_slots = config["maxSlots"] - len(active_coins)
 
+    if not actionable:
+        output({"success": True, "heartbeat": "HEARTBEAT_OK"})
+        return
+
     output({
         "action": "momentum_scan",
-        "scanned": len(candidates),
-        "signals_found": len(signals),
         "actionable": len(actionable),
         "available_slots": available_slots,
-        "min_score": min_score,
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
-        "all_signals": [s["asset"] + " " + s["direction"] + " " + str(s["score"]) for s in signals[:10]],
-        "active_positions": list(active_coins)
     })
 
 

--- a/tiger/scripts/momentum-scanner.py
+++ b/tiger/scripts/momentum-scanner.py
@@ -104,26 +104,23 @@ def scan_asset(asset: str, context: dict, config: dict, get_asset_candles_fn) ->
 
     score = confluence_score(factors)
 
-    return {
+    result = {
         "asset": asset,
         "pattern": "MOMENTUM_BREAKOUT",
         "score": round(score, 2),
         "direction": direction,
         "current_price": current_price,
-        "move_1h_pct": round(move_1h, 2),
-        "move_2h_pct": round(move_2h, 2),
-        "move_4h_pct": round(move_4h, 2),
-        "volume_ratio": round(vol_r, 2) if vol_r else None,
-        "volume_surging": volume_surging,
-        "rsi": round(current_rsi, 1) if current_rsi else None,
         "rsi_ok": rsi_ok,
-        "trend_aligned": trend_aligned,
-        "sma_aligned": sma_aligned,
-        "atr_pct": round(atr_pct, 2),
-        "funding_annualized_pct": round(funding_annualized, 1),
         "max_leverage": context.get("max_leverage", 0),
-        "factors": {k: v[0] for k, v in factors.items()}
     }
+    if os.environ.get("TIGER_VERBOSE") == "1":
+        result["move_1h_pct"] = round(move_1h, 2)
+        result["move_2h_pct"] = round(move_2h, 2)
+        result["volume_ratio"] = round(vol_r, 2) if vol_r else None
+        result["rsi"] = round(current_rsi, 1) if current_rsi else None
+        result["trend_aligned"] = trend_aligned
+        result["factors"] = {k: v[0] for k, v in factors.items()}
+    return result
 
 
 def main(deps=None):

--- a/tiger/scripts/momentum-scanner.py
+++ b/tiger/scripts/momentum-scanner.py
@@ -202,7 +202,11 @@ def main(deps=None):
     output({
         "action": "momentum_scan",
         "actionable": len(actionable),
-        "available_slots": available_slots,
+        "strategySlots": {
+            "available": available_slots,
+            "max": config["maxSlots"],
+            "anySlotsAvailable": available_slots > 0,
+        },
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
     })

--- a/tiger/scripts/momentum-scanner.py
+++ b/tiger/scripts/momentum-scanner.py
@@ -112,13 +112,13 @@ def scan_asset(asset: str, context: dict, config: dict, get_asset_candles_fn) ->
         "rsi_ok": rsi_ok,
         "max_leverage": context.get("max_leverage", 0),
     }
-    if os.environ.get("TIGER_VERBOSE") == "1":
-        result["move_1h_pct"] = round(move_1h, 2)
-        result["move_2h_pct"] = round(move_2h, 2)
-        result["volume_ratio"] = round(vol_r, 2) if vol_r else None
-        result["rsi"] = round(current_rsi, 1) if current_rsi else None
-        result["trend_aligned"] = trend_aligned
-        result["factors"] = {k: v[0] for k, v in factors.items()}
+    result["move_1h_pct"] = round(move_1h, 2)
+    result["move_2h_pct"] = round(move_2h, 2)
+    result["volume_ratio"] = round(vol_r, 2) if vol_r else None
+    result["rsi"] = round(current_rsi, 1) if current_rsi else None
+    result["trend_aligned"] = trend_aligned
+    result["funding_annualized_pct"] = round(funding_annualized, 1)
+    result["factors"] = {k: v[0] for k, v in factors.items()}
     return result
 
 

--- a/tiger/scripts/momentum-scanner.py
+++ b/tiger/scripts/momentum-scanner.py
@@ -25,12 +25,11 @@ from tiger_lib import (
 def scan_asset(asset: str, context: dict, config: dict, get_asset_candles_fn) -> dict:
     """Scan for momentum breakout on a single asset."""
     result = get_asset_candles_fn(asset, ["1h", "4h"])
-    if not result.get("success") and not result.get("data"):
+    if not result or result.get("error"):
         return None
 
-    data = result.get("data", result)
-    candles_1h = data.get("candles", {}).get("1h", [])
-    candles_4h = data.get("candles", {}).get("4h", [])
+    candles_1h = result.get("candles", {}).get("1h", [])
+    candles_4h = result.get("candles", {}).get("4h", [])
 
     if len(candles_1h) < 20 or len(candles_4h) < 20:
         return None

--- a/tiger/scripts/oi-tracker.py
+++ b/tiger/scripts/oi-tracker.py
@@ -61,25 +61,7 @@ def main(deps=None):
             tracked_assets.add(name)
             sampled += 1
 
-    # Report
-    oi_history = load_oi_history(config=config)
-    history_stats = {}
-    for asset in list(active_coins) + ["BTC", "ETH"]:
-        if asset in oi_history:
-            entries = oi_history[asset]
-            history_stats[asset] = {
-                "entries": len(entries),
-                "latest_oi": entries[-1]["oi"] if entries else 0,
-                "oldest_ts": entries[0]["ts"] if entries else 0
-            }
-
-    output({
-        "action": "oi_track",
-        "sampled": sampled,
-        "total_tracked_assets": len(tracked_assets),
-        "active_positions_tracked": list(active_coins & tracked_assets),
-        "history_stats": history_stats
-    })
+    output({"success": True, "heartbeat": "HEARTBEAT_OK"})
 
 
 if __name__ == "__main__":

--- a/tiger/scripts/reversion-scanner.py
+++ b/tiger/scripts/reversion-scanner.py
@@ -227,15 +227,16 @@ def main(deps=None):
     actionable = [s for s in signals if s["score"] >= min_score]
     available_slots = config["maxSlots"] - len(active_coins)
 
+    if not actionable:
+        output({"success": True, "heartbeat": "HEARTBEAT_OK"})
+        return
+
     output({
         "action": "reversion_scan",
-        "scanned": len(candidates),
-        "signals_found": len(signals),
         "actionable": len(actionable),
         "available_slots": available_slots,
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
-        "active_positions": list(active_coins)
     })
 
 

--- a/tiger/scripts/reversion-scanner.py
+++ b/tiger/scripts/reversion-scanner.py
@@ -129,28 +129,25 @@ def scan_asset(asset: str, context: dict, config: dict, oi_hist: dict, get_asset
     else:
         expected_move_pct = atr_pct * 2
 
-    return {
+    result = {
         "asset": asset,
         "pattern": "MEAN_REVERSION",
         "score": round(score, 2),
         "direction": direction,
         "current_price": current_price,
         "rsi_4h": round(current_rsi_4h, 1),
-        "rsi_1h": round(current_rsi_1h, 1) if current_rsi_1h else None,
-        "divergence": divergence,
         "divergence_aligned": divergence_aligned,
-        "price_change_24h_pct": round(price_change_24h, 1),
-        "volume_exhaustion": volume_exhaustion,
-        "volume_ratio": round(vol_ratio_val, 2) if vol_ratio_val else None,
-        "at_extreme_bb": at_extreme_bb,
-        "oi_crowded": oi_at_high,
-        "expected_move_pct": round(expected_move_pct, 1),
-        "atr_pct": round(atr_pct, 2),
-        "funding_annualized_pct": round(funding_annualized, 1),
-        "funding_pays_us": funding_pays_us,
         "max_leverage": context.get("max_leverage", 0),
-        "factors": {k: v[0] for k, v in factors.items()}
     }
+    if os.environ.get("TIGER_VERBOSE") == "1":
+        result["rsi_1h"] = round(current_rsi_1h, 1) if current_rsi_1h else None
+        result["price_change_24h_pct"] = round(price_change_24h, 1)
+        result["volume_exhaustion"] = volume_exhaustion
+        result["at_extreme_bb"] = at_extreme_bb
+        result["oi_crowded"] = oi_at_high
+        result["expected_move_pct"] = round(expected_move_pct, 1)
+        result["factors"] = {k: v[0] for k, v in factors.items()}
+    return result
 
 
 def main(deps=None):

--- a/tiger/scripts/reversion-scanner.py
+++ b/tiger/scripts/reversion-scanner.py
@@ -23,12 +23,11 @@ from tiger_lib import (
 def scan_asset(asset: str, context: dict, config: dict, oi_hist: dict, get_asset_candles_fn) -> dict:
     """Scan for mean reversion setup on a single asset."""
     result = get_asset_candles_fn(asset, ["1h", "4h"])
-    if not result.get("success") and not result.get("data"):
+    if not result or result.get("error"):
         return None
 
-    data = result.get("data", result)
-    candles_1h = data.get("candles", {}).get("1h", [])
-    candles_4h = data.get("candles", {}).get("4h", [])
+    candles_1h = result.get("candles", {}).get("1h", [])
+    candles_4h = result.get("candles", {}).get("4h", [])
 
     if len(candles_1h) < 30 or len(candles_4h) < 25:
         return None

--- a/tiger/scripts/reversion-scanner.py
+++ b/tiger/scripts/reversion-scanner.py
@@ -138,14 +138,14 @@ def scan_asset(asset: str, context: dict, config: dict, oi_hist: dict, get_asset
         "divergence_aligned": divergence_aligned,
         "max_leverage": context.get("max_leverage", 0),
     }
-    if os.environ.get("TIGER_VERBOSE") == "1":
-        result["rsi_1h"] = round(current_rsi_1h, 1) if current_rsi_1h else None
-        result["price_change_24h_pct"] = round(price_change_24h, 1)
-        result["volume_exhaustion"] = volume_exhaustion
-        result["at_extreme_bb"] = at_extreme_bb
-        result["oi_crowded"] = oi_at_high
-        result["expected_move_pct"] = round(expected_move_pct, 1)
-        result["factors"] = {k: v[0] for k, v in factors.items()}
+    result["rsi_1h"] = round(current_rsi_1h, 1) if current_rsi_1h else None
+    result["price_change_24h_pct"] = round(price_change_24h, 1)
+    result["volume_exhaustion"] = volume_exhaustion
+    result["at_extreme_bb"] = at_extreme_bb
+    result["oi_crowded"] = oi_at_high
+    result["expected_move_pct"] = round(expected_move_pct, 1)
+    result["funding_annualized_pct"] = round(funding_annualized, 1)
+    result["factors"] = {k: v[0] for k, v in factors.items()}
     return result
 
 

--- a/tiger/scripts/reversion-scanner.py
+++ b/tiger/scripts/reversion-scanner.py
@@ -230,7 +230,11 @@ def main(deps=None):
     output({
         "action": "reversion_scan",
         "actionable": len(actionable),
-        "available_slots": available_slots,
+        "strategySlots": {
+            "available": available_slots,
+            "max": config["maxSlots"],
+            "anySlotsAvailable": available_slots > 0,
+        },
         "aggression": state.get("aggression", "NORMAL"),
         "top_signals": actionable[:5],
     })

--- a/tiger/scripts/risk-guardian.py
+++ b/tiger/scripts/risk-guardian.py
@@ -248,10 +248,9 @@ def main(deps=None):
         output({"error": f"Clearinghouse failed: {ch['error']}"})
         return
 
-    ch_data = ch.get("data", ch)
-    margin_summary = ch_data.get("marginSummary", ch_data.get("crossMarginSummary", {}))
+    margin_summary = ch.get("marginSummary", ch.get("crossMarginSummary", {}))
     current_balance = float(margin_summary.get("accountValue", state["currentBalance"]))
-    positions = ch_data.get("assetPositions", [])
+    positions = ch.get("assetPositions", [])
 
     # Parse positions
     parsed_positions = []

--- a/tiger/scripts/risk-guardian.py
+++ b/tiger/scripts/risk-guardian.py
@@ -244,8 +244,8 @@ def main(deps=None):
 
     # Fetch current state
     ch = get_clearinghouse(wallet)
-    if ch.get("error"):
-        output({"error": f"Clearinghouse failed: {ch['error']}"})
+    if not ch or ch.get("error"):
+        output({"error": f"Clearinghouse failed: {ch.get('error', 'empty response') if ch else 'no response'}"})
         return
 
     margin_summary = ch.get("marginSummary", ch.get("crossMarginSummary", {}))

--- a/tiger/scripts/risk-guardian.py
+++ b/tiger/scripts/risk-guardian.py
@@ -288,6 +288,13 @@ def main(deps=None):
     pnl_alerts = check_position_pnl(config, state, parsed_positions)
     all_alerts.extend(pnl_alerts)
 
+    # No alerts → heartbeat
+    if not all_alerts:
+        state["currentBalance"] = current_balance
+        save_state(config, state)
+        output({"success": True, "heartbeat": "HEARTBEAT_OK"})
+        return
+
     # Determine if we need to halt
     critical_alerts = [a for a in all_alerts if a.get("type") in ("DAILY_LOSS", "MAX_DRAWDOWN", "DEADLINE_REACHED")]
     if critical_alerts:

--- a/tiger/scripts/risk-guardian.py
+++ b/tiger/scripts/risk-guardian.py
@@ -337,22 +337,11 @@ def main(deps=None):
 
     report = {
         "action": "risk_check",
-        "current_balance": round(current_balance, 2),
-        "daily_loss_pct": daily_check.get("loss_pct", 0),
-        "drawdown_pct": dd_check.get("drawdown_pct", 0),
-        "days_remaining": round(days_remaining(config), 1),
-        "active_positions": len(parsed_positions),
-        "alerts": all_alerts,
         "alert_count": len(all_alerts),
         "critical": len(critical_alerts) > 0,
         "halted": is_halted(state),
-        "actions_needed": {
-            "close": close_coins,
-            "reduce": reduce_coins,
-            "take_profit": tp_coins,
-            "close_all": close_all
-        },
-        "execution": execution
+        "alerts": all_alerts,
+        "execution": execution,
     }
 
     output(report)

--- a/tiger/scripts/roar-analyst.py
+++ b/tiger/scripts/roar-analyst.py
@@ -370,7 +370,7 @@ def main(deps=None):
         "summary": " | ".join(summary_parts),
     }
 
-    print(json.dumps(output, indent=2))
+    print(json.dumps(output))
 
 
 if __name__ == "__main__":

--- a/tiger/scripts/tiger-exit.py
+++ b/tiger/scripts/tiger-exit.py
@@ -237,14 +237,10 @@ def main(deps=None):
 
     output({
         "action": "exit_check",
-        "positions_checked": len(positions),
         "exit_signals": len(exit_signals),
         "close_needed": [{"coin": e["coin"], "reason": e["primary_action"]["reason"]} for e in close_needed],
         "partial_needed": [{"coin": e["coin"], "reason": e["primary_action"]["reason"]} for e in partial_needed],
-        "all_signals": exit_signals,
-        "aggression": state.get("aggression", "NORMAL"),
-        "days_remaining": round(state.get("daysRemaining", 7), 1),
-        "execution": execution
+        "execution": execution,
     })
 
 

--- a/tiger/scripts/tiger-exit.py
+++ b/tiger/scripts/tiger-exit.py
@@ -207,6 +207,10 @@ def main(deps=None):
     set_active_positions(state, active_pos)
     save_state(config, state)
 
+    if not exit_signals:
+        output({"success": True, "heartbeat": "HEARTBEAT_OK"})
+        return
+
     # Categorize actions
     close_needed = [e for e in exit_signals if e["primary_action"]["action"] == "CLOSE"]
     partial_needed = [e for e in exit_signals if "PARTIAL" in e["primary_action"]["action"]]

--- a/tiger/scripts/tiger-exit.py
+++ b/tiger/scripts/tiger-exit.py
@@ -190,8 +190,7 @@ def main(deps=None):
         output({"error": f"Clearinghouse failed: {ch['error']}"})
         return
 
-    ch_data = ch.get("data", ch)
-    positions = ch_data.get("assetPositions", [])
+    positions = ch.get("assetPositions", [])
 
     active_pos = get_active_positions(state)
     exit_signals = []

--- a/tiger/scripts/tiger-exit.py
+++ b/tiger/scripts/tiger-exit.py
@@ -186,8 +186,8 @@ def main(deps=None):
 
     wallet = config["strategyWallet"]
     ch = get_clearinghouse(wallet)
-    if ch.get("error"):
-        output({"error": f"Clearinghouse failed: {ch['error']}"})
+    if not ch or ch.get("error"):
+        output({"error": f"Clearinghouse failed: {ch.get('error', 'empty response') if ch else 'no response'}"})
         return
 
     positions = ch.get("assetPositions", [])

--- a/tiger/scripts/tiger_config.py
+++ b/tiger/scripts/tiger_config.py
@@ -25,8 +25,8 @@ def _resolve_workspace(env=None):
     env = env or os.environ
     if env.get("TIGER_WORKSPACE"):
         return env["TIGER_WORKSPACE"]
-    if env.get("OPENCLAW_WORKSPACE"):
-        return env["OPENCLAW_WORKSPACE"]
+    if env.get("OPENCLAW_WORKSPACE_DIR"):
+        return env["OPENCLAW_WORKSPACE_DIR"]
     # Fallback to the script parent (workspace/scripts -> workspace).
     return str(Path(__file__).resolve().parent.parent)
 
@@ -47,7 +47,7 @@ def build_runtime(env=None, workspace=None, require_workspace_env=True):
         ws = workspace
     else:
         tiger_ws = env.get("TIGER_WORKSPACE")
-        openclaw_ws = env.get("OPENCLAW_WORKSPACE")
+        openclaw_ws = env.get("OPENCLAW_WORKSPACE_DIR")
         if tiger_ws:
             ws = tiger_ws
             source = "env:TIGER_WORKSPACE"
@@ -59,7 +59,7 @@ def build_runtime(env=None, workspace=None, require_workspace_env=True):
         elif openclaw_ws:
             # Backward-compatible fallback for non-strict contexts/tests.
             ws = openclaw_ws
-            source = "env:OPENCLAW_WORKSPACE"
+            source = "env:OPENCLAW_WORKSPACE_DIR"
         else:
             # Non-strict fallback for imports/tests. Runtime entrypoints use strict mode.
             ws = _resolve_workspace(env)

--- a/tiger/scripts/tiger_config.py
+++ b/tiger/scripts/tiger_config.py
@@ -37,11 +37,10 @@ class TigerRuntime:
     scripts_dir: str
     state_dir: str
     config_file: str
-    verbose: bool
     source: str
 
 
-def build_runtime(env=None, workspace=None, verbose=None, require_workspace_env=True):
+def build_runtime(env=None, workspace=None, require_workspace_env=True):
     env = env or os.environ
     source = "explicit"
     if workspace:
@@ -65,13 +64,11 @@ def build_runtime(env=None, workspace=None, verbose=None, require_workspace_env=
             # Non-strict fallback for imports/tests. Runtime entrypoints use strict mode.
             ws = _resolve_workspace(env)
             source = "fallback"
-    vb = (env.get("TIGER_VERBOSE") == "1") if verbose is None else bool(verbose)
     return TigerRuntime(
         workspace=ws,
         scripts_dir=os.path.join(ws, "scripts"),
         state_dir=os.path.join(ws, "state"),
         config_file=os.path.join(ws, "tiger-config.json"),
-        verbose=vb,
         source=source,
     )
 
@@ -215,11 +212,10 @@ def _normalize_dict_with_aliases(data, aliases):
 
 def atomic_write(path, data, runtime=None):
     """Write JSON atomically — crash-safe via os.replace()."""
-    verbose = _runtime_attr(runtime, "verbose")
     os.makedirs(os.path.dirname(path), exist_ok=True)
     tmp = path + ".tmp"
     with open(tmp, "w") as f:
-        json.dump(data, f, indent=2 if verbose else None)
+        json.dump(data, f, indent=2)
     os.replace(tmp, path)
 
 
@@ -769,11 +765,8 @@ def close_position(wallet, coin, reason="", call_fn=None):
 # ─── Output ──────────────────────────────────────────────────
 
 def output(data, runtime=None):
-    """Print JSON output. Minimal by default, verbose opt-in via TIGER_VERBOSE=1."""
-    verbose = _runtime_attr(runtime, "verbose")
-    if not verbose and "debug" in data:
-        del data["debug"]
-    print(json.dumps(data) if not verbose else json.dumps(data, indent=2))
+    """Print JSON output with full signal data."""
+    print(json.dumps(data, indent=2))
 
 
 def output_heartbeat(runtime=None):

--- a/tiger/scripts/tiger_config.py
+++ b/tiger/scripts/tiger_config.py
@@ -618,7 +618,9 @@ def save_dsl_state(asset, dsl_state, config=None, runtime=None):
 # ─── MCP Helpers ─────────────────────────────────────────────
 
 def mcporter_call(tool, runner=None, sleep_fn=None, timeout_seconds=30, **kwargs):
-    """Call a Senpi MCP tool via mcporter with 3-attempt retry."""
+    """Call a Senpi MCP tool via mcporter with 3-attempt retry.
+    Uses temp file for stdout to prevent pipe buffer truncation on large responses."""
+    import tempfile
     runner = runner or subprocess.Popen
     sleep_fn = sleep_fn or time.sleep
     cmd = ["mcporter", "call", f"senpi.{tool}"]
@@ -632,17 +634,20 @@ def mcporter_call(tool, runner=None, sleep_fn=None, timeout_seconds=30, **kwargs
 
     last_error = None
     for attempt in range(3):
+        fd, tmp_path = tempfile.mkstemp(suffix=".json", prefix="mcporter_")
         try:
-            proc = runner(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            try:
-                stdout, stderr = proc.communicate(timeout=timeout_seconds)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait()
-                raise RuntimeError("timeout")
-            if proc.returncode != 0:
-                raise RuntimeError(stderr.strip())
-            data = json.loads(stdout)
+            with os.fdopen(fd, "w+") as tmp_out:
+                proc = runner(cmd, stdout=tmp_out, stderr=subprocess.PIPE, text=True)
+                try:
+                    _, stderr = proc.communicate(timeout=timeout_seconds)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                    raise RuntimeError("timeout")
+                if proc.returncode != 0:
+                    raise RuntimeError(stderr.strip())
+            with open(tmp_path) as f:
+                data = json.load(f)
             if isinstance(data, dict) and data.get("success") is False:
                 raise ValueError(data.get("error", "unknown"))
             # Strip {success, data} envelope — callers get inner data directly
@@ -653,6 +658,11 @@ def mcporter_call(tool, runner=None, sleep_fn=None, timeout_seconds=30, **kwargs
             last_error = e
             if attempt < 2:
                 sleep_fn(3)
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
     # Return error dict on total failure (don't crash)
     return {"error": str(last_error), "success": False}
 

--- a/tiger/scripts/tiger_config.py
+++ b/tiger/scripts/tiger_config.py
@@ -619,7 +619,8 @@ def save_dsl_state(asset, dsl_state, config=None, runtime=None):
 
 def mcporter_call(tool, runner=None, sleep_fn=None, timeout_seconds=30, **kwargs):
     """Call a Senpi MCP tool via mcporter with 3-attempt retry.
-    Uses temp file for stdout to prevent pipe buffer truncation on large responses."""
+    Raises RuntimeError after 3 failed attempts.
+    Uses temp file for stdout to prevent pipe buffer truncation."""
     import tempfile
     runner = runner or subprocess.Popen
     sleep_fn = sleep_fn or time.sleep
@@ -663,13 +664,21 @@ def mcporter_call(tool, runner=None, sleep_fn=None, timeout_seconds=30, **kwargs
                 os.unlink(tmp_path)
             except OSError:
                 pass
-    # Return error dict on total failure (don't crash)
-    return {"error": str(last_error), "success": False}
+    raise RuntimeError(f"mcporter {tool} failed after 3 attempts: {last_error}")
+
+
+def mcporter_call_safe(tool, **kwargs):
+    """Like mcporter_call but returns error dict instead of raising.
+    Use for non-critical calls where the caller handles errors gracefully."""
+    try:
+        return mcporter_call(tool, **kwargs)
+    except RuntimeError as e:
+        return {"error": str(e)}
 
 
 def get_all_instruments(call_fn=None):
     """Fetch all instruments with OI, funding, volume."""
-    call = call_fn or mcporter_call
+    call = call_fn or mcporter_call_safe
     result = call("market_list_instruments")
     if not result or result.get("error"):
         return []
@@ -680,7 +689,7 @@ def get_asset_candles(asset, intervals=None, include_funding=False, call_fn=None
     """Fetch candle data for an asset."""
     if intervals is None:
         intervals = ["1h", "4h"]
-    call = call_fn or mcporter_call
+    call = call_fn or mcporter_call_safe
     return call(
         "market_get_asset_data",
         asset=asset,
@@ -695,13 +704,13 @@ def get_prices(assets=None, call_fn=None):
     kwargs = {}
     if assets:
         kwargs["assets"] = assets
-    call = call_fn or mcporter_call
+    call = call_fn or mcporter_call_safe
     return call("market_get_prices", **kwargs)
 
 
 def get_sm_markets(limit=50, call_fn=None):
     """Get smart money market concentration."""
-    call = call_fn or mcporter_call
+    call = call_fn or mcporter_call_safe
     result = call("leaderboard_get_markets", limit=limit)
     if not result or result.get("error"):
         return []
@@ -714,19 +723,19 @@ def get_sm_markets(limit=50, call_fn=None):
 
 def get_portfolio(call_fn=None):
     """Get current portfolio."""
-    call = call_fn or mcporter_call
+    call = call_fn or mcporter_call_safe
     return call("account_get_portfolio")
 
 
 def get_clearinghouse(wallet, call_fn=None):
     """Get clearinghouse state for a strategy wallet."""
-    call = call_fn or mcporter_call
+    call = call_fn or mcporter_call_safe
     return call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
 
 
 def create_position(wallet, orders, reason="", call_fn=None):
     """Create a position."""
-    call = call_fn or mcporter_call
+    call = call_fn or mcporter_call_safe
     return call(
         "create_position",
         strategyWalletAddress=wallet,
@@ -737,7 +746,7 @@ def create_position(wallet, orders, reason="", call_fn=None):
 
 def edit_position(wallet, coin, call_fn=None, **kwargs):
     """Edit a position."""
-    call = call_fn or mcporter_call
+    call = call_fn or mcporter_call_safe
     return call(
         "edit_position",
         strategyWalletAddress=wallet,
@@ -748,7 +757,7 @@ def edit_position(wallet, coin, call_fn=None, **kwargs):
 
 def close_position(wallet, coin, reason="", call_fn=None):
     """Close a position."""
-    call = call_fn or mcporter_call
+    call = call_fn or mcporter_call_safe
     return call(
         "close_position",
         strategyWalletAddress=wallet,

--- a/tiger/scripts/tiger_config.py
+++ b/tiger/scripts/tiger_config.py
@@ -672,7 +672,7 @@ def mcporter_call_safe(tool, **kwargs):
     Use for non-critical calls where the caller handles errors gracefully."""
     try:
         return mcporter_call(tool, **kwargs)
-    except RuntimeError as e:
+    except Exception as e:
         return {"error": str(e)}
 
 

--- a/tiger/scripts/tiger_config.py
+++ b/tiger/scripts/tiger_config.py
@@ -645,6 +645,9 @@ def mcporter_call(tool, runner=None, sleep_fn=None, timeout_seconds=30, **kwargs
             data = json.loads(stdout)
             if isinstance(data, dict) and data.get("success") is False:
                 raise ValueError(data.get("error", "unknown"))
+            # Strip {success, data} envelope — callers get inner data directly
+            if isinstance(data, dict) and "data" in data:
+                return data["data"]
             return data
         except Exception as e:
             last_error = e
@@ -658,8 +661,9 @@ def get_all_instruments(call_fn=None):
     """Fetch all instruments with OI, funding, volume."""
     call = call_fn or mcporter_call
     result = call("market_list_instruments")
-    data = result.get("data", result)
-    return data.get("instruments", [])
+    if not result or result.get("error"):
+        return []
+    return result.get("instruments", [])
 
 
 def get_asset_candles(asset, intervals=None, include_funding=False, call_fn=None):
@@ -689,8 +693,10 @@ def get_sm_markets(limit=50, call_fn=None):
     """Get smart money market concentration."""
     call = call_fn or mcporter_call
     result = call("leaderboard_get_markets", limit=limit)
-    data = result.get("data", {})
-    markets = data.get("markets", data)
+    if not result or result.get("error"):
+        return []
+    # leaderboard_get_markets nests: {markets: {markets: [...]}}
+    markets = result.get("markets", result)
     if isinstance(markets, dict):
         markets = markets.get("markets", [])
     return markets if isinstance(markets, list) else []

--- a/tiger/tests/conftest.py
+++ b/tiger/tests/conftest.py
@@ -104,10 +104,10 @@ def mock_deps(tmp_runtime):
         overrides={
             "output": lambda payload: captured.append(payload),
             "get_all_instruments": lambda: SAMPLE_INSTRUMENTS,
-            "get_asset_candles": lambda asset, intervals=None: {"success": False},
+            "get_asset_candles": lambda asset, intervals=None: {"error": "not mocked"},
             "get_prices": lambda assets=None: {},
             "get_sm_markets": lambda limit=50: [],
-            "get_clearinghouse": lambda wallet: {"data": {"marginSummary": {"accountValue": "1000"}, "assetPositions": []}},
+            "get_clearinghouse": lambda wallet: {"marginSummary": {"accountValue": "1000"}, "assetPositions": []},
             "close_position": lambda wallet, coin, reason="": {"success": True},
             "edit_position": lambda wallet, coin, **kw: {"success": True},
         }

--- a/tiger/tests/conftest.py
+++ b/tiger/tests/conftest.py
@@ -89,7 +89,6 @@ def tmp_runtime(tmp_path):
         scripts_dir=str(workspace / "scripts"),
         state_dir=str(state_dir),
         config_file=str(config_file),
-        verbose=False,
         source="test",
     )
 

--- a/tiger/tests/test_compression.py
+++ b/tiger/tests/test_compression.py
@@ -23,12 +23,9 @@ class TestScanAsset:
 
         def fn(asset, intervals):
             return {
-                "success": True,
-                "data": {
-                    "candles": {
-                        "1h": make_candles(closes_1h),
-                        "4h": make_candles(closes_4h),
-                    }
+                "candles": {
+                    "1h": make_candles(closes_1h),
+                    "4h": make_candles(closes_4h),
                 }
             }
         return fn
@@ -36,32 +33,26 @@ class TestScanAsset:
     def test_insufficient_1h_candles(self):
         """Returns None when fewer than 30 1h candles."""
         def fn(asset, intervals):
-            return {
-                "success": True,
-                "data": {"candles": {
-                    "1h": make_candles([100] * 10),  # Only 10
-                    "4h": make_candles([100] * 25),
-                }}
-            }
+            return {"candles": {
+                "1h": make_candles([100] * 10),  # Only 10
+                "4h": make_candles([100] * 25),
+            }}
         result = comp.scan_asset("ETH", {}, {"bbSqueezePercentile": 35}, {}, fn)
         assert result is None
 
     def test_insufficient_4h_candles(self):
         """Returns None when fewer than 25 4h candles."""
         def fn(asset, intervals):
-            return {
-                "success": True,
-                "data": {"candles": {
-                    "1h": make_candles([100] * 30),
-                    "4h": make_candles([100] * 10),  # Only 10
-                }}
-            }
+            return {"candles": {
+                "1h": make_candles([100] * 30),
+                "4h": make_candles([100] * 10),  # Only 10
+            }}
         result = comp.scan_asset("ETH", {}, {"bbSqueezePercentile": 35}, {}, fn)
         assert result is None
 
     def test_fetch_failure_returns_none(self):
         def fn(asset, intervals):
-            return {"success": False}
+            return {"error": "fetch failed"}
         result = comp.scan_asset("ETH", {}, {"bbSqueezePercentile": 35}, {}, fn)
         assert result is None
 
@@ -74,13 +65,10 @@ class TestScanAsset:
         tight_4h = [100 + (i % 2) * 0.01 for i in range(25)]
 
         def fn(asset, intervals):
-            return {
-                "success": True,
-                "data": {"candles": {
-                    "1h": make_candles(tight),
-                    "4h": make_candles(tight_4h),
-                }}
-            }
+            return {"candles": {
+                "1h": make_candles(tight),
+                "4h": make_candles(tight_4h),
+            }}
 
         config = {"bbSqueezePercentile": 50, "minOiChangePct": 5, "minLeverage": 5}
         context = {"openInterest": 50000, "funding": "0.0001", "max_leverage": 20}
@@ -91,7 +79,6 @@ class TestScanAsset:
             assert result["pattern"] == "COMPRESSION_BREAKOUT"
             assert result["asset"] == "ETH"
             assert "score" in result
-            assert "factors" in result
 
     def test_squeeze_pctl_above_40_returns_none(self):
         """scan_asset returns None when squeeze_pctl >= 40 (line 107 filter)."""
@@ -100,13 +87,10 @@ class TestScanAsset:
         volatile_4h = [100 + (i % 10) * 5 for i in range(25)]
 
         def fn(asset, intervals):
-            return {
-                "success": True,
-                "data": {"candles": {
-                    "1h": make_candles(volatile),
-                    "4h": make_candles(volatile_4h),
-                }}
-            }
+            return {"candles": {
+                "1h": make_candles(volatile),
+                "4h": make_candles(volatile_4h),
+            }}
 
         config = {"bbSqueezePercentile": 35, "minOiChangePct": 5, "minLeverage": 5}
         context = {"openInterest": 50000, "funding": "0.0001", "max_leverage": 20}
@@ -185,7 +169,7 @@ class TestMainIntegration:
 
         def mock_get_candles(asset, intervals):
             scanned_assets.append(asset)
-            return {"success": False}
+            return {"error": "not mocked"}
 
         instruments = [
             {"name": "ETH", "max_leverage": 20, "is_delisted": False,

--- a/tiger/tests/test_compression.py
+++ b/tiger/tests/test_compression.py
@@ -193,3 +193,107 @@ class TestMainIntegration:
 
         # ETH should NOT be scanned (active position)
         assert "ETH" not in scanned_assets
+
+
+class TestWatchingPipeline:
+    """Regression: two-stage pipeline (watching → actionable) must be preserved.
+
+    The compression scanner splits signals into:
+    - actionable: squeeze + breakout + score >= threshold
+    - watching: squeeze + score >= threshold, but NO breakout yet (coiled spring)
+
+    HEARTBEAT_OK should only fire when BOTH lists are empty.
+    """
+
+    def _make_deps(self, tmp_runtime, scan_asset_fn):
+        """Build deps with a patched scan_asset via prescreened candidates."""
+        instruments = [
+            {"name": "ETH", "max_leverage": 20, "is_delisted": False,
+             "context": {"dayNtlVlm": "100000000", "openInterest": "50000",
+                         "funding": "0.0001", "markPx": "3500", "prevDayPx": "3450"}},
+            {"name": "SOL", "max_leverage": 20, "is_delisted": False,
+             "context": {"dayNtlVlm": "80000000", "openInterest": "30000",
+                         "funding": "-0.0002", "markPx": "150", "prevDayPx": "145"}},
+        ]
+        candidates = [
+            ("ETH", instruments[0]["context"], 20),
+            ("SOL", instruments[1]["context"], 20),
+        ]
+        captured = []
+        deps = tiger_config.resolve_dependencies(
+            runtime=tmp_runtime,
+            overrides={
+                "output": lambda payload: captured.append(payload),
+                "get_all_instruments": lambda: instruments,
+                "get_asset_candles": lambda asset, intervals: {"error": "not mocked"},
+                "load_prescreened_candidates": lambda instruments, config=None, include_leverage=True: candidates,
+            },
+        )
+        return deps, captured
+
+    def test_watching_reported_when_no_actionable(self, tmp_runtime, monkeypatch):
+        """Squeeze signals without breakout must appear in watching_list, NOT swallowed by HEARTBEAT_OK."""
+        def mock_scan_asset(asset, context, config, oi_hist, get_asset_candles_fn):
+            return {
+                "asset": asset, "pattern": "COMPRESSION_BREAKOUT",
+                "score": 0.75, "direction": None,
+                "breakout": False,  # squeeze but no breakout → watching
+                "current_price": 100, "max_leverage": 20,
+                "factors": {},
+            }
+
+        monkeypatch.setattr(comp, "scan_asset", mock_scan_asset)
+        deps, captured = self._make_deps(tmp_runtime, mock_scan_asset)
+        comp.main(deps)
+
+        assert len(captured) == 1
+        report = captured[0]
+        assert "heartbeat" not in report, "watching signals must not be swallowed by HEARTBEAT_OK"
+        assert report["watching"] > 0
+        assert len(report["watching_list"]) > 0
+        assert report["actionable"] == 0
+
+    def test_heartbeat_when_both_empty(self, tmp_runtime, monkeypatch):
+        """HEARTBEAT_OK should fire only when no actionable AND no watching signals."""
+        monkeypatch.setattr(comp, "scan_asset", lambda *a, **kw: None)
+        deps, captured = self._make_deps(tmp_runtime, None)
+        comp.main(deps)
+
+        assert len(captured) == 1
+        assert captured[0].get("heartbeat") == "HEARTBEAT_OK"
+
+    def test_actionable_and_watching_both_in_report(self, tmp_runtime, monkeypatch):
+        """When both actionable and watching exist, report must include both."""
+        call_count = {"n": 0}
+
+        def mock_scan_asset(asset, context, config, oi_hist, get_asset_candles_fn):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # First asset: actionable (breakout = True)
+                return {
+                    "asset": asset, "pattern": "COMPRESSION_BREAKOUT",
+                    "score": 0.80, "direction": "LONG",
+                    "breakout": True,
+                    "current_price": 100, "max_leverage": 20,
+                    "factors": {},
+                }
+            else:
+                # Second asset: watching (breakout = False)
+                return {
+                    "asset": asset, "pattern": "COMPRESSION_BREAKOUT",
+                    "score": 0.75, "direction": None,
+                    "breakout": False,
+                    "current_price": 50, "max_leverage": 20,
+                    "factors": {},
+                }
+
+        monkeypatch.setattr(comp, "scan_asset", mock_scan_asset)
+        deps, captured = self._make_deps(tmp_runtime, mock_scan_asset)
+        comp.main(deps)
+
+        assert len(captured) == 1
+        report = captured[0]
+        assert report["actionable"] >= 1
+        assert report["watching"] >= 1
+        assert len(report["top_signals"]) >= 1
+        assert len(report["watching_list"]) >= 1

--- a/tiger/tests/test_correlation.py
+++ b/tiger/tests/test_correlation.py
@@ -13,7 +13,7 @@ class TestCheckBtcMove:
     def _make_candles_result(self, closes):
         """Build a mock get_asset_candles return value from closes."""
         candles = make_candles(closes)
-        return {"success": True, "data": {"candles": {"1h": candles}}}
+        return {"candles": {"1h": candles}}
 
     def test_no_trigger_flat(self):
         # BTC barely moved: all closes ~65000
@@ -94,7 +94,7 @@ class TestCheckBtcMove:
         state = {}
 
         def get_candles(asset, intervals):
-            return {"success": False}
+            return {"error": "fetch failed"}
 
         result = corr.check_btc_move(config, state, get_candles)
         assert result["triggered"] is False
@@ -105,12 +105,9 @@ class TestCheckAltLag:
         """Build a mock get_asset_candles function."""
         def fn(asset, intervals):
             return {
-                "success": True,
-                "data": {
-                    "candles": {
-                        "1h": make_candles(closes_1h),
-                        "4h": make_candles(closes_4h),
-                    }
+                "candles": {
+                    "1h": make_candles(closes_1h),
+                    "4h": make_candles(closes_4h),
                 }
             }
         return fn
@@ -219,13 +216,10 @@ class TestConfluenceFactors:
         closes_4h = [100] * 20 + [100.1]
 
         def mock_candles(asset, intervals):
-            return {
-                "success": True,
-                "data": {"candles": {
-                    "1h": make_candles(closes_1h),
-                    "4h": make_candles(closes_4h),
-                }}
-            }
+            return {"candles": {
+                "1h": make_candles(closes_1h),
+                "4h": make_candles(closes_4h),
+            }}
 
         instruments_map = {
             "ETH": {"max_leverage": 20, "context": {"openInterest": "50000", "funding": "0.0001"}}
@@ -247,13 +241,10 @@ class TestConfluenceFactors:
         closes_4h = [100] * 20 + [100.1]
 
         def mock_candles(asset, intervals):
-            return {
-                "success": True,
-                "data": {"candles": {
-                    "1h": make_candles(closes_1h),
-                    "4h": make_candles(closes_4h),
-                }}
-            }
+            return {"candles": {
+                "1h": make_candles(closes_1h),
+                "4h": make_candles(closes_4h),
+            }}
 
         instruments_map = {
             "RANDOMCOIN": {"max_leverage": 20, "context": {"openInterest": "50000", "funding": "0.0001"}}

--- a/tiger/tests/test_correlation.py
+++ b/tiger/tests/test_correlation.py
@@ -212,8 +212,9 @@ class TestCheckAltLag:
 class TestConfluenceFactors:
     """Verify the confluence factor booleans are computed correctly."""
 
-    def test_high_corr_alt_factor(self):
+    def test_high_corr_alt_factor(self, monkeypatch):
         """Assets in HIGH_CORR_ALTS get the high_correlation_alt factor."""
+        monkeypatch.setenv("TIGER_VERBOSE", "1")
         closes_1h = [100] * 5 + [100.1]
         closes_4h = [100] * 20 + [100.1]
 
@@ -239,8 +240,9 @@ class TestConfluenceFactors:
         if result:
             assert result["factors"]["high_correlation_alt"] is True
 
-    def test_non_corr_alt_factor(self):
+    def test_non_corr_alt_factor(self, monkeypatch):
         """Assets NOT in HIGH_CORR_ALTS don't get the factor."""
+        monkeypatch.setenv("TIGER_VERBOSE", "1")
         closes_1h = [100] * 5 + [100.1]
         closes_4h = [100] * 20 + [100.1]
 

--- a/tiger/tests/test_correlation.py
+++ b/tiger/tests/test_correlation.py
@@ -209,9 +209,8 @@ class TestCheckAltLag:
 class TestConfluenceFactors:
     """Verify the confluence factor booleans are computed correctly."""
 
-    def test_high_corr_alt_factor(self, monkeypatch):
+    def test_high_corr_alt_factor(self):
         """Assets in HIGH_CORR_ALTS get the high_correlation_alt factor."""
-        monkeypatch.setenv("TIGER_VERBOSE", "1")
         closes_1h = [100] * 5 + [100.1]
         closes_4h = [100] * 20 + [100.1]
 
@@ -234,9 +233,8 @@ class TestConfluenceFactors:
         if result:
             assert result["factors"]["high_correlation_alt"] is True
 
-    def test_non_corr_alt_factor(self, monkeypatch):
+    def test_non_corr_alt_factor(self):
         """Assets NOT in HIGH_CORR_ALTS don't get the factor."""
-        monkeypatch.setenv("TIGER_VERBOSE", "1")
         closes_1h = [100] * 5 + [100.1]
         closes_4h = [100] * 20 + [100.1]
 

--- a/tiger/tests/test_dsl_v4.py
+++ b/tiger/tests/test_dsl_v4.py
@@ -406,3 +406,187 @@ class TestProcessStateFile:
         assert errored is True
         assert result["consecutive_failures"] == 10
         assert result["deactivated"] is True
+
+    def test_price_error_dict_handled(self, tmp_path):
+        """get_prices returning error dict (mcporter_call_safe) is handled gracefully."""
+        state = self._make_state()
+        state_file = str(tmp_path / "dsl-ETH.json")
+        with open(state_file, "w") as f:
+            json.dump(state, f)
+
+        deps = {
+            "get_prices": lambda assets=None: {"error": "timeout after 3 attempts"},
+            "close_position": lambda w, a, reason="": {"success": True},
+            "atomic_write": lambda path, data: None,
+        }
+
+        result, errored = dsl._process_state_file(state_file, {}, deps)
+        assert errored is True
+        assert result["status"] == "error"
+        assert result["consecutive_failures"] == 1
+
+    def test_price_none_response_handled(self, tmp_path):
+        """get_prices returning None is handled gracefully."""
+        state = self._make_state()
+        state_file = str(tmp_path / "dsl-ETH.json")
+        with open(state_file, "w") as f:
+            json.dump(state, f)
+
+        deps = {
+            "get_prices": lambda assets=None: None,
+            "close_position": lambda w, a, reason="": {"success": True},
+            "atomic_write": lambda path, data: None,
+        }
+
+        result, errored = dsl._process_state_file(state_file, {}, deps)
+        assert errored is True
+        assert result["status"] == "error"
+
+
+class TestCombinedMode:
+    """Tests for DSL combined mode — main() without DSL_STATE_FILE."""
+
+    def _make_state(self, **overrides):
+        base = {
+            "active": True,
+            "asset": "ETH",
+            "wallet": "0xTEST",
+            "direction": "LONG",
+            "entryPrice": 3000.0,
+            "size": 1.0,
+            "leverage": 10,
+            "highWaterPrice": 3100.0,
+            "phase": 1,
+            "currentBreachCount": 0,
+            "currentTierIndex": -1,
+            "tierFloorPrice": None,
+            "pendingClose": False,
+            "breachDecay": "hard",
+            "maxFetchFailures": 10,
+            "consecutiveFetchFailures": 0,
+            "tiers": [],
+            "phase1": {
+                "retraceThreshold": 0.015,
+                "consecutiveBreachesRequired": 2,
+                "absoluteFloor": 2900.0,
+            },
+            "phase2": {
+                "retraceThreshold": 0.012,
+                "consecutiveBreachesRequired": 3,
+            },
+            "phase2TriggerTier": 1,
+        }
+        base.update(overrides)
+        return base
+
+    def _setup_combined(self, tmp_path, state_files, price=3080.0):
+        """Write state files and build deps for combined mode main()."""
+        instance_dir = tmp_path / "state" / "test-strategy"
+        instance_dir.mkdir(parents=True)
+
+        for filename, state_data in state_files.items():
+            with open(instance_dir / filename, "w") as f:
+                json.dump(state_data, f)
+
+        captured = []
+        writes = {}
+
+        config = {"strategyId": "test-strategy"}
+
+        def mock_load_config():
+            return config
+
+        deps = {
+            "load_config": mock_load_config,
+            "workspace": str(tmp_path),
+            "get_prices": lambda assets=None: {"prices": {"ETH": str(price), "BTC": str(price)}},
+            "close_position": lambda wallet, asset, reason="": {"success": True},
+            "atomic_write": lambda path, data: writes.update({path: data}),
+        }
+        return deps, captured
+
+    def test_heartbeat_when_all_quiet(self, tmp_path, capsys):
+        """All positions active but no breaches/changes → HEARTBEAT_OK."""
+        state_files = {
+            "dsl-ETH.json": self._make_state(asset="ETH", highWaterPrice=3100.0),
+            "dsl-BTC.json": self._make_state(asset="BTC", highWaterPrice=3100.0),
+        }
+        deps, _ = self._setup_combined(tmp_path, state_files, price=3080.0)
+
+        dsl.main(deps=deps, env={})
+        output = json.loads(capsys.readouterr().out.strip())
+
+        assert output["heartbeat"] == "HEARTBEAT_OK"
+
+    def test_breached_position_included(self, tmp_path, capsys):
+        """A breached position appears in results; a quiet one does not."""
+        state_files = {
+            # ETH: price 3040 < floor max(2900, 3100*0.985=3053.5) → breached
+            "dsl-ETH.json": self._make_state(asset="ETH", highWaterPrice=3100.0),
+            # BTC: price 3080 > floor → not breached, quiet
+            "dsl-BTC.json": self._make_state(asset="BTC", highWaterPrice=3100.0),
+        }
+        deps, _ = self._setup_combined(tmp_path, state_files)
+        # Override prices: ETH breached, BTC fine
+        deps["get_prices"] = lambda assets=None: {"prices": {"ETH": "3040", "BTC": "3080"}}
+
+        dsl.main(deps=deps, env={})
+        output = json.loads(capsys.readouterr().out.strip())
+
+        assert output["status"] == "ok"
+        assert output["mode"] == "combined"
+        # Only ETH (breached) should be in results
+        result_assets = [r["asset"] for r in output["results"]]
+        assert "ETH" in result_assets
+        assert "BTC" not in result_assets
+
+    def test_inactive_position_excluded(self, tmp_path, capsys):
+        """Inactive positions are filtered out of combined results."""
+        state_files = {
+            "dsl-ETH.json": self._make_state(asset="ETH", active=False, pendingClose=False),
+            # BTC breached to have at least one result
+            "dsl-BTC.json": self._make_state(asset="BTC", highWaterPrice=3100.0),
+        }
+        deps, _ = self._setup_combined(tmp_path, state_files)
+        deps["get_prices"] = lambda assets=None: {"prices": {"ETH": "3000", "BTC": "3040"}}
+
+        dsl.main(deps=deps, env={})
+        output = json.loads(capsys.readouterr().out.strip())
+
+        result_assets = [r["asset"] for r in output.get("results", [])]
+        assert "ETH" not in result_assets
+
+    def test_no_state_files_returns_idle(self, tmp_path, capsys):
+        """No dsl-*.json files → idle status."""
+        # Create instance dir but no state files
+        (tmp_path / "state" / "test-strategy").mkdir(parents=True)
+
+        config = {"strategyId": "test-strategy"}
+        deps = {
+            "load_config": lambda: config,
+            "workspace": str(tmp_path),
+        }
+
+        dsl.main(deps=deps, env={})
+        output = json.loads(capsys.readouterr().out.strip())
+
+        assert output["status"] == "idle"
+        assert output["processed"] == 0
+
+    def test_closed_position_included(self, tmp_path, capsys):
+        """A position that gets closed appears in results."""
+        state_files = {
+            # ETH: breach count 1 + price below floor → breach count 2 = close
+            "dsl-ETH.json": self._make_state(
+                asset="ETH", highWaterPrice=3100.0, currentBreachCount=1,
+            ),
+        }
+        deps, _ = self._setup_combined(tmp_path, state_files)
+        deps["get_prices"] = lambda assets=None: {"prices": {"ETH": "3040"}}
+
+        dsl.main(deps=deps, env={})
+        output = json.loads(capsys.readouterr().out.strip())
+
+        assert len(output["results"]) == 1
+        assert output["results"][0]["closed"] is True
+        assert output["closed"] == 1

--- a/tiger/tests/test_dsl_v4.py
+++ b/tiger/tests/test_dsl_v4.py
@@ -130,7 +130,7 @@ class TestProcessStateFile:
         writes = {}
 
         def mock_get_prices(assets=None):
-            return {"data": {"prices": {"ETH": str(price)}}}
+            return {"prices": {"ETH": str(price)}}
 
         def mock_close_position(wallet, asset, reason=""):
             if close_success:

--- a/tiger/tests/test_goal_engine.py
+++ b/tiger/tests/test_goal_engine.py
@@ -1,0 +1,60 @@
+"""
+Tests for goal-engine.py — clearinghouse response guards.
+Verifies that recalculate_goal handles error/empty clearinghouse responses
+gracefully instead of crashing.
+"""
+
+import pytest
+from datetime import datetime, timezone
+
+from conftest import import_script
+
+goal = import_script("goal_engine", "goal-engine.py")
+
+
+def _make_deps(ch_response):
+    """Build minimal deps for recalculate_goal with a given clearinghouse response."""
+    return {
+        "get_clearinghouse": lambda wallet: ch_response,
+        "days_remaining": lambda config: 5,
+        "day_number": lambda config: 2,
+        "now_utc": lambda: datetime(2025, 1, 1, tzinfo=timezone.utc),
+        "set_halt_state": lambda state, halt, reason: None,
+        "get_active_positions": lambda state: {},
+    }
+
+
+class TestClearinghouseGuard:
+    """Tests for empty response guards in recalculate_goal."""
+
+    def test_error_response_returns_error(self, sample_config, sample_state):
+        """Clearinghouse returning error dict → returns error, no crash."""
+        deps = _make_deps({"error": "timeout after 3 attempts"})
+        result = goal.recalculate_goal(sample_config, sample_state, deps)
+        assert "error" in result
+        assert "Clearinghouse fetch failed" in result["error"]
+
+    def test_none_response_returns_error(self, sample_config, sample_state):
+        """Clearinghouse returning None → returns error, no crash."""
+        deps = _make_deps(None)
+        result = goal.recalculate_goal(sample_config, sample_state, deps)
+        assert "error" in result
+        assert "no response" in result["error"]
+
+    def test_empty_dict_response_returns_error(self, sample_config, sample_state):
+        """Clearinghouse returning {} → falsy empty dict."""
+        deps = _make_deps({})
+        result = goal.recalculate_goal(sample_config, sample_state, deps)
+        assert "error" in result
+
+    def test_no_wallet_returns_error(self, sample_state):
+        """Missing strategyWallet → returns error before calling clearinghouse."""
+        import tiger_config
+        config = tiger_config._to_alias_dict(tiger_config.deep_merge(
+            tiger_config.DEFAULT_CONFIG,
+            {"strategyWallet": ""}
+        ))
+        deps = _make_deps(None)
+        result = goal.recalculate_goal(config, sample_state, deps)
+        assert "error" in result
+        assert "wallet" in result["error"].lower()

--- a/tiger/tests/test_mcporter.py
+++ b/tiger/tests/test_mcporter.py
@@ -1,0 +1,268 @@
+"""
+Tests for mcporter_call and mcporter_call_safe — core MCP I/O primitive.
+Verifies retry logic, temp-file handling, envelope stripping, timeout,
+and the safe wrapper's error-dict return.
+"""
+
+import json
+import os
+import pytest
+
+import tiger_config
+
+
+class _FakeProc:
+    """Minimal subprocess.Popen stand-in for mcporter_call tests."""
+
+    def __init__(self, stdout_data=None, returncode=0, stderr="", raise_timeout=False):
+        self._stdout_data = stdout_data
+        self.returncode = returncode
+        self._stderr = stderr
+        self._raise_timeout = raise_timeout
+
+    def communicate(self, timeout=None):
+        if self._raise_timeout:
+            import subprocess
+            raise subprocess.TimeoutExpired(cmd="mcporter", timeout=timeout)
+        return None, self._stderr
+
+    def kill(self):
+        pass
+
+    def wait(self):
+        pass
+
+
+def _make_runner(stdout_data, returncode=0, stderr="", raise_timeout=False):
+    """Return a runner function that writes stdout_data to the temp file."""
+
+    def runner(cmd, stdout=None, stderr=None, text=True):
+        proc = _FakeProc(
+            stdout_data=stdout_data,
+            returncode=returncode,
+            stderr=stderr if isinstance(stderr, str) else "",
+            raise_timeout=raise_timeout,
+        )
+        # Write data to the temp file (stdout is an open file handle)
+        if stdout is not None and stdout_data is not None:
+            stdout.write(json.dumps(stdout_data))
+            stdout.flush()
+        return proc
+
+    return runner
+
+
+def _noop_sleep(seconds):
+    """No-op sleep for fast tests."""
+    pass
+
+
+class TestMcporterCall:
+    """Tests for the raising mcporter_call variant."""
+
+    def test_success_returns_data_directly(self):
+        """Raw dict without envelope is returned as-is."""
+        data = {"candles": {"1h": [1, 2, 3]}}
+        result = tiger_config.mcporter_call(
+            "get_candles",
+            runner=_make_runner(data),
+            sleep_fn=_noop_sleep,
+            asset="ETH",
+        )
+        assert result == {"candles": {"1h": [1, 2, 3]}}
+
+    def test_envelope_stripped(self):
+        """Success envelope {success, data} is stripped — inner data returned."""
+        inner = {"instruments": [{"name": "BTC"}]}
+        envelope = {"success": True, "data": inner}
+        result = tiger_config.mcporter_call(
+            "market_list_instruments",
+            runner=_make_runner(envelope),
+            sleep_fn=_noop_sleep,
+        )
+        assert result == inner
+
+    def test_list_response_returned_as_is(self):
+        """Non-dict responses (e.g., JSON arrays) pass through unchanged."""
+        data = [1, 2, 3]
+        result = tiger_config.mcporter_call(
+            "some_tool",
+            runner=_make_runner(data),
+            sleep_fn=_noop_sleep,
+        )
+        assert result == [1, 2, 3]
+
+    def test_success_false_retries_and_raises(self):
+        """{success: false} triggers retry and eventually raises."""
+        data = {"success": False, "error": "rate limited"}
+        with pytest.raises(RuntimeError, match="failed after 3 attempts"):
+            tiger_config.mcporter_call(
+                "some_tool",
+                runner=_make_runner(data),
+                sleep_fn=_noop_sleep,
+            )
+
+    def test_nonzero_returncode_retries_and_raises(self):
+        """Non-zero exit code triggers retry and eventually raises."""
+        with pytest.raises(RuntimeError, match="failed after 3 attempts"):
+            tiger_config.mcporter_call(
+                "some_tool",
+                runner=_make_runner(None, returncode=1, stderr="connection refused"),
+                sleep_fn=_noop_sleep,
+            )
+
+    def test_timeout_retries_and_raises(self):
+        """Subprocess timeout triggers retry and eventually raises."""
+        with pytest.raises(RuntimeError, match="failed after 3 attempts"):
+            tiger_config.mcporter_call(
+                "some_tool",
+                runner=_make_runner(None, raise_timeout=True),
+                sleep_fn=_noop_sleep,
+                timeout_seconds=1,
+            )
+
+    def test_retries_three_times_before_raising(self):
+        """Verify exactly 3 attempts are made."""
+        attempt_count = 0
+
+        def counting_runner(cmd, stdout=None, stderr=None, text=True):
+            nonlocal attempt_count
+            attempt_count += 1
+            return _FakeProc(returncode=1, stderr="fail")
+
+        with pytest.raises(RuntimeError):
+            tiger_config.mcporter_call(
+                "some_tool",
+                runner=counting_runner,
+                sleep_fn=_noop_sleep,
+            )
+        assert attempt_count == 3
+
+    def test_sleep_called_between_retries(self):
+        """Sleep is called with 3s between retry attempts (not after last)."""
+        sleeps = []
+
+        def tracking_sleep(seconds):
+            sleeps.append(seconds)
+
+        with pytest.raises(RuntimeError):
+            tiger_config.mcporter_call(
+                "some_tool",
+                runner=_make_runner(None, returncode=1, stderr="fail"),
+                sleep_fn=tracking_sleep,
+            )
+        # 3 attempts → 2 sleeps (between attempt 1→2 and 2→3)
+        assert sleeps == [3, 3]
+
+    def test_temp_file_cleaned_up_on_success(self, tmp_path):
+        """Temp file is removed after successful call."""
+        created_files = []
+        original_mkstemp = __import__("tempfile").mkstemp
+
+        def tracking_mkstemp(**kwargs):
+            fd, path = original_mkstemp(**kwargs)
+            created_files.append(path)
+            return fd, path
+
+        import tempfile
+        original = tempfile.mkstemp
+        tempfile.mkstemp = tracking_mkstemp
+        try:
+            tiger_config.mcporter_call(
+                "some_tool",
+                runner=_make_runner({"result": "ok"}),
+                sleep_fn=_noop_sleep,
+            )
+        finally:
+            tempfile.mkstemp = original
+
+        # All temp files should be cleaned up
+        for f in created_files:
+            assert not os.path.exists(f), f"Temp file {f} was not cleaned up"
+
+    def test_temp_file_cleaned_up_on_failure(self):
+        """Temp file is removed even when all attempts fail."""
+        created_files = []
+        original_mkstemp = __import__("tempfile").mkstemp
+
+        def tracking_mkstemp(**kwargs):
+            fd, path = original_mkstemp(**kwargs)
+            created_files.append(path)
+            return fd, path
+
+        import tempfile
+        original = tempfile.mkstemp
+        tempfile.mkstemp = tracking_mkstemp
+        try:
+            with pytest.raises(RuntimeError):
+                tiger_config.mcporter_call(
+                    "some_tool",
+                    runner=_make_runner(None, returncode=1, stderr="fail"),
+                    sleep_fn=_noop_sleep,
+                )
+        finally:
+            tempfile.mkstemp = original
+
+        assert len(created_files) == 3  # One per attempt
+        for f in created_files:
+            assert not os.path.exists(f), f"Temp file {f} was not cleaned up"
+
+    def test_cmd_builds_correctly(self):
+        """Verify command construction with various kwarg types."""
+        captured_cmd = []
+
+        def capturing_runner(cmd, stdout=None, stderr=None, text=True):
+            captured_cmd.extend(cmd)
+            if stdout is not None:
+                stdout.write(json.dumps({"ok": True}))
+                stdout.flush()
+            return _FakeProc()
+
+        tiger_config.mcporter_call(
+            "get_candles",
+            runner=capturing_runner,
+            sleep_fn=_noop_sleep,
+            asset="ETH",
+            intervals=["1h", "4h"],
+            include_funding=True,
+        )
+        assert captured_cmd[0] == "mcporter"
+        assert captured_cmd[1] == "call"
+        assert captured_cmd[2] == "senpi.get_candles"
+        assert "asset=ETH" in captured_cmd
+        assert 'intervals=["1h", "4h"]' in captured_cmd
+        assert "include_funding=true" in captured_cmd
+
+
+class TestMcporterCallSafe:
+    """Tests for the non-raising mcporter_call_safe wrapper."""
+
+    def test_success_passes_through(self):
+        """Successful calls return data directly."""
+        data = {"instruments": []}
+        result = tiger_config.mcporter_call_safe(
+            "some_tool",
+            runner=_make_runner(data),
+            sleep_fn=_noop_sleep,
+        )
+        assert result == {"instruments": []}
+
+    def test_failure_returns_error_dict(self):
+        """Failed calls return {error: str} instead of raising."""
+        result = tiger_config.mcporter_call_safe(
+            "some_tool",
+            runner=_make_runner(None, returncode=1, stderr="timeout"),
+            sleep_fn=_noop_sleep,
+        )
+        assert "error" in result
+        assert "failed after 3 attempts" in result["error"]
+
+    def test_envelope_stripped_through_safe(self):
+        """Envelope stripping works through the safe wrapper too."""
+        envelope = {"success": True, "data": {"prices": {"BTC": "67000"}}}
+        result = tiger_config.mcporter_call_safe(
+            "get_prices",
+            runner=_make_runner(envelope),
+            sleep_fn=_noop_sleep,
+        )
+        assert result == {"prices": {"BTC": "67000"}}

--- a/tiger/tests/test_risk_guardian.py
+++ b/tiger/tests/test_risk_guardian.py
@@ -299,3 +299,32 @@ class TestCheckPositionPnl:
         # Should not crash on division by zero
         result = risk.check_position_pnl(config, state, positions)
         assert isinstance(result, list)
+
+
+class TestMainClearinghouseGuard:
+    """Tests for empty response guards in main()."""
+
+    def test_error_response_outputs_error(self, mock_deps):
+        """Clearinghouse returning error dict → output error, no crash."""
+        mock_deps["get_clearinghouse"] = lambda wallet: {"error": "timeout after 3 attempts"}
+        risk.main(deps=mock_deps)
+        captured = mock_deps["_captured_output"]
+        assert len(captured) == 1
+        assert "error" in captured[0]
+        assert "Clearinghouse failed" in captured[0]["error"]
+
+    def test_none_response_outputs_error(self, mock_deps):
+        """Clearinghouse returning None → output error, no crash."""
+        mock_deps["get_clearinghouse"] = lambda wallet: None
+        risk.main(deps=mock_deps)
+        captured = mock_deps["_captured_output"]
+        assert len(captured) == 1
+        assert "no response" in captured[0]["error"]
+
+    def test_empty_dict_response_outputs_error(self, mock_deps):
+        """Clearinghouse returning {} → falsy but not None."""
+        mock_deps["get_clearinghouse"] = lambda wallet: {}
+        risk.main(deps=mock_deps)
+        captured = mock_deps["_captured_output"]
+        assert len(captured) == 1
+        assert "error" in captured[0]

--- a/tiger/tests/test_tiger_exit.py
+++ b/tiger/tests/test_tiger_exit.py
@@ -265,3 +265,24 @@ class TestActionPriority:
         assert result is not None
         # DEADLINE=CRITICAL should outrank TRAILING_LOCK=HIGH
         assert result["primary_action"]["type"] == "DEADLINE"
+
+
+class TestMainClearinghouseGuard:
+    """Tests for empty response guards in main()."""
+
+    def test_error_response_outputs_error(self, mock_deps):
+        """Clearinghouse returning error dict → output error, no crash."""
+        mock_deps["get_clearinghouse"] = lambda wallet: {"error": "timeout after 3 attempts"}
+        exit_mod.main(deps=mock_deps)
+        captured = mock_deps["_captured_output"]
+        assert len(captured) == 1
+        assert "error" in captured[0]
+        assert "Clearinghouse failed" in captured[0]["error"]
+
+    def test_none_response_outputs_error(self, mock_deps):
+        """Clearinghouse returning None → output error, no crash."""
+        mock_deps["get_clearinghouse"] = lambda wallet: None
+        exit_mod.main(deps=mock_deps)
+        captured = mock_deps["_captured_output"]
+        assert len(captured) == 1
+        assert "no response" in captured[0]["error"]


### PR DESCRIPTION
## Token Optimization for Tiger

**Base branch:** `TIGER`

### Summary
- **Improve scanner output tokens usage** — all scanners emit full signal data (indicator + factor values), and return `HEARTBEAT_OK` early when nothing is actionable instead of dumping full reports
- **Hardened `mcporter_call`** — switched stdout capture to temp files to prevent pipe buffer truncation on large responses, stripped the `{success, data}` MCP envelope internally so callers receive clean data directly, and split into raising (`mcporter_call`) and safe (`mcporter_call_safe`) variants
- **Moved OI/Risk/Exit/DSL crons to isolated sessions** — these no longer compete for the main session's context window; each runs with an explicit model (`claude-haiku-4-5` for data-only work, `claude-sonnet-4-5` for decision-makers)
- **Standardized slot guard** — scanners now emit a `strategySlots` object (`available`, `max`, `anySlotsAvailable`) and cron prompts enforce a mandatory `SLOT GUARD` check before entry
- **Added comprehensive tests** — new `test_mcporter.py` (raising vs safe, envelope stripping, temp-file I/O, retry logic), expanded `test_dsl_v4.py` (combined mode filtering), plus response-guard and goal-engine tests
- **Lifecycle walkthrough** — added to `SKILL.md` (already mentioned in the PR body but was committed separately after the PR was written).
- **Coiling asset support** — compression scanner gained awareness of "coiling" assets (assets in prolonged squeeze), with new test coverage in `test_compression.py`
- **Workspace path fix** — `TIGER_WORKSPACE` path updated for Railway volume mount.
- **Communication discipline** — new `SKILL.md` section defining when the agent should communicate vs stay silent. 
- **Goal Engine** cron moved from `main/systemEvent` to `isolated/agentTurn` with `delivery.mode: "announce"`. Scanner prompts tightened to enforce strict `HEARTBEAT_OK` silence on no-action cycles.
- **Version bump to 1.2.x** and added a lifecycle walkthrough section to `SKILL.md`

### Changes by area

| Area | Files | What changed |
|------|-------|-------------|
| Core infra | `tiger_config.py` | `mcporter_call` temp-file stdout, envelope stripping, raising/safe split; all MCP helpers use `mcporter_call_safe` |
| Scanners | `compression-scanner.py`, `momentum-scanner.py`, `correlation-scanner.py`, `reversion-scanner.py`, `funding-scanner.py` | Actionable-only output, `HEARTBEAT_OK` early exit, `strategySlots` object, verbose fields gated |
| Decision-makers | `oi-tracker.py`, `risk-guardian.py`, `tiger-exit.py`, `dsl-v4.py` | Heartbeat early exits, stripped envelope references, DSL combined mode filters to meaningful state changes only |
| Cron templates | `cron-templates.md` | OI/Risk/Exit/DSL → `isolated` + `agentTurn` + explicit models; mandatory `SLOT GUARD` in scanner prompts |
| Docs | `SKILL.md` | Version 1.2.0, lifecycle walkthrough, updated cron table |
| Tests | `test_mcporter.py`, `test_dsl_v4.py`, `test_compression.py`, `test_correlation.py`, `test_goal_engine.py`, `test_risk_guardian.py`, `test_tiger_exit.py` | New and updated test coverage |

### Test plan
- [ ] Run `pytest tiger/tests/` — all tests pass
- [ ] Deploy crons to staging and verify isolated sessions launch with correct models
- [ ] Confirm scanners return `HEARTBEAT_OK` when no signals are actionable
- [ ] Verify `mcporter_call` raises on failure and `mcporter_call_safe` returns error dict
- [ ] Spot-check that `TIGER_VERBOSE=1` re-enables full diagnostic fields


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core MCP call semantics (envelope stripping + raising vs safe wrappers) and alters scanner/decision-maker JSON outputs and cron execution modes, which could affect automated trade entry/exit behavior if any consumer relies on prior shapes or error handling.
> 
> **Overview**
> **Reduces token usage and notification noise across crons** by making scanners/decision-makers emit `HEARTBEAT_OK` early when nothing is actionable, and by tightening DSL combined-mode output to only include meaningful state changes.
> 
> **Hardens MCP and data-fetch plumbing** by rewriting `mcporter_call` to use temp-file stdout capture, strip the `{success, data}` envelope, and introduce `mcporter_call_safe`; all MCP helper wrappers and multiple scripts are updated to handle `None`/`{error: ...}` responses (including new clearinghouse guards in goal/risk/exit). **Standardizes scanner outputs** with a `strategySlots` object and updates cron templates to enforce mandatory SLOT GUARD plus moving OI/goal/risk/exit/DSL to `isolated/agentTurn` with explicit models/delivery. Documentation is refreshed (version bump, lifecycle/communication discipline), and new/expanded tests cover MCP retries/envelope stripping, DSL combined mode filtering, and the new response guards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4c814b8d2e0f28be796c4fa83433e88d2069fd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->