### PR TITLE
Fixed math for account value

### DIFF
--- a/wolf-strategy/scripts/risk-guardian.py
+++ b/wolf-strategy/scripts/risk-guardian.py
@@ -47,11 +47,9 @@ def get_account_value(wallet):
     total = 0.0
     for section_key in ("main", "xyz"):
         section = data.get(section_key, {})
-        av = section.get("crossMarginSummary", {}).get("accountValue")
+        av = section.get("marginSummary", {}).get("accountValue")
         if av is not None:
             total += float(av)
-        elif section.get("marginSummary", {}).get("accountValue") is not None:
-            total += float(section["marginSummary"]["accountValue"])
     return total
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the account-value field used to drive daily-loss and entry-bypass guardrails, which could alter when strategies are halted or allowed to trade. Scope is small but impacts risk gating behavior.
> 
> **Overview**
> Updates `get_account_value` in `risk-guardian.py` to read `accountValue` from `marginSummary` (instead of `crossMarginSummary`) for both `main` and `xyz` sections, removing the prior fallback logic.
> 
> This corrects the account-value input used by guardrails like daily loss halt (G1) and profit-based bypass for max entries (G3).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1e4fe52b0e7763843b814c0d65ea991c444beb1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->