### PR TITLE
Added risk guardian

### DIFF
--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -132,7 +132,7 @@ To add a second strategy, run `wolf-setup.py` again with a different wallet/budg
 - Budget should be the cheapest model that can follow explicit if/then rules. Mid should handle structured JSON parsing and multi-strategy routing reliably.
 - Agents are often not model-aware — they may suggest deprecated IDs (e.g. `claude-3-5-haiku-20241022`) or hallucinate model names. Always use `--provider` instead of manually specifying model IDs.
 - If a cron fails to create or run due to an invalid model ID, fall back to your Mid model for that cron. A working cron on the "wrong" tier is better than a broken cron.
-- When in doubt, use your Mid model for all 5 crons (single-model option) and optimize tiers later.
+- When in doubt, use your Mid model for all 6 crons (single-model option) and optimize tiers later.
 
 ## Cron Setup
 

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -3,9 +3,9 @@ name: wolf-strategy
 description: >-
   WOLF v6.1 — Fully autonomous multi-strategy trading for Hyperliquid perps via Senpi MCP.
   Manages multiple strategies simultaneously, each with independent wallets, budgets, slots,
-  and DSL configs. 5-cron architecture with Emerging Movers scanner (3min, FIRST_JUMP + IMMEDIATE_MOVER),
+  and DSL configs. 6-cron architecture with Emerging Movers scanner (3min, FIRST_JUMP + IMMEDIATE_MOVER),
   DSL v4 trailing stops (combined runner every 3min, 4-tier at 5/10/15/20% ROE),
-  SM flip detector (5min), watchdog (5min),
+  SM flip detector (5min), watchdog (5min), risk guardian (5min, account-level guard rails),
   and health checks (10min). Same asset can be traded in different strategies simultaneously.
   Enter early on first jumps, not at confirmed peaks. Dynamic risk-based leverage per strategy.
   Requires Senpi MCP connection, python3, mcporter CLI, and OpenClaw cron system.
@@ -82,14 +82,14 @@ Leaderboard rank confirmation LAGS price. When an asset jumps from #31->#16 in o
 3. Fund the wallet via `strategy_top_up` with your budget
 4. **Determine the user's AI provider** — which provider is configured in OpenClaw? (`anthropic`, `openai`, or `google`)
 5. Run setup: `python3 scripts/wolf-setup.py --wallet 0x... --strategy-id UUID --budget 6500 --chat-id 12345 --provider anthropic`
-6. Create the 5 OpenClaw crons using templates from `references/cron-templates.md`
+6. Create the 6 OpenClaw crons using templates from `references/cron-templates.md`
 7. The WOLF is hunting
 
 To add a second strategy, run `wolf-setup.py` again with a different wallet/budget. It adds to the registry.
 
 ---
 
-## Architecture — 5 Cron Jobs
+## Architecture — 6 Cron Jobs
 
 | # | Job | Interval | Session | Script | Purpose |
 |---|-----|----------|---------|--------|---------|
@@ -98,6 +98,7 @@ To add a second strategy, run `wolf-setup.py` again with a different wallet/budg
 | 3 | SM Flip Detector | 5min | isolated | `scripts/sm-flip-check.py` | Cut positions where SM conviction collapses |
 | 4 | Watchdog | 5min | isolated | `scripts/wolf-monitor.py` | Per-strategy margin buffer, liq distances, rotation candidates |
 | 5 | Health Check | 10min | isolated | `scripts/job-health-check.py` | Per-strategy orphan DSL detection, state validation |
+| 6 | Risk Guardian | 5min | isolated | `scripts/risk-guardian.py` | Account-level guard rails: daily loss halt, max entries, consecutive loss cooldown |
 
 **v6 change:** One set of crons for all strategies. Each script reads `wolf-strategies.json` and iterates all enabled strategies internally.
 
@@ -122,8 +123,9 @@ To add a second strategy, run `wolf-setup.py` again with a different wallet/budg
 | Health Check | isolated | Mid | Rule-based file repair, action routing |
 | SM Flip Detector | isolated | Budget | Binary: conviction≥4 + 100 traders → close |
 | Watchdog | isolated | Budget | Threshold checks → alert |
+| Risk Guardian | isolated | Budget | Guard rail evaluation, send notifications |
 
-**Single-model option:** All 5 crons can run on one model. Simpler but costs more for the crons that do simple threshold/binary work.
+**Single-model option:** All 6 crons can run on one model. Simpler but costs more for the crons that do simple threshold/binary work.
 
 **Model ID gotchas:**
 - `--provider` auto-selects models. Only use `--mid-model`/`--budget-model` to override specific tiers.
@@ -134,9 +136,9 @@ To add a second strategy, run `wolf-setup.py` again with a different wallet/budg
 
 ## Cron Setup
 
-**Critical:** Crons are **OpenClaw crons**, NOT senpi crons. All 5 crons run in **isolated sessions** (`agentTurn`) — each runs in its own session with no context pollution, enabling cheaper model tiers.
+**Critical:** Crons are **OpenClaw crons**, NOT senpi crons. All 6 crons run in **isolated sessions** (`agentTurn`) — each runs in its own session with no context pollution, enabling cheaper model tiers.
 
-Create each cron using the OpenClaw cron tool. The exact mandate text for each cron is in **`references/cron-templates.md`**. Read that file, replace the placeholders (`{TELEGRAM}`, `{SCRIPTS}`, and `{WORKSPACE}` in v6), and create all 5 crons.
+Create each cron using the OpenClaw cron tool. The exact mandate text for each cron is in **`references/cron-templates.md`**. Read that file, replace the placeholders (`{TELEGRAM}`, `{SCRIPTS}`, and `{WORKSPACE}` in v6), and create all 6 crons.
 
 **v6 simplification:** No more per-wallet/per-strategy placeholders in cron mandates. Scripts read all strategy info from the registry.
 
@@ -396,6 +398,45 @@ Pass `--leverage N` to `open-position.py` to bypass auto-calculation (capped aga
 
 ---
 
+## Guard Rails — Risk Guardian
+
+The Risk Guardian (6th cron, 5min, Budget tier) enforces account-level guard rails that protect against runaway losses across all positions in a strategy. Per-position DSL handles individual trailing stops; guard rails handle the portfolio.
+
+### Gate States
+
+| Gate | Meaning | Resets |
+|------|---------|--------|
+| `OPEN` | Normal trading | — |
+| `COOLDOWN` | Temporary pause after consecutive losses | Auto-expires after `cooldownMinutes` |
+| `CLOSED` | Halted for the day | Midnight UTC |
+
+When gate != OPEN, `open-position.py` refuses new entries and `emerging-movers.py` shows `available: 0` for that strategy.
+
+### Guard Rail Rules
+
+| Rule | Trigger | Action |
+|------|---------|--------|
+| **G1** Daily Loss Halt | `accountValue - accountValueStart <= -dailyLossLimit` | Gate → CLOSED |
+| **G3** Max Entries | `entries >= maxEntriesPerDay` (bypass if profitable day + `bypassOnProfit`) | Gate → CLOSED |
+| **G4** Consecutive Losses | Last N results all "L" (N = `maxConsecutiveLosses`) | Gate → COOLDOWN for `cooldownMinutes` |
+
+### Config (`guardRails` in strategy registry)
+
+```json
+{
+  "guardRails": {
+    "maxEntriesPerDay": 8,
+    "bypassOnProfit": true,
+    "maxConsecutiveLosses": 3,
+    "cooldownMinutes": 60
+  }
+}
+```
+
+All parameters are optional — defaults are used for any missing key. Set per strategy in `wolf-strategies.json`.
+
+---
+
 ## Known Limitations
 
 - **Watchdog blind spot for XYZ isolated:** The watchdog monitors cross-margin buffer but can't see isolated position liquidation distances in the same way. XYZ positions rely on DSL for protection.
@@ -433,3 +474,4 @@ See `references/learnings.md` for known bugs, gotchas, and trading discipline ru
 | `scripts/sm-flip-check.py` | SM conviction flip detector (multi-strategy) |
 | `scripts/wolf-monitor.py` | Watchdog — per-strategy margin buffer + position health |
 | `scripts/job-health-check.py` | Per-strategy orphan DSL / state validation |
+| `scripts/risk-guardian.py` | Risk Guardian — account-level guard rails (daily loss, max entries, consecutive loss cooldown) |

--- a/wolf-strategy/references/cron-templates.md
+++ b/wolf-strategy/references/cron-templates.md
@@ -11,6 +11,7 @@ WOLF uses isolated sessions and a 2-tier model approach. Configure per-cron in O
 | Health Check | 10min (6x/hr) | isolated | agentTurn | Mid |
 | SM Flip Detector | 5min (12x/hr) | isolated | agentTurn | Budget (cheapest available) |
 | Watchdog | 5min (12x/hr) | isolated | agentTurn | Budget (cheapest available) |
+| Risk Guardian | 5min (12x/hr) | isolated | agentTurn | Budget (cheapest available) |
 
 **2-tier model approach** — auto-configured by `wolf-setup.py --provider`:
 
@@ -22,7 +23,7 @@ WOLF uses isolated sessions and a 2-tier model approach. Configure per-cron in O
 
 > Model IDs in the `cronTemplates` output from `wolf-setup.py` are already correct for your provider. Use them directly when creating crons.
 
-All 5 crons can also run on a single model if you prefer simplicity over cost savings.
+All 6 crons can also run on a single model if you prefer simplicity over cost savings.
 
 ---
 
@@ -143,6 +144,16 @@ If `action_required` is empty → HEARTBEAT_OK.
 
 ```
 WOLF Health Check: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS}/job-health-check.py`, parse JSON.
+Send each message in `notifications` to Telegram ({TELEGRAM}).
+If `notifications` is empty → HEARTBEAT_OK.
+```
+
+---
+
+## 6. Risk Guardian (every 5min) — isolated / agentTurn
+
+```
+WOLF Risk Guardian: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS}/risk-guardian.py`, parse JSON.
 Send each message in `notifications` to Telegram ({TELEGRAM}).
 If `notifications` is empty → HEARTBEAT_OK.
 ```

--- a/wolf-strategy/references/state-schema.md
+++ b/wolf-strategy/references/state-schema.md
@@ -85,6 +85,7 @@ The central config file. Holds multiple strategies, each with independent wallet
 | `autoDeleverThreshold` | number | Account value below which to reduce slots by 1 |
 | `dsl.preset` | string | "aggressive" or "conservative" |
 | `dsl.tiers` | array | 4-tier DSL config |
+| `guardRails` | object | Guard rail overrides: `maxEntriesPerDay`, `bypassOnProfit`, `maxConsecutiveLosses`, `cooldownMinutes`. All optional; defaults used for missing keys. |
 | `enabled` | boolean | false pauses strategy without deleting config |
 
 ### Key Design Decisions
@@ -106,9 +107,11 @@ The central config file. Holds multiple strategies, each with independent wallet
 │   ├── wolf-abc12345/                # Strategy A state dir
 │   │   ├── dsl-HYPE.json
 │   │   ├── dsl-SOL.json
+│   │   ├── trade-counter.json        # Daily trade counter (guard rails)
 │   │   └── watchdog-last.json
 │   └── wolf-xyz78901/                # Strategy B state dir
 │       ├── dsl-HYPE.json             # Same asset, different strategy = OK
+│       ├── trade-counter.json
 │       └── watchdog-last.json
 ├── history/
 │   └── emerging-movers.json          # Shared (market data)
@@ -262,3 +265,54 @@ path = dsl_state_path("wolf-abc12345", "HYPE")
 10. **`phase2.retraceFromHW` is a percentage** — Use `5` for 5%, matching `phase1.retraceThreshold` convention. The code divides by 100 internally. Do NOT use `0.05`.
 
 11. **`stagnation.thresholdHours` not `staleHours`** — The stagnation idle duration field is `thresholdHours`. Using `staleHours` will be silently ignored (defaults to 1.0h).
+
+---
+
+## Trade Counter (`state/{strategyKey}/trade-counter.json`)
+
+Created and maintained by `risk-guardian.py`. Read by `check_gate()` in `wolf_config.py` for gate checks in `open-position.py` and `emerging-movers.py`.
+
+```json
+{
+  "date": "2026-03-05",
+  "accountValueStart": 6500.00,
+  "entries": 3,
+  "closedTrades": 1,
+  "realizedPnl": -45.20,
+  "gate": "OPEN",
+  "gateReason": null,
+  "cooldownUntil": null,
+  "lastResults": ["W", "L", "W"],
+  "processedOrderIds": ["ord-abc123", "ord-def456"],
+  "maxEntriesPerDay": 8,
+  "bypassOnProfit": true,
+  "maxConsecutiveLosses": 3,
+  "cooldownMinutes": 60,
+  "updatedAt": "2026-03-05T10:00:00Z"
+}
+```
+
+### Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `date` | string | UTC date (YYYY-MM-DD). Triggers rollover when != today. |
+| `accountValueStart` | number\|null | Account value at first run of the day. Set once, used by G1. |
+| `entries` | number | Positions opened today. Incremented by `open-position.py`. |
+| `closedTrades` | number | Trades closed today (recorded by risk-guardian). |
+| `realizedPnl` | number | Sum of realized PnL from today's closed trades. |
+| `gate` | string | `"OPEN"`, `"COOLDOWN"`, or `"CLOSED"`. |
+| `gateReason` | string\|null | Human-readable reason for current gate state. |
+| `cooldownUntil` | string\|null | ISO timestamp when COOLDOWN expires. |
+| `lastResults` | array | Last 20 W/L/R results. Carries across days. "R" = cooldown reset marker. |
+| `processedOrderIds` | array | `closedOrderId` strings already recorded (dedup). Reset on day rollover. |
+| `maxEntriesPerDay` | number | Config: max entries before G3 fires. |
+| `bypassOnProfit` | boolean | Config: skip G3 if day is profitable. |
+| `maxConsecutiveLosses` | number | Config: consecutive "L" count before G4 cooldown. |
+| `cooldownMinutes` | number | Config: minutes for G4 cooldown duration. |
+| `updatedAt` | string | ISO timestamp of last save. |
+
+### Day Rollover Rules (date != today UTC)
+
+- **Reset:** `entries`, `closedTrades`, `realizedPnl` → 0; `accountValueStart` → null; `gate` → OPEN (unless active cooldown); `processedOrderIds` → []
+- **Preserve:** `lastResults` (streak carries across days), active cooldown if `cooldownUntil` is still in the future

--- a/wolf-strategy/scripts/emerging-movers.py
+++ b/wolf-strategy/scripts/emerging-movers.py
@@ -31,7 +31,7 @@ import json, sys, os
 from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from wolf_config import atomic_write, mcporter_call, mcporter_call_safe, load_all_strategies, dsl_state_glob, heartbeat, SIGNAL_CONVICTION, WORKSPACE, ROTATION_COOLDOWN_MINUTES
+from wolf_config import atomic_write, mcporter_call, mcporter_call_safe, load_all_strategies, dsl_state_glob, heartbeat, check_gate, SIGNAL_CONVICTION, WORKSPACE, ROTATION_COOLDOWN_MINUTES
 
 heartbeat("emerging_movers")
 
@@ -451,6 +451,16 @@ try:
             "rotationCooldownMinutes": ROTATION_COOLDOWN_MINUTES,
             "hasRotationCandidate": len(rotation_eligible_coins) > 0,
         }
+
+        # Guard rail gate status
+        try:
+            gate_status, gate_reason = check_gate(key)
+        except Exception:
+            gate_status, gate_reason = "OPEN", None
+        strategy_slots[key]["gate"] = gate_status
+        strategy_slots[key]["gateReason"] = gate_reason
+        if gate_status != "OPEN":
+            strategy_slots[key]["available"] = 0
 except Exception:
     pass
 

--- a/wolf-strategy/scripts/job-health-check.py
+++ b/wolf-strategy/scripts/job-health-check.py
@@ -551,6 +551,7 @@ EXPECTED_CRONS = {
     "sm_flip": 15,           # expect every 5min, alert at 15min
     "watchdog": 15,          # expect every 5min, alert at 15min
     "health_check": 20,      # expect every 10min, alert at 20min
+    "risk_guardian": 15,     # expect every 5min, alert at 15min
 }
 
 

--- a/wolf-strategy/scripts/open-position.py
+++ b/wolf-strategy/scripts/open-position.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from wolf_config import (load_strategy, dsl_state_path, dsl_state_glob,
                          dsl_state_template, atomic_write, mcporter_call,
                          mcporter_call_safe, calculate_leverage, strategy_lock,
+                         check_gate, increment_entry_counter,
                          WORKSPACE, ROTATION_COOLDOWN_MINUTES)
 
 
@@ -162,6 +163,11 @@ def main():
     margin = margin_override if margin_override else cfg.get("marginPerSlot", 0)
     if margin <= 0:
         fail("invalid_margin", margin=margin, strategyKey=strategy_key)
+
+    # 2a. Guard rail gate check
+    gate_status, gate_reason = check_gate(strategy_key)
+    if gate_status != "OPEN":
+        fail("strategy_gated", gate=gate_status, gateReason=gate_reason, strategyKey=strategy_key)
 
     # 2. Resolve leverage — auto-calculate or validate explicit value
     max_lev_data = load_max_leverage()
@@ -380,6 +386,12 @@ def main():
         # 9. Write DSL state atomically
         dsl_path = dsl_state_path(strategy_key, clean_asset)
         atomic_write(dsl_path, dsl_state)
+
+        # 10. Increment guard rail entry counter
+        try:
+            increment_entry_counter(strategy_key)
+        except Exception:
+            pass  # Never fail the open for counter bookkeeping
     finally:
         lock_ctx.__exit__(None, None, None)
 

--- a/wolf-strategy/scripts/risk-guardian.py
+++ b/wolf-strategy/scripts/risk-guardian.py
@@ -61,7 +61,7 @@ def record_new_closings(counter, closed_positions):
     processed = set(counter.get("processedOrderIds", []))
     new_closings = []
 
-    for pos in closed_positions:
+    for pos in reversed(closed_positions):
         closed_order_id = pos.get("closedOrderId") or pos.get("closed_order_id")
         if not closed_order_id:
             continue

--- a/wolf-strategy/scripts/risk-guardian.py
+++ b/wolf-strategy/scripts/risk-guardian.py
@@ -18,7 +18,7 @@ from datetime import datetime, timezone, timedelta
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from wolf_config import (
     load_all_strategies, load_trade_counter, save_trade_counter,
-    mcporter_call_safe, heartbeat, GUARD_RAIL_DEFAULTS,
+    mcporter_call_safe, heartbeat, GUARD_RAIL_DEFAULTS, strategy_lock,
 )
 
 heartbeat("risk_guardian")
@@ -52,7 +52,7 @@ def get_account_value(wallet):
             total += float(av)
         elif section.get("marginSummary", {}).get("accountValue") is not None:
             total += float(section["marginSummary"]["accountValue"])
-    return total if total > 0 else None
+    return total
 
 
 def record_new_closings(counter, closed_positions):
@@ -172,10 +172,30 @@ def evaluate_guard_rails(counter, wallet, cfg):
             )
             return notifications
 
+    # --- Check if cooldown just expired (must run before G4 to append "R" streak-breaker) ---
+    last_results = counter.get("lastResults", [])
+    if counter.get("gate") == "COOLDOWN" and counter.get("cooldownUntil"):
+        try:
+            cd_dt = datetime.fromisoformat(
+                counter["cooldownUntil"].replace("Z", "+00:00")
+            )
+            if cd_dt <= datetime.now(timezone.utc):
+                counter["gate"] = "OPEN"
+                counter["gateReason"] = None
+                counter["cooldownUntil"] = None
+                last_results.append("R")
+                counter["lastResults"] = last_results[-20:]
+                notifications.append(
+                    f"\u2705 COOLDOWN EXPIRED [{strategy_key}]: gate re-opened"
+                )
+        except (ValueError, TypeError):
+            counter["gate"] = "OPEN"
+            counter["gateReason"] = None
+            counter["cooldownUntil"] = None
+
     # --- G4: Consecutive Losses Cooldown ---
     max_consec = counter.get("maxConsecutiveLosses", GUARD_RAIL_DEFAULTS["maxConsecutiveLosses"])
     cooldown_min = counter.get("cooldownMinutes", GUARD_RAIL_DEFAULTS["cooldownMinutes"])
-    last_results = counter.get("lastResults", [])
 
     if len(last_results) >= max_consec:
         tail = last_results[-max_consec:]
@@ -203,26 +223,6 @@ def evaluate_guard_rails(counter, wallet, cfg):
             )
             return notifications
 
-    # --- Check if cooldown just expired ---
-    if counter.get("gate") == "COOLDOWN" and counter.get("cooldownUntil"):
-        try:
-            cd_dt = datetime.fromisoformat(
-                counter["cooldownUntil"].replace("Z", "+00:00")
-            )
-            if cd_dt <= datetime.now(timezone.utc):
-                counter["gate"] = "OPEN"
-                counter["gateReason"] = None
-                counter["cooldownUntil"] = None
-                last_results.append("R")
-                counter["lastResults"] = last_results[-20:]
-                notifications.append(
-                    f"\u2705 COOLDOWN EXPIRED [{strategy_key}]: gate re-opened"
-                )
-        except (ValueError, TypeError):
-            counter["gate"] = "OPEN"
-            counter["gateReason"] = None
-            counter["cooldownUntil"] = None
-
     return notifications
 
 
@@ -247,27 +247,29 @@ def main():
         if not wallet:
             continue
 
-        # 1. Load trade counter (handles day rollover)
-        counter = load_trade_counter(key)
-
-        # 2. Set account value start (first run of day)
-        if counter.get("accountValueStart") is None:
-            av = get_account_value(wallet)
-            if av is not None:
-                counter["accountValueStart"] = round(av, 2)
-
-        # 3. Fetch closed trades
+        # 3. Fetch closed trades (outside lock — read-only network call)
         closed_positions = fetch_closed_trades(wallet)
 
-        # 4. Record new closings
-        new_closings = record_new_closings(counter, closed_positions)
+        # Lock to serialize with open-position.py's increment_entry_counter
+        with strategy_lock(key):
+            # 1. Load trade counter (handles day rollover)
+            counter = load_trade_counter(key)
 
-        # 5. Evaluate guard rails
-        notifications = evaluate_guard_rails(counter, wallet, cfg)
-        all_notifications.extend(notifications)
+            # 2. Set account value start (first run of day)
+            if counter.get("accountValueStart") is None:
+                av = get_account_value(wallet)
+                if av is not None:
+                    counter["accountValueStart"] = round(av, 2)
 
-        # 6. Save counter
-        save_trade_counter(key, counter)
+            # 4. Record new closings
+            new_closings = record_new_closings(counter, closed_positions)
+
+            # 5. Evaluate guard rails
+            notifications = evaluate_guard_rails(counter, wallet, cfg)
+            all_notifications.extend(notifications)
+
+            # 6. Save counter
+            save_trade_counter(key, counter)
 
         strategy_results[key] = {
             "gate": counter.get("gate", "OPEN"),

--- a/wolf-strategy/scripts/risk-guardian.py
+++ b/wolf-strategy/scripts/risk-guardian.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""
+risk-guardian.py — WOLF v6.1 Risk Guardian (Account-Level Guard Rails)
+
+6th cron: enforces three account-level guardrails across all strategies:
+  G1: Daily loss halt (accountValue drop from start-of-day)
+  G3: Max entries per day (with bypass-on-profit option)
+  G4: Consecutive loss cooldown
+
+Runs every 5 minutes. Budget model tier.
+
+Usage:
+  python3 risk-guardian.py
+"""
+import json, sys, os
+from datetime import datetime, timezone, timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from wolf_config import (
+    load_all_strategies, load_trade_counter, save_trade_counter,
+    mcporter_call_safe, heartbeat, GUARD_RAIL_DEFAULTS,
+)
+
+heartbeat("risk_guardian")
+
+
+def fetch_closed_trades(wallet):
+    """Fetch recent closed trades for a wallet via discovery_get_trader_history."""
+    data = mcporter_call_safe(
+        "discovery_get_trader_history",
+        traderAddress=wallet,
+        sort_by="CLOSED_TIME",
+        sort_direction="DESC",
+        limit=20,
+        latest=True,
+    )
+    if not data:
+        return []
+    return data.get("closed_positions", data.get("closedPositions", []))
+
+
+def get_account_value(wallet):
+    """Fetch current total account value (main + xyz) from clearinghouse."""
+    data = mcporter_call_safe("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+    if not data:
+        return None
+    total = 0.0
+    for section_key in ("main", "xyz"):
+        section = data.get(section_key, {})
+        av = section.get("crossMarginSummary", {}).get("accountValue")
+        if av is not None:
+            total += float(av)
+        elif section.get("marginSummary", {}).get("accountValue") is not None:
+            total += float(section["marginSummary"]["accountValue"])
+    return total if total > 0 else None
+
+
+def record_new_closings(counter, closed_positions):
+    """Process unrecorded closed trades, update counter. Returns list of newly recorded trades."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    processed = set(counter.get("processedOrderIds", []))
+    new_closings = []
+
+    for pos in closed_positions:
+        closed_order_id = pos.get("closedOrderId") or pos.get("closed_order_id")
+        if not closed_order_id:
+            continue
+        if closed_order_id in processed:
+            continue
+
+        # Check if trade was closed today
+        close_time = pos.get("closeTime") or pos.get("close_time")
+        if close_time:
+            try:
+                # closeTime is Unix milliseconds
+                ct = int(close_time)
+                close_date = datetime.fromtimestamp(ct / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
+                if close_date != today:
+                    continue
+            except (ValueError, TypeError, OSError):
+                continue
+        else:
+            continue
+
+        # Parse realizedPnl
+        rpnl_raw = pos.get("realizedPnl") or pos.get("realized_pnl") or 0
+        try:
+            rpnl = float(rpnl_raw)
+        except (ValueError, TypeError):
+            rpnl = 0.0
+
+        # Update counter
+        result = "W" if rpnl >= 0 else "L"
+        last_results = counter.get("lastResults", [])
+        last_results.append(result)
+        counter["lastResults"] = last_results[-20:]
+        counter["realizedPnl"] = counter.get("realizedPnl", 0.0) + rpnl
+        counter["closedTrades"] = counter.get("closedTrades", 0) + 1
+        processed.add(closed_order_id)
+
+        coin = pos.get("coin") or pos.get("token") or "?"
+        new_closings.append({
+            "coin": coin,
+            "pnl": round(rpnl, 2),
+            "result": result,
+            "closedOrderId": closed_order_id,
+        })
+
+    counter["processedOrderIds"] = list(processed)
+    return new_closings
+
+
+def evaluate_guard_rails(counter, wallet, cfg):
+    """Evaluate G1, G3, G4 guard rails. Mutates counter. Returns list of notifications."""
+    notifications = []
+    strategy_key = cfg.get("_key", "unknown")
+
+    # If already CLOSED for today, stay closed (sticky)
+    if counter.get("gate") == "CLOSED":
+        return notifications
+
+    # --- G1: Daily Loss Halt ---
+    daily_loss_limit = cfg.get("dailyLossLimit", 0)
+    account_value_start = counter.get("accountValueStart")
+
+    if daily_loss_limit > 0 and account_value_start is not None:
+        current_value = get_account_value(wallet)
+        if current_value is not None:
+            daily_pnl = current_value - account_value_start
+            counter["_dailyPnl"] = round(daily_pnl, 2)
+            counter["_currentAccountValue"] = round(current_value, 2)
+
+            if daily_pnl <= -daily_loss_limit:
+                counter["gate"] = "CLOSED"
+                counter["gateReason"] = (
+                    f"G1 daily loss halt: PnL ${daily_pnl:+.2f} exceeded "
+                    f"-${daily_loss_limit:.2f} limit"
+                )
+                notifications.append(
+                    f"\U0001f6d1 GATE CLOSED [{strategy_key}]: {counter['gateReason']}"
+                )
+                return notifications
+
+    # --- G3: Max Entries Per Day ---
+    max_entries = counter.get("maxEntriesPerDay", GUARD_RAIL_DEFAULTS["maxEntriesPerDay"])
+    entries = counter.get("entries", 0)
+
+    if entries >= max_entries:
+        bypass = counter.get("bypassOnProfit", GUARD_RAIL_DEFAULTS["bypassOnProfit"])
+        if bypass and account_value_start is not None:
+            current_value = counter.get("_currentAccountValue")
+            if current_value is None:
+                current_value = get_account_value(wallet)
+            if current_value is not None and current_value > account_value_start:
+                pass  # bypass — profitable day
+            else:
+                counter["gate"] = "CLOSED"
+                counter["gateReason"] = (
+                    f"G3 max entries: {entries}/{max_entries} entries reached on losing day"
+                )
+                notifications.append(
+                    f"\U0001f6d1 GATE CLOSED [{strategy_key}]: {counter['gateReason']}"
+                )
+                return notifications
+        else:
+            counter["gate"] = "CLOSED"
+            counter["gateReason"] = (
+                f"G3 max entries: {entries}/{max_entries} entries reached"
+            )
+            notifications.append(
+                f"\U0001f6d1 GATE CLOSED [{strategy_key}]: {counter['gateReason']}"
+            )
+            return notifications
+
+    # --- G4: Consecutive Losses Cooldown ---
+    max_consec = counter.get("maxConsecutiveLosses", GUARD_RAIL_DEFAULTS["maxConsecutiveLosses"])
+    cooldown_min = counter.get("cooldownMinutes", GUARD_RAIL_DEFAULTS["cooldownMinutes"])
+    last_results = counter.get("lastResults", [])
+
+    if len(last_results) >= max_consec:
+        tail = last_results[-max_consec:]
+        if all(r == "L" for r in tail):
+            # Already in active cooldown?
+            if counter.get("gate") == "COOLDOWN" and counter.get("cooldownUntil"):
+                try:
+                    cd_dt = datetime.fromisoformat(
+                        counter["cooldownUntil"].replace("Z", "+00:00")
+                    )
+                    if cd_dt > datetime.now(timezone.utc):
+                        return notifications  # already cooling down
+                except (ValueError, TypeError):
+                    pass
+            # Set new cooldown
+            expiry = datetime.now(timezone.utc) + timedelta(minutes=cooldown_min)
+            counter["gate"] = "COOLDOWN"
+            counter["cooldownUntil"] = expiry.strftime("%Y-%m-%dT%H:%M:%SZ")
+            counter["gateReason"] = (
+                f"G4 consecutive losses: {max_consec} losses in a row, "
+                f"cooldown until {counter['cooldownUntil']}"
+            )
+            notifications.append(
+                f"\u23f3 COOLDOWN [{strategy_key}]: {counter['gateReason']}"
+            )
+            return notifications
+
+    # --- Check if cooldown just expired ---
+    if counter.get("gate") == "COOLDOWN" and counter.get("cooldownUntil"):
+        try:
+            cd_dt = datetime.fromisoformat(
+                counter["cooldownUntil"].replace("Z", "+00:00")
+            )
+            if cd_dt <= datetime.now(timezone.utc):
+                counter["gate"] = "OPEN"
+                counter["gateReason"] = None
+                counter["cooldownUntil"] = None
+                last_results.append("R")
+                counter["lastResults"] = last_results[-20:]
+                notifications.append(
+                    f"\u2705 COOLDOWN EXPIRED [{strategy_key}]: gate re-opened"
+                )
+        except (ValueError, TypeError):
+            counter["gate"] = "OPEN"
+            counter["gateReason"] = None
+            counter["cooldownUntil"] = None
+
+    return notifications
+
+
+def main():
+    now = datetime.now(timezone.utc)
+    strategies = load_all_strategies()
+
+    if not strategies:
+        print(json.dumps({
+            "status": "ok",
+            "time": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "strategies": {},
+            "notifications": [],
+        }))
+        return
+
+    all_notifications = []
+    strategy_results = {}
+
+    for key, cfg in strategies.items():
+        wallet = cfg.get("wallet", "")
+        if not wallet:
+            continue
+
+        # 1. Load trade counter (handles day rollover)
+        counter = load_trade_counter(key)
+
+        # 2. Set account value start (first run of day)
+        if counter.get("accountValueStart") is None:
+            av = get_account_value(wallet)
+            if av is not None:
+                counter["accountValueStart"] = round(av, 2)
+
+        # 3. Fetch closed trades
+        closed_positions = fetch_closed_trades(wallet)
+
+        # 4. Record new closings
+        new_closings = record_new_closings(counter, closed_positions)
+
+        # 5. Evaluate guard rails
+        notifications = evaluate_guard_rails(counter, wallet, cfg)
+        all_notifications.extend(notifications)
+
+        # 6. Save counter
+        save_trade_counter(key, counter)
+
+        strategy_results[key] = {
+            "gate": counter.get("gate", "OPEN"),
+            "gateReason": counter.get("gateReason"),
+            "entries": counter.get("entries", 0),
+            "closedTrades": counter.get("closedTrades", 0),
+            "realizedPnl": round(counter.get("realizedPnl", 0.0), 2),
+            "lastResults": counter.get("lastResults", []),
+            "dailyPnl": counter.get("_dailyPnl"),
+            "newClosings": new_closings,
+        }
+
+    output = {
+        "status": "ok",
+        "time": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "strategies": strategy_results,
+        "notifications": all_notifications,
+    }
+    print(json.dumps(output, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/wolf-strategy/scripts/wolf-setup.py
+++ b/wolf-strategy/scripts/wolf-setup.py
@@ -185,12 +185,7 @@ strategy_entry = {
         "preset": dsl_preset,
         "tiers": DSL_PRESETS[dsl_preset]
     },
-    "guardRails": {
-        "maxEntriesPerDay": 8,
-        "bypassOnProfit": True,
-        "maxConsecutiveLosses": 3,
-        "cooldownMinutes": 60,
-    },
+    "guardRails": GUARD_RAIL_DEFAULTS.copy(),
     "enabled": True
 }
 

--- a/wolf-strategy/scripts/wolf-setup.py
+++ b/wolf-strategy/scripts/wolf-setup.py
@@ -19,7 +19,7 @@ Usage:
 import json, sys, os, math, argparse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from wolf_config import mcporter_call
+from wolf_config import mcporter_call, GUARD_RAIL_DEFAULTS
 
 WORKSPACE = os.environ.get("WOLF_WORKSPACE",
     os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace"))
@@ -185,6 +185,12 @@ strategy_entry = {
         "preset": dsl_preset,
         "tiers": DSL_PRESETS[dsl_preset]
     },
+    "guardRails": {
+        "maxEntriesPerDay": 8,
+        "bypassOnProfit": True,
+        "maxConsecutiveLosses": 3,
+        "cooldownMinutes": 60,
+    },
     "enabled": True
 }
 
@@ -317,6 +323,16 @@ cron_templates = {
             "message": f"WOLF Health Check: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/job-health-check.py`, parse JSON.\nSend each message in `notifications` to Telegram ({tg}).\nIf `notifications` is empty → HEARTBEAT_OK."
         }
     },
+    "risk_guardian": {
+        "name": "WOLF Risk Guardian v6.1 (5min)",
+        "schedule": {"kind": "every", "everyMs": 300000},
+        "sessionTarget": "isolated",
+        "payload": {
+            "kind": "agentTurn",
+            "model": budget_model,
+            "message": f"WOLF Risk Guardian: Run `PYTHONUNBUFFERED=1 python3 {SCRIPTS_DIR}/risk-guardian.py`, parse JSON.\nSend each message in `notifications` to Telegram ({tg}).\nIf `notifications` is empty → HEARTBEAT_OK."
+        }
+    },
 }
 
 print("\n" + "=" * 60)
@@ -346,11 +362,11 @@ if strategies_count > 1:
     print(f"  All strategies: {list(registry['strategies'].keys())}")
 
 print("\n" + "=" * 60)
-print("  Next Steps: Create 5 cron jobs")
+print("  Next Steps: Create 6 cron jobs")
 print("=" * 60)
 print(f"""
 Use OpenClaw cron to create each job. See references/cron-templates.md
-for the exact payload text for each of the 5 jobs.
+for the exact payload text for each of the 6 jobs.
 
 With multi-strategy, crons iterate all enabled strategies internally.
 You only need ONE set of crons regardless of strategy count.
@@ -364,10 +380,14 @@ You only need ONE set of crons regardless of strategy count.
   │ Health Check         │ isolated │ agentTrn │ Mid: {mid_model}  │
   │ SM Flip Detector     │ isolated │ agentTrn │ Budget: {budget_model}       │
   │ Watchdog             │ isolated │ agentTrn │ Budget: {budget_model}       │
+  │ Risk Guardian        │ isolated │ agentTrn │ Budget: {budget_model}       │
   └──────────────────────┴──────────┴──────────┴─────────────────────────────────────────────┘
 
+  Guard Rails (per strategy): maxEntries={GUARD_RAIL_DEFAULTS['maxEntriesPerDay']}/day, \
+consecutiveLossCooldown={GUARD_RAIL_DEFAULTS['maxConsecutiveLosses']}L→{GUARD_RAIL_DEFAULTS['cooldownMinutes']}min
+
   All crons run in isolated sessions (agentTurn) — no context pollution.
-  All 5 crons can also run on a single model if you prefer simplicity.
+  All 6 crons can also run on a single model if you prefer simplicity.
 """)
 
 # Output full result as JSON for programmatic use

--- a/wolf-strategy/scripts/wolf_config.py
+++ b/wolf-strategy/scripts/wolf_config.py
@@ -639,14 +639,19 @@ def check_gate(strategy_key):
                     return ("COOLDOWN", counter.get("gateReason"))
             except (ValueError, TypeError):
                 pass
-        # Cooldown expired — clear and append "R" to break streak
-        counter["gate"] = "OPEN"
-        counter["gateReason"] = None
-        counter["cooldownUntil"] = None
-        results = counter.get("lastResults", [])
-        results.append("R")
-        counter["lastResults"] = results[-20:]
-        save_trade_counter(strategy_key, counter)
+        # Cooldown expired — acquire lock, re-read, then clear
+        with strategy_lock(strategy_key):
+            counter = load_trade_counter(strategy_key)
+            # Re-check: another process may have already cleared it
+            if counter.get("gate") != "COOLDOWN":
+                return (counter.get("gate", "OPEN"), counter.get("gateReason"))
+            counter["gate"] = "OPEN"
+            counter["gateReason"] = None
+            counter["cooldownUntil"] = None
+            results = counter.get("lastResults", [])
+            results.append("R")
+            counter["lastResults"] = results[-20:]
+            save_trade_counter(strategy_key, counter)
         return ("OPEN", None)
 
     return ("OPEN", None)

--- a/wolf-strategy/scripts/wolf_config.py
+++ b/wolf-strategy/scripts/wolf_config.py
@@ -15,6 +15,7 @@ Usage:
 
 import json, os, sys, glob, subprocess, time, tempfile, shlex, fcntl
 from contextlib import contextmanager
+from datetime import datetime, timezone
 
 WORKSPACE = os.environ.get("WOLF_WORKSPACE",
     os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace"))
@@ -507,3 +508,153 @@ def dsl_state_template(asset, direction, entry_price, size, leverage,
         "strategyKey": strategy_key,
         "createdBy": created_by,
     }
+
+
+# --- Guard Rail defaults & helpers ---
+
+GUARD_RAIL_DEFAULTS = {
+    "maxEntriesPerDay": 8,
+    "bypassOnProfit": True,
+    "maxConsecutiveLosses": 3,
+    "cooldownMinutes": 60,
+}
+
+
+def trade_counter_path(strategy_key):
+    """Return the path to the trade counter file for a strategy."""
+    return os.path.join(state_dir(strategy_key), "trade-counter.json")
+
+
+def load_trade_counter(strategy_key):
+    """Load (or create) the daily trade counter for a strategy.
+
+    Handles day rollover: if the stored date != today (UTC), resets daily
+    counters but preserves lastResults (streak carries across days),
+    active cooldowns, and processedOrderIds.
+
+    Merges guard rail config from the strategy registry with defaults.
+    Does NOT auto-save — callers save after modifications.
+    """
+    path = trade_counter_path(strategy_key)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    old = {}
+    try:
+        with open(path) as f:
+            old = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+
+    # Load guard rail config from strategy registry
+    try:
+        cfg = load_strategy(strategy_key)
+        gr_cfg = cfg.get("guardRails", {})
+    except (SystemExit, Exception):
+        gr_cfg = {}
+
+    merged_config = {k: gr_cfg.get(k, v) for k, v in GUARD_RAIL_DEFAULTS.items()}
+
+    if old.get("date") == today:
+        # Same day — update config overlay but keep counters
+        old.update(merged_config)
+        return old
+
+    # Day rollover — reset daily counters, preserve streaks + active cooldown
+    counter = {
+        "date": today,
+        "accountValueStart": None,
+        "entries": 0,
+        "closedTrades": 0,
+        "realizedPnl": 0.0,
+        "gate": "OPEN",
+        "gateReason": None,
+        "cooldownUntil": None,
+        "lastResults": old.get("lastResults", []),
+        "processedOrderIds": [],
+        "updatedAt": None,
+    }
+    counter.update(merged_config)
+
+    # Preserve active cooldown across day boundary
+    cooldown_until = old.get("cooldownUntil")
+    if cooldown_until:
+        try:
+            cd_dt = datetime.fromisoformat(cooldown_until.replace("Z", "+00:00"))
+            if cd_dt > datetime.now(timezone.utc):
+                counter["gate"] = "COOLDOWN"
+                counter["gateReason"] = "consecutive_losses_cooldown (carried from previous day)"
+                counter["cooldownUntil"] = cooldown_until
+        except (ValueError, TypeError):
+            pass
+
+    return counter
+
+
+def save_trade_counter(strategy_key, counter):
+    """Save the trade counter, stamping updatedAt."""
+    counter["updatedAt"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    atomic_write(trade_counter_path(strategy_key), counter)
+
+
+def check_gate(strategy_key):
+    """Lightweight gate check. Returns (gate_status, gate_reason).
+
+    - CLOSED -> ("CLOSED", reason)  — sticky until midnight
+    - COOLDOWN with future expiry -> ("COOLDOWN", reason)
+    - COOLDOWN expired -> clears gate, saves, returns ("OPEN", None)
+    - Default -> ("OPEN", None)
+    """
+    path = trade_counter_path(strategy_key)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    try:
+        with open(path) as f:
+            counter = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return ("OPEN", None)
+
+    # Day rollover — treat as OPEN (but preserve active cooldown)
+    if counter.get("date") != today:
+        cooldown_until = counter.get("cooldownUntil")
+        if cooldown_until:
+            try:
+                cd_dt = datetime.fromisoformat(cooldown_until.replace("Z", "+00:00"))
+                if cd_dt > datetime.now(timezone.utc):
+                    return ("COOLDOWN", counter.get("gateReason", "consecutive_losses_cooldown"))
+            except (ValueError, TypeError):
+                pass
+        return ("OPEN", None)
+
+    gate = counter.get("gate", "OPEN")
+
+    if gate == "CLOSED":
+        return ("CLOSED", counter.get("gateReason"))
+
+    if gate == "COOLDOWN":
+        cooldown_until = counter.get("cooldownUntil")
+        if cooldown_until:
+            try:
+                cd_dt = datetime.fromisoformat(cooldown_until.replace("Z", "+00:00"))
+                if cd_dt > datetime.now(timezone.utc):
+                    return ("COOLDOWN", counter.get("gateReason"))
+            except (ValueError, TypeError):
+                pass
+        # Cooldown expired — clear and append "R" to break streak
+        counter["gate"] = "OPEN"
+        counter["gateReason"] = None
+        counter["cooldownUntil"] = None
+        results = counter.get("lastResults", [])
+        results.append("R")
+        counter["lastResults"] = results[-20:]
+        save_trade_counter(strategy_key, counter)
+        return ("OPEN", None)
+
+    return ("OPEN", None)
+
+
+def increment_entry_counter(strategy_key):
+    """Load counter, increment entries, save. Returns updated counter."""
+    counter = load_trade_counter(strategy_key)
+    counter["entries"] = counter.get("entries", 0) + 1
+    save_trade_counter(strategy_key, counter)
+    return counter


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new gating mechanism that can block position opens based on daily PnL, entry limits, and loss streaks, affecting live trading behavior across strategies. Introduces new state files and cron wiring, so misconfigurations or edge cases could halt trading unexpectedly until reset/cooldown expires.
> 
> **Overview**
> Adds a **6th cron, `Risk Guardian`**, implemented in `scripts/risk-guardian.py`, to enforce per-strategy account-level guard rails: daily loss halt, max entries/day (optionally bypassed on profitable days), and consecutive-loss cooldown.
> 
> Introduces a new per-strategy `state/{strategyKey}/trade-counter.json` and adds helpers in `wolf_config.py` (`GUARD_RAIL_DEFAULTS`, `load_trade_counter`, `check_gate`, `increment_entry_counter`) so `open-position.py` can refuse entries when gated and increment daily entry counts, while `emerging-movers.py` reports gate status and forces `available` slots to 0 when trading is paused.
> 
> Updates setup/docs/templates to reflect the 6-cron architecture: `wolf-setup.py` now seeds `guardRails` in new strategies and emits a `risk_guardian` cron template; health check heartbeat expectations include `risk_guardian`; and docs (`SKILL.md`, `cron-templates.md`, `state-schema.md`) document guard rail behavior and configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81b3bad085303bd7213cf9cc2bccf445bda07171. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->