### PR TITLE
fix: use numeric Telegram user ID as subject in Privy account creation

### DIFF
--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -109,11 +109,11 @@ Set `MCPORTER_AVAILABLE=true` once installed and proceed.
 
 ### Step 1: Collect Identity
 
-Ask the user which identity type to use. Try each option in order:
+Present all three options to the user and wait for them to choose:
 
-1. **Option A -- Telegram user ID** (preferred): Read from `${OPENCLAW_WORKSPACE_DIR}/USER.md` if available, otherwise ask the user.
+1. **Option A -- Telegram user ID**: The skill will read your Telegram identity from USER.md automatically.
 2. **Option B -- User-provided wallet**: Must be `0x`-prefixed, exactly 42 hex characters. Validate before proceeding.
-3. **Option C -- Agent-generated wallet** (fallback when user has neither).
+3. **Option C -- Agent-generated wallet** (only if you have neither).
 
 #### Option A: Collect Telegram user ID
 

--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -111,28 +111,27 @@ Set `MCPORTER_AVAILABLE=true` once installed and proceed.
 
 Ask the user which identity type to use. Try each option in order:
 
-1. **Option A -- Telegram** (preferred): Collect the username and numeric user ID separately (see below).
+1. **Option A -- Telegram user ID** (preferred): Ask for the numeric Telegram user ID (see below).
 2. **Option B -- User-provided wallet**: Must be `0x`-prefixed, exactly 42 hex characters. Validate before proceeding.
 3. **Option C -- Agent-generated wallet** (fallback when user has neither).
 
-#### Option A: Collect Telegram identity
+#### Option A: Collect Telegram user ID
 
-Ask the user for their Telegram username. Strip the `@` prefix if present:
+When the user chooses Telegram, present these instructions before asking for input:
 
-```bash
-TELEGRAM_USERNAME="username"  # without @, used for display
-```
-
-Then ask for their **numeric Telegram user ID**. Explain that this is a number, not their username:
-
-> "I also need your **numeric Telegram user ID** (e.g. `8362644815`). This is different from your username. To find it, open Telegram and message [@userinfobot](https://t.me/userinfobot) — it will instantly reply with your numeric ID."
+> **To find your Telegram user ID:**
+> 1. Open Telegram and search for **@userinfobot**
+> 2. Start a chat and send any message (e.g. `/start`)
+> 3. It will reply instantly with your numeric user ID (e.g. `8362644815`)
+>
+> Please enter your numeric Telegram user ID:
 
 ```bash
 IDENTITY_TYPE="TELEGRAM"
 IDENTITY_VALUE="8362644815"  # numeric Telegram user ID (digits only)
 ```
 
-Validate that `IDENTITY_VALUE` contains only digits. If it contains any non-digit characters (letters, `@`, etc.), reject it and re-prompt with the same @userinfobot instructions.
+Validate that `IDENTITY_VALUE` contains only digits. If it contains any non-digit characters (letters, `@`, spaces, etc.), reject it and re-prompt with the same instructions above.
 
 #### Option B: Set variables
 
@@ -201,7 +200,6 @@ Notify the user that a wallet was generated and saved to `~/.config/senpi/wallet
 Before Step 2, confirm these are set:
 - `IDENTITY_TYPE` -- `"WALLET"` or `"TELEGRAM"`
 - `IDENTITY_VALUE` -- wallet address (with `0x`) or Telegram numeric user ID (digits only)
-- `TELEGRAM_USERNAME` -- Telegram username without `@` (only set when `IDENTITY_TYPE` is `TELEGRAM`)
 - `WALLET_GENERATED` -- `true` if Option C was used, unset otherwise
 
 **Persist progress for resume:** Update `~/.config/senpi/state.json`: set `onboarding.step` to `REFERRAL`, and if available set `onboarding.identityType`, `onboarding.subject`, `onboarding.walletGenerated` from current variables. Use read-modify-write so other fields are preserved.
@@ -233,7 +231,7 @@ RESPONSE=$(curl -s -X POST https://moxie-backend.prod.senpi.ai/graphql \
       "input": {
         "from": "'"${IDENTITY_TYPE}"'",
         "subject": "'"${IDENTITY_VALUE}"'",
-        '"$([ "$IDENTITY_TYPE" = "TELEGRAM" ] && echo "\"userName\": \"${TELEGRAM_USERNAME}\",")"'
+        '"$([ "$IDENTITY_TYPE" = "TELEGRAM" ] && echo "\"userName\": \"${IDENTITY_VALUE}\",")"'
         "referralCode": "'"${REFERRAL_CODE}"'",
         "apiKeyName": "agent-'"$(date +%s)"'"
       }
@@ -241,7 +239,7 @@ RESPONSE=$(curl -s -X POST https://moxie-backend.prod.senpi.ai/graphql \
   }')
 ```
 
-**Note for TELEGRAM identity:** Include the additional `"userName"` field set to `TELEGRAM_USERNAME` (the display username) in the input. `subject` must be set to `IDENTITY_VALUE` (the numeric user ID).
+**Note for TELEGRAM identity:** Include the additional `"userName"` field set to `IDENTITY_VALUE` (the numeric user ID) in the input.
 
 **Persist progress for resume:** Update `~/.config/senpi/state.json`: set `onboarding.step` to `PARSE`. Use read-modify-write.
 

--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -204,6 +204,7 @@ Before Step 2, confirm these are set:
 - `IDENTITY_TYPE` -- `"WALLET"` or `"TELEGRAM"`
 - `IDENTITY_VALUE` -- wallet address (with `0x`) or Telegram numeric user ID (digits only)
 - `WALLET_GENERATED` -- `true` if Option C was used, unset otherwise
+- `TELEGRAM_USERNAME` -- required and non-empty when `IDENTITY_TYPE="TELEGRAM"` (unset otherwise)
 
 **Persist progress for resume:** Update `~/.config/senpi/state.json`: set `onboarding.step` to `REFERRAL`, and if available set `onboarding.identityType`, `onboarding.subject`, `onboarding.walletGenerated` from current variables. Use read-modify-write so other fields are preserved.
 
@@ -226,6 +227,11 @@ If empty and user hasn't provided one, that's fine -- it's optional. Do not prom
 Execute the `CreateAgentStubAccount` GraphQL mutation. This is a **public endpoint** -- no auth required.
 
 ```bash
+if [ "$IDENTITY_TYPE" = "TELEGRAM" ] && [ -z "${TELEGRAM_USERNAME:-}" ]; then
+  echo "TELEGRAM_USERNAME must be set when IDENTITY_TYPE=TELEGRAM" >&2
+  exit 1
+fi
+
 RESPONSE=$(curl -s -X POST https://moxie-backend.prod.senpi.ai/graphql \
   -H "Content-Type: application/json" \
   -d '{

--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -124,6 +124,7 @@ USER_MD="${OPENCLAW_WORKSPACE_DIR}/USER.md"
 if [ -f "$USER_MD" ]; then
   TELEGRAM_USER_ID=$(awk '/^## Telegram/{f=1; next} f && /^## /{f=0} f && /- Chat ID:/{print $NF; exit}' "$USER_MD")
   TELEGRAM_USERNAME=$(awk '/^## Telegram/{f=1; next} f && /^## /{f=0} f && /- Username:/{print $NF; exit}' "$USER_MD")
+  TELEGRAM_USERNAME="${TELEGRAM_USERNAME#@}" # normalize for API userName field
 fi
 ```
 
@@ -134,7 +135,7 @@ IDENTITY_TYPE="TELEGRAM"
 IDENTITY_VALUE="$TELEGRAM_USER_ID"
 ```
 
-If USER.md is missing or either field is absent/invalid, fall back to the manual prompt: see [references/telegram-identity.md](references/telegram-identity.md) for user-facing instructions and validation rules. Also set `TELEGRAM_USERNAME` from the user's input if prompted manually.
+If USER.md is missing or either field is absent/invalid, fall back to the manual prompt: see [references/telegram-identity.md](references/telegram-identity.md) for user-facing instructions and validation rules. Also set `TELEGRAM_USERNAME` from the user's input if prompted manually, then normalize it before API use with `TELEGRAM_USERNAME="${TELEGRAM_USERNAME#@}"`.
 
 #### Option B: Set variables
 
@@ -242,7 +243,7 @@ RESPONSE=$(curl -s -X POST https://moxie-backend.prod.senpi.ai/graphql \
   }')
 ```
 
-**Note for TELEGRAM identity:** Include the additional `"userName"` field set to `TELEGRAM_USERNAME` (the Telegram username from USER.md or user input) in the input.
+**Note for TELEGRAM identity:** Include the additional `"userName"` field set to normalized `TELEGRAM_USERNAME` (Telegram username without a leading `@`, from USER.md or user input) in the input.
 
 **Persist progress for resume:** Update `~/.config/senpi/state.json`: set `onboarding.step` to `PARSE`. Use read-modify-write.
 

--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -111,15 +111,34 @@ Set `MCPORTER_AVAILABLE=true` once installed and proceed.
 
 Ask the user which identity type to use. Try each option in order:
 
-1. **Option A -- Telegram username** (preferred): Strip the `@` prefix before sending to the API.
+1. **Option A -- Telegram** (preferred): Collect the username and numeric user ID separately (see below).
 2. **Option B -- User-provided wallet**: Must be `0x`-prefixed, exactly 42 hex characters. Validate before proceeding.
 3. **Option C -- Agent-generated wallet** (fallback when user has neither).
 
-#### Option A or B: Set variables
+#### Option A: Collect Telegram identity
+
+Ask the user for their Telegram username. Strip the `@` prefix if present:
 
 ```bash
-IDENTITY_TYPE="TELEGRAM"  # or "WALLET"
-IDENTITY_VALUE="username"  # without @ for Telegram, or 0x... for wallet
+TELEGRAM_USERNAME="username"  # without @, used for display
+```
+
+Then ask for their **numeric Telegram user ID**. Explain that this is a number, not their username:
+
+> "I also need your **numeric Telegram user ID** (e.g. `8362644815`). This is different from your username. To find it, open Telegram and message [@userinfobot](https://t.me/userinfobot) — it will instantly reply with your numeric ID."
+
+```bash
+IDENTITY_TYPE="TELEGRAM"
+IDENTITY_VALUE="8362644815"  # numeric Telegram user ID (digits only)
+```
+
+Validate that `IDENTITY_VALUE` contains only digits. If it contains any non-digit characters (letters, `@`, etc.), reject it and re-prompt with the same @userinfobot instructions.
+
+#### Option B: Set variables
+
+```bash
+IDENTITY_TYPE="WALLET"
+IDENTITY_VALUE="0x..."  # 0x-prefixed wallet address
 ```
 
 #### Option C: Generate EVM wallet
@@ -181,7 +200,8 @@ Notify the user that a wallet was generated and saved to `~/.config/senpi/wallet
 
 Before Step 2, confirm these are set:
 - `IDENTITY_TYPE` -- `"WALLET"` or `"TELEGRAM"`
-- `IDENTITY_VALUE` -- wallet address (with `0x`) or Telegram username (without `@`)
+- `IDENTITY_VALUE` -- wallet address (with `0x`) or Telegram numeric user ID (digits only)
+- `TELEGRAM_USERNAME` -- Telegram username without `@` (only set when `IDENTITY_TYPE` is `TELEGRAM`)
 - `WALLET_GENERATED` -- `true` if Option C was used, unset otherwise
 
 **Persist progress for resume:** Update `~/.config/senpi/state.json`: set `onboarding.step` to `REFERRAL`, and if available set `onboarding.identityType`, `onboarding.subject`, `onboarding.walletGenerated` from current variables. Use read-modify-write so other fields are preserved.
@@ -213,7 +233,7 @@ RESPONSE=$(curl -s -X POST https://moxie-backend.prod.senpi.ai/graphql \
       "input": {
         "from": "'"${IDENTITY_TYPE}"'",
         "subject": "'"${IDENTITY_VALUE}"'",
-        '"$([ "$IDENTITY_TYPE" = "TELEGRAM" ] && echo "\"userName\": \"${IDENTITY_VALUE}\",")"'
+        '"$([ "$IDENTITY_TYPE" = "TELEGRAM" ] && echo "\"userName\": \"${TELEGRAM_USERNAME}\",")"'
         "referralCode": "'"${REFERRAL_CODE}"'",
         "apiKeyName": "agent-'"$(date +%s)"'"
       }
@@ -221,7 +241,7 @@ RESPONSE=$(curl -s -X POST https://moxie-backend.prod.senpi.ai/graphql \
   }')
 ```
 
-**Note for TELEGRAM identity:** Include the additional `"userName"` field set to `IDENTITY_VALUE` in the input.
+**Note for TELEGRAM identity:** Include the additional `"userName"` field set to `TELEGRAM_USERNAME` (the display username) in the input. `subject` must be set to `IDENTITY_VALUE` (the numeric user ID).
 
 **Persist progress for resume:** Update `~/.config/senpi/state.json`: set `onboarding.step` to `PARSE`. Use read-modify-write.
 

--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -111,13 +111,30 @@ Set `MCPORTER_AVAILABLE=true` once installed and proceed.
 
 Ask the user which identity type to use. Try each option in order:
 
-1. **Option A -- Telegram user ID** (preferred): Ask for the numeric Telegram user ID (see below).
+1. **Option A -- Telegram user ID** (preferred): Read from `${OPENCLAW_WORKSPACE_DIR}/USER.md` if available, otherwise ask the user.
 2. **Option B -- User-provided wallet**: Must be `0x`-prefixed, exactly 42 hex characters. Validate before proceeding.
 3. **Option C -- Agent-generated wallet** (fallback when user has neither).
 
 #### Option A: Collect Telegram user ID
 
-See [references/telegram-identity.md](references/telegram-identity.md) for user-facing instructions and validation rules.
+When the user chooses Option A, first attempt to read from `${OPENCLAW_WORKSPACE_DIR}/USER.md`:
+
+```bash
+USER_MD="${OPENCLAW_WORKSPACE_DIR}/USER.md"
+if [ -f "$USER_MD" ]; then
+  TELEGRAM_USER_ID=$(awk '/## Telegram/{f=1} f && /- Chat ID:/{print $NF; exit}' "$USER_MD")
+  TELEGRAM_USERNAME=$(awk '/## Telegram/{f=1} f && /- Username:/{print $NF; exit}' "$USER_MD")
+fi
+```
+
+If both `TELEGRAM_USER_ID` (digits-only, non-empty) and `TELEGRAM_USERNAME` (non-empty) are found, set the variables automatically without prompting the user:
+
+```bash
+IDENTITY_TYPE="TELEGRAM"
+IDENTITY_VALUE="$TELEGRAM_USER_ID"
+```
+
+If USER.md is missing or either field is absent/invalid, fall back to the manual prompt: see [references/telegram-identity.md](references/telegram-identity.md) for user-facing instructions and validation rules. Also set `TELEGRAM_USERNAME` from the user's input if prompted manually.
 
 #### Option B: Set variables
 
@@ -217,7 +234,7 @@ RESPONSE=$(curl -s -X POST https://moxie-backend.prod.senpi.ai/graphql \
       "input": {
         "from": "'"${IDENTITY_TYPE}"'",
         "subject": "'"${IDENTITY_VALUE}"'",
-        '"$([ "$IDENTITY_TYPE" = "TELEGRAM" ] && echo "\"userName\": \"${IDENTITY_VALUE}\",")"'
+        '"$([ "$IDENTITY_TYPE" = "TELEGRAM" ] && echo "\"userName\": \"${TELEGRAM_USERNAME}\",")"'
         "referralCode": "'"${REFERRAL_CODE}"'",
         "apiKeyName": "agent-'"$(date +%s)"'"
       }
@@ -225,7 +242,7 @@ RESPONSE=$(curl -s -X POST https://moxie-backend.prod.senpi.ai/graphql \
   }')
 ```
 
-**Note for TELEGRAM identity:** Include the additional `"userName"` field set to `IDENTITY_VALUE` (the numeric user ID) in the input.
+**Note for TELEGRAM identity:** Include the additional `"userName"` field set to `TELEGRAM_USERNAME` (the Telegram username from USER.md or user input) in the input.
 
 **Persist progress for resume:** Update `~/.config/senpi/state.json`: set `onboarding.step` to `PARSE`. Use read-modify-write.
 

--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -122,8 +122,8 @@ When the user chooses Option A, first attempt to read from `${OPENCLAW_WORKSPACE
 ```bash
 USER_MD="${OPENCLAW_WORKSPACE_DIR}/USER.md"
 if [ -f "$USER_MD" ]; then
-  TELEGRAM_USER_ID=$(awk '/## Telegram/{f=1} f && /- Chat ID:/{print $NF; exit}' "$USER_MD")
-  TELEGRAM_USERNAME=$(awk '/## Telegram/{f=1} f && /- Username:/{print $NF; exit}' "$USER_MD")
+  TELEGRAM_USER_ID=$(awk '/^## Telegram/{f=1; next} f && /^## /{f=0} f && /- Chat ID:/{print $NF; exit}' "$USER_MD")
+  TELEGRAM_USERNAME=$(awk '/^## Telegram/{f=1; next} f && /^## /{f=0} f && /- Username:/{print $NF; exit}' "$USER_MD")
 fi
 ```
 

--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -117,21 +117,7 @@ Ask the user which identity type to use. Try each option in order:
 
 #### Option A: Collect Telegram user ID
 
-When the user chooses Telegram, present these instructions before asking for input:
-
-> **To find your Telegram user ID:**
-> 1. Open Telegram and search for **@userinfobot**
-> 2. Start a chat and send any message (e.g. `/start`)
-> 3. It will reply instantly with your numeric user ID (e.g. `8362644815`)
->
-> Please enter your numeric Telegram user ID:
-
-```bash
-IDENTITY_TYPE="TELEGRAM"
-IDENTITY_VALUE="8362644815"  # numeric Telegram user ID (digits only)
-```
-
-Validate that `IDENTITY_VALUE` contains only digits. If it contains any non-digit characters (letters, `@`, spaces, etc.), reject it and re-prompt with the same instructions above.
+See [references/telegram-identity.md](references/telegram-identity.md) for user-facing instructions and validation rules.
 
 #### Option B: Set variables
 

--- a/senpi-onboard/references/telegram-identity.md
+++ b/senpi-onboard/references/telegram-identity.md
@@ -1,0 +1,21 @@
+# Telegram Identity Reference
+
+## Finding Your Numeric Telegram User ID
+
+Present these instructions to the user before prompting for input:
+
+> **To find your Telegram user ID:**
+> 1. Open Telegram and search for **@userinfobot**
+> 2. Start a chat and send any message (e.g. `/start`)
+> 3. It will reply instantly with your numeric user ID (e.g. `8362644815`)
+>
+> Please enter your numeric Telegram user ID:
+
+## Validation
+
+`IDENTITY_VALUE` must contain only digits. If it contains any non-digit characters (letters, `@`, spaces, etc.), reject it and re-prompt with the instructions above.
+
+```bash
+IDENTITY_TYPE="TELEGRAM"
+IDENTITY_VALUE="8362644815"  # numeric Telegram user ID (digits only)
+```

--- a/senpi-onboard/references/telegram-identity.md
+++ b/senpi-onboard/references/telegram-identity.md
@@ -1,5 +1,7 @@
 # Telegram Identity Reference
 
+> **Note:** These instructions are only needed as a fallback when `${OPENCLAW_WORKSPACE_DIR}/USER.md` is unavailable or missing the `## Telegram` section. In normal OpenClaw usage, the Telegram user ID and username are read automatically.
+
 ## Finding Your Numeric Telegram User ID
 
 Present these instructions to the user before prompting for input:
@@ -17,5 +19,6 @@ Present these instructions to the user before prompting for input:
 
 ```bash
 IDENTITY_TYPE="TELEGRAM"
-IDENTITY_VALUE="8362644815"  # numeric Telegram user ID (digits only)
+IDENTITY_VALUE="8362644815"   # numeric Telegram user ID (digits only)
+TELEGRAM_USERNAME="@username" # Telegram username (ask the user, e.g. "@johndoe")
 ```

--- a/senpi-onboard/references/telegram-identity.md
+++ b/senpi-onboard/references/telegram-identity.md
@@ -17,8 +17,11 @@ Present these instructions to the user before prompting for input:
 
 `IDENTITY_VALUE` must contain only digits. If it contains any non-digit characters (letters, `@`, spaces, etc.), reject it and re-prompt with the instructions above.
 
+For the Telegram username, accept input with or without a leading `@`, but always normalize before API use by removing the leading `@`.
+
 ```bash
 IDENTITY_TYPE="TELEGRAM"
 IDENTITY_VALUE="8362644815"   # numeric Telegram user ID (digits only)
-TELEGRAM_USERNAME="@username" # Telegram username (ask the user, e.g. "@johndoe")
+RAW_TELEGRAM_USERNAME="@username"     # user input may include leading "@"
+TELEGRAM_USERNAME="${RAW_TELEGRAM_USERNAME#@}" # normalized for API: "username"
 ```


### PR DESCRIPTION
## Summary

- Fixes a bug where the Telegram **username** (e.g. `tubebuffler`) was being passed as the `subject` field in `CreateAgentStubAccount`, causing Privy to store the wrong value as `telegram_user_id`
- The `subject` field must be the **numeric Telegram user ID** (e.g. `8362644815`) — the onboarding skill now collects this separately from the username
- `userName` (display field) continues to use the Telegram username; `subject` now correctly uses the numeric ID

## Changes

- **Step 1 Option A** now collects two values: username (for display) and numeric user ID (for Privy subject)
- Includes inline guidance pointing users to [@userinfobot](https://t.me/userinfobot) to find their numeric ID
- Adds digit-only validation — rejects non-numeric input and re-prompts with instructions
- `userName` field in the API call now uses `TELEGRAM_USERNAME` instead of `IDENTITY_VALUE`

## Test plan

- [ ] Run `/senpi-onboard` and choose Option A (Telegram)
- [ ] Enter a username → skill prompts for numeric ID
- [ ] Enter a non-numeric value for the ID → rejected with @userinfobot guidance
- [ ] Enter a valid numeric ID → proceeds to Step 2
- [ ] After completing onboarding, verify in Privy that `telegram_user_id` is the numeric ID, not the username

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes identity collection and the onboarding API payload for Telegram users, which can affect account creation and Privy identity linkage if mis-collected or missing fields. Adds new required `TELEGRAM_USERNAME` validation that could block onboarding if USER.md parsing or prompts are incorrect.
> 
> **Overview**
> Fixes Telegram onboarding identity handling so `CreateAgentStubAccount.subject` is the **numeric Telegram user ID** (from `USER.md` or manual entry) instead of the username, while `userName` is now explicitly sourced from a normalized `TELEGRAM_USERNAME`.
> 
> Adds automatic extraction of both Telegram fields from `${OPENCLAW_WORKSPACE_DIR}/USER.md`, introduces a fallback reference doc (`references/telegram-identity.md`) for manually finding/validating the numeric ID, and enforces a pre-flight check that `TELEGRAM_USERNAME` is set before making the GraphQL call when `IDENTITY_TYPE=TELEGRAM`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02dad5df208645946bf3b8aad204e12ad1f2d538. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->