### PR TITLE
Require TELEGRAM_USERNAME before Telegram onboarding API call

### DIFF
--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -204,6 +204,7 @@ Before Step 2, confirm these are set:
 - `IDENTITY_TYPE` -- `"WALLET"` or `"TELEGRAM"`
 - `IDENTITY_VALUE` -- wallet address (with `0x`) or Telegram numeric user ID (digits only)
 - `WALLET_GENERATED` -- `true` if Option C was used, unset otherwise
+- `TELEGRAM_USERNAME` -- required and non-empty when `IDENTITY_TYPE="TELEGRAM"` (unset otherwise)
 
 **Persist progress for resume:** Update `~/.config/senpi/state.json`: set `onboarding.step` to `REFERRAL`, and if available set `onboarding.identityType`, `onboarding.subject`, `onboarding.walletGenerated` from current variables. Use read-modify-write so other fields are preserved.
 
@@ -226,6 +227,11 @@ If empty and user hasn't provided one, that's fine -- it's optional. Do not prom
 Execute the `CreateAgentStubAccount` GraphQL mutation. This is a **public endpoint** -- no auth required.
 
 ```bash
+if [ "$IDENTITY_TYPE" = "TELEGRAM" ] && [ -z "${TELEGRAM_USERNAME:-}" ]; then
+  echo "TELEGRAM_USERNAME must be set when IDENTITY_TYPE=TELEGRAM" >&2
+  exit 1
+fi
+
 RESPONSE=$(curl -s -X POST https://moxie-backend.prod.senpi.ai/graphql \
   -H "Content-Type: application/json" \
   -d '{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- verified the issue in `senpi-onboard/SKILL.md`: the pre-step checklist required `IDENTITY_TYPE`, `IDENTITY_VALUE`, and `WALLET_GENERATED` but did not require `TELEGRAM_USERNAME`
- updated **Verify before proceeding** to require non-empty `TELEGRAM_USERNAME` when `IDENTITY_TYPE="TELEGRAM"`
- added a Step 3 shell guard that exits with an error if Telegram identity is selected and `TELEGRAM_USERNAME` is unset/empty before composing the GraphQL payload

## Files changed
- `senpi-onboard/SKILL.md`

## Why this fixes it
This prevents agents from following the checklist and reaching the API mutation with a missing Telegram username, avoiding empty/missing `userName` in Telegram onboarding requests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ec5ef7b-ed1f-43f6-9cf9-1e42b7645fac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ec5ef7b-ed1f-43f6-9cf9-1e42b7645fac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

