### PR TITLE
[fleet-fix] add _analysis/ persistence files for fleet operations loop

### DIFF
--- a/_analysis/experiment-registry.md
+++ b/_analysis/experiment-registry.md
@@ -1,0 +1,86 @@
+# Experiment Registry
+
+Last updated: April 10, 2026
+Updated by: Claude Code session (fleet analysis handoff from web chat)
+
+---
+
+## Format
+
+Each experiment gets a unique ID (EXP-NNN), a clear hypothesis, a single variable changed, a measurement plan, and a result field that gets filled after observation.
+
+---
+
+## EXP-001: Phoenix v2.0 time cuts
+- **PR:** Senpi-ai/senpi-skills#147
+- **Branch:** fleet-fix/phoenix-v2.0-time-cuts
+- **Variable changed:** hard_timeout 180->45, weak_peak_cut disabled->enabled at 15 min (min_value 1.5%), dead_weight_cut disabled->enabled at 20 min
+- **Hypothesis:** Median hold time drops from ~3h to ~30 min. Gross PnL improves as trades close near signal resolution.
+- **Baseline (pre-merge):** 39 positions, -$72.43 net, -$250.67 with fees. Median hold ~3h. 48.7% WR.
+- **Measurement plan:** Pull Phoenix closed positions 24h and 48h after merge. Compute: median hold time, gross PnL, net PnL, WR, avg winner/loser.
+- **Prediction logged:** Median hold <45 min. Gross PnL per trade improves by >30%.
+- **Result:** PENDING
+
+## EXP-002: Condor v2.0 time cuts
+- **PR:** Senpi-ai/senpi-skills#148
+- **Branch:** fleet-fix/condor-v2.0-time-cuts
+- **Variable changed:** hard_timeout 240->75, weak_peak_cut 90->40, dead_weight_cut 60->30
+- **Hypothesis:** Median hold time drops from ~141 min to ~45 min.
+- **Baseline (pre-merge):** 9 positions, -$95.32 net. Median hold 141 min, avg 170 min.
+- **Measurement plan:** Same as EXP-001 but for Condor.
+- **Prediction logged:** Median hold <60 min. Gross PnL per trade improves.
+- **Result:** PENDING
+
+## EXP-003: Fleet-wide FEE_OPTIMIZED_LIMIT
+- **PR:** Senpi-ai/senpi-skills#149 (DRAFT)
+- **Branch:** fleet-fix/fee-optimized-limit-all-agents
+- **Variable changed:** DSL exit order_type MARKET -> FEE_OPTIMIZED_LIMIT with ensure_execution_as_taker: true across 20 yaml agents
+- **Hypothesis:** Maker fill rate goes from 0% to ~70%. Fee rate drops from ~0.078% to ~0.025%. 3-4 agents flip to net-positive.
+- **Baseline:** Fleet-wide fees-to-volume 0.075-0.085%. Total fees paid ~$1.1K-1.3K across 13 active agents.
+- **Measurement plan:** Within 1h of merge: capture baseline fees-to-volume per agent. Within 4h: check for maker fills. Within 24h: clean before/after comparison.
+- **Prediction logged:** Polar +$101, Kodiak +$33, Scorpion ~break-even, Lemon +$9 (fee fix alone).
+- **Dependency:** Sarvesh's order-type-configuration runtime release must deploy first (expected April 14-15).
+- **Result:** PENDING
+
+## EXP-004: Roach-B scalp mode (already on main)
+- **Variable changed:** weak_peak_cut 12 min, dead_weight_cut 8 min, hard_timeout 25 min (already merged)
+- **Hypothesis:** Give-back drops from 62% of peak to <40%.
+- **Baseline:** Avg peak ROE 3.92%, avg realized ROE 1.48%, 62% give-back.
+- **Measurement plan:** After dual DSL tracker health fix, measure over 20+ new positions.
+- **Blocker:** Dual DSL tracker instances must be killed first (health issue). Performance measurement meaningless until then.
+- **Result:** PENDING (BLOCKED on health fix)
+
+---
+
+## Queued experiments (not yet implemented)
+
+### EXP-Q1: Lemon 10x leverage A/B
+- Remove hard_timeout (let counter-trade unwinds run indefinitely)
+- Add tighter trailing DSL
+- Test 10x leverage vs current 5x
+- Requires Python scanner changes (no runtime.yaml)
+
+### EXP-Q2: Sentinel per-asset DSL tuning
+- Widen HYPE/BTC stops, keep ETH/SOL/TAO tight
+- May require scanner-level logic since runtime DSL is per-strategy not per-asset
+
+### EXP-Q3: Mantis v4.0 asset whitelist
+- Restrict to top-50 volume assets (remove BLAST, XPL, ZRO)
+- Raise STRIKER_MIN_SCORE
+- Consider signal direction flip
+
+### EXP-Q4: Wolverine mercy-kill logic
+- Re-enable thesis exit with a "mercy kill" threshold
+- Target: close if 15m velocity goes deeply negative AND position has been open >25 min
+- Requires Python scanner changes
+
+---
+
+## Scoring methodology
+
+For each experiment:
+1. Log prediction BEFORE merge
+2. Wait for measurement window (24h minimum, 48h preferred)
+3. Pull data and score against prediction
+4. Update calibration log in fleet-hypotheses.md
+5. If prediction wrong, document why and what was learned

--- a/_analysis/fleet-dossiers.md
+++ b/_analysis/fleet-dossiers.md
@@ -1,0 +1,107 @@
+# Fleet Dossiers — Predators Agent Profiles
+
+Last updated: April 10, 2026
+Updated by: Claude Code session (fleet analysis handoff from web chat)
+
+---
+
+## Tier 1: Fee fix alone makes profitable
+
+### Kodiak (SOL hunter)
+- **Signal:** Grizzly 3-mode lifecycle on SOL. SM consensus + velocity.
+- **Stats (lifetime as of April 10):** 56 positions, 55.4% WR, avg winner +$20.24, avg loser -$11.68. 1.73:1 payoff ratio with majority win rate. Median hold: 45 min. 3.8 fills/position.
+- **Exit quality:** 8 of 10 best winners captured peaks within pennies. Phase 2 tiers are excellently calibrated. Unlike Polar, Kodiak is NOT clipping winners.
+- **Exit cause distribution:** Phase 1 breaches 60%, Phase 2 trailing 32.5%, hard timeout 7.5%.
+- **Disease:** Fee only. $238.84 in fees paid on -$119.56 net. Fee fix recovers ~$153, flipping to ~+$33.
+- **Status:** No yaml changes needed beyond FEE_OPTIMIZED_LIMIT. runtime.yaml hard_timeout: 45 min.
+
+### Polar (ETH hunter)
+- **Signal:** Grizzly 3-mode lifecycle on ETH. Strong gross alpha but extreme-conviction entries at local tops/bottoms.
+- **Stats:** 56 positions, 26.8% WR, avg winner +$29.97, avg loser -$14.81. Median hold: 41.4 min. 5.0 fills/position.
+- **Exit quality:** Winners are being severely clipped by Phase 2 tiers. One winner would have gone +113.5% ROI vs captured +82.0%. DSL is too tight on the upside.
+- **Disease:** Fee primary, winner-clipping secondary. $367.86 in fees paid. Fee fix recovers ~$235, flipping to ~+$101.
+- **Status:** Phase 1: ship fee fix. Phase 2: consider widening Phase 2 tiers. runtime.yaml hard_timeout: 180 min.
+
+### Lemon (counter-trade, degen fader)
+- **Signal:** Fades DEGEN/CHOPPY traders losing >10% ROE at 10x+ leverage. 50% WR with 3.7:1 R/R ratio.
+- **Stats:** 6 positions, 3W/3L. Avg winner +$5.48, avg loss -$1.45. Median hold: ~3h (all exits by hard timeout).
+- **Exit quality:** Timer-based only. Clipping winners (BTC short missed $263 of additional downside). Losers sat in drawdown for full 3h when they should have been cut early by DSL.
+- **Disease:** Fee (minor, $8.44 total). Primary issue: hard_timeout is the only exit mechanism.
+- **Status:** Python-only (no runtime.yaml). Needs: remove hard_timeout, add tighter trailing DSL, test 10x leverage A/B.
+- **Open item:** Scanner doesn't persist addresses of faded traders. Needs lemon_config.py patch.
+
+---
+
+## Tier 2: Fee fix + one surgical change
+
+### Sentinel (inverted pipeline scanner)
+- **Signal:** Rising assets -> verify quality traders. Inversion test: actual -$38, inverted -$119. Signal is 3x correct.
+- **Stats:** Highly predictive on ETH (70% WR) and TAO (100% WR). Entire negative PnL isolated to HYPE (-$20.46) and BTC (-$22.50) where volatility triggers DSL stops on correct trades.
+- **Disease:** Per-asset DSL mismatch. HYPE/BTC need wider stops; ETH/SOL/TAO can keep tight stops.
+- **Status:** runtime.yaml hard_timeout: 240 min. Needs per-asset DSL tuning (not yet supported in runtime — may need scanner-level logic).
+
+### Phoenix v2.0 (contribution velocity divergence)
+- **Signal:** SM profit velocity diverging from price. Inversion: actual -$72, inverted -$295. Signal is 4x correct.
+- **Stats:** 39 positions, 48.7% WR. Avg winner +$11.93, avg loser -$14.95. Median hold: ~3h.
+- **Disease:** Thesis-exit removed (`_v2_no_thesis_exit: true`). Trades drift to 180-min hard timeout long after 15-min signal resolves.
+- **Status:** PR #147 ships time cuts (hard_timeout 180->45, weak_peak_cut enabled at 15 min, dead_weight_cut at 20 min).
+- **Fees:** $179.38 paid. Fee fix recovers ~$115.
+
+### Wolverine v2.0 (HYPE alpha hunter)
+- **Signal:** Extreme SM conviction + 15m/1h momentum spikes on HYPE. Same thesis-exit disease as Phoenix.
+- **Stats:** 8 positions, 57 fills. Median hold: 180.3 min. 62.5% of trades hit hard timeout.
+- **Disease:** `_v2_no_thesis_exit: true`. DSL handles 100% of exits. Needs mercy-kill logic.
+- **Status:** Python-only (no runtime.yaml). Target DSL values: weak_peak_cut 25 min, dead_weight_cut 35 min, hard_timeout 60 min. Must be applied via DSL CLI at deploy time.
+- **Fees:** $35.35 paid. Fee fix recovers ~$23.
+
+### Condor v2.0 (multi-asset alpha hunter)
+- **Signal:** SM consensus + 15m/1h extreme velocity on BTC/ETH/SOL/HYPE. Same thesis-exit disease.
+- **Stats:** 9 positions, 57 fills. Median hold: 141 min, avg: 170 min. 3 of 9 hit hard timeout.
+- **Disease:** Time cuts too loose (hard_timeout was 240 min, weak_peak_cut 90 min, dead_weight_cut 60 min).
+- **Status:** PR #148 tightens to 75/40/30 min. Condor was wrong about its own config during self-diagnosis.
+- **Fees:** $94.91 paid. Fee fix recovers ~$61.
+- **Critical methodological note:** Always read yaml directly. Condor reported hard_timeout: 180 when actual was 240.
+
+### Roach-B (Python cron, custom scoring)
+- **Signal:** Striker-class momentum scalps. Median time-to-peak: 11.28 minutes. 62% give-back from peak.
+- **Stats:** 84% of positions exit in Phase 1. Avg peak ROE 3.92%, avg realized ROE 1.48%.
+- **Disease:** DSL was too loose for scalp signals. Already fixed on main: weak_peak_cut 12 min, dead_weight_cut 8 min, hard_timeout 25 min.
+- **Status:** Scalp-mode values already shipped. Needs fee fix + re-measurement.
+- **Health issue (from transcript):** Dual DSL tracker instances detected. Needs runtime fix before performance re-measurement.
+
+---
+
+## Tier 3: Needs more work
+
+### Mantis v4.0 (Vixen/Orca scanner)
+- **Signal:** Marginally inverted. Original gross: -$11.33, inverted: +$11.33. But fee drag destroys both directions.
+- **Stats:** 15 positions, 46.7% WR. Median hold: 15.6 min. BLAST caused 150% of total gross loss.
+- **Disease:** Asset universe problem. Signal works on mid/large-caps, gets chopped on low-liquidity pairs.
+- **Status:** Needs whitelist to top-50 volume assets, raise STRIKER_MIN_SCORE, consider signal flip.
+
+### TBD — Owl, Spider, Orca v2.0 not yet interrogated
+
+---
+
+## Hold and monitor
+
+### Bison v1.2 (conviction holder)
+- **Signal:** 4H/1H signal agreement. Very low frequency.
+- **Stats:** 5 positions, 1W/3L closed, 1 open HYPE covering all realized losses. Avg closed hold: 14.18h.
+- **Disease:** Not fee-bound ($9.41 total fees). Sample too small to diagnose. Open HYPE position has +$116 unrealized.
+- **Status:** Monitor. Don't change anything until sample size reaches 15+ closed positions.
+
+---
+
+## Not yet profiled (need interrogation)
+
+- Scorpion v2.0 — near break-even after fee fix (~+$2). Needs examination.
+- Spider — $57.44 in fees, -$51.23 net. Needs interrogation.
+- Orca v2.0 — $52.70 in fees, -$49.83 net. Needs interrogation.
+- Owl — $4.25 in fees, -$8.83 net. Low activity.
+- Grizzly Horribilis — $113.29 in fees, -$166.34 net. Conviction class, needs examination.
+- Cobra, Jaguar, Raptor, Dog, Fox — not profiled in the April 10 session.
+- Hawk — single best signal, 20x leverage too high.
+- Barracuda — funding decay scanner, not profiled.
+- Bald Eagle — XYZ equities/commodities, not profiled.
+- 4 zero-trade agents — need identification and health check.

--- a/_analysis/fleet-hypotheses.md
+++ b/_analysis/fleet-hypotheses.md
@@ -1,0 +1,78 @@
+# Fleet Hypotheses Log
+
+Last updated: April 10, 2026
+Updated by: Claude Code session (fleet analysis handoff from web chat)
+
+---
+
+## Active hypotheses
+
+### H1: Fee fix alone flips 3-4 agents to net-positive
+**Filed:** April 10, 2026
+**Status:** AWAITING (Sarvesh's runtime release, expected April 14-15)
+**Prediction:** Polar (+$101), Kodiak (+$33), Scorpion (~break-even), Lemon (improves to +$9). Based on 0% maker -> ~70% maker, fee rate 0.078% -> ~0.025%.
+**How to score:** Pull each agent's net PnL 7 days after the fee fix merges. Compare to pre-fix baseline. If Polar and Kodiak are net-positive, H1 confirmed.
+**Risk:** Actual maker fill rate may be lower than 70% — depends on market depth and timeout settings.
+
+### H2: Phoenix time cuts (PR #147) reduce median hold from 3h to ~30 min
+**Filed:** April 10, 2026
+**Status:** AWAITING (PR merge + 24h measurement)
+**Prediction:** With hard_timeout 45 min, weak_peak_cut 15 min, dead_weight_cut 20 min, most trades should resolve within 30 minutes. Gross PnL improves because trades close near signal resolution.
+**How to score:** Pull Phoenix closed positions 48h after merge. Compute median hold time. Target: <45 min.
+**Risk:** If the signal genuinely needs >45 min to resolve on some assets (BTC may trend longer than SOL), the new hard_timeout could cut winners.
+
+### H3: Condor time cuts (PR #148) reduce median hold from 141 min to ~45 min
+**Filed:** April 10, 2026
+**Status:** AWAITING (PR merge + 24h measurement)
+**Prediction:** Same thesis as H2 but for multi-asset signals. Signal window is 15-45 min for extreme velocity spikes.
+**How to score:** Same method as H2. Target median hold: <60 min.
+
+### H4: Roach-B scalp mode (already on main) captures >60% of peak ROE
+**Filed:** April 10, 2026
+**Status:** AWAITING (re-measurement after dual DSL tracker is killed)
+**Prediction:** Pre-fix give-back was 62% of peak. With weak_peak_cut at 12 min and dead_weight_cut at 8 min, give-back should drop to <40%.
+**How to score:** After health fix (kill duplicate DSL), measure avg peak ROE vs avg realized ROE over 20+ positions.
+**Confound:** Dual DSL tracker must be fixed first or measurements are meaningless.
+
+### H5: Thesis-exit-removed disease affects all v2.0 agents uniformly
+**Filed:** April 10, 2026
+**Status:** PARTIALLY CONFIRMED
+**Evidence:** Phoenix, Wolverine, Condor all confirmed `_v2_no_thesis_exit: true` and exhibit the same pattern (trades drifting to hard timeout). All three diagnosed independently.
+**Open question:** Are there other v2.0 agents with this flag that we haven't checked?
+
+### H6: Agent self-reports are high-quality leads but not ground truth
+**Filed:** April 10, 2026
+**Status:** CONFIRMED (two instances)
+**Evidence:**
+1. Phoenix said "limits at mid-price getting shredded into 75 fills." Actual cause: executor hardcodes MARKET, no limit orders placed at all.
+2. Condor said "hard_timeout: 180, weak_peak_cut disabled." Actual yaml: hard_timeout: 240, weak_peak_cut enabled at 90 min.
+**Implication:** Always read yamls before drafting changes. Cross-check agent claims against repo source of truth.
+
+---
+
+## Retired hypotheses
+
+### H0: "Lemon is the existence proof for the fleet"
+**Filed:** April 10, 2026
+**Status:** SUPERSEDED by Polar
+**Original claim:** Lemon being the only profitable agent means it has the only working strategy.
+**Correction:** Polar has stronger gross alpha and is only unprofitable due to fees. After fee fix, Polar is the better existence proof — it demonstrates that the Grizzly 3-mode lifecycle scanner generates real alpha when execution doesn't destroy it.
+
+---
+
+## Calibration log
+
+### April 10, 2026 session predictions (from web chat)
+
+**Correct (3/7):**
+- Bison v1.2 not fee-bound (different category from strikers)
+- Mantis v4.0 has signal issues (inversion test confirmed, marginally)
+- Polar fills-per-position 5-8 confirming chunking
+
+**Wrong (4/7):**
+- "Lemon is the existence proof" — Polar is better
+- "Kodiak will show same clipping pattern as Polar" — Kodiak's exits are excellent
+- "Phoenix's inverted PnL would be marginally better" — it's 4x worse
+- "Polar will show clean win/loss distribution" — noisy with extreme-conviction loser problem
+
+**Calibration lesson:** Overweight architectural similarity. Same-lineage agents (Polar/Kodiak both Grizzly 3-mode) can have opposite outcomes due to underlying asset volatility differences.


### PR DESCRIPTION
## What this adds

Three markdown files at `_analysis/` to maintain cross-session context for the fleet analysis workstream:

- **fleet-dossiers.md** — per-agent profiles with signal description, stats, disease diagnosis, and current status
- **fleet-hypotheses.md** — active hypotheses with predictions, scoring criteria, and calibration log
- **experiment-registry.md** — every config change as a tracked experiment with baseline, prediction, measurement plan, and result

## Why

Every new analysis session currently starts from scratch. These files get updated at the end of every session so the next session can `git pull` and have full context automatically. This is the loop that makes us learn instead of repeating ourselves daily.

## Populated from

The complete April 10 web chat session transcript — all 10 agent interrogations, findings, diffs, and predictions.