### PR TITLE
fix: Arena routing hard-gate in SKILL.md for pre-context enforcement

### DIFF
--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -70,6 +70,8 @@ check in
 reuse the captured `UPDATE_OUTPUT` for all downstream response contracts.
 Do not run the same check a second time in the same invocation.
 
+**Arena intent hard-gate:** If the user's message contains "arena", "agents arena", "competition", "prize pool", "qualify", "qualification", "weekly cycle", or "weekly competition" — call `read_senpi_guide(uri="senpi://guides/arena")` before composing any answer. Do not use web search or leaderboard data for Arena questions. Full routing rules in [references/post-onboarding.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-entrypoint/references/post-onboarding.md).
+
 ---
 
 ## Initial check: Skip only Step 1 if already authenticated

--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -27,6 +27,8 @@ Onboard an AI agent into the Senpi trading platform. After this flow the agent w
 - `SENPI_MCP_ENDPOINT`: `https://mcp.prod.senpi.ai` (use this if `{{SENPI_MCP_ENDPOINT}}` is a literal unsubstituted placeholder)
 - `REFERRAL_CODE`: empty/optional (use this if `{{REFERRAL_CODE}}` is a literal unsubstituted placeholder)
 
+**Arena intent hard-gate:** If the user's message contains "arena", "agents arena", "competition", "prize pool", "qualify", "qualification", "weekly cycle", or "weekly competition" — call `read_senpi_guide(uri="senpi://guides/arena")` before composing any answer. Do not use web search or leaderboard data for Arena questions. Full routing rules in [references/post-onboarding.md](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/senpi-onboard/references/post-onboarding.md).
+
 ---
 
 ## Onboarding Flow


### PR DESCRIPTION
## Summary

- Fixes bug: Arena/prize queries not routing to `senpi://guides/arena` on first attempt
- Root cause: routing rule only lived in `post-onboarding.md`, which is loaded at Step 2 — queries asked before that file enters context (or in a fresh session) had no rule to enforce, falling back to web/leaderboard data
- Adds a single-line `**Arena intent hard-gate:**` to both `SKILL.md` files so it fires from the very first invocation, regardless of session state

## Files changed

| File | Change |
|---|---|
| `senpi-entrypoint/SKILL.md` | Added Arena hard-gate line inside `Pre-Response Check` section |
| `senpi-onboard/SKILL.md` | Added Arena hard-gate line inside `Defaults` section |

## Routing rule added

> **Arena intent hard-gate:** If the user's message contains "arena", "agents arena", "competition", "prize pool", "qualify", "qualification", "weekly cycle", or "weekly competition" — call `read_senpi_guide(uri="senpi://guides/arena")` before composing any answer. Full routing rules in `references/post-onboarding.md`.

## Design note

Kept the gate minimal (one line, inline with existing sections) to honour the token-efficiency constraint from the previous refactor. The full routing rules remain in `post-onboarding.md`; `SKILL.md` carries only the hard stop needed to block wrong data surfaces from being used first.

## Test plan

- [ ] Fresh session: ask "what is agents arena?" → agent calls `read_senpi_guide(senpi://guides/arena)` before answering
- [ ] Mid-onboarding (before Step 2): ask "tell me about the prize pool" → same routing enforced
- [ ] Ask "how do I qualify?" → `read_senpi_guide` called, no web/leaderboard fallback
- [ ] Normal onboarding (no Arena question) → no regression, no extra tokens consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/routing-instruction change that only affects how Arena-related user queries are handled, adding a deterministic guide lookup before answering.
> 
> **Overview**
> Ensures Arena/competition-related questions are **hard-routed** to `read_senpi_guide(uri="senpi://guides/arena")` *before any answer is composed*, even in fresh sessions.
> 
> This adds the same "Arena intent hard-gate" trigger line to both `senpi-entrypoint/SKILL.md` (in the pre-response check) and `senpi-onboard/SKILL.md` (in defaults), and explicitly forbids using web/leaderboard data for those queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d1b25c66c06191e6291fc98ef5d998a8d2d0f92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->