### PR TITLE
feat: Fleet audit — 7 patches across 6 agents + Dog v1.0 + Phase 2 DS…

### DIFF
--- a/Grizzly-Horribilis/runtime.yaml
+++ b/Grizzly-Horribilis/runtime.yaml
@@ -1,9 +1,10 @@
 name: horribilis-tracker
-version: 1.0.0
+version: 1.3.0
 description: >
-  BTC conviction-scaled leverage hunter v1.1. 7x at score 8-9, 10x at score 10+.
-  50% margin per trade. Always protected by RatchetStop.
-  Aggressive Phase 2 locks — profits protected fast.
+  BTC conviction-scaled leverage hunter v1.3. Fleet audit fixes applied.
+  7x at score 8-9, 10x at score 10+. 50% margin per trade.
+  v1.3: reduceOnly filter, midnight fix, move-exhaustion, same-dir cooldown,
+  leverage-aware Phase 2 tiers.
 
 strategy:
   wallet: "${WALLET_ADDRESS}"
@@ -23,14 +24,10 @@ actions:
     decision_mode: rule
     scanners: [position_tracker]
 
-# RatchetStop configuration (user-facing: DSL)
-# Scanner enters. RatchetStop exits. Scanner must NEVER exit positions.
-# BTC-tuned timings: BTC moves slowly, needs hours not minutes.
 exit:
   engine: dsl
   interval_seconds: 30
   dsl_preset:
-    # BTC needs wide timings — 0.6% moves in 4 hours
     hard_timeout:
       enabled: true
       interval_in_minutes: 360
@@ -41,24 +38,20 @@ exit:
     dead_weight_cut:
       enabled: true
       interval_in_minutes: 90
-
-    # Phase 1: Loss protection
     phase1:
       enabled: true
       max_loss_pct: 25.0
       retrace_threshold: 8
       consecutive_breaches_required: 3
-
-    # Phase 2: RatchetStop profit trailing
-    # Aggressive locks — Horribilis takes profits fast
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5, lock_hw_pct: 30 }
-        - { trigger_pct: 10, lock_hw_pct: 50 }
-        - { trigger_pct: 15, lock_hw_pct: 70 }
-        - { trigger_pct: 20, lock_hw_pct: 85 }
-        - { trigger_pct: 30, lock_hw_pct: 90 }
+        # Phase 2 tiers — leverage-aware for BTC (fleet audit April 2026)
+        - { trigger_pct: 8,  lock_hw_pct: 25 }
+        - { trigger_pct: 15, lock_hw_pct: 50 }
+        - { trigger_pct: 25, lock_hw_pct: 65 }
+        - { trigger_pct: 35, lock_hw_pct: 80 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/Grizzly-Horribilis/scripts/grizzly-scanner.py
+++ b/Grizzly-Horribilis/scripts/grizzly-scanner.py
@@ -46,6 +46,7 @@ MIN_SCORE = 8                  # Min score for initial entry
 SCALE_MIN_SCORE = 9            # Higher bar for adding to position
 SCALE_MIN_ROE_PCT = 5.0        # Position must be at least +5% ROE to add
 XYZ_BANNED = True
+SAME_DIR_COOLDOWN_MINUTES = 60
 
 LEVERAGE_TIERS = [
     {"min_score": 10, "leverage": 10},
@@ -69,15 +70,17 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
-    """Check if there are resting entry orders on the book."""
+    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list) and len(orders) > 0:
-        return True
+    if isinstance(orders, list):
+        for o in orders:
+            if not o.get("reduceOnly", False):
+                return True
     return False
 
 
@@ -133,6 +136,14 @@ def evaluate_btc():
     if (d=="LONG" and p1h>0.2) or (d=="SHORT" and p1h<-0.2):
         score += 1; reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
 
+    # Move-exhaustion penalty — large existing moves reduce conviction
+    if abs(p4h) >= 4.0:
+        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
+            score -= 2; reasons.append(f"MOVE_EXHAUSTION {p4h:+.1f}%")
+    elif abs(p4h) >= 2.5:
+        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
+            score -= 1; reasons.append(f"MOVE_TIRING {p4h:+.1f}%")
+
     # Contribution velocity — multi-window (NEW: 15m + 1h + 4h)
     # 15m = entry timing signal (SM interest spiking NOW)
     # 1h = trend confirmation
@@ -181,13 +192,22 @@ def execute_entry(direction, margin, leverage):
 
 
 def load_tc():
+    """Load trade counter. Timestamps persist across midnight."""
     p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
+    default = {"date": now_date(), "entries": 0, "scale_ups": 0,
+               "last_entry_ts": 0, "last_win_direction": None, "last_win_ts": 0}
     if os.path.exists(p):
         try:
             with open(p) as f: tc = json.load(f)
-            if tc.get("date") == now_date(): return tc
+            if tc.get("date") != now_date():
+                tc["date"] = now_date()
+                tc["entries"] = 0
+                tc["scale_ups"] = 0
+            for k, v in default.items():
+                if k not in tc: tc[k] = v
+            return tc
         except: pass
-    return {"date": now_date(), "entries": 0, "scale_ups": 0}
+    return dict(default)
 
 def save_tc(tc):
     tc["date"] = now_date()
@@ -250,6 +270,18 @@ def run():
         if cfg.is_asset_cooled_down(ASSET, COOLDOWN_MINUTES):
             cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "BTC on cooldown"})
             return
+
+        # Same-direction re-entry cooldown after a win
+        last_win_dir = tc.get("last_win_direction")
+        last_win_ts = tc.get("last_win_ts", 0)
+        if last_win_dir and last_win_ts:
+            if (time.time() - last_win_ts) < SAME_DIR_COOLDOWN_MINUTES * 60:
+                thesis = evaluate_btc()
+                if thesis and thesis["direction"] == last_win_dir:
+                    remaining = int((SAME_DIR_COOLDOWN_MINUTES * 60 - (time.time() - last_win_ts)) / 60)
+                    cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                        "note": f"SAME_DIR_COOLDOWN: won {last_win_dir} {remaining}min ago"})
+                    return
 
         thesis = evaluate_btc()
         if not thesis:

--- a/Grizzly-Horribilis/scripts/grizzly_config.py
+++ b/Grizzly-Horribilis/scripts/grizzly_config.py
@@ -86,6 +86,8 @@ def load_trade_counter():
         "date": today, "entries": 0, "realizedPnl": 0,
         "gate": "OPEN", "gateReason": None, "cooldownUntil": None,
         "lastResults": [],
+        "last_win_direction": None,
+        "last_win_ts": 0,
     }
     if path.exists():
         try:

--- a/condor/runtime.yaml
+++ b/condor/runtime.yaml
@@ -1,8 +1,10 @@
 name: condor-tracker
-version: 1.0.0
+version: 2.1.0
 description: >
-  Multi-asset alpha hunter — evaluates BTC, ETH, SOL, HYPE and picks
-  the strongest thesis. Conviction-scaled margin. Lifecycle hunter DSL.
+  Multi-asset alpha hunter v2.1. Evaluates BTC, ETH, SOL, HYPE and picks
+  the strongest thesis. Conviction-scaled margin. Fleet audit fixes applied.
+  v2.1: has_resting_orders reduceOnly, midnight fix, move-exhaustion,
+  same-dir cooldown, conviction leverage tiers, leverage-aware Phase 2 DSL.
 
 strategy:
   wallet: "${WALLET_ADDRESS}"
@@ -28,11 +30,14 @@ exit:
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 180
+      interval_in_minutes: 240
     weak_peak_cut:
-      enabled: false
+      enabled: true
+      interval_in_minutes: 90
+      min_value: 2.0
     dead_weight_cut:
-      enabled: false
+      enabled: true
+      interval_in_minutes: 60
     phase1:
       enabled: true
       max_loss_pct: 25.0
@@ -41,11 +46,12 @@ exit:
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,  lock_hw_pct: 25 }
-        - { trigger_pct: 10, lock_hw_pct: 45 }
-        - { trigger_pct: 15, lock_hw_pct: 65 }
-        - { trigger_pct: 20, lock_hw_pct: 80 }
-        - { trigger_pct: 30, lock_hw_pct: 85 }
+        # Phase 2 tiers — leverage-aware for multi-asset (fleet audit April 2026)
+        - { trigger_pct: 8,  lock_hw_pct: 25 }
+        - { trigger_pct: 15, lock_hw_pct: 50 }
+        - { trigger_pct: 25, lock_hw_pct: 65 }
+        - { trigger_pct: 35, lock_hw_pct: 80 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/condor/scripts/condor-scanner.py
+++ b/condor/scripts/condor-scanner.py
@@ -50,6 +50,7 @@ MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 3
 COOLDOWN_MINUTES = 120
 MIN_SCORE = 8
+SAME_DIR_COOLDOWN_MINUTES = 60
 
 MIN_SM_PCT = 3.0
 MIN_SM_TRADERS = 20
@@ -81,6 +82,20 @@ def now_date():
 
 def now_iso():
     return datetime.now(timezone.utc).isoformat()
+
+
+def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
+    if not data: return False
+    orders = data.get("data", data)
+    if isinstance(orders, dict):
+        orders = orders.get("orders", orders.get("openOrders", []))
+    if isinstance(orders, list):
+        for o in orders:
+            if not o.get("reduceOnly", False):
+                return True
+    return False
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -209,6 +224,16 @@ def evaluate_thesis(asset, sm_data):
         score += 1
         reasons.append(f"1H_CONFIRMS {p1h:.2f}%")
 
+    # Move-exhaustion penalty — large existing moves reduce conviction
+    if abs(p4h) >= 4.0:
+        if (direction == "LONG" and p4h > 0) or (direction == "SHORT" and p4h < 0):
+            score -= 2
+            reasons.append(f"MOVE_EXHAUSTION {p4h:+.1f}%")
+    elif abs(p4h) >= 2.5:
+        if (direction == "LONG" and p4h > 0) or (direction == "SHORT" and p4h < 0):
+            score -= 1
+            reasons.append(f"MOVE_TIRING {p4h:+.1f}%")
+
     # 4. CONTRIBUTION VELOCITY (0-2)
     contrib = sm.get("contrib_change", 0)
     if abs(contrib) >= 0.03:
@@ -260,19 +285,25 @@ def get_margin_pct(score):
 # ═══════════════════════════════════════════════════════════════
 
 def load_trade_counter():
+    """Load trade counter. Timestamps persist across midnight."""
     p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
+    default = {"date": now_date(), "entries": 0,
+               "last_entry_ts": 0, "last_win_direction": None, "last_win_ts": 0}
     if os.path.exists(p):
         try:
-            with open(p) as f:
-                return json.load(f)
-        except (json.JSONDecodeError, IOError):
-            pass
-    return {"date": now_date(), "entries": 0}
+            with open(p) as f: tc = json.load(f)
+            if tc.get("date") != now_date():
+                tc["date"] = now_date()
+                tc["entries"] = 0
+            for k, v in default.items():
+                if k not in tc: tc[k] = v
+            return tc
+        except (json.JSONDecodeError, IOError): pass
+    return dict(default)
 
 
 def save_trade_counter(tc):
-    if tc.get("date") != now_date():
-        tc = {"date": now_date(), "entries": 0}
+    tc["date"] = now_date()
     cfg.atomic_write(os.path.join(cfg.STATE_DIR, "trade-counter.json"), tc)
 
 
@@ -313,13 +344,24 @@ def run():
                      "_v2_no_thesis_exit": True})
         return
 
+    # Check for resting orders
+    if has_resting_orders(wallet):
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": "RESTING ORDER: limit order pending."})
+        return
+
     tc = load_trade_counter()
-    if tc.get("date") != now_date():
-        tc = {"date": now_date(), "entries": 0}
-        save_trade_counter(tc)
     if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
                     "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
+        return
+
+    # General cooldown
+    last_entry = tc.get("last_entry_ts", 0)
+    if last_entry and (time.time() - last_entry) < COOLDOWN_MINUTES * 60:
+        remaining = int((COOLDOWN_MINUTES * 60 - (time.time() - last_entry)) / 60)
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+            "note": f"Cooldown ({remaining}min remaining)"})
         return
 
     sm_data = fetch_all_sm_data()
@@ -355,10 +397,21 @@ def run():
     theses.sort(key=lambda t: t["score"], reverse=True)
     best = theses[0]
 
+    # Same-direction re-entry cooldown after a win
+    last_win_dir = tc.get("last_win_direction")
+    last_win_ts = tc.get("last_win_ts", 0)
+    if last_win_dir and last_win_dir == best["direction"]:
+        if last_win_ts and (time.time() - last_win_ts) < SAME_DIR_COOLDOWN_MINUTES * 60:
+            remaining = int((SAME_DIR_COOLDOWN_MINUTES * 60 - (time.time() - last_win_ts)) / 60)
+            cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                "note": f"SAME_DIR_COOLDOWN: won {last_win_dir} {remaining}min ago"})
+            return
+
     margin_pct = get_margin_pct(best["score"])
     margin = round(account_value * margin_pct, 2)
 
     tc["entries"] = tc.get("entries", 0) + 1
+    tc["last_entry_ts"] = int(time.time())
     save_trade_counter(tc)
 
     cfg.output({
@@ -380,6 +433,10 @@ def run():
             "asset": best["asset"], "direction": best["direction"],
             "leverage": DEFAULT_LEVERAGE, "margin": margin,
             "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 30
+            },
         },
         "constraints": {
             "maxPositions": MAX_POSITIONS, "maxLeverage": MAX_LEVERAGE,
@@ -388,7 +445,7 @@ def run():
             "_v2_no_thesis_exit": True,
             "_note": "DSL managed by plugin runtime. Scanner does NOT manage exits.",
         },
-        "_condor_version": "2.0",
+        "_condor_version": "2.1",
     })
 
 

--- a/kodiak/runtime.yaml
+++ b/kodiak/runtime.yaml
@@ -46,10 +46,13 @@ exit:
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 7, lock_hw_pct: 40 }
-        - { trigger_pct: 12, lock_hw_pct: 55 }
-        - { trigger_pct: 15, lock_hw_pct: 75 }
-        - { trigger_pct: 20, lock_hw_pct: 85 }
+        # Phase 2 tiers — leverage-aware for SOL (fleet audit April 2026)
+        # At 10x on SOL, old Tier 1 created a $0.13 lock — normal SOL wick is $0.42
+        - { trigger_pct: 8,  lock_hw_pct: 25 }
+        - { trigger_pct: 15, lock_hw_pct: 50 }
+        - { trigger_pct: 25, lock_hw_pct: 65 }
+        - { trigger_pct: 35, lock_hw_pct: 80 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
 
 # ── NOTIFICATIONS ──
 notifications:

--- a/kodiak/scripts/kodiak-scanner.py
+++ b/kodiak/scripts/kodiak-scanner.py
@@ -20,6 +20,7 @@ Runs every 3 minutes.
 
 import sys
 import os
+import time
 from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -306,6 +307,16 @@ def build_sol_thesis(entry_cfg):
         score += 1
         reasons.append(f"4h_momentum_{mom_4h:+.1f}%")
 
+    # Move-exhaustion penalty — large existing moves reduce conviction
+    if abs(mom_4h) >= 4.0:
+        if (direction == "LONG" and mom_4h > 0) or (direction == "SHORT" and mom_4h < 0):
+            score -= 2
+            reasons.append(f"MOVE_EXHAUSTION {mom_4h:+.1f}%")
+    elif abs(mom_4h) >= 2.5:
+        if (direction == "LONG" and mom_4h > 0) or (direction == "SHORT" and mom_4h < 0):
+            score -= 1
+            reasons.append(f"MOVE_TIRING {mom_4h:+.1f}%")
+
     return {
         "coin": "SOL",
         "direction": direction,
@@ -519,6 +530,22 @@ def evaluate_reload(exit_state, entry_cfg):
 
 MAX_LEVERAGE = 15         # SOL max on HL is 20x; cap at 15x for conviction scaling
 MIN_LEVERAGE = 5
+SAME_DIR_COOLDOWN_MINUTES = 60
+
+
+def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
+    if not data:
+        return False
+    orders = data.get("data", data)
+    if isinstance(orders, dict):
+        orders = orders.get("orders", orders.get("openOrders", []))
+    if isinstance(orders, list):
+        for o in orders:
+            if not o.get("reduceOnly", False):
+                return True
+    return False
 
 
 # ─── Main ─────────────────────────────────────────────────────
@@ -655,13 +682,28 @@ def run():
         cfg.output({"success": True, "heartbeat": "NO_REPLY", "note": f"max entries ({max_entries})"})
         return
 
-    # Build BTC thesis
+    if has_resting_orders(wallet):
+        cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                     "note": "RESTING ORDER: limit order pending."})
+        return
+
+    # Build SOL thesis
     thesis = build_sol_thesis(entry_cfg)
 
     if not thesis or thesis["score"] < entry_cfg.get("minScore", 10):
         note = "no SOL thesis" if not thesis else f"SOL score {thesis['score']} below {entry_cfg.get('minScore', 10)}"
         cfg.output({"success": True, "heartbeat": "NO_REPLY", "note": note})
         return
+
+    # Same-direction re-entry cooldown after a win
+    last_win_dir = tc.get("last_win_direction")
+    last_win_ts = tc.get("last_win_ts", 0)
+    if last_win_dir and last_win_ts and thesis["direction"] == last_win_dir:
+        if (time.time() - last_win_ts) < SAME_DIR_COOLDOWN_MINUTES * 60:
+            remaining = int((SAME_DIR_COOLDOWN_MINUTES * 60 - (time.time() - last_win_ts)) / 60)
+            cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                "note": f"SAME_DIR_COOLDOWN: won {last_win_dir} {remaining}min ago"})
+            return
 
     # Conviction-scaled leverage (v2.1 fleet: fixed tiers 7/10/12/15x)
     if thesis["score"] >= 14:

--- a/kodiak/scripts/kodiak_config.py
+++ b/kodiak/scripts/kodiak_config.py
@@ -81,7 +81,8 @@ def load_trade_counter():
     default = {
         "date": today, "entries": 0, "realizedPnl": 0,
         "gate": "OPEN", "gateReason": None, "cooldownUntil": None,
-        "lastResults": []
+        "lastResults": [],
+        "last_entry_ts": 0, "last_win_direction": None, "last_win_ts": 0,
     }
     if path.exists():
         try:

--- a/polar/runtime.yaml
+++ b/polar/runtime.yaml
@@ -41,11 +41,13 @@ exit:
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,  lock_hw_pct: 30 }
-        - { trigger_pct: 10, lock_hw_pct: 50 }
-        - { trigger_pct: 15, lock_hw_pct: 65 }
-        - { trigger_pct: 20, lock_hw_pct: 80 }
-        - { trigger_pct: 30, lock_hw_pct: 85 }
+        # Phase 2 tiers — leverage-aware for ETH (fleet audit April 2026)
+        # At 20x, old Tier 1 (5%/30%) created a $1.19 lock — normal ETH wick is $5-8
+        - { trigger_pct: 8,  lock_hw_pct: 25 }
+        - { trigger_pct: 15, lock_hw_pct: 50 }
+        - { trigger_pct: 25, lock_hw_pct: 65 }
+        - { trigger_pct: 35, lock_hw_pct: 80 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/polar/scripts/polar-scanner.py
+++ b/polar/scripts/polar-scanner.py
@@ -67,12 +67,16 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data: return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list) and len(orders) > 0: return True
+    if isinstance(orders, list):
+        for o in orders:
+            if not o.get("reduceOnly", False):
+                return True
     return False
 
 

--- a/sentinel/runtime.yaml
+++ b/sentinel/runtime.yaml
@@ -1,8 +1,10 @@
 name: sentinel-tracker
-version: 1.0.0
+version: 2.1.0
 description: >
-  Quality trader convergence scanner. Finds assets where multiple
-  ELITE/RELIABLE traders converge. Lifecycle hunter DSL.
+  Quality trader convergence scanner v2.1. Finds assets where multiple
+  ELITE/RELIABLE traders converge. Fleet audit fixes applied.
+  v2.1: has_resting_orders reduceOnly, midnight fix, move-exhaustion,
+  same-dir cooldown, leverage-aware Phase 2 tiers.
 
 strategy:
   wallet: "${WALLET_ADDRESS}"
@@ -28,11 +30,14 @@ exit:
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 180
+      interval_in_minutes: 240
     weak_peak_cut:
-      enabled: false
+      enabled: true
+      interval_in_minutes: 90
+      min_value: 2.0
     dead_weight_cut:
-      enabled: false
+      enabled: true
+      interval_in_minutes: 60
     phase1:
       enabled: true
       max_loss_pct: 25.0
@@ -41,11 +46,12 @@ exit:
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,  lock_hw_pct: 25 }
-        - { trigger_pct: 10, lock_hw_pct: 45 }
-        - { trigger_pct: 15, lock_hw_pct: 65 }
-        - { trigger_pct: 20, lock_hw_pct: 80 }
-        - { trigger_pct: 30, lock_hw_pct: 85 }
+        # Phase 2 tiers — leverage-aware (fleet audit April 2026)
+        - { trigger_pct: 8,  lock_hw_pct: 25 }
+        - { trigger_pct: 15, lock_hw_pct: 50 }
+        - { trigger_pct: 25, lock_hw_pct: 65 }
+        - { trigger_pct: 35, lock_hw_pct: 80 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/sentinel/scripts/sentinel-scanner.py
+++ b/sentinel/scripts/sentinel-scanner.py
@@ -53,6 +53,7 @@ MAX_DAILY_ENTRIES = 4
 COOLDOWN_MINUTES = 120
 MARGIN_PCT = 0.20
 MIN_SCORE = 7
+SAME_DIR_COOLDOWN_MINUTES = 60
 XYZ_BANNED = True
 
 # Convergence thresholds
@@ -86,6 +87,20 @@ def now_date():
 
 def now_iso():
     return datetime.now(timezone.utc).isoformat()
+
+
+def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
+    if not data: return False
+    orders = data.get("data", data)
+    if isinstance(orders, dict):
+        orders = orders.get("orders", orders.get("openOrders", []))
+    if isinstance(orders, list):
+        for o in orders:
+            if not o.get("reduceOnly", False):
+                return True
+    return False
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -316,6 +331,14 @@ def score_candidate(cand):
         score += 1
         reasons.append(f"1H_CONFIRMS {p1h:.2f}%")
 
+    # Move-exhaustion penalty — large existing moves reduce conviction
+    if abs(p4h) >= 4.0:
+        if (direction == "LONG" and p4h > 0) or (direction == "SHORT" and p4h < 0):
+            score -= 2; reasons.append(f"MOVE_EXHAUSTION {p4h:+.1f}%")
+    elif abs(p4h) >= 2.5:
+        if (direction == "LONG" and p4h > 0) or (direction == "SHORT" and p4h < 0):
+            score -= 1; reasons.append(f"MOVE_TIRING {p4h:+.1f}%")
+
     # 4. Contribution velocity (0-1 point)
     contrib = abs(cand.get("contrib_change", 0))
     if contrib >= 0.01:
@@ -330,19 +353,25 @@ def score_candidate(cand):
 # ═══════════════════════════════════════════════════════════════
 
 def load_trade_counter():
+    """Load trade counter. Timestamps persist across midnight."""
     p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
+    default = {"date": now_date(), "entries": 0,
+               "last_entry_ts": 0, "last_win_direction": None, "last_win_ts": 0}
     if os.path.exists(p):
         try:
-            with open(p) as f:
-                return json.load(f)
-        except (json.JSONDecodeError, IOError):
-            pass
-    return {"date": now_date(), "entries": 0}
+            with open(p) as f: tc = json.load(f)
+            if tc.get("date") != now_date():
+                tc["date"] = now_date()
+                tc["entries"] = 0
+            for k, v in default.items():
+                if k not in tc: tc[k] = v
+            return tc
+        except (json.JSONDecodeError, IOError): pass
+    return dict(default)
 
 
 def save_trade_counter(tc):
-    if tc.get("date") != now_date():
-        tc = {"date": now_date(), "entries": 0}
+    tc["date"] = now_date()
     cfg.atomic_write(os.path.join(cfg.STATE_DIR, "trade-counter.json"), tc)
 
 
@@ -383,10 +412,13 @@ def run():
                      "_v2_no_thesis_exit": True})
         return
 
+    # Check for resting orders
+    if has_resting_orders(wallet):
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": "RESTING ORDER: limit order pending."})
+        return
+
     tc = load_trade_counter()
-    if tc.get("date") != now_date():
-        tc = {"date": now_date(), "entries": 0}
-        save_trade_counter(tc)
     if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
                     "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
@@ -430,11 +462,18 @@ def run():
 
     candidates.sort(key=lambda x: x["score"], reverse=True)
 
+    # Same-direction re-entry cooldown
+    last_win_dir = tc.get("last_win_direction")
+    last_win_ts = tc.get("last_win_ts", 0)
+
     for cand in candidates:
         asset = cand["asset"]
 
         if cand["score"] < MIN_SCORE:
             continue
+        if last_win_dir and last_win_dir == cand["direction"]:
+            if last_win_ts and (time.time() - last_win_ts) < SAME_DIR_COOLDOWN_MINUTES * 60:
+                continue
         if is_on_cooldown(asset):
             continue
         if any(p["coin"].upper() == asset.upper() for p in positions):
@@ -444,6 +483,7 @@ def run():
         margin = round(account_value * MARGIN_PCT, 2)
 
         tc["entries"] = tc.get("entries", 0) + 1
+        tc["last_entry_ts"] = int(time.time())
         save_trade_counter(tc)
 
         cfg.output({
@@ -466,6 +506,10 @@ def run():
                 "leverage": DEFAULT_LEVERAGE,
                 "margin": margin,
                 "orderType": "FEE_OPTIMIZED_LIMIT",
+                "feeOptimizedLimitOptions": {
+                    "ensureExecutionAsTaker": False,
+                    "executionTimeoutSeconds": 30
+                },
             },
             "constraints": {
                 "maxPositions": MAX_POSITIONS,
@@ -476,7 +520,7 @@ def run():
                 "_v2_no_thesis_exit": True,
                 "_note": "DSL managed by plugin runtime. Scanner does NOT manage exits.",
             },
-            "_sentinel_version": "2.0",
+            "_sentinel_version": "2.1",
         })
         return
 

--- a/spider/runtime.yaml
+++ b/spider/runtime.yaml
@@ -42,11 +42,12 @@ exit:
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,  lock_hw_pct: 30 }
-        - { trigger_pct: 10, lock_hw_pct: 50 }
-        - { trigger_pct: 15, lock_hw_pct: 65 }
-        - { trigger_pct: 20, lock_hw_pct: 80 }
-        - { trigger_pct: 30, lock_hw_pct: 85 }
+        # Phase 2 tiers — leverage-aware (fleet audit April 2026)
+        - { trigger_pct: 8,  lock_hw_pct: 25 }
+        - { trigger_pct: 15, lock_hw_pct: 50 }
+        - { trigger_pct: 25, lock_hw_pct: 65 }
+        - { trigger_pct: 35, lock_hw_pct: 80 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/spider/scripts/spider-scanner.py
+++ b/spider/scripts/spider-scanner.py
@@ -101,12 +101,17 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data: return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    return isinstance(orders, list) and len(orders) > 0
+    if isinstance(orders, list):
+        for o in orders:
+            if not o.get("reduceOnly", False):
+                return True
+    return False
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -308,6 +313,15 @@ def score_convergences(convergences, velocity):
             if cc_1h > 1.0:
                 score += 1; reasons.append(f"1H_ACCEL +{cc_1h:.2f}")
 
+            # v1.1: Move-exhaustion penalty — large existing moves reduce conviction
+            p4h = vm.get("p4h", 0)
+            if abs(p4h) >= 4.0:
+                if (direction == "LONG" and p4h > 0) or (direction == "SHORT" and p4h < 0):
+                    score -= 2; reasons.append(f"MOVE_EXHAUSTION {p4h:+.1f}%")
+            elif abs(p4h) >= 2.5:
+                if (direction == "LONG" and p4h > 0) or (direction == "SHORT" and p4h < 0):
+                    score -= 1; reasons.append(f"MOVE_TIRING {p4h:+.1f}%")
+
         # US session (0-1)
         hour = datetime.now(timezone.utc).hour
         if 13 <= hour <= 21:
@@ -349,13 +363,21 @@ def execute_entry(asset, direction, margin, leverage):
 
 
 def load_tc():
+    """Load trade counter. Timestamps persist across midnight."""
     p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
+    default = {"date": now_date(), "entries": 0,
+               "last_entry_ts": 0, "last_win_direction": None, "last_win_ts": 0}
     if os.path.exists(p):
         try:
             with open(p) as f: tc = json.load(f)
-            if tc.get("date") == now_date(): return tc
+            if tc.get("date") != now_date():
+                tc["date"] = now_date()
+                tc["entries"] = 0
+            for k, v in default.items():
+                if k not in tc: tc[k] = v
+            return tc
         except: pass
-    return {"date": now_date(), "entries": 0}
+    return dict(default)
 
 def save_tc(tc):
     tc["date"] = now_date()
@@ -423,6 +445,13 @@ def run():
     # Phase 2: Score with live velocity
     velocity = fetch_sm_velocity()
     scored = score_convergences(convergences, velocity)
+
+    # v1.1: Same-direction re-entry cooldown after a win
+    SAME_DIR_COOLDOWN_MINUTES = 60
+    last_win_dir = tc.get("last_win_direction")
+    last_win_ts = tc.get("last_win_ts", 0)
+    if last_win_dir and last_win_ts and (time.time() - last_win_ts) < SAME_DIR_COOLDOWN_MINUTES * 60:
+        scored = [s for s in scored if s["direction"] != last_win_dir]
 
     if not scored or scored[0]["score"] < MIN_SCORE:
         best = scored[0] if scored else None


### PR DESCRIPTION
…L tiers

## Fleet Audit — April 8, 2026

### Summary
Full diagnostic and upgrade pass across 6 agents plus new Dog v1.0 agent. Core finding: fleet has +$800 in gross directional profits being consumed by ~$1,100 in fees. These patches address execution efficiency and entry quality.

### Changes per agent

**Polar v2.3** — reduceOnly filter + Phase 2 DSL tiers **Grizzly-Horribilis v1.3** — reduceOnly + move-exhaustion + same-dir cooldown + Phase 2 tiers **Spider v1.1** — reduceOnly + midnight fix + move-exhaustion + same-dir cooldown + Phase 2 tiers **Condor v2.1** — has_resting_orders (new) + midnight fix + move-exhaustion + same-dir cooldown + fee options + Phase 2 tiers **Sentinel v2.1** — has_resting_orders (new) + midnight fix + move-exhaustion + same-dir cooldown + fee options + Phase 2 tiers **Kodiak** — reduceOnly + Phase 2 tiers
**Dog v1.0** — New agent: consistency-focused multi-asset trader targeting 5% ROE/week

### 7 fleet-standard patches
1. has_resting_orders reduceOnly filter — prevents DSL stop-losses from blocking new entries
2. UTC midnight cooldown fix — timestamps persist across date change
3. Move-exhaustion scoring — penalizes entries after >2.5% 4H moves
4. Same-direction re-entry cooldown — 60 min block after winning same direction
5. Gate check order — positions → resting orders → daily limit → cooldown → evaluate
6. feeOptimizedLimitOptions — explicit maker-only entry config
7. Phase 2 DSL tiers — leverage-aware, wider triggers to prevent wick-outs