### PR TITLE
per tick update

### DIFF
--- a/dsl-dynamic-stop-loss/scripts/dsl-v5.py
+++ b/dsl-dynamic-stop-loss/scripts/dsl-v5.py
@@ -551,6 +551,19 @@ def apply_tier_upgrades(
             tier_floor = new_floor
             state["tierFloorPrice"] = tier_floor
 
+    # Recalculate floor for CURRENT tier using latest HW (lockPct as % of range) — per-tick trailing.
+    # In pct_of_high_water mode when tier uses lockPct (not lockHwPct), floor must move every tick.
+    if tier_idx >= 0 and tier_idx < len(tiers) and lock_mode == "pct_of_high_water" and "lockHwPct" not in tiers[tier_idx]:
+        tier = tiers[tier_idx]
+        lock_pct = tier.get("lockPct", 0)
+        if is_long:
+            new_floor = round(entry + (hw - entry) * lock_pct / 100, 4)
+            tier_floor = max(new_floor, float(state.get("tierFloorPrice", 0)))
+        else:
+            new_floor = round(entry - (entry - hw) * lock_pct / 100, 4)
+            tier_floor = min(new_floor, float(state.get("tierFloorPrice", float("inf"))))
+        state["tierFloorPrice"] = tier_floor
+
     return tier_idx, tier_floor, tier_changed, previous_tier_idx
 
 

--- a/fox/skills/dsl-dynamic-stop-loss/scripts/dsl-v5.py
+++ b/fox/skills/dsl-dynamic-stop-loss/scripts/dsl-v5.py
@@ -406,6 +406,18 @@ def apply_tier_upgrades(
                 state["currentBreachCount"] = 0
                 phase = 2
 
+    # Recalculate floor for CURRENT tier using latest HW (per-tick trailing).
+    # Floor = lockPct % of (entry→hw) range; must update whenever HW advances.
+    if tier_idx >= 0 and tier_idx < len(tiers):
+        tier = tiers[tier_idx]
+        if is_long:
+            new_floor = round(entry + (hw - entry) * tier.get("lockPct", 0) / 100, 4)
+            tier_floor = max(new_floor, float(state.get("tierFloorPrice", 0)))
+        else:
+            new_floor = round(entry - (entry - hw) * tier.get("lockPct", 0) / 100, 4)
+            tier_floor = min(new_floor, float(state.get("tierFloorPrice", float("inf"))))
+        state["tierFloorPrice"] = tier_floor
+
     return tier_idx, tier_floor, tier_changed, previous_tier_idx
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes stop-loss floor calculation in `apply_tier_upgrades`, which directly affects when positions may close and what SL price is synced. Risk is moderate because it alters core trading/exit behavior but is localized to tier-floor recomputation logic.
> 
> **Overview**
> Ensures the tier floor *trails per tick* by recalculating the current tier’s `tierFloorPrice` from the latest high-water price, rather than only updating on tier transitions.
> 
> In `pct_of_high_water` mode, this adds/adjusts logic so tiers that rely on `lockPct` (not `lockHwPct`) also advance their floor as high-water moves, while still ratcheting to never regress.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 216e14b8aa1398479bc7d0ef6db1678487936eec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->