### PR TITLE
DSL 5.1 changes

### DIFF
--- a/dsl-dynamic-stop-loss/SKILL.md
+++ b/dsl-dynamic-stop-loss/SKILL.md
@@ -11,7 +11,7 @@ compatibility: >-
   Hyperliquid perp positions only (main dex and xyz dex).
 metadata:
   author: jason-goldberg
-  version: "5.0"
+  version: "5.1"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -32,19 +32,19 @@ metadata:
 
 ---
 
-Automated trailing stop loss for leveraged perp positions on Hyperliquid (main and xyz dex). Monitors price via cron, ratchets profit floors upward through configurable tiers, and **syncs the stop loss to Hyperliquid** via Senpi `edit_position` so that **Hyperliquid executes the SL** when price hits — reducing loss exposure versus a 3-minute cron-only close. Breach detection, tier upgrades, and retraction logic still run in the cron; cancellation and setup of the SL happen via Senpi API; the new SL order ID is stored in state and status can be checked via `strategy_get_open_orders`. On breach the script may still call `close_position` as a backup. v5 adds strategy-scoped state paths and delete-on-close cleanup.
+Automated trailing stop loss for leveraged perp positions on Hyperliquid (main and xyz dex). Monitors price via cron, ratchets profit floors upward through configurable tiers, and **syncs the stop loss to Hyperliquid** via Senpi `edit_position` so that **Hyperliquid executes the SL** when price hits — reducing loss exposure versus a 3-minute cron-only close. Breach detection, tier upgrades, and retraction logic still run in the cron; cancellation and setup of the SL happen via Senpi API; the new SL order ID is stored in state and status can be checked via `strategy_get_open_orders`. On breach the script may still call `close_position` as a backup. v5 adds strategy-scoped state paths and archive-on-close (state file renamed to `{asset}_archived_{epoch}.json`).
 
 ## Self-Contained Design
 
 ```
 Script handles:              Agent handles:
 ✅ Strategy active check (MCP strategy_get)   📢 Telegram alerts
-✅ Reconcile state vs positions (delete orphan state files)   🧹 On strategy_inactive: remove cron, run cleanup
+✅ Reconcile state vs positions (rename orphan state files to *_archived_external_*)   🧹 On strategy_inactive: remove cron, run cleanup
 ✅ Price monitoring           📊 Portfolio reporting
 ✅ High water + tier upgrades  🔄 Retry awareness (pendingClose alerts)
 ✅ Sync SL via edit_position (Senpi MCP); HL executes SL when price hits  ⏰ One cron per strategy when user sets up DSL
 ✅ Breach + close_position backup (mcporter)  📋 sl_synced / sl_order_id in output
-✅ State delete on close
+✅ State archive on close (rename to *_archived_{epoch}.json)
 ✅ Error handling (fetch failures)
 ```
 
@@ -60,7 +60,7 @@ The script syncs the current effective floor to Hyperliquid as a native stop-los
 
 ### Phase 2: "Lock the Bag" (uPnL ≥ first tier)
 - **Tight retrace**: 1.5% ROE from high water (or per-tier retrace), leverage-adjusted
-- **Quick exit**: 1–2 consecutive breaches to close
+- **Quick exit**: 1 consecutive breach to close (default; configurable via `phase2.consecutiveBreachesRequired`)
 - **Tier floors**: ratchet up as profit grows — never go back down
 - **Effective floor**: best of tier floor and trailing floor
 
@@ -127,24 +127,23 @@ For LONGs, "best" = maximum. For SHORTs, "best" = minimum.
 ├──────────────────────────────────────────────────────────────────────────┤
 │ scripts/dsl-v5.py (each run)                                              │
 │ 1. MCP: strategy_get(strategy_id -> uuid) → strategy status from Senpi (not clearinghouse). │
-│    If status not ACTIVE/PAUSED → delete all state files; print strategy_inactive;   │
-│    agent removes cron for this strategy.                                         │
-│ 2. Wallet from strategy_get response; MCP: strategy_get_clearinghouse_state(wallet) │
-│    → set of active position coins (main + xyz).                                   │
-│ 3. Reconcile: delete state files whose asset is not in active positions  │
-│    (position was closed outside DSL).                                     │
-│ 4. For each active position that has a state file:                        │
-│    • Fetch price via MCP (market_get_prices / allMids)                     │
-│    • Update high water, tier upgrades (ROE-based), effective floor         │
-│    • Sync SL: if no slOrderId or floor changed → edit_position(floor);    │
-│      store slOrderId (from response or strategy_get_open_orders)          │
-│    • Detect breaches (with decay modes)                                   │
-│    • ON BREACH: close_position via mcporter (backup); delete state on ok  │
-│    • Print one JSON line per position (ndjson)                            │
+│    If status not ACTIVE/PAUSED → remove active state files; print strategy_inactive.      │
+│ 2. For each state file with slOrderId: MCP execution_get_order_status; if filled,         │
+│    rename to {asset}_archived_sl_{epoch}.json (SL already hit on HL).                    │
+│ 3. MCP: strategy_get_clearinghouse_state(wallet) → active position coins (main + xyz).   │
+│ 4. Reconcile: rename state files whose asset is not in active positions to              │
+│    {asset}_archived_external_{epoch}.json (position closed outside DSL).                │
+│ 5. For each active position that has a state file:                                       │
+│    • Fetch price via MCP (market_get_prices / allMids)                                    │
+│    • Update high water, tier upgrades (ROE-based), effective floor                        │
+│    • Sync SL: Phase 1 → edit_position(floor, MARKET); Phase 2 → edit_position(floor, LIMIT) │
+│    • Detect breaches (Phase 2 default: 1 breach to close)                                  │
+│    • ON BREACH: close_position via mcporter (backup); rename state to {asset}_archived_{epoch}.json  │
+│    • Print one JSON line per position (ndjson)                                             │
 ├──────────────────────────────────────────────────────────────────────────┤
 │ Agent reads output (one line per position, or one strategy-level line):  │
 │ • strategy_inactive → remove cron for this strategy; run cleanup if needed│
-│ • closed=true → alert user (script already deleted state file)             │
+│ • closed=true → alert user (script archived state file to {asset}_archived_{epoch}.json)   │
 │ • pending_close=true → alert, will retry                                  │
 │ • tier_changed=true → notify user                                         │
 │ • status=error → log, check failures                                      │
@@ -156,7 +155,7 @@ For LONGs, "best" = maximum. For SHORTs, "best" = minimum.
 | File | Purpose |
 |------|---------|
 | `scripts/dsl-v5.py` | Strategy-scoped DSL: MCP clearinghouse + reconcile state, then per-position monitor/close, outputs ndjson |
-| `scripts/dsl-cleanup.py` | Strategy-level cleanup — deletes strategy dir when all positions closed |
+| `scripts/dsl-cleanup.py` | Strategy-level cleanup — deletes entire strategy dir (including archived state files) when no active positions remain |
 | State file (JSON) | Per-position config + runtime state; path: `{DSL_STATE_DIR}/{strategyId}/{asset}.json` |
 | [references/migration.md](references/migration.md) | Upgrading from cron-only DSL to Hyperliquid SL flow |
 
@@ -187,7 +186,7 @@ Minimal required fields to create a new state file:
   "phase2TriggerTier": 1,
   "phase2": {
     "retraceThreshold": 0.015,
-    "consecutiveBreachesRequired": 2
+    "consecutiveBreachesRequired": 1
   },
   "tiers": [
     {"triggerPct": 10, "lockPct": 5},
@@ -222,7 +221,7 @@ Key fields for agent decision-making:
 | Field / status | Agent action |
 |----------------|--------------|
 | `status: "strategy_inactive"` | Remove cron for this strategy; run strategy cleanup |
-| `closed: true` | Alert user (script already deleted state file) |
+| `closed: true` | Alert user (script archived state file to `{asset}_archived_{epoch}.json`) |
 | `pending_close: true` | Alert — close failed, retrying next tick |
 | `tier_changed: true` | Notify user with tier details |
 | `status: "error"` | Log; alert if `consecutive_failures >= 3` |
@@ -263,12 +262,12 @@ No `DSL_ASSET` — the script discovers positions from MCP clearinghouse and sta
 
 ### When a Position Closes
 
-1. ✅ **Hyperliquid** may close the position when price hits the synced SL (no cron delay). The script reconciles: on the next run the coin is no longer in clearinghouse, so the state file is deleted.
-2. ✅ On breach the script may close via `senpi:close_position` (backup; coin with `xyz:` prefix as-is; with retry)
-3. ✅ Script deletes the state file when position is closed (no archive)
+1. ✅ **Hyperliquid** may close the position when price hits the synced SL (no cron delay). Each run the script calls `execution_get_order_status` for state files with `slOrderId`; if the SL order is **filled**, the state file is renamed to `{asset}_archived_sl_{epoch}.json` and not processed further.
+2. ✅ If the position was closed outside DSL (e.g. manually), the next run finds the asset missing from clearinghouse and renames the state file to `{asset}_archived_external_{epoch}.json`.
+3. ✅ On breach the script may close via `senpi:close_position` (backup; coin with `xyz:` prefix as-is; with retry). On successful close the state file is renamed to `{asset}_archived_{epoch}.json` (archived, not deleted). Archive filenames use epoch (Unix time) and underscores.
 4. 🤖 **Agent:** On `closed=true` in script output — alert user. No need to disable a “position cron” (cron is per strategy and keeps running).
-5. 🤖 **Agent:** On `status: "strategy_inactive"` — remove the cron for that strategy and run strategy cleanup so the strategy directory is removed — see [references/cleanup.md](references/cleanup.md).
-6. 🤖 **Agent:** When the strategy has no state files left (e.g. all positions closed), the next run will output strategy_inactive; then agent removes cron and runs cleanup.
+5. 🤖 **Agent:** On `status: "strategy_inactive"` — remove the cron for that strategy and run strategy cleanup (`dsl-cleanup.py`). The script only removes **active** state files; the agent must run cleanup to remove the strategy directory (and any archived files in it) — see [references/cleanup.md](references/cleanup.md).
+6. 🤖 **Agent:** When the strategy has no active state files left, remove cron and run cleanup so the strategy directory is removed.
 
 If close fails, script sets `pendingClose: true` and retries on the next cron tick.
 
@@ -281,8 +280,8 @@ See [references/customization.md](references/customization.md) for conservative/
 - **Strategy active**: `senpi:strategy_get` via mcporter (by `strategy_id`); status must be ACTIVE or PAUSED for DSL to run
 - **Positions**: `senpi:strategy_get_clearinghouse_state` via mcporter (by strategy wallet from strategy_get)
 - **Price**: `senpi:market_get_prices` or `senpi:allMids` via mcporter (main + xyz dex)
-- **Sync stop loss**: `senpi:edit_position` via mcporter (`strategyWalletAddress`, `coin`, `stopLoss: { price, orderType: "LIMIT" }`); cancels previous SL and sets new SL on Hyperliquid
-- **SL order status**: `senpi:strategy_get_open_orders` via mcporter (`strategy_wallet`, `dex`) to resolve or verify SL order ID
+- **Sync stop loss**: `senpi:edit_position` via mcporter (`strategyWalletAddress`, `coin`, `stopLoss: { price, orderType }`). Phase 1 (initial/absolute floor) uses `orderType: "MARKET"` for fast exit; Phase 2 (tiered) uses `orderType: "LIMIT"`. Cancels previous SL and sets new SL on Hyperliquid.
+- **SL order status**: `senpi:execution_get_order_status` (user/wallet, orderId) to detect if SL was already filled before reconcile; `senpi:strategy_get_open_orders` to resolve or verify SL order ID after edit.
 - **Close position**: `senpi:close_position` via mcporter (backup on breach; pass `coin` with `xyz:` prefix for xyz assets)
 
 > ⚠️ **Do NOT use `strategy_close_strategy`** to close individual positions. That closes the **entire strategy** (irreversible). Use `close_position`.

--- a/dsl-dynamic-stop-loss/references/cleanup.md
+++ b/dsl-dynamic-stop-loss/references/cleanup.md
@@ -1,24 +1,24 @@
 # DSL v5 Cleanup
 
-Two-level cleanup: position close (Level 1) and strategy close (Level 2). No archiving — closed state and strategy directories are **deleted**.
+Two-level cleanup: position close (Level 1) and strategy close (Level 2). State files are **archived** (renamed) on position close; the strategy directory is **deleted** only when the agent runs Level 2 cleanup.
 
-## Level 1: Position Close
+## Level 1: Position Close (archive)
 
 When `dsl-v5.py` reports `closed=true` (breach + successful close or deactivation):
 
-- The script **deletes** the state file for that position.
-- No `_closed/` archive; the file is removed.
+- The script **renames** the state file to `{asset}_archived_{epoch}.json` (e.g. `ETH_archived_1709722800.json`). The file stays in the strategy dir as an archive.
+- Other renames: SL already filled on HL → `{asset}_archived_sl_{epoch}.json`; position closed outside DSL → `{asset}_archived_external_{epoch}.json`.
 
 **Agent:** Alert user. (Cron is per strategy; no per-position cron to disable.)
 
-When `dsl-v5.py` reports `status: "strategy_inactive"` (strategy not active or clearinghouse failed, or no state files):
+When `dsl-v5.py` reports `status: "strategy_inactive"` (strategy not active):
 
-- The script has **deleted** all state files in the strategy dir (when inactive) or reports no state files.
+- The script **removes only active** state files (e.g. `ETH.json`) from the strategy dir. It does **not** remove `*_archived_*` files or the strategy directory itself.
 - **Agent:** Remove the cron job for this strategy and run Level 2 cleanup below.
 
 ## Level 2: Strategy Cleanup
 
-When an entire strategy is shut down (all positions closed, or agent signals strategy close):
+When the agent runs cleanup after strategy is inactive or all positions are closed:
 
 **Script:** `scripts/dsl-cleanup.py`
 
@@ -32,16 +32,16 @@ DSL_STRATEGY_ID=<strategy-uuid> python3 scripts/dsl-cleanup.py
 
 **Behavior:**
 
-1. Scans all `*.json` files in the strategy directory.
-2. If any file has `active=true` → exits with `status: "blocked"` and lists `blocked_by_active` (no deletion).
-3. If all positions are closed (or directory is empty) → **deletes** the entire strategy directory.
+1. Scans all `*.json` files in the strategy directory (including `*_archived_*` files).
+2. If any file has `active=true` in its JSON → exits with `status: "blocked"` and lists `blocked_by_active` (no deletion). Archived files have `active=false`, so they do not block.
+3. If no file has `active=true` (or directory is empty) → **deletes the entire strategy directory**, including all archived state files.
 
 **Output (stdout):**
 
 | Status    | Meaning |
 |----------|---------|
-| `cleaned` | Strategy directory removed. `positions_deleted` is the number of state files that were in it. |
-| `blocked` | At least one position still `active`; directory not touched. `blocked_by_active` lists assets. |
+| `cleaned` | Strategy directory removed (including any archived files). `positions_deleted` is the count of `.json` files that were in the dir. |
+| `blocked` | At least one state file has `active=true`; directory not touched. `blocked_by_active` lists assets. |
 
 Example cleaned:
 
@@ -70,20 +70,24 @@ Example blocked:
 
 | Event | Agent action |
 |-------|--------------|
-| `closed=true` in dsl-v5.py output | Alert user; script already deleted state file |
+| `closed=true` in dsl-v5.py output | Alert user; script archived state file to `{asset}_archived_{epoch}.json` |
 | `status: "strategy_inactive"` in dsl-v5.py output | Remove cron for that strategy; run `dsl-cleanup.py` for that strategy |
-| All positions in strategy closed (no state files left) | Next run will output strategy_inactive; then remove cron and run `dsl-cleanup.py` |
+| All positions in strategy closed (no active state files left) | Next run may output no_positions or strategy_inactive; then remove cron and run `dsl-cleanup.py` |
 | `strategy_close_strategy` called | After strategy is inactive, run `dsl-cleanup.py` |
 
-## File Layout After Cleanup
+## File Layout
 
-Only active strategy dirs and active position files remain. No `_closed/`.
+- **While strategy is active:** Strategy dir contains active state files (`ETH.json`, …) and, after some closes, archived files (`ETH_archived_1709722800.json`, …). Only active files are listed/processed by dsl-v5.
+- **After strategy_inactive:** dsl-v5 has removed active state files; dir may still contain `*_archived_*` files.
+- **After dsl-cleanup.py runs:** The entire strategy directory is removed (no archived files left).
+
 Paths use `DSL_STATE_DIR` (default `/data/workspace/dsl` when unset):
 
 ```
 $DSL_STATE_DIR/
   strat-abc-123/
-    ETH.json
+    ETH.json              # active
+    BTC_archived_1709722800.json   # archived (after close)
 ```
 
-Closed positions and fully closed strategies are deleted.
+Once cleanup runs, `strat-abc-123/` is deleted.

--- a/dsl-dynamic-stop-loss/references/state-schema.md
+++ b/dsl-dynamic-stop-loss/references/state-schema.md
@@ -85,7 +85,7 @@ Complete JSON schema for DSL v4/v5 state files. One state file per position. v5 
 | Field | Type | Description |
 |-------|------|-------------|
 | `retraceThreshold` | float | Default retrace (ROE fraction) for tiers without per-tier override |
-| `consecutiveBreachesRequired` | int | Checks below floor before close |
+| `consecutiveBreachesRequired` | int | Consecutive breach checks before close (default: 1 — close on first breach in Phase 2) |
 
 ### Tier Objects
 

--- a/dsl-dynamic-stop-loss/scripts/dsl-v5.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-v5.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""DSL v5 — Strategy-scoped cron, MCP clearinghouse + price, delete on close.
+"""DSL v5 — Strategy-scoped cron, MCP clearinghouse + price, archive on close.
 Cron is per strategy (DSL_STATE_DIR + DSL_STRATEGY_ID only). Each run:
-1. Check if strategy is active via MCP; if not, cleanup all state files and output strategy_inactive.
-2. Get active positions from MCP clearinghouse; delete state files for positions that no longer exist.
-3. For each remaining position with a state file: fetch price, update tiers, breach, close if needed, delete state on close.
+1. Check if strategy is active via MCP; if not, cleanup active state files and output strategy_inactive.
+2. For each state file with slOrderId: call execution_get_order_status; if filled, rename to {asset}_archived_sl_{epoch}.json.
+3. Get active positions from MCP clearinghouse; rename state files for positions no longer present to {asset}_archived_external_{epoch}.json.
+4. For each remaining position: fetch price, update tiers, breach, close if needed; on close rename to {asset}_archived_{epoch}.json.
+Phase 1 SL uses MARKET (fast exit); Phase 2 (tiered) SL uses LIMIT. Phase 2 default: 1 breach to close.
 Output: one JSON line per position (ndjson), or one line for strategy-level outcome (inactive / no_positions).
 """
 from __future__ import annotations
@@ -52,12 +54,14 @@ def resolve_state_file(state_dir: str, strategy_id: str, asset: str) -> tuple[st
 
 
 def list_strategy_state_files(state_dir: str, strategy_id: str) -> list[tuple[str, str]]:
-    """Return list of (path, asset) for each .json in strategy dir. asset from filename."""
+    """Return list of (path, asset) for each active .json in strategy dir (excludes *_archived_* files)."""
     out = []
     strategy_dir = os.path.join(state_dir, strategy_id)
     if not os.path.isdir(strategy_dir):
         return out
     for name in os.listdir(strategy_dir):
+        if "_archived" in name or ".archived" in name:
+            continue
         path = os.path.join(strategy_dir, name)
         if not name.endswith(".json") or not os.path.isfile(path):
             continue
@@ -186,12 +190,14 @@ def get_active_position_coins(wallet: str) -> tuple[set[str], str | None]:
 
 
 def cleanup_strategy_state_dir(state_dir: str, strategy_id: str) -> int:
-    """Delete all .json state files in strategy dir. Return count deleted."""
+    """Remove only active .json state files in strategy dir (excludes *_archived_* files). Return count removed."""
     deleted = 0
     strategy_dir = os.path.join(state_dir, strategy_id)
     if not os.path.isdir(strategy_dir):
         return 0
     for name in os.listdir(strategy_dir):
+        if "_archived" in name or ".archived" in name:
+            continue
         path = os.path.join(strategy_dir, name)
         if name.endswith(".json") and os.path.isfile(path):
             try:
@@ -278,7 +284,7 @@ def fetch_price_mcp(dex: str, lookup_symbol: str) -> tuple[float | None, str | N
 DEFAULT_PHASE1_RETRACE = 0.03
 DEFAULT_PHASE1_BREACHES = 3
 DEFAULT_PHASE2_RETRACE = 0.015
-DEFAULT_PHASE2_BREACHES = 2
+DEFAULT_PHASE2_BREACHES = 1
 
 
 def normalize_state_phase_config(state: dict) -> bool:
@@ -506,6 +512,37 @@ def _mcp_strategy_get_open_orders(wallet: str, dex: str = "") -> tuple[list[dict
         return [], str(e)
 
 
+def _mcp_execution_get_order_status(wallet: str, order_id: int) -> tuple[bool, str | None, str | None]:
+    """Call senpi execution_get_order_status. Returns (success, order_status, error).
+    order_status is e.g. 'open', 'filled', 'canceled' when success; None on error or unknownOid.
+    """
+    args = {"user": wallet, "orderId": order_id}
+    try:
+        r = subprocess.run(
+            ["mcporter", "call", "senpi", "execution_get_order_status", "--args", json.dumps(args)],
+            capture_output=True, text=True, timeout=15,
+        )
+        raw = _unwrap_mcporter_response(r.stdout) if r.stdout else None
+        if r.returncode != 0:
+            return False, None, (r.stderr or r.stdout or "non-zero exit")
+        if not raw or not isinstance(raw, dict):
+            return False, None, "execution_get_order_status: invalid or empty response"
+        if raw.get("success") is False:
+            err = raw.get("error", {})
+            msg = err.get("message", str(err)) if isinstance(err, dict) else str(err)
+            return False, None, msg
+        data = raw.get("data") or raw
+        if data.get("status") == "unknownOid":
+            return True, None, None
+        if data.get("status") == "order":
+            order = data.get("order")
+            if isinstance(order, dict):
+                return True, (order.get("status") or "").strip().lower(), None
+        return False, None, "execution_get_order_status: unexpected response shape"
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        return False, None, str(e)
+
+
 def _resolve_sl_order_id_after_edit(
     wallet: str, dex: str, coin: str, trigger_price: float, orders: list[dict]
 ) -> int | None:
@@ -537,17 +574,20 @@ def sync_sl_to_hyperliquid(
     effective_floor: float,
     now: str,
     dex: str,
+    phase: int,
 ) -> tuple[bool, bool, str | None]:
     """Set or update SL on Hyperliquid at effective_floor via edit_position. Resolve slOrderId via open orders if needed.
+    Phase 1 (initial/absolute floor): MARKET for fast exit; Phase 2 (tiered): LIMIT.
     Mutates state: slOrderId, lastSyncedFloorPrice, slOrderIdUpdatedAt.
     Returns (success, sl_synced_this_tick, error_message)."""
     wallet = state.get("wallet", "")
     coin = state["asset"]
     if not wallet:
         return False, False, "no wallet in state"
+    order_type = "MARKET" if phase == 1 else "LIMIT"
 
     success, err, oid_from_api = _mcp_edit_position(
-        wallet, coin, effective_floor, order_type="LIMIT"
+        wallet, coin, effective_floor, order_type=order_type
     )
     if not success:
         return False, False, err
@@ -617,19 +657,29 @@ def try_close_position(
 
 
 # ---------------------------------------------------------------------------
-# Persist: save or delete state file
+# Persist: save or rename state file on close (archive instead of delete)
 # ---------------------------------------------------------------------------
 
-def save_or_delete_state(
+def _archived_state_filename(state_file: str, now: str, suffix: str = "archived") -> str:
+    """Build archived filename with epoch and underscores: e.g. ETH.json -> ETH_archived_1709722800.json."""
+    epoch = int(time.time())
+    suffix_safe = suffix.replace("-", "_")
+    base, ext = os.path.splitext(state_file)
+    return f"{base}_{suffix_safe}_{epoch}{ext}"
+
+
+def save_or_rename_state(
     state: dict, state_file: str, closed: bool, now: str, close_result: str | None
 ) -> str | None:
-    """Persist state (save or delete file). Caller must set state['lastPrice'] before calling.
-    If closed but delete fails, writes state (active: False) so cleanup can proceed later.
+    """Persist state: save file, or if closed rename to {base}_archived_{epoch}.json (archive).
+    Caller must set state['lastPrice'] before calling.
+    If closed but rename fails, writes state (active: False) so cleanup can proceed later.
     """
     state["lastCheck"] = now
     if closed:
+        dest = _archived_state_filename(state_file, now, "archived")
         try:
-            os.remove(state_file)
+            os.rename(state_file, dest)
             return close_result
         except OSError as e:
             # Fallback: write state so dsl-cleanup sees active: false and can clean strategy
@@ -638,7 +688,7 @@ def save_or_delete_state(
                     json.dump(state, f, indent=2)
             except OSError:
                 pass
-            return (close_result or "") + f"; delete_failed: {e}"
+            return (close_result or "") + f"; rename_failed: {e}"
     with open(state_file, "w") as f:
         json.dump(state, f, indent=2)
     return close_result
@@ -851,7 +901,9 @@ def process_one_position(state_file: str, strategy_id: str, now: str) -> None:
     )
     sl_synced_this_tick = False
     if need_sync:
-        sync_ok, sl_synced_this_tick, sync_err = sync_sl_to_hyperliquid(state, effective_floor, now, dex)
+        sync_ok, sl_synced_this_tick, sync_err = sync_sl_to_hyperliquid(
+            state, effective_floor, now, dex, phase
+        )
         if not sync_ok and sync_err:
             # Log but continue; backup close on breach still available
             state["lastSlSyncError"] = sync_err
@@ -870,7 +922,7 @@ def process_one_position(state_file: str, strategy_id: str, now: str) -> None:
             state.get("closeRetries", 2), state.get("closeRetryDelaySec", 3),
         )
 
-    close_result = save_or_delete_state(state, state_file, closed, now, close_result)
+    close_result = save_or_rename_state(state, state_file, closed, now, close_result)
 
     out = build_output(
         state,
@@ -939,7 +991,30 @@ def main() -> None:
             }))
             sys.exit(1)
 
-    # 2. Active positions from clearinghouse.
+    # 2. List state files and check SL order status (before reconcile): if SL already filled, archive and skip.
+    state_files = list_strategy_state_files(state_dir, strategy_id)
+    for path, asset in list(state_files):
+        try:
+            with open(path) as f:
+                state = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        oid = state.get("slOrderId")
+        if oid is None:
+            continue
+        try:
+            oid = int(oid)
+        except (TypeError, ValueError):
+            continue
+        ok, order_status, _ = _mcp_execution_get_order_status(wallet, oid)
+        if ok and order_status == "filled":
+            try:
+                dest = _archived_state_filename(path, now, "archived-sl")
+                os.rename(path, dest)
+            except OSError:
+                pass
+
+    # 3. Active positions from clearinghouse.
     coins, ch_error = get_active_position_coins(wallet)
     if ch_error is not None:
         print(json.dumps({
@@ -951,11 +1026,13 @@ def main() -> None:
         }))
         sys.exit(1)
 
+    # 4. Reconcile: archive state files for positions no longer in clearinghouse (closed externally).
     state_files = list_strategy_state_files(state_dir, strategy_id)
     for path, asset in list(state_files):
         if asset not in coins:
             try:
-                os.remove(path)
+                dest = _archived_state_filename(path, now, "archived-external")
+                os.rename(path, dest)
             except OSError:
                 pass
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes stop-loss syncing/exit behavior (Phase 1 MARKET vs Phase 2 LIMIT and Phase 2 closes on first breach) and alters reconciliation/cleanup flows, which can affect when positions are considered closed and how state is retained.
> 
> **Overview**
> Bumps DSL to **v5.1**, changing state lifecycle from *delete-on-close* to **archive-on-close**: state files are renamed to `*_archived_{epoch}.json`, with additional archive suffixes for SL-filled (`*_archived_sl_*`) and externally closed (`*_archived_external_*`) positions; strategy-inactive cleanup now removes only active state files, leaving archives for `dsl-cleanup.py` to delete at strategy cleanup time.
> 
> In `dsl-v5.py`, adds an `execution_get_order_status` pre-pass to detect SL orders that already filled on Hyperliquid and archive those states, updates reconciliation to archive rather than remove orphaned states, and switches SL placement to **Phase 1 `MARKET`** vs **Phase 2 `LIMIT`**. Phase 2 defaults to **1 consecutive breach** (configurable) and docs/schema are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2df040c70cef006974a72e2327f1e796d74f2156. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->