### PR TITLE
[fleet-fix] Condor v2.0 — tighten DSL time cuts to match signal validity window

### DIFF
--- a/condor/runtime.yaml
+++ b/condor/runtime.yaml
@@ -30,14 +30,14 @@ exit:
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 240
+      interval_in_minutes: 75
     weak_peak_cut:
       enabled: true
-      interval_in_minutes: 90
+      interval_in_minutes: 40
       min_value: 2.0
     dead_weight_cut:
       enabled: true
-      interval_in_minutes: 60
+      interval_in_minutes: 30
     phase1:
       enabled: true
       max_loss_pct: 25.0


### PR DESCRIPTION
## Diagnosis

Condor v2.0's SM consensus + 15m/1h extreme velocity signal resolves in 15-45 minutes. From Condor's self-diagnosis (April 10):

> "Entering trades based on a violently fast 15-minute momentum thesis but holding them for 2.5 hours. By the time DSL or 3-hour timeout finally kills the trade, initial momentum is long dead."

3 of 9 positions closed at exactly ~178-182 minutes (hard timeout). Median hold: 141 min. The signal had resolved hours before the exit fired.

**Critical note:** Condor was wrong about its own current config. It reported "hard_timeout: 180, weak_peak_cut needs to be enabled." The actual yaml on main shows hard_timeout: 240, weak_peak_cut already enabled at 90 min. Cuts were enabled but far too loose, not disabled.

## Current config → Target config

| Parameter | Before | After |
|-----------|--------|-------|
| hard_timeout | 240 min | 75 min |
| weak_peak_cut | 90 min | 40 min |
| dead_weight_cut | 60 min | 30 min |
| min_value (weak_peak_cut) | 2.0% ROE | 2.0% ROE (unchanged) |

## Predicted impact

- Median hold time: ~141 min → ~45 min
- Dead-weight trades that never went positive get cut at 30 min instead of 60
- Weak-peak trades (peaked below 2% ROE) get cut at 40 min instead of 90
- Hard timeout backstop at 75 min instead of 240

## What this does NOT change

- Entry signal, asset universe, conviction scaling — untouched
- Phase 1 retrace parameters — untouched
- Phase 2 tier structure (leverage-aware) — untouched