### PR TITLE
[fleet-fix] Orca v2.0 — widen DSL time cuts for breakout signal window

### DIFF
--- a/orca/runtime.yaml
+++ b/orca/runtime.yaml
@@ -29,14 +29,14 @@ exit:
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 30
+      interval_in_minutes: 45
     weak_peak_cut:
       enabled: true
-      interval_in_minutes: 15
+      interval_in_minutes: 25
       min_value: 3.0
     dead_weight_cut:
       enabled: true
-      interval_in_minutes: 10
+      interval_in_minutes: 15
     phase1:
       enabled: true
       max_loss_pct: 20.0


### PR DESCRIPTION
## Diagnosis

Orca v2.0's FIRST_JUMP breakout signal is proven directionally correct (inversion test: +$4.29 actual vs -$4.29 inverted). Gross realized PnL is positive. But the DSL patience filters are suffocating winners — 4 of 5 best winners were clipped before the breakout matured.

From Orca's self-diagnosis:

> "Your scanner is excellent at picking direction, but the DSL patience filters are suffocating your winners. Because ORCA is entering breakouts (which often test support before expanding), the weak_peak_cut (15m) and hard_timeout (30m) are killing trades right as the breakout begins to mature."

Exit distribution: 50% weak_peak_cut, 23% dead_weight_cut, 23% Phase 1, 4% hard timeout. The DSL is cutting too fast for breakout signals.

## Current config → Target config

| Parameter | Before | After |
|-----------|--------|-------|
| hard_timeout | 30 min | 45 min |
| weak_peak_cut | 15 min | 25 min |
| dead_weight_cut | 10 min | 15 min |
| min_value (weak_peak_cut) | 3.0% ROE | 3.0% ROE (unchanged) |

## Predicted impact

- Winners get 10 more minutes to develop before weak_peak_cut fires
- Dead trades still cut at 15 min (not too generous)
- Combined with fee fix, should flip Orca from -$51 to net-positive