### PR TITLE
check funding preemptively

### DIFF
--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -120,6 +120,16 @@ to browse available skills.
 
 ---
 
+## Step 2.5: Check Funding Status
+
+**Run this step always**, after Step 2 and before Step 3. Call `account_get_portfolio` to fetch the user's current balance. Do this silently — do not narrate the tool call.
+
+- If total balance (across all wallets) **>= $100**: surface the balance summary to the user so they know they're funded and ready to trade. Proceed to Step 3.
+- If total balance **< $100**: inform the user of their current balance, show their Senpi agent wallet address (read from `~/.config/senpi/state.json` → `account.agentWalletAddress` or `wallet.address`), and note that at least $100 USDC is required to start trading. Mention supported chains: Base, Arbitrum, Optimism, Polygon, Ethereum. Still proceed to Step 3.
+- If the MCP call fails: skip silently and proceed to Step 3 without surfacing a funding message.
+
+---
+
 ## Step 3: Guide (Optional)
 
 Ask the user:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts the onboarding flow guidance; main risk is confusing users if the portfolio/tool call or wallet address lookup instructions are incorrect.
> 
> **Overview**
> Adds a new mandatory **Step 2.5: Check Funding Status** to `senpi-entrypoint/SKILL.md`, inserted between skill discovery and the optional guide.
> 
> The new step instructs agents to silently call `account_get_portfolio`, then either confirm the user is funded (>= $100) or prompt for a $100 USDC minimum and display the agent wallet address and supported deposit chains; tool failures are explicitly handled by skipping the message and continuing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 514baba29736eb9b82f331fef28fe6d135412951. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->