### PR TITLE
[fleet-fix] Polar — market-driven exits for single-asset ETH hunter

### DIFF
--- a/polar/runtime.yaml
+++ b/polar/runtime.yaml
@@ -28,11 +28,14 @@ exit:
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 180
+      interval_in_minutes: 480
     weak_peak_cut:
-      enabled: false
+      enabled: true
+      interval_in_minutes: 60
+      min_value: 2.0
     dead_weight_cut:
-      enabled: false
+      enabled: true
+      interval_in_minutes: 30
     phase1:
       enabled: true
       max_loss_pct: 25.0


### PR DESCRIPTION
## Problem

Polar just closed an ETH LONG at +$13.71 (+3.27% ROE) via 180-min hard timeout. The clock killed a profitable trade, not market conditions. As a single-asset ETH hunter, Polar has no slot pressure — there's no other asset waiting for capital. Time-based rotation is pure waste.

Additionally, weak_peak_cut and dead_weight_cut were both disabled. The only exits were Phase 1 retrace breaches and the 180-min hard timeout — no middle ground.

## Changes

| Parameter | Before | After |
|-----------|--------|-------|
| hard_timeout | 180 min | 480 min (backstop, not rotation) |
| weak_peak_cut | disabled | 60 min, min_value 2.0% ROE |
| dead_weight_cut | disabled | 30 min |

## Impact

- Winners run on market conditions instead of being killed by a clock
- Flat trades (peak ROE < 2% after 60 min) get cut instead of sitting for 3 hours
- Dead trades (never positive) cut at 30 min instead of 180 min
- Combined with fee fix, Polar should improve from -$153 toward net-positive