### PR TITLE
About senpi broken references

### DIFF
--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -220,9 +220,9 @@ If the user asks to turn notifications off or back on, follow the procedure in
 For any summary or Q&A response, follow
 [references/about-senpi.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/about-senpi.md)
 (`Summary Response Contract` and `Mandatory Invocation Procedure` sections).
-Use the `UPDATE_OUTPUT` produced by the top-level `Pre-Response Check` above;
-do not rerun `Pre-Response Invocation Check` here unless it has not yet been
-run in the current invocation.
+Do not rely on stale precomputed update payloads or local update-check scripts
+in this summary flow. For "What's new?", follow the transparent fallback rules in
+`references/about-senpi.md` when verified updates are unavailable.
 Do not consider the response complete until those procedures are satisfied.
 
 ### "What is Senpi?" / "Summarize Senpi" / "Summarize skills and capabilities" / "How do I install skills?" / "What's new?"

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -17,17 +17,12 @@ Do not auto-insert this summary during normal onboarding.
 ## Mandatory Invocation Procedure (NOT Optional)
 
 Run this procedure for every summary/Q&A response handled by `senpi-entrypoint`:
-1. Ensure the pre-response invocation check has been executed exactly once for
-   this invocation, and use that `UPDATE_OUTPUT`.
-   - If `UPDATE_OUTPUT` is already available from `SKILL.md`'s top-level
-     `Pre-Response Check`, reuse it and do **not** run the check again.
-   - Run the checker from
-     [references/skill-update-checker.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-update-checker.md)
-     (`Pre-Response Invocation Check`) only as a fallback when it has not yet
-     been run in the current invocation.
-2. Compose the core answer using this summary contract.
-3. Resolve "What's new" using the rules in the `What's New` section below.
-4. If updates exist, append a short user-friendly "What's new" addendum; otherwise omit it.
+1. Compose the core answer using this summary contract.
+2. Resolve "What's new" using the rules in the `What's New` section below.
+3. If verified updates exist, append a short user-friendly "What's new"
+   addendum; otherwise use the fallback response defined below.
+4. Never rely on stale precomputed update payloads or local update-check
+   scripts for this summary flow.
 
 Completion gate: response is NOT complete until all steps above are executed.
 
@@ -36,19 +31,19 @@ Default response order (compact + actionable):
 2. Core capabilities
 3. Full skill catalog (bullet list)
 4. Install guidance
-5. What's new (only if updates exist)
+5. What's new (only when verified updates exist or user explicitly asks)
 6. Closing question
 
 Behavior rules:
-- Use queued startup `UPDATE_OUTPUT` for "what's new" when available.
-- If no queued updates exist, run one fresh update check before deciding.
-- If both queued and fresh checks show no updates, do not mention "what's new" at all.
 - Do not mention CLI/commands in user-facing summary replies.
 - If user wants install/setup help, offer to handle it for them directly.
 - Present the entire skill catalog as bullet points (no tables).
 - For "What is Senpi?", include a short onboarding-status note (`SENPI_AUTH_TOKEN` set/unset and next step).
 - For goal-based picks, also consult
   [references/skill-recommendations.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/skill-recommendations.md).
+- Do not run local update-check scripts as part of summary replies.
+- If verified update notes are unavailable, be transparent and offer to check
+  the official Senpi repository/release notes.
 - End with: "Want me to recommend which skills to install next and set them up for you?"
 
 ## Core Capabilities
@@ -84,27 +79,16 @@ For tailored recommendations by objective and budget, see
 
 ## What's New
 
-Use queued updates from the entrypoint startup pending file
-(`$SENPI_STATE_DIR/pending-skill-updates.json` when present).
+Use this section only when the user explicitly asks "What's new?" or when
+verified update notes are already available in context.
 
-If no queued updates exist, run one live check with the checker script:
-
-```bash
-SENPI_ENTRYPOINT_SCRIPTS=$(node -e "
-  const path = require('path'), os = require('os'), fs = require('fs');
-  const p = path.join(os.homedir(), '.agents', 'skills', 'senpi-entrypoint', 'scripts');
-  console.log(fs.existsSync(path.join(p, 'check-skill-updates.py')) ? p : '');
-" 2>/dev/null)
-
-if [ -n "$SENPI_ENTRYPOINT_SCRIPTS" ]; then
-  LIVE_UPDATE_OUTPUT=$(python3 "$SENPI_ENTRYPOINT_SCRIPTS/check-skill-updates.py" 2>/dev/null || true)
-fi
-```
-
-Rendering rule:
-- Prefer queued `UPDATE_OUTPUT` when it contains updates.
-- Otherwise use `LIVE_UPDATE_OUTPUT` if it contains updates.
-- If both are `HEARTBEAT_OK` / empty / invalid, skip this section in the reply.
+Rendering rules:
+- If verified updates are available, provide a concise plain-language summary.
+- If verified updates are not available, respond transparently:
+  "I don't have verified update notes in this context. Want me to check the
+  latest changes in the official Senpi Skills repository?"
+- Do not execute local scripts or rely on stale precomputed update payloads in
+  this flow.
 
 ## Platform Reference
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes stale references to deleted update-check scripts and `UPDATE_OUTPUT` from `about-senpi.md` and `SKILL.md` to prevent broken instructions and errors.

The `about-senpi.md` file, actively referenced by `SKILL.md`, contained a "Mandatory Invocation Procedure" referencing `UPDATE_OUTPUT`, a link to the deleted `skill-update-checker.md`, and a "What's New" section that tried to execute the deleted `check-skill-updates.py`. This PR updates these documents to remove those dependencies and provide a safe fallback for "What's New" information.

---
<p><a href="https://cursor.com/agents/bc-fad44e49-ebb9-4912-84a0-dc80273552c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fad44e49-ebb9-4912-84a0-dc80273552c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->