### PR TITLE
[fleet-fix] revert FEE_OPTIMIZED_LIMIT — runtime not yet deployed

### DIFF
--- a/Grizzly-Horribilis/runtime.yaml
+++ b/Grizzly-Horribilis/runtime.yaml
@@ -27,10 +27,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 45
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/bald-eagle/runtime.yaml
+++ b/bald-eagle/runtime.yaml
@@ -27,10 +27,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 15
   dsl_preset:
     # Time-based exits — XYZ-tuned wide timings
     # Oil/commodities move slowly — 45min kills every trade

--- a/bison/runtime.yaml
+++ b/bison/runtime.yaml
@@ -26,10 +26,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 45
   dsl_preset:
     # Time-based exits — conviction holder needs patience
     hard_timeout:

--- a/cheetah/runtime.yaml
+++ b/cheetah/runtime.yaml
@@ -26,10 +26,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/cobra/runtime.yaml
+++ b/cobra/runtime.yaml
@@ -39,10 +39,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/condor/runtime.yaml
+++ b/condor/runtime.yaml
@@ -27,10 +27,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 15
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/dog/runtime.yaml
+++ b/dog/runtime.yaml
@@ -25,10 +25,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     # Dog's DSL is tuned for QUICK PROFIT-TAKING, not riding winners.
     # Key differences from fleet standard:

--- a/fox/runtime.yaml
+++ b/fox/runtime.yaml
@@ -27,10 +27,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/hydra/runtime.yaml
+++ b/hydra/runtime.yaml
@@ -33,10 +33,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/jaguar/runtime.yaml
+++ b/jaguar/runtime.yaml
@@ -28,10 +28,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/kodiak/runtime.yaml
+++ b/kodiak/runtime.yaml
@@ -27,10 +27,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 45
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/mantis/runtime.yaml
+++ b/mantis/runtime.yaml
@@ -27,10 +27,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/orca/runtime.yaml
+++ b/orca/runtime.yaml
@@ -26,10 +26,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/phoenix/runtime.yaml
+++ b/phoenix/runtime.yaml
@@ -25,10 +25,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/polar/runtime.yaml
+++ b/polar/runtime.yaml
@@ -25,10 +25,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 45
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/roach/runtime.yaml
+++ b/roach/runtime.yaml
@@ -27,10 +27,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/scorpion/runtime.yaml
+++ b/scorpion/runtime.yaml
@@ -35,10 +35,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/sentinel/runtime.yaml
+++ b/sentinel/runtime.yaml
@@ -27,10 +27,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/shark/runtime.yaml
+++ b/shark/runtime.yaml
@@ -27,10 +27,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/spider/runtime.yaml
+++ b/spider/runtime.yaml
@@ -26,10 +26,6 @@ actions:
 exit:
   engine: dsl
   interval_seconds: 30
-  order_type: FEE_OPTIMIZED_LIMIT
-  fee_optimized_limit_options:
-    ensure_execution_as_taker: true
-    execution_timeout_seconds: 10
   dsl_preset:
     hard_timeout:
       enabled: true


### PR DESCRIPTION
Reverts PR #149. The `order_type: FEE_OPTIMIZED_LIMIT` yaml fields were merged prematurely — Sarvesh's runtime release that adds support for these fields hasn't deployed yet (expected Tue/Wed April 14-15).

The branch `fleet-fix/fee-optimized-limit-all-agents` is preserved. Once the runtime deploys, we re-open from that branch or cherry-pick.