### PR TITLE
[fleet-fix] Scorpion v2.0 — blacklist low-liquidity assets (XPL, LIT, FARTCOIN)

### DIFF
--- a/scorpion/scripts/scorpion-scanner.py
+++ b/scorpion/scripts/scorpion-scanner.py
@@ -75,6 +75,12 @@ MIN_SWARM_COUNT = 5
 # XYZ equities banned from trading (but counted in swarm for context)
 XYZ_BANNED_TRADING = True
 
+# Low-liquidity assets blacklisted from TRADING (still counted in swarm detection).
+# XPL: -$52.89 single trade loss, violent wicks through DSL floors.
+# LIT: -$42.97 single trade loss (pre-margin-scaling-fix), erratic price action.
+# FARTCOIN: -$9.87, insufficient book depth for reliable execution.
+BLACKLISTED_ASSETS = {"XPL", "LIT", "FARTCOIN"}
+
 # State file
 STATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                           "..", "config", "scorpion-state.json")
@@ -294,6 +300,10 @@ def pick_best_target(swarm, state):
 
     for target in swarm:
         token = target["token"]
+
+        # Skip blacklisted low-liquidity assets
+        if token in BLACKLISTED_ASSETS:
+            continue
 
         # Check per-asset cooldown
         clear, _ = check_asset_cooldown(state, token)


### PR DESCRIPTION
## Diagnosis

Scorpion's altcoin swarm signal has a 64.3% win rate on 14 positions. The swarm detection meta-signal is strong. But two low-liquidity assets caused $96 of $122 total losses:

- XPL: -$52.89 on a single trade (violent wicks through DSL floors)
- LIT: -$42.97 on a single trade (pre-margin-scaling-fix, erratic price action)
- FARTCOIN: -$9.87 (insufficient book depth)

The other 12 trades are +$124 combined (ZRO: +$118, MON: +$28).

## Fix

Blacklist XPL, LIT, and FARTCOIN from trading. They're still counted in swarm detection (they contribute to the coordinated risk event signal), but excluded from trade execution.

## Predicted impact

Removing $96 in losses from 3 garbage trades while preserving $124 in gains from 12 quality trades. Combined with fee fix (~$49 recovery), Scorpion should be solidly net-positive.