### PR TITLE
excluding state details from AI response

### DIFF
--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -44,7 +44,20 @@ use the default value from the table above.
 
 ## Agent Behavior
 
-Do not narrate or explain tool calls. Execute silently and only present final results to the user.
+**CRITICAL: Every word you output goes directly to the user.** There is no internal channel. Execute all steps silently — no narration, no status updates, no reasoning. The ONLY text you may produce is the final welcome message in Step 2.
+
+**Between every tool call: zero text output. Not a single word.**
+
+**Forbidden — never write any of these:**
+- "State is empty / not READY / FRESH / ONBOARDING...", "State is ...", anything about internal state
+- "Let me...", "Now let me...", "Let me check...", "Let me fetch...", "Let me read..."
+- "Token is set...", "Skipping Step 1...", "Proceeding to Step...", "Per BOOTSTRAP.md..."
+- "Now I have...", "I already have...", "I now have..."
+- "Good, ...", "Great, ...", "OK, ...", "Alright, ..."
+- Any mention of internal steps, file paths, state values, tool names, or what comes next
+- Any observation about what a tool returned, what was found, or what wasn't found
+
+If you find yourself about to write anything — stop. Execute the next step silently instead.
 
 ---
 

--- a/senpi-onboard/references/post-onboarding.md
+++ b/senpi-onboard/references/post-onboarding.md
@@ -1,3 +1,4 @@
+<!-- Used by senpi-entrypoint Step 2 (Welcome). Keep in sync with senpi-entrypoint/references/post-onboarding.md when updating welcome or catalog content. -->
 # Post-Onboarding Reference
 
 ## About Senpi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that tightens response constraints for the onboarding agent; no code paths or data handling are modified.
> 
> **Overview**
> **Tightens the `senpi-entrypoint` response contract** by adding explicit, stricter rules in `SKILL.md` to prevent any narration of tool usage, internal state, step progression, or other non-user-facing metadata (only the final Step 2 welcome text may be emitted).
> 
> Adds a short header comment to `senpi-onboard/references/post-onboarding.md` clarifying it is consumed by entrypoint Step 2 and should be kept in sync with the corresponding entrypoint reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6a30e32a615a16a36c06d41be2554a370708196. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->