### PR TITLE
adding versioning for tiger skill

### DIFF
--- a/tiger-strategy/SKILL.md
+++ b/tiger-strategy/SKILL.md
@@ -25,6 +25,12 @@ metadata:
 
 ---
 
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.
+
+---
+
 ## Architecture
 
 ```

--- a/tiger-strategy/SKILL.md
+++ b/tiger-strategy/SKILL.md
@@ -58,10 +58,37 @@ metadata:
 
 ---
 
+## Skill Attribution
+
+**Skill ID:** `tiger-strategy`
+
+When calling `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "tiger-strategy",
+"skill_version": "4.1"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 1000,
+    "positions": [],
+    "skill_name": "tiger-strategy",
+    "skill_version": "4.1"
+  }
+}
+```
+
+---
+
 ## Quick Start
 
 1. Ensure Senpi MCP is connected (`mcporter list` shows `senpi`)
-2. Create a custom strategy: `strategy_create_custom_strategy`
+2. Create a custom strategy: `strategy_create_custom_strategy` — include `skill_name: "tiger-strategy"` and `skill_version: "4.1"` (see Skill Attribution above)
 3. Fund the wallet: `strategy_top_up`
 4. Run setup:
    ```bash

--- a/tiger-strategy/references/skill-attribution.md
+++ b/tiger-strategy/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "tiger-strategy",
+"skill_version": "4.1"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 5000,
+    "positions": [],
+    "skill_name": "tiger-strategy",
+    "skill_version": "4.1"
+  }
+}
+```

--- a/tiger-strategy/scripts/tiger-setup.py
+++ b/tiger-strategy/scripts/tiger-setup.py
@@ -6,6 +6,9 @@ Creates config from user parameters, validates wallet, and initializes state.
 Usage:
   python3 tiger-setup.py --wallet 0x... --strategy-id UUID --budget 5000 \
     --target 10000 --days 7 --chat-id 12345 [--max-slots 3] [--max-leverage 10]
+
+Skill attribution: when creating the strategy via strategy_create_custom_strategy,
+always pass skill_name="tiger-strategy" and skill_version="4.1".
 """
 
 import sys
@@ -18,7 +21,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 from tiger_config import (
     load_config, save_config, save_state, DEFAULT_CONFIG, DEFAULT_STATE,
-    CONFIG_FILE, STATE_FILE, WORKSPACE
+    CONFIG_FILE, STATE_FILE, WORKSPACE, SKILL_NAME, SKILL_VERSION
 )
 
 
@@ -84,6 +87,8 @@ def main():
     # Summary
     summary = {
         "status": "TIGER configured",
+        "skill_name": SKILL_NAME,
+        "skill_version": SKILL_VERSION,
         "config_file": CONFIG_FILE,
         "state_file": STATE_FILE,
         "budget": f"${args.budget:,.0f}",
@@ -95,8 +100,13 @@ def main():
         "wallet": args.wallet,
         "max_slots": args.max_slots,
         "max_leverage": args.max_leverage,
+        "strategy_create_attribution": {
+            "skill_name": SKILL_NAME,
+            "skill_version": SKILL_VERSION,
+        },
         "next_steps": [
-            "Create 7 OpenClaw crons from references/cron-templates.md",
+            f"If not done: call strategy_create_custom_strategy with skill_name='{SKILL_NAME}' skill_version='{SKILL_VERSION}'",
+            "Create 10 OpenClaw crons from references/cron-templates.md",
             "TIGER will start hunting on next cron cycle"
         ]
     }

--- a/tiger-strategy/scripts/tiger_config.py
+++ b/tiger-strategy/scripts/tiger_config.py
@@ -162,7 +162,12 @@ def load_prescreened_candidates(instruments, config=None, include_leverage=True)
 
 # ─── Config ──────────────────────────────────────────────────
 
+SKILL_NAME = "tiger-strategy"
+SKILL_VERSION = "4.1"
+
 DEFAULT_CONFIG = {
+    "skill_name": SKILL_NAME,
+    "skill_version": SKILL_VERSION,
     "budget": 1000,
     "target": 2000,
     "deadline_days": 7,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: primarily documentation plus adding two new config fields and exposing them in `tiger-setup.py` output. Main risk is minor compatibility issues if any downstream tooling assumes an exact config schema.
> 
> **Overview**
> **Introduces skill attribution/versioning for TIGER.** The PR standardizes `skill_name: "tiger-strategy"` and `skill_version: "4.1"` as required arguments when calling `strategy_create_custom_strategy` (and `strategy_create`), and documents this in `SKILL.md` plus a new `references/skill-attribution.md`.
> 
> The Python setup/config flow is updated to define `SKILL_NAME`/`SKILL_VERSION` in `tiger_config.py`, include them in `DEFAULT_CONFIG`, and surface them in `scripts/tiger-setup.py`’s printed summary/next-steps so operators consistently create attributed strategies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6792d19d7a0e1267acdc681aff97c870c8eb8ee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->