### PR TITLE
[fleet-fix] Cheetah v3.0 + Dog v2.0 — contrarian direction flips

### DIFF
--- a/cheetah/scripts/cheetah-scanner.py
+++ b/cheetah/scripts/cheetah-scanner.py
@@ -2,26 +2,25 @@
 # Senpi CHEETAH Scanner v2.1.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""CHEETAH v2.1.1 — HYPE Predator (Hardened + Hyperfeed Scoring + Extreme Velocity Tiers).
+"""CHEETAH v3.0 — HYPE Contrarian (SM Exhaustion Fader).
 
-v2.1 changes from fleet audit (2026-04-07):
-- Scanner calls create_position internally via mcporter (Wolverine pattern)
-- feeOptimizedLimitOptions with ensureExecutionAsTaker: false
-- Conviction-scaled leverage: score 8-9 → 7x, score 10+ → 10x
-- Margin increased to 50%
-- Hard gates (SM%, 4H price, trader count) → score contributors
-- Hyperfeed multi-window contribution velocity (15m, 1h, 4h)
-- Resting order check prevents stacking maker orders
-- BTC trend as score contributor (fetched from same API call, no double-call)
-- No thesis exit (confirmed from v2.0)
+v3.0 — DIRECTION FLIP.
+Fleet analysis (April 10, 2026) found Cheetah's signal was perfectly
+inverted: 33 trades, actual gross -$175, inverted +$175. The momentum
+scanner was buying HYPE breakouts that immediately mean-reverted.
+Cheetah's own diagnosis: "the thesis itself is actively broken for
+HYPE's current price action."
 
-Trade analysis context (23 positions):
-- Winners hold long: +$72.30 (9h), +$22.94 (12.6h), +$13.64 (4h)
-- Losers die fast: -$43.63 (11m), -$36.98 (19m)
-- SHORT 60% win rate vs LONG 46%
-- Gross PnL: -$74.56 on direction, -$95.50 in fees = -$170.06 net
+Fix: flip direction. When SM piles into HYPE, fade it.
 
-HYPE single-asset hunter. HUNT → RIDE → re-HUNT.
+Changes from v2.1.1:
+- CONTRARIAN FLIP: trade opposite to SM consensus direction
+- Added MOVE_EXHAUSTION penalty (aligns with Horribilis/Grizzly v4.0)
+- Simplified 15m velocity tiers (less spike-chasing)
+- Added same-direction cooldown (60 min)
+- Fixed resting order filter (now ignores reduceOnly DSL stops)
+
+HYPE single-asset contrarian. CIRCLE → FADE → RIDE reversal.
 Uses: leaderboard_get_markets + strategy_get_open_orders (2 API calls)
 Runs every 90 seconds.
 """
@@ -36,6 +35,7 @@ ASSET = "HYPE"
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 4
 COOLDOWN_MINUTES = 90
+SAME_DIR_COOLDOWN_MINUTES = 60
 MARGIN_PCT = 0.50
 MIN_SCORE = 8
 XYZ_BANNED = True
@@ -64,15 +64,17 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
-    """Check if there are resting entry orders on the book."""
+    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list) and len(orders) > 0:
-        return True
+    if isinstance(orders, list):
+        for o in orders:
+            if not o.get("reduceOnly", False):
+                return True
     return False
 
 
@@ -139,16 +141,20 @@ def evaluate_hype():
     if (d == "LONG" and p1h > 0.2) or (d == "SHORT" and p1h < -0.2):
         score += 1; reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
 
-    # Contribution velocity — multi-window (15m + 1h + 4h)
-    # Expanded tiers: extreme spikes should push score to 11+ for max leverage
-    if cc_15m > 5.0: score += 4; reasons.append(f"15M_EXTREME_SPIKE +{cc_15m:.2f}")
-    elif cc_15m > 2.0: score += 3; reasons.append(f"15M_STRONG_SPIKE +{cc_15m:.2f}")
-    elif cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
+    # Move-exhaustion penalty
+    if abs(p4h) >= 4.0:
+        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
+            score -= 2; reasons.append(f"MOVE_EXHAUSTION {p4h:+.1f}%")
+    elif abs(p4h) >= 2.5:
+        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
+            score -= 1; reasons.append(f"MOVE_TIRING {p4h:+.1f}%")
+
+    # Contribution velocity — simplified tiers (aligned with fleet contrarian agents)
+    if cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
     elif cc_15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
     elif cc_15m < -0.5: score -= 1; reasons.append(f"15M_FADING {cc_15m:.2f}")
 
-    if cc_1h > 3.0: score += 2; reasons.append(f"1H_STRONG_ACCEL +{cc_1h:.2f}")
-    elif cc_1h > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h:.2f}")
+    if cc_1h > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h:.2f}")
 
     if abs(cc_4h) >= 5.0: score += 1; reasons.append(f"4H_MAJOR_SHIFT {cc_4h:+.1f}")
 
@@ -194,12 +200,19 @@ def execute_entry(direction, margin, leverage):
 
 def load_tc():
     p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
+    default = {"date": now_date(), "entries": 0, "last_entry_ts": 0,
+               "last_win_direction": None, "last_win_ts": 0}
     if os.path.exists(p):
         try:
             with open(p) as f: tc = json.load(f)
-            if tc.get("date") == now_date(): return tc
+            if tc.get("date") != now_date():
+                tc["date"] = now_date()
+                tc["entries"] = 0
+            for k, v in default.items():
+                if k not in tc: tc[k] = v
+            return tc
         except: pass
-    return {"date": now_date(), "entries": 0}
+    return dict(default)
 
 def save_tc(tc):
     tc["date"] = now_date()
@@ -248,12 +261,28 @@ def run():
     thesis = evaluate_hype()
     if not thesis:
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": "HUNTING: no HYPE thesis"})
+            "note": "CIRCLING: no HYPE thesis"})
         return
     if thesis["score"] < MIN_SCORE:
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"HUNTING: HYPE {thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"})
+            "note": f"CIRCLING: HYPE SM={thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"})
         return
+
+    # ── CONTRARIAN FLIP ──
+    sm_direction = thesis["direction"]
+    thesis["direction"] = "SHORT" if sm_direction == "LONG" else "LONG"
+    thesis["reasons"].insert(0, f"CONTRARIAN_FLIP (SM is {sm_direction})")
+
+    # Same-direction cooldown (post-flip direction)
+    last_win_dir = tc.get("last_win_direction")
+    last_win_ts = tc.get("last_win_ts", 0)
+    if last_win_dir and last_win_ts:
+        if (time.time() - last_win_ts) < SAME_DIR_COOLDOWN_MINUTES * 60:
+            if thesis["direction"] == last_win_dir:
+                remaining = int((SAME_DIR_COOLDOWN_MINUTES * 60 - (time.time() - last_win_ts)) / 60)
+                cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                    "note": f"SAME_DIR_COOLDOWN: won {last_win_dir} {remaining}min ago"})
+                return
 
     leverage = get_leverage_for_score(thesis["score"])
     margin = round(av * MARGIN_PCT, 2)
@@ -273,14 +302,14 @@ def run():
                 "leverage": leverage, "margin": margin,
                 "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
             "result": result,
-            "_cheetah_version": "2.1.1",
+            "_cheetah_version": "3.0",
         })
     else:
         cfg.output({
             "status": "ok", "action": "ENTRY_FAILED",
             "signal": {"asset": ASSET, "direction": thesis["direction"],
                 "score": thesis["score"], "reasons": thesis["reasons"]},
-            "error": result, "_cheetah_version": "2.1.1",
+            "error": result, "_cheetah_version": "3.0",
         })
 
 

--- a/dog/runtime.yaml
+++ b/dog/runtime.yaml
@@ -1,8 +1,8 @@
 name: dog-tracker
-version: 1.0.0
+version: 2.0.0
 description: >
-  The Loyal Consistent Performer. Multi-asset SM consensus scanner targeting
-  5% ROE/week through small, steady wins. Quick profit-taking DSL.
+  The Contrarian Pup. Multi-asset SM exhaustion fader. Detects exhausted
+  moves on BTC/ETH/SOL/HYPE and trades the opposite direction. Wide DSL.
 
 strategy:
   wallet: "${WALLET_ADDRESS}"
@@ -26,43 +26,31 @@ exit:
   engine: dsl
   interval_seconds: 30
   dsl_preset:
-    # Dog's DSL is tuned for QUICK PROFIT-TAKING, not riding winners.
-    # Key differences from fleet standard:
-    # - Tier 1 triggers at 3% ROE (fleet: 5%) — take profits earlier
-    # - Tier 1 lock at 50% (fleet: 25-30%) — meaningful floor, not noise
-    # - Dead weight cut at 45 min (fleet: disabled) — cut non-performers fast
-    # - Hard timeout at 120 min (fleet: 180-360) — don't overstay
-    # - Weak peak cut at 60 min (fleet: disabled) — if it's not working, leave
+    # Dog v2.0 — WIDE DSL for contrarian fades.
+    # Reversals take time to develop. Let winners run.
     hard_timeout:
       enabled: true
-      interval_in_minutes: 120
+      interval_in_minutes: 360
     weak_peak_cut:
       enabled: true
-      interval_in_minutes: 60
-      min_value: 1.0
+      interval_in_minutes: 90
+      min_value: 2.0
     dead_weight_cut:
       enabled: true
-      interval_in_minutes: 45
+      interval_in_minutes: 30
     phase1:
       enabled: true
       max_loss_pct: 15.0
-      retrace_threshold: 6
+      retrace_threshold: 8
       consecutive_breaches_required: 3
     phase2:
       enabled: true
       tiers:
-        # Dog's profit-taking tiers — designed for QUICK but MEANINGFUL exits
-        # Tier 1: 5% ROE trigger, 50% lock = 2.5% ROE floor
-        #   At 10x, that's 0.5% price move trigger, 0.25% floor
-        #   After ~$3 fees: nets $4.50+ guaranteed. Every Tier 1 exit is a real win.
-        - { trigger_pct: 5,  lock_hw_pct: 50 }
-        # Tier 2: 8% ROE — lock 65% = 5.2% ROE floor
-        - { trigger_pct: 8,  lock_hw_pct: 65 }
-        # Tier 3: 12% ROE — lock 75% = 9% ROE floor (great week in one trade!)
-        - { trigger_pct: 12, lock_hw_pct: 75 }
-        # Tier 4+: if Dog gets lucky and a trade runs, protect it hard
-        - { trigger_pct: 20, lock_hw_pct: 85 }
-        - { trigger_pct: 30, lock_hw_pct: 90 }
+        - { trigger_pct: 5,  lock_hw_pct: 20 }
+        - { trigger_pct: 10, lock_hw_pct: 40 }
+        - { trigger_pct: 15, lock_hw_pct: 60 }
+        - { trigger_pct: 20, lock_hw_pct: 75 }
+        - { trigger_pct: 30, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/dog/scripts/dog-scanner.py
+++ b/dog/scripts/dog-scanner.py
@@ -2,48 +2,23 @@
 # Senpi DOG Scanner v1.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""DOG v1.0 — The Loyal Consistent Performer.
+"""DOG v2.0 — The Contrarian Pup (SM Exhaustion Fader).
 
-GOAL: 5% ROE per week. Not homeruns. Not glory. Just steady, reliable profits
-that compound over time. The most loyal pup in the fleet.
+v2.0 — DIRECTION FLIP.
+Fleet analysis (April 10, 2026) found Dog's signal was perfectly inverted:
+actual gross -$61, inverted +$61. HYPE caused -$91 of the -$105 net loss.
+The SM consensus scanner was systematically entering after exhausted moves.
 
-DESIGN PHILOSOPHY (learned from 22-agent fleet analysis):
-1. NEVER CHASE — the #1 fleet failure is entering after exhausted moves.
-   Dog has the strictest move-exhaustion gates in the fleet.
-2. TAKE PROFITS EARLY — other agents try to ride to 20-50% ROE and get
-   stopped at Tier 1. Dog targets 3-5% ROE and exits cleanly.
-3. SMALL POSITIONS — 30% margin, max 10x leverage. Smaller bets, more of them.
-4. MULTI-ASSET — BTC, ETH, SOL, HYPE. Diversified, not concentrated.
-5. QUALITY OVER QUANTITY — MIN_SCORE 10. Fewer trades, better quality.
-   Fleet data shows higher-score entries have better win rates.
-6. FEE-CONSCIOUS — 10x max leverage keeps notional reasonable. Maker-only.
-   At 10x with $300 margin = $3,000 notional = ~$3 fees/trade.
-7. FAST EXITS ON LOSERS — tight Phase 1, quick dead weight cut. Don't let
-   losers linger. The fleet's losing trades average 79 min; Dog cuts at 60.
-8. PATIENCE BETWEEN TRADES — 180-min cooldown. Only 2-3 trades per day max.
-   The fleet's overtrading agents (Mantis old, Orca old) lost the most.
+Dog v2.0 flips the thesis: instead of chasing SM consensus, fade it.
+When SM consensus is overwhelmingly strong and the move is already
+extended, trade the opposite direction.
 
-MATH: 5% ROE/week = $50 on $1,000.
-  3 trades/day × 5 days = 15 trades/week.
-  Need: +$50 net / 15 trades = +$3.33 net per trade average.
-  At $3 fees/trade: need +$6.33 gross per trade.
-  At 10x / $300 margin: need +2.1% ROE per trade average.
-  With 60% win rate, avg winner +5% ROE, avg loser -3% ROE:
-    0.6 × $15 - 0.4 × $9 = $9 - $3.60 = $5.40 gross/trade
-    $5.40 - $3 fees = $2.40 net/trade × 15 = $36/week (3.6% ROE)
-  With 65% win rate: $4.05 net/trade × 15 = $60.75/week (6.1% ROE) ✅
-
-THESIS: Multi-asset SM consensus scanner. Scans BTC, ETH, SOL, HYPE every
-3 minutes. Enters ONLY when SM consensus is overwhelming (>15%), velocity
-is fresh (15m spike), price hasn't already moved too far (exhaustion gates),
-and the move is EARLY (4h change < 2%). Takes profit at 3-5% ROE via a
-tight Phase 2 Tier 1, with a quick exit on non-performers.
-
-KEY DIFFERENCE FROM FLEET: Dog's Phase 2 is designed for QUICK PROFIT-TAKING.
-Tier 1 triggers at 3% ROE and locks at 50% (1.5% ROE floor). This is TIGHTER
-than the fleet standard — intentionally. Dog doesn't want to ride to 20% ROE.
-Dog wants to bank 2-4% ROE and move on. The high lock % (50% vs 25-30%)
-means once Tier 1 triggers, the floor is meaningful — not noise-level.
+Key changes from v1.0:
+- CONTRARIAN FLIP: trade opposite to SM consensus direction
+- Move-exhaustion inverted: now a BONUS (bigger move = better fade)
+- Early-move bonus removed (early moves have nothing to fade)
+- Leverage reduced: 7x base, 10x max (contrarian needs room)
+- MIN_SCORE lowered to 8 (contrarian signals should fire more often)
 
 Uses: leaderboard_get_markets + market_get_asset_data + strategy_get_open_orders
 Runs every 3 minutes.
@@ -65,28 +40,22 @@ MAX_DAILY_ENTRIES = 3          # 2-3 trades/day max. Quality over quantity.
 COOLDOWN_MINUTES = 180         # 3 hours between entries. Patience.
 SAME_DIR_COOLDOWN_MINUTES = 90 # 90 min after a win in the same direction
 MARGIN_PCT = 0.30              # 30% of account per trade. Small bets.
-MIN_SCORE = 9                  # High bar, but reachable in moderate markets.
+MIN_SCORE = 8                  # Lowered from 9 — contrarian signals need to fire
 
 # Max leverage caps per asset (from Hyperliquid)
 ASSET_MAX_LEVERAGE = {"BTC": 40, "ETH": 25, "SOL": 20, "HYPE": 10}
 
-# Mild conviction scaling — 10x base, 12x only on the strongest signals.
-# No 15-20x. Fleet data shows that range amplifies fees into net losses.
+# Conservative leverage for contrarian — need room for reversals
 LEVERAGE_TIERS = [
-    {"min_score": 12, "leverage": 12},
-    {"min_score": 9,  "leverage": 10},
+    {"min_score": 10, "leverage": 10},
+    {"min_score": 8,  "leverage": 7},
 ]
-DEFAULT_LEVERAGE = 10
-MAX_LEVERAGE = 12
+DEFAULT_LEVERAGE = 7
+MAX_LEVERAGE = 10
 
-# Move exhaustion — Dog has the STRICTEST gates in the fleet.
-# If the 4h move is already >2% in entry direction, Dog sits out.
-# The fleet standard is 2.5%/-1 and 4%/-2. Dog is tighter: 2%/-2 and 3%/-3.
-EXHAUSTION_SEVERE_PCT = 3.0    # -3 points (effectively blocks entry)
-EXHAUSTION_MODERATE_PCT = 2.0  # -2 points (makes score 10 very hard to reach)
-
-# Early-move bonus — Dog REWARDS entering early moves
-EARLY_MOVE_THRESHOLD = 0.5     # 4h change < 0.5% = early move bonus +1
+# Move exhaustion — INVERTED for contrarian. Bigger moves = BETTER fades.
+EXHAUSTION_BONUS_SEVERE_PCT = 4.0   # +2 points (deep exhaustion = great fade)
+EXHAUSTION_BONUS_MODERATE_PCT = 2.5 # +1 point
 
 
 def safe_float(v, d=0.0):
@@ -177,19 +146,14 @@ def evaluate_assets():
             if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
                 score += 1; reasons.append(f"4H_CONFIRMS {p4h:+.1f}%")
 
-        # ── MOVE EXHAUSTION — Dog's strictest-in-fleet gates ──
-        # Dog penalizes MORE aggressively than the fleet standard
-        if abs(p4h) >= EXHAUSTION_SEVERE_PCT:
+        # ── MOVE EXHAUSTION — INVERTED for contrarian ──
+        # Bigger moves = better fade opportunities (opposite of v1.0)
+        if abs(p4h) >= EXHAUSTION_BONUS_SEVERE_PCT:
             if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
-                score -= 3; reasons.append(f"DOG_EXHAUSTION_SEVERE {p4h:+.1f}% (>3% already moved)")
-        elif abs(p4h) >= EXHAUSTION_MODERATE_PCT:
+                score += 2; reasons.append(f"DEEP_EXHAUSTION {p4h:+.1f}% (great fade)")
+        elif abs(p4h) >= EXHAUSTION_BONUS_MODERATE_PCT:
             if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
-                score -= 2; reasons.append(f"DOG_EXHAUSTION {p4h:+.1f}% (>2% already moved)")
-
-        # ── EARLY MOVE BONUS — Dog rewards getting in early ──
-        if abs(p4h) < EARLY_MOVE_THRESHOLD:
-            if (d == "LONG" and p4h >= 0) or (d == "SHORT" and p4h <= 0):
-                score += 1; reasons.append(f"EARLY_MOVE {p4h:+.1f}% (fresh)")
+                score += 1; reasons.append(f"EXHAUSTION {p4h:+.1f}% (fadeable)")
 
         # ── 1H momentum (0-1) ──
         if (d == "LONG" and p1h > 0.2) or (d == "SHORT" and p1h < -0.2):
@@ -337,11 +301,16 @@ def run():
         top = candidates[0] if candidates else None
         note = "SNIFFING: no asset above threshold"
         if top:
-            note = (f"SNIFFING: best {top['asset']} {top['direction']} "
+            note = (f"SNIFFING: best {top['asset']} SM={top['direction']} "
                     f"score {top['score']}<{MIN_SCORE}. {', '.join(top['reasons'][:3])}")
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": note}); return
 
-    # Execute entry — mild conviction scaling
+    # ── CONTRARIAN FLIP ──
+    sm_direction = best["direction"]
+    best["direction"] = "SHORT" if sm_direction == "LONG" else "LONG"
+    best["reasons"].insert(0, f"CONTRARIAN_FLIP {best['asset']} (SM is {sm_direction})")
+
+    # Execute entry — conservative leverage for contrarian
     leverage = DEFAULT_LEVERAGE
     for tier in LEVERAGE_TIERS:
         if best["score"] >= tier["min_score"]:
@@ -361,12 +330,12 @@ def run():
             "execution": {"asset": best["asset"], "direction": best["direction"],
                 "leverage": leverage, "margin": margin,
                 "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
-            "result": result, "_dog_version": "1.0"})
+            "result": result, "_dog_version": "2.0"})
     else:
         cfg.output({"status": "ok", "action": "ENTRY_FAILED",
             "signal": {"asset": best["asset"], "direction": best["direction"],
                 "score": best["score"], "reasons": best["reasons"]},
-            "error": result, "_dog_version": "1.0"})
+            "error": result, "_dog_version": "2.0"})
 
 if __name__ == "__main__":
     try: run()


### PR DESCRIPTION
## Signal inversion disease — agents 4 and 5

Both agents have perfectly inverted signals confirmed by inversion tests:

| Agent | Trades | Actual Gross | Inverted Gross | Asset(s) |
|-------|--------|-------------|----------------|----------|
| Cheetah | 33 | -$175 | +$175 | HYPE |
| Dog | 8 | -$61 | +$61 | BTC/ETH/SOL/HYPE |

Same mechanism as Grizzly v4.0/Horribilis v2.0 (PR #156): SM consensus scanners enter after the move is exhausted.

## Cheetah v3.0 — HYPE contrarian

Same pattern as the Grizzly flip:
- Contrarian flip after evaluate_hype()
- Added MOVE_EXHAUSTION, simplified velocity tiers, same-dir cooldown, resting order filter fix
- All other settings unchanged

Cheetah is the highest dollar-impact flip in the fleet ($350+ swing potential).

## Dog v2.0 — multi-asset contrarian (different design)

Dog required deeper changes because its v1.0 design philosophy was "early entry, quick profit" — the exact opposite of contrarian:
- Contrarian flip after evaluate_assets()
- **Move-exhaustion INVERTED**: now a BONUS (+2 at >4%, +1 at >2.5%). Bigger moves = better fades.
- Early-move bonus removed (nothing to fade on fresh moves)
- Leverage reduced to 7x/10x (was 10x/12x)
- MIN_SCORE lowered to 8 (was 9)
- **runtime.yaml DSL widened**: hard_timeout 120→360, weak_peak_cut 60→90, Phase 2 tiers widened. Quick profit-taking DSL replaced with contrarian-patience DSL.