### PR TITLE
onboarding: handle single-result leaderboard fallbacks

### DIFF
--- a/senpi-entrypoint/references/post-onboarding.md
+++ b/senpi-entrypoint/references/post-onboarding.md
@@ -167,26 +167,35 @@ This covers all known cases: slugs that match directly (e.g. `fox`, `viper`, `co
 
 ### If user says "Set me up" or "skip tutorial"
 
-Fetch the top 2 strategies by ROE and ask the user to choose, then deploy the chosen one — go through the full setup end to end without stopping:
+Fetch leaderboard strategies by ROE, handle 2/1/0 results correctly, and deploy end to end without stopping:
 
-1. Fetch the leaderboard sorted by ROE to identify the top 2 strategies:
+1. Fetch the leaderboard sorted by ROE (limit 2):
    ```bash
    curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server \
      -H "Content-Type: application/json" \
      -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_leaderboard","arguments":{"sort_by":"roe","limit":2}}}'
    ```
-   Extract both strategies' `slug` and `name`. Label them `TOP1` (rank 1) and `TOP2` (rank 2).
+   Parse results with these branches:
+   - **2 results:** label them `TOP1` (rank 1) and `TOP2` (rank 2).
+   - **1 result:** label it `TOP1` only.
+   - **0 results or fetch failure:** set `CHOSEN_SKILL=fox` and continue (do not block setup).
 
-2. If the user has not already indicated which strategy they want, present a choice:
-   ```
-   Which strategy would you like to deploy?
+2. If `CHOSEN_SKILL` is not already set:
+   - If the user has already indicated a strategy, map their choice to the corresponding slug and set `CHOSEN_SKILL`.
+   - If there are **2 results** and the user has not indicated a strategy, present:
+     ```
+     Which strategy would you like to deploy?
 
-   1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
-   2️⃣ {TOP2_NAME} (+{TOP2_ROE}% ROE)
+     1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
+     2️⃣ {TOP2_NAME} (+{TOP2_ROE}% ROE)
 
-   Reply with 1, 2, or the strategy name.
-   ```
-   Wait for the user's response, then set `CHOSEN_SKILL` to the slug of their selection.
+     Reply with 1, 2, or the strategy name.
+     ```
+     Wait for the user's response, then set `CHOSEN_SKILL` to the slug of their selection.
+   - If there is **1 result** and the user has not indicated a strategy, set `CHOSEN_SKILL` to `TOP1`'s slug and inform them:
+     ```
+     I found one top strategy right now: {TOP1_NAME} (+{TOP1_ROE}% ROE). I'll deploy it now.
+     ```
 
 3. Install using the slug resolution convention above:
    ```bash
@@ -196,7 +205,7 @@ Fetch the top 2 strategies by ROE and ask the user to choose, then deploy the ch
 4. Read the installed SKILL.md and run the full bootstrap — create the strategy wallet, fund it, run setup, create all crons. Do not stop to ask for permission between steps. If a step requires user input (e.g. budget amount), ask once and proceed.
 5. Confirm when live: "{name} is deployed and scanning. You'll get Telegram alerts when positions open or close. It runs 24/7 — you don't need to do anything.\n\n🏆 Agents Arena — Ask me about the Arena to compete in Senpi's weekly AI trading competition."
 
-**If the leaderboard fetch fails**, default to installing `fox-strategy` (historically the top performer) and proceed. Do not block setup on a failed leaderboard call.
+**If the leaderboard fetch fails or returns 0 rows**, default to installing `fox-strategy` (historically the top performer) and proceed. Do not block setup on leaderboard issues.
 
 ### Budget-Based Recommendations
 

--- a/senpi-entrypoint/references/post-onboarding.md
+++ b/senpi-entrypoint/references/post-onboarding.md
@@ -47,9 +47,14 @@ curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_strategies","arguments":{}}}'
 ```
 
-Join on `slug` to get the top 2 strategies' `name`, `emoji`, `roe`, and `slug`. Label them `TOP1` (rank 1) and `TOP2` (rank 2). If either fetch fails, omit the names/ROE and fall back to the generic wording.
+Join on `slug` to get the top strategies' `name`, `emoji`, `roe`, and `slug`.
 
-Render the template substituting `{TOP1_NAME}`, `{TOP1_ROE}`, `{TOP2_NAME}`, and `{TOP2_ROE}`:
+Handle leaderboard result count explicitly:
+- **2 results:** label them `TOP1` (rank 1) and `TOP2` (rank 2), then render the 2-option template.
+- **1 result:** label it `TOP1` and render the 1-option template (do not reference `TOP2` placeholders).
+- **0 results or either fetch fails:** omit names/ROE and use the generic fallback wording.
+
+Render the 2-option template substituting `{TOP1_NAME}`, `{TOP1_ROE}`, `{TOP2_NAME}`, and `{TOP2_ROE}`:
 
 ```
 Welcome to Senpi! You're set up on Hyperliquid.
@@ -69,7 +74,15 @@ All strategies are open source and tracked live at strategies.senpi.ai
 🏆 Agents Arena — Ask me about the Arena to learn about Senpi's weekly AI trading competition.
 ```
 
-Fallback if leaderboard unavailable:
+Render this 1-option template when only one leaderboard result is available:
+```
+🟡 "Set me up" — Deploy our current top performer and start trading in under a minute:
+   1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
+
+🏆 Agents Arena — Ask me about the Arena to learn about Senpi's weekly AI trading competition.
+```
+
+Fallback if leaderboard unavailable or empty:
 ```
 🟡 "Set me up" — I'll deploy our current top-performing strategy and get you trading in under a minute.
 

--- a/senpi-entrypoint/references/post-onboarding.md
+++ b/senpi-entrypoint/references/post-onboarding.md
@@ -33,13 +33,13 @@ Send ONLY this message. Do NOT render the strategy catalog here — wait for the
 
 **Do not include balance or funding status here.** Balance is fetched in Step 2.5 (after this message); Step 2.5 will surface either a balance summary (if funded) or the funding reminder (if &lt; $100).
 
-**Before rendering this message**, fetch the top strategy so the "Set me up" line can name it. Run both calls in parallel:
+**Before rendering this message**, fetch the top 2 strategies so the "Set me up" line can name them. Run both calls in parallel:
 
 ```bash
-# Leaderboard — top 1 by ROE
+# Leaderboard — top 2 by ROE
 curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_leaderboard","arguments":{"sort_by":"roe","limit":1}}}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_leaderboard","arguments":{"sort_by":"roe","limit":2}}}'
 
 # Strategy metadata
 curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server \
@@ -47,9 +47,9 @@ curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_strategies","arguments":{}}}'
 ```
 
-Join on `slug` to get the top strategy's `name`, `emoji`, `roe`, and `slug`. If either fetch fails, omit the name/ROE and fall back to the generic wording.
+Join on `slug` to get the top 2 strategies' `name`, `emoji`, `roe`, and `slug`. Label them `TOP1` (rank 1) and `TOP2` (rank 2). If either fetch fails, omit the names/ROE and fall back to the generic wording.
 
-Render the template substituting `{TOP_NAME}` and `{TOP_ROE}`:
+Render the template substituting `{TOP1_NAME}`, `{TOP1_ROE}`, `{TOP2_NAME}`, and `{TOP2_ROE}`:
 
 ```
 Welcome to Senpi! You're set up on Hyperliquid.
@@ -60,7 +60,9 @@ To get started:
 
 🟢 "I'm new" — I'll walk you through your first trade.
 🔵 "Show me the strategies" — Full catalog of AI trading strategies I can deploy.
-🟡 "Set me up" — I'll deploy {TOP_NAME} (+{TOP_ROE}% ROE), our current top performer, and get you trading in under a minute.
+🟡 "Set me up" — Deploy one of our top 2 performers and start trading in under a minute:
+   1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
+   2️⃣ {TOP2_NAME} (+{TOP2_ROE}% ROE)
 
 All strategies are open source and tracked live at strategies.senpi.ai
 
@@ -152,23 +154,34 @@ This covers all known cases: slugs that match directly (e.g. `fox`, `viper`, `co
 
 ### If user says "Set me up" or "skip tutorial"
 
-Fetch the leaderboard to identify the current top-performing strategy, then deploy it immediately — go through the full setup end to end without stopping:
+Fetch the top 2 strategies by ROE and ask the user to choose, then deploy the chosen one — go through the full setup end to end without stopping:
 
-1. Fetch the leaderboard sorted by ROE to identify the #1 strategy:
+1. Fetch the leaderboard sorted by ROE to identify the top 2 strategies:
    ```bash
    curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server \
      -H "Content-Type: application/json" \
-     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_leaderboard","arguments":{"sort_by":"roe","limit":1}}}'
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_leaderboard","arguments":{"sort_by":"roe","limit":2}}}'
    ```
-   Extract the top strategy's `slug` and `name`. Call the slug `TOP_SKILL`.
+   Extract both strategies' `slug` and `name`. Label them `TOP1` (rank 1) and `TOP2` (rank 2).
 
-2. Install using the slug resolution convention above:
-   ```bash
-   npx skills add https://github.com/Senpi-ai/senpi-skills --skill "${TOP_SKILL}" -g -y 2>/dev/null || \
-   npx skills add https://github.com/Senpi-ai/senpi-skills --skill "${TOP_SKILL}-strategy" -g -y
+2. If the user has not already indicated which strategy they want, present a choice:
    ```
-3. Read the installed SKILL.md and run the full bootstrap — create the strategy wallet, fund it, run setup, create all crons. Do not stop to ask for permission between steps. If a step requires user input (e.g. budget amount), ask once and proceed.
-4. Confirm when live: "{name} is deployed and scanning. You'll get Telegram alerts when positions open or close. It runs 24/7 — you don't need to do anything.\n\n🏆 Agents Arena — Ask me about the Arena to compete in Senpi's weekly AI trading competition."
+   Which strategy would you like to deploy?
+
+   1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
+   2️⃣ {TOP2_NAME} (+{TOP2_ROE}% ROE)
+
+   Reply with 1, 2, or the strategy name.
+   ```
+   Wait for the user's response, then set `CHOSEN_SKILL` to the slug of their selection.
+
+3. Install using the slug resolution convention above:
+   ```bash
+   npx skills add https://github.com/Senpi-ai/senpi-skills --skill "${CHOSEN_SKILL}" -g -y 2>/dev/null || \
+   npx skills add https://github.com/Senpi-ai/senpi-skills --skill "${CHOSEN_SKILL}-strategy" -g -y
+   ```
+4. Read the installed SKILL.md and run the full bootstrap — create the strategy wallet, fund it, run setup, create all crons. Do not stop to ask for permission between steps. If a step requires user input (e.g. budget amount), ask once and proceed.
+5. Confirm when live: "{name} is deployed and scanning. You'll get Telegram alerts when positions open or close. It runs 24/7 — you don't need to do anything.\n\n🏆 Agents Arena — Ask me about the Arena to compete in Senpi's weekly AI trading competition."
 
 **If the leaderboard fetch fails**, default to installing `fox-strategy` (historically the top performer) and proceed. Do not block setup on a failed leaderboard call.
 
@@ -193,7 +206,7 @@ Always lead with the current #1 by ROE from the leaderboard as the primary recom
 
 **DO NOT explain crons, mcporter, DSL internals, or implementation details** unless the user asks. They deployed a trading agent — show them trading strategies, not plumbing.
 
-**DO lead with the current #1 strategy by ROE** from `get_leaderboard` as the default recommendation. Always fetch fresh leaderboard data rather than assuming a fixed strategy is on top.
+**DO lead with the current top 2 strategies by ROE** from `get_leaderboard` as the default recommendation. Present both so the user makes an active choice. Always fetch fresh leaderboard data rather than assuming a fixed strategy is on top.
 
 ---
 

--- a/senpi-onboard/references/post-onboarding.md
+++ b/senpi-onboard/references/post-onboarding.md
@@ -166,26 +166,35 @@ This covers all known cases: slugs that match directly (e.g. `fox`, `viper`, `co
 
 ### If user says "Set me up" or "skip tutorial"
 
-Fetch the top 2 strategies by ROE and ask the user to choose, then deploy the chosen one — go through the full setup end to end without stopping:
+Fetch leaderboard strategies by ROE, handle 2/1/0 results correctly, and deploy end to end without stopping:
 
-1. Fetch the leaderboard sorted by ROE to identify the top 2 strategies:
+1. Fetch the leaderboard sorted by ROE (limit 2):
    ```bash
    curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server \
      -H "Content-Type: application/json" \
      -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_leaderboard","arguments":{"sort_by":"roe","limit":2}}}'
    ```
-   Extract both strategies' `slug` and `name`. Label them `TOP1` (rank 1) and `TOP2` (rank 2).
+   Parse results with these branches:
+   - **2 results:** label them `TOP1` (rank 1) and `TOP2` (rank 2).
+   - **1 result:** label it `TOP1` only.
+   - **0 results or fetch failure:** set `CHOSEN_SKILL=fox` and continue (do not block setup).
 
-2. If the user has not already indicated which strategy they want, present a choice:
-   ```
-   Which strategy would you like to deploy?
+2. If `CHOSEN_SKILL` is not already set:
+   - If the user has already indicated a strategy, map their choice to the corresponding slug and set `CHOSEN_SKILL`.
+   - If there are **2 results** and the user has not indicated a strategy, present:
+     ```
+     Which strategy would you like to deploy?
 
-   1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
-   2️⃣ {TOP2_NAME} (+{TOP2_ROE}% ROE)
+     1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
+     2️⃣ {TOP2_NAME} (+{TOP2_ROE}% ROE)
 
-   Reply with 1, 2, or the strategy name.
-   ```
-   Wait for the user's response, then set `CHOSEN_SKILL` to the slug of their selection.
+     Reply with 1, 2, or the strategy name.
+     ```
+     Wait for the user's response, then set `CHOSEN_SKILL` to the slug of their selection.
+   - If there is **1 result** and the user has not indicated a strategy, set `CHOSEN_SKILL` to `TOP1`'s slug and inform them:
+     ```
+     I found one top strategy right now: {TOP1_NAME} (+{TOP1_ROE}% ROE). I'll deploy it now.
+     ```
 
 3. Install using the slug resolution convention above:
    ```bash
@@ -195,7 +204,7 @@ Fetch the top 2 strategies by ROE and ask the user to choose, then deploy the ch
 4. Read the installed SKILL.md and run the full bootstrap — create the strategy wallet, fund it, run setup, create all crons. Do not stop to ask for permission between steps. If a step requires user input (e.g. budget amount), ask once and proceed.
 5. Confirm when live: "{name} is deployed and scanning. You'll get Telegram alerts when positions open or close. It runs 24/7 — you don't need to do anything.\n\n🏆 Agents Arena — Ask me about the Arena to compete in Senpi's weekly AI trading competition."
 
-**If the leaderboard fetch fails**, default to installing `fox-strategy` (historically the top performer) and proceed. Do not block setup on a failed leaderboard call.
+**If the leaderboard fetch fails or returns 0 rows**, default to installing `fox-strategy` (historically the top performer) and proceed. Do not block setup on leaderboard issues.
 
 ### Budget-Based Recommendations
 

--- a/senpi-onboard/references/post-onboarding.md
+++ b/senpi-onboard/references/post-onboarding.md
@@ -46,9 +46,14 @@ curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_strategies","arguments":{}}}'
 ```
 
-Join on `slug` to get the top 2 strategies' `name`, `emoji`, `roe`, and `slug`. Label them `TOP1` (rank 1) and `TOP2` (rank 2). If either fetch fails, omit the names/ROE and fall back to the generic wording.
+Join on `slug` to get the top strategies' `name`, `emoji`, `roe`, and `slug`.
 
-Render the template substituting `{TOP1_NAME}`, `{TOP1_ROE}`, `{TOP2_NAME}`, and `{TOP2_ROE}`:
+Handle leaderboard result count explicitly:
+- **2 results:** label them `TOP1` (rank 1) and `TOP2` (rank 2), then render the 2-option template.
+- **1 result:** label it `TOP1` and render the 1-option template (do not reference `TOP2` placeholders).
+- **0 results or either fetch fails:** omit names/ROE and use the generic fallback wording.
+
+Render the 2-option template substituting `{TOP1_NAME}`, `{TOP1_ROE}`, `{TOP2_NAME}`, and `{TOP2_ROE}`:
 
 ```
 Welcome to Senpi! You're set up on Hyperliquid.
@@ -68,7 +73,15 @@ All strategies are open source and tracked live at strategies.senpi.ai
 🏆 Agents Arena — Ask me about the Arena to learn about Senpi's weekly AI trading competition.
 ```
 
-Fallback if leaderboard unavailable:
+Render this 1-option template when only one leaderboard result is available:
+```
+🟡 "Set me up" — Deploy our current top performer and start trading in under a minute:
+   1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
+
+🏆 Agents Arena — Ask me about the Arena to learn about Senpi's weekly AI trading competition.
+```
+
+Fallback if leaderboard unavailable or empty:
 ```
 🟡 "Set me up" — I'll deploy our current top-performing strategy and get you trading in under a minute.
 

--- a/senpi-onboard/references/post-onboarding.md
+++ b/senpi-onboard/references/post-onboarding.md
@@ -32,13 +32,13 @@ Send ONLY this message. Do NOT render the strategy catalog here — wait for the
 
 **Do not include balance or funding status here.** Balance is fetched in Step 2.5 (after this message); Step 2.5 will surface either a balance summary (if funded) or the funding reminder (if &lt; $100).
 
-**Before rendering this message**, fetch the top strategy so the "Set me up" line can name it. Run both calls in parallel:
+**Before rendering this message**, fetch the top 2 strategies so the "Set me up" line can name them. Run both calls in parallel:
 
 ```bash
-# Leaderboard — top 1 by ROE
+# Leaderboard — top 2 by ROE
 curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_leaderboard","arguments":{"sort_by":"roe","limit":1}}}'
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_leaderboard","arguments":{"sort_by":"roe","limit":2}}}'
 
 # Strategy metadata
 curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server \
@@ -46,9 +46,9 @@ curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_strategies","arguments":{}}}'
 ```
 
-Join on `slug` to get the top strategy's `name`, `emoji`, `roe`, and `slug`. If either fetch fails, omit the name/ROE and fall back to the generic wording.
+Join on `slug` to get the top 2 strategies' `name`, `emoji`, `roe`, and `slug`. Label them `TOP1` (rank 1) and `TOP2` (rank 2). If either fetch fails, omit the names/ROE and fall back to the generic wording.
 
-Render the template substituting `{TOP_NAME}` and `{TOP_ROE}`:
+Render the template substituting `{TOP1_NAME}`, `{TOP1_ROE}`, `{TOP2_NAME}`, and `{TOP2_ROE}`:
 
 ```
 Welcome to Senpi! You're set up on Hyperliquid.
@@ -59,7 +59,9 @@ To get started:
 
 🟢 "I'm new" — I'll walk you through your first trade.
 🔵 "Show me the strategies" — Full catalog of AI trading strategies I can deploy.
-🟡 "Set me up" — I'll deploy {TOP_NAME} (+{TOP_ROE}% ROE), our current top performer, and get you trading in under a minute.
+🟡 "Set me up" — Deploy one of our top 2 performers and start trading in under a minute:
+   1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
+   2️⃣ {TOP2_NAME} (+{TOP2_ROE}% ROE)
 
 All strategies are open source and tracked live at strategies.senpi.ai
 
@@ -151,23 +153,34 @@ This covers all known cases: slugs that match directly (e.g. `fox`, `viper`, `co
 
 ### If user says "Set me up" or "skip tutorial"
 
-Fetch the leaderboard to identify the current top-performing strategy, then deploy it immediately — go through the full setup end to end without stopping:
+Fetch the top 2 strategies by ROE and ask the user to choose, then deploy the chosen one — go through the full setup end to end without stopping:
 
-1. Fetch the leaderboard sorted by ROE to identify the #1 strategy:
+1. Fetch the leaderboard sorted by ROE to identify the top 2 strategies:
    ```bash
    curl -s -X POST https://ypofdvbavcdgseguddey.supabase.co/functions/v1/mcp-server \
      -H "Content-Type: application/json" \
-     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_leaderboard","arguments":{"sort_by":"roe","limit":1}}}'
+     -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_leaderboard","arguments":{"sort_by":"roe","limit":2}}}'
    ```
-   Extract the top strategy's `slug` and `name`. Call the slug `TOP_SKILL`.
+   Extract both strategies' `slug` and `name`. Label them `TOP1` (rank 1) and `TOP2` (rank 2).
 
-2. Install using the slug resolution convention above:
-   ```bash
-   npx skills add https://github.com/Senpi-ai/senpi-skills --skill "${TOP_SKILL}" -g -y 2>/dev/null || \
-   npx skills add https://github.com/Senpi-ai/senpi-skills --skill "${TOP_SKILL}-strategy" -g -y
+2. If the user has not already indicated which strategy they want, present a choice:
    ```
-3. Read the installed SKILL.md and run the full bootstrap — create the strategy wallet, fund it, run setup, create all crons. Do not stop to ask for permission between steps. If a step requires user input (e.g. budget amount), ask once and proceed.
-4. Confirm when live: "{name} is deployed and scanning. You'll get Telegram alerts when positions open or close. It runs 24/7 — you don't need to do anything.\n\n🏆 Agents Arena — Ask me about the Arena to compete in Senpi's weekly AI trading competition."
+   Which strategy would you like to deploy?
+
+   1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
+   2️⃣ {TOP2_NAME} (+{TOP2_ROE}% ROE)
+
+   Reply with 1, 2, or the strategy name.
+   ```
+   Wait for the user's response, then set `CHOSEN_SKILL` to the slug of their selection.
+
+3. Install using the slug resolution convention above:
+   ```bash
+   npx skills add https://github.com/Senpi-ai/senpi-skills --skill "${CHOSEN_SKILL}" -g -y 2>/dev/null || \
+   npx skills add https://github.com/Senpi-ai/senpi-skills --skill "${CHOSEN_SKILL}-strategy" -g -y
+   ```
+4. Read the installed SKILL.md and run the full bootstrap — create the strategy wallet, fund it, run setup, create all crons. Do not stop to ask for permission between steps. If a step requires user input (e.g. budget amount), ask once and proceed.
+5. Confirm when live: "{name} is deployed and scanning. You'll get Telegram alerts when positions open or close. It runs 24/7 — you don't need to do anything.\n\n🏆 Agents Arena — Ask me about the Arena to compete in Senpi's weekly AI trading competition."
 
 **If the leaderboard fetch fails**, default to installing `fox-strategy` (historically the top performer) and proceed. Do not block setup on a failed leaderboard call.
 
@@ -192,7 +205,7 @@ Always lead with the current #1 by ROE from the leaderboard as the primary recom
 
 **DO NOT explain crons, mcporter, DSL internals, or implementation details** unless the user asks. They deployed a trading agent — show them trading strategies, not plumbing.
 
-**DO lead with the current #1 strategy by ROE** from `get_leaderboard` as the default recommendation. Always fetch fresh leaderboard data rather than assuming a fixed strategy is on top.
+**DO lead with the current top 2 strategies by ROE** from `get_leaderboard` as the default recommendation. Present both so the user makes an active choice. Always fetch fresh leaderboard data rather than assuming a fixed strategy is on top.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keeps post-onboarding references in `senpi-entrypoint` and `senpi-onboard` in sync
- preserves explicit leaderboard cardinality handling in welcome messaging (2/1/0)
- fixes the "Set me up" deployment flow to explicitly branch on 2/1/0 results
  - **2 results:** show both numbered choices and wait for selection
  - **1 result:** set `CHOSEN_SKILL` from `TOP1` and use a single-strategy message (no `TOP2` placeholders)
  - **0 results/fetch failure:** set `CHOSEN_SKILL=fox` and continue setup
- updates fallback wording to cover both fetch failures and empty result sets

## Why
`get_leaderboard(limit=2)` can return exactly one row. The prior deployment instructions still required `TOP2` placeholders, creating a broken prompt path.

## Scope
Docs-only update in:
- `senpi-entrypoint/references/post-onboarding.md`
- `senpi-onboard/references/post-onboarding.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1472f401-dfed-4d16-a02e-3feb9ec7969f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1472f401-dfed-4d16-a02e-3feb9ec7969f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/reference update that changes onboarding copy and the recommended "Set me up" procedure to require a user choice; no runtime code changes.
> 
> **Overview**
> Updates the post-onboarding reference docs in both `senpi-entrypoint` and `senpi-onboard` to **recommend the top 2 strategies by ROE** instead of auto-highlighting a single #1.
> 
> The welcome message and "Set me up" flow now fetch `get_leaderboard(limit=2)`, handle 0/1/2-result cases, present a **numbered 1/2 choice**, and deploy the user-selected strategy (with the existing slug/`-strategy` install fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56928e41b0f6cdfa82adc5d6416da42f274c695c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->