### PR TITLE
DSL wolf changes

### DIFF
--- a/wolf-strategy/README.md
+++ b/wolf-strategy/README.md
@@ -1,4 +1,4 @@
-# WOLF Strategy v6.1.1
+# WOLF Strategy v6.1.2
 
 Fully autonomous multi-strategy trading for Hyperliquid perps. The WOLF hunts for its human — scans, enters, exits, and rotates positions without asking permission. Manages multiple strategies simultaneously, each with independent wallets, budgets, slots, and DSL configs.
 
@@ -31,7 +31,7 @@ Fully autonomous multi-strategy trading for Hyperliquid perps. The WOLF hunts fo
 - **Shared config loader** (`wolf_config.py`) — all scripts use same module for config, paths, legacy migration
 - **Backward compatible** — auto-migrates legacy `wolf-strategy.json` and old state files on first run
 
-## What's New in v6.1.1
+## What's New in v6.1.2
 
 - **Risk Guardian** — 6th cron (5min, Budget tier) enforcing account-level guard rails: daily loss halt, max entries per day, consecutive loss cooldown
 - **Strategy lock** — concurrency protection (file-based `fcntl` locking) for position operations, preventing race conditions between scanner and guardian
@@ -56,6 +56,7 @@ Fully autonomous multi-strategy trading for Hyperliquid perps. The WOLF hunts fo
 
 | Version | Date | Changes |
 |---------|------|---------|
+| v6.1.2 | 2026-03-06 | Major DSL v5.1 migration: strategy active check (archives on inactive), SL pre-fill check (archives if SL order filled), clearinghouse reconcile (archives externally closed), SL sync to Hyperliquid via edit_position (Phase 1 MARKET / Phase 2 LIMIT), archive-on-close rename, state normalization for phase fields |
 | v6.1.1 | 2026-03-05 | Risk Guardian (account-level guard rails), strategy lock (concurrency protection), gate check in open-position.py, entry counter tracking |
 | v6.1 | 2026-03-03 | Reduced leverage ranges, risk-based dynamic leverage, rotation cooldown (45min), atomic open-position.py |
 | v6.0 | 2026-02-24 | Multi-strategy support, strategy registry, per-strategy state dirs, signal routing, shared config loader |

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: wolf-strategy
 description: >-
-  WOLF v6.1.1 — Fully autonomous multi-strategy trading for Hyperliquid perps via Senpi MCP.
+  WOLF v6.1.2 — Fully autonomous multi-strategy trading for Hyperliquid perps via Senpi MCP.
   Manages multiple strategies simultaneously, each with independent wallets, budgets, slots,
   and DSL configs. 6-cron architecture with Emerging Movers scanner (3min, FIRST_JUMP + IMMEDIATE_MOVER),
-  DSL v4 trailing stops (combined runner every 3min, 4-tier at 5/10/15/20% ROE),
+  DSL v5.1 trailing stops (combined runner every 3min, 4-tier at 5/10/15/20% ROE),
   SM flip detector (5min), watchdog (5min), risk guardian (5min, account-level guard rails),
   and health checks (10min). Same asset can be traded in different strategies simultaneously.
   Enter early on first jumps, not at confirmed peaks. Dynamic risk-based leverage per strategy.
@@ -12,7 +12,7 @@ description: >-
 
 ---
 
-# WOLF v6.1.1 — Autonomous Multi-Strategy Trading
+# WOLF v6.1.2 — Autonomous Multi-Strategy Trading
 
 The WOLF hunts for its human. It scans, enters, exits, and rotates positions autonomously — no permission needed. When criteria are met, it acts. Speed is edge.
 
@@ -21,6 +21,8 @@ The WOLF hunts for its human. It scans, enters, exits, and rotates positions aut
 **v6: Multi-strategy support.** Each strategy has independent wallet, budget, slots, and DSL config. Same asset can be held in different strategies simultaneously (e.g., Strategy A LONG HYPE + Strategy B SHORT HYPE).
 
 **v6.1.1: Risk Guardian & strategy lock.** 6th cron (5min, Budget tier) enforcing account-level guard rails — daily loss halt, max entries per day, consecutive loss cooldown. Strategy lock for concurrency protection. Gate check in `open-position.py` refuses new entries when gate != OPEN.
+
+**v6.1.2:** DSL v5.1: strategy active check (archive state when not ACTIVE/PAUSED), SL pre-fill check (archive when SL order filled on HL), clearinghouse reconcile (archive when asset no longer in clearinghouse), SL sync to Hyperliquid (Phase 1 MARKET / Phase 2 LIMIT), archive-on-close rename; state normalization for missing phase1/phase2/stagnation.
 
 **v6.1: Reduced leverage ranges.** All risk tiers lowered — aggressive now caps at 75% of max leverage (was 100%), moderate at 50% (was 75%), conservative at 25% (was 50%). Prevents over-leveraging on high-max-leverage assets.
 
@@ -260,11 +262,23 @@ When ANY job closes a position -> immediately:
 2. Alert user
 3. Evaluate: empty slot in that strategy for next signal?
 
-**v6 note:** Since DSL is a combined runner iterating all strategies, no per-position crons to manage. Just set `active: false` in the state file.
+**v6 note:** Since DSL is a combined runner iterating all strategies, no per-position crons to manage. When closing manually, set `active: false` in the state file; the next DSL run will archive it as `_archived_external_` when clearinghouse reconcile sees the position is gone.
 
 ---
 
-## DSL v4 — Trailing Stop System
+## DSL v5.1 — Trailing Stop System
+
+The combined runner (`dsl-combined.py`) implements DSL v5.1: **SL sync to Hyperliquid** (native stop order so HL closes when price hits, not just on cron tick), **strategy active check**, **clearinghouse reconcile**, and **archive on close**.
+
+### Per-run pre-processing (v5.1)
+1. **Strategy active:** MCP `strategy_get(strategy_id)`. If status is not ACTIVE or PAUSED, all DSL state files for that strategy are archived as `dsl-{asset}_archived_strategy_inactive_{epoch}.json` and the run emits `strategies_inactive: [strategyKey]`.
+2. **SL pre-fill:** For each state file with `slOrderId`, MCP `execution_get_order_status`. If the order is **filled** (HL already closed the position), the file is archived as `dsl-{asset}_archived_sl_{epoch}.json` and emitted in `sl_filled`.
+3. **Clearinghouse reconcile:** MCP `strategy_get_clearinghouse_state(wallet)`. State files whose asset is no longer in clearinghouse (e.g. closed manually) are archived as `dsl-{asset}_archived_external_{epoch}.json` and emitted in `externally_closed`.
+
+Only state files **not** matching `*_archived_*` are processed. Archived files are never picked up again.
+
+### SL sync to Hyperliquid
+After computing the effective floor each tick, the script calls MCP `edit_position` to set/update a **native SL order** on Hyperliquid at that price. Phase 1 uses `orderType: "MARKET"` (fast exit); Phase 2 uses `orderType: "LIMIT"`. Re-sync only when the floor actually changes or when the existing SL order was cancelled externally. State stores `slOrderId`, `lastSyncedFloorPrice`, `slOrderIdUpdatedAt`; optional `lastSlSyncError` on sync failure (non-fatal).
 
 ### Phase 1 (Pre-Tier 1): Absolute floor
 - LONG floor = entry x (1 - 10%/leverage)
@@ -284,8 +298,11 @@ When ANY job closes a position -> immediately:
 ### Stagnation Take-Profit
 Auto-close if ROE >= 8% and high-water stale for 1 hour.
 
+### Archive on close
+On breach/stagnation/phase1-cut close, the state file is **renamed** to `dsl-{asset}_archived_breach_{epoch}.json`. Pre-processing archives use `_archived_strategy_inactive_`, `_archived_sl_`, or `_archived_external_`. The file is not updated in place with `active: false`.
+
 ### DSL State File
-Each position gets `state/{strategyKey}/dsl-{ASSET}.json`. The combined runner iterates all active state files across all strategies. See `references/state-schema.md` for the full schema and critical gotchas (triggerPct not threshold, lockPct not retracePct, etc.).
+Each position gets `state/{strategyKey}/dsl-{ASSET}.json`. The combined runner iterates all **active** state files (excluding `*_archived_*`) across all strategies. See `references/state-schema.md` for the full schema and critical gotchas (triggerPct not threshold, lockPct not retracePct, etc.). New optional state fields: `slOrderId`, `lastSyncedFloorPrice`, `slOrderIdUpdatedAt`, `lastSlSyncError`.
 
 ---
 
@@ -472,7 +489,7 @@ See `references/learnings.md` for known bugs, gotchas, and trading discipline ru
 | `scripts/wolf-setup.py` | Setup wizard — adds strategy to registry from budget |
 | `scripts/wolf_config.py` | Shared config loader — all scripts import this |
 | `scripts/emerging-movers.py` | Emerging Movers v4 scanner (FIRST_JUMP, IMMEDIATE, CONTRIB_EXPLOSION) |
-| `scripts/dsl-combined.py` | DSL v4 combined trailing stop engine (all positions, all strategies) |
+| `scripts/dsl-combined.py` | DSL v5.1 combined trailing stop engine (all positions, all strategies; SL sync, strategy/clearinghouse checks, archive on close) |
 | `scripts/sm-flip-check.py` | SM conviction flip detector (multi-strategy) |
 | `scripts/wolf-monitor.py` | Watchdog — per-strategy margin buffer + position health |
 | `scripts/job-health-check.py` | Per-strategy orphan DSL / state validation |

--- a/wolf-strategy/scripts/dsl-combined.py
+++ b/wolf-strategy/scripts/dsl-combined.py
@@ -1,36 +1,75 @@
 #!/usr/bin/env python3
-"""DSL Combined Runner v2.0 — Multi-strategy support.
+"""DSL Combined Runner v3.0 — Multi-strategy + DSL v5.1 features.
 
 Iterates ALL enabled strategies, processes ALL active DSL state files per strategy.
 Each position uses its own strategy's wallet for close operations.
 
-v2.0 changes (WOLF v6):
-  - Multi-strategy: iterates load_all_strategies(), uses per-strategy state dirs
-  - Each result includes strategyKey for routing
-  - Two HYPE positions in different strategies processed independently
-  - Uses wolf_config for paths and config loading
+v3.0 (DSL v5.1 migration):
+  - Strategy active check (MCP strategy_get); archive state and emit strategy_inactive if not ACTIVE/PAUSED
+  - SL pre-fill check: state files with slOrderId → execution_get_order_status; if filled, archive as _archived_sl_
+  - Clearinghouse reconcile: archive state files whose asset no longer in clearinghouse (_archived_external_)
+  - SL sync to Hyperliquid via edit_position (Phase 1 MARKET, Phase 2 LIMIT); re-sync when floor changes or SL cancelled
+  - Archive on close: rename to dsl-{asset}_archived_{suffix}_{epoch}.json instead of active:false
+  - State normalization: backfill missing phase1/phase2/stagnation fields
 
-v1.0 (WOLF v5):
-  - Single cron manages ALL active WOLF positions
-  - Batch pricing, per-position DSL v4.1 logic
+v2.0 (WOLF v6): Multi-strategy, per-strategy state dirs, strategyKey in results.
 
 Usage:
   PYTHONUNBUFFERED=1 python3 dsl-combined.py
 
-Output: JSON with per-position results + summary.
+Output: JSON with per-position results + summary (strategies_inactive, externally_closed, sl_filled).
 """
-import json, os, sys, glob
+import json, os, sys, time
 from datetime import datetime, timezone
 
 # Add scripts dir to path for wolf_config import
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from wolf_config import (load_all_strategies, dsl_state_glob, atomic_write,
-                         validate_dsl_state, mcporter_call, mcporter_call_safe,
-                         heartbeat)
+from wolf_config import (
+    load_all_strategies, dsl_state_files_active, dsl_state_glob, atomic_write,
+    archive_state_file, validate_dsl_state, mcporter_call, mcporter_call_safe,
+    mcp_strategy_get, mcp_clearinghouse_coins, mcp_order_status, mcp_edit_position, mcp_get_open_orders,
+    heartbeat,
+)
 
 heartbeat("dsl_combined")
 
 now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+DSL_ACTIVE_STATUSES = ("ACTIVE", "PAUSED")
+
+
+def normalize_dsl_state(state):
+    """Backfill missing phase1/phase2/stagnation fields so older state files don't crash. Wolf: retraceThreshold as integer ROE %."""
+    if not isinstance(state, dict):
+        return
+    # Stagnation
+    if "stagnation" not in state or not isinstance(state.get("stagnation"), dict):
+        state["stagnation"] = {"enabled": True, "minROE": 8.0, "thresholdHours": 1.0, "priceRangePct": 1.0}
+    stag = state["stagnation"]
+    for k, v in [("enabled", True), ("minROE", 8.0), ("thresholdHours", 1.0), ("staleHours", 1.0), ("priceRangePct", 1.0)]:
+        if k not in stag:
+            stag[k] = v
+    # Phase2
+    if "phase2" not in state or not isinstance(state.get("phase2"), dict):
+        state["phase2"] = {}
+    if "consecutiveBreachesRequired" not in state["phase2"]:
+        state["phase2"]["consecutiveBreachesRequired"] = 2
+    if "retraceFromHW" not in state["phase2"]:
+        state["phase2"]["retraceFromHW"] = 5
+    # Phase1 absoluteFloor from entry/leverage/retraceThreshold (wolf integer ROE %)
+    phase1 = state.get("phase1")
+    if isinstance(phase1, dict) and "absoluteFloor" not in phase1:
+        entry = state.get("entryPrice")
+        leverage = state.get("leverage", 10)
+        retrace_roe = abs(phase1.get("retraceThreshold", 10))
+        if entry and leverage:
+            retrace_price = (retrace_roe / 100) / leverage
+            is_long = (state.get("direction", "LONG").upper() == "LONG")
+            if is_long:
+                phase1["absoluteFloor"] = round(entry * (1 - retrace_price), 6)
+            else:
+                phase1["absoluteFloor"] = round(entry * (1 + retrace_price), 6)
+            state["floorPrice"] = phase1["absoluteFloor"]
 
 
 def fetch_all_mids(dex=None):
@@ -59,7 +98,8 @@ def close_position(wallet, coin, reason):
 
 
 def process_position(state_file, state, price, strategy_cfg):
-    """Run DSL v4.1 logic on a single position. Returns result dict."""
+    """Run DSL v5.1 logic on a single position. Returns result dict."""
+    normalize_dsl_state(state)
     direction = state.get("direction", "LONG").upper()
     is_long = direction == "LONG"
     is_xyz = state.get("dex") == "xyz" or state.get("asset", "").startswith("xyz:")
@@ -76,6 +116,7 @@ def process_position(state_file, state, price, strategy_cfg):
     tier_floor = state["tierFloorPrice"]
     tiers = state["tiers"]
     force_close = state.get("pendingClose", False)
+    asset = state["asset"]
 
     # --- Stagnation config ---
     stag_cfg = state.get("stagnation", {})
@@ -179,6 +220,56 @@ def process_position(state_file, state, price, strategy_cfg):
 
     state["floorPrice"] = round(effective_floor, 4)
 
+    # --- SL sync to Hyperliquid (v5.1) ---
+    wallet = state.get("wallet", strategy_cfg.get("wallet", ""))
+    last_synced = state.get("lastSyncedFloorPrice")
+    had_sl_order = state.get("slOrderId") is not None
+    # If SL was cancelled externally, force re-sync
+    if had_sl_order and wallet:
+        status = mcp_order_status(wallet, state["slOrderId"])
+        if status == "canceled":
+            state["lastSyncedFloorPrice"] = None
+            last_synced = None
+    floor_changed = last_synced is None or abs(last_synced - effective_floor) > 1e-9
+    sl_synced = False
+    sl_initial_sync = False
+    if floor_changed and wallet:
+        order_type = "MARKET" if phase == 1 else "LIMIT"
+        close_coin = asset if asset.startswith("xyz:") else (f"xyz:{asset}" if is_xyz else asset)
+        sync_ok, oid, sync_err = mcp_edit_position(wallet, close_coin, effective_floor, order_type)
+        if sync_ok:
+            state["lastSyncedFloorPrice"] = round(effective_floor, 4)
+            state["slOrderIdUpdatedAt"] = now
+            if oid is None:
+                # Resolve slOrderId from open orders if API didn't return it
+                dex_arg = "xyz" if is_xyz else ""
+                orders, _ = mcp_get_open_orders(wallet, dex_arg)
+                trigger_px = round(effective_floor, 4)
+                for o in (orders or []):
+                    if o.get("coin") != close_coin:
+                        continue
+                    if not (o.get("isTrigger") or o.get("isPositionTpsl")):
+                        continue
+                    try:
+                        tp = float(o.get("triggerPx", 0))
+                    except (TypeError, ValueError):
+                        continue
+                    if abs(tp - trigger_px) < 1e-6:
+                        oid = o.get("oid")
+                        if oid is not None:
+                            try:
+                                oid = int(oid)
+                                break
+                            except (TypeError, ValueError):
+                                pass
+            if oid:
+                state["slOrderId"] = oid
+            state["lastSlSyncError"] = None
+            sl_synced = True
+            sl_initial_sync = not had_sl_order
+        else:
+            state["lastSlSyncError"] = sync_err
+
     # --- Stagnation check ---
     stagnation_triggered = False
     stag_hours_stale = 0.0
@@ -279,13 +370,13 @@ def process_position(state_file, state, price, strategy_cfg):
             else:
                 state["pendingClose"] = True
 
-    # --- Save state ---
+    # --- Save state (archive on close, else atomic_write with external-close guard) ---
     state["lastCheck"] = now
     state["lastPrice"] = price
-    # Guard: if this run didn't trigger a close, check whether the agent
-    # externally set active=false (e.g. SM flip close) since we read the file.
-    # If so, skip writing to avoid resurrecting a closed position.
-    if not should_close:
+    if closed:
+        archive_state_file(state_file, "breach")
+    else:
+        # Guard: if agent externally set active=false (e.g. SM flip close), skip writing.
         try:
             with open(state_file) as _f:
                 _current = json.load(_f)
@@ -296,10 +387,13 @@ def process_position(state_file, state, price, strategy_cfg):
                     "strategyKey": strategy_cfg.get("_key", "unknown"),
                     "status": "externally_closed",
                     "skipped_write": True,
+                    "sl_synced": sl_synced,
+                    "sl_initial_sync": sl_initial_sync,
+                    "sl_order_id": state.get("slOrderId"),
                 }
         except (json.JSONDecodeError, IOError):
             pass
-    atomic_write(state_file, state)
+        atomic_write(state_file, state)
 
     # --- Build result ---
     if is_long:
@@ -327,6 +421,9 @@ def process_position(state_file, state, price, strategy_cfg):
         "tier_changed": tier_changed,
         "phase1_autocut": phase1_autocut,
         "notification": notif_msg,
+        "sl_synced": sl_synced,
+        "sl_initial_sync": sl_initial_sync,
+        "sl_order_id": state.get("slOrderId"),
     }
     if phase1_autocut:
         result["elapsed_minutes"] = round(elapsed_minutes)
@@ -364,6 +461,9 @@ if not strategies:
         "strategies": 0,
         "positions": 0,
         "results": [],
+        "strategies_inactive": [],
+        "externally_closed": [],
+        "sl_filled": [],
         "message": "No enabled strategies found"
     }))
     sys.exit(0)
@@ -372,18 +472,76 @@ if not strategies:
 all_mids = fetch_all_mids()
 xyz_mids = fetch_all_mids(dex="xyz")
 
-# Collect all state files across strategies
+# Per-strategy pre-processing (v5.1): strategy active, SL pre-fill, clearinghouse reconcile
+strategies_inactive = []
+sl_filled = []
+externally_closed = []
+errors = []
 all_state_entries = []  # (state_file_path, strategy_cfg)
 
 for key, cfg in strategies.items():
-    state_files = sorted(glob.glob(dsl_state_glob(key)))
+    state_files = sorted(dsl_state_files_active(key))
+    strategy_id = cfg.get("strategyId", "")
+    wallet = cfg.get("wallet", "")
+
+    # a. Strategy active check
+    status, wallet_from_api, err = mcp_strategy_get(strategy_id)
+    if err is not None:
+        errors.append({"strategyKey": key, "error": "strategy_get_failed", "message": err})
+        continue
+    if status not in DSL_ACTIVE_STATUSES:
+        for sf in state_files:
+            try:
+                archive_state_file(sf, "strategy_inactive")
+            except OSError:
+                pass
+        strategies_inactive.append(key)
+        continue
+    if wallet_from_api:
+        wallet = wallet_from_api
+
+    # b. SL pre-fill check (state files with slOrderId that are already filled on HL)
+    for sf in list(state_files):
+        try:
+            with open(sf) as f:
+                s = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            continue
+        oid = s.get("slOrderId")
+        if not oid:
+            continue
+        order_status = mcp_order_status(wallet, oid)
+        if order_status == "filled":
+            try:
+                archive_state_file(sf, "sl")
+            except OSError:
+                pass
+            state_files.remove(sf)
+            sl_filled.append({"asset": s.get("asset", ""), "strategyKey": key})
+
+    # c. Clearinghouse reconcile (archive state files whose asset no longer in clearinghouse)
+    active_coins = mcp_clearinghouse_coins(wallet)
+    for sf in list(state_files):
+        try:
+            with open(sf) as f:
+                s = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            continue
+        asset = s.get("asset", "")
+        if asset and asset not in active_coins:
+            try:
+                archive_state_file(sf, "external")
+            except OSError:
+                pass
+            state_files.remove(sf)
+            externally_closed.append({"asset": asset, "strategyKey": key})
+
     for sf in state_files:
         all_state_entries.append((sf, cfg))
 
 # Process each position
 results = []
 closed_positions = []
-errors = []
 
 for sf, cfg in all_state_entries:
     try:
@@ -482,5 +640,8 @@ print(json.dumps({
     "any_closed": any_closed,
     "any_tier_change": any_tier_change,
     "notifications": notifications,
-    "state_files_found": len(all_state_entries)
+    "state_files_found": len(all_state_entries),
+    "strategies_inactive": strategies_inactive,
+    "externally_closed": externally_closed,
+    "sl_filled": sl_filled,
 }))

--- a/wolf-strategy/scripts/risk-guardian.py
+++ b/wolf-strategy/scripts/risk-guardian.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-risk-guardian.py — WOLF v6.1.1 Risk Guardian (Account-Level Guard Rails)
+risk-guardian.py — WOLF v6.1.2 Risk Guardian (Account-Level Guard Rails)
 
 6th cron: enforces three account-level guardrails across all strategies:
   G1: Daily loss halt (accountValue drop from start-of-day)

--- a/wolf-strategy/scripts/wolf-setup.py
+++ b/wolf-strategy/scripts/wolf-setup.py
@@ -319,7 +319,7 @@ cron_templates = {
         }
     },
     "risk_guardian": {
-        "name": "WOLF Risk Guardian v6.1.1 (5min)",
+        "name": "WOLF Risk Guardian v6.1.2 (5min)",
         "schedule": {"kind": "every", "everyMs": 300000},
         "sessionTarget": "isolated",
         "payload": {

--- a/wolf-strategy/scripts/wolf_config.py
+++ b/wolf-strategy/scripts/wolf_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-wolf_config.py — Multi-strategy config loader for WOLF v6.1.1
+wolf_config.py — Multi-strategy config loader for WOLF v6.1.2
 
 Provides a single importable module every script uses to load strategy config,
 resolve state file paths, and handle legacy migration.
@@ -195,8 +195,33 @@ def dsl_state_path(strategy_key, asset):
 
 
 def dsl_state_glob(strategy_key):
-    """Get the glob pattern for all DSL state files in a strategy."""
+    """Get the glob pattern for all DSL state files in a strategy (includes archived).
+    Prefer dsl_state_files_active() to get only processable state files."""
     return os.path.join(state_dir(strategy_key), "dsl-*.json")
+
+
+def dsl_state_files_active(strategy_key):
+    """Return list of state file paths for a strategy, excluding *_archived_* files."""
+    pattern = dsl_state_glob(strategy_key)
+    paths = glob.glob(pattern)
+    return [p for p in paths if "_archived_" not in os.path.basename(p)]
+
+
+def archive_state_file(state_file, suffix):
+    """Rename state file to dsl-{base}_archived_{suffix}_{epoch}.json. Returns destination path."""
+    epoch = int(time.time())
+    dirpath = os.path.dirname(state_file)
+    basename = os.path.basename(state_file)
+    # dsl-HYPE.json -> base HYPE; dsl-xyz--SILVER.json -> base xyz--SILVER
+    if not basename.startswith("dsl-") or not basename.endswith(".json"):
+        base = basename.replace(".json", "")
+    else:
+        base = basename[len("dsl-"):-len(".json")]
+    new_name = f"dsl-{base}_archived_{suffix}_{epoch}.json"
+    dest = os.path.join(dirpath, new_name)
+    if os.path.exists(state_file):
+        os.rename(state_file, dest)
+    return dest
 
 
 def get_all_active_positions():
@@ -207,7 +232,7 @@ def get_all_active_positions():
     """
     positions = {}
     for key, cfg in load_all_strategies().items():
-        for sf in glob.glob(dsl_state_glob(key)):
+        for sf in dsl_state_files_active(key):
             try:
                 with open(sf) as f:
                     s = json.load(f)
@@ -283,6 +308,92 @@ def mcporter_call_safe(tool, retries=3, timeout=30, **kwargs):
         return mcporter_call(tool, retries=retries, timeout=timeout, **kwargs)
     except RuntimeError:
         return None
+
+
+# --- DSL v5.1 MCP helpers (strategy active, clearinghouse, order status, edit_position) ---
+
+def mcp_strategy_get(strategy_id):
+    """Call senpi strategy_get. Returns (status, wallet, error). error is None on success."""
+    data = mcporter_call_safe("strategy_get", strategy_id=strategy_id)
+    if not data or not isinstance(data, dict):
+        return None, None, "strategy_get failed or empty response"
+    strategy = data.get("strategy") if isinstance(data, dict) else data
+    if not strategy or not isinstance(strategy, dict):
+        return None, None, "no strategy in response"
+    status = (strategy.get("status") or "").strip().upper()
+    wallet = (strategy.get("strategyWalletAddress") or strategy.get("strategy_wallet_address") or "").strip()
+    return status, wallet, None
+
+
+def mcp_clearinghouse_coins(wallet):
+    """Call senpi strategy_get_clearinghouse_state; return set of active position coin names."""
+    data = mcporter_call_safe("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+    if not data or not isinstance(data, dict):
+        return set()
+    coins = set()
+    for section in ("main", "xyz"):
+        section_data = data.get(section, {}) or {}
+        for p in section_data.get("assetPositions", []):
+            pos = p.get("position", {}) if isinstance(p, dict) else {}
+            coin = pos.get("coin")
+            if coin and float(pos.get("szi", 0)) != 0:
+                coins.add(coin)
+    return coins
+
+
+def mcp_order_status(wallet, order_id):
+    """Call senpi execution_get_order_status. Returns order status string ('open','filled','canceled') or None on error."""
+    data = mcporter_call_safe("execution_get_order_status", user=wallet, orderId=order_id)
+    if not data or not isinstance(data, dict):
+        return None
+    if data.get("status") == "unknownOid":
+        return None
+    if data.get("status") == "order":
+        order = data.get("order")
+        if isinstance(order, dict):
+            return (order.get("status") or "").strip().lower()
+    return None
+
+
+def mcp_edit_position(wallet, coin, floor_price, order_type="LIMIT"):
+    """Call senpi edit_position to set/update SL. Returns (ok, order_id, error). order_id may be None if API doesn't return it. Non-fatal on failure."""
+    data = mcporter_call_safe(
+        "edit_position",
+        strategyWalletAddress=wallet,
+        coin=coin,
+        stopLoss={"price": round(floor_price, 4), "orderType": order_type},
+    )
+    if data is None:
+        return False, None, "edit_position failed"
+    if not isinstance(data, dict):
+        return False, None, "edit_position: invalid response"
+    oid = None
+    ou = data.get("ordersUpdated") or data.get("orders_updated")
+    if isinstance(ou, dict):
+        sl = ou.get("stopLoss") or ou.get("stop_loss")
+        if isinstance(sl, dict):
+            oid = sl.get("orderId") or sl.get("order_id")
+    if oid is None:
+        oid = data.get("stopLossOrderId") or data.get("stop_loss_order_id")
+    if oid is not None:
+        try:
+            oid = int(oid)
+        except (TypeError, ValueError):
+            oid = None
+    return True, oid, None
+
+
+def mcp_get_open_orders(wallet, dex=""):
+    """Call senpi strategy_get_open_orders. Returns (list of order dicts, error). error is None on success."""
+    data = mcporter_call_safe("strategy_get_open_orders", strategy_wallet=wallet, dex=dex)
+    if data is None:
+        return [], "strategy_get_open_orders failed"
+    if not isinstance(data, dict):
+        return [], "invalid response"
+    orders = data.get("orders")
+    if not isinstance(orders, list):
+        return [], None
+    return orders, None
 
 
 def send_notification(message):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because this changes core automated trade exit logic and introduces new MCP calls (`edit_position`, order-status checks) plus a new state archival/selection scheme that could impact stop placement and slot/state bookkeeping if any scripts still glob all `dsl-*.json` files.
> 
> **Overview**
> **Upgrades the DSL engine to v5.1.** `dsl-combined.py` now pre-filters state per strategy by checking `strategy_get` status (archives all state when inactive), reconciling against clearinghouse positions (archives externally closed), and archiving when an existing `slOrderId` is already filled.
> 
> **Adds native stop-loss synchronization on Hyperliquid.** After each floor update, the runner calls `edit_position` to create/update an on-exchange SL (Phase 1 `MARKET`, Phase 2 `LIMIT`), tracks `slOrderId`/`lastSyncedFloorPrice`, and emits new summary fields (`strategies_inactive`, `externally_closed`, `sl_filled`).
> 
> **Changes DSL state lifecycle.** Closed positions are now archived by renaming to `dsl-*_archived_*_{epoch}.json` (instead of relying on `active: false`), and `wolf_config.py` adds helpers for `dsl_state_files_active`, `archive_state_file`, and MCP wrappers used by the new DSL flow; docs/version strings are updated to `v6.1.2` and describe the new DSL behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4171c786b9c2197780f7d832bb20b2b61104c081. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->