### PR TITLE
enhancing balance check whilst onboarding

### DIFF
--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -355,15 +355,19 @@ After the confirmation, share the About Senpi information from [references/post-
 
 ## Balance Monitoring
 
-After onboarding completes (state = `UNFUNDED`), check wallet balance on each user message:
+After onboarding completes (state = `UNFUNDED`), check wallet balance on each user message **before deciding whether to show a reminder**:
 
-1. Use MCP to fetch portfolio/balance
+1. Use MCP to fetch portfolio/balance. This check is mandatory — do not skip it or assume the wallet is unfunded.
 2. If balance >= $100:
    - Update state to `AWAITING_FIRST_TRADE`
    - Prompt: "🎉 Your wallet is funded! Ready for your first trade? Say **'let's trade'** to start, or **'skip tutorial'** if you're experienced."
-3. If balance < $100:
+   - Do **not** show a funding reminder.
+3. If balance < $100 (confirmed by a successful MCP check):
    - Prepend funding reminder (max 3 automatic reminders); include agent wallet address and state that at least $100 USDC is required (see [references/post-onboarding.md](references/post-onboarding.md) funding reminder template)
    - Continue processing user's request
+4. If the MCP balance check fails (e.g. MCP not yet connected after restart):
+   - Do **not** show a funding reminder. Do **not** assume the wallet is unfunded.
+   - Silently retry on the next user message.
 
 When state transitions to `AWAITING_FIRST_TRADE`, the `senpi-getting-started-guide` skill takes over.
 

--- a/senpi-onboard/references/post-onboarding.md
+++ b/senpi-onboard/references/post-onboarding.md
@@ -44,7 +44,7 @@ Use this template for the Step 7 confirmation:
    Currency: USDC
    Minimum: $100 to start your first trade
 
-   When you've sent at least $100 USDC, say **"I funded my wallet"** or **"check my balance"** so I can verify and we can start your first trade.
+   I'll automatically detect when your wallet is funded and guide you through your first trade.
 
 🔗 **Your referral link:** senpi.ai/skill.md?ref={USER_REFERRAL_CODE}
 
@@ -105,7 +105,7 @@ When showing a funding reminder (balance < $100, up to 3 times — or when user 
    **Chains:** Base, Arbitrum, Optimism, Polygon, Ethereum
    **Currency:** USDC
 
-   When you've sent the funds, say **"I funded my wallet"** or **"check my balance"** so I can verify.
+   I'll automatically check your balance on each message and notify you once you're ready to trade.
 ```
 
 Use this for each of the 3 automatic reminders and when responding to "let's trade" / "first trade" while still UNFUNDED.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts onboarding guidance and user-facing reminder templates; no runtime code paths are modified.
> 
> **Overview**
> Clarifies the `senpi-onboard` post-onboarding *Balance Monitoring* flow to **always** attempt an MCP portfolio/balance fetch before deciding to show a funding reminder, and to **suppress reminders** when the check fails or when funding is already confirmed.
> 
> Updates the post-onboarding confirmation and funding reminder templates to remove “ask me to check” language and instead state that the agent will automatically detect funding and notify the user.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39bcf52fc77e964ea89e6ff966793c207a2b0dc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->