### PR TITLE
adding skill attribution

### DIFF
--- a/lion/SKILL.md
+++ b/lion/SKILL.md
@@ -26,6 +26,33 @@ Wait for the market to break. Trade the repair.
 
 ---
 
+## Skill Attribution
+
+**Skill ID:** `lion-strategy`
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "lion-strategy",
+"skill_version": "1.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 5000,
+    "positions": [],
+    "skill_name": "lion-strategy",
+    "skill_version": "1.0"
+  }
+}
+```
+
+---
+
 ## Architecture
 
 ```

--- a/lion/SKILL.md
+++ b/lion/SKILL.md
@@ -28,28 +28,7 @@ Wait for the market to break. Trade the repair.
 
 ## Skill Attribution
 
-**Skill ID:** `lion-strategy`
-
-When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
-
-```json
-"skill_name": "lion-strategy",
-"skill_version": "1.0"
-```
-
-This is required for attribution and tracking. Example:
-
-```json
-{
-  "tool": "strategy_create_custom_strategy",
-  "args": {
-    "initialBudget": 5000,
-    "positions": [],
-    "skill_name": "lion-strategy",
-    "skill_version": "1.0"
-  }
-}
-```
+When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.
 
 ---
 

--- a/lion/references/skill-attribution.md
+++ b/lion/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "lion-strategy",
+"skill_version": "1.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 5000,
+    "positions": [],
+    "skill_name": "lion-strategy",
+    "skill_version": "1.0"
+  }
+}
+```

--- a/lion/scripts/lion_config.py
+++ b/lion/scripts/lion_config.py
@@ -29,6 +29,10 @@ OI_HISTORY_FILE = os.path.join(HISTORY_DIR, "oi-history.json")
 
 VERBOSE = os.environ.get("LION_VERBOSE") == "1"
 
+# Skill attribution — injected automatically into every call_mcp()
+SKILL_NAME = "lion-strategy"
+SKILL_VERSION = "1.0"
+
 
 # ─── Atomic Write ────────────────────────────────────────────
 
@@ -274,6 +278,9 @@ def log_trade(config, trade):
 
 def call_mcp(tool, **kwargs):
     """Call a Senpi MCP tool with 3-attempt retry."""
+    # Inject skill attribution so every tool call is traceable to this skill
+    kwargs.setdefault("skill_name", SKILL_NAME)
+    kwargs.setdefault("skill_version", SKILL_VERSION)
     cmd = ["mcporter", "call", f"senpi.{tool}"]
     for k, v in kwargs.items():
         if isinstance(v, (list, dict, bool)):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the shared `call_mcp()` wrapper used by all LION scripts to always pass `skill_name`/`skill_version`, which could affect every Senpi MCP invocation if those parameters are unsupported or conflict with existing args. Otherwise the change is small and mostly documentation.
> 
> **Overview**
> Adds *skill attribution* to the LION strategy by documenting required `skill_name`/`skill_version` fields and introducing a new `references/skill-attribution.md` reference.
> 
> Updates `lion_config.call_mcp()` to automatically inject `skill_name="lion-strategy"` and `skill_version="1.0"` into every Senpi MCP tool call (unless already provided), making all executions traceable without changing individual call sites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54caf9b5caecc23e8f79c57494a00666053f654a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->