### PR TITLE
adding skill attribution

### DIFF
--- a/autonomous-trading/SKILL.md
+++ b/autonomous-trading/SKILL.md
@@ -23,6 +23,31 @@ metadata:
 
 Give your agent a budget, a target, and a deadline — then let it trade. The agent creates a strategy wallet, scans for opportunities, opens positions, protects profits with DSL, and enforces risk controls.
 
+## Skill Attribution
+
+**Skill ID:** `autonomous-trading`
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "autonomous-trading",
+"skill_version": "6.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "autonomous-trading",
+    "skill_version": "6.0"
+  }
+}
+```
+
 ## Prerequisites
 
 Install these companion skills first:

--- a/autonomous-trading/SKILL.md
+++ b/autonomous-trading/SKILL.md
@@ -25,28 +25,9 @@ Give your agent a budget, a target, and a deadline — then let it trade. The ag
 
 ## Skill Attribution
 
-**Skill ID:** `autonomous-trading`
+When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.
 
-When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
-
-```json
-"skill_name": "autonomous-trading",
-"skill_version": "6.0"
-```
-
-This is required for attribution and tracking. Example:
-
-```json
-{
-  "tool": "strategy_create_custom_strategy",
-  "args": {
-    "initialBudget": 500,
-    "positions": [],
-    "skill_name": "autonomous-trading",
-    "skill_version": "6.0"
-  }
-}
-```
+---
 
 ## Prerequisites
 

--- a/autonomous-trading/references/skill-attribution.md
+++ b/autonomous-trading/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "autonomous-trading",
+"skill_version": "6.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "autonomous-trading",
+    "skill_version": "6.0"
+  }
+}
+```

--- a/whale-index/SKILL.md
+++ b/whale-index/SKILL.md
@@ -21,6 +21,33 @@ metadata:
 
 Scan the Discovery leaderboard, score traders, create mirror strategies, and rebalance daily. Set your risk level and budget — the agent handles selection, allocation, monitoring, and swaps.
 
+## Skill Attribution
+
+**Skill ID:** `whale-index`
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "whale-index",
+"skill_version": "1.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create",
+  "args": {
+    "traderAddress": "0x...",
+    "initialBudget": 500,
+    "mirrorMultiplier": 1,
+    "slippage": 3,
+    "skill_name": "whale-index",
+    "skill_version": "1.0"
+  }
+}
+```
+
 ## 5-Step Flow
 
 ### Step 1: Onboard the User

--- a/whale-index/SKILL.md
+++ b/whale-index/SKILL.md
@@ -23,30 +23,9 @@ Scan the Discovery leaderboard, score traders, create mirror strategies, and reb
 
 ## Skill Attribution
 
-**Skill ID:** `whale-index`
+When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.
 
-When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
-
-```json
-"skill_name": "whale-index",
-"skill_version": "1.0"
-```
-
-This is required for attribution and tracking. Example:
-
-```json
-{
-  "tool": "strategy_create",
-  "args": {
-    "traderAddress": "0x...",
-    "initialBudget": 500,
-    "mirrorMultiplier": 1,
-    "slippage": 3,
-    "skill_name": "whale-index",
-    "skill_version": "1.0"
-  }
-}
-```
+---
 
 ## 5-Step Flow
 

--- a/whale-index/references/skill-attribution.md
+++ b/whale-index/references/skill-attribution.md
@@ -1,0 +1,24 @@
+# Skill Attribution
+
+When calling `strategy_create`, always include:
+
+```json
+"skill_name": "whale-index",
+"skill_version": "1.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create",
+  "args": {
+    "traderAddress": "0x...",
+    "initialBudget": 500,
+    "mirrorMultiplier": 1,
+    "slippage": 3,
+    "skill_name": "whale-index",
+    "skill_version": "1.0"
+  }
+}
+```

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -26,6 +26,31 @@ The WOLF hunts for its human. It scans, enters, exits, and rotates positions aut
 
 ---
 
+## Skill Attribution
+
+**Skill ID:** `wolf-strategy`
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "wolf-strategy",
+"skill_version": "6.1.1"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "wolf-strategy",
+    "skill_version": "6.1.1"
+  }
+}
+```
+
 ## Multi-Strategy Architecture
 
 ### Strategy Registry (`wolf-strategies.json`)

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -28,28 +28,9 @@ The WOLF hunts for its human. It scans, enters, exits, and rotates positions aut
 
 ## Skill Attribution
 
-**Skill ID:** `wolf-strategy`
+When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.
 
-When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
-
-```json
-"skill_name": "wolf-strategy",
-"skill_version": "6.1.1"
-```
-
-This is required for attribution and tracking. Example:
-
-```json
-{
-  "tool": "strategy_create_custom_strategy",
-  "args": {
-    "initialBudget": 500,
-    "positions": [],
-    "skill_name": "wolf-strategy",
-    "skill_version": "6.1.1"
-  }
-}
-```
+---
 
 ## Multi-Strategy Architecture
 

--- a/wolf-strategy/references/skill-attribution.md
+++ b/wolf-strategy/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "wolf-strategy",
+"skill_version": "6.1.1"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "wolf-strategy",
+    "skill_version": "6.1.1"
+  }
+}
+```

--- a/wolf-strategy/scripts/wolf_config.py
+++ b/wolf-strategy/scripts/wolf_config.py
@@ -23,6 +23,10 @@ REGISTRY_FILE = os.path.join(WORKSPACE, "wolf-strategies.json")
 LEGACY_CONFIG = os.path.join(WORKSPACE, "wolf-strategy.json")
 LEGACY_STATE_PATTERN = os.path.join(WORKSPACE, "dsl-state-WOLF-*.json")
 
+# Skill attribution — injected automatically into every mcporter_call()
+SKILL_NAME = "wolf-strategy"
+SKILL_VERSION = "6.1.1"
+
 
 def _fail(msg):
     """Print error JSON and exit."""
@@ -243,6 +247,9 @@ def mcporter_call(tool, retries=3, timeout=30, **kwargs):
     Raises:
         RuntimeError: If all retries fail or the tool returns success=false.
     """
+    # Inject skill attribution so every tool call is traceable to this skill
+    kwargs.setdefault("skill_name", SKILL_NAME)
+    kwargs.setdefault("skill_version", SKILL_VERSION)
     filtered_args = {k: v for k, v in kwargs.items() if v is not None}
 
     mcporter_bin = os.environ.get("MCPORTER_CMD", "mcporter")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds `skill_name`/`skill_version` parameters to all `wolf-strategy` MCP tool invocations and documents the requirement across multiple skills; risk is moderate if any downstream tools reject or treat these new args differently.
> 
> **Overview**
> Adds a **skill attribution requirement** across `autonomous-trading`, `whale-index`, and `wolf-strategy`, updating each `SKILL.md` and introducing `references/skill-attribution.md` docs with required `skill_name`/`skill_version` fields and examples for strategy creation calls.
> 
> In `wolf-strategy`, updates `scripts/wolf_config.py` so `mcporter_call()` automatically injects `skill_name="wolf-strategy"` and `skill_version="6.1.1"` into every Senpi MCP tool call for consistent attribution/traceability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc5b6bce4760cd08c8871124b93f6d6f99eecb73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->