### PR TITLE
[fleet-fix] enable FEE_OPTIMIZED_LIMIT across all 20 yaml agents

### DIFF
--- a/Grizzly-Horribilis/runtime.yaml
+++ b/Grizzly-Horribilis/runtime.yaml
@@ -27,6 +27,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/bald-eagle/runtime.yaml
+++ b/bald-eagle/runtime.yaml
@@ -27,6 +27,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 15
   dsl_preset:
     # Time-based exits — XYZ-tuned wide timings
     # Oil/commodities move slowly — 45min kills every trade

--- a/bison/runtime.yaml
+++ b/bison/runtime.yaml
@@ -26,6 +26,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
   dsl_preset:
     # Time-based exits — conviction holder needs patience
     hard_timeout:

--- a/cheetah/runtime.yaml
+++ b/cheetah/runtime.yaml
@@ -26,6 +26,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/cobra/runtime.yaml
+++ b/cobra/runtime.yaml
@@ -39,6 +39,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/condor/runtime.yaml
+++ b/condor/runtime.yaml
@@ -27,6 +27,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 15
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/dog/runtime.yaml
+++ b/dog/runtime.yaml
@@ -25,6 +25,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     # Dog's DSL is tuned for QUICK PROFIT-TAKING, not riding winners.
     # Key differences from fleet standard:

--- a/fox/runtime.yaml
+++ b/fox/runtime.yaml
@@ -27,6 +27,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/hydra/runtime.yaml
+++ b/hydra/runtime.yaml
@@ -33,6 +33,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/jaguar/runtime.yaml
+++ b/jaguar/runtime.yaml
@@ -27,6 +27,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/kodiak/runtime.yaml
+++ b/kodiak/runtime.yaml
@@ -27,6 +27,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/mantis/runtime.yaml
+++ b/mantis/runtime.yaml
@@ -27,6 +27,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/orca/runtime.yaml
+++ b/orca/runtime.yaml
@@ -26,6 +26,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/phoenix/runtime.yaml
+++ b/phoenix/runtime.yaml
@@ -25,6 +25,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/polar/runtime.yaml
+++ b/polar/runtime.yaml
@@ -25,6 +25,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/roach/runtime.yaml
+++ b/roach/runtime.yaml
@@ -27,6 +27,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/scorpion/runtime.yaml
+++ b/scorpion/runtime.yaml
@@ -35,6 +35,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/sentinel/runtime.yaml
+++ b/sentinel/runtime.yaml
@@ -27,6 +27,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/shark/runtime.yaml
+++ b/shark/runtime.yaml
@@ -27,6 +27,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/spider/runtime.yaml
+++ b/spider/runtime.yaml
@@ -26,6 +26,10 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true


### PR DESCRIPTION
## Problem

Fleet-wide executor bug: all agents hardcode `MARKET` orders. 0% maker rate. Fees-to-volume runs 0.075-0.085% — roughly 3x expected taker rate and 5-10x maker rate. This has cost ~$1.1K-1.3K in already-paid fees across 13 active trading agents. Sarvesh's order-type-configuration release (expected Tue/Wed April 14-15) adds runtime support for `FEE_OPTIMIZED_LIMIT`.

## What this PR does

Adds `order_type: FEE_OPTIMIZED_LIMIT` with `ensure_execution_as_taker: true` to the DSL `exit:` block of all 20 agents that have `runtime.yaml`. This means DSL exits (Phase 1 breaches, Phase 2 trailing stops, weak peak cuts, dead weight cuts, hard timeouts) will attempt maker fills first, falling back to taker if the ALO doesn't fill within the timeout.

## Per-agent class timeout assignments

| Class | Agents | Timeout | Rationale |
|-------|--------|---------|-----------|
| **Striker** | phoenix, roach, spider, mantis, orca, scorpion, sentinel, cobra, jaguar, dog, fox, cheetah, hydra, shark | 10s | Speed matters more than fee savings; signals are 11-45 min windows |
| **Conviction** | bison, Grizzly-Horribilis, polar, kodiak | 45s | Hold periods are hours; can afford to wait for maker fills |
| **Multi-asset** | condor, bald-eagle | 15s | Compromise between speed and fee optimization |

## Not covered (Python-only agents, need code changes)

wolverine, lemon, barracuda, owl, raptor, hawk, grizzly — these call `create_position` directly from Python scanners and need `orderType` changes in their scripts.

## Predicted impact (from execution-hardening-spec-v2)

If maker rate goes from 0% to ~70%, fee rate drops from ~0.078% to ~0.025%. On the current 13 active trading agents, this recovers ~$700-800 in forward-looking fees over the next month and flips 3-4 agents to net-positive (Polar, Kodiak, Scorpion, Lemon improved).

## DRAFT — do not merge yet

This PR is staged and ready. **Merge only after Sarvesh's runtime release deploys.** The runtime must support the new `order_type` and `fee_optimized_limit_options` yaml fields before agents read them. Target: same day as runtime deploy.

## Open question: hard-trigger override

Per execution-hardening-spec-v2 Addition 2, deadweight cuts and hard timeouts should ideally bypass the ALO wait and use MARKET directly. Sarvesh's runtime currently applies one global `closeOrderType` for all DSL exits. If Option A (implicit hard-trigger override) ships with the runtime, this PR needs no changes. If it doesn't, we accept that hard exits will have a brief ALO window before falling back to taker.