### PR TITLE
[fleet-fix] Lemon v1.2 — retune DSL for counter-trade signal window

### DIFF
--- a/lemon/runtime.yaml
+++ b/lemon/runtime.yaml
@@ -19,22 +19,23 @@ actions:
     decision_mode: rule
     scanners: [position_tracker]
 
-# Fade trades need time — mean reversion can take hours.
-# Wide DSL, long timeout, generous Phase 1.
+# Fade trades need time — mean reversion can take 8+ hours.
+# Hard timeout raised to 480 min to let winners run.
+# Dead weight tightened to cut losers faster.
 exit:
   engine: dsl
   interval_seconds: 30
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 240
+      interval_in_minutes: 480
     weak_peak_cut:
       enabled: true
-      interval_in_minutes: 90
-      min_value: 3.0
+      interval_in_minutes: 60
+      min_value: 2.0
     dead_weight_cut:
       enabled: true
-      interval_in_minutes: 30
+      interval_in_minutes: 20
     phase1:
       enabled: true
       max_loss_pct: 15.0


### PR DESCRIPTION
## Diagnosis

Lemon fades DEGEN/CHOPPY traders losing >10% ROE. The signal works — 50% WR with 3.7:1 R/R ratio. Two exit problems from Lemon's self-diagnosis (April 10):

**Winners clipped by timeout:**
> "Best BTC short entered $66,972, timed out at $66,509. Daily low hit $66,246. Missed $263 of additional downside."

**Losers held too long:**
> "The timer actually saved us on losers, but for the wrong reason. We sat in drawdown for 3 hours instead of letting a DSL kill the trade when momentum stalled."

## Current config → Target config

| Parameter | Before | After | Rationale |
|-----------|--------|-------|-----------|
| hard_timeout | 240 min | 480 min | Counter-trade unwinds can take 8+ hours. Let winners run. |
| weak_peak_cut | 90 min / 3.0% ROE | 60 min / 2.0% ROE | Cut flat trades faster — if peak ROE never hit 2% after 60 min, the thesis isn't working |
| dead_weight_cut | 30 min | 20 min | If never positive after 20 min, kill it sooner |

## Pushback on "remove hard_timeout entirely"

The transcript recommended disabling hard_timeout completely. I kept it at 480 min instead. Reason: a trade that clears dead_weight_cut (went slightly positive) but then drifts flat for hours needs a backstop. 480 min gives 8 hours for the counter-trade thesis to play out while preventing zombie positions. If 480 min proves too conservative, we can raise it further or disable it in a follow-up.

## Not in this PR (queued for next experiment)

- 10x leverage A/B test against current 5x (separate experiment, one variable at a time)
- Scanner patch to persist addresses of faded traders to state file