### PR TITLE
Fixed timestamp format issue

### DIFF
--- a/wolf-strategy/scripts/risk-guardian.py
+++ b/wolf-strategy/scripts/risk-guardian.py
@@ -70,9 +70,9 @@ def record_new_closings(counter, closed_positions):
         close_time = pos.get("closeTime") or pos.get("close_time")
         if close_time:
             try:
-                # closeTime is Unix milliseconds
+                # closeTime is Unix seconds
                 ct = int(close_time)
-                close_date = datetime.fromtimestamp(ct / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
+                close_date = datetime.fromtimestamp(ct, tz=timezone.utc).strftime("%Y-%m-%d")
                 if close_date != today:
                     continue
             except (ValueError, TypeError, OSError):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Small change but affects day-boundary detection for closed trades, which can impact daily counters and guard-rail gating decisions. If upstream timestamps are not actually seconds, trades could be misclassified as "today" or skipped.
> 
> **Overview**
> Fixes a timestamp unit bug in `risk-guardian.py` by treating `closeTime` as Unix *seconds* rather than milliseconds when filtering closed trades to “today”.
> 
> This removes the `/ 1000` conversion in `record_new_closings`, which changes which trades are counted toward daily realized PnL and win/loss streak tracking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9adfc31cd093fa0b51ca27a629469f15d01c2ea. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->