### PR TITLE
[fleet-fix] Grizzly v4.0 + Horribilis v2.0 — contrarian BTC direction flip (A/B on pyramiding)

### DIFF
--- a/Grizzly-Horribilis/scripts/grizzly-scanner.py
+++ b/Grizzly-Horribilis/scripts/grizzly-scanner.py
@@ -2,12 +2,17 @@
 # Senpi GRIZZLY HORRIBILIS Scanner v1.2
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""GRIZZLY HORRIBILIS v1.2 — BTC Conviction-Scaled Leverage Hunter.
+"""GRIZZLY HORRIBILIS v2.0 — BTC Contrarian with Pyramiding.
 
-v1.2: Position scaling (pyramiding into winners).
-Unlike other fleet agents with MAX_POSITIONS=1, Horribilis can ADD to a
-winning BTC position when conviction remains strong. This is the aggressive
-bear — it presses winners.
+v2.0: DIRECTION FLIP — trade opposite to SM consensus.
+Fleet analysis (April 10, 2026) found that the SM consensus signal is
+perfectly inverted on BTC. Inversion test: actual -$53 gross, inverted +$53.
+The scanner enters after the move is exhausted, so we flip to fade it.
+
+A/B variable vs Grizzly v4.0: Horribilis pyramids into winners,
+Grizzly does not. All other signal logic is identical.
+
+Pyramiding rules (unchanged from v1.2):
 
 Pyramiding rules:
 1. Only add if existing position is in profit (ROE > +5%)
@@ -289,8 +294,13 @@ def run():
             return
         if thesis["score"] < MIN_SCORE:
             cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                "note": f"HUNTING: BTC {thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"})
+                "note": f"HUNTING: BTC SM={thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"})
             return
+
+        # ── CONTRARIAN FLIP ──
+        sm_direction = thesis["direction"]
+        thesis["direction"] = "SHORT" if sm_direction == "LONG" else "LONG"
+        thesis["reasons"].insert(0, f"CONTRARIAN_FLIP (SM is {sm_direction})")
 
         leverage = get_leverage_for_score(thesis["score"])
         margin = round(av * INITIAL_MARGIN_PCT, 2)
@@ -315,13 +325,13 @@ def run():
                 "execution": {"asset": ASSET, "direction": thesis["direction"],
                     "leverage": leverage, "margin": margin,
                     "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
-                "result": result, "_horribilis_version": "1.2",
+                "result": result, "_horribilis_version": "2.0",
             })
         else:
             cfg.output({"status": "ok", "action": "ENTRY_FAILED",
                 "signal": {"asset": ASSET, "direction": thesis["direction"],
                     "score": thesis["score"], "reasons": thesis["reasons"]},
-                "error": result, "_horribilis_version": "1.2"})
+                "error": result, "_horribilis_version": "2.0"})
         return
 
     # ── CASE 2: Position exists — evaluate for scale-up ──
@@ -351,10 +361,11 @@ def run():
             "note": f"RIDING: BTC {current_direction} ROE {current_roe:+.1f}%. No SM signal. DSL manages exit."})
         return
 
-    # Must agree with current direction
-    if thesis["direction"] != current_direction:
+    # CONTRARIAN: SM must still be OPPOSITE to our position (= same as original SM direction).
+    # We're fading SM. If SM flips to agree with us, the fade thesis is dead.
+    if thesis["direction"] == current_direction:
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"RIDING: BTC {current_direction} ROE {current_roe:+.1f}%. SM flipped {thesis['direction']} — not adding."})
+            "note": f"RIDING: BTC {current_direction} ROE {current_roe:+.1f}%. SM flipped to agree with us — fade thesis over, not adding."})
         return
 
     # Higher bar for scale-ups
@@ -408,13 +419,13 @@ def run():
                 "existingMargin": round(current_margin, 2),
                 "newMargin": scale_margin,
             },
-            "result": result, "_horribilis_version": "1.2",
+            "result": result, "_horribilis_version": "2.0",
         })
     else:
         cfg.output({"status": "ok", "action": "SCALE_UP_FAILED",
             "signal": {"asset": ASSET, "direction": thesis["direction"],
                 "score": thesis["score"], "reasons": thesis["reasons"]},
-            "error": result, "_horribilis_version": "1.2"})
+            "error": result, "_horribilis_version": "2.0"})
 
 
 if __name__ == "__main__":

--- a/grizzly/scripts/grizzly-scanner.py
+++ b/grizzly/scripts/grizzly-scanner.py
@@ -2,22 +2,23 @@
 # Senpi GRIZZLY Scanner v3.2
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""GRIZZLY v3.2 — BTC Alpha Hunter (Conviction Leverage + Extreme Velocity).
+"""GRIZZLY v4.0 — BTC Contrarian (SM Exhaustion Fader).
 
-v3.2 changes:
-- Conviction-scaled leverage: score 8->7x, 9->10x, 10->15x, 11+->20x
-- Extreme velocity tiers: 15m >5.0->+4pts, >2.0->+3pts (was capped at +2)
-- 1h acceleration: >3.0->+2pts (was capped at +1)
-- BTC max leverage on Hyperliquid is 40x, we cap at 20x
+v4.0 — DIRECTION FLIP + A/B alignment with Horribilis.
+Fleet analysis (April 10, 2026) found that the SM consensus signal is
+perfectly inverted on BTC: the multi-timeframe confirmation requirement
+means the scanner enters after the move is exhausted. Inversion test on
+11 trades showed 81.8% WR if direction were flipped.
 
-v3.1 changes from fleet audit:
-- Scanner calls create_position internally via mcporter (Wolverine pattern)
-- feeOptimizedLimitOptions with ensureExecutionAsTaker: false
-- 4H price alignment: was HARD GATE -> now score contributor
-- SM thresholds: was HARD GATE (5%/30t) -> now score contributors
-- Margin increased to 50%
-- No thesis exit (unchanged from v3.0)
-- Checks resting orders before placing new entries (race condition fix)
+Changes from v3.2:
+- CONTRARIAN FLIP: trade opposite to SM consensus direction
+- Leverage tiers aligned with Horribilis: 7x/10x (was 7x/10x/15x/20x)
+- Added MOVE_EXHAUSTION penalty (was missing, Horribilis had it)
+- 15m velocity tiers aligned with Horribilis (simpler, less spike-chasing)
+- 1h acceleration aligned with Horribilis
+- Added same-direction cooldown (60 min)
+- Fixed resting order filter (now ignores reduceOnly DSL stops)
+- A/B variable vs Horribilis: Grizzly = single entry, Horribilis = pyramids
 
 Uses: leaderboard_get_markets + market_get_asset_data + strategy_get_open_orders
 Runs every 3 minutes.
@@ -36,14 +37,13 @@ COOLDOWN_MINUTES = 180
 MARGIN_PCT = 0.50
 MIN_SCORE = 8
 
+SAME_DIR_COOLDOWN_MINUTES = 60
+
 LEVERAGE_TIERS = [
-    {"min_score": 11, "leverage": 20},
-    {"min_score": 10, "leverage": 15},
-    {"min_score": 9,  "leverage": 10},
+    {"min_score": 10, "leverage": 10},
     {"min_score": 8,  "leverage": 7},
 ]
 DEFAULT_LEVERAGE = 7
-MAX_LEVERAGE = 20  # BTC max on HL is 40x, we cap at 20x
 
 def safe_float(v, d=0.0):
     try: return float(v)
@@ -58,12 +58,16 @@ def get_leverage_for_score(score):
     return DEFAULT_LEVERAGE
 
 def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data: return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list) and len(orders) > 0: return True
+    if isinstance(orders, list):
+        for o in orders:
+            if not o.get("reduceOnly", False):
+                return True
     return False
 
 
@@ -121,15 +125,20 @@ def evaluate_btc():
     if (d=="LONG" and p1h>0.2) or (d=="SHORT" and p1h<-0.2):
         score += 1; reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
 
-    # Contribution velocity — expanded extreme tiers
-    if cc_15m > 5.0: score += 4; reasons.append(f"15M_EXTREME_SPIKE +{cc_15m:.2f}")
-    elif cc_15m > 2.0: score += 3; reasons.append(f"15M_STRONG_SPIKE +{cc_15m:.2f}")
-    elif cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
+    # Move-exhaustion penalty — large existing moves reduce conviction
+    if abs(p4h) >= 4.0:
+        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
+            score -= 2; reasons.append(f"MOVE_EXHAUSTION {p4h:+.1f}%")
+    elif abs(p4h) >= 2.5:
+        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
+            score -= 1; reasons.append(f"MOVE_TIRING {p4h:+.1f}%")
+
+    # Contribution velocity — aligned with Horribilis (simpler tiers)
+    if cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
     elif cc_15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
     elif cc_15m < -0.5: score -= 1; reasons.append(f"15M_FADING {cc_15m:.2f}")
 
-    if cc_1h_contrib > 3.0: score += 2; reasons.append(f"1H_STRONG_ACCEL +{cc_1h_contrib:.2f}")
-    elif cc_1h_contrib > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h_contrib:.2f}")
+    if cc_1h_contrib > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h_contrib:.2f}")
 
     if abs(cc)>=5.0: score += 1; reasons.append(f"4H_MAJOR_SHIFT {cc:+.1f}")
 
@@ -159,12 +168,19 @@ def execute_entry(direction, margin, leverage):
 
 def load_tc():
     p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
+    default = {"date": now_date(), "entries": 0,
+               "last_win_direction": None, "last_win_ts": 0}
     if os.path.exists(p):
         try:
             with open(p) as f: tc = json.load(f)
-            if tc.get("date") == now_date(): return tc
+            if tc.get("date") != now_date():
+                tc["date"] = now_date()
+                tc["entries"] = 0
+            for k, v in default.items():
+                if k not in tc: tc[k] = v
+            return tc
         except: pass
-    return {"date": now_date(), "entries": 0}
+    return dict(default)
 
 def save_tc(tc):
     tc["date"] = now_date()
@@ -192,12 +208,31 @@ def run():
     if cfg.is_asset_cooled_down(ASSET, COOLDOWN_MINUTES):
         cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"BTC on cooldown"}); return
 
+    # Same-direction re-entry cooldown after a win
+    last_win_dir = tc.get("last_win_direction")
+    last_win_ts = tc.get("last_win_ts", 0)
+
     thesis = evaluate_btc()
     if not thesis:
         cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"HUNTING: no BTC thesis"}); return
     if thesis["score"] < MIN_SCORE:
         cfg.output({"status":"ok","heartbeat":"NO_REPLY",
-            "note":f"HUNTING: BTC {thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"}); return
+            "note":f"HUNTING: BTC SM={thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"}); return
+
+    # ── CONTRARIAN FLIP ──
+    # SM says LONG → we go SHORT. SM says SHORT → we go LONG.
+    # The inversion test on 11 trades showed 81.8% WR if flipped.
+    sm_direction = thesis["direction"]
+    thesis["direction"] = "SHORT" if sm_direction == "LONG" else "LONG"
+    thesis["reasons"].insert(0, f"CONTRARIAN_FLIP (SM is {sm_direction})")
+
+    # Same-direction cooldown (post-flip direction)
+    if last_win_dir and last_win_ts:
+        if (time.time() - last_win_ts) < SAME_DIR_COOLDOWN_MINUTES * 60:
+            if thesis["direction"] == last_win_dir:
+                remaining = int((SAME_DIR_COOLDOWN_MINUTES * 60 - (time.time() - last_win_ts)) / 60)
+                cfg.output({"status":"ok","heartbeat":"NO_REPLY",
+                    "note":f"SAME_DIR_COOLDOWN: won {last_win_dir} {remaining}min ago"}); return
 
     leverage = get_leverage_for_score(thesis["score"])
     margin = round(av * MARGIN_PCT, 2)
@@ -211,11 +246,11 @@ def run():
                 "leverage":leverage,"mode":"BTC_HUNTER","reasons":thesis["reasons"]},
             "execution":{"asset":ASSET,"direction":thesis["direction"],"leverage":leverage,
                 "margin":margin,"orderType":"FEE_OPTIMIZED_LIMIT","ensureExecutionAsTaker":False},
-            "result":result,"_grizzly_version":"3.2"})
+            "result":result,"_grizzly_version":"4.0"})
     else:
         cfg.output({"status":"ok","action":"ENTRY_FAILED",
             "signal":{"asset":ASSET,"direction":thesis["direction"],"score":thesis["score"],"reasons":thesis["reasons"]},
-            "error":result,"_grizzly_version":"3.2"})
+            "error":result,"_grizzly_version":"4.0"})
 
 if __name__ == "__main__":
     try: run()


### PR DESCRIPTION
## The signal inversion disease

Both BTC hunters have perfectly inverted signals. The multi-timeframe SM confirmation (4H + 1H + 15M) means the scanner enters after the move is exhausted — systematically buying tops and shorting bottoms.

| Agent | Trades | WR | Actual Gross | Inverted |
|-------|--------|-----|-------------|----------|
| Grizzly v3.0 | 11 | 18% | -$146 | 81.8% WR |
| Horribilis | 17 | 47% | -$53 | +$53 |

Both share the same `evaluate_btc()` core. Two copies of the same broken signal, both bleeding on BTC.

## The fix: contrarian flip

After `evaluate_btc()` scores the SM consensus, both agents now flip the direction. When SM piles into BTC LONG, we go SHORT. The thesis: by the time SM consensus is strong enough to clear the scoring threshold, the move is exhausted and about to reverse — so fade it.

## A/B design (now clean)

Before this PR, the two agents had 6+ uncontrolled variables (leverage tiers, MOVE_EXHAUSTION, velocity scoring, cooldowns, resting order filter, pyramiding). This PR aligns everything except the one intended variable:

**Controlled (identical in both):** evaluate_btc() scoring, leverage tiers (7x/10x), MOVE_EXHAUSTION penalty, 15m velocity tiers, cooldowns, resting order filter, contrarian flip

**Variable:** Grizzly v4.0 = single entry per position. Horribilis v2.0 = pyramids up to 3 entries when winning position stays strong.

## Horribilis scale-up logic change

The scale-up direction check is flipped: Horribilis adds to a winning contrarian position when SM is STILL strong in the original (opposite) direction. If SM flips to agree with our position, the fade thesis is dead and we stop adding.

## Predicted impact

If the inversion tests hold in production, both agents swing from significant losers to potential winners. This is the highest-risk, highest-reward experiment in the fleet — first contrarian flip in production.