### PR TITLE
feat: fleet conviction leverage + extreme velocity tiers + Spider v1.0

### DIFF
--- a/cheetah/scripts/cheetah-scanner.py
+++ b/cheetah/scripts/cheetah-scanner.py
@@ -1,32 +1,28 @@
 #!/usr/bin/env python3
-# Senpi CHEETAH Scanner v2.0
+# Senpi CHEETAH Scanner v2.1.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""CHEETAH v2.0 — HYPE Predator.
+"""CHEETAH v2.1.1 — HYPE Predator (Hardened + Hyperfeed Scoring + Extreme Velocity Tiers).
 
-Hunts HYPE exclusively using SM commitment as the primary signal.
-Unlike Wolverine (full timeframe alignment), Cheetah fires when SM
-commitment exceeds threshold — overwhelming smart money consensus.
+v2.1 changes from fleet audit (2026-04-07):
+- Scanner calls create_position internally via mcporter (Wolverine pattern)
+- feeOptimizedLimitOptions with ensureExecutionAsTaker: false
+- Conviction-scaled leverage: score 8-9 → 7x, score 10+ → 10x
+- Margin increased to 50%
+- Hard gates (SM%, 4H price, trader count) → score contributors
+- Hyperfeed multi-window contribution velocity (15m, 1h, 4h)
+- Resting order check prevents stacking maker orders
+- BTC trend as score contributor (fetched from same API call, no double-call)
+- No thesis exit (confirmed from v2.0)
 
-Top performer in the fleet at +7.6% / 38 trades.
+Trade analysis context (23 positions):
+- Winners hold long: +$72.30 (9h), +$22.94 (12.6h), +$13.64 (4h)
+- Losers die fast: -$43.63 (11m), -$36.98 (19m)
+- SHORT 60% win rate vs LONG 46%
+- Gross PnL: -$74.56 on direction, -$95.50 in fees = -$170.06 net
 
-Key signals:
-- SM_DOMINANT: SM concentration on HYPE (threshold: high %)
-- 4H trend alignment (hard gate)
-- 1H momentum (score booster)
-- CONTRIB_SURGE: contribution_pct_change_4h (SM velocity)
-- BTC as booster, not gate
-
-All v2.0 fleet fixes:
-- MCP response parsing: handles data.markets.markets nesting
-- Trade counter increments BEFORE output (Phoenix fix)
-- Trade counter auto-resets on stale date
-- _v2_no_thesis_exit: True on every output
-- RIDING mode outputs NO_REPLY only
-- Config helper points to cheetah-strategy
-
-DSL exit managed by plugin runtime via runtime.yaml.
-Uses: leaderboard_get_markets (single API call per scan)
+HYPE single-asset hunter. HUNT → RIDE → re-HUNT.
+Uses: leaderboard_get_markets + strategy_get_open_orders (2 API calls)
 Runs every 90 seconds.
 """
 
@@ -37,166 +33,164 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import cheetah_config as cfg
 
 ASSET = "HYPE"
-DEFAULT_LEVERAGE = 7
-MAX_LEVERAGE = 7
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 4
 COOLDOWN_MINUTES = 90
-MARGIN_PCT = 0.25
+MARGIN_PCT = 0.50
 MIN_SCORE = 8
 XYZ_BANNED = True
 
-# SM thresholds for HYPE
-MIN_SM_PCT = 8.0
-MIN_SM_TRADERS = 30
+LEVERAGE_TIERS = [
+    {"min_score": 10, "leverage": 10},   # HYPE max leverage on Hyperliquid is 10x
+    {"min_score": 8,  "leverage": 7},
+]
+DEFAULT_LEVERAGE = 7
+MAX_LEVERAGE = 10  # Hyperliquid HYPE hard cap
 
 
 def safe_float(v, d=0.0):
+    if v is None: return d
     try: return float(v)
     except: return d
 
 def now_date(): return datetime.now(timezone.utc).strftime("%Y-%m-%d")
 def now_iso(): return datetime.now(timezone.utc).isoformat()
 
+def get_leverage_for_score(score):
+    for tier in LEVERAGE_TIERS:
+        if score >= tier["min_score"]:
+            return tier["leverage"]
+    return DEFAULT_LEVERAGE
 
-# ═══════════════════════════════════════════════════════════════
-# MCP PARSING — handles data.markets.markets nesting
-# ═══════════════════════════════════════════════════════════════
 
-def fetch_sm_for_hype():
-    """Fetch SM data for HYPE. Correctly handles nested MCP response."""
+def has_resting_orders(wallet):
+    """Check if there are resting entry orders on the book."""
+    data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
+    if not data:
+        return False
+    orders = data.get("data", data)
+    if isinstance(orders, dict):
+        orders = orders.get("orders", orders.get("openOrders", []))
+    if isinstance(orders, list) and len(orders) > 0:
+        return True
+    return False
+
+
+def evaluate_hype():
+    """Score HYPE with multi-window Hyperfeed velocity. No hard gates."""
     raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
     if not raw: return None
-
-    # Handle triple nesting: data.markets.markets
-    markets = raw
-    if isinstance(markets, dict):
-        markets = markets.get("data", markets)
-    if isinstance(markets, dict):
-        markets = markets.get("markets", markets)
-    if isinstance(markets, dict):
-        markets = markets.get("markets", [])
-    if not isinstance(markets, list):
-        return None
-
-    for m in markets:
-        if not isinstance(m, dict): continue
-        token = str(m.get("token", "")).upper()
-        if token == ASSET:
-            return {
-                "direction": str(m.get("direction", "")).upper(),
-                "pct": safe_float(m.get("pct_of_top_traders_gain", 0)),
-                "traders": int(m.get("trader_count", 0)),
-                "price_chg_4h": safe_float(m.get("token_price_change_pct_4h", 0)),
-                "price_chg_1h": safe_float(m.get("token_price_change_pct_1h",
-                                           m.get("price_change_1h", 0))),
-                "contrib_change": safe_float(m.get("contribution_pct_change_4h", 0)),
-            }
-    return None
-
-
-def fetch_btc_trend():
-    """Check BTC 4H trend as a conviction booster."""
-    raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
-    if not raw: return 0
 
     markets = raw
     if isinstance(markets, dict): markets = markets.get("data", markets)
     if isinstance(markets, dict): markets = markets.get("markets", markets)
     if isinstance(markets, dict): markets = markets.get("markets", [])
-    if not isinstance(markets, list): return 0
+    if not isinstance(markets, list): return None
 
+    hype = None
+    btc_4h = 0
     for m in markets:
         if not isinstance(m, dict): continue
-        if str(m.get("token", "")).upper() == "BTC":
-            return safe_float(m.get("token_price_change_pct_4h", 0))
-    return 0
+        token = str(m.get("token", "")).upper()
+        if token == ASSET:
+            hype = m
+        elif token == "BTC":
+            btc_4h = safe_float(m.get("token_price_change_pct_4h", 0))
 
-
-# ═══════════════════════════════════════════════════════════════
-# HYPE THESIS EVALUATION — 14-point scoring
-# ═══════════════════════════════════════════════════════════════
-
-def evaluate_hype():
-    """Evaluate HYPE entry thesis. Returns dict or None."""
-
-    hype = fetch_sm_for_hype()
     if not hype: return None
 
-    d = hype["direction"]
+    d = str(hype.get("direction", "")).upper()
     if d not in ("LONG", "SHORT"): return None
 
-    pct = hype["pct"]
-    traders = hype["traders"]
-    p4h = hype["price_chg_4h"]
-    p1h = hype["price_chg_1h"]
-    cc = hype["contrib_change"]
+    pct = safe_float(hype.get("pct_of_top_traders_gain", 0))
+    traders = int(hype.get("trader_count", 0))
+    p4h = safe_float(hype.get("token_price_change_pct_4h", 0))
+    p1h = safe_float(hype.get("token_price_change_pct_1h", hype.get("price_change_1h", 0)))
+    cc_4h = safe_float(hype.get("contribution_pct_change_4h", 0))
+    cc_15m = safe_float(hype.get("contribution_pct_change_15m", 0))
+    cc_1h = safe_float(hype.get("contribution_pct_change_1h", 0))
 
-    # Hard gates
-    if pct < MIN_SM_PCT: return None
-    if traders < MIN_SM_TRADERS: return None
-
-    # 4H must align with SM direction
-    if d == "LONG" and p4h < 0: return None
-    if d == "SHORT" and p4h > 0: return None
-
-    # ── Scoring (14-point system) ─────────────────────────────
+    # Need minimum data
+    if traders < 15: return None
 
     score, reasons = 0, []
 
-    # SM concentration (0-4)
-    if pct >= 30:
-        score += 4; reasons.append(f"SM_DOMINANT {pct:.1f}% ({traders}t)")
-    elif pct >= 20:
-        score += 3; reasons.append(f"SM_HEAVY {pct:.1f}% ({traders}t)")
-    elif pct >= 12:
-        score += 2; reasons.append(f"SM_STRONG {pct:.1f}% ({traders}t)")
-    else:
-        score += 1; reasons.append(f"SM_ALIGNED {pct:.1f}% ({traders}t)")
+    # SM concentration (0-4) — Cheetah uses higher tiers than fleet for HYPE
+    if pct >= 30: score += 4; reasons.append(f"SM_DOMINANT {pct:.1f}% ({traders}t)")
+    elif pct >= 20: score += 3; reasons.append(f"SM_HEAVY {pct:.1f}% ({traders}t)")
+    elif pct >= 12: score += 2; reasons.append(f"SM_STRONG {pct:.1f}% ({traders}t)")
+    elif pct >= 5: score += 1; reasons.append(f"SM_ALIGNED {pct:.1f}% ({traders}t)")
 
-    # SM depth — trader count (0-2)
-    if traders >= 200:
-        score += 2; reasons.append(f"DEEP_SM ({traders}t)")
-    elif traders >= 100:
-        score += 1; reasons.append(f"BROAD_SM ({traders}t)")
+    # SM depth (0-2)
+    if traders >= 200: score += 2; reasons.append(f"DEEP_SM ({traders}t)")
+    elif traders >= 100: score += 1; reasons.append(f"BROAD_SM ({traders}t)")
 
-    # 4H trend strength (0-2)
-    abs_4h = abs(p4h)
-    if abs_4h >= 2.0:
-        score += 2; reasons.append(f"4H_STRONG {p4h:+.1f}%")
-    elif abs_4h >= 0.5:
-        score += 1; reasons.append(f"4H_CONFIRMS {p4h:+.1f}%")
+    # 4H price alignment (±2) — score contributor, not gate
+    if abs(p4h) >= 2.0:
+        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
+            score += 2; reasons.append(f"4H_STRONG {p4h:+.1f}%")
+        else:
+            score -= 1; reasons.append(f"4H_OPPOSING {p4h:+.1f}%")
+    elif abs(p4h) >= 0.5:
+        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
+            score += 1; reasons.append(f"4H_CONFIRMS {p4h:+.1f}%")
 
     # 1H momentum (0-1)
     if (d == "LONG" and p1h > 0.2) or (d == "SHORT" and p1h < -0.2):
         score += 1; reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
 
-    # Contribution velocity (0-2)
-    if abs(cc) >= 0.03:
-        score += 2; reasons.append(f"CONTRIB_SURGE +{abs(cc)*100:.1f}%")
-    elif abs(cc) >= 0.01:
-        score += 1; reasons.append(f"CONTRIB_GROWING +{abs(cc)*100:.2f}%")
+    # Contribution velocity — multi-window (15m + 1h + 4h)
+    # Expanded tiers: extreme spikes should push score to 11+ for max leverage
+    if cc_15m > 5.0: score += 4; reasons.append(f"15M_EXTREME_SPIKE +{cc_15m:.2f}")
+    elif cc_15m > 2.0: score += 3; reasons.append(f"15M_STRONG_SPIKE +{cc_15m:.2f}")
+    elif cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
+    elif cc_15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
+    elif cc_15m < -0.5: score -= 1; reasons.append(f"15M_FADING {cc_15m:.2f}")
 
-    # BTC as booster (0-1) — not a gate
-    btc_4h = fetch_btc_trend()
+    if cc_1h > 3.0: score += 2; reasons.append(f"1H_STRONG_ACCEL +{cc_1h:.2f}")
+    elif cc_1h > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h:.2f}")
+
+    if abs(cc_4h) >= 5.0: score += 1; reasons.append(f"4H_MAJOR_SHIFT {cc_4h:+.1f}")
+
+    # Acceleration pattern: 15m > 1h > 0
+    if cc_15m > 0 and cc_1h > 0 and cc_15m > cc_1h:
+        score += 1; reasons.append(f"ACCEL_PATTERN 15m({cc_15m:.2f})>1h({cc_1h:.2f})")
+
+    # BTC as booster (0-1) — not a gate, fetched from same API call
     if d == "LONG" and btc_4h > 0.5:
         score += 1; reasons.append(f"BTC_CONFIRMS +{btc_4h:.1f}%")
     elif d == "SHORT" and btc_4h < -0.5:
         score += 1; reasons.append(f"BTC_CONFIRMS {btc_4h:.1f}%")
 
-    # Time of day (0-1)
+    # US session bonus (0-1)
     hour = datetime.now(timezone.utc).hour
     if 13 <= hour <= 21:
         score += 1; reasons.append("US_SESSION")
 
     return {"score": score, "direction": d, "reasons": reasons,
-            "smPct": pct, "smTraders": traders, "priceChg4h": p4h,
-            "contribChange": cc}
+            "smPct": pct, "smTraders": traders, "priceChg4h": p4h}
 
 
-# ═══════════════════════════════════════════════════════════════
-# TRADE COUNTER — HARDENED (Phoenix fix)
-# ═══════════════════════════════════════════════════════════════
+def execute_entry(direction, margin, leverage):
+    """Call create_position directly via mcporter."""
+    result = cfg.mcporter_call(
+        "create_position",
+        coin=ASSET,
+        direction=direction,
+        leverage=leverage,
+        margin=margin,
+        orderType="FEE_OPTIMIZED_LIMIT",
+        feeOptimizedLimitOptions={
+            "ensureExecutionAsTaker": False,
+            "executionTimeoutSeconds": 30,
+        },
+    )
+    if result and result.get("success"):
+        return True, result
+    else:
+        error = result.get("error", "unknown") if result else "mcporter_call returned None"
+        return False, {"error": error}
+
 
 def load_tc():
     p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
@@ -212,10 +206,6 @@ def save_tc(tc):
     cfg.atomic_write(os.path.join(cfg.STATE_DIR, "trade-counter.json"), tc)
 
 
-# ═══════════════════════════════════════════════════════════════
-# MAIN
-# ═══════════════════════════════════════════════════════════════
-
 def run():
     wallet, sid = cfg.get_wallet_and_strategy()
     if not wallet:
@@ -227,7 +217,13 @@ def run():
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "cannot read account"})
         return
 
-    # ── RIDING: HYPE position open → NO_REPLY ─────────────────
+    # Check for resting orders
+    if has_resting_orders(wallet):
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": "RESTING ORDER: HYPE limit order pending. Waiting for fill."})
+        return
+
+    # RIDING: position open → NO_REPLY. DSL manages ALL exits.
     for p in positions:
         if p.get("coin", "").upper() == ASSET:
             cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
@@ -235,76 +231,62 @@ def run():
                 "_v2_no_thesis_exit": True})
             return
 
-    # ── Trade counter (HARDENED) ──────────────────────────────
     tc = load_tc()
     if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached. Counter: {tc['entries']}/{MAX_DAILY_ENTRIES}"})
+            "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
         return
 
-    # ── Cooldown ──────────────────────────────────────────────
-    if cfg.is_asset_cooled_down(ASSET, COOLDOWN_MINUTES):
+    # Cooldown
+    last_entry = tc.get("last_entry_ts", 0)
+    if last_entry and (time.time() - last_entry) < COOLDOWN_MINUTES * 60:
+        remaining = int((COOLDOWN_MINUTES * 60 - (time.time() - last_entry)) / 60)
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"HYPE on cooldown ({COOLDOWN_MINUTES}min)"})
+            "note": f"HYPE on cooldown ({remaining}min remaining)"})
         return
 
-    # ── Evaluate thesis ───────────────────────────────────────
     thesis = evaluate_hype()
-
     if not thesis:
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
             "note": "HUNTING: no HYPE thesis"})
         return
-
     if thesis["score"] < MIN_SCORE:
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"HUNTING: HYPE {thesis['direction']} score {thesis['score']}<{MIN_SCORE}. "
-                    f"{', '.join(thesis['reasons'][:3])}"})
+            "note": f"HUNTING: HYPE {thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"})
         return
 
-    # ── Entry ─────────────────────────────────────────────────
+    leverage = get_leverage_for_score(thesis["score"])
     margin = round(av * MARGIN_PCT, 2)
 
-    # INCREMENT COUNTER BEFORE OUTPUT (Phoenix fix)
-    tc["entries"] = tc.get("entries", 0) + 1
-    save_tc(tc)
+    success, result = execute_entry(thesis["direction"], margin, leverage)
 
-    cfg.output({
-        "status": "ok",
-        "signal": {
-            "asset": ASSET,
-            "direction": thesis["direction"],
-            "score": thesis["score"],
-            "mode": "HYPE_PREDATOR",
-            "reasons": thesis["reasons"],
-            "smPct": thesis["smPct"],
-            "smTraders": thesis["smTraders"],
-            "priceChg4h": thesis["priceChg4h"],
-        },
-        "entry": {
-            "asset": ASSET,
-            "direction": thesis["direction"],
-            "leverage": DEFAULT_LEVERAGE,
-            "margin": margin,
-            "orderType": "FEE_OPTIMIZED_LIMIT",
-        },
-        "constraints": {
-            "maxPositions": MAX_POSITIONS,
-            "maxLeverage": MAX_LEVERAGE,
-            "maxDailyEntries": MAX_DAILY_ENTRIES,
-            "cooldownMinutes": COOLDOWN_MINUTES,
-            "_v2_no_thesis_exit": True,
-            "_note": f"DSL managed by plugin runtime. Counter: {tc['entries']}/{MAX_DAILY_ENTRIES}",
-        },
-        "_cheetah_version": "2.0",
-    })
+    if success:
+        tc["entries"] = tc.get("entries", 0) + 1
+        tc["last_entry_ts"] = time.time()
+        save_tc(tc)
+        cfg.output({
+            "status": "ok", "action": "ENTRY",
+            "signal": {"asset": ASSET, "direction": thesis["direction"],
+                "score": thesis["score"], "leverage": leverage,
+                "mode": "HYPE_PREDATOR", "reasons": thesis["reasons"]},
+            "execution": {"asset": ASSET, "direction": thesis["direction"],
+                "leverage": leverage, "margin": margin,
+                "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
+            "result": result,
+            "_cheetah_version": "2.1.1",
+        })
+    else:
+        cfg.output({
+            "status": "ok", "action": "ENTRY_FAILED",
+            "signal": {"asset": ASSET, "direction": thesis["direction"],
+                "score": thesis["score"], "reasons": thesis["reasons"]},
+            "error": result, "_cheetah_version": "2.1.1",
+        })
 
 
 if __name__ == "__main__":
-    try:
-        run()
+    try: run()
     except Exception as e:
         cfg.log(f"CRITICAL: {e}")
-        import traceback
-        traceback.print_exc(file=sys.stderr)
+        import traceback; traceback.print_exc(file=sys.stderr)
         cfg.output({"status": "error", "error": str(e)})

--- a/grizzly/scripts/grizzly-scanner.py
+++ b/grizzly/scripts/grizzly-scanner.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
-# Senpi GRIZZLY Scanner v3.1
+# Senpi GRIZZLY Scanner v3.2
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""GRIZZLY v3.1 — BTC Alpha Hunter (Hardened).
+"""GRIZZLY v3.2 — BTC Alpha Hunter (Conviction Leverage + Extreme Velocity).
+
+v3.2 changes:
+- Conviction-scaled leverage: score 8->7x, 9->10x, 10->15x, 11+->20x
+- Extreme velocity tiers: 15m >5.0->+4pts, >2.0->+3pts (was capped at +2)
+- 1h acceleration: >3.0->+2pts (was capped at +1)
+- BTC max leverage on Hyperliquid is 40x, we cap at 20x
 
 v3.1 changes from fleet audit:
 - Scanner calls create_position internally via mcporter (Wolverine pattern)
 - feeOptimizedLimitOptions with ensureExecutionAsTaker: false
-- Conviction-scaled leverage: score 8-9 → 7x, score 10+ → 10x
-- 4H price alignment: was HARD GATE → now score contributor
-- SM thresholds: was HARD GATE (5%/30t) → now score contributors
+- 4H price alignment: was HARD GATE -> now score contributor
+- SM thresholds: was HARD GATE (5%/30t) -> now score contributors
 - Margin increased to 50%
 - No thesis exit (unchanged from v3.0)
 - Checks resting orders before placing new entries (race condition fix)
@@ -32,10 +37,13 @@ MARGIN_PCT = 0.50
 MIN_SCORE = 8
 
 LEVERAGE_TIERS = [
-    {"min_score": 10, "leverage": 10},
+    {"min_score": 11, "leverage": 20},
+    {"min_score": 10, "leverage": 15},
+    {"min_score": 9,  "leverage": 10},
     {"min_score": 8,  "leverage": 7},
 ]
 DEFAULT_LEVERAGE = 7
+MAX_LEVERAGE = 20  # BTC max on HL is 40x, we cap at 20x
 
 def safe_float(v, d=0.0):
     try: return float(v)
@@ -50,21 +58,16 @@ def get_leverage_for_score(score):
     return DEFAULT_LEVERAGE
 
 def has_resting_orders(wallet):
-    """Check if there are resting entry orders on the book.
-    Prevents stacking multiple maker orders that lock up margin."""
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
-    if not data:
-        return False
+    if not data: return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list) and len(orders) > 0:
-        return True
+    if isinstance(orders, list) and len(orders) > 0: return True
     return False
 
 
 def evaluate_btc():
-    """Score BTC. All signals are score contributors — no hard gates."""
     raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
     if not raw: return None
     markets = raw.get("data", raw)
@@ -87,7 +90,6 @@ def evaluate_btc():
     cc_15m = safe_float(btc.get("contribution_pct_change_15m",0))
     cc_1h_contrib = safe_float(btc.get("contribution_pct_change_1h",0))
 
-    # Need minimum data to score anything
     if traders < 10: return None
 
     funding = 0
@@ -105,7 +107,7 @@ def evaluate_btc():
     elif pct >= 10: score += 2; reasons.append(f"STRONG_SM {pct:.1f}% ({traders}t)")
     elif pct >= 5: score += 1; reasons.append(f"SM_ALIGNED {pct:.1f}% ({traders}t)")
 
-    # 4H price alignment (±2) — was hard gate, now score contributor
+    # 4H price alignment (+/-2)
     if abs(p4h) >= 2.0:
         if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
             score += 2; reasons.append(f"STRONG_4H {p4h:+.1f}%")
@@ -119,12 +121,15 @@ def evaluate_btc():
     if (d=="LONG" and p1h>0.2) or (d=="SHORT" and p1h<-0.2):
         score += 1; reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
 
-    # Contribution velocity — multi-window (NEW: 15m + 1h + 4h)
-    if cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
+    # Contribution velocity — expanded extreme tiers
+    if cc_15m > 5.0: score += 4; reasons.append(f"15M_EXTREME_SPIKE +{cc_15m:.2f}")
+    elif cc_15m > 2.0: score += 3; reasons.append(f"15M_STRONG_SPIKE +{cc_15m:.2f}")
+    elif cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
     elif cc_15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
     elif cc_15m < -0.5: score -= 1; reasons.append(f"15M_FADING {cc_15m:.2f}")
 
-    if cc_1h_contrib > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h_contrib:.2f}")
+    if cc_1h_contrib > 3.0: score += 2; reasons.append(f"1H_STRONG_ACCEL +{cc_1h_contrib:.2f}")
+    elif cc_1h_contrib > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h_contrib:.2f}")
 
     if abs(cc)>=5.0: score += 1; reasons.append(f"4H_MAJOR_SHIFT {cc:+.1f}")
 
@@ -142,24 +147,14 @@ def evaluate_btc():
 
 
 def execute_entry(direction, margin, leverage):
-    """Call create_position directly via mcporter."""
     result = cfg.mcporter_call(
-        "create_position",
-        coin=ASSET,
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 30,
-        },
+        "create_position", coin=ASSET, direction=direction, leverage=leverage,
+        margin=margin, orderType="FEE_OPTIMIZED_LIMIT",
+        feeOptimizedLimitOptions={"ensureExecutionAsTaker": False, "executionTimeoutSeconds": 30},
     )
-    if result and result.get("success"):
-        return True, result
-    else:
-        error = result.get("error", "unknown") if result else "mcporter_call returned None"
-        return False, {"error": error}
+    if result and result.get("success"): return True, result
+    error = result.get("error", "unknown") if result else "mcporter_call returned None"
+    return False, {"error": error}
 
 
 def load_tc():
@@ -183,15 +178,12 @@ def run():
     av, positions = cfg.get_positions(wallet)
     if av <= 0: cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"cannot read account"}); return
 
-    # Check for resting orders — don't stack entries
     if has_resting_orders(wallet):
-        cfg.output({"status":"ok","heartbeat":"NO_REPLY",
-                     "note":"RESTING ORDER: BTC limit order pending. Waiting for fill."}); return
+        cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"RESTING ORDER: BTC limit order pending."}); return
 
     for p in positions:
         if p.get("coin","").upper() == ASSET:
-            cfg.output({"status":"ok","heartbeat":"NO_REPLY",
-                "note":"RIDING: BTC. DSL manages exit.","_v2_no_thesis_exit":True}); return
+            cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"RIDING: BTC. DSL manages exit.","_v2_no_thesis_exit":True}); return
 
     tc = load_tc()
     if tc.get("entries",0) >= MAX_DAILY_ENTRIES:
@@ -211,25 +203,19 @@ def run():
     margin = round(av * MARGIN_PCT, 2)
 
     success, result = execute_entry(thesis["direction"], margin, leverage)
-
     if success:
         tc["entries"] = tc.get("entries",0) + 1
         save_tc(tc)
-        cfg.output({
-            "status":"ok", "action":"ENTRY",
+        cfg.output({"status":"ok","action":"ENTRY",
             "signal":{"asset":ASSET,"direction":thesis["direction"],"score":thesis["score"],
                 "leverage":leverage,"mode":"BTC_HUNTER","reasons":thesis["reasons"]},
             "execution":{"asset":ASSET,"direction":thesis["direction"],"leverage":leverage,
                 "margin":margin,"orderType":"FEE_OPTIMIZED_LIMIT","ensureExecutionAsTaker":False},
-            "result":result,
-            "_grizzly_version":"3.1",
-        })
+            "result":result,"_grizzly_version":"3.2"})
     else:
-        cfg.output({
-            "status":"ok","action":"ENTRY_FAILED",
+        cfg.output({"status":"ok","action":"ENTRY_FAILED",
             "signal":{"asset":ASSET,"direction":thesis["direction"],"score":thesis["score"],"reasons":thesis["reasons"]},
-            "error":result, "_grizzly_version":"3.1",
-        })
+            "error":result,"_grizzly_version":"3.2"})
 
 if __name__ == "__main__":
     try: run()

--- a/kodiak/scripts/kodiak-scanner.py
+++ b/kodiak/scripts/kodiak-scanner.py
@@ -517,7 +517,7 @@ def evaluate_reload(exit_state, entry_cfg):
 
 # ─── Hardcoded Constants ──────────────────────────────────────
 
-MAX_LEVERAGE = 7          # Reduced from 10x — SOL at 10x is too volatile
+MAX_LEVERAGE = 15         # SOL max on HL is 20x; cap at 15x for conviction scaling
 MIN_LEVERAGE = 5
 
 
@@ -663,16 +663,15 @@ def run():
         cfg.output({"success": True, "heartbeat": "NO_REPLY", "note": note})
         return
 
-    # Conviction-scaled leverage
-    lev_cfg = config.get("leverage", {})
+    # Conviction-scaled leverage (v2.1 fleet: fixed tiers 7/10/12/15x)
     if thesis["score"] >= 14:
-        leverage = min(lev_cfg.get("max", 20), MAX_LEVERAGE)
+        leverage = 15
     elif thesis["score"] >= 12:
-        leverage = min(lev_cfg.get("high", 18), MAX_LEVERAGE)
+        leverage = 12
     elif thesis["score"] >= 10:
-        leverage = min(lev_cfg.get("default", 15), MAX_LEVERAGE)
+        leverage = 10
     else:
-        leverage = min(lev_cfg.get("min", 12), MAX_LEVERAGE)
+        leverage = 7
 
     # Conviction-scaled margin
     base_margin_pct = entry_cfg.get("marginPctBase", 0.30)

--- a/polar/scripts/polar-scanner.py
+++ b/polar/scripts/polar-scanner.py
@@ -1,25 +1,25 @@
 #!/usr/bin/env python3
-# Senpi POLAR Scanner v2.1
+# Senpi POLAR Scanner v2.2
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""POLAR v2.1 — ETH Alpha Hunter (Hardened + Hyperfeed Scoring).
+"""POLAR v2.2 — ETH Alpha Hunter (Conviction Leverage + Extreme Velocity).
+
+v2.2 changes:
+- Conviction-scaled leverage: score 8->7x, 9->10x, 10->15x, 11+->20x
+- Extreme velocity tiers: 15m >5.0->+4pts, >2.0->+3pts (was capped at +2)
+- 1h acceleration: >3.0->+2pts (was capped at +1)
+- ETH max leverage on Hyperliquid is 25x, we cap at 20x
 
 v2.1 changes from fleet audit (2026-04-06):
 - Scanner calls create_position internally via mcporter (Wolverine pattern)
 - feeOptimizedLimitOptions with ensureExecutionAsTaker: false
-- Conviction-scaled leverage: score 8-9 → 7x, score 10+ → 10x
 - Margin increased to 50%
-- Hard gates (SM%, 4H price, trader count) → score contributors
+- Hard gates (SM%, 4H price, trader count) -> score contributors
 - Hyperfeed multi-window contribution velocity (15m, 1h, 4h)
 - Resting order check prevents stacking maker orders
-- No thesis exit (confirmed from v2.0 — scanner enters, DSL exits)
+- No thesis exit (scanner enters, DSL exits)
 
-CRITICAL CONTEXT: Polar is the best gross trader in the fleet (+$235.91
-gross PnL) destroyed by taker fees ($249.79). The ensureExecutionAsTaker=false
-fix is the single highest-impact change. At maker rates, Polar would be
-at +23% ROI instead of -1.4%.
-
-ETH single-asset lifecycle hunter. HUNT → RIDE → re-HUNT.
+ETH single-asset lifecycle hunter. HUNT -> RIDE -> re-HUNT.
 Uses: leaderboard_get_markets + market_get_asset_data + strategy_get_open_orders
 Runs every 3 minutes.
 """
@@ -39,10 +39,13 @@ MIN_SCORE = 8
 XYZ_BANNED = True
 
 LEVERAGE_TIERS = [
-    {"min_score": 10, "leverage": 10},
+    {"min_score": 11, "leverage": 20},
+    {"min_score": 10, "leverage": 15},
+    {"min_score": 9,  "leverage": 10},
     {"min_score": 8,  "leverage": 7},
 ]
 DEFAULT_LEVERAGE = 7
+MAX_LEVERAGE = 20  # ETH max on HL is 25x, we cap at 20x
 
 
 def safe_float(v, d=0.0):
@@ -61,23 +64,18 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
-    """Check if there are resting entry orders on the book."""
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
-    if not data:
-        return False
+    if not data: return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list) and len(orders) > 0:
-        return True
+    if isinstance(orders, list) and len(orders) > 0: return True
     return False
 
 
 def evaluate_eth():
-    """Score ETH. All signals are score contributors — no hard gates."""
     raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
     if not raw: return None
-
     markets = raw
     if isinstance(markets, dict): markets = markets.get("data", markets)
     if isinstance(markets, dict): markets = markets.get("markets", markets)
@@ -87,8 +85,7 @@ def evaluate_eth():
     eth = None
     for m in markets:
         if not isinstance(m, dict): continue
-        if str(m.get("token", "")).upper() == ASSET:
-            eth = m; break
+        if str(m.get("token", "")).upper() == ASSET: eth = m; break
     if not eth: return None
 
     d = str(eth.get("direction", "")).upper()
@@ -102,10 +99,8 @@ def evaluate_eth():
     cc_15m = safe_float(eth.get("contribution_pct_change_15m", 0))
     cc_1h = safe_float(eth.get("contribution_pct_change_1h", 0))
 
-    # Need minimum data to score
     if traders < 15: return None
 
-    # Fetch funding
     funding = 0
     try:
         ad = cfg.mcporter_call("market_get_asset_data", asset=ASSET,
@@ -127,7 +122,7 @@ def evaluate_eth():
     # Trader depth (0-1)
     if traders >= 100: score += 1; reasons.append(f"DEEP_CONSENSUS ({traders}t)")
 
-    # 4H price alignment (±2) — score contributor, not gate
+    # 4H price alignment (+/-2)
     if abs(p4h) >= 2.0:
         if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
             score += 2; reasons.append(f"STRONG_4H {p4h:+.1f}%")
@@ -141,12 +136,15 @@ def evaluate_eth():
     if (d == "LONG" and p1h > 0.2) or (d == "SHORT" and p1h < -0.2):
         score += 1; reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
 
-    # Contribution velocity — multi-window (NEW: 15m + 1h + 4h)
-    if cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
+    # Contribution velocity — expanded extreme tiers
+    if cc_15m > 5.0: score += 4; reasons.append(f"15M_EXTREME_SPIKE +{cc_15m:.2f}")
+    elif cc_15m > 2.0: score += 3; reasons.append(f"15M_STRONG_SPIKE +{cc_15m:.2f}")
+    elif cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
     elif cc_15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
     elif cc_15m < -0.5: score -= 1; reasons.append(f"15M_FADING {cc_15m:.2f}")
 
-    if cc_1h > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h:.2f}")
+    if cc_1h > 3.0: score += 2; reasons.append(f"1H_STRONG_ACCEL +{cc_1h:.2f}")
+    elif cc_1h > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h:.2f}")
 
     if abs(cc_4h) >= 5.0: score += 1; reasons.append(f"4H_MAJOR_SHIFT {cc_4h:+.1f}")
 
@@ -167,24 +165,14 @@ def evaluate_eth():
 
 
 def execute_entry(direction, margin, leverage):
-    """Call create_position directly via mcporter."""
     result = cfg.mcporter_call(
-        "create_position",
-        coin=ASSET,
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 30,
-        },
+        "create_position", coin=ASSET, direction=direction, leverage=leverage,
+        margin=margin, orderType="FEE_OPTIMIZED_LIMIT",
+        feeOptimizedLimitOptions={"ensureExecutionAsTaker": False, "executionTimeoutSeconds": 30},
     )
-    if result and result.get("success"):
-        return True, result
-    else:
-        error = result.get("error", "unknown") if result else "mcporter_call returned None"
-        return False, {"error": error}
+    if result and result.get("success"): return True, result
+    error = result.get("error", "unknown") if result else "mcporter_call returned None"
+    return False, {"error": error}
 
 
 def load_tc():
@@ -204,80 +192,61 @@ def save_tc(tc):
 def run():
     wallet, sid = cfg.get_wallet_and_strategy()
     if not wallet:
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "no wallet"})
-        return
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "no wallet"}); return
 
     av, positions = cfg.get_positions(wallet)
     if av <= 0:
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "cannot read account"})
-        return
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "cannot read account"}); return
 
-    # Check for resting orders
     if has_resting_orders(wallet):
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                     "note": "RESTING ORDER: ETH limit order pending. Waiting for fill."})
-        return
+                     "note": "RESTING ORDER: ETH limit order pending."}); return
 
-    # RIDING: position open → NO_REPLY. DSL manages ALL exits.
     for p in positions:
         if p.get("coin", "").upper() == ASSET:
             cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
                 "note": f"RIDING: ETH {p.get('direction','?')}. DSL manages exit.",
-                "_v2_no_thesis_exit": True})
-            return
+                "_v2_no_thesis_exit": True}); return
 
     tc = load_tc()
     if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
-        return
+            "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"}); return
 
-    # Cooldown
     last_entry = tc.get("last_entry_ts", 0)
     if last_entry and (time.time() - last_entry) < COOLDOWN_MINUTES * 60:
         remaining = int((COOLDOWN_MINUTES * 60 - (time.time() - last_entry)) / 60)
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"ETH on cooldown ({remaining}min remaining)"})
-        return
+            "note": f"ETH on cooldown ({remaining}min remaining)"}); return
 
     thesis = evaluate_eth()
     if not thesis:
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": "HUNTING: no ETH thesis"})
-        return
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "HUNTING: no ETH thesis"}); return
     if thesis["score"] < MIN_SCORE:
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"HUNTING: ETH {thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"})
-        return
+            "note": f"HUNTING: ETH {thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"}); return
 
     leverage = get_leverage_for_score(thesis["score"])
     margin = round(av * MARGIN_PCT, 2)
 
     success, result = execute_entry(thesis["direction"], margin, leverage)
-
     if success:
         tc["entries"] = tc.get("entries", 0) + 1
         tc["last_entry_ts"] = time.time()
         save_tc(tc)
-        cfg.output({
-            "status": "ok", "action": "ENTRY",
+        cfg.output({"status": "ok", "action": "ENTRY",
             "signal": {"asset": ASSET, "direction": thesis["direction"],
                 "score": thesis["score"], "leverage": leverage,
                 "mode": "ETH_HUNTER", "reasons": thesis["reasons"]},
             "execution": {"asset": ASSET, "direction": thesis["direction"],
                 "leverage": leverage, "margin": margin,
                 "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
-            "result": result,
-            "_polar_version": "2.1",
-        })
+            "result": result, "_polar_version": "2.2"})
     else:
-        cfg.output({
-            "status": "ok", "action": "ENTRY_FAILED",
+        cfg.output({"status": "ok", "action": "ENTRY_FAILED",
             "signal": {"asset": ASSET, "direction": thesis["direction"],
                 "score": thesis["score"], "reasons": thesis["reasons"]},
-            "error": result, "_polar_version": "2.1",
-        })
-
+            "error": result, "_polar_version": "2.2"})
 
 if __name__ == "__main__":
     try: run()

--- a/wolverine/scripts/wolverine-scanner.py
+++ b/wolverine/scripts/wolverine-scanner.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
-# Senpi WOLVERINE Scanner v2.1
+# Senpi WOLVERINE Scanner v2.2
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""WOLVERINE v2.1 — HYPE Alpha Hunter (Hardened).
+"""WOLVERINE v2.2 — HYPE Alpha Hunter (Hardened).
+
+v2.2 changes (fleet conviction leverage):
+- Extreme velocity tiers on 15m/1h contribution (score up to +4 / +2)
+- MAX_LEVERAGE constant 10x (HL cap)
 
 v2.1 changes from fleet audit:
 - Scanner calls create_position internally via mcporter (Wolverine pattern)
@@ -38,10 +42,11 @@ MIN_SM_RANK = 30
 XYZ_BANNED = True
 
 LEVERAGE_TIERS = [
-    {"min_score": 10, "leverage": 10},
+    {"min_score": 10, "leverage": 10},  # HYPE max on HL is 10x
     {"min_score": 8,  "leverage": 7},
 ]
 DEFAULT_LEVERAGE = 7
+MAX_LEVERAGE = 10
 
 
 def safe_float(val, default=0.0):
@@ -118,9 +123,15 @@ def score_hype_signal(markets_data):
         score += 1
         reasons.append(f"MODERATE_CONTRIB {contribution:.1f}%")
 
-    # Contribution velocity — multi-window (NEW: 15m + 1h + 4h)
+    # Contribution velocity — multi-window (15m + 1h + 4h); v2.2 extreme tiers
     # 15m is the entry timing signal — HYPE moves fast, this catches the inflection
-    if contrib_15m > 0.5:
+    if contrib_15m > 5.0:
+        score += 4
+        reasons.append(f"15M_EXTREME_SPIKE +{contrib_15m:.2f}")
+    elif contrib_15m > 2.0:
+        score += 3
+        reasons.append(f"15M_STRONG_SPIKE +{contrib_15m:.2f}")
+    elif contrib_15m > 0.5:
         score += 2
         reasons.append(f"15M_SPIKE +{contrib_15m:.2f}")
     elif contrib_15m > 0.1:
@@ -130,7 +141,10 @@ def score_hype_signal(markets_data):
         score -= 1
         reasons.append(f"15M_FADING {contrib_15m:.2f}")
 
-    if contrib_1h > 1.0:
+    if contrib_1h > 3.0:
+        score += 2
+        reasons.append(f"1H_STRONG_ACCEL +{contrib_1h:.2f}")
+    elif contrib_1h > 1.0:
         score += 1
         reasons.append(f"1H_ACCEL +{contrib_1h:.2f}")
 
@@ -286,7 +300,7 @@ def run():
                           "orderType": "FEE_OPTIMIZED_LIMIT",
                           "ensureExecutionAsTaker": False},
             "result": result,
-            "_wolverine_version": "2.1",
+            "_wolverine_version": "2.2",
         })
     else:
         cfg.output({
@@ -294,7 +308,7 @@ def run():
             "signal": {"asset": ASSET, "direction": direction.upper(),
                        "score": score, "reasons": reasons},
             "error": result,
-            "_wolverine_version": "2.1",
+            "_wolverine_version": "2.2",
         })
 
 


### PR DESCRIPTION
New skill: Spider v1.0 — Elite Convergence Scanner
- Enters when 2+ ELITE/RELIABLE traders with SNIPER/AGGRESSIVE risk independently converge on same asset+direction
- Two-phase: convergence map (5 min) + velocity trigger (90 sec)
- Full package: README, SKILL.md, runtime.yaml, config, scanner, config helper

Fleet-wide leverage scaling (conviction-based):
- Grizzly v3.2 (BTC): 8->7x, 9->10x, 10->15x, 11+->20x (HL max 40x)
- Polar v2.2 (ETH): 8->7x, 9->10x, 10->15x, 11+->20x (HL max 25x)
- Cheetah v2.1.1 (HYPE): 8->7x, 10+->10x (HL max 10x)
- Wolverine v2.2 (HYPE): 8->7x, 10+->10x (HL max 10x)
- Kodiak v2.1 (SOL): MAX_LEVERAGE 7->15x (HL max 20x)
- Horribilis already updated live: 8->7x, 9->10x, 10->15x, 11+->20x

Extreme velocity scoring (all Hyperfeed agents):
- 15m: >0.1->+1, >0.5->+2, >2.0->+3, >5.0->+4 (was capped at +2)
- 1h: >1.0->+1, >3.0->+2 (was capped at +1)
- Enables score 11+ triggering 15-20x leverage on extreme spikes

Context: Horribilis entered BTC today at score 9/7x during +14.16 15m spike. With expanded tiers, same signal scores 12 -> 20x -> 3x more ROE on winners.