### PR TITLE
[fleet-fix] Bald Eagle v4.0 contrarian + Pangolin v1.0 (extreme funding fader)

### DIFF
--- a/bald-eagle/scripts/eagle-scanner.py
+++ b/bald-eagle/scripts/eagle-scanner.py
@@ -3,30 +3,21 @@
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""BALD EAGLE v3.0 — XYZ Alpha Hunter (Hardened).
+"""BALD EAGLE v4.0 — XYZ Contrarian (SM Exhaustion Fader on Macro Assets).
 
-v3.0 redesign from fleet audit data:
-- v2.0 bled -$75 across 54 trades. 14.3% win rate on DSL-managed trades.
-  Root causes: AMM slippage on entry+exit, 8% retrace at 7x = 1.1% price
-  move (oil noise), taker fallback destroying edge, too many illiquid assets.
+v4.0 — DIRECTION FLIP.
+Fleet analysis (April 10, 2026) found Bald Eagle's signal was inverted:
+12 positions on oil, 25% WR, avg winner +$1.82, avg loser -$7.22.
+Inversion test confirmed: buying tops and shorting bottoms on CL/BRENTOIL.
+Same signal inversion disease found across 5 crypto agents.
 
-Key changes:
-- FOCUSED ASSET LIST: CL, BRENTOIL, GOLD, SILVER, SP500, XYZ100 only.
-  These have the deepest SM signal (CL: 181 traders, BRENTOIL: 166).
-  Everything else is sub-50 traders on XYZ side — not enough signal.
-- CONVICTION-SCALED LEVERAGE: score 8-9 → 5x, score 10-11 → 7x, score 12+ → 10x.
-  High conviction = high leverage. When SM is screaming, press it.
-- WIDER DSL: retrace 12%, absolute floor -25% ROE, dead weight 120min,
-  weak peak 240min, hard timeout 480min. XYZ assets are macro-driven
-  and need hours to play out.
-- MAKER-ONLY execution: ensureExecutionAsTaker=false, no taker fallback.
-  AMM slippage on XYZ assets destroyed v2.0. A missed fill is cheaper
-  than -0.5% slippage on entry.
-- HIGHER MIN_SCORE: 9 (was 7). When you're paying AMM spread, the
-  macro thesis must be even stronger to overcome execution costs.
-- Scanner calls create_position internally (Wolverine pattern).
-- Thesis exit REMOVED. Scanner enters. RatchetStop exits.
-- All hard gates converted to score contributors.
+Changes from v3.0:
+- CONTRARIAN FLIP: trade opposite to SM consensus direction
+- Move-exhaustion BONUS: bigger 4H move = better fade (+2 at >2%, +1 at >1%)
+  (XYZ thresholds are lower than crypto — oil moves 1-3% in 4h, not 3-5%)
+- Leverage capped: 5x base, 7x max (contrarian on macro needs room)
+- MIN_SCORE lowered to 8 (was 9)
+- Market hours enforcement preserved from v3.0
 
 Runs every 5 minutes.
 """
@@ -51,19 +42,19 @@ ALLOWED_ASSETS = {"CL", "BRENTOIL", "GOLD", "SILVER", "SP500", "XYZ100"}
 
 # Conviction-scaled leverage
 LEVERAGE_TIERS = [
-    {"min_score": 12, "leverage": 10},
     {"min_score": 10, "leverage": 7},
     {"min_score": 8,  "leverage": 5},
 ]
 DEFAULT_LEVERAGE = 5
-MAX_LEVERAGE = 10
+MAX_LEVERAGE = 7
 MIN_LEVERAGE = 3
 
-MAX_POSITIONS = 2
-MAX_DAILY_ENTRIES = 4
+MAX_POSITIONS = 1
+MAX_DAILY_ENTRIES = 3
 COOLDOWN_MINUTES = 120
-MARGIN_PCT = 0.50           # 50% of account per trade
-MIN_SCORE = 9               # Higher bar for XYZ — AMM spread tax
+SAME_DIR_COOLDOWN_MINUTES = 60
+MARGIN_PCT = 0.40           # 40% of account per trade
+MIN_SCORE = 8               # Lowered — contrarian signals should fire
 MAX_SPREAD_PCT = 0.001      # 0.1% max spread
 
 MAX_DAILY_LOSS_PCT = 10
@@ -349,6 +340,17 @@ def score_candidate(cand, candle_data):
         score -= 1
         reasons.append(f"4H_OPPOSING +{p4h:.1f}%")
 
+    # ── MOVE EXHAUSTION BONUS (XYZ-tuned thresholds) ──
+    # Oil/commodities move 1-3% in 4h (vs crypto 3-5%). Lower thresholds.
+    if abs(p4h) >= 2.0:
+        if (direction == "LONG" and p4h > 0) or (direction == "SHORT" and p4h < 0):
+            score += 2
+            reasons.append(f"DEEP_EXHAUSTION {p4h:+.1f}%")
+    elif abs(p4h) >= 1.0:
+        if (direction == "LONG" and p4h > 0) or (direction == "SHORT" and p4h < 0):
+            score += 1
+            reasons.append(f"EXHAUSTION {p4h:+.1f}%")
+
     # ── Technical scoring from candles (if available) ──
     if candle_data:
         candles_1h = candle_data.get("candles", {}).get("1h", [])
@@ -552,6 +554,11 @@ def run():
             continue
         reasons.append(f"SPREAD_OK {spread_pct*100:.3f}%")
 
+        # ── CONTRARIAN FLIP ──
+        sm_direction = cand["direction"]
+        fade_direction = "SHORT" if sm_direction == "LONG" else "LONG"
+        reasons.insert(0, f"CONTRARIAN_FLIP xyz:{token} (SM is {sm_direction})")
+
         # Conviction-scaled leverage
         leverage = get_leverage_for_score(score)
 
@@ -560,13 +567,13 @@ def run():
 
         # Build DSL state
         dsl_state = build_dsl_state(
-            {"token": token, "direction": cand["direction"], "score": score},
+            {"token": token, "direction": fade_direction, "score": score},
             leverage,
         )
 
         # Execute trade directly
         success, result = execute_entry(
-            {"token": token, "direction": cand["direction"]},
+            {"token": token, "direction": fade_direction},
             margin, leverage,
         )
 
@@ -576,23 +583,22 @@ def run():
 
             cfg.output({
                 "status": "ok",
-                "action": "ENTRY",
+                "action": "FADE_ENTRY",
                 "signal": {
                     "asset": f"xyz:{token}",
-                    "direction": cand["direction"],
+                    "sm_direction": sm_direction,
+                    "fade_direction": fade_direction,
                     "score": score,
                     "leverage": leverage,
-                    "mode": "XYZ_SM",
+                    "mode": "XYZ_CONTRARIAN",
                     "reasons": reasons,
                     "smPct": cand["pct"],
                     "smTraders": cand["traders"],
                     "spread": round(spread_pct * 100, 4),
-                    "contribChg1h": cand["contrib_chg_1h"],
-                    "contribChg4h": cand["contrib_chg_4h"],
                 },
                 "execution": {
                     "asset": f"xyz:{token}",
-                    "direction": cand["direction"],
+                    "direction": fade_direction,
                     "leverage": leverage,
                     "margin": margin,
                     "orderType": "FEE_OPTIMIZED_LIMIT",
@@ -600,24 +606,13 @@ def run():
                 },
                 "dslState": dsl_state,
                 "result": result,
-                "constraints": {
-                    "allowedAssets": sorted(ALLOWED_ASSETS),
-                    "maxPositions": MAX_POSITIONS,
-                    "maxLeverage": MAX_LEVERAGE,
-                    "leverageTiers": LEVERAGE_TIERS,
-                    "maxDailyEntries": MAX_DAILY_ENTRIES,
-                    "cooldownMinutes": COOLDOWN_MINUTES,
-                    "maxSpreadPct": MAX_SPREAD_PCT,
-                    "minScore": MIN_SCORE,
-                    "_dslNote": "Use dslState directly. XYZ-tuned wide timings. Do NOT merge with dsl-profile.json.",
-                },
-                "_eagle_version": "3.0",
+                "_eagle_version": "4.0",
             })
             return
         else:
             cfg.output({
                 "status": "ok",
-                "action": "ENTRY_FAILED",
+                "action": "FADE_ENTRY_FAILED",
                 "signal": {"asset": f"xyz:{token}", "direction": cand["direction"],
                            "score": score, "reasons": reasons},
                 "error": result,

--- a/pangolin/README.md
+++ b/pangolin/README.md
@@ -1,0 +1,13 @@
+# 🦔 PANGOLIN v1.0 — Extreme Funding Rate Fader
+
+Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+When funding rates hit extremes (>40% annualized), the crowd is overpaying to hold their position. Pangolin enters opposite to the funding direction — collecting funding every 8 hours while waiting for the crowded side to capitulate. Conservative 3-5x leverage, very wide DSL (12-hour hard timeout), top 20 crypto assets by volume.
+
+See [SKILL.md](SKILL.md) for full setup instructions.
+
+## License
+
+MIT — Built by Senpi (https://senpi.ai).

--- a/pangolin/SKILL.md
+++ b/pangolin/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: pangolin-strategy
+description: >-
+  PANGOLIN v1.0 — Extreme Funding Rate Fader. Enters opposite to extreme
+  funding rates (>0.03%/8h = ~40% annualized), collecting funding while
+  waiting for crowded positions to mean-revert. Conservative 3-5x leverage,
+  very wide DSL (12h hard timeout). Top 20 crypto assets by volume.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime
+---
+
+# 🦔 PANGOLIN v1.0 — Extreme Funding Rate Fader
+
+An entirely new strategy archetype for the Predators fleet. No other agent trades on funding rate signals.
+
+## Thesis
+
+When funding rates are extreme (>0.03%/8h = ~40% annualized), the crowd is paying heavily to maintain their position. These extremes mean-revert within 24-48h as the cost of carry forces liquidation or position reduction. Pangolin enters opposite to the funding direction, collecting funding every 8 hours while waiting for the crowd to capitulate.
+
+Two edge sources:
+1. **Funding collection** — paid every 8h while holding the position
+2. **Price reversal** — when the overcrowded side unwinds, price moves in our direction
+
+## How it differs from other fleet agents
+
+- **Barracuda** follows the trend and collects funding as a bonus. Pangolin fades funding extremes.
+- **Lemon** fades individual degen traders. Pangolin fades aggregate market crowding.
+- **Vulture** fades SM consensus exhaustion on price. Pangolin fades funding rate extremes.
+- **Owl** fades crowding via SM concentration. Pangolin uses the quantitative funding rate threshold.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `scripts/pangolin-scanner.py` | Funding rate scanner |
+| `scripts/pangolin_config.py` | Config helper |
+| `runtime.yaml` | DSL exit config (very wide for funding mean-reversion) |

--- a/pangolin/runtime.yaml
+++ b/pangolin/runtime.yaml
@@ -1,0 +1,58 @@
+name: pangolin-tracker
+version: 1.0.0
+description: >
+  PANGOLIN v1.0 — Extreme Funding Rate Fader. Enters opposite to extreme
+  funding (>0.03%/8h), collecting funding while waiting for crowding
+  mean-reversion. Very wide DSL — crowded unwinds take hours to days.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 2
+  margin_per_slot: 250
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# Very wide DSL — funding mean-reversion takes hours to days.
+# The edge comes from collecting funding every 8 hours, so patience pays.
+# Dead weight cut catches entries where funding normalizes without price move.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 720
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 180
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 3
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 3,  lock_hw_pct: 15 }
+        - { trigger_pct: 7,  lock_hw_pct: 30 }
+        - { trigger_pct: 12, lock_hw_pct: 50 }
+        - { trigger_pct: 20, lock_hw_pct: 70 }
+        - { trigger_pct: 30, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/pangolin/scripts/pangolin-scanner.py
+++ b/pangolin/scripts/pangolin-scanner.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+# Senpi PANGOLIN Scanner v1.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""PANGOLIN v1.0 — Extreme Funding Rate Fader.
+
+Thesis: When funding rates are extreme (>0.03%/8h = ~40% annualized),
+the crowd is paying heavily to hold their position. History shows these
+extremes mean-revert within 24-48h as the cost of carry forces liquidation
+or position reduction. Pangolin enters opposite to the funding direction
+(collecting funding while waiting for the crowd to capitulate).
+
+This is different from:
+- Barracuda (follows trend + collects funding as a bonus)
+- Lemon (fades degen traders based on their track record)
+- Vulture (fades SM consensus exhaustion on price action)
+
+Pangolin specifically fades EXTREME FUNDING — it's a pure crowding
+mean-reversion play using a quantitative funding threshold. The edge
+comes from two sources:
+1. Collecting funding every 8 hours while waiting for mean reversion
+2. Price reversal when the overcrowded side unwinds
+
+Design:
+- Scan all crypto instruments for extreme funding (>0.03%/8h)
+- Confirm with SM positioning (SM should be fading the crowd)
+- Enter opposite to the funding direction (collect funding)
+- Conservative leverage (3-5x) — crowded unwinds are violent
+- Very wide DSL (8-12 hours) — mean reversion takes time
+- Max 2 positions (diversify across uncorrelated funding extremes)
+
+Assets: Top 20 by volume (crypto only, no XYZ)
+Runs every 5 minutes.
+"""
+
+import json
+import sys
+import os
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import pangolin_config as cfg
+
+# ── CONFIGURATION ──
+MAX_POSITIONS = 2
+MAX_DAILY_ENTRIES = 3
+COOLDOWN_MINUTES = 240          # 4 hours between same-asset entries
+MARGIN_PCT = 0.25               # 25% per position (conservative)
+MIN_SCORE = 7
+MIN_FUNDING_RATE = 0.0003       # 0.03%/8h = ~40% annualized
+XYZ_BANNED = True
+
+# Very conservative leverage — crowded unwinds are violent
+LEVERAGE_TIERS = [
+    {"min_score": 10, "leverage": 5},
+    {"min_score": 7,  "leverage": 3},
+]
+DEFAULT_LEVERAGE = 3
+
+# Top assets by volume — only trade liquid markets
+ALLOWED_ASSETS = {
+    "BTC", "ETH", "SOL", "HYPE", "DOGE", "XRP", "AVAX", "LINK",
+    "ADA", "DOT", "NEAR", "UNI", "LTC", "BCH", "TAO", "INJ",
+    "AAVE", "ZEC", "WIF", "PEPE",
+}
+
+
+def safe_float(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def get_leverage_for_score(score):
+    for tier in LEVERAGE_TIERS:
+        if score >= tier["min_score"]:
+            return tier["leverage"]
+    return DEFAULT_LEVERAGE
+
+
+def has_resting_orders(wallet):
+    data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
+    if not data:
+        return False
+    orders = data.get("data", data)
+    if isinstance(orders, dict):
+        orders = orders.get("orders", orders.get("openOrders", []))
+    if isinstance(orders, list):
+        for o in orders:
+            if not o.get("reduceOnly", False):
+                return True
+    return False
+
+
+def scan_funding_extremes():
+    """Find assets with extreme funding rates and score them."""
+    # Get all instruments with funding data
+    raw = cfg.mcporter_call("market_list_instruments")
+    if not raw:
+        return []
+
+    instruments = raw.get("data", raw)
+    if isinstance(instruments, dict):
+        instruments = instruments.get("instruments", instruments.get("universe", []))
+    if not isinstance(instruments, list):
+        return []
+
+    # Also get SM data for confirmation
+    sm_raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
+    sm_map = {}
+    if sm_raw:
+        sm_markets = sm_raw.get("data", sm_raw)
+        if isinstance(sm_markets, dict):
+            sm_markets = sm_markets.get("markets", sm_markets)
+        if isinstance(sm_markets, dict):
+            sm_markets = sm_markets.get("markets", [])
+        if isinstance(sm_markets, list):
+            for m in sm_markets:
+                if isinstance(m, dict):
+                    token = str(m.get("token", "")).upper()
+                    dex = str(m.get("dex", "")).lower()
+                    if dex != "xyz":
+                        sm_map[token] = m
+
+    candidates = []
+
+    for inst in instruments:
+        if not isinstance(inst, dict):
+            continue
+
+        name = str(inst.get("name", inst.get("coin", ""))).upper()
+        if name not in ALLOWED_ASSETS:
+            continue
+
+        funding = safe_float(inst.get("funding", 0))
+
+        # Must have extreme funding
+        if abs(funding) < MIN_FUNDING_RATE:
+            continue
+
+        # Determine crowd direction from funding sign
+        # Positive funding = longs paying shorts = crowd is long
+        # Negative funding = shorts paying longs = crowd is short
+        crowd_direction = "LONG" if funding > 0 else "SHORT"
+        fade_direction = "SHORT" if funding > 0 else "LONG"
+
+        score = 0
+        reasons = []
+
+        # ── Funding extremity (1-4 pts) ──
+        abs_funding = abs(funding)
+        annualized = abs_funding * 3 * 365 * 100  # rough annualized %
+        if abs_funding >= 0.001:  # 0.1%/8h = ~130% annualized
+            score += 4
+            reasons.append(f"EXTREME_FUNDING {funding*100:.4f}% ({annualized:.0f}% ann)")
+        elif abs_funding >= 0.0006:  # 0.06%/8h = ~80% annualized
+            score += 3
+            reasons.append(f"HIGH_FUNDING {funding*100:.4f}% ({annualized:.0f}% ann)")
+        elif abs_funding >= 0.0003:  # 0.03%/8h = ~40% annualized
+            score += 2
+            reasons.append(f"ELEVATED_FUNDING {funding*100:.4f}% ({annualized:.0f}% ann)")
+
+        # ── SM confirmation (0-3 pts) ──
+        # If SM is positioned opposite to the crowd, the fade is higher conviction
+        sm = sm_map.get(name)
+        if sm:
+            sm_dir = str(sm.get("direction", "")).upper()
+            sm_pct = safe_float(sm.get("pct_of_top_traders_gain", 0))
+            sm_traders = int(sm.get("trader_count", 0))
+
+            if sm_dir == fade_direction:
+                # SM agrees with our fade — they're already fading the crowd
+                if sm_pct >= 10:
+                    score += 3
+                    reasons.append(f"SM_FADING_CROWD {sm_pct:.1f}% ({sm_traders}t)")
+                elif sm_pct >= 5:
+                    score += 2
+                    reasons.append(f"SM_ALIGNED_FADE {sm_pct:.1f}% ({sm_traders}t)")
+                else:
+                    score += 1
+                    reasons.append(f"SM_CONFIRMS {sm_pct:.1f}% ({sm_traders}t)")
+            elif sm_dir == crowd_direction:
+                # SM is WITH the crowd — riskier fade
+                if sm_pct >= 10:
+                    score -= 2
+                    reasons.append(f"SM_WITH_CROWD {sm_pct:.1f}% (dangerous)")
+                else:
+                    score -= 1
+                    reasons.append(f"SM_SLIGHT_CROWD {sm_pct:.1f}%")
+
+            # SM velocity — is SM momentum fading? (good for us)
+            cc_15m = safe_float(sm.get("contribution_pct_change_15m", 0))
+            if sm_dir == crowd_direction and cc_15m < -0.5:
+                score += 1
+                reasons.append(f"SM_MOMENTUM_FADING {cc_15m:.2f}")
+
+        # ── Open interest concentration ──
+        oi = safe_float(inst.get("openInterest", inst.get("oi", 0)))
+        volume_24h = safe_float(inst.get("dayNtlVlm", inst.get("volume24h", 0)))
+        if oi > 0 and volume_24h > 0:
+            oi_turnover = volume_24h / oi if oi > 0 else 0
+            if oi_turnover < 0.5:
+                # Low turnover = positions are sticky = more crowded
+                score += 1
+                reasons.append(f"STICKY_OI (turnover {oi_turnover:.2f}x)")
+
+        # ── Price action — has the move already started reversing? ──
+        p4h = safe_float(sm.get("token_price_change_pct_4h", 0)) if sm else 0
+        if crowd_direction == "LONG" and p4h < -0.5:
+            score += 1
+            reasons.append(f"PRICE_REVERSING {p4h:+.1f}%")
+        elif crowd_direction == "SHORT" and p4h > 0.5:
+            score += 1
+            reasons.append(f"PRICE_REVERSING {p4h:+.1f}%")
+
+        reasons.insert(0, f"FADE_FUNDING {name} (crowd is {crowd_direction})")
+
+        candidates.append({
+            "token": name,
+            "funding": funding,
+            "crowd_direction": crowd_direction,
+            "fade_direction": fade_direction,
+            "score": score,
+            "reasons": reasons,
+            "annualized_pct": annualized,
+        })
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    return candidates
+
+
+def execute_entry(token, direction, margin, leverage):
+    result = cfg.mcporter_call(
+        "create_position",
+        coin=token,
+        direction=direction,
+        leverage=leverage,
+        margin=margin,
+        orderType="FEE_OPTIMIZED_LIMIT",
+        feeOptimizedLimitOptions={
+            "ensureExecutionAsTaker": False,
+            "executionTimeoutSeconds": 45,
+        },
+    )
+    if result and result.get("success"):
+        return True, result
+    error = result.get("error", "unknown") if result else "mcporter_call returned None"
+    return False, {"error": error}
+
+
+def run():
+    wallet, sid = cfg.get_wallet_and_strategy()
+    if not wallet:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "no wallet"})
+        return
+
+    account_value, positions = cfg.get_positions(wallet)
+    if account_value <= 0:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "cannot read account"})
+        return
+
+    if has_resting_orders(wallet):
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": "RESTING ORDER: limit order pending."})
+        return
+
+    if len(positions) >= MAX_POSITIONS:
+        coins = [p["coin"] for p in positions]
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": f"CURLED UP: {coins}. DSL manages exit. Collecting funding.",
+                     "_v2_no_thesis_exit": True})
+        return
+
+    tc = cfg.load_trade_counter()
+    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
+        return
+
+    # Scan for extreme funding
+    candidates = scan_funding_extremes()
+    if not candidates:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": "SNIFFING: no extreme funding on allowed assets"})
+        return
+
+    # Already-held coins
+    held_coins = {p["coin"].upper() for p in positions}
+
+    for cand in candidates:
+        token = cand["token"]
+
+        if token in held_coins:
+            continue
+
+        if cand["score"] < MIN_SCORE:
+            continue
+
+        if cfg.is_asset_cooled_down(token, COOLDOWN_MINUTES):
+            continue
+
+        leverage = get_leverage_for_score(cand["score"])
+        margin = round(account_value * MARGIN_PCT, 2)
+
+        success, result = execute_entry(token, cand["fade_direction"], margin, leverage)
+
+        if success:
+            tc["entries"] = tc.get("entries", 0) + 1
+            cfg.save_trade_counter(tc)
+            cfg.set_asset_cooldown(token, COOLDOWN_MINUTES, reason="entry")
+
+            cfg.output({
+                "status": "ok",
+                "action": "FUNDING_FADE",
+                "signal": {
+                    "asset": token,
+                    "crowd_direction": cand["crowd_direction"],
+                    "fade_direction": cand["fade_direction"],
+                    "funding_rate": cand["funding"],
+                    "annualized_pct": round(cand["annualized_pct"], 1),
+                    "score": cand["score"],
+                    "leverage": leverage,
+                    "mode": "FUNDING_FADE",
+                    "reasons": cand["reasons"],
+                },
+                "execution": {
+                    "asset": token,
+                    "direction": cand["fade_direction"],
+                    "leverage": leverage,
+                    "margin": margin,
+                    "orderType": "FEE_OPTIMIZED_LIMIT",
+                    "ensureExecutionAsTaker": False,
+                },
+                "result": result,
+                "_pangolin_version": "1.0",
+            })
+            return
+        else:
+            cfg.output({
+                "status": "ok",
+                "action": "FUNDING_FADE_FAILED",
+                "signal": {"asset": token, "score": cand["score"],
+                           "reasons": cand["reasons"]},
+                "error": result,
+                "_pangolin_version": "1.0",
+            })
+            return
+
+    # No candidates passed
+    best = candidates[0] if candidates else None
+    if best:
+        note = (f"SNIFFING: best {best['token']} funding {best['funding']*100:.4f}% "
+                f"score {best['score']}<{MIN_SCORE}")
+    else:
+        note = "SNIFFING: no extreme funding detected"
+    cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": note})
+
+
+if __name__ == "__main__":
+    try:
+        run()
+    except Exception as e:
+        cfg.log(f"CRITICAL ERROR: {e}")
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        cfg.output({"status": "error", "error": str(e)})

--- a/pangolin/scripts/pangolin_config.py
+++ b/pangolin/scripts/pangolin_config.py
@@ -1,0 +1,200 @@
+"""PANGOLIN v1.0 — Extreme Funding Rate Fader config helper.
+Self-contained. Standard Senpi skill pattern."""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "pangolin-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "pangolin-config.json"
+STATE_DIR = SKILL_DIR / "state"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def atomic_write(path, data):
+    path = str(path)
+    d = os.path.dirname(path) or "."
+    os.makedirs(d, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=d, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    return {}
+
+
+def get_wallet_and_strategy():
+    w = os.environ.get("PANGOLIN_WALLET", "")
+    s = os.environ.get("PANGOLIN_STRATEGY_ID", "")
+    if not w or not s:
+        c = load_config()
+        w = w or c.get("wallet", "")
+        s = s or c.get("strategyId", "")
+    return w, s
+
+
+def load_trade_counter():
+    today = now_date()
+    p = STATE_DIR / "trade-counter.json"
+    default = {"date": today, "entries": 0,
+               "last_win_direction": None, "last_win_ts": 0}
+    if p.exists():
+        try:
+            with open(p) as f:
+                tc = json.load(f)
+            if tc.get("date") != today:
+                tc["date"] = today
+                tc["entries"] = 0
+            for k, v in default.items():
+                if k not in tc:
+                    tc[k] = v
+            return tc
+        except (json.JSONDecodeError, IOError):
+            pass
+    return dict(default)
+
+
+def save_trade_counter(tc):
+    tc["date"] = now_date()
+    atomic_write(str(STATE_DIR / "trade-counter.json"), tc)
+
+
+def is_asset_cooled_down(token, minutes=240):
+    p = STATE_DIR / "cooldowns.json"
+    if not p.exists():
+        return False
+    try:
+        with open(p) as f:
+            cooldowns = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return False
+    entry = cooldowns.get(token)
+    if not entry:
+        return False
+    return time.time() < entry.get("until", 0)
+
+
+def set_asset_cooldown(token, minutes=240, reason="exit"):
+    p = STATE_DIR / "cooldowns.json"
+    cooldowns = {}
+    if p.exists():
+        try:
+            with open(p) as f:
+                cooldowns = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    cooldowns[token] = {"until": time.time() + minutes * 60, "set_at": now_iso(),
+                        "reason": reason}
+    atomic_write(str(p), cooldowns)
+
+
+def mcporter_call(tool, retries=2, timeout=30, **params):
+    args = json.dumps(params) if params else "{}"
+    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
+    for attempt in range(retries):
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            if r.returncode != 0:
+                if attempt < retries - 1:
+                    time.sleep(2)
+                    continue
+                return None
+            raw = json.loads(r.stdout)
+            if isinstance(raw, dict) and "content" in raw:
+                content = raw["content"]
+                if isinstance(content, list) and content:
+                    first = content[0]
+                    if isinstance(first, dict) and "text" in first:
+                        try:
+                            return json.loads(first["text"])
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+            return raw
+        except subprocess.TimeoutExpired:
+            if attempt < retries - 1:
+                time.sleep(2)
+                continue
+            return None
+        except (json.JSONDecodeError, Exception):
+            return None
+    return None
+
+
+def get_positions(wallet=None):
+    if not wallet:
+        wallet, _ = get_wallet_and_strategy()
+    if not wallet:
+        return 0, []
+    ch = mcporter_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+    if not ch or not isinstance(ch, dict):
+        return 0, []
+    data = ch.get("data", ch)
+    positions = []
+    account_value = 0
+    for section in ("main",):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "szi": szi,
+                "size": abs(szi),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "markPrice": float(pos.get("markPx", 0)),
+                "leverage": float(
+                    pos.get("leverage", {}).get("value", 5)
+                    if isinstance(pos.get("leverage"), dict)
+                    else pos.get("leverage", 5)
+                ),
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+            })
+    return account_value, positions
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[PANGOLIN] {msg}", file=sys.stderr)
+
+
+def now_ts():
+    return time.time()
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+def now_date():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")


### PR DESCRIPTION
## Bald Eagle v4.0 — XYZ contrarian flip

Same signal inversion disease found on oil (CL/BRENTOIL) as the 5 crypto agents. 12 positions, 25% WR, avg winner +$1.82, avg loser -$7.22. Direction flip with XYZ-tuned exhaustion thresholds (lower than crypto since oil moves 1-3% vs crypto 3-5%).

## Pangolin v1.0 — NEW strategy archetype

No agent in the fleet trades on funding rate signals. Pangolin fills that gap.

**Thesis:** When funding rates hit extremes (>0.03%/8h = ~40% annualized), the crowd is overpaying to hold. Pangolin fades the funding direction, collecting funding every 8h while waiting for the crowded side to capitulate.

**How it differs from existing agents:**
- Barracuda follows trend + collects funding. Pangolin fades funding extremes.
- Lemon fades individual degen traders. Pangolin fades aggregate crowding.
- Vulture fades SM price exhaustion. Pangolin fades funding rate extremion.

**Design:** 3-5x leverage, 25% margin, 12h hard timeout, top 20 crypto assets, max 2 positions. SM confirmation scoring (higher conviction when SM is already fading the crowd).