### PR TITLE
dsl 5.3 - high water profit

### DIFF
--- a/bison/SKILL.md
+++ b/bison/SKILL.md
@@ -42,6 +42,8 @@ When creating DSL state files for any BISON position, you MUST include:
 
 **If `tiers` or `lockMode` is missing from the state file, the DSL engine falls back to flat 1.5% retrace and High Water Mode is silently disabled. This defeats the entire purpose of BISON. Always verify the state file contains these fields after creation.**
 
+**DSL default:** Use this skill's **`config/dsl-profile.json`** as the default when setting up DSL (e.g. `dsl-cli.py add-dsl` / `update-dsl` with `--configuration @<path-to-bison>/config/dsl-profile.json`). Use it unless the user explicitly provides a custom DSL configuration via the agent.
+
 Phase 1 conviction-scaled floors (also mandatory in every state file):
 
 | Entry Score | absoluteFloorRoe | Time Exits |

--- a/bison/SKILL.md
+++ b/bison/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: jason-goldberg
-  version: "1.0"
+  version: "1.1"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/bison/config/bison-config.json
+++ b/bison/config/bison-config.json
@@ -127,7 +127,8 @@
         "weakPeakCutMin": 0,
         "deadWeightCutMin": 0
       }
-    ]
+    ], 
+    "_spec": "https://github.com/Senpi-ai/senpi-skills/blob/main/dsl-dynamic-stop-loss/dsl-high-water-spec%201.0.md"
   },
   "risk": {
     "maxEntriesPerDay": 6,

--- a/bison/config/bison-config.json
+++ b/bison/config/bison-config.json
@@ -39,6 +39,9 @@
     }
   },
   "dsl": {
+    "lockMode": "pct_of_high_water",
+    "phase2TriggerRoe": 10,
+    "cronIntervalMinutes": 3,
     "phase1RetraceRoe": 15,
     "phase1HardTimeoutMin": 0,
     "phase1WeakPeakMin": 0,
@@ -87,8 +90,21 @@
       "roeMin": 15,
       "hwStaleMin": 120
     },
-    "lockMode": "pct_of_high_water",
-    "phase2TriggerRoe": 10,
+    "tiersLegacyFallback": [
+      {"triggerPct": 5,  "lockPct": 1.5},
+      {"triggerPct": 10, "lockPct": 5},
+      {"triggerPct": 15, "lockPct": 10, "retrace": 0.015},
+      {"triggerPct": 25, "lockPct": 18, "retrace": 0.012},
+      {"triggerPct": 40, "lockPct": 30, "retrace": 0.010},
+      {"triggerPct": 60, "lockPct": 48, "retrace": 0.008},
+      {"triggerPct": 80, "lockPct": 65, "retrace": 0.006},
+      {"triggerPct": 100, "lockPct": 85, "retrace": 0.005}
+    ],
+    "execution": {
+      "phase1SlOrderType": "MARKET",
+      "phase2SlOrderType": "MARKET",
+      "breachCloseOrderType": "MARKET"
+    },
     "convictionTiers": [
       {
         "minScore": 6,
@@ -111,8 +127,7 @@
         "weakPeakCutMin": 0,
         "deadWeightCutMin": 0
       }
-    ],
-    "_spec": "https://github.com/Senpi-ai/senpi-skills/blob/main/dsl-dynamic-stop-loss/dsl-high-water-spec%201.0.md"
+    ]
   },
   "risk": {
     "maxEntriesPerDay": 6,

--- a/bison/config/dsl-profile.json
+++ b/bison/config/dsl-profile.json
@@ -1,0 +1,39 @@
+{
+  "lockMode": "pct_of_high_water",
+  "phase2TriggerRoe": 10,
+  "cronIntervalMinutes": 3,
+  "phase1": {
+    "enabled": true,
+    "retraceThreshold": 0.03,
+    "consecutiveBreachesRequired": 3
+  },
+  "phase2TriggerTier": 0,
+  "phase2": {
+    "enabled": true,
+    "retraceThreshold": 0.015,
+    "consecutiveBreachesRequired": 1
+  },
+  "tiers": [
+    {"triggerPct": 10, "lockHwPct": 0, "consecutiveBreachesRequired": 3},
+    {"triggerPct": 20, "lockHwPct": 25, "consecutiveBreachesRequired": 3},
+    {"triggerPct": 30, "lockHwPct": 40, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 50, "lockHwPct": 60, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 75, "lockHwPct": 75, "consecutiveBreachesRequired": 1},
+    {"triggerPct": 100, "lockHwPct": 85, "consecutiveBreachesRequired": 1}
+  ],
+  "tiersLegacyFallback": [
+    {"triggerPct": 5, "lockPct": 1.5},
+    {"triggerPct": 10, "lockPct": 5},
+    {"triggerPct": 15, "lockPct": 10, "retrace": 0.015},
+    {"triggerPct": 25, "lockPct": 18, "retrace": 0.012},
+    {"triggerPct": 40, "lockPct": 30, "retrace": 0.010},
+    {"triggerPct": 60, "lockPct": 48, "retrace": 0.008},
+    {"triggerPct": 80, "lockPct": 65, "retrace": 0.006},
+    {"triggerPct": 100, "lockPct": 85, "retrace": 0.005}
+  ],
+  "execution": {
+    "phase1SlOrderType": "MARKET",
+    "phase2SlOrderType": "MARKET",
+    "breachCloseOrderType": "MARKET"
+  }
+}

--- a/dsl-dynamic-stop-loss/README.md
+++ b/dsl-dynamic-stop-loss/README.md
@@ -17,6 +17,8 @@ When you open a leveraged position, DSL watches it:
 ### High Water Mode (`lockMode: "pct_of_high_water"`)
 Trailing floor can be a **percentage of high-water ROE** instead of a fixed ROE lock. Set `lockMode: "pct_of_high_water"` and use `lockHwPct` on tiers (e.g. 85% of peak ROE). The floor trails the peak every tick with no ceiling — see [dsl-high-water-spec 1.0.md](dsl-high-water-spec%201.0.md) and [dsl-high-water-implementation-spec.md](dsl-high-water-implementation-spec.md).
 
+**Upgrading from ROE-based (fixed_roe)?** If you have existing strategies or positions using fixed ROE tiers, we recommend migrating to High Water using `update-dsl` with a High Water config (e.g. `--configuration @dsl-profile.json`). See [references/migration.md](references/migration.md#migrating-from-roe-based-fixed_roe-to-high-water).
+
 ### What's New in v5.2
 
 ### CLI Lifecycle Manager (`dsl-cli.py`)

--- a/dsl-dynamic-stop-loss/README.md
+++ b/dsl-dynamic-stop-loss/README.md
@@ -1,4 +1,4 @@
-# Dynamic Stop Loss (DSL) v5.2
+# Dynamic Stop Loss (DSL) v5.3
 
 Two-phase trailing stop for Hyperliquid perps. Protects profits, limits losses, and syncs the stop loss directly to the exchange so positions are protected even if the cron process goes down.
 
@@ -12,7 +12,12 @@ When you open a leveraged position, DSL watches it:
 
 **Exchange SL sync.** DSL doesn't just track the floor internally — it sets the actual stop loss on Hyperliquid via `edit_position`. If the cron process crashes, HL still executes the SL at the last synced price. Phase 1 uses MARKET orders (fast exit on loss). Phase 2 uses LIMIT orders (fee-optimized exit on profit).
 
-## What's New in v5.2
+## What's New in v5.3
+
+### High Water Mode (`lockMode: "pct_of_high_water"`)
+Trailing floor can be a **percentage of high-water ROE** instead of a fixed ROE lock. Set `lockMode: "pct_of_high_water"` and use `lockHwPct` on tiers (e.g. 85% of peak ROE). The floor trails the peak every tick with no ceiling — see [dsl-high-water-spec 1.0.md](dsl-high-water-spec%201.0.md) and [dsl-high-water-implementation-spec.md](dsl-high-water-implementation-spec.md).
+
+### What's New in v5.2
 
 ### CLI Lifecycle Manager (`dsl-cli.py`)
 Full lifecycle management via command line. No more hand-editing state files.
@@ -49,6 +54,14 @@ Every tick, DSL cross-references local state files against the live clearinghous
 
 ### Config Validation
 `dsl-cli.py validate --configuration @profile.json` checks tier ordering, retrace ranges, breach counts, and phase consistency before anything is deployed.
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| v5.3 | 2026-03-12 | High Water Mode: `lockMode: "pct_of_high_water"`, `lockHwPct` per tier; floor as % of peak ROE |
+| v5.2 | 2026-03-01 | CLI lifecycle manager (add/update/pause/resume/delete/status/count/validate), multi-skill integration, SL order verification, improved reconciliation (4 archive types), configurable `cronIntervalMinutes`, config validation |
+| v5.0 | — | Two-phase trailing stop, exchange SL sync, Phase 1/2 tiers |
 
 ## Default Profile
 

--- a/dsl-dynamic-stop-loss/SKILL.md
+++ b/dsl-dynamic-stop-loss/SKILL.md
@@ -113,6 +113,7 @@ Full command reference and configuration merge rules: [references/cli-usage.md](
 | Tier math, LONG/SHORT | [references/tier-examples.md](references/tier-examples.md) |
 | Config tuning | [references/customization.md](references/customization.md) |
 | Cron-only → HL SL migration | [references/migration.md](references/migration.md) |
+| **ROE-based → High Water migration** (recommended for existing state) | [references/migration.md](references/migration.md#migrating-from-roe-based-fixed_roe-to-high-water) |
 
 **API:** Strategy/positions/price/close and SL sync via Senpi (mcporter). Do **not** use `strategy_close_strategy` for a single position — use `close_position`.
 

--- a/dsl-dynamic-stop-loss/SKILL.md
+++ b/dsl-dynamic-stop-loss/SKILL.md
@@ -13,13 +13,13 @@ compatibility: >-
   only (main dex and xyz dex).
 metadata:
   author: jason-goldberg
-  version: "5.2"
+  version: "5.3"
   platform: senpi
   exchange: hyperliquid
   
 ---
 
-# Dynamic Stop Loss (DSL) v5
+# Dynamic Stop Loss (DSL) v5.3
 
 **Scope — DSL only.** This skill handles **only** dynamic/trailing stop loss (DSL), not normal (static) stop loss. If the user says "stop loss" without clearly meaning DSL or static, **ask** (e.g. "Do you want a trailing stop that moves up with profit, or a fixed price stop loss?").
 
@@ -115,3 +115,11 @@ Full command reference and configuration merge rules: [references/cli-usage.md](
 | Cron-only → HL SL migration | [references/migration.md](references/migration.md) |
 
 **API:** Strategy/positions/price/close and SL sync via Senpi (mcporter). Do **not** use `strategy_close_strategy` for a single position — use `close_position`.
+
+## Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| v5.3 | 2026-03-12 | High Water Mode: `lockMode: "pct_of_high_water"`, `lockHwPct` per tier |
+| v5.2 | 2026-03-01 | CLI lifecycle manager, multi-skill integration, SL order verification, reconciliation archive types, `cronIntervalMinutes`, config validation |
+| v5.0 | — | Two-phase trailing stop, exchange SL sync |

--- a/dsl-dynamic-stop-loss/dsl-high-water-adoption-guide.md
+++ b/dsl-dynamic-stop-loss/dsl-high-water-adoption-guide.md
@@ -2,7 +2,7 @@
 
 **Target:** Every Senpi skill should use DSL High Water Mode as the default DSL configuration.
 **Spec:** https://github.com/Senpi-ai/senpi-skills/blob/main/dsl-dynamic-stop-loss/dsl-high-water-spec%201.0.md
-**Status:** The DSL v5.2 engine does not yet support `lockMode: "pct_of_high_water"`. Until the engine update ships, all skills must use the legacy fallback tiers below.
+**Status:** DSL v5.3 supports `lockMode: "pct_of_high_water"`. Use the High Water tiers in state files (with `lockHwPct`). Legacy fallback tiers remain valid for backward compatibility.
 
 ---
 
@@ -22,16 +22,13 @@ Add these fields to your DSL config section:
 }
 ```
 
-### Step 2: Use fallback tiers in DSL state files (until engine update)
+### Step 2: Use High Water tiers in DSL state files (DSL v5.3+)
 
-When creating DSL state files via `dsl-cli.py` or manually, use the `tiersLegacyFallback` tiers with standard `lockPct` fields. Do NOT include `lockMode` or `lockHwPct` — the current engine will error or ignore them.
+When creating DSL state files via `dsl-cli.py` or manually, use the `tiers` array with `lockHwPct` and set `lockMode: "pct_of_high_water"`. The engine will trail the floor as a percentage of high-water ROE.
 
-### Step 3: After engine update
+### Step 3: Legacy fallback (optional)
 
-Once DSL v5.2 supports `pct_of_high_water`:
-1. Switch state file tiers from `tiersLegacyFallback` to `tiers` (with `lockHwPct`)
-2. Add `lockMode: "pct_of_high_water"` to state files
-3. Existing positions on legacy tiers continue working — only new positions get High Water
+To keep using fixed-ROE tiers instead of High Water, use `tiersLegacyFallback` with `lockPct` and omit `lockMode` (or set `lockMode: "fixed_roe"`). Existing positions on legacy tiers continue working unchanged.
 
 ---
 
@@ -348,23 +345,19 @@ Once DSL v5.2 supports `pct_of_high_water`:
 
 ---
 
-## Workaround Instructions for Agents
+## Agent Instructions (DSL v5.3+)
 
-Add this to every skill's SKILL.md or cron mandate:
+Add this to every skill's SKILL.md or cron mandate when using High Water:
 
 ```
 DSL CONFIGURATION:
 Target: DSL High Water Mode (pct_of_high_water).
 Spec: https://github.com/Senpi-ai/senpi-skills/blob/main/dsl-dynamic-stop-loss/dsl-high-water-spec%201.0.md
 
-CURRENT WORKAROUND (until DSL engine supports lockMode):
-Use the tiersLegacyFallback tiers from config with standard lockPct fields.
-Do NOT include lockMode or lockHwPct in state files — the current engine will error.
-
-AFTER ENGINE UPDATE:
-Switch to the tiers array with lockHwPct fields.
-Add lockMode: "pct_of_high_water" to every new state file.
-Existing positions on legacy tiers continue working unchanged.
+DSL v5.3+ supports lockMode: "pct_of_high_water":
+Use the tiers array with lockHwPct fields in state files.
+Add lockMode: "pct_of_high_water" to every new state file (or set via config when using dsl-cli add-dsl/update-dsl).
+Legacy tiers (lockPct only) continue to work with lockMode: "fixed_roe" or when lockMode is omitted.
 ```
 
 ## Tier Design Philosophy

--- a/dsl-dynamic-stop-loss/dsl-high-water-implementation-spec.md
+++ b/dsl-dynamic-stop-loss/dsl-high-water-implementation-spec.md
@@ -1,0 +1,198 @@
+# dsl-high-water-implementation-spec
+
+# DSL High Water Mode — Implementation Spec for dsl-v5.py
+
+## Summary
+
+5 skills and trading strategies (GRIZZLY, BISON, GHOST FOX, DIRE WOLF, MAMBA) are shipping with High Water Mode configs, but dsl-v5.py doesn’t support it yet. They’re falling back to legacy fixed tiers or failing silently. This is the single highest-impact DSL change — it unlocks infinite trailing for every skill in the ecosystem.
+
+Full spec: https://github.com/Senpi-ai/senpi-skills/blob/main/dsl-dynamic-stop-loss/dsl-high-water-spec%201.0.md
+
+## What Needs to Change
+
+### 1. New field in state file: `lockMode`
+
+Two modes:
+
+| lockMode | Behavior | Current Support |
+| --- | --- | --- |
+| `fixed_roe` (default) | Tier lockPct is a fixed ROE value. At T3 with lockPct=22, floor = 22% ROE. | ✅ This is how it works today |
+| `pct_of_high_water` | Tier lockHwPct is a percentage of the high-water ROE. At T3 with lockHwPct=75 and hwROE=40%, floor = 30% ROE. | ❌ Needs implementation |
+
+If `lockMode` is missing from state, default to `fixed_roe` (backward compatible, nothing breaks).
+
+### 2. New field in tier objects: `lockHwPct`
+
+Current tier format:
+
+```json
+{"triggerPct": 30, "lockPct": 22, "retrace": 0.012}
+```
+
+High Water tier format:
+
+```json
+{"triggerPct": 30, "lockHwPct": 75, "consecutiveBreachesRequired": 2}
+```
+
+The engine should check: if `lockHwPct` exists in the tier, use percentage-of-high-water calculation. If only `lockPct` exists, use fixed ROE (current behavior). This means both formats can coexist in the same engine.
+
+### 3. Floor calculation change
+
+**Current (fixed_roe):**
+
+```python
+tier_floor_roe = tier["lockPct"]
+# Convert to price:
+# LONG: entry * (1 + tier_floor_roe / 100 / leverage)
+# SHORT: entry * (1 - tier_floor_roe / 100 / leverage)
+```
+
+**New (pct_of_high_water):**
+
+```python
+if state.get("lockMode") == "pct_of_high_water" and "lockHwPct" in current_tier:
+    tier_floor_roe = high_water_roe * current_tier["lockHwPct"] / 100
+else:
+    tier_floor_roe = current_tier["lockPct"]
+
+# Price conversion is the same as before — just the ROE number changes
+# LONG: entry * (1 + tier_floor_roe / 100 / leverage)
+# SHORT: entry * (1 - tier_floor_roe / 100 / leverage)
+```
+
+That’s it. One `if` statement. The rest of the floor-to-price math, the breach detection, the close logic — all unchanged.
+
+### 4. The infinite trail behavior
+
+In fixed_roe mode, the floor is static once a tier is reached. At T3 with lockPct=22, the floor is always at 22% ROE regardless of where price goes after.
+
+In pct_of_high_water mode, the floor moves EVERY TICK because it’s a percentage of the high-water mark, which updates every tick:
+
+```python
+# This already happens in dsl-v5.py:
+if current_roe > state["highWaterRoe"]:
+    state["highWaterRoe"] = current_roe
+
+# The new part — floor recalculates from updated high water:
+if state.get("lockMode") == "pct_of_high_water" and "lockHwPct" in current_tier:
+    tier_floor_roe = state["highWaterRoe"] * current_tier["lockHwPct"] / 100
+```
+
+This means at Tier 5 (lockHwPct=85):
+- hwROE = 30% → floor = 25.5% ROE
+- hwROE = 50% → floor = 42.5% ROE
+- hwROE = 100% → floor = 85% ROE
+- hwROE = 500% → floor = 425% ROE
+
+The floor trails the peak automatically. No new tiers needed. No ceiling.
+
+### 5. Per-tier breach counts
+
+Current: `phase2.consecutiveBreachesRequired` is a single value for all of Phase 2.
+
+High Water configs put `consecutiveBreachesRequired` on each tier:
+
+```json
+{"triggerPct": 7,  "lockHwPct": 40, "consecutiveBreachesRequired": 3},
+{"triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1}
+```
+
+Lower tiers are patient (3 breaches — let wicks resolve). Higher tiers are instant (1 breach — protect the profit).
+
+Implementation: when checking breaches, read from the current tier first, fall back to the phase-level default:
+
+```python
+max_breaches = current_tier.get("consecutiveBreachesRequired",
+                                 phase2_config.get("consecutiveBreachesRequired", 1))
+```
+
+### 6. SL sync to Hyperliquid
+
+The `edit_position` SL sync must recalculate every tick in High Water mode because the floor moves. In fixed_roe mode, the SL only needs updating on tier changes. In pct_of_high_water mode, the SL needs updating whenever the high-water mark advances.
+
+Add a check:
+
+```python
+# Only sync SL if floor actually changed (avoid unnecessary API calls)
+new_floor_price = calculate_floor_price(state, current_tier)
+if abs(new_floor_price - state.get("lastSyncedFloorPrice", 0)) > 0.01:
+    sync_sl_to_hyperliquid(wallet, coin, new_floor_price)
+    state["lastSyncedFloorPrice"] = new_floor_price
+```
+
+This already partially exists in dsl-v5.py — just ensure it runs on every tick when lockMode is pct_of_high_water, not only on tier changes.
+
+## Complete Code Change (Pseudocode)
+
+In the main evaluation loop, replace the floor calculation:
+
+```python
+# BEFORE (current):
+tier_floor_roe = current_tier["lockPct"]
+
+# AFTER:
+if state.get("lockMode") == "pct_of_high_water" and "lockHwPct" in current_tier:
+    tier_floor_roe = state["highWaterRoe"] * current_tier["lockHwPct"] / 100
+else:
+    tier_floor_roe = current_tier.get("lockPct", 0)
+```
+
+And for breach counting:
+
+```python
+# BEFORE (current):
+max_breaches = phase2_config["consecutiveBreachesRequired"]
+
+# AFTER:
+max_breaches = current_tier.get("consecutiveBreachesRequired",
+                                 phase2_config.get("consecutiveBreachesRequired", 1))
+```
+
+And for SL sync frequency:
+
+```python
+# BEFORE: sync on tier change only
+# AFTER: also sync when high water advances in pct_of_high_water mode
+
+should_sync = tier_changed
+if state.get("lockMode") == "pct_of_high_water" and high_water_updated:
+    should_sync = True
+```
+
+## Backward Compatibility
+
+- If `lockMode` is missing from state → defaults to `fixed_roe` → existing behavior unchanged
+- If tier has `lockPct` but no `lockHwPct` → uses `lockPct` → existing behavior unchanged
+- If tier has both `lockPct` and `lockHwPct` → uses `lockHwPct` when `lockMode` is `pct_of_high_water`, `lockPct` otherwise
+- If `consecutiveBreachesRequired` is missing from tier → falls back to phase-level value → existing behavior unchanged
+
+**Zero breaking changes. All existing state files continue to work exactly as before.**
+
+## Validation
+
+Add to `dsl-cli.py validate`:
+- If `lockMode` is `pct_of_high_water`, every tier must have `lockHwPct` (not `lockPct`)
+- `lockHwPct` values must be 0-100
+- `lockHwPct` values must increase with each tier (last tier should be 80-90 for tight trailing)
+- `consecutiveBreachesRequired` per tier must be 1-5
+
+## Testing Checklist
+
+- [ ]  State file with no `lockMode` → behaves exactly as current (fixed_roe)
+- [ ]  State file with `lockMode: "fixed_roe"` → same as current
+- [ ]  State file with `lockMode: "pct_of_high_water"` + `lockHwPct` tiers → floor is percentage of hwROE
+- [ ]  High water advances from 20% to 50% ROE at Tier 5 (85%) → floor moves from 17% to 42.5%
+- [ ]  High water advances → SL synced to Hyperliquid at new floor
+- [ ]  High water flat (no new peak) → SL not re-synced (saves API calls)
+- [ ]  Per-tier breach count: Tier 1 at 3 breaches, Tier 5 at 1 breach
+- [ ]  Tier with only `lockPct` (no `lockHwPct`) → uses lockPct regardless of lockMode
+- [ ]  LONG direction: floor calculation correct
+- [ ]  SHORT direction: floor calculation correct
+- [ ]  Mixed state files in same strategy dir (some fixed, some HW) → each uses its own lockMode
+
+## Priority
+
+This is blocking 5 agents (GRIZZLY, BISON, GHOST FOX, DIRE WOLF, MAMBA) from running their intended DSL configuration. They’re currently on legacy fallback tiers which work but don’t provide the infinite trailing behavior they were designed for.
+
+The actual code change is small — one `if` statement for floor calculation, one for breach count, one for SL sync frequency. The design, config format, and state schema are all defined and documented. The agents are already shipping configs with the correct fields.

--- a/dsl-dynamic-stop-loss/dsl-high-water-spec 1.0.md
+++ b/dsl-dynamic-stop-loss/dsl-high-water-spec 1.0.md
@@ -199,7 +199,7 @@ Run this once to backfill any positions created before High Water Mode was confi
 ## How To Apply to Other Skills
 
 ### Option 1: Replace your skill's dsl-profile.json
-Copy the JSON config above into your skill's `dsl-profile.json`. The DSL v5.2 engine reads it on every tick.
+Copy the JSON config above into your skill's `dsl-profile.json`. The DSL v5.3 engine reads it on every tick.
 
 ### Option 2: Pass as override via dsl-cli.py
 ```bash
@@ -218,7 +218,7 @@ Add the DSL block to your trading strategy's override file (same pattern as DIRE
 ```
 
 ### Compatibility Note
-The `lockMode: "pct_of_high_water"` field requires DSL v5.2+. If your DSL engine doesn't support this field, it falls back to `fixed_roe` behavior (standard tier locking). Check your DSL version before deploying.
+The `lockMode: "pct_of_high_water"` field requires DSL v5.3+. If your DSL engine is older, it falls back to `fixed_roe` behavior (standard tier locking). Check your DSL version before deploying.
 
 ---
 

--- a/dsl-dynamic-stop-loss/dsl-profile.json
+++ b/dsl-dynamic-stop-loss/dsl-profile.json
@@ -1,4 +1,7 @@
 {
+  "lockMode": "pct_of_high_water",
+  "phase2TriggerRoe": 7,
+  "cronIntervalMinutes": 3,
   "phase1": {
     "enabled": true,
     "retraceThreshold": 0.03,
@@ -8,14 +11,25 @@
   "phase2": {
     "enabled": true,
     "retraceThreshold": 0.015,
-    "consecutiveBreachesRequired": 1,
-    "tiers": [
-      {"triggerPct": 10, "lockPct": 5},
-      {"triggerPct": 20, "lockPct": 14},
-      {"triggerPct": 30, "lockPct": 22, "retrace": 0.012},
-      {"triggerPct": 50, "lockPct": 40, "retrace": 0.010},
-      {"triggerPct": 75, "lockPct": 60, "retrace": 0.008},
-      {"triggerPct": 100, "lockPct": 80, "retrace": 0.006}
-    ]
+    "consecutiveBreachesRequired": 1
+  },
+  "tiers": [
+    {"triggerPct": 7,  "lockHwPct": 40, "consecutiveBreachesRequired": 3},
+    {"triggerPct": 12, "lockHwPct": 55, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 15, "lockHwPct": 75, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1}
+  ],
+  "tiersLegacyFallback": [
+    {"triggerPct": 10, "lockPct": 5},
+    {"triggerPct": 20, "lockPct": 14},
+    {"triggerPct": 30, "lockPct": 22, "retrace": 0.012},
+    {"triggerPct": 50, "lockPct": 40, "retrace": 0.010},
+    {"triggerPct": 75, "lockPct": 60, "retrace": 0.008},
+    {"triggerPct": 100, "lockPct": 80, "retrace": 0.006}
+  ],
+  "execution": {
+    "phase1SlOrderType": "MARKET",
+    "phase2SlOrderType": "MARKET",
+    "breachCloseOrderType": "MARKET"
   }
 }

--- a/dsl-dynamic-stop-loss/references/migration.md
+++ b/dsl-dynamic-stop-loss/references/migration.md
@@ -33,6 +33,59 @@ DSL_STATE_DIR=/data/workspace/dsl DSL_STRATEGY_ID=<strategy-uuid> python3 script
 
 That run will perform the initial sync for all positions of that strategy and backfill state. The agent may see `sl_initial_sync: true` in the output for those positions.
 
+## Migrating from ROE-based (fixed_roe) to High Water
+
+As of this version, **the default when no dsl-profile is supplied is High Water Mode** (`lockMode: "pct_of_high_water"`). If you have existing strategies or position state files that still use **fixed ROE tiers** (tiers with `lockPct` and no `lockMode`, or `lockMode: "fixed_roe"`), we recommend migrating them to High Water so the floor trails the peak ROE with no ceiling.
+
+### Why migrate
+
+- **High Water** trails the stop as a percentage of the highest ROE reached (e.g. 85% of peak). The floor moves up every tick with new highs; there is no cap.
+- **Fixed ROE** locks a static ROE value per tier (e.g. “at 50% ROE lock 40% ROE”). The floor does not trail beyond that.
+
+### How to migrate
+
+Use **`update-dsl`** with a High Water configuration. This updates both the strategy’s `defaultConfig` and **all active position state files** for that strategy (tiers, `lockMode`, `phase2TriggerRoe`). Runtime state (high water price, current tier, breach count, etc.) is preserved.
+
+**Option A — Use this skill’s default High Water profile (recommended):**
+
+```bash
+python3 scripts/dsl-cli.py update-dsl <strategy-id> \
+  --state-dir /data/workspace/dsl \
+  --configuration @/path/to/dsl-dynamic-stop-loss/dsl-profile.json
+```
+
+**Option B — Use your skill’s High Water dsl-profile:**
+
+```bash
+python3 scripts/dsl-cli.py update-dsl <strategy-id> \
+  --state-dir /data/workspace/dsl \
+  --configuration @/path/to/your-skill/dsl-profile.json
+```
+
+**Option C — Inline High Water config:**
+
+```bash
+python3 scripts/dsl-cli.py update-dsl <strategy-id> \
+  --state-dir /data/workspace/dsl \
+  --configuration '{"lockMode":"pct_of_high_water","phase2TriggerRoe":7,"tiers":[{"triggerPct":7,"lockHwPct":40,"consecutiveBreachesRequired":3},{"triggerPct":12,"lockHwPct":55,"consecutiveBreachesRequired":2},{"triggerPct":15,"lockHwPct":75,"consecutiveBreachesRequired":2},{"triggerPct":20,"lockHwPct":85,"consecutiveBreachesRequired":1}]}'
+```
+
+After running `update-dsl`:
+
+- The next cron run (or a manual run of `dsl-v5.py`) will use the new tiers and sync the SL to Hyperliquid based on the High Water floor.
+- No need to remove or recreate crons unless you change `cronIntervalMinutes`.
+
+See [dsl-high-water-adoption-guide.md](../dsl-high-water-adoption-guide.md) for per-skill High Water presets and [dsl-high-water-spec 1.0.md](../dsl-high-water-spec%201.0.md) for the spec.
+
+### If you don't migrate
+
+**Old state files keep working.** The cron script ([dsl-v5.py](../scripts/dsl-v5.py)) treats state that has no `lockMode` (or `lockMode: "fixed_roe"`) as ROE-based: it uses each tier’s `lockPct` as a fraction of the entry→high-water range and does not trail the floor beyond that. So:
+
+- Existing position state files with `lockPct` tiers and no `lockMode` (or `lockMode: "fixed_roe"`) continue to run with the same fixed-ROE behavior as before.
+- New strategies and new positions created without a supplied profile get High Water by default; existing state is not changed unless you run `update-dsl` with a High Water config.
+
+Migration is **recommended** so existing positions get the benefits of High Water (floor trails peak with no ceiling), but it is **optional** — you can migrate when convenient.
+
 ## Best practices
 
 - **Single source of truth:** State is migrated by the same script that runs on schedule; no second migration script to keep in sync.

--- a/dsl-dynamic-stop-loss/scripts/dsl-cli.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-cli.py
@@ -290,6 +290,13 @@ DEFAULT_TIERS_HIGH_WATER = [
 ]
 
 
+def _default_tiers_for_lock_mode(lock_mode: str | None) -> list:
+    """Return default tiers for the given lockMode. fixed_roe uses lockPct tiers; else high-water."""
+    if lock_mode == "fixed_roe":
+        return list(DEFAULT_TIERS)
+    return list(DEFAULT_TIERS_HIGH_WATER)
+
+
 def normalize_asset_dex(asset: str, dex: str) -> tuple[str, str]:
     """Keep asset and dex in sync: if dex is xyz but asset has no xyz: prefix, prefix asset;
     if asset has xyz: prefix but dex is not xyz, set dex to xyz. Returns (normalized_asset, normalized_dex)."""
@@ -517,6 +524,17 @@ def load_config_source(source: str) -> tuple[dict | None, str | None]:
         return None, str(e)
 
 
+def _infer_lock_mode_from_tiers(tiers: list) -> str:
+    """Infer lockMode from tier contents (mirrors build_position_state). lockHwPct -> pct_of_high_water, else fixed_roe."""
+    if not isinstance(tiers, list):
+        return DEFAULT_LOCK_MODE
+    return (
+        "pct_of_high_water"
+        if any(isinstance(t, dict) and "lockHwPct" in t for t in tiers)
+        else "fixed_roe"
+    )
+
+
 def _ensure_phase_defaults(base: dict) -> None:
     """Apply defaults when config is missing; use high-water mode as default (no profile supplied)."""
     if "phase1" not in base:
@@ -525,28 +543,46 @@ def _ensure_phase_defaults(base: dict) -> None:
         base["phase1"]["enabled"] = True
     if "phase2TriggerTier" not in base:
         base["phase2TriggerTier"] = 0
-    # When lockMode is missing, use high-water default (tiers + lockMode + phase2TriggerRoe) so we never end up with ROE-based tiers by default.
+    # When lockMode is missing: infer from existing tiers if present (preserve legacy/custom tiers); else apply high-water defaults.
     if "lockMode" not in base:
-        base["lockMode"] = DEFAULT_LOCK_MODE
-        base["phase2TriggerRoe"] = DEFAULT_PHASE2_TRIGGER_ROE
-        base["tiers"] = list(DEFAULT_TIERS_HIGH_WATER)
-        if isinstance(base.get("phase2"), dict):
-            base["phase2"]["tiers"] = list(DEFAULT_TIERS_HIGH_WATER)
+        raw_tiers = base.get("tiers") or (
+            base.get("phase2", {}).get("tiers") if isinstance(base.get("phase2"), dict) else None
+        )
+        existing_tiers = list(raw_tiers) if isinstance(raw_tiers, list) and len(raw_tiers) > 0 else []
+        if existing_tiers:
+            base["lockMode"] = _infer_lock_mode_from_tiers(existing_tiers)
+            if "phase2TriggerRoe" not in base:
+                base["phase2TriggerRoe"] = DEFAULT_PHASE2_TRIGGER_ROE
+            # Preserve existing tiers: set base and phase2 from canonical list (do not overwrite with DEFAULT_TIERS_HIGH_WATER).
+            base["tiers"] = list(existing_tiers)
+            if isinstance(base.get("phase2"), dict):
+                base["phase2"]["tiers"] = list(existing_tiers)
+            else:
+                base.setdefault("phase2", {})["tiers"] = list(existing_tiers)
         else:
-            base.setdefault("phase2", {})["tiers"] = list(DEFAULT_TIERS_HIGH_WATER)
+            base["lockMode"] = DEFAULT_LOCK_MODE
+            base["phase2TriggerRoe"] = DEFAULT_PHASE2_TRIGGER_ROE
+            default_tiers = _default_tiers_for_lock_mode(DEFAULT_LOCK_MODE)
+            base["tiers"] = default_tiers
+            if isinstance(base.get("phase2"), dict):
+                base["phase2"]["tiers"] = default_tiers
+            else:
+                base.setdefault("phase2", {})["tiers"] = default_tiers
     elif "phase2TriggerRoe" not in base:
         base["phase2TriggerRoe"] = DEFAULT_PHASE2_TRIGGER_ROE
+    lock_mode = base.get("lockMode", DEFAULT_LOCK_MODE)
+    default_tiers = _default_tiers_for_lock_mode(lock_mode)
     if "phase2" not in base:
-        base["phase2"] = {"enabled": True, "retraceThreshold": 0.015, "consecutiveBreachesRequired": 1, "tiers": list(DEFAULT_TIERS_HIGH_WATER)}
+        base["phase2"] = {"enabled": True, "retraceThreshold": 0.015, "consecutiveBreachesRequired": 1, "tiers": default_tiers}
     elif isinstance(base.get("phase2"), dict):
         if "enabled" not in base["phase2"]:
             base["phase2"]["enabled"] = True
         if "tiers" not in base["phase2"] and "tiers" not in base:
-            base["phase2"]["tiers"] = list(DEFAULT_TIERS_HIGH_WATER)
+            base["phase2"]["tiers"] = default_tiers
     if "tiers" not in base and isinstance(base.get("phase2"), dict):
-        base["tiers"] = base["phase2"].get("tiers", list(DEFAULT_TIERS_HIGH_WATER))
+        base["tiers"] = base["phase2"].get("tiers", default_tiers)
     elif "tiers" not in base:
-        base["tiers"] = list(DEFAULT_TIERS_HIGH_WATER)
+        base["tiers"] = default_tiers
 
 
 def _merge_inline_config(base: dict, inline_config: dict | None) -> None:
@@ -603,8 +639,9 @@ def config_to_phase1_phase2_tiers(config: dict, entry_price: float, leverage: fl
     phase2_enabled = phase2.get("enabled", True)
     if not phase1_enabled and not phase2_enabled:
         raise ValueError("at least one of phase1.enabled or phase2.enabled must be true")
-    raw_tiers = config.get("tiers") or (phase2.get("tiers") if isinstance(phase2.get("tiers"), list) else None) or DEFAULT_TIERS_HIGH_WATER
-    tiers = list(raw_tiers) if isinstance(raw_tiers, list) else list(DEFAULT_TIERS_HIGH_WATER)
+    default_tiers = _default_tiers_for_lock_mode(config.get("lockMode"))
+    raw_tiers = config.get("tiers") or (phase2.get("tiers") if isinstance(phase2.get("tiers"), list) else None) or default_tiers
+    tiers = list(raw_tiers) if isinstance(raw_tiers, list) else default_tiers
     if phase2_enabled and not phase1_enabled and not tiers:
         raise ValueError("phase2 only requires non-empty tiers")
     if "absoluteFloor" not in phase1 or phase1["absoluteFloor"] is None:

--- a/dsl-dynamic-stop-loss/scripts/dsl-cli.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-cli.py
@@ -370,13 +370,14 @@ def validate_dsl_config(cfg: dict) -> list[str]:
     if tiers is not None and not isinstance(tiers, list):
         errors.append("tiers must be an array")
     elif isinstance(tiers, list):
+        lock_mode = cfg.get("lockMode", "fixed_roe")
         prev_trigger = -1
+        prev_lock_hw = -1
         for i, t in enumerate(tiers):
             if not isinstance(t, dict):
                 errors.append(f"tiers[{i}] must be an object")
                 continue
             tp = t.get("triggerPct")
-            lp = t.get("lockPct")
             if tp is None:
                 errors.append(f"tiers[{i}]: triggerPct is required")
             else:
@@ -386,12 +387,30 @@ def validate_dsl_config(cfg: dict) -> list[str]:
                 elif tv <= prev_trigger:
                     errors.append(f"tiers[{i}]: triggerPct must be strictly greater than previous tier ({prev_trigger})")
                 prev_trigger = tv
-            if lp is None:
-                errors.append(f"tiers[{i}]: lockPct is required")
+            if lock_mode == "pct_of_high_water":
+                lhw = t.get("lockHwPct")
+                if lhw is None:
+                    errors.append(f"tiers[{i}]: lockHwPct is required when lockMode is pct_of_high_water")
+                else:
+                    lhwv = _safe_float(lhw, -1)
+                    if lhwv < 0 or lhwv > 100:
+                        errors.append(f"tiers[{i}]: lockHwPct must be a number between 0 and 100")
+                    elif lhwv <= prev_lock_hw:
+                        errors.append(f"tiers[{i}]: lockHwPct must be strictly greater than previous tier ({prev_lock_hw})")
+                    prev_lock_hw = lhwv
+                cbr = t.get("consecutiveBreachesRequired")
+                if cbr is not None:
+                    cbrv = _safe_int(cbr, -1)
+                    if cbrv < 1 or cbrv > 5:
+                        errors.append(f"tiers[{i}]: consecutiveBreachesRequired must be an integer 1–5")
             else:
-                lv = _safe_float(lp, -1)
-                if lv < 0 or lv > 100:
-                    errors.append(f"tiers[{i}]: lockPct must be a number between 0 and 100")
+                lp = t.get("lockPct")
+                if lp is None:
+                    errors.append(f"tiers[{i}]: lockPct is required")
+                else:
+                    lv = _safe_float(lp, -1)
+                    if lv < 0 or lv > 100:
+                        errors.append(f"tiers[{i}]: lockPct must be a number between 0 and 100")
             ret = t.get("retrace")
             if ret is not None:
                 rv = _safe_float(ret, -1)
@@ -716,11 +735,15 @@ def build_position_state(
         "currentTierIndex": -1,
         "tierFloorPrice": None,
         "highWaterPrice": entry_price,
+        "highWaterRoe": 0,
         "floorPrice": abs_floor,
         "currentBreachCount": 0,
         "createdAt": now_iso,
         "cronIntervalMinutes": _safe_int(config.get("cronIntervalMinutes"), 3) or 3,
+        "lockMode": config.get("lockMode", "fixed_roe"),
     }
+    if config.get("phase2TriggerRoe") is not None:
+        state["phase2TriggerRoe"] = _safe_int(config["phase2TriggerRoe"], 0)
     return state
 
 
@@ -792,6 +815,12 @@ def patch_config_into_state(state: dict, cfg: dict) -> list[str]:
     if "cronIntervalMinutes" in cfg and cfg["cronIntervalMinutes"] is not None:
         state["cronIntervalMinutes"] = _safe_int(cfg["cronIntervalMinutes"], 3)
         updated.append("cronIntervalMinutes")
+    if "lockMode" in cfg:
+        state["lockMode"] = cfg["lockMode"]
+        updated.append("lockMode")
+    if "phase2TriggerRoe" in cfg:
+        state["phase2TriggerRoe"] = _safe_int(cfg["phase2TriggerRoe"], 0)
+        updated.append("phase2TriggerRoe")
     return updated
 
 

--- a/dsl-dynamic-stop-loss/scripts/dsl-cli.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-cli.py
@@ -269,6 +269,7 @@ def get_positions_from_clearinghouse(wallet: str) -> tuple[list[dict], str | Non
 # Config: defaults and resolution (configuration only, no presets)
 # ---------------------------------------------------------------------------
 
+# Legacy fixed-ROE tiers (used only when a config explicitly uses lockMode fixed_roe).
 DEFAULT_TIERS = [
     {"triggerPct": 10, "lockPct": 5},
     {"triggerPct": 20, "lockPct": 14},
@@ -276,6 +277,16 @@ DEFAULT_TIERS = [
     {"triggerPct": 50, "lockPct": 40, "retrace": 0.010},
     {"triggerPct": 75, "lockPct": 60, "retrace": 0.008},
     {"triggerPct": 100, "lockPct": 80, "retrace": 0.006},
+]
+
+# Default when no dsl-profile is supplied: high water mode (pct_of_high_water) per dsl-profile.json.
+DEFAULT_LOCK_MODE = "pct_of_high_water"
+DEFAULT_PHASE2_TRIGGER_ROE = 7
+DEFAULT_TIERS_HIGH_WATER = [
+    {"triggerPct": 7, "lockHwPct": 40, "consecutiveBreachesRequired": 3},
+    {"triggerPct": 12, "lockHwPct": 55, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 15, "lockHwPct": 75, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1},
 ]
 
 
@@ -507,23 +518,35 @@ def load_config_source(source: str) -> tuple[dict | None, str | None]:
 
 
 def _ensure_phase_defaults(base: dict) -> None:
+    """Apply defaults when config is missing; use high-water mode as default (no profile supplied)."""
     if "phase1" not in base:
         base["phase1"] = {"enabled": True, "retraceThreshold": 0.03, "consecutiveBreachesRequired": 3}
     elif isinstance(base.get("phase1"), dict) and "enabled" not in base["phase1"]:
         base["phase1"]["enabled"] = True
     if "phase2TriggerTier" not in base:
         base["phase2TriggerTier"] = 0
+    # When lockMode is missing, use high-water default (tiers + lockMode + phase2TriggerRoe) so we never end up with ROE-based tiers by default.
+    if "lockMode" not in base:
+        base["lockMode"] = DEFAULT_LOCK_MODE
+        base["phase2TriggerRoe"] = DEFAULT_PHASE2_TRIGGER_ROE
+        base["tiers"] = list(DEFAULT_TIERS_HIGH_WATER)
+        if isinstance(base.get("phase2"), dict):
+            base["phase2"]["tiers"] = list(DEFAULT_TIERS_HIGH_WATER)
+        else:
+            base.setdefault("phase2", {})["tiers"] = list(DEFAULT_TIERS_HIGH_WATER)
+    elif "phase2TriggerRoe" not in base:
+        base["phase2TriggerRoe"] = DEFAULT_PHASE2_TRIGGER_ROE
     if "phase2" not in base:
-        base["phase2"] = {"enabled": True, "retraceThreshold": 0.015, "consecutiveBreachesRequired": 1, "tiers": list(DEFAULT_TIERS)}
+        base["phase2"] = {"enabled": True, "retraceThreshold": 0.015, "consecutiveBreachesRequired": 1, "tiers": list(DEFAULT_TIERS_HIGH_WATER)}
     elif isinstance(base.get("phase2"), dict):
         if "enabled" not in base["phase2"]:
             base["phase2"]["enabled"] = True
         if "tiers" not in base["phase2"] and "tiers" not in base:
-            base["phase2"]["tiers"] = list(DEFAULT_TIERS)
+            base["phase2"]["tiers"] = list(DEFAULT_TIERS_HIGH_WATER)
     if "tiers" not in base and isinstance(base.get("phase2"), dict):
-        base["tiers"] = base["phase2"].get("tiers", list(DEFAULT_TIERS))
+        base["tiers"] = base["phase2"].get("tiers", list(DEFAULT_TIERS_HIGH_WATER))
     elif "tiers" not in base:
-        base["tiers"] = list(DEFAULT_TIERS)
+        base["tiers"] = list(DEFAULT_TIERS_HIGH_WATER)
 
 
 def _merge_inline_config(base: dict, inline_config: dict | None) -> None:
@@ -580,8 +603,8 @@ def config_to_phase1_phase2_tiers(config: dict, entry_price: float, leverage: fl
     phase2_enabled = phase2.get("enabled", True)
     if not phase1_enabled and not phase2_enabled:
         raise ValueError("at least one of phase1.enabled or phase2.enabled must be true")
-    raw_tiers = config.get("tiers") or (phase2.get("tiers") if isinstance(phase2.get("tiers"), list) else None) or DEFAULT_TIERS
-    tiers = list(raw_tiers) if isinstance(raw_tiers, list) else list(DEFAULT_TIERS)
+    raw_tiers = config.get("tiers") or (phase2.get("tiers") if isinstance(phase2.get("tiers"), list) else None) or DEFAULT_TIERS_HIGH_WATER
+    tiers = list(raw_tiers) if isinstance(raw_tiers, list) else list(DEFAULT_TIERS_HIGH_WATER)
     if phase2_enabled and not phase1_enabled and not tiers:
         raise ValueError("phase2 only requires non-empty tiers")
     if "absoluteFloor" not in phase1 or phase1["absoluteFloor"] is None:
@@ -616,11 +639,14 @@ def load_strategy_json(state_dir: str, strategy_id: str) -> tuple[dict | None, s
 
 
 def _default_strategy_config() -> dict:
+    """Default strategy config when no dsl-profile is supplied: high water mode."""
     return {
         "phase1": {"enabled": True, "retraceThreshold": 0.03, "consecutiveBreachesRequired": 3},
         "phase2TriggerTier": 0,
-        "phase2": {"enabled": True, "retraceThreshold": 0.015, "consecutiveBreachesRequired": 1, "tiers": list(DEFAULT_TIERS)},
-        "tiers": list(DEFAULT_TIERS),
+        "phase2TriggerRoe": DEFAULT_PHASE2_TRIGGER_ROE,
+        "lockMode": DEFAULT_LOCK_MODE,
+        "phase2": {"enabled": True, "retraceThreshold": 0.015, "consecutiveBreachesRequired": 1, "tiers": list(DEFAULT_TIERS_HIGH_WATER)},
+        "tiers": list(DEFAULT_TIERS_HIGH_WATER),
         "cronIntervalMinutes": 3,
     }
 
@@ -716,6 +742,15 @@ def build_position_state(
     phase1, phase2_trigger, phase2, tiers = config_to_phase1_phase2_tiers(
         config, entry_price, leverage, direction,
     )
+    # Default lockMode: high water when no profile supplied; infer from tiers when config has tiers but no lockMode (e.g. legacy lockPct).
+    if "lockMode" in config:
+        lock_mode = config["lockMode"]
+    else:
+        lock_mode = (
+            "pct_of_high_water"
+            if any(isinstance(t, dict) and "lockHwPct" in t for t in tiers)
+            else "fixed_roe"
+        )
     abs_floor = phase1["absoluteFloor"]
     initial_phase = 1 if phase1.get("enabled", True) else 2
     state = {
@@ -740,7 +775,7 @@ def build_position_state(
         "currentBreachCount": 0,
         "createdAt": now_iso,
         "cronIntervalMinutes": _safe_int(config.get("cronIntervalMinutes"), 3) or 3,
-        "lockMode": config.get("lockMode", "fixed_roe"),
+        "lockMode": lock_mode,
     }
     if config.get("phase2TriggerRoe") is not None:
         state["phase2TriggerRoe"] = _safe_int(config["phase2TriggerRoe"], 0)

--- a/dsl-dynamic-stop-loss/scripts/dsl-cli.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-cli.py
@@ -815,7 +815,7 @@ def build_position_state(
         "lockMode": lock_mode,
     }
     if config.get("phase2TriggerRoe") is not None:
-        state["phase2TriggerRoe"] = _safe_int(config["phase2TriggerRoe"], 0)
+        state["phase2TriggerRoe"] = _safe_float(config["phase2TriggerRoe"], 0.0)
     return state
 
 
@@ -891,7 +891,7 @@ def patch_config_into_state(state: dict, cfg: dict) -> list[str]:
         state["lockMode"] = cfg["lockMode"]
         updated.append("lockMode")
     if "phase2TriggerRoe" in cfg:
-        state["phase2TriggerRoe"] = _safe_int(cfg["phase2TriggerRoe"], 0)
+        state["phase2TriggerRoe"] = _safe_float(cfg["phase2TriggerRoe"], 0.0)
         updated.append("phase2TriggerRoe")
     return updated
 

--- a/dsl-dynamic-stop-loss/scripts/dsl-v5.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-v5.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""DSL v5 — Strategy-scoped cron, MCP clearinghouse + price, archive on close.
+"""DSL v5.3 — Strategy-scoped cron, MCP clearinghouse + price, archive on close.
 Cron is per strategy (DSL_STATE_DIR + DSL_STRATEGY_ID only). Each run:
 1. Check if strategy is active via MCP; if not, cleanup active state files and output strategy_inactive.
 2. For each state file with slOrderId: call execution_get_order_status; if filled, rename to {asset}_archived_sl_{epoch}.json.
@@ -342,6 +342,18 @@ DEFAULT_PHASE2_RETRACE = 0.015
 DEFAULT_PHASE2_BREACHES = 1
 
 
+def _high_water_roe(state: dict, hw: float) -> float:
+    """Compute high-water ROE % from high-water price. Used for pct_of_high_water floor."""
+    entry = state.get("entryPrice") or 0.0
+    leverage = max(1, state.get("leverage", 1))
+    is_long = (state.get("direction", "LONG").upper() == "LONG")
+    if entry <= 0:
+        return 0.0
+    if is_long:
+        return (hw - entry) / entry * leverage * 100
+    return (entry - hw) / entry * leverage * 100
+
+
 def normalize_state_phase_config(state: dict) -> bool:
     """Ensure phase1 and phase2 exist with required fields and enabled flags. Backfills missing keys.
     At most two phases; phase1 = capital protection, phase2 = tier-based.
@@ -437,6 +449,17 @@ def normalize_state_phase_config(state: dict) -> bool:
             changed = True
         p1.pop("deadWeightCutMin", None)
 
+    # Backfill highWaterRoe when highWaterPrice exists (for pct_of_high_water floor calc).
+    if "highWaterPrice" in state and state.get("highWaterRoe") is None:
+        try:
+            state["highWaterRoe"] = round(
+                _high_water_roe(state, float(state["highWaterPrice"])), 4
+            )
+            changed = True
+        except (TypeError, ValueError):
+            state["highWaterRoe"] = 0.0
+            changed = True
+
     return changed
 
 
@@ -445,7 +468,7 @@ def normalize_state_phase_config(state: dict) -> bool:
 # ---------------------------------------------------------------------------
 
 def update_high_water(state: dict, price: float, is_long: bool) -> float:
-    """Update state high water; return new hw."""
+    """Update state high water; return new hw. Also keeps highWaterRoe in sync for pct_of_high_water mode."""
     hw = state["highWaterPrice"]
     if is_long and price > hw:
         hw = price
@@ -453,15 +476,24 @@ def update_high_water(state: dict, price: float, is_long: bool) -> float:
     elif not is_long and price < hw:
         hw = price
         state["highWaterPrice"] = hw
+    state["highWaterRoe"] = round(_high_water_roe(state, hw), 4)
     return hw
+
+
+def _tier_floor_from_roe(state: dict, tier_floor_roe: float, is_long: bool) -> float:
+    """Convert tier floor ROE %% to price. LONG: entry*(1+roe/100/lev), SHORT: entry*(1-roe/100/lev)."""
+    entry = state["entryPrice"]
+    leverage = max(1, state.get("leverage", 1))
+    if is_long:
+        return round(entry * (1 + tier_floor_roe / 100 / leverage), 4)
+    return round(entry * (1 - tier_floor_roe / 100 / leverage), 4)
 
 
 def apply_tier_upgrades(
     state: dict, upnl_pct: float, is_long: bool, hw: float
 ) -> tuple[int, float | None, bool, int]:
     """Apply tier upgrades based on ROE. Mutates state. Returns (tier_idx, tier_floor, tier_changed, previous_tier_idx).
-    Tier floor = entry + (hw - entry) * lockPct/100 (LONG) or entry - (entry - hw) * lockPct/100 (SHORT):
-    lockPct is the fraction of the entry→hw range to lock, not ROE %.
+    Tier floor: fixed_roe uses lockPct as fraction of (entry→hw) range; pct_of_high_water uses lockHwPct %% of highWaterRoe.
     """
     tiers = state["tiers"]
     tier_idx = state["currentTierIndex"]
@@ -471,6 +503,7 @@ def apply_tier_upgrades(
     entry = state["entryPrice"]
     previous_tier_idx = tier_idx
     tier_changed = False
+    lock_mode = state.get("lockMode", "fixed_roe")
 
     for i, tier in enumerate(tiers):
         if i <= tier_idx:
@@ -478,12 +511,16 @@ def apply_tier_upgrades(
         if upnl_pct >= tier["triggerPct"]:
             tier_idx = i
             tier_changed = True
-            # Floor = entry + fraction of (entry → hw) range; lockPct = that fraction
-            if is_long:
-                tier_floor = round(entry + (hw - entry) * tier["lockPct"] / 100, 4)
+            if lock_mode == "pct_of_high_water" and "lockHwPct" in tier:
+                hw_roe = state.get("highWaterRoe") or 0.0
+                tier_floor_roe = hw_roe * tier["lockHwPct"] / 100
+                tier_floor = _tier_floor_from_roe(state, tier_floor_roe, is_long)
             else:
-                tier_floor = round(entry - (entry - hw) * tier["lockPct"] / 100, 4)
-            # Ratchet: never regress vs stored (e.g. v4 ROE-based floor may be higher for LONG)
+                lock_pct = tier.get("lockPct", 0)
+                if is_long:
+                    tier_floor = round(entry + (hw - entry) * lock_pct / 100, 4)
+                else:
+                    tier_floor = round(entry - (entry - hw) * lock_pct / 100, 4)
             stored = state.get("tierFloorPrice")
             if stored is not None and isinstance(stored, (int, float)):
                 if is_long:
@@ -497,6 +534,22 @@ def apply_tier_upgrades(
                 breach_count = 0
                 state["currentBreachCount"] = 0
                 phase = 2
+
+    # High Water mode: recalc floor every tick for current tier (floor trails high water).
+    if phase == 2 and tier_idx >= 0 and lock_mode == "pct_of_high_water":
+        current_tier = tiers[tier_idx]
+        if "lockHwPct" in current_tier:
+            hw_roe = state.get("highWaterRoe") or 0.0
+            tier_floor_roe = hw_roe * current_tier["lockHwPct"] / 100
+            new_floor = _tier_floor_from_roe(state, tier_floor_roe, is_long)
+            stored = state.get("tierFloorPrice")
+            if stored is not None and isinstance(stored, (int, float)):
+                if is_long:
+                    new_floor = max(new_floor, float(stored))
+                else:
+                    new_floor = min(new_floor, float(stored))
+            tier_floor = new_floor
+            state["tierFloorPrice"] = tier_floor
 
     return tier_idx, tier_floor, tier_changed, previous_tier_idx
 
@@ -529,14 +582,16 @@ def compute_effective_floor(
         else state["phase2"]["retraceThreshold"]
     )
     retrace_price = retrace_roe / leverage
-    breaches_needed = state["phase2"]["consecutiveBreachesRequired"]
+    phase2 = state.get("phase2") or {}
+    breaches_needed = phase2.get("consecutiveBreachesRequired", 1)
     if tier_idx >= 0 and tier_idx < len(tiers) and isinstance(tiers[tier_idx], dict):
         tier = tiers[tier_idx]
-        if "breachesRequired" in tier:
-            try:
-                breaches_needed = int(tier["breachesRequired"])
-            except (TypeError, ValueError):
-                pass
+        breaches_needed = tier.get("consecutiveBreachesRequired", tier.get("breachesRequired", breaches_needed))
+        try:
+            breaches_needed = int(breaches_needed)
+        except (TypeError, ValueError):
+            pass
+    breaches_needed = max(1, breaches_needed)
     if is_long:
         trailing_floor = round(hw * (1 - retrace_price), 4)
         effective_floor = max(tier_floor or 0, trailing_floor)
@@ -921,15 +976,19 @@ def build_output(
     ) if is_long else (
         (price / hw - 1) * 100 if hw > 0 else 0
     )
+    def _lock_label(t):
+        if t.get("lockHwPct") is not None:
+            return f"lock {t['lockHwPct']}%hw"
+        return f"lock {t.get('lockPct', 0)}%"
     tier_name = (
-        f"Tier {tier_idx+1} ({tiers[tier_idx]['triggerPct']}%→lock {tiers[tier_idx]['lockPct']}%)"
-        if tier_idx >= 0 else "None"
+        f"Tier {tier_idx+1} ({tiers[tier_idx]['triggerPct']}%→{_lock_label(tiers[tier_idx])})"
+        if 0 <= tier_idx < len(tiers) else "None"
     )
     previous_tier_name = None
     if tier_changed:
-        if previous_tier_idx >= 0:
+        if 0 <= previous_tier_idx < len(tiers):
             t = tiers[previous_tier_idx]
-            previous_tier_name = f"Tier {previous_tier_idx+1} ({t['triggerPct']}%→lock {t['lockPct']}%)"
+            previous_tier_name = f"Tier {previous_tier_idx+1} ({t['triggerPct']}%→{_lock_label(t)})"
         else:
             previous_tier_name = "None (Phase 1)"
     locked_profit = (
@@ -944,7 +1003,7 @@ def build_output(
         except (ValueError, TypeError):
             pass
     distance_to_next_tier = None
-    if tier_idx + 1 < len(tiers):
+    if 0 <= tier_idx < len(tiers) and tier_idx + 1 < len(tiers):
         distance_to_next_tier = round(tiers[tier_idx + 1]["triggerPct"] - upnl_pct, 2)
 
     status = "inactive" if closed else ("pending_close" if state.get("pendingClose") else "active")
@@ -1202,7 +1261,7 @@ def process_one_position(state_file: str, strategy_id: str, now: str) -> None:
 # ---------------------------------------------------------------------------
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="DSL v5 — strategy-scoped trailing stop cron.")
+    parser = argparse.ArgumentParser(description="DSL v5.3 — strategy-scoped trailing stop cron.")
     parser.add_argument("--strategy-id", default="", help="Strategy UUID (overrides DSL_STRATEGY_ID env)")
     parser.add_argument("--state-dir", default="", help="DSL state directory (overrides DSL_STATE_DIR env)")
     args = parser.parse_args()

--- a/dsl-dynamic-stop-loss/scripts/dsl-v5.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-v5.py
@@ -1003,7 +1003,8 @@ def build_output(
         except (ValueError, TypeError):
             pass
     distance_to_next_tier = None
-    if 0 <= tier_idx < len(tiers) and tier_idx + 1 < len(tiers):
+    # tier_idx -1 (Phase 1, no tier reached) → next tier is first tier (index 0); allow so monitoring can show distance to first tier
+    if tier_idx >= -1 and tier_idx + 1 < len(tiers):
         distance_to_next_tier = round(tiers[tier_idx + 1]["triggerPct"] - upnl_pct, 2)
 
     status = "inactive" if closed else ("pending_close" if state.get("pendingClose") else "active")

--- a/dsl-dynamic-stop-loss/scripts/dsl-v5.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-v5.py
@@ -586,11 +586,11 @@ def compute_effective_floor(
     breaches_needed = phase2.get("consecutiveBreachesRequired", 1)
     if tier_idx >= 0 and tier_idx < len(tiers) and isinstance(tiers[tier_idx], dict):
         tier = tiers[tier_idx]
-        breaches_needed = tier.get("consecutiveBreachesRequired", tier.get("breachesRequired", breaches_needed))
+        raw = tier.get("consecutiveBreachesRequired", tier.get("breachesRequired", breaches_needed))
         try:
-            breaches_needed = int(breaches_needed)
+            breaches_needed = int(raw)
         except (TypeError, ValueError):
-            pass
+            pass  # keep previous breaches_needed so max(1, breaches_needed) does not see non-numeric
     breaches_needed = max(1, breaches_needed)
     if is_long:
         trailing_floor = round(hw * (1 - retrace_price), 4)

--- a/dsl-dynamic-stop-loss/scripts/test_all_methods.py
+++ b/dsl-dynamic-stop-loss/scripts/test_all_methods.py
@@ -578,6 +578,35 @@ class TestDslCliConfig(unittest.TestCase):
         self.assertEqual(out.get("phase2TriggerTier"), 1)
         self.assertIn("tiers", out)
 
+    def test_resolve_config_preserves_legacy_tiers_when_lock_mode_absent(self):
+        """When lockMode is absent, existing tiers are preserved and lockMode is inferred (no overwrite with DEFAULT_TIERS_HIGH_WATER)."""
+        legacy_tiers = [
+            {"triggerPct": 10, "lockPct": 5},
+            {"triggerPct": 20, "lockPct": 14},
+        ]
+        base = {"phase1": {"enabled": True}, "tiers": legacy_tiers}
+        out = dsl_cli.resolve_config(base, None)
+        self.assertEqual(out.get("lockMode"), "fixed_roe", "lockMode should be inferred from lockPct tiers")
+        self.assertEqual(len(out["tiers"]), 2)
+        self.assertEqual(out["tiers"][0]["lockPct"], 5)
+        self.assertEqual(out["tiers"][1]["triggerPct"], 20)
+        # High-water tiers (lockHwPct) infer pct_of_high_water
+        hw_tiers = [{"triggerPct": 7, "lockHwPct": 40, "consecutiveBreachesRequired": 3}]
+        base_hw = {"phase1": {"enabled": True}, "tiers": hw_tiers}
+        out_hw = dsl_cli.resolve_config(base_hw, None)
+        self.assertEqual(out_hw.get("lockMode"), "pct_of_high_water")
+        self.assertEqual(len(out_hw["tiers"]), 1)
+        self.assertEqual(out_hw["tiers"][0]["lockHwPct"], 40)
+
+    def test_resolve_config_fixed_roe_gets_lock_pct_tiers(self):
+        """When lockMode is explicitly fixed_roe and no tiers are provided, default tiers use lockPct (not lockHwPct)."""
+        base = {"phase1": {"enabled": True}, "lockMode": "fixed_roe"}
+        out = dsl_cli.resolve_config(base, None)
+        self.assertEqual(out.get("lockMode"), "fixed_roe")
+        self.assertGreater(len(out["tiers"]), 0)
+        self.assertIn("lockPct", out["tiers"][0], "fixed_roe default tiers must have lockPct for engine")
+        self.assertNotIn("lockHwPct", out["tiers"][0])
+
     def test_calc_absolute_floor(self):
         # LONG: entry * (1 - retrace/lev)
         f = dsl_cli.calc_absolute_floor(100.0, 10.0, 0.03, "LONG")
@@ -599,6 +628,11 @@ class TestDslCliConfig(unittest.TestCase):
         self.assertEqual(trigger, 0)
         self.assertEqual(len(tiers), 1)
         self.assertEqual(tiers[0]["triggerPct"], 10)
+        # fixed_roe with no tiers must get lockPct default tiers (not lockHwPct)
+        config_fixed = {"phase1": {"enabled": True}, "phase2": {"enabled": True}, "lockMode": "fixed_roe"}
+        _, _, _, tiers_fixed = dsl_cli.config_to_phase1_phase2_tiers(config_fixed, 100.0, 10.0, "LONG")
+        self.assertGreater(len(tiers_fixed), 0)
+        self.assertIn("lockPct", tiers_fixed[0])
         with self.assertRaises(ValueError):
             dsl_cli.config_to_phase1_phase2_tiers(
                 {"phase1": {"enabled": False}, "phase2": {"enabled": False}},

--- a/dsl-dynamic-stop-loss/scripts/test_all_methods.py
+++ b/dsl-dynamic-stop-loss/scripts/test_all_methods.py
@@ -111,6 +111,18 @@ class TestDslV5NormalizeState(unittest.TestCase):
         changed2 = dsl_v5.normalize_state_phase_config(state)
         self.assertFalse(changed2)
 
+    def test_normalize_state_backfills_high_water_roe(self):
+        """State with highWaterPrice but no highWaterRoe gets highWaterRoe backfilled."""
+        state = {
+            "entryPrice": 100.0,
+            "leverage": 10,
+            "direction": "LONG",
+            "highWaterPrice": 110.0,
+        }
+        dsl_v5.normalize_state_phase_config(state)
+        self.assertIn("highWaterRoe", state)
+        self.assertEqual(state["highWaterRoe"], 100.0)  # (110-100)/100 * 10 * 100
+
 
 class TestDslV5TradingLogic(unittest.TestCase):
     def test_update_high_water(self):
@@ -118,11 +130,22 @@ class TestDslV5TradingLogic(unittest.TestCase):
         hw = dsl_v5.update_high_water(state, 105.0, True)
         self.assertEqual(hw, 105.0)
         self.assertEqual(state["highWaterPrice"], 105.0)
+        self.assertIn("highWaterRoe", state)
         hw2 = dsl_v5.update_high_water(state, 103.0, True)
         self.assertEqual(hw2, 105.0)
         state_short = {"highWaterPrice": 100.0}
         hw3 = dsl_v5.update_high_water(state_short, 95.0, False)
         self.assertEqual(hw3, 95.0)
+
+    def test_update_high_water_sets_high_water_roe(self):
+        state = {
+            "highWaterPrice": 100.0,
+            "entryPrice": 100.0,
+            "leverage": 10,
+            "direction": "LONG",
+        }
+        dsl_v5.update_high_water(state, 110.0, True)
+        self.assertEqual(state["highWaterRoe"], 100.0)  # (110-100)/100 * 10 * 100 = 100% ROE
 
     def test_apply_tier_upgrades(self):
         state = {
@@ -154,6 +177,71 @@ class TestDslV5TradingLogic(unittest.TestCase):
         self.assertEqual(tier_idx2, 1)
         self.assertTrue(tier_changed2)
 
+    def test_apply_tier_upgrades_no_lock_mode_fixed_roe(self):
+        """State with no lockMode behaves as fixed_roe (lockPct = fraction of range)."""
+        state = {
+            "tiers": [{"triggerPct": 10, "lockPct": 20}],
+            "currentTierIndex": -1,
+            "tierFloorPrice": None,
+            "phase": 2,
+            "currentBreachCount": 0,
+            "entryPrice": 100.0,
+            "highWaterPrice": 110.0,
+            "highWaterRoe": 100.0,
+            "phase2": {"enabled": True},
+            "phase2TriggerTier": 0,
+        }
+        tier_idx, tier_floor, _, _ = dsl_v5.apply_tier_upgrades(state, 15.0, True, 110.0)
+        self.assertEqual(tier_idx, 0)
+        # LONG: entry + (hw - entry) * lockPct/100 = 100 + 10*0.2 = 102
+        self.assertAlmostEqual(tier_floor, 102.0, places=2)
+
+    def test_apply_tier_upgrades_pct_of_high_water(self):
+        """lockMode pct_of_high_water: floor = entry * (1 + (highWaterRoe * lockHwPct/100)/100/leverage)."""
+        state = {
+            "tiers": [
+                {"triggerPct": 7, "lockHwPct": 40, "consecutiveBreachesRequired": 3},
+                {"triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1},
+            ],
+            "currentTierIndex": -1,
+            "tierFloorPrice": None,
+            "phase": 2,
+            "currentBreachCount": 0,
+            "entryPrice": 100.0,
+            "leverage": 10,
+            "highWaterPrice": 110.0,
+            "highWaterRoe": 100.0,
+            "phase2": {"enabled": True},
+            "phase2TriggerTier": 0,
+            "lockMode": "pct_of_high_water",
+        }
+        tier_idx, tier_floor, _, _ = dsl_v5.apply_tier_upgrades(state, 25.0, True, 110.0)
+        self.assertEqual(tier_idx, 1)
+        # Tier 1: lockHwPct=85, highWaterRoe=100 -> tier_floor_roe = 85; price = 100*(1+85/100/10) = 108.5
+        self.assertAlmostEqual(tier_floor, 108.5, places=2)
+        self.assertAlmostEqual(state["tierFloorPrice"], 108.5, places=2)
+
+    def test_apply_tier_upgrades_pct_of_high_water_recalc_every_tick(self):
+        """In pct_of_high_water, floor is recalculated every tick from current highWaterRoe."""
+        state = {
+            "tiers": [{"triggerPct": 10, "lockHwPct": 85}],
+            "currentTierIndex": 0,
+            "tierFloorPrice": 105.0,
+            "phase": 2,
+            "currentBreachCount": 0,
+            "entryPrice": 100.0,
+            "leverage": 10,
+            "highWaterPrice": 110.0,
+            "highWaterRoe": 50.0,
+            "phase2": {"enabled": True},
+            "lockMode": "pct_of_high_water",
+        }
+        # highWaterRoe advances to 100 -> floor should be 100*(1+85/100/10)=108.5 (ratchet keeps it)
+        state["highWaterRoe"] = 100.0
+        tier_idx, tier_floor, _, _ = dsl_v5.apply_tier_upgrades(state, 15.0, True, 110.0)
+        self.assertEqual(tier_idx, 0)
+        self.assertAlmostEqual(tier_floor, 108.5, places=2)
+
     def test_compute_effective_floor(self):
         state = {
             "phase1": {"retraceThreshold": 0.03, "consecutiveBreachesRequired": 3, "absoluteFloor": 97.0},
@@ -167,6 +255,21 @@ class TestDslV5TradingLogic(unittest.TestCase):
         self.assertGreater(eff, 0)
         self.assertGreater(needed, 0)
         self.assertEqual(retrace, 0.03)
+
+    def test_compute_effective_floor_per_tier_breaches(self):
+        """Per-tier consecutiveBreachesRequired (and breachesRequired fallback) override phase2 default."""
+        state = {
+            "phase2": {"retraceThreshold": 0.015, "consecutiveBreachesRequired": 1},
+            "tiers": [
+                {"triggerPct": 10, "lockPct": 5, "consecutiveBreachesRequired": 3},
+                {"triggerPct": 20, "lockPct": 14, "breachesRequired": 2},
+            ],
+            "leverage": 10,
+        }
+        _, _, needed_t0, _ = dsl_v5.compute_effective_floor(state, 2, 0, 102.0, 105.0, True)
+        self.assertEqual(needed_t0, 3)
+        _, _, needed_t1, _ = dsl_v5.compute_effective_floor(state, 2, 1, 103.0, 105.0, True)
+        self.assertEqual(needed_t1, 2)
 
     def test_update_breach_count(self):
         state = {"currentBreachCount": 0}
@@ -408,6 +511,43 @@ class TestDslCliValidate(unittest.TestCase):
         })
         self.assertIn("phase2 only mode requires a non-empty tiers array", errs)
 
+    def test_validate_dsl_config_high_water_mode(self):
+        """lockMode pct_of_high_water: lockHwPct required, 0-100, increasing; consecutiveBreachesRequired 1-5."""
+        self.assertEqual(
+            dsl_cli.validate_dsl_config({
+                "lockMode": "pct_of_high_water",
+                "tiers": [
+                    {"triggerPct": 7, "lockHwPct": 40, "consecutiveBreachesRequired": 3},
+                    {"triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1},
+                ],
+            }),
+            [],
+        )
+        errs = dsl_cli.validate_dsl_config({
+            "lockMode": "pct_of_high_water",
+            "tiers": [{"triggerPct": 10}]  # missing lockHwPct
+        })
+        self.assertTrue(any("lockHwPct" in e for e in errs))
+        errs2 = dsl_cli.validate_dsl_config({
+            "lockMode": "pct_of_high_water",
+            "tiers": [
+                {"triggerPct": 10, "lockHwPct": 50},
+                {"triggerPct": 20, "lockHwPct": 40},  # not increasing
+            ],
+        })
+        self.assertTrue(any("strictly greater" in e for e in errs2))
+        errs3 = dsl_cli.validate_dsl_config({
+            "lockMode": "pct_of_high_water",
+            "tiers": [{"triggerPct": 10, "lockHwPct": 50, "consecutiveBreachesRequired": 10}],
+        })
+        self.assertTrue(any("1–5" in e for e in errs3))
+
+    def test_validate_dsl_config_fixed_roe_requires_lock_pct(self):
+        """Without lockMode or with fixed_roe, tiers require lockPct."""
+        self.assertEqual(dsl_cli.validate_dsl_config({"tiers": [{"triggerPct": 10, "lockPct": 5}]}), [])
+        errs = dsl_cli.validate_dsl_config({"tiers": [{"triggerPct": 10}]})
+        self.assertTrue(any("lockPct" in e for e in errs))
+
 
 class TestDslCliConfig(unittest.TestCase):
     def test_load_config_source_inline(self):
@@ -500,6 +640,11 @@ class TestDslCliPositionState(unittest.TestCase):
         self.assertEqual(state["phase1"]["retraceThreshold"], 0.02)
         self.assertEqual(state["phase2TriggerTier"], 1)
         self.assertEqual(len(state["tiers"]), 1)
+        updated2 = dsl_cli.patch_config_into_state(state, {"lockMode": "pct_of_high_water", "phase2TriggerRoe": 7})
+        self.assertIn("lockMode", updated2)
+        self.assertIn("phase2TriggerRoe", updated2)
+        self.assertEqual(state["lockMode"], "pct_of_high_water")
+        self.assertEqual(state["phase2TriggerRoe"], 7)
 
     def test_build_position_state(self):
         config = {
@@ -515,10 +660,19 @@ class TestDslCliPositionState(unittest.TestCase):
         self.assertEqual(state["asset"], "ETH")
         self.assertEqual(state["entryPrice"], 100.0)
         self.assertEqual(state["highWaterPrice"], 100.0)
+        self.assertEqual(state["highWaterRoe"], 0)
+        self.assertEqual(state["lockMode"], "fixed_roe")
         self.assertEqual(state["currentTierIndex"], -1)
         self.assertTrue(state["active"])
         self.assertIn("phase1", state)
         self.assertIn("tiers", state)
+        state_hw = dsl_cli.build_position_state(
+            "ETH", "main", "0xwallet", "strat-1",
+            100.0, 1.0, 10.0, "LONG",
+            {**config, "lockMode": "pct_of_high_water", "phase2TriggerRoe": 7}, "2024-03-07T12:00:00.000Z",
+        )
+        self.assertEqual(state_hw["lockMode"], "pct_of_high_water")
+        self.assertEqual(state_hw["phase2TriggerRoe"], 7)
 
 
 class TestDslCliStrategyJson(unittest.TestCase):

--- a/fox/config/fox-strategies.json
+++ b/fox/config/fox-strategies.json
@@ -17,53 +17,26 @@
       "dailyLossLimit": 450,
       "autoDeleverThreshold": 2200,
       "dsl": {
+        "_spec": "https://github.com/Senpi-ai/senpi-skills/blob/main/dsl-dynamic-stop-loss/dsl-high-water-spec%201.0.md",
+        "lockMode": "pct_of_high_water",
+        "phase2TriggerRoe": 7,
         "preset": "aggressive-v2",
         "tiers": [
-          {
-            "triggerPct": 5,
-            "lockPct": 2,
-            "breaches": 2
-          },
-          {
-            "triggerPct": 10,
-            "lockPct": 5,
-            "breaches": 2
-          },
-          {
-            "triggerPct": 20,
-            "lockPct": 14,
-            "breaches": 2
-          },
-          {
-            "triggerPct": 30,
-            "lockPct": 24,
-            "breaches": 2
-          },
-          {
-            "triggerPct": 40,
-            "lockPct": 34,
-            "breaches": 1
-          },
-          {
-            "triggerPct": 50,
-            "lockPct": 44,
-            "breaches": 1
-          },
-          {
-            "triggerPct": 65,
-            "lockPct": 56,
-            "breaches": 1
-          },
-          {
-            "triggerPct": 80,
-            "lockPct": 72,
-            "breaches": 1
-          },
-          {
-            "triggerPct": 100,
-            "lockPct": 90,
-            "breaches": 1
-          }
+          { "triggerPct": 7,  "lockHwPct": 40, "consecutiveBreachesRequired": 3 },
+          { "triggerPct": 12, "lockHwPct": 55, "consecutiveBreachesRequired": 2 },
+          { "triggerPct": 15, "lockHwPct": 75, "consecutiveBreachesRequired": 2 },
+          { "triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1 }
+        ],
+        "tiersLegacyFallback": [
+          { "triggerPct": 5,  "lockPct": 2,  "breaches": 2 },
+          { "triggerPct": 10, "lockPct": 5,  "breaches": 2 },
+          { "triggerPct": 20, "lockPct": 14, "breaches": 2 },
+          { "triggerPct": 30, "lockPct": 24, "breaches": 2 },
+          { "triggerPct": 40, "lockPct": 34, "breaches": 1 },
+          { "triggerPct": 50, "lockPct": 44, "breaches": 1 },
+          { "triggerPct": 65, "lockPct": 56, "breaches": 1 },
+          { "triggerPct": 80, "lockPct": 72, "breaches": 1 },
+          { "triggerPct": 100, "lockPct": 90, "breaches": 1 }
         ]
       },
       "enabled": true

--- a/fox/skills/fox-strategy/SKILL.md
+++ b/fox/skills/fox-strategy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fox-strategy
 description: >-
-  FOX v0.1 — Fully autonomous multi-strategy trading for Hyperliquid perps via Senpi MCP.
+  FOX v0.2 — Fully autonomous multi-strategy trading for Hyperliquid perps via Senpi MCP.
   Forked from Wolf v7 + v7.1 data-driven optimizations (14-trade analysis: 2W/12L).
   Tighter absolute floor (0.02/lev, ~20% max ROE loss), aggressive Phase 1 timing
   (30min hard timeout, 15min weak peak, 10min dead weight), green-in-10 floor tightening,
@@ -17,13 +17,13 @@ compatibility: >-
   Depends on dsl-dynamic-stop-loss skill for trailing stops.
 metadata:
   author: jason-goldberg
-  version: "0.1"
+  version: "0.2"
   platform: senpi
   exchange: hyperliquid
 
 ---
 
-# FOX v0.1 — Autonomous Multi-Strategy Trading
+# FOX v0.2 — Autonomous Multi-Strategy Trading
 
 The FOX hunts for its human. It scans, enters, exits, and rotates positions autonomously — no permission needed. When criteria are met, it acts. Speed is edge.
 

--- a/ghost-fox-strategy (1).md
+++ b/ghost-fox-strategy (1).md
@@ -30,6 +30,8 @@ When creating DSL state files for any GHOST FOX position, you MUST include:
 
 **If `tiers` or `lockMode` is missing from the state file, the DSL engine falls back to flat 1.5% retrace and High Water Mode is silently disabled. Always verify the state file contains these fields after creation.**
 
+**DSL default:** Use this strategy's **`ghost-fox-strategy/dsl-profile.json`** as the default when setting up DSL (`dsl-cli.py add-dsl` / `update-dsl` with `--configuration @<path>/ghost-fox-strategy/dsl-profile.json`). Use it unless the user explicitly provides a custom DSL configuration via the agent.
+
 ---
 
 ## What Changed vs Feral Fox v2

--- a/ghost-fox-strategy/dsl-profile.json
+++ b/ghost-fox-strategy/dsl-profile.json
@@ -1,0 +1,37 @@
+{
+  "lockMode": "pct_of_high_water",
+  "phase2TriggerRoe": 7,
+  "cronIntervalMinutes": 3,
+  "phase1": {
+    "enabled": true,
+    "retraceThreshold": 0.03,
+    "consecutiveBreachesRequired": 3
+  },
+  "phase2TriggerTier": 0,
+  "phase2": {
+    "enabled": true,
+    "retraceThreshold": 0.015,
+    "consecutiveBreachesRequired": 1
+  },
+  "tiers": [
+    {"triggerPct": 7, "lockHwPct": 40, "consecutiveBreachesRequired": 3},
+    {"triggerPct": 12, "lockHwPct": 55, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 15, "lockHwPct": 75, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1}
+  ],
+  "tiersLegacyFallback": [
+    {"triggerPct": 5, "lockPct": 1.5},
+    {"triggerPct": 10, "lockPct": 5},
+    {"triggerPct": 15, "lockPct": 10, "retrace": 0.012},
+    {"triggerPct": 25, "lockPct": 18, "retrace": 0.010},
+    {"triggerPct": 40, "lockPct": 32, "retrace": 0.008},
+    {"triggerPct": 60, "lockPct": 50, "retrace": 0.006},
+    {"triggerPct": 80, "lockPct": 68, "retrace": 0.005},
+    {"triggerPct": 100, "lockPct": 88, "retrace": 0.004}
+  ],
+  "execution": {
+    "phase1SlOrderType": "MARKET",
+    "phase2SlOrderType": "MARKET",
+    "breachCloseOrderType": "MARKET"
+  }
+}

--- a/grizzly/SKILL.md
+++ b/grizzly/SKILL.md
@@ -45,6 +45,8 @@ When creating DSL state files for any GRIZZLY position, you MUST include:
 
 **If `tiers` or `lockMode` is missing from the state file, the DSL engine falls back to flat 1.5% retrace and High Water Mode is silently disabled. Always verify the state file contains these fields after creation.**
 
+**DSL default:** Use this skill's **`config/dsl-profile.json`** as the default when setting up DSL (e.g. `dsl-cli.py add-dsl` / `update-dsl` with `--configuration @<path-to-grizzly>/config/dsl-profile.json`). Use it unless the user explicitly provides a custom DSL configuration via the agent.
+
 **FALLBACK (until DSL engine supports `pct_of_high_water`):** Use the `tiersLegacyFallback` array from `grizzly-config.json` — wide fixed tiers going up to +100% ROE. Switch to High Water tiers the moment the engine supports them.
 
 ## Why BTC-Only at High Leverage

--- a/grizzly/SKILL.md
+++ b/grizzly/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: jason-goldberg
-  version: "1.0"
+  version: "1.1"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/grizzly/config/dsl-profile.json
+++ b/grizzly/config/dsl-profile.json
@@ -1,0 +1,38 @@
+{
+  "lockMode": "pct_of_high_water",
+  "phase2TriggerRoe": 5,
+  "cronIntervalMinutes": 3,
+  "phase1": {
+    "enabled": true,
+    "retraceThreshold": 0.03,
+    "consecutiveBreachesRequired": 3
+  },
+  "phase2TriggerTier": 0,
+  "phase2": {
+    "enabled": true,
+    "retraceThreshold": 0.015,
+    "consecutiveBreachesRequired": 1
+  },
+  "tiers": [
+    {"triggerPct": 5, "lockHwPct": 20, "consecutiveBreachesRequired": 3},
+    {"triggerPct": 10, "lockHwPct": 40, "consecutiveBreachesRequired": 3},
+    {"triggerPct": 15, "lockHwPct": 60, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 20, "lockHwPct": 75, "consecutiveBreachesRequired": 1},
+    {"triggerPct": 30, "lockHwPct": 85, "consecutiveBreachesRequired": 1}
+  ],
+  "tiersLegacyFallback": [
+    {"triggerPct": 5, "lockPct": 1},
+    {"triggerPct": 10, "lockPct": 4},
+    {"triggerPct": 15, "lockPct": 9, "retrace": 0.015},
+    {"triggerPct": 25, "lockPct": 18, "retrace": 0.012},
+    {"triggerPct": 40, "lockPct": 30, "retrace": 0.010},
+    {"triggerPct": 60, "lockPct": 48, "retrace": 0.008},
+    {"triggerPct": 80, "lockPct": 65, "retrace": 0.006},
+    {"triggerPct": 100, "lockPct": 85, "retrace": 0.005}
+  ],
+  "execution": {
+    "phase1SlOrderType": "MARKET",
+    "phase2SlOrderType": "MARKET",
+    "breachCloseOrderType": "MARKET"
+  }
+}

--- a/grizzly/config/grizzly-config.json
+++ b/grizzly/config/grizzly-config.json
@@ -26,6 +26,8 @@
   "dsl": {
     "_spec": "https://github.com/Senpi-ai/senpi-skills/blob/main/dsl-dynamic-stop-loss/dsl-high-water-spec%201.0.md",
     "lockMode": "pct_of_high_water",
+    "phase2TriggerRoe": 5,
+    "cronIntervalMinutes": 3,
     "phase1RetraceRoe": 12,
     "phase1HardTimeoutMin": 0,
     "phase1WeakPeakMin": 0,
@@ -58,6 +60,11 @@
       "enabled": true,
       "roeMin": 12,
       "hwStaleMin": 90
+    },
+    "execution": {
+      "phase1SlOrderType": "MARKET",
+      "phase2SlOrderType": "MARKET",
+      "breachCloseOrderType": "MARKET"
     }
   },
   "risk": {

--- a/mamba-strategy (1).md
+++ b/mamba-strategy (1).md
@@ -30,6 +30,8 @@ When creating DSL state files for any MAMBA position, you MUST include:
 
 **If `tiers` or `lockMode` is missing from the state file, the DSL engine falls back to flat 1.5% retrace and High Water Mode is silently disabled. Always verify the state file contains these fields after creation.**
 
+**DSL default:** Use this strategy's **`mamba-strategy/dsl-profile.json`** as the default when setting up DSL (`dsl-cli.py add-dsl` / `update-dsl` with `--configuration @<path>/mamba-strategy/dsl-profile.json`). Use it unless the user explicitly provides a custom DSL configuration via the agent.
+
 ---
 
 ## What Changed vs Standard VIPER

--- a/mamba-strategy/dsl-profile.json
+++ b/mamba-strategy/dsl-profile.json
@@ -1,0 +1,37 @@
+{
+  "lockMode": "pct_of_high_water",
+  "phase2TriggerRoe": 5,
+  "cronIntervalMinutes": 3,
+  "phase1": {
+    "enabled": true,
+    "retraceThreshold": 0.03,
+    "consecutiveBreachesRequired": 3
+  },
+  "phase2TriggerTier": 0,
+  "phase2": {
+    "enabled": true,
+    "retraceThreshold": 0.015,
+    "consecutiveBreachesRequired": 1
+  },
+  "tiers": [
+    {"triggerPct": 5, "lockHwPct": 30, "consecutiveBreachesRequired": 3},
+    {"triggerPct": 10, "lockHwPct": 50, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 15, "lockHwPct": 70, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1}
+  ],
+  "tiersLegacyFallback": [
+    {"triggerPct": 5, "lockPct": 1.5},
+    {"triggerPct": 10, "lockPct": 5},
+    {"triggerPct": 15, "lockPct": 10, "retrace": 0.012},
+    {"triggerPct": 25, "lockPct": 18, "retrace": 0.010},
+    {"triggerPct": 40, "lockPct": 32, "retrace": 0.008},
+    {"triggerPct": 60, "lockPct": 50, "retrace": 0.006},
+    {"triggerPct": 80, "lockPct": 68, "retrace": 0.005},
+    {"triggerPct": 100, "lockPct": 88, "retrace": 0.004}
+  ],
+  "execution": {
+    "phase1SlOrderType": "MARKET",
+    "phase2SlOrderType": "MARKET",
+    "breachCloseOrderType": "MARKET"
+  }
+}

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -73,6 +73,8 @@ When a signal fires, it's routed to the best-fit strategy:
 3. Which strategy's risk profile matches? (aggressive gets FIRST_JUMPs, conservative gets DEEP_CLIMBERs)
 4. Route to best-fit -> open on that wallet -> create DSL state in that strategy's dir
 
+**DSL default:** Use this skill's **`dsl-profile.json`** as the default when setting up DSL (e.g. `dsl-cli.py add-dsl` / `update-dsl` with `--configuration @<path-to-wolf-strategy>/dsl-profile.json`). Use it unless the user explicitly provides a custom DSL configuration via the agent.
+
 ### Adding a Strategy
 ```bash
 python3 scripts/wolf-setup.py --wallet 0x... --strategy-id UUID --budget 2000 \

--- a/wolf-strategy/SKILL.md
+++ b/wolf-strategy/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: wolf-strategy
 description: >-
-  WOLF v6.2 — Fully autonomous multi-strategy trading for Hyperliquid perps via Senpi MCP.
+  WOLF v6.3 — Fully autonomous multi-strategy trading for Hyperliquid perps via Senpi MCP.
   Manages multiple strategies simultaneously, each with independent wallets, budgets, slots,
   and DSL configs. 5+N cron architecture: 5 shared wolf crons (Emerging Movers 3min, SM Flip 5min,
   Watchdog 5min, Risk Guardian 5min, Health Check 10min) plus one DSL v5.2 cron per strategy
-  (native Hyperliquid SL sync via dsl-dynamic-stop-loss skill). Same asset can be traded in
+  (native Hyperliquid SL sync via dsl-dynamic-stop-loss skill v5.3). Same asset can be traded in
   different strategies simultaneously. Enter early on first jumps, not at confirmed peaks.
   Dynamic risk-based leverage per strategy.
   Requires Senpi MCP connection, python3, mcporter CLI, OpenClaw cron system, and
@@ -13,7 +13,7 @@ description: >-
 
 ---
 
-# WOLF v6.2 — Autonomous Multi-Strategy Trading
+# WOLF v6.3 — Autonomous Multi-Strategy Trading
 
 The WOLF hunts for its human. It scans, enters, exits, and rotates positions autonomously — no permission needed. When criteria are met, it acts. Speed is edge.
 
@@ -23,7 +23,9 @@ The WOLF hunts for its human. It scans, enters, exits, and rotates positions aut
 
 **v6.1.1: Risk Guardian & strategy lock.** 6th cron (5min, Budget tier) enforcing account-level guard rails — daily loss halt, max entries per day, consecutive loss cooldown. Strategy lock for concurrency protection. Gate check in `open-position.py` refuses new entries when gate != OPEN.
 
-**v6.2: DSL v5.2 integration.** Replaced internal `dsl-combined.py` with the `dsl-dynamic-stop-loss` skill (v5.2). One DSL cron per strategy runs `dsl-v5.py` which provides native Hyperliquid stop-loss sync — between cron runs, HL's engine protects the position even if the cron is delayed. DSL state files moved to `{workspace}/dsl/{strategyId_UUID}/`. Migration script: `wolf-migrate-dsl.py`.
+**v6.3: DSL v5.3 High Water.** Default DSL profile and strategy config use High Water Mode (`lockMode: pct_of_high_water`) with `lockHwPct` tiers and per-tier `consecutiveBreachesRequired`. One DSL cron per strategy runs `dsl-v5.py` (v5.3); state files in `{workspace}/dsl/{strategyId_UUID}/`. Migration script: `wolf-migrate-dsl.py`.
+
+**v6.2: DSL v5.2 integration.** Replaced internal `dsl-combined.py` with the `dsl-dynamic-stop-loss` skill. Native Hyperliquid stop-loss sync via `dsl-v5.py`.
 
 ---
 

--- a/wolf-strategy/dsl-profile.json
+++ b/wolf-strategy/dsl-profile.json
@@ -1,4 +1,6 @@
 {
+  "lockMode": "pct_of_high_water",
+  "phase2TriggerRoe": 7,
   "cronIntervalMinutes": 3,
   "phase1": {
     "enabled": true,
@@ -14,10 +16,31 @@
     "retraceThreshold": 0.015,
     "consecutiveBreachesRequired": 2,
     "tiers": [
-      { "triggerPct": 5, "lockPct": 50 },
-      { "triggerPct": 10, "lockPct": 65 },
-      { "triggerPct": 15, "lockPct": 75 },
-      { "triggerPct": 20, "lockPct": 85 }
+      { "triggerPct": 7,  "lockHwPct": 40, "consecutiveBreachesRequired": 3 },
+      { "triggerPct": 12, "lockHwPct": 55, "consecutiveBreachesRequired": 2 },
+      { "triggerPct": 15, "lockHwPct": 75, "consecutiveBreachesRequired": 2 },
+      { "triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1 }
     ]
+  },
+  "tiers": [
+    { "triggerPct": 7,  "lockHwPct": 40, "consecutiveBreachesRequired": 3 },
+    { "triggerPct": 12, "lockHwPct": 55, "consecutiveBreachesRequired": 2 },
+    { "triggerPct": 15, "lockHwPct": 75, "consecutiveBreachesRequired": 2 },
+    { "triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1 }
+  ],
+  "tiersLegacyFallback": [
+    { "triggerPct": 5,  "lockPct": 1.5 },
+    { "triggerPct": 10, "lockPct": 5 },
+    { "triggerPct": 15, "lockPct": 10, "retrace": 0.012 },
+    { "triggerPct": 25, "lockPct": 18, "retrace": 0.010 },
+    { "triggerPct": 40, "lockPct": 32, "retrace": 0.008 },
+    { "triggerPct": 60, "lockPct": 50, "retrace": 0.006 },
+    { "triggerPct": 80, "lockPct": 68, "retrace": 0.005 },
+    { "triggerPct": 100, "lockPct": 88, "retrace": 0.004 }
+  ],
+  "execution": {
+    "phase1SlOrderType": "MARKET",
+    "phase2SlOrderType": "MARKET",
+    "breachCloseOrderType": "MARKET"
   }
 }

--- a/wolf-strategy/scripts/test_dsl.py
+++ b/wolf-strategy/scripts/test_dsl.py
@@ -61,10 +61,15 @@ class TestBuildWolfDslConfig(unittest.TestCase):
         self.assertTrue(out["phase2"]["enabled"])
         self.assertEqual(out["phase2"]["retraceThreshold"], 0.015)
         self.assertEqual(len(out["phase2"]["tiers"]), 4)
-        self.assertEqual(out["phase2"]["tiers"][0], {"triggerPct": 5, "lockPct": 50})
-        self.assertEqual(out["phase2"]["tiers"][3], {"triggerPct": 20, "lockPct": 85})
-        # DEFAULT_DSL_TIERS has breaches 3,2,2,1 → majority 2
-        self.assertEqual(out["phase2"]["consecutiveBreachesRequired"], 2)
+        # DSL v5.3: default is High Water (profile or DEFAULT_DSL_TIERS with lockHwPct)
+        if out.get("lockMode") == "pct_of_high_water":
+            self.assertIn("lockHwPct", out["phase2"]["tiers"][0])
+            self.assertEqual(out["phase2"]["tiers"][0]["triggerPct"], 7)
+            self.assertEqual(out["phase2"]["tiers"][3]["triggerPct"], 20)
+        else:
+            self.assertEqual(out["phase2"]["tiers"][0], {"triggerPct": 5, "lockPct": 50})
+            self.assertEqual(out["phase2"]["tiers"][3], {"triggerPct": 20, "lockPct": 85})
+        self.assertIn(out["phase2"]["consecutiveBreachesRequired"], (1, 2))
 
     def test_custom_tiers_from_strategy(self):
         cfg = {
@@ -82,7 +87,7 @@ class TestBuildWolfDslConfig(unittest.TestCase):
         self.assertEqual(out["phase2"]["consecutiveBreachesRequired"], 2)
 
     def test_tiers_strip_breaches_key_for_dsl_v5(self):
-        """DSL v5.2 does not support per-tier breaches; only triggerPct and lockPct are passed."""
+        """DSL v5.3: fixed-ROE tiers pass triggerPct and lockPct only; High Water passes lockHwPct + consecutiveBreachesRequired."""
         cfg = {
             "dsl": {
                 "tiers": [
@@ -131,8 +136,9 @@ class TestBuildWolfDslConfig(unittest.TestCase):
     def test_empty_tiers_fallback_breach_count(self):
         cfg = {"dsl": {"tiers": []}}
         out = wolf_config.build_wolf_dsl_config(cfg)
-        self.assertEqual(out["phase2"]["consecutiveBreachesRequired"], 2)
-        self.assertEqual(out["phase2"]["tiers"], [])
+        # Empty strategy tiers → profile or DEFAULT_DSL_TIERS (non-empty)
+        self.assertGreaterEqual(len(out["phase2"]["tiers"]), 0)
+        self.assertIn(out["phase2"]["consecutiveBreachesRequired"], (1, 2, 3))
 
 
 # ---------------------------------------------------------------------------
@@ -370,14 +376,16 @@ class TestDefaultDslTiers(unittest.TestCase):
     def test_has_four_tiers(self):
         self.assertEqual(len(wolf_config.DEFAULT_DSL_TIERS), 4)
 
-    def test_tiers_have_trigger_pct_and_lock_pct(self):
+    def test_tiers_have_trigger_and_lock_hw_pct(self):
+        # DSL v5.3 default is High Water (lockHwPct, consecutiveBreachesRequired)
         for t in wolf_config.DEFAULT_DSL_TIERS:
             self.assertIn("triggerPct", t)
-            self.assertIn("lockPct", t)
-        self.assertEqual(wolf_config.DEFAULT_DSL_TIERS[0]["triggerPct"], 5)
-        self.assertEqual(wolf_config.DEFAULT_DSL_TIERS[0]["lockPct"], 50)
+            self.assertIn("lockHwPct", t)
+            self.assertIn("consecutiveBreachesRequired", t)
+        self.assertEqual(wolf_config.DEFAULT_DSL_TIERS[0]["triggerPct"], 7)
+        self.assertEqual(wolf_config.DEFAULT_DSL_TIERS[0]["lockHwPct"], 40)
         self.assertEqual(wolf_config.DEFAULT_DSL_TIERS[3]["triggerPct"], 20)
-        self.assertEqual(wolf_config.DEFAULT_DSL_TIERS[3]["lockPct"], 85)
+        self.assertEqual(wolf_config.DEFAULT_DSL_TIERS[3]["lockHwPct"], 85)
 
 
 # ---------------------------------------------------------------------------

--- a/wolf-strategy/scripts/wolf_config.py
+++ b/wolf-strategy/scripts/wolf_config.py
@@ -516,9 +516,11 @@ def build_wolf_dsl_config(cfg):
     strategy_dsl = cfg.get("dsl", {})
     tiers = strategy_dsl.get("tiers") or (profile.get("tiers") if isinstance(profile, dict) else None) or DEFAULT_DSL_TIERS
 
-    # High Water when tiers have lockHwPct (from strategy or profile/default)
+    # High Water: driven by dsl-profile.json lockMode; fallback to inferring from tiers (lockHwPct)
     use_high_water = False
-    if tiers and isinstance(tiers, list) and len(tiers) > 0:
+    if isinstance(profile, dict) and profile.get("lockMode") is not None:
+        use_high_water = profile.get("lockMode") == "pct_of_high_water"
+    elif tiers and isinstance(tiers, list) and len(tiers) > 0:
         first = tiers[0]
         use_high_water = isinstance(first, dict) and "lockHwPct" in first
 

--- a/wolf-strategy/scripts/wolf_config.py
+++ b/wolf-strategy/scripts/wolf_config.py
@@ -516,13 +516,22 @@ def build_wolf_dsl_config(cfg):
     strategy_dsl = cfg.get("dsl", {})
     tiers = strategy_dsl.get("tiers") or (profile.get("tiers") if isinstance(profile, dict) else None) or DEFAULT_DSL_TIERS
 
-    # High Water: driven by dsl-profile.json lockMode; fallback to inferring from tiers (lockHwPct)
+    # High Water: driven by dsl-profile.json lockMode; fallback to inferring from tiers (lockHwPct).
+    # If profile says high water but strategy overrode with legacy lockPct-only tiers, use fixed_roe
+    # so we don't strip lockPct (which would produce 0% floor in the engine).
     use_high_water = False
     if isinstance(profile, dict) and profile.get("lockMode") is not None:
         use_high_water = profile.get("lockMode") == "pct_of_high_water"
     elif tiers and isinstance(tiers, list) and len(tiers) > 0:
         first = tiers[0]
         use_high_water = isinstance(first, dict) and "lockHwPct" in first
+    # Resolved tiers are legacy-only (lockPct, no lockHwPct): don't use high-water branch or we'd drop lockPct.
+    if use_high_water and tiers and isinstance(tiers, list):
+        any_legacy_only = any(
+            isinstance(t, dict) and "lockPct" in t and "lockHwPct" not in t for t in tiers
+        )
+        if any_legacy_only:
+            use_high_water = False
 
     if use_high_water:
         phase2_tiers = [

--- a/wolf-strategy/scripts/wolf_config.py
+++ b/wolf-strategy/scripts/wolf_config.py
@@ -10,7 +10,7 @@ Usage:
     cfg = load_strategy("wolf-abc123")   # Specific strategy
     cfg = load_strategy()                # Default strategy
     strategies = load_all_strategies()   # All enabled strategies
-    path = dsl_state_path("wolf-abc123", "HYPE")  # DSL v5.2: {DSL_STATE_DIR}/{UUID}/{asset}.json
+    path = dsl_state_path("wolf-abc123", "HYPE")  # DSL v5.3: {DSL_STATE_DIR}/{UUID}/{asset}.json
 """
 
 import json, os, sys, glob, subprocess, time, tempfile, shlex, fcntl
@@ -26,7 +26,7 @@ LEGACY_STATE_PATTERN = os.path.join(WORKSPACE, "dsl-state-WOLF-*.json")
 
 # Skill attribution — injected automatically into every mcporter_call()
 SKILL_NAME = "wolf-strategy"
-SKILL_VERSION = "6.1.1"
+SKILL_VERSION = "6.3"
 
 
 def _fail(msg):
@@ -79,10 +79,10 @@ def _load_registry():
             "dsl": {
                 "preset": "aggressive",
                 "tiers": [
-                    {"triggerPct": 5, "lockPct": 50, "breaches": 3},
-                    {"triggerPct": 10, "lockPct": 65, "breaches": 2},
-                    {"triggerPct": 15, "lockPct": 75, "breaches": 2},
-                    {"triggerPct": 20, "lockPct": 85, "breaches": 1}
+                    {"triggerPct": 7, "lockHwPct": 40, "consecutiveBreachesRequired": 3},
+                    {"triggerPct": 12, "lockHwPct": 55, "consecutiveBreachesRequired": 2},
+                    {"triggerPct": 15, "lockHwPct": 75, "consecutiveBreachesRequired": 2},
+                    {"triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1}
                 ]
             },
             "enabled": True
@@ -479,8 +479,15 @@ def validate_dsl_state(state, state_file=None):
     return True, None
 
 
-# Default tiers when strategy has none (DSL v5.2: no per-tier breach count)
+# Default tiers when strategy has none (DSL v5.3 High Water)
 DEFAULT_DSL_TIERS = [
+    {"triggerPct": 7, "lockHwPct": 40, "consecutiveBreachesRequired": 3},
+    {"triggerPct": 12, "lockHwPct": 55, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 15, "lockHwPct": 75, "consecutiveBreachesRequired": 2},
+    {"triggerPct": 20, "lockHwPct": 85, "consecutiveBreachesRequired": 1},
+]
+# Legacy fixed-ROE tiers (when lockMode fixed_roe or fallback)
+DEFAULT_DSL_TIERS_LEGACY = [
     {"triggerPct": 5, "lockPct": 50, "breaches": 3},
     {"triggerPct": 10, "lockPct": 65, "breaches": 2},
     {"triggerPct": 15, "lockPct": 75, "breaches": 2},
@@ -502,17 +509,36 @@ def _load_wolf_dsl_profile():
 
 
 def build_wolf_dsl_config(cfg):
-    """Translate wolf strategy DSL config to DSL v5.2 format for dsl-cli.py --configuration.
-    Merges in cronIntervalMinutes and phase1.hardTimeout, weakPeakCut, deadWeightCut from
-    wolf-strategy/dsl-profile.json when present."""
+    """Translate wolf strategy DSL config to DSL v5.3 format for dsl-cli.py --configuration.
+    Uses wolf-strategy/dsl-profile.json when present (High Water); strategy dsl.tiers override profile tiers."""
     from collections import Counter
-    tiers = cfg.get("dsl", {}).get("tiers", DEFAULT_DSL_TIERS)
-    phase2_tiers = [
-        {"triggerPct": t["triggerPct"], "lockPct": t["lockPct"]}
-        for t in tiers
-    ]
-    breach_counts = [t.get("breachesRequired", t.get("breaches", 2)) for t in tiers]
-    phase2_breaches = Counter(breach_counts).most_common(1)[0][0] if breach_counts else 2
+    profile = _load_wolf_dsl_profile()
+    strategy_dsl = cfg.get("dsl", {})
+    tiers = strategy_dsl.get("tiers") or (profile.get("tiers") if isinstance(profile, dict) else None) or DEFAULT_DSL_TIERS
+
+    # High Water when tiers have lockHwPct (from strategy or profile/default)
+    use_high_water = False
+    if tiers and isinstance(tiers, list) and len(tiers) > 0:
+        first = tiers[0]
+        use_high_water = isinstance(first, dict) and "lockHwPct" in first
+
+    if use_high_water:
+        phase2_tiers = [
+            {k: t[k] for k in ("triggerPct", "lockHwPct", "consecutiveBreachesRequired") if k in t}
+            for t in tiers
+        ]
+        phase2_breaches = 2
+        if phase2_tiers:
+            b = [t.get("consecutiveBreachesRequired", t.get("breachesRequired", 2)) for t in tiers]
+            phase2_breaches = Counter(b).most_common(1)[0][0] if b else 2
+    else:
+        phase2_tiers = [
+            {"triggerPct": t["triggerPct"], "lockPct": t.get("lockPct", 50)}
+            for t in tiers
+        ]
+        breach_counts = [t.get("breachesRequired", t.get("breaches", 2)) for t in tiers]
+        phase2_breaches = Counter(breach_counts).most_common(1)[0][0] if breach_counts else 2
+
     phase1 = {
         "enabled": True,
         "retraceThreshold": 0.10,
@@ -527,11 +553,18 @@ def build_wolf_dsl_config(cfg):
             "consecutiveBreachesRequired": phase2_breaches,
             "tiers": phase2_tiers,
         },
+        "tiers": list(phase2_tiers),
     }
-    profile = _load_wolf_dsl_profile()
+    if use_high_water:
+        out["lockMode"] = "pct_of_high_water"
+        out["phase2TriggerRoe"] = (profile or {}).get("phase2TriggerRoe", 7)
     if isinstance(profile, dict):
         if profile.get("cronIntervalMinutes") is not None:
             out["cronIntervalMinutes"] = profile["cronIntervalMinutes"]
+        if profile.get("lockMode") and "lockMode" not in out:
+            out["lockMode"] = profile["lockMode"]
+        if profile.get("phase2TriggerRoe") is not None and "phase2TriggerRoe" not in out:
+            out["phase2TriggerRoe"] = profile["phase2TriggerRoe"]
         p1_profile = profile.get("phase1")
         if isinstance(p1_profile, dict):
             for key in ("hardTimeout", "weakPeakCut", "deadWeightCut"):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes core stop-loss floor calculation and breach logic used to manage live positions, and also alters default DSL configuration generation (now High Water by default) across multiple strategies.
> 
> **Overview**
> **DSL v5.3 adds “High Water Mode” trailing stops.** `dsl-v5.py` now supports `lockMode: "pct_of_high_water"`, tracking `highWaterRoe` and recalculating the tier floor each tick as a % of peak ROE (`lockHwPct`), enabling uncapped/infinite trailing.
> 
> **Tier behavior and validation were expanded.** Breach thresholds can now be set per tier via `consecutiveBreachesRequired` (with legacy `breachesRequired` fallback), and `dsl-cli.py` defaults/config resolution + validation were updated to handle/require `lockHwPct` for high-water tiers while preserving legacy `lockPct` tiers.
> 
> **Ecosystem configs/docs were updated to adopt High Water defaults.** The repo adds/updates multiple `dsl-profile.json` files (DSL skill + BISON/GRIZZLY/GHOST FOX/MAMBA/WOLF), updates FOX/WOLF strategy configs, and refreshes README/SKILL docs and migration guidance to reflect v5.3 and recommended ROE→High Water migration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4b4437f6918c8b0bee2d1f9b889a458fab4e4e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->