### PR TITLE
dsl configurable changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 design/*
 .env
+.verify-dsl
+design*

--- a/dsl-dynamic-stop-loss/SKILL.md
+++ b/dsl-dynamic-stop-loss/SKILL.md
@@ -11,12 +11,12 @@ compatibility: >-
   Hyperliquid perp positions only (main dex and xyz dex).
 metadata:
   author: jason-goldberg
-  version: "5.0"
+  version: "5.1"
   platform: senpi
   exchange: hyperliquid
 ---
 
-# Dynamic Stop Loss (DSL) v5
+# Dynamic Stop Loss (DSL) v5.1
 
 **Scope — DSL only.** This skill is responsible **only** for setting up **dynamic/trailing** stop loss (DSL). It does **not** handle normal (static) stop loss. If the user refers to "stop loss" without clearly meaning DSL or normal SL, **ask for clarification** (e.g. "Do you want a trailing stop that moves up with profit, or a fixed price stop loss?") before acting.
 
@@ -32,7 +32,7 @@ metadata:
 
 ---
 
-Automated trailing stop loss for leveraged perp positions on Hyperliquid (main and xyz dex). Monitors price via cron, ratchets profit floors upward through configurable tiers, and **syncs the stop loss to Hyperliquid** via Senpi `edit_position` so that **Hyperliquid executes the SL** when price hits — reducing loss exposure versus a 3-minute cron-only close. Breach detection, tier upgrades, and retraction logic still run in the cron; cancellation and setup of the SL happen via Senpi API; the new SL order ID is stored in state and status can be checked via `strategy_get_open_orders`. On breach the script may still call `close_position` as a backup. v5 adds strategy-scoped state paths and delete-on-close cleanup.
+Automated trailing stop loss for leveraged perp positions on Hyperliquid (main and xyz dex). Monitors price via cron, ratchets profit floors upward through configurable tiers, and **syncs the stop loss to Hyperliquid** via Senpi `edit_position` so that **Hyperliquid executes the SL** when price hits — reducing loss exposure versus a 3-minute cron-only close. Breach detection, tier upgrades, and retraction logic still run in the cron; cancellation and setup of the SL happen via Senpi API; the new SL order ID is stored in state and status can be checked via `strategy_get_open_orders`. On breach the script may still call `close_position` as a backup. v5.1 adds strategy-scoped state paths, delete-on-close cleanup, and add-dsl/update-dsl CLI.
 
 ## Self-Contained Design
 
@@ -155,12 +155,16 @@ For LONGs, "best" = maximum. For SHORTs, "best" = minimum.
 
 | File | Purpose |
 |------|---------|
-| `scripts/dsl-v5.py` | Strategy-scoped DSL: MCP clearinghouse + reconcile state, then per-position monitor/close, outputs ndjson |
+| `scripts/dsl-v5.py` | Strategy-scoped DSL: MCP clearinghouse + reconcile state, then per-position monitor/close, outputs ndjson. Run with no args for monitor; use subcommands add-dsl, update-dsl, pause-dsl, resume-dsl, delete-dsl, status-dsl for state management. |
 | `scripts/dsl-cleanup.py` | Strategy-level cleanup — deletes strategy dir when all positions closed |
-| State file (JSON) | Per-position config + runtime state; path: `{DSL_STATE_DIR}/{strategyId}/{asset}.json` |
+| State file (JSON) | Per-position config + runtime state; path: `{DSL_STATE_DIR}/{strategyId}/{asset}.json` or `xyz--SYMBOL.json` for xyz |
+| [references/cli-options.md](references/cli-options.md) | All CLI options and `--config` keys for constructing add-dsl/update-dsl commands |
+| [references/examples.md](references/examples.md) | CLI and workflow examples (add-dsl, update-dsl, pause, status, delete, cron) |
+| [references/state-schema.md](references/state-schema.md) | State file path conventions and JSON schema |
 | [references/migration.md](references/migration.md) | Upgrading from cron-only DSL to Hyperliquid SL flow |
+| [references/cleanup.md](references/cleanup.md) | Strategy cleanup on inactive / no positions |
 
-Use `DSL_STATE_DIR` + `DSL_STRATEGY_ID` only for cron (no per-position env). See [references/state-schema.md](references/state-schema.md) for path conventions. Cleanup: [references/cleanup.md](references/cleanup.md). Upgrading from cron-only DSL: [references/migration.md](references/migration.md).
+Use `DSL_STATE_DIR` + `DSL_STRATEGY_ID` only for cron (no per-position env).
 
 ## State File Schema
 
@@ -247,19 +251,10 @@ No `DSL_ASSET` — the script discovers positions from MCP clearinghouse and sta
 **Agent must complete all steps; cron is one per strategy, created automatically.**
 
 1. Open position via Senpi API (`create_position`) if not already open.
-2. **Create state directory and file** (see "State directory and file creation" below) — pay close attention to path and filename. Ensure the state file’s `wallet` and `strategyId` match the strategy (script uses wallet to call clearinghouse).
-3. **Cron:** One cron per strategy. If this is the first position for this strategy, create the cron (every 3–5 min) with `DSL_STATE_DIR` and `DSL_STRATEGY_ID` only. If the strategy already has a cron, do not add another; the same cron run will pick up the new position via clearinghouse and its state file.
-4. DSL handles monitoring and close from there.
+2. **Create state via CLI:** run `python3 scripts/dsl-v5.py add-dsl <preset> --strategy-id ID --asset ASSET --direction LONG|SHORT --leverage N --margin N`. Entry/size/wallet from clearinghouse; position must exist. Use output `cron_env` and `cron_schedule`; if `is_first_position_for_strategy` create one cron per strategy. For all options (e.g. `--config`, `--dex`) see [references/cli-options.md](references/cli-options.md).
+3. DSL handles monitoring and close from there.
 
-### State directory and file creation
-
-- **Base directory:** Use `DSL_STATE_DIR` (e.g. `/data/workspace/dsl`). Ensure it exists; create it if missing.
-- **Strategy directory:** `{DSL_STATE_DIR}/{strategyId}` — create this directory if it does not exist. One directory per strategy.
-- **State filename:**
-  - Main dex: `{asset}.json` (e.g. `ETH` → `ETH.json`, `HYPE` → `HYPE.json`).
-  - xyz dex: replace colon with double-dash — `xyz:SILVER` → `xyz--SILVER.json`, `xyz:AAPL` → `xyz--AAPL.json`.
-- **Full path:** `{DSL_STATE_DIR}/{strategyId}/{filename}.json`. The script finds state files by listing the strategy dir and matching assets to clearinghouse positions.
-- **State file contents:** Include all required fields from the schema, including **`wallet`** (used for clearinghouse and close). **Double-check `direction`** (LONG/SHORT). **Calculate `absoluteFloor`** correctly for the direction (see Absolute Floor Calculation below). Set `highWaterPrice` to entry price, `currentBreachCount` to 0, `currentTierIndex` to -1, `tierFloorPrice` to null, `floorPrice` to the absolute floor.
+**Commands:** add-dsl, update-dsl, pause-dsl, resume-dsl, delete-dsl, status-dsl — run `python3 scripts/dsl-v5.py <subcommand> ...`. **All options and --config:** [references/cli-options.md](references/cli-options.md). **Examples:** [references/examples.md](references/examples.md). **State schema:** [references/state-schema.md](references/state-schema.md).
 
 ### When a Position Closes
 
@@ -290,7 +285,7 @@ See [references/customization.md](references/customization.md) for conservative/
 ## Setup Checklist (agent responsibilities)
 
 1. Ensure required scripts and mcporter (Senpi auth) are available.
-2. **State:** Create base dir if needed; create strategy dir `{DSL_STATE_DIR}/{strategyId}`; create state file per position with correct filename (main: `{asset}.json`, xyz: `xyz--SYMBOL.json`). See [references/state-schema.md](references/state-schema.md). Each state file must include `wallet` (strategy wallet).
+2. **State:** Create state per position via CLI: `python3 scripts/dsl-v5.py add-dsl <preset> --strategy-id ID --asset ASSET --direction LONG|SHORT --leverage N --margin N`. See [references/cli-options.md](references/cli-options.md) for all options and `--config`. State path: `{DSL_STATE_DIR}/{strategyId}/{asset}.json` or `xyz--SYMBOL.json` for xyz ([references/state-schema.md](references/state-schema.md)).
 3. **Cron:** One cron per strategy (every 3–5 min), env `DSL_STATE_DIR` and `DSL_STRATEGY_ID` only — user must not set up cron manually.
 4. **Alerts:** Read script output (ndjson); on `closed=true` alert user; on `strategy_inactive` remove cron for that strategy and run cleanup.
 5. **Cleanup:** On `strategy_inactive` or when strategy has no positions left, run strategy cleanup so the strategy directory is removed — see [references/cleanup.md](references/cleanup.md).

--- a/dsl-dynamic-stop-loss/references/cleanup.md
+++ b/dsl-dynamic-stop-loss/references/cleanup.md
@@ -1,4 +1,4 @@
-# DSL v5 Cleanup
+# DSL v5.1 Cleanup
 
 Two-level cleanup: position close (Level 1) and strategy close (Level 2). No archiving — closed state and strategy directories are **deleted**.
 

--- a/dsl-dynamic-stop-loss/references/cli-options.md
+++ b/dsl-dynamic-stop-loss/references/cli-options.md
@@ -1,0 +1,158 @@
+# DSL v5.1 — CLI options
+
+Reference for all options used when constructing and running the DSL script. Script: `python3 scripts/dsl-v5.py` (or path to `dsl-v5.py`).
+
+## Subcommands
+
+| Subcommand | Purpose |
+|------------|---------|
+| *(none)* | Monitor mode (cron): read state, fetch prices, update tiers, sync SL, close on breach |
+| `add-dsl <preset>` | Create state for a new position (entry/size/wallet from clearinghouse) |
+| `update-dsl` | Merge config into existing position(s) |
+| `pause-dsl` | Set `active: false` for position(s) |
+| `resume-dsl` | Set `active: true` for position(s) |
+| `delete-dsl` | Remove state file(s) |
+| `status-dsl` | Print state JSON (read-only) |
+
+## Global flags (all subcommands except monitor)
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--state-dir` | `$DSL_STATE_DIR` or `/data/workspace/dsl` | State directory root |
+| `--strategy-id` | `$DSL_STRATEGY_ID` | Strategy ID (required if env not set) |
+
+## add-dsl
+
+```text
+python3 scripts/dsl-v5.py add-dsl <preset> --strategy-id ID --asset ASSET --direction LONG|SHORT --leverage N --margin N [--dex DEX] [--config '{}']
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `preset` | Yes (positional) | Preset name (e.g. `default`, `dsl-tight`) |
+| `--asset` | Yes | Ticker: main → `ETH`; xyz → `xyz:SILVER` or `SILVER` with `--dex xyz` |
+| `--dex` | No | DEX when asset has no prefix: `''`/`main` = main, `xyz` = xyz. Inferred from `xyz:` prefix if omitted. |
+| `--direction` | Yes | `LONG` or `SHORT` |
+| `--leverage` | Yes | Positive number |
+| `--margin` | Yes | Position margin (collateral) in quote units; used for ROE. Must be > 0. |
+| `--config` | No | JSON object to override defaults. See [The `--config` JSON](#the---config-json) below. |
+
+Entry, size, and wallet are resolved from clearinghouse; position must already exist.
+
+## update-dsl
+
+```text
+python3 scripts/dsl-v5.py update-dsl --config '<json>' [--asset ASSET] [--dex DEX]
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--config` | Yes | JSON to merge into state. Same keys and merge rules as add-dsl. |
+| `--asset` | No | Limit to one position (e.g. `ETH`, `xyz:SILVER`, or `SILVER` with `--dex xyz`). Omit = all positions in strategy. |
+| `--dex` | No | DEX when asset has no prefix. |
+
+## pause-dsl / resume-dsl
+
+```text
+python3 scripts/dsl-v5.py pause-dsl  [--asset ASSET] [--dex DEX]
+python3 scripts/dsl-v5.py resume-dsl [--asset ASSET] [--dex DEX]
+```
+
+Omit `--asset` to pause/resume all positions in the strategy. Use `--asset` and optionally `--dex` for one position.
+
+## delete-dsl
+
+```text
+python3 scripts/dsl-v5.py delete-dsl [--asset ASSET] [--dex DEX]
+```
+
+Omit `--asset` to delete all state files for the strategy. Use `--asset` and optionally `--dex` for one position.
+
+## status-dsl
+
+```text
+python3 scripts/dsl-v5.py status-dsl [--asset ASSET] [--dex DEX]
+```
+
+Prints state JSON (pretty if single `--asset`, ndjson if all). Use `--asset` and optionally `--dex` to target one position.
+
+## Asset and DEX
+
+- **Main dex:** `--asset ETH` (no `--dex` or `--dex main`/`''`). State file: `ETH.json`.
+- **XYZ via prefix:** `--asset xyz:SILVER`. State file: `xyz--SILVER.json`. DEX inferred.
+- **XYZ via flag:** `--asset SILVER --dex xyz`. Canonical asset becomes `xyz:SILVER`; state file `xyz--SILVER.json`.
+
+Same `--asset` / `--dex` rules apply for update-dsl, pause-dsl, resume-dsl, delete-dsl, status-dsl when targeting one position.
+
+---
+
+## The `--config` JSON
+
+Used by **add-dsl** (optional) and **update-dsl** (required). Single JSON object. Only the keys below are accepted; others are ignored. Include only keys you want to override; omitted keys keep preset/default (add-dsl) or existing state (update-dsl).
+
+### Allowed top-level keys
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `phase1` | object | Phase 1 overrides. Sub-keys: `retraceThreshold`, `consecutiveBreachesRequired`, `absoluteFloor`. Deep-merged. |
+| `phase2` | object | Phase 2 overrides. Sub-keys: `retraceThreshold`, `consecutiveBreachesRequired`. Deep-merged. |
+| `phase2TriggerTier` | int | Tier index (0-based) where Phase 2 starts. `>= 0`, `< len(tiers)`. |
+| `tiers` | array | Tier list. **Full replacement** (not merged). Each tier: `triggerPct`, `lockPct`; optional `retrace`, `breachesRequired`. |
+| `breachDecay` | string | `"hard"` or `"soft"`. |
+| `closeRetries` | int | Close attempts before `pendingClose`. 1–20. |
+| `closeRetryDelaySec` | number | Seconds between retries. 0–60. |
+| `maxFetchFailures` | int | Consecutive price failures before deactivate. 1–100. |
+
+### phase1 object (when using `phase1` in --config)
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `retraceThreshold` | number | ROE fraction (e.g. 0.03 = 3%). > 0, ≤ 0.5. |
+| `consecutiveBreachesRequired` | int | 1–20. |
+| `absoluteFloor` | number | Optional at add-dsl (auto from entry + retrace/leverage). LONG: < entry; SHORT: > entry. |
+
+### phase2 object (when using `phase2` in --config)
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `retraceThreshold` | number | ROE fraction. > 0, ≤ 0.5. |
+| `consecutiveBreachesRequired` | int | 1–20. |
+
+### Tier object (each element of `tiers`)
+
+| Key | Required | Notes |
+|-----|----------|-------|
+| `triggerPct` | Yes | ROE % for tier (e.g. 10 = 10% ROE). ≥ 0. Order ascending. |
+| `lockPct` | Yes | % of entry→HW range to lock. 0–100. |
+| `retrace` | No | Per-tier retrace (ROE fraction). |
+| `breachesRequired` | No | Breaches to close at this tier. 1–20. |
+
+### Merge behavior
+
+- **add-dsl:** Start from preset/core defaults. For objects (`phase1`, `phase2`): **deep-merge**. For scalars: replace. For `tiers`: **replace** entire array.
+- **update-dsl:** Same rules applied to **existing state**. Runtime fields (highWaterPrice, currentTierIndex, etc.) are never changed by `--config`.
+
+### Example: add-dsl with config
+
+```bash
+python3 scripts/dsl-v5.py add-dsl dsl-tight --strategy-id strat-1 --asset HYPE --direction LONG --leverage 10 --margin 500 \
+  --config '{
+    "phase1": {"retraceThreshold": 0.05, "consecutiveBreachesRequired": 3},
+    "phase2": {"retraceThreshold": 0.02, "consecutiveBreachesRequired": 2},
+    "tiers": [
+      {"triggerPct": 10, "lockPct": 50, "retrace": 0.015, "breachesRequired": 3},
+      {"triggerPct": 20, "lockPct": 65, "retrace": 0.012, "breachesRequired": 2},
+      {"triggerPct": 40, "lockPct": 75, "retrace": 0.010, "breachesRequired": 2},
+      {"triggerPct": 75, "lockPct": 85, "retrace": 0.006, "breachesRequired": 1}
+    ]
+  }'
+```
+
+### Example: update-dsl (partial)
+
+```bash
+python3 scripts/dsl-v5.py update-dsl --strategy-id strat-1 --asset HYPE \
+  --config '{"phase2": {"retraceThreshold": 0.01}}'
+```
+
+For more examples (minimal add-dsl, xyz, pause, status, delete, cron), see [examples.md](examples.md). For state file schema, see [state-schema.md](state-schema.md).

--- a/dsl-dynamic-stop-loss/references/examples.md
+++ b/dsl-dynamic-stop-loss/references/examples.md
@@ -1,0 +1,193 @@
+# DSL v5.1 — Examples
+
+Practical examples for the CLI and monitor. Replace `strategy-id`, `asset`, and paths with your values. Position must already exist in clearinghouse before `add-dsl`.
+
+## add-dsl
+
+### Minimal (default preset, no config override)
+
+```bash
+python3 scripts/dsl-v5.py add-dsl default \
+  --strategy-id strat-abc-123 \
+  --asset ETH \
+  --direction LONG \
+  --leverage 10 \
+  --margin 500
+```
+
+Uses 6 default tiers, phase1/phase2 breach=1, retrace 3%/1.5%. Entry/size/wallet come from clearinghouse.
+
+### With preset and optional config
+
+```bash
+python3 scripts/dsl-v5.py add-dsl dsl-tight \
+  --strategy-id strat-abc-123 \
+  --asset HYPE \
+  --direction LONG \
+  --leverage 10 \
+  --margin 500 \
+  --config '{
+    "phase1": {"retraceThreshold": 0.05, "consecutiveBreachesRequired": 3},
+    "phase2": {"retraceThreshold": 0.02, "consecutiveBreachesRequired": 2},
+    "tiers": [
+      {"triggerPct": 10, "lockPct": 50, "retrace": 0.015, "breachesRequired": 3},
+      {"triggerPct": 20, "lockPct": 65, "retrace": 0.012, "breachesRequired": 2},
+      {"triggerPct": 40, "lockPct": 75, "retrace": 0.010, "breachesRequired": 2},
+      {"triggerPct": 75, "lockPct": 85, "retrace": 0.006, "breachesRequired": 1}
+    ]
+  }'
+```
+
+### XYZ dex asset (two ways)
+
+**Option 1 — prefix in asset:** DEX is inferred from `xyz:`.
+
+```bash
+python3 scripts/dsl-v5.py add-dsl default \
+  --strategy-id strat-abc-123 \
+  --asset xyz:SILVER \
+  --direction SHORT \
+  --leverage 5 \
+  --margin 200
+```
+
+**Option 2 — separate `--dex`:** Use when the ticker has no prefix (e.g. `SILVER` on xyz). Canonical asset becomes `xyz:SILVER`; state file `xyz--SILVER.json`.
+
+```bash
+python3 scripts/dsl-v5.py add-dsl default \
+  --strategy-id strat-abc-123 \
+  --asset SILVER \
+  --dex xyz \
+  --direction SHORT \
+  --leverage 5 \
+  --margin 200
+```
+
+State file is always `xyz--SILVER.json` under the strategy dir for xyz SILVER. Main dex: `--asset ETH` (no `--dex` or `--dex main`/`''`).
+
+### Example add-dsl output
+
+```json
+{
+  "action": "add-dsl",
+  "status": "ok",
+  "preset": "dsl-tight",
+  "asset": "HYPE",
+  "strategy_id": "strat-abc-123",
+  "state_file": "/data/workspace/dsl/strat-abc-123/HYPE.json",
+  "is_first_position_for_strategy": true,
+  "cron_needed": true,
+  "cron_env": {
+    "DSL_STATE_DIR": "/data/workspace/dsl",
+    "DSL_STRATEGY_ID": "strat-abc-123",
+    "DSL_PRESET": "dsl-tight"
+  },
+  "cron_schedule": "*/3 * * * *"
+}
+```
+
+If `is_first_position_for_strategy` is true, create one cron with `cron_env`; otherwise reuse the existing strategy cron.
+
+---
+
+## update-dsl
+
+### Tighten retrace for one asset
+
+```bash
+python3 scripts/dsl-v5.py update-dsl \
+  --strategy-id strat-abc-123 \
+  --asset HYPE \
+  --config '{"phase2": {"retraceThreshold": 0.01}}'
+```
+
+For xyz asset use `--asset xyz:SILVER` or `--asset SILVER --dex xyz`.
+
+### Update all positions in strategy (e.g. more breach tolerance)
+
+```bash
+python3 scripts/dsl-v5.py update-dsl \
+  --strategy-id strat-abc-123 \
+  --config '{"phase1": {"consecutiveBreachesRequired": 3}}'
+```
+
+Omit `--asset` to apply to every state file in the strategy dir.
+
+---
+
+## pause-dsl / resume-dsl
+
+### Pause one position
+
+```bash
+python3 scripts/dsl-v5.py pause-dsl --strategy-id strat-abc-123 --asset ETH
+```
+
+For xyz: `--asset xyz:SILVER` or `--asset SILVER --dex xyz`.
+
+### Resume all positions for a strategy
+
+```bash
+python3 scripts/dsl-v5.py resume-dsl --strategy-id strat-abc-123
+```
+
+---
+
+## status-dsl
+
+### One position (pretty-printed)
+
+```bash
+python3 scripts/dsl-v5.py status-dsl --strategy-id strat-abc-123 --asset HYPE
+```
+
+### All positions (one JSON line per position)
+
+```bash
+python3 scripts/dsl-v5.py status-dsl --strategy-id strat-abc-123
+```
+
+---
+
+## delete-dsl
+
+### Remove DSL for one asset
+
+```bash
+python3 scripts/dsl-v5.py delete-dsl --strategy-id strat-abc-123 --asset ETH
+```
+
+For xyz: `--asset xyz:SILVER` or `--asset SILVER --dex xyz`.
+
+### Remove all DSL state for a strategy
+
+```bash
+python3 scripts/dsl-v5.py delete-dsl --strategy-id strat-abc-123
+```
+
+Deletes all state files in the strategy dir; removes the strategy dir if empty.
+
+---
+
+## Monitor (cron)
+
+Cron runs the script with no subcommand. Env vars: `DSL_STATE_DIR`, `DSL_STRATEGY_ID`, optionally `DSL_PRESET`.
+
+```bash
+DSL_STATE_DIR=/data/workspace/dsl DSL_STRATEGY_ID=strat-abc-123 DSL_PRESET=dsl-tight python3 /path/to/dsl-dynamic-stop-loss/scripts/dsl-v5.py
+```
+
+Output is one JSON line per position (ndjson), or one strategy-level line (`strategy_inactive`, `no_positions`, or `error`).
+
+---
+
+## Using --state-dir and --strategy-id
+
+All subcommands accept `--state-dir` and `--strategy-id`; if omitted they fall back to `DSL_STATE_DIR` and `DSL_STRATEGY_ID` env vars.
+
+```bash
+python3 scripts/dsl-v5.py add-dsl default \
+  --state-dir /data/workspace/dsl \
+  --strategy-id strat-abc-123 \
+  --asset ETH --direction LONG --leverage 10 --margin 500
+```

--- a/dsl-dynamic-stop-loss/references/output-schema.md
+++ b/dsl-dynamic-stop-loss/references/output-schema.md
@@ -7,6 +7,7 @@ The script prints a single JSON line to stdout on each run. The agent reads this
 ```json
 {
   "status": "active",
+  "preset": "dsl-tight",
   "asset": "HYPE",
   "direction": "LONG",
   "price": 29.26,
@@ -53,6 +54,7 @@ The script prints a single JSON line to stdout on each run. The agent reads this
 | Field | Type | Description |
 |-------|------|-------------|
 | `status` | string | `"active"`, `"inactive"`, `"pending_close"`, or `"error"` |
+| `preset` | string | Preset name from state (`state.get("preset", "default")`) |
 | `asset` | string | Ticker symbol |
 | `direction` | string | `"LONG"` or `"SHORT"` |
 | `price` | float | Current price |
@@ -85,7 +87,7 @@ The script prints a single JSON line to stdout on each run. The agent reads this
 | `pending_close` | bool | True if close was attempted and failed |
 | `consecutive_failures` | int | Number of consecutive price fetch failures |
 
-### v5 Hyperliquid SL Fields
+### v5.1 Hyperliquid SL Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -123,7 +125,7 @@ otherwise:
   → silent (HEARTBEAT_OK)
 ```
 
-## dsl-cleanup.py Output (v5)
+## dsl-cleanup.py Output (v5.1)
 
 Strategy-level cleanup script prints a single JSON line:
 

--- a/dsl-dynamic-stop-loss/references/state-schema.md
+++ b/dsl-dynamic-stop-loss/references/state-schema.md
@@ -1,6 +1,6 @@
 # State File Schema
 
-Complete JSON schema for DSL v4/v5 state files. One state file per position. v5 adds path conventions; the JSON schema is unchanged.
+Complete JSON schema for DSL v4/v5.1 state files. One state file per position. v5.1 adds path conventions; the JSON schema is unchanged.
 
 ## Full Example
 
@@ -10,20 +10,22 @@ Complete JSON schema for DSL v4/v5 state files. One state file per position. v5 
   "asset": "HYPE",
   "direction": "LONG",
   "leverage": 10,
+  "margin": 5460.43,
   "entryPrice": 28.87,
   "size": 1890.28,
   "wallet": "0xYourStrategyWalletAddress",
   "strategyId": "uuid-of-strategy",
+  "preset": "dsl-tight",
   "phase": 1,
   "phase1": {
     "retraceThreshold": 0.03,
-    "consecutiveBreachesRequired": 3,
+    "consecutiveBreachesRequired": 1,
     "absoluteFloor": 28.00
   },
   "phase2TriggerTier": 1,
   "phase2": {
     "retraceThreshold": 0.015,
-    "consecutiveBreachesRequired": 2
+    "consecutiveBreachesRequired": 1
   },
   "tiers": [
     {"triggerPct": 10, "lockPct": 5},
@@ -58,10 +60,12 @@ Complete JSON schema for DSL v4/v5 state files. One state file per position. v5 
 | `asset` | string | Ticker symbol (e.g., "HYPE", "BTC", "ETH"). For xyz dex use prefix: "xyz:SILVER", "xyz:AAPL". |
 | `direction` | string | `"LONG"` or `"SHORT"` — controls all math |
 | `leverage` | number | Position leverage (used for ROE calculation) |
+| `margin` | number | Position margin (collateral) in quote units; used for ROE. Set by add-dsl from `--margin`. If missing (legacy state), script uses entry×size/leverage. |
 | `entryPrice` | number | Average entry price |
 | `size` | number | Position size in units |
 | `wallet` | string | Strategy wallet address — required for auto-close |
 | `strategyId` | string | Strategy UUID |
+| `preset` | string | Optional. Preset name (e.g. `"dsl-tight"`); defaults to `"default"`. Set by `add-dsl` CLI. |
 | `phase` | int | Current phase: `1` or `2` |
 | `phase1` | object | Phase 1 configuration (see below) |
 | `phase2TriggerTier` | int | Tier index that triggers Phase 2 transition (default: 0 = first tier) |
@@ -94,6 +98,7 @@ Complete JSON schema for DSL v4/v5 state files. One state file per position. v5 
 | `triggerPct` | float | Yes | ROE % that activates this tier |
 | `lockPct` | float | Yes | % of (entry→high water) range to lock as floor (e.g. 50 = lock half the gain) |
 | `retrace` | float | No | Per-tier retrace override in ROE terms (uses `phase2.retraceThreshold` if omitted) |
+| `breachesRequired` | int | No | Breaches needed before close for this tier; if omitted uses `phase2.consecutiveBreachesRequired` |
 
 ## v4 Optional Fields (all have defaults)
 
@@ -110,7 +115,7 @@ Complete JSON schema for DSL v4/v5 state files. One state file per position. v5 
 | `lastCheck` | `null` | Last check timestamp — set by script |
 | `lastPrice` | `null` | Last fetched price — set by script |
 
-## v5 Hyperliquid SL Fields (optional)
+## v5.1 Hyperliquid SL Fields (optional)
 
 When the script syncs the dynamic stop loss to Hyperliquid via Senpi `edit_position`, it stores and updates these fields:
 
@@ -123,7 +128,7 @@ When the script syncs the dynamic stop loss to Hyperliquid via Senpi `edit_posit
 
 Path and file naming stay the same; these fields are optional and backfilled by the script when syncing.
 
-## v5 Path Conventions
+## v5.1 Path Conventions
 
 State files are stored under a directory per strategy. Required env vars:
 

--- a/dsl-dynamic-stop-loss/scripts/dsl-cleanup.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-cleanup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""DSL v5 strategy-level cleanup.
+"""DSL v5.1 strategy-level cleanup.
 When all positions in a strategy are closed, removes the strategy directory
 (no archiving). Run after disabling all crons for the strategy.
 

--- a/dsl-dynamic-stop-loss/scripts/dsl-v5.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-v5.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""DSL v5 — Strategy-scoped cron, MCP clearinghouse + price, delete on close.
+"""DSL v5.1 — Strategy-scoped cron, MCP clearinghouse + price, delete on close.
 Cron is per strategy (DSL_STATE_DIR + DSL_STRATEGY_ID only). Each run:
 1. Check if strategy is active via MCP; if not, cleanup all state files and output strategy_inactive.
 2. Get active positions from MCP clearinghouse; delete state files for positions that no longer exist.
@@ -8,6 +8,7 @@ Output: one JSON line per position (ndjson), or one line for strategy-level outc
 """
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import subprocess
@@ -72,6 +73,21 @@ def dex_and_lookup_symbol(asset: str) -> tuple[str, str]:
     if asset.startswith("xyz:"):
         return "xyz", asset.split(":", 1)[1]
     return "", asset
+
+
+def normalize_asset_dex(asset: str, dex: str | None) -> tuple[str, str]:
+    """Return (canonical_asset, dex). Canonical asset has 'xyz:' prefix for xyz dex.
+    - asset xyz:SILVER → (xyz:SILVER, 'xyz'); dex arg inferred from prefix.
+    - asset SILVER, dex 'xyz' → (xyz:SILVER, 'xyz').
+    - asset ETH, dex '' or 'main' or None → (ETH, '').
+    """
+    asset = (asset or "").strip()
+    dex_val = (dex or "").strip().lower() if dex else ""
+    if asset.startswith("xyz:"):
+        return asset, "xyz"
+    if dex_val == "xyz":
+        return f"xyz:{asset}", "xyz"
+    return asset, ""
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +201,30 @@ def get_active_position_coins(wallet: str) -> tuple[set[str], str | None]:
     return coins, None
 
 
+def get_position_from_clearinghouse(wallet: str, asset: str) -> tuple[dict | None, str | None]:
+    """Get position dict for one asset from clearinghouse. Returns (position, error).
+    position has entryPx, szi, coin. Error if position not found or clearinghouse failed.
+    """
+    data, err = _mcp_clearinghouse(wallet)
+    if err is not None:
+        return None, err
+    for section in ("main", "xyz"):
+        if not data or section not in data:
+            continue
+        for p in data.get(section, {}).get("assetPositions", []):
+            pos = p.get("position", {})
+            coin = pos.get("coin")
+            if not coin:
+                continue
+            if coin != asset and not (asset.startswith("xyz:") and coin == asset.split(":", 1)[1]):
+                continue
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            return pos, None
+    return None, f"no open position for asset {asset!r}"
+
+
 def cleanup_strategy_state_dir(state_dir: str, strategy_id: str) -> int:
     """Delete all .json state files in strategy dir. Return count deleted."""
     deleted = 0
@@ -276,9 +316,18 @@ def fetch_price_mcp(dex: str, lookup_symbol: str) -> tuple[float | None, str | N
 
 # Schema defaults for phase config (see references/state-schema.md)
 DEFAULT_PHASE1_RETRACE = 0.03
-DEFAULT_PHASE1_BREACHES = 3
+DEFAULT_PHASE1_BREACHES = 1
 DEFAULT_PHASE2_RETRACE = 0.015
-DEFAULT_PHASE2_BREACHES = 2
+DEFAULT_PHASE2_BREACHES = 1
+
+DEFAULT_TIERS = [
+    {"triggerPct": 10, "lockPct": 5},
+    {"triggerPct": 20, "lockPct": 14},
+    {"triggerPct": 30, "lockPct": 22, "retrace": 0.012},
+    {"triggerPct": 50, "lockPct": 40, "retrace": 0.010},
+    {"triggerPct": 75, "lockPct": 60, "retrace": 0.008},
+    {"triggerPct": 100, "lockPct": 80, "retrace": 0.006},
+]
 
 
 def normalize_state_phase_config(state: dict) -> bool:
@@ -711,7 +760,7 @@ def build_output(
         distance_to_next_tier = round(tiers[tier_idx + 1]["triggerPct"] - upnl_pct, 2)
 
     status = "inactive" if closed else ("pending_close" if state.get("pendingClose") else "active")
-    return {
+    out = {
         "status": status,
         "asset": state["asset"],
         "direction": direction,
@@ -743,6 +792,8 @@ def build_output(
         "sl_initial_sync": sl_initial_sync,
         "sl_order_id": state.get("slOrderId"),
     }
+    out["preset"] = state.get("preset", "default")
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -811,7 +862,9 @@ def process_one_position(state_file: str, strategy_id: str, now: str) -> None:
     hw = update_high_water(state, price, is_long)
 
     upnl = (price - entry) * size if is_long else (entry - price) * size
-    margin = entry * size / leverage
+    margin = state.get("margin")
+    if margin is None or margin <= 0:
+        margin = entry * size / leverage
     upnl_pct = upnl / margin * 100
 
     tier_idx, tier_floor, tier_changed, previous_tier_idx = apply_tier_upgrades(
@@ -902,10 +955,335 @@ def process_one_position(state_file: str, strategy_id: str, now: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Main (strategy-scoped)
+# CLI subcommands (add-dsl, update-dsl, pause-dsl, resume-dsl, delete-dsl, status-dsl)
 # ---------------------------------------------------------------------------
 
-def main() -> None:
+SUBCOMMANDS = {"add-dsl", "update-dsl", "pause-dsl", "resume-dsl", "delete-dsl", "status-dsl"}
+CRON_SCHEDULE = "*/3 * * * *"
+
+
+def _deep_merge_config(base: dict, override: dict, configurable_keys: set) -> None:
+    """Merge override into base for configurable keys. phase1/phase2 deep-merge; tiers full replace."""
+    for key in list(override.keys()):
+        if key not in configurable_keys:
+            continue
+        val = override[key]
+        if key == "tiers":
+            if isinstance(val, list):
+                base[key] = list(val)
+            continue
+        if key in ("phase1", "phase2") and isinstance(val, dict):
+            if key not in base or not isinstance(base[key], dict):
+                base[key] = {}
+            for k, v in val.items():
+                base[key][k] = v
+            continue
+        base[key] = val
+
+
+def _add_dsl_build_state(
+    asset: str,
+    direction: str,
+    leverage: float,
+    margin: float,
+    entry_price: float,
+    size: float,
+    wallet: str,
+    strategy_id: str,
+    preset: str,
+    config_json: dict | None,
+) -> dict:
+    """Build state dict for add-dsl. Uses defaults and optional --config merge."""
+    configurable = {
+        "phase1", "phase2", "phase2TriggerTier", "tiers",
+        "breachDecay", "closeRetries", "closeRetryDelaySec", "maxFetchFailures",
+    }
+    state = {
+        "phase1": {
+            "retraceThreshold": DEFAULT_PHASE1_RETRACE,
+            "consecutiveBreachesRequired": DEFAULT_PHASE1_BREACHES,
+            "absoluteFloor": 0.0,
+        },
+        "phase2": {
+            "retraceThreshold": DEFAULT_PHASE2_RETRACE,
+            "consecutiveBreachesRequired": DEFAULT_PHASE2_BREACHES,
+        },
+        "phase2TriggerTier": 0,
+        "tiers": list(DEFAULT_TIERS),
+        "breachDecay": "hard",
+        "closeRetries": 2,
+        "closeRetryDelaySec": 3,
+        "maxFetchFailures": 10,
+    }
+    if config_json and isinstance(config_json, dict):
+        _deep_merge_config(state, config_json, configurable)
+    lev = max(1, leverage)
+    is_long = direction.upper() == "LONG"
+    retrace_roe = state["phase1"]["retraceThreshold"]
+    if is_long:
+        abs_floor = round(entry_price * (1 - retrace_roe / lev), 4)
+    else:
+        abs_floor = round(entry_price * (1 + retrace_roe / lev), 4)
+    state["phase1"]["absoluteFloor"] = abs_floor
+    state["active"] = True
+    state["asset"] = asset
+    state["direction"] = direction.upper()
+    state["leverage"] = lev
+    state["entryPrice"] = round(entry_price, 4)
+    state["size"] = round(size, 4)
+    state["margin"] = round(margin, 4)
+    state["wallet"] = wallet
+    state["strategyId"] = strategy_id
+    state["preset"] = preset or "default"
+    state["phase"] = 1
+    state["highWaterPrice"] = round(entry_price, 4)
+    state["floorPrice"] = abs_floor
+    state["currentTierIndex"] = -1
+    state["tierFloorPrice"] = None
+    state["currentBreachCount"] = 0
+    state["consecutiveFetchFailures"] = 0
+    state["pendingClose"] = False
+    state["lastCheck"] = None
+    state["lastPrice"] = None
+    state["createdAt"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    return state
+
+
+def cmd_add_dsl() -> None:
+    parser = argparse.ArgumentParser(prog="dsl-v5.py add-dsl")
+    parser.add_argument("preset", nargs="?", default="default", help="Preset name (e.g. dsl-tight)")
+    parser.add_argument("--asset", required=True, help="Ticker: ETH (main) or xyz:SILVER (xyz) or SILVER with --dex xyz")
+    parser.add_argument("--dex", type=str, default=None, help="DEX: main or '' for main, xyz for xyz. Required when asset has no prefix and position is on xyz (e.g. --asset SILVER --dex xyz). Inferred from xyz: prefix when omitted.")
+    parser.add_argument("--direction", required=True, choices=["LONG", "SHORT"], help="LONG or SHORT")
+    parser.add_argument("--leverage", type=float, required=True, help="Leverage (positive)")
+    parser.add_argument("--margin", type=float, required=True, help="Position margin (collateral) in quote units; used for ROE. Must be > 0.")
+    parser.add_argument("--config", type=str, default=None, help="Optional JSON config override")
+    parser.add_argument("--state-dir", type=str, default=None, help="State directory (default: env or /data/workspace/dsl)")
+    parser.add_argument("--strategy-id", type=str, default=None, help="Strategy ID (default: DSL_STRATEGY_ID)")
+    args = parser.parse_args(sys.argv[2:])
+    asset, _dex = normalize_asset_dex(args.asset, args.dex)
+    state_dir = args.state_dir or os.environ.get("DSL_STATE_DIR", DEFAULT_STATE_DIR)
+    strategy_id = (args.strategy_id or os.environ.get("DSL_STRATEGY_ID", "")).strip()
+    if not strategy_id:
+        print(json.dumps({"action": "add-dsl", "status": "error", "error": "strategy_id_required", "message": "Set --strategy-id or DSL_STRATEGY_ID"}))
+        sys.exit(1)
+    if args.leverage <= 0:
+        print(json.dumps({"action": "add-dsl", "status": "error", "error": "invalid_leverage", "message": "leverage must be > 0"}))
+        sys.exit(1)
+    if args.margin <= 0:
+        print(json.dumps({"action": "add-dsl", "status": "error", "error": "invalid_margin", "message": "margin must be > 0"}))
+        sys.exit(1)
+    config_json = None
+    if args.config:
+        try:
+            config_json = json.loads(args.config)
+            if not isinstance(config_json, dict):
+                config_json = None
+        except json.JSONDecodeError as e:
+            print(json.dumps({"action": "add-dsl", "status": "error", "error": "invalid_config_json", "message": str(e)}))
+            sys.exit(1)
+    active, wallet, err, _ = get_strategy_active_and_wallet(strategy_id)
+    if not active:
+        print(json.dumps({"action": "add-dsl", "status": "error", "error": "strategy_get_failed", "message": err or "Strategy not active or not found"}))
+        sys.exit(1)
+    pos, pos_err = get_position_from_clearinghouse(wallet, asset)
+    if pos is None:
+        print(json.dumps({"action": "add-dsl", "status": "error", "error": "position_not_found", "message": pos_err, "asset": asset}))
+        sys.exit(1)
+    try:
+        entry_price = float(pos.get("entryPx", 0))
+        szi = float(pos.get("szi", 0))
+        size = abs(szi)
+    except (TypeError, ValueError):
+        print(json.dumps({"action": "add-dsl", "status": "error", "error": "invalid_position_data", "message": "entryPx/szi missing or invalid"}))
+        sys.exit(1)
+    if entry_price <= 0 or size <= 0:
+        print(json.dumps({"action": "add-dsl", "status": "error", "error": "invalid_position_data", "message": "entryPx and size must be > 0"}))
+        sys.exit(1)
+    state = _add_dsl_build_state(
+        asset, args.direction.upper(), args.leverage, args.margin,
+        entry_price, size, wallet, strategy_id, args.preset, config_json,
+    )
+    state_file = os.path.join(state_dir, strategy_id, f"{asset_to_filename(asset)}.json")
+    if os.path.isfile(state_file):
+        print(json.dumps({"action": "add-dsl", "status": "error", "error": "state_file_exists", "message": "State file already exists; overwrite not allowed", "state_file": state_file}))
+        sys.exit(1)
+    try:
+        os.makedirs(os.path.dirname(state_file), exist_ok=True)
+        with open(state_file, "w") as f:
+            json.dump(state, f, indent=2)
+    except OSError as e:
+        print(json.dumps({"action": "add-dsl", "status": "error", "error": "write_failed", "message": str(e), "state_file": state_file}))
+        sys.exit(1)
+    existing = list_strategy_state_files(state_dir, strategy_id)
+    is_first = len(existing) == 1
+    out = {
+        "action": "add-dsl",
+        "status": "ok",
+        "preset": state["preset"],
+        "asset": asset,
+        "strategy_id": strategy_id,
+        "state_file": state_file,
+        "is_first_position_for_strategy": is_first,
+        "cron_needed": is_first,
+        "cron_env": {"DSL_STATE_DIR": state_dir, "DSL_STRATEGY_ID": strategy_id, "DSL_PRESET": state["preset"]},
+        "cron_schedule": CRON_SCHEDULE,
+    }
+    print(json.dumps(out))
+
+
+def cmd_update_dsl() -> None:
+    parser = argparse.ArgumentParser(prog="dsl-v5.py update-dsl")
+    parser.add_argument("--asset", type=str, default=None, help="Omit to update all positions in strategy. Use xyz:SILVER or SILVER with --dex xyz for xyz.")
+    parser.add_argument("--dex", type=str, default=None, help="DEX when asset has no prefix (e.g. --asset SILVER --dex xyz)")
+    parser.add_argument("--config", type=str, required=True, help="JSON config to merge")
+    parser.add_argument("--state-dir", type=str, default=None)
+    parser.add_argument("--strategy-id", type=str, default=None)
+    args = parser.parse_args(sys.argv[2:])
+    state_dir = args.state_dir or os.environ.get("DSL_STATE_DIR", DEFAULT_STATE_DIR)
+    strategy_id = (args.strategy_id or os.environ.get("DSL_STRATEGY_ID", "")).strip()
+    if not strategy_id:
+        print(json.dumps({"action": "update-dsl", "status": "error", "error": "strategy_id_required"}))
+        sys.exit(1)
+    try:
+        config_json = json.loads(args.config)
+        if not isinstance(config_json, dict):
+            raise ValueError("config must be a JSON object")
+    except (json.JSONDecodeError, ValueError) as e:
+        print(json.dumps({"action": "update-dsl", "status": "error", "error": "invalid_config", "message": str(e)}))
+        sys.exit(1)
+    configurable = {"phase1", "phase2", "phase2TriggerTier", "tiers", "breachDecay", "closeRetries", "closeRetryDelaySec", "maxFetchFailures"}
+    files = list_strategy_state_files(state_dir, strategy_id)
+    if args.asset:
+        canonical_asset, _ = normalize_asset_dex(args.asset, args.dex)
+        files = [(p, a) for p, a in files if a == canonical_asset]
+    if not files:
+        print(json.dumps({"action": "update-dsl", "status": "error", "error": "no_state_files", "message": "No matching state file(s)"}))
+        sys.exit(1)
+    updated = 0
+    for path, asset in files:
+        try:
+            with open(path) as f:
+                state = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        _deep_merge_config(state, config_json, configurable)
+        if "phase1" in config_json and "absoluteFloor" not in config_json.get("phase1", {}):
+            entry = state.get("entryPrice")
+            lev = max(1, state.get("leverage", 1))
+            is_long = (state.get("direction", "LONG").upper() == "LONG")
+            if entry is not None:
+                retrace = state["phase1"].get("retraceThreshold", DEFAULT_PHASE1_RETRACE)
+                if is_long:
+                    state["phase1"]["absoluteFloor"] = round(entry * (1 - retrace / lev), 4)
+                else:
+                    state["phase1"]["absoluteFloor"] = round(entry * (1 + retrace / lev), 4)
+        try:
+            with open(path, "w") as f:
+                json.dump(state, f, indent=2)
+            updated += 1
+        except OSError:
+            pass
+    print(json.dumps({"action": "update-dsl", "status": "ok", "strategy_id": strategy_id, "updated_count": updated}))
+
+
+def _cmd_pause_resume_dsl(active: bool) -> None:
+    name = "resume-dsl" if active else "pause-dsl"
+    parser = argparse.ArgumentParser(prog=f"dsl-v5.py {name}")
+    parser.add_argument("--asset", type=str, default=None, help="e.g. ETH or xyz:SILVER or SILVER with --dex xyz")
+    parser.add_argument("--dex", type=str, default=None, help="DEX when asset has no prefix")
+    parser.add_argument("--state-dir", type=str, default=None)
+    parser.add_argument("--strategy-id", type=str, default=None)
+    args = parser.parse_args(sys.argv[2:])
+    state_dir = args.state_dir or os.environ.get("DSL_STATE_DIR", DEFAULT_STATE_DIR)
+    strategy_id = (args.strategy_id or os.environ.get("DSL_STRATEGY_ID", "")).strip()
+    if not strategy_id:
+        print(json.dumps({"action": name, "status": "error", "error": "strategy_id_required"}))
+        sys.exit(1)
+    files = list_strategy_state_files(state_dir, strategy_id)
+    if args.asset:
+        canonical_asset, _ = normalize_asset_dex(args.asset, args.dex)
+        files = [(p, a) for p, a in files if a == canonical_asset]
+    for path, _ in files:
+        try:
+            with open(path) as f:
+                state = json.load(f)
+            state["active"] = active
+            with open(path, "w") as f:
+                json.dump(state, f, indent=2)
+        except (OSError, json.JSONDecodeError):
+            pass
+    print(json.dumps({"action": name, "status": "ok", "strategy_id": strategy_id, "active": active}))
+
+
+def cmd_delete_dsl() -> None:
+    parser = argparse.ArgumentParser(prog="dsl-v5.py delete-dsl")
+    parser.add_argument("--asset", type=str, default=None, help="e.g. ETH or xyz:SILVER or SILVER with --dex xyz")
+    parser.add_argument("--dex", type=str, default=None, help="DEX when asset has no prefix")
+    parser.add_argument("--state-dir", type=str, default=None)
+    parser.add_argument("--strategy-id", type=str, default=None)
+    args = parser.parse_args(sys.argv[2:])
+    state_dir = args.state_dir or os.environ.get("DSL_STATE_DIR", DEFAULT_STATE_DIR)
+    strategy_id = (args.strategy_id or os.environ.get("DSL_STRATEGY_ID", "")).strip()
+    if not strategy_id:
+        print(json.dumps({"action": "delete-dsl", "status": "error", "error": "strategy_id_required"}))
+        sys.exit(1)
+    files = list_strategy_state_files(state_dir, strategy_id)
+    if args.asset:
+        canonical_asset, _ = normalize_asset_dex(args.asset, args.dex)
+        files = [(p, a) for p, a in files if a == canonical_asset]
+    deleted = 0
+    for path, _ in files:
+        try:
+            os.remove(path)
+            deleted += 1
+        except OSError:
+            pass
+    strategy_dir = os.path.join(state_dir, strategy_id)
+    if os.path.isdir(strategy_dir) and not os.listdir(strategy_dir):
+        try:
+            os.rmdir(strategy_dir)
+        except OSError:
+            pass
+    print(json.dumps({"action": "delete-dsl", "status": "ok", "strategy_id": strategy_id, "deleted_count": deleted}))
+
+
+def cmd_status_dsl() -> None:
+    parser = argparse.ArgumentParser(prog="dsl-v5.py status-dsl")
+    parser.add_argument("--asset", type=str, default=None, help="e.g. ETH or xyz:SILVER or SILVER with --dex xyz")
+    parser.add_argument("--dex", type=str, default=None, help="DEX when asset has no prefix")
+    parser.add_argument("--state-dir", type=str, default=None)
+    parser.add_argument("--strategy-id", type=str, default=None)
+    args = parser.parse_args(sys.argv[2:])
+    state_dir = args.state_dir or os.environ.get("DSL_STATE_DIR", DEFAULT_STATE_DIR)
+    strategy_id = (args.strategy_id or os.environ.get("DSL_STRATEGY_ID", "")).strip()
+    if not strategy_id:
+        print(json.dumps({"action": "status-dsl", "status": "error", "error": "strategy_id_required"}))
+        sys.exit(1)
+    files = list_strategy_state_files(state_dir, strategy_id)
+    if args.asset:
+        canonical_asset, _ = normalize_asset_dex(args.asset, args.dex)
+        files = [(p, a) for p, a in files if a == canonical_asset]
+    if not files:
+        print(json.dumps({"action": "status-dsl", "status": "ok", "strategy_id": strategy_id, "positions": []}))
+        return
+    for path, asset in files:
+        try:
+            with open(path) as f:
+                state = json.load(f)
+            if args.asset:
+                print(json.dumps(state, indent=2))
+            else:
+                print(json.dumps(state))
+        except (OSError, json.JSONDecodeError):
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Main (strategy-scoped monitor)
+# ---------------------------------------------------------------------------
+
+def main_monitor() -> None:
     state_dir = os.environ.get("DSL_STATE_DIR", DEFAULT_STATE_DIR)
     strategy_id = os.environ.get("DSL_STRATEGY_ID", "").strip()
     if not strategy_id:
@@ -919,9 +1297,11 @@ def main() -> None:
     if not active:
         if confirmed_inactive:
             deleted = cleanup_strategy_state_dir(state_dir, strategy_id)
+            dsl_preset = os.environ.get("DSL_PRESET", "") or "default"
             print(json.dumps({
                 "status": "strategy_inactive",
                 "strategy_id": strategy_id,
+                "preset": dsl_preset,
                 "message": "Strategy not active (Senpi MCP). State files cleaned. Agent: remove cron for this strategy.",
                 "reason": active_error,
                 "state_files_deleted": deleted,
@@ -929,11 +1309,12 @@ def main() -> None:
             }))
             sys.exit(0)
         else:
-            # Transient/API error (timeout, mcporter down, malformed response): do not delete state.
+            dsl_preset = os.environ.get("DSL_PRESET", "") or "default"
             print(json.dumps({
                 "status": "error",
                 "error": "strategy_get_failed",
                 "strategy_id": strategy_id,
+                "preset": dsl_preset,
                 "message": active_error,
                 "time": now,
             }))
@@ -942,10 +1323,12 @@ def main() -> None:
     # 2. Active positions from clearinghouse.
     coins, ch_error = get_active_position_coins(wallet)
     if ch_error is not None:
+        dsl_preset = os.environ.get("DSL_PRESET", "") or "default"
         print(json.dumps({
             "status": "error",
             "error": "clearinghouse_failed",
             "strategy_id": strategy_id,
+            "preset": dsl_preset,
             "message": ch_error,
             "time": now,
         }))
@@ -967,12 +1350,33 @@ def main() -> None:
             processed += 1
 
     if processed == 0:
+        dsl_preset = os.environ.get("DSL_PRESET", "") or "default"
         print(json.dumps({
             "status": "no_positions",
             "strategy_id": strategy_id,
+            "preset": dsl_preset,
             "message": "Strategy active but no position state files to process. Agent: keep cron; next run may have positions or output strategy_inactive after cleanup.",
             "time": now,
         }))
+
+
+def main() -> None:
+    if len(sys.argv) >= 2 and sys.argv[1] in SUBCOMMANDS:
+        cmd = sys.argv[1]
+        if cmd == "add-dsl":
+            cmd_add_dsl()
+        elif cmd == "update-dsl":
+            cmd_update_dsl()
+        elif cmd == "pause-dsl":
+            _cmd_pause_resume_dsl(active=False)
+        elif cmd == "resume-dsl":
+            _cmd_pause_resume_dsl(active=True)
+        elif cmd == "delete-dsl":
+            cmd_delete_dsl()
+        elif cmd == "status-dsl":
+            cmd_status_dsl()
+        return
+    main_monitor()
 
 
 if __name__ == "__main__":

--- a/dsl-tight/SKILL.md
+++ b/dsl-tight/SKILL.md
@@ -2,7 +2,7 @@
 name: dsl-tight
 description: >-
   Opinionated trailing stop loss preset for Hyperliquid perps with tighter
-  defaults than DSL v5. 4 tiers with per-tier breach counts that tighten as
+  defaults than DSL v5.1. 4 tiers with per-tier breach counts that tighten as
   profit grows (3→2→2→1), auto-calculated price floors from entry and leverage,
   stagnation take-profit that closes if ROE ≥8% but high-water stalls for 1 hour.
   Same ROE-based engine as DSL v4 — different defaults, fewer knobs.
@@ -19,11 +19,11 @@ metadata:
   exchange: hyperliquid
 ---
 
-# DSL-Tight — Opinionated Stop-Loss Preset (v5)
+# DSL-Tight — Opinionated Stop-Loss Preset (v5.1)
 
-A tighter, more opinionated variant of DSL for aggressive profit protection. Uses the **same script and architecture as DSL v5** (`dsl-v5.py`) — strategy-scoped cron, MCP clearinghouse, state under `{DSL_STATE_DIR}/{strategyId}/{asset}.json`. All tier triggers are ROE-based (`PnL / margin × 100`); leverage is accounted for automatically.
+A tighter, more opinionated variant of DSL for aggressive profit protection. Uses the **same script and architecture as DSL v5.1** (`dsl-v5.py`) — strategy-scoped cron, MCP clearinghouse, state under `{DSL_STATE_DIR}/{strategyId}/{asset}.json`. All tier triggers are ROE-based (`PnL / margin × 100`); leverage is accounted for automatically.
 
-**Key difference from default DSL v5:** DSL v5 is the configurable engine with maximum flexibility. DSL-Tight is the "just works" preset — fewer knobs, tighter defaults, per-tier breach counts, stagnation exits, and auto-calculated floors.
+**Key difference from default DSL v5.1:** DSL v5.1 is the configurable engine with maximum flexibility. DSL-Tight is the "just works" preset — fewer knobs, tighter defaults, per-tier breach counts, stagnation exits, and auto-calculated floors.
 ## Core Concept
 
 All thresholds defined in ROE. The script auto-converts to price levels:
@@ -63,62 +63,25 @@ Catches winners that stall — takes the profit rather than waiting for a revers
 - Per-tier breach requirements (3→2→2→1) replace the global Phase 1/Phase 2 split
 - Floor is always: `max(tier_floor, trailing_floor)` for LONG, `min()` for SHORT
 
-## State File Schema
+## Setup
 
-State files live in the **DSL v5 strategy directory**: `{DSL_STATE_DIR}/{strategyId}/{asset}.json` (main dex) or `{DSL_STATE_DIR}/{strategyId}/xyz--SYMBOL.json` (xyz dex). See [dsl-dynamic-stop-loss references/state-schema.md](../dsl-dynamic-stop-loss/references/state-schema.md) for path conventions.
+Use the core DSL CLI so the script creates state from clearinghouse:
 
-```json
-{
-  "active": true,
-  "asset": "HYPE",
-  "direction": "LONG",
-  "leverage": 10,
-  "entryPrice": 28.87,
-  "size": 1890.28,
-  "wallet": "0xYourStrategyWalletAddress",
-  "strategyId": "uuid-of-strategy",
-  "phase": 1,
-  "phase1": {
-    "retraceThreshold": 0.05,
-    "consecutiveBreachesRequired": 3
-  },
-  "phase2TriggerTier": 0,
-  "phase2": {
-    "retraceThreshold": 0.015,
-    "consecutiveBreachesRequired": 2
-  },
-  "tiers": [
-    {"triggerPct": 10, "lockPct": 50, "retrace": 0.015},
-    {"triggerPct": 20, "lockPct": 65, "retrace": 0.012},
-    {"triggerPct": 40, "lockPct": 75, "retrace": 0.010},
-    {"triggerPct": 75, "lockPct": 85, "retrace": 0.006}
-  ],
-  "breachDecay": "hard",
-  "currentTierIndex": -1,
-  "tierFloorPrice": null,
-  "highWaterPrice": 28.87,
-  "floorPrice": 28.78,
-  "currentBreachCount": 0,
-  "createdAt": "2026-02-23T10:00:00.000Z"
-}
+```bash
+python3 path/to/dsl-v5.py add-dsl dsl-tight --strategy-id ID --asset ASSET --direction LONG|SHORT --leverage N --margin N
 ```
 
-Omit `phase1.absoluteFloor` — dsl-v5 fills it from entry and leverage. Set `highWaterPrice` to entry price, `floorPrice` to entry (or the computed absolute floor) for Phase 1 start.
+Replace `path/to/dsl-v5.py` with the resolved path to the dsl-dynamic-stop-loss script (e.g. `.../dsl-dynamic-stop-loss/scripts/dsl-v5.py`). Position must exist. Optional: `--config '<json>'` for phase1/phase2/tiers, `--dex xyz` for xyz assets without prefix. **For all options and constructing `--config`:** [cli-options](../dsl-dynamic-stop-loss/references/cli-options.md). State path: `{DSL_STATE_DIR}/{strategyId}/{asset}.json` or `xyz--SYMBOL.json` for xyz.
 
-### Field Reference
-
-| Field | Purpose |
-|-------|---------|
-| `phase1.absoluteFloor` | **Not needed** — auto-calculated from entry, leverage, retrace |
-| `tiers[].breachesRequired` | Per-tier breach count (replaces global phase2 setting) |
+| Config (when using `--config`) | Purpose |
+|--------------------------------|---------|
+| `tiers[].breachesRequired` | Per-tier breach count (3→2→2→1) |
 | `tiers[].retrace` | Per-tier trailing stop tightness |
-| `stagnation.enabled` | Enable stagnation take-profit |
-| `stagnation.minRoePct` | Minimum ROE to trigger stagnation check |
-| `stagnation.maxStaleSec` | Max seconds HW can be stale before auto-close |
+| `stagnation.*` | Stagnation take-profit (if supported by runner) |
 
 ## Cron Setup
 
-**Same as DSL v5:** one cron **per strategy** (not per position), every 3–5 minutes. The agent creates it when setting up DSL for a strategy.
+**Same as DSL v5.1:** one cron **per strategy** (not per position), every 3–5 minutes. The agent creates it when setting up DSL for a strategy.
 
 **Resolving the script path:** When setting up the cron, **locate the dsl-dynamic-stop-loss skill on disk** (e.g. search the workspace, skills directory, or ClawHub install path for a folder named `dsl-dynamic-stop-loss` containing `scripts/dsl-v5.py`). Use that resolved path in the cron command — do not assume a fixed relative path. Example once resolved:
 
@@ -130,11 +93,11 @@ No `DSL_ASSET` — the script discovers positions from MCP clearinghouse and sta
 
 **Clock-aligned schedule (OpenClaw):** For runs at fixed 3-minute boundaries (e.g. :00, :03, :06…), create the job with a cron expression: `"schedule": { "kind": "cron", "expr": "*/3 * * * *", "tz": "UTC" }`. See [dsl-dynamic-stop-loss SKILL.md](../dsl-dynamic-stop-loss/SKILL.md) Cron Setup and [references/explained.md](../dsl-dynamic-stop-loss/references/explained.md) §0.
 
-Agent responsibilities (same as DSL v5): on `strategy_inactive` remove cron and run strategy cleanup; on `closed=true` alert user; on `pending_close=true` alert and retry next tick.
+Agent responsibilities (same as DSL v5.1): on `strategy_inactive` remove cron and run strategy cleanup; on `closed=true` alert user; on `pending_close=true` alert and retry next tick.
 
 ## Key Safety Features
 
-- Same as DSL v5: strategy active check, reconcile state vs clearinghouse, delete state on close
+- Same as DSL v5.1: strategy active check, reconcile state vs clearinghouse, delete state on close
 - Auto-calculated floors eliminate manual math errors
 - Per-tier breach tightening means large profits get maximum protection
 - Stagnation TP prevents stalled winners from reversing


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates core stop-loss behavior defaults (breach thresholds) and ROE calculations (adds `margin`), which can materially change when positions close; also introduces new CLI paths that create/modify/delete state files.
> 
> **Overview**
> **DSL v5.1 adds a first-class CLI for state management**: `scripts/dsl-v5.py` now supports `add-dsl`, `update-dsl`, `pause-dsl`, `resume-dsl`, `delete-dsl`, and `status-dsl`, including asset/DEX normalization (e.g. `--dex xyz`) and emitting recommended cron env/schedule on `add-dsl`.
> 
> **State/output schema changes:** state now records `margin` (used for ROE; legacy states fall back to `entry×size/leverage`) and optional `preset`, and monitor output includes `preset` on both per-position and strategy-level lines.
> 
> **Behavior/config defaults changed:** phase breach defaults are tightened (`phase1` 3→1, `phase2` 2→1) and a default tier set is centralized; documentation is updated accordingly with new reference docs (`cli-options.md`, `examples.md`) and updated setup guidance for `dsl-tight`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24a8c60d0bfd457bdb336f72121c7f7a1e6c1a07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->