### PR TITLE
[fleet-fix] Phoenix v2.0 — tighten DSL time cuts to match signal validity window

### DIFF
--- a/phoenix/runtime.yaml
+++ b/phoenix/runtime.yaml
@@ -28,11 +28,14 @@ exit:
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 180
+      interval_in_minutes: 45
     weak_peak_cut:
-      enabled: false
+      enabled: true
+      interval_in_minutes: 15
+      min_value: 1.5
     dead_weight_cut:
-      enabled: false
+      enabled: true
+      interval_in_minutes: 20
     phase1:
       enabled: true
       max_loss_pct: 25.0


### PR DESCRIPTION
## Diagnosis

Phoenix v2.0's contribution-velocity divergence signal resolves in 15-45 minutes. From Phoenix's self-diagnosis (April 10):

> "In Phoenix v2.0, the tagline literally says: 'Thesis exit removed — scanner enters, DSL exits.' This is the primary reason the strategy is failing. Phoenix is identifying a short-term momentum reversal (divergence), entering the trade, but then doing absolutely nothing to exit when the divergence corrects itself 15 minutes later. It just sits there holding the bag for 3 hours until the DSL hard timeout kills it."

Inversion test confirmed the signal is 4x correct in direction — inverting would lose -$295 vs actual -$72. The signal works; exits are destroying the alpha.

## Current config → Target config

| Parameter | Before | After |
|-----------|--------|-------|
| hard_timeout | 180 min | 45 min |
| weak_peak_cut | disabled | enabled, 15 min, min_value 1.5% ROE |
| dead_weight_cut | disabled | enabled, 20 min |

**min_value semantics (confirmed from DSL docs):** `weak_peak_cut` fires after `interval_in_minutes` if peak ROE never exceeded `min_value`% and current ROE is below peak. So `min_value: 1.5` means "if after 15 min the best this trade ever did was <1.5% ROE, kill it."

## Predicted impact

- Median hold time: ~3 hours → ~30 minutes
- Trades that would have drifted to the 180-min hard timeout now get cut at 20 min (dead weight) or 15 min (weak peak) if the signal hasn't materialized
- Combined with Sarvesh's fee fix (landing Tue/Wed), Phoenix should move from -$250 toward break-even

## What this does NOT change

- Entry signal (scanner) — untouched
- Phase 1 retrace parameters — untouched
- Phase 2 tier structure — untouched
- `_v2_no_thesis_exit: true` — still in scanner config (Python), not in this yaml