### PR TITLE
[fleet-fix] Kestrel v1.0 — XYZ Macro Breakout Rider (new agent)

### DIFF
--- a/kestrel/README.md
+++ b/kestrel/README.md
@@ -1,0 +1,13 @@
+# 🦅 KESTREL v1.0 — XYZ Macro Breakout Rider
+
+Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+When a commodity, metal, or equity moves >1.5% in an hour during US market hours, something macro happened. Kestrel detects the breakout via price action, confirms with early SM buildup and volume surge, and rides the trend with wide DSL. Commodities trend — Kestrel follows.
+
+See [SKILL.md](SKILL.md) for full setup instructions.
+
+## License
+
+MIT — Built by Senpi (https://senpi.ai).

--- a/kestrel/SKILL.md
+++ b/kestrel/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: kestrel-strategy
+description: >-
+  KESTREL v1.0 — XYZ Macro Breakout Rider. Detects significant hourly price
+  breakouts on commodities, precious metals, indices, and high-volume equities
+  during US market hours. Rides the macro trend. Price action is the primary
+  signal; Smart Money is confirmation only. Conservative 3-5x leverage.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime
+---
+
+# 🦅 KESTREL v1.0 — XYZ Macro Breakout Rider
+
+A fundamentally new approach to XYZ trading on Hyperliquid. Where Bald Eagle used SM consensus (thin, lagging on XYZ), Kestrel uses price action as the primary signal and SM as confirmation.
+
+## Thesis
+
+When a commodity or equity moves >1.5% in 1 hour during US market hours, something macro happened. Unlike crypto where big moves exhaust quickly, commodity and equity macro moves tend to continue for hours or days. Kestrel catches the breakout and rides the trend.
+
+## Why this is different from Bald Eagle
+
+| | Bald Eagle | Kestrel |
+|---|---|---|
+| Primary signal | SM consensus | Price action (breakout) |
+| SM role | Trigger | Confirmation only |
+| Direction | Contrarian (v4.0) | Momentum (ride the trend) |
+| Trigger condition | SM concentration >3% | 1H price move >1.5% |
+| Asset universe | 6 assets (CL, BRENTOIL, GOLD, SILVER, SP500, XYZ100) | 13 assets (adds AAPL, NVDA, GOOGL, TSLA, AMZN, META, MSFT) |
+
+## Assets
+
+Commodities: CL, BRENTOIL. Metals: GOLD, SILVER. Indices: SP500, XYZ100.
+Equities: AAPL, NVDA, GOOGL, TSLA, AMZN, META, MSFT.
+
+## Scoring
+
+- 1H breakout magnitude (2-4 pts) — the core signal
+- 4H trend alignment (0-2 pts)
+- Volume surge (0-2 pts)
+- SM confirmation (0-2 pts, can be -1 if SM is heavily opposing)
+- Funding alignment (0-1 pts)
+- Spread gate (hard gate — don't trade if spread >0.2%)
+
+MIN_SCORE: 6. Market hours only: 9:45 AM - 3:30 PM ET.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `scripts/kestrel-scanner.py` | Breakout detection scanner |
+| `scripts/kestrel_config.py` | Config helper |
+| `runtime.yaml` | Wide DSL for macro trend riding |

--- a/kestrel/runtime.yaml
+++ b/kestrel/runtime.yaml
@@ -1,0 +1,60 @@
+name: kestrel-tracker
+version: 1.0.0
+description: >
+  KESTREL v1.0 — XYZ Macro Breakout Rider. Detects >1.5% hourly price
+  breakouts on commodities, metals, indices, and equities during US market
+  hours. Rides the macro trend with wide DSL. Price action primary,
+  SM confirmation secondary.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 2
+  margin_per_slot: 300
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# Wide DSL — macro trends on commodities/equities persist for hours/days.
+# Unlike crypto contrarian, this is MOMENTUM — ride the trend.
+# Dead weight cut catches false breakouts early.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 480
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 180
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 45
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 3
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 3,  lock_hw_pct: 15 }
+        - { trigger_pct: 7,  lock_hw_pct: 30 }
+        - { trigger_pct: 12, lock_hw_pct: 50 }
+        - { trigger_pct: 20, lock_hw_pct: 65 }
+        - { trigger_pct: 30, lock_hw_pct: 80 }
+        - { trigger_pct: 50, lock_hw_pct: 90 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/kestrel/scripts/kestrel-scanner.py
+++ b/kestrel/scripts/kestrel-scanner.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+# Senpi KESTREL Scanner v1.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""KESTREL v1.0 — XYZ Macro Breakout Rider.
+
+Thesis: When a commodity, equity, or precious metal moves >1.5% in 1 hour
+during US market hours, something macro happened (war, rate decision, OPEC,
+earnings). Unlike crypto where big moves exhaust quickly, commodity macro
+moves tend to CONTINUE for hours or days. Kestrel catches the breakout
+early and rides the trend.
+
+Key insight from fleet analysis: Bald Eagle failed because it used SM
+consensus as the PRIMARY signal. SM on XYZ is thin (26-181 traders vs
+300+ on crypto) and lags. Kestrel inverts the priority:
+- PRICE ACTION is the trigger (breakout detection)
+- SM is confirmation only (is smart money starting to build?)
+
+This is a MOMENTUM strategy on XYZ, not a contrarian one. Commodity
+trends persist — oil doesn't mean-revert after a war starts.
+
+Design:
+- Watch commodities (CL, BRENTOIL, GOLD, SILVER) + indices (SP500, XYZ100)
+  + high-volume equities (AAPL, NVDA, GOOGL, TSLA, AMZN)
+- Trigger: 1H price move >1.5% (breakout detected)
+- Confirmation: SM building in breakout direction (early, not exhausted)
+- Anti-confirmation: SM AGAINST breakout direction = even stronger signal
+  (crowd is wrong, breakout will squeeze them)
+- Market hours only: 9:45 AM - 3:30 PM ET
+- Conservative leverage: 3-5x (XYZ can gap)
+- Wide DSL: 480-min hard timeout, let macro trends run
+
+Runs every 5 minutes.
+"""
+
+import json
+import sys
+import os
+import time
+from datetime import datetime, timezone, timedelta
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import kestrel_config as cfg
+
+# ── CONFIGURATION ──
+# Commodities + precious metals + indices + high-volume equities
+ALLOWED_ASSETS = {
+    # Commodities
+    "CL", "BRENTOIL",
+    # Precious metals
+    "GOLD", "SILVER",
+    # Indices
+    "SP500", "XYZ100",
+    # High-volume equities
+    "AAPL", "NVDA", "GOOGL", "TSLA", "AMZN", "META", "MSFT",
+}
+
+MAX_POSITIONS = 2               # Can hold 2 uncorrelated macro bets
+MAX_DAILY_ENTRIES = 4
+COOLDOWN_MINUTES = 180          # 3 hours between same-asset entries
+MARGIN_PCT = 0.30               # 30% per position
+MIN_SCORE = 6                   # Lower bar — price action is the primary signal
+BREAKOUT_THRESHOLD_1H = 1.5     # 1.5% move in 1 hour = breakout
+BREAKOUT_THRESHOLD_4H = 3.0     # 3.0% move in 4 hours = strong trend
+
+LEVERAGE_TIERS = [
+    {"min_score": 9, "leverage": 5},
+    {"min_score": 6, "leverage": 3},
+]
+DEFAULT_LEVERAGE = 3
+
+# US market hours (ET = UTC-4 in EDT, UTC-5 in EST)
+# We use UTC and approximate: 13:45 - 19:30 UTC covers 9:45 AM - 3:30 PM ET
+MARKET_OPEN_UTC = 13    # 9 AM ET (approximate, covers both EDT and EST)
+MARKET_CLOSE_UTC = 20   # 4 PM ET
+
+
+def safe_float(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def get_leverage_for_score(score):
+    for tier in LEVERAGE_TIERS:
+        if score >= tier["min_score"]:
+            return tier["leverage"]
+    return DEFAULT_LEVERAGE
+
+
+def is_market_hours():
+    """Check if we're in US market hours (approximate UTC window)."""
+    hour = datetime.now(timezone.utc).hour
+    # 13:45 UTC (9:45 AM ET) to 19:30 UTC (3:30 PM ET)
+    if hour < MARKET_OPEN_UTC or hour >= MARKET_CLOSE_UTC:
+        return False
+    if hour == MARKET_OPEN_UTC:
+        minute = datetime.now(timezone.utc).minute
+        if minute < 45:
+            return False
+    return True
+
+
+def has_resting_orders(wallet):
+    data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
+    if not data:
+        return False
+    orders = data.get("data", data)
+    if isinstance(orders, dict):
+        orders = orders.get("orders", orders.get("openOrders", []))
+    if isinstance(orders, list):
+        for o in orders:
+            if not o.get("reduceOnly", False):
+                return True
+    return False
+
+
+def scan_xyz_breakouts():
+    """Detect XYZ assets with significant price breakouts.
+    Uses candle data as primary signal, SM data as confirmation."""
+
+    # Get SM data for confirmation scoring
+    sm_raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
+    sm_map = {}
+    if sm_raw:
+        sm_markets = sm_raw.get("data", sm_raw)
+        if isinstance(sm_markets, dict):
+            sm_markets = sm_markets.get("markets", sm_markets)
+        if isinstance(sm_markets, dict):
+            sm_markets = sm_markets.get("markets", [])
+        if isinstance(sm_markets, list):
+            for m in sm_markets:
+                if isinstance(m, dict):
+                    token = str(m.get("token", "")).upper()
+                    dex = str(m.get("dex", "")).lower()
+                    if dex == "xyz":
+                        sm_map[token] = m
+
+    candidates = []
+
+    for asset in ALLOWED_ASSETS:
+        # Fetch candle data — this is the PRIMARY signal
+        data = cfg.mcporter_call("market_get_asset_data",
+                                  asset=f"xyz:{asset}",
+                                  candle_intervals=["1h", "4h"],
+                                  include_funding=True,
+                                  include_order_book=True,
+                                  dex="xyz")
+        if not data:
+            continue
+
+        ad = data.get("data", data)
+        if not isinstance(ad, dict):
+            continue
+
+        candles = ad.get("candles", {})
+        candles_1h = candles.get("1h", [])
+        candles_4h = candles.get("4h", [])
+
+        if len(candles_1h) < 3:
+            continue
+
+        # ── BREAKOUT DETECTION (primary signal) ──
+        # Calculate 1H price change from the last closed candle
+        last_1h = candles_1h[-1]
+        prev_1h = candles_1h[-2]
+        close_now = safe_float(last_1h.get("close", last_1h.get("c", 0)))
+        close_prev = safe_float(prev_1h.get("close", prev_1h.get("c", 0)))
+
+        if close_prev <= 0 or close_now <= 0:
+            continue
+
+        pct_1h = ((close_now - close_prev) / close_prev) * 100
+
+        # Also check 4H trend
+        pct_4h = 0
+        if len(candles_4h) >= 2:
+            close_4h_now = safe_float(candles_4h[-1].get("close", candles_4h[-1].get("c", 0)))
+            close_4h_prev = safe_float(candles_4h[-2].get("close", candles_4h[-2].get("c", 0)))
+            if close_4h_prev > 0:
+                pct_4h = ((close_4h_now - close_4h_prev) / close_4h_prev) * 100
+
+        # Must have a meaningful 1H breakout
+        if abs(pct_1h) < BREAKOUT_THRESHOLD_1H:
+            continue
+
+        # Determine breakout direction from price action
+        breakout_dir = "LONG" if pct_1h > 0 else "SHORT"
+
+        score = 0
+        reasons = []
+
+        # ── 1H Breakout magnitude (2-4 pts) — the core signal ──
+        if abs(pct_1h) >= 3.0:
+            score += 4
+            reasons.append(f"MASSIVE_BREAKOUT_1H {pct_1h:+.2f}%")
+        elif abs(pct_1h) >= 2.0:
+            score += 3
+            reasons.append(f"STRONG_BREAKOUT_1H {pct_1h:+.2f}%")
+        elif abs(pct_1h) >= BREAKOUT_THRESHOLD_1H:
+            score += 2
+            reasons.append(f"BREAKOUT_1H {pct_1h:+.2f}%")
+
+        # ── 4H trend alignment (0-2 pts) ──
+        if abs(pct_4h) >= BREAKOUT_THRESHOLD_4H:
+            if (breakout_dir == "LONG" and pct_4h > 0) or \
+               (breakout_dir == "SHORT" and pct_4h < 0):
+                score += 2
+                reasons.append(f"4H_TREND_CONFIRMS {pct_4h:+.2f}%")
+        elif abs(pct_4h) >= 1.0:
+            if (breakout_dir == "LONG" and pct_4h > 0) or \
+               (breakout_dir == "SHORT" and pct_4h < 0):
+                score += 1
+                reasons.append(f"4H_ALIGNED {pct_4h:+.2f}%")
+
+        # ── Volume surge (0-2 pts) ──
+        if len(candles_1h) >= 4:
+            vols = [safe_float(c.get("volume", c.get("v", c.get("vlm", 0))))
+                    for c in candles_1h[-4:]]
+            if len(vols) >= 4 and vols[-2] > 0:
+                vol_ratio = vols[-1] / vols[-2] if vols[-2] > 0 else 0
+                avg_prev = sum(vols[:-1]) / len(vols[:-1]) if vols[:-1] else 1
+                vol_vs_avg = vols[-1] / avg_prev if avg_prev > 0 else 0
+                if vol_vs_avg >= 2.0:
+                    score += 2
+                    reasons.append(f"VOLUME_SURGE {vol_vs_avg:.1f}x avg")
+                elif vol_vs_avg >= 1.3:
+                    score += 1
+                    reasons.append(f"VOLUME_UP {vol_vs_avg:.1f}x avg")
+
+        # ── SM confirmation (0-2 pts, can be negative) ──
+        sm = sm_map.get(asset)
+        if sm:
+            sm_dir = str(sm.get("direction", "")).upper()
+            sm_pct = safe_float(sm.get("pct_of_top_traders_gain", 0))
+            sm_traders = int(sm.get("trader_count", 0))
+
+            if sm_dir == breakout_dir and sm_pct >= 3:
+                # SM agrees with breakout — confirmation
+                score += 2
+                reasons.append(f"SM_CONFIRMS {sm_pct:.1f}% ({sm_traders}t)")
+            elif sm_dir == breakout_dir and sm_pct >= 1:
+                score += 1
+                reasons.append(f"SM_BUILDING {sm_pct:.1f}% ({sm_traders}t)")
+            elif sm_dir != breakout_dir and sm_pct >= 5:
+                # SM is AGAINST the breakout — crowd is wrong, squeeze potential
+                score += 1
+                reasons.append(f"SM_TRAPPED_{sm_dir} {sm_pct:.1f}% (squeeze potential)")
+
+        # ── Spread gate ──
+        ob = ad.get("order_book", ad.get("orderBook", {}))
+        spread_ok = True
+        if isinstance(ob, dict):
+            bids = ob.get("bids", ob.get("bid", []))
+            asks = ob.get("asks", ob.get("ask", []))
+            if bids and asks:
+                best_bid = safe_float(bids[0][0] if isinstance(bids[0], list)
+                                      else bids[0].get("price", 0))
+                best_ask = safe_float(asks[0][0] if isinstance(asks[0], list)
+                                      else asks[0].get("price", 0))
+                if best_bid > 0 and best_ask > 0:
+                    mid = (best_bid + best_ask) / 2
+                    spread_pct = (best_ask - best_bid) / mid
+                    if spread_pct > 0.002:  # 0.2% max spread
+                        spread_ok = False
+                        reasons.append(f"SPREAD_WIDE {spread_pct*100:.3f}%")
+                    else:
+                        reasons.append(f"SPREAD_OK {spread_pct*100:.3f}%")
+
+        if not spread_ok:
+            continue
+
+        # ── Funding alignment (0-1 pts) ──
+        asset_ctx = ad.get("asset_context", ad.get("assetContext", {}))
+        if isinstance(asset_ctx, dict):
+            funding = safe_float(asset_ctx.get("funding", 0))
+            if (breakout_dir == "LONG" and funding < -0.001) or \
+               (breakout_dir == "SHORT" and funding > 0.001):
+                score += 1
+                reasons.append(f"FUNDING_ALIGNED {funding*100:.4f}%")
+
+        reasons.insert(0, f"BREAKOUT xyz:{asset} {breakout_dir}")
+
+        candidates.append({
+            "token": asset,
+            "breakout_direction": breakout_dir,
+            "pct_1h": pct_1h,
+            "pct_4h": pct_4h,
+            "score": score,
+            "reasons": reasons,
+        })
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    return candidates
+
+
+def execute_entry(token, direction, margin, leverage):
+    result = cfg.mcporter_call(
+        "create_position",
+        coin=token,
+        direction=direction,
+        leverage=leverage,
+        margin=margin,
+        orderType="FEE_OPTIMIZED_LIMIT",
+        feeOptimizedLimitOptions={
+            "ensureExecutionAsTaker": False,
+            "executionTimeoutSeconds": 45,
+        },
+        dex="xyz",
+    )
+    if result and result.get("success"):
+        return True, result
+    error = result.get("error", "unknown") if result else "mcporter_call returned None"
+    return False, {"error": error}
+
+
+def run():
+    wallet, sid = cfg.get_wallet_and_strategy()
+    if not wallet:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "no wallet"})
+        return
+
+    # Market hours gate
+    if not is_market_hours():
+        hour = datetime.now(timezone.utc).hour
+        minute = datetime.now(timezone.utc).minute
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": f"OFF_HOURS: UTC {hour:02d}:{minute:02d}. "
+                             f"Kestrel hunts during US market hours only."})
+        return
+
+    account_value, positions = cfg.get_positions(wallet)
+    if account_value <= 0:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "cannot read account"})
+        return
+
+    if has_resting_orders(wallet):
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": "RESTING ORDER: entry pending."})
+        return
+
+    if len(positions) >= MAX_POSITIONS:
+        coins = [p["coin"] for p in positions]
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": f"PERCHED: {coins}. DSL manages exit.",
+                     "_v2_no_thesis_exit": True})
+        return
+
+    tc = cfg.load_trade_counter()
+    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
+        return
+
+    # Scan for breakouts
+    candidates = scan_xyz_breakouts()
+    if not candidates:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": "SCANNING: no XYZ breakouts >1.5% detected"})
+        return
+
+    # Filter and enter
+    held_coins = {p["coin"].upper().replace("XYZ:", "") for p in positions}
+
+    for cand in candidates:
+        token = cand["token"]
+
+        if token in held_coins:
+            continue
+
+        if cand["score"] < MIN_SCORE:
+            continue
+
+        if cfg.is_asset_cooled_down(token, COOLDOWN_MINUTES):
+            continue
+
+        leverage = get_leverage_for_score(cand["score"])
+        margin = round(account_value * MARGIN_PCT, 2)
+
+        success, result = execute_entry(token, cand["breakout_direction"],
+                                         margin, leverage)
+
+        if success:
+            tc["entries"] = tc.get("entries", 0) + 1
+            tc["last_entry_ts"] = cfg.now_ts()
+            cfg.save_trade_counter(tc)
+            cfg.set_asset_cooldown(token, COOLDOWN_MINUTES, reason="entry")
+
+            cfg.output({
+                "status": "ok",
+                "action": "BREAKOUT_ENTRY",
+                "signal": {
+                    "asset": f"xyz:{token}",
+                    "direction": cand["breakout_direction"],
+                    "pct_1h": round(cand["pct_1h"], 2),
+                    "pct_4h": round(cand["pct_4h"], 2),
+                    "score": cand["score"],
+                    "leverage": leverage,
+                    "mode": "XYZ_BREAKOUT",
+                    "reasons": cand["reasons"],
+                },
+                "execution": {
+                    "asset": f"xyz:{token}",
+                    "direction": cand["breakout_direction"],
+                    "leverage": leverage,
+                    "margin": margin,
+                    "orderType": "FEE_OPTIMIZED_LIMIT",
+                    "ensureExecutionAsTaker": False,
+                },
+                "result": result,
+                "_kestrel_version": "1.0",
+            })
+            return
+        else:
+            cfg.output({
+                "status": "ok",
+                "action": "BREAKOUT_ENTRY_FAILED",
+                "signal": {"asset": f"xyz:{token}",
+                           "score": cand["score"],
+                           "reasons": cand["reasons"]},
+                "error": result,
+                "_kestrel_version": "1.0",
+            })
+            return
+
+    # No candidates passed
+    best = candidates[0] if candidates else None
+    if best:
+        note = (f"SCANNING: best xyz:{best['token']} {best['breakout_direction']} "
+                f"{best['pct_1h']:+.1f}% 1H, score {best['score']}<{MIN_SCORE}")
+    else:
+        note = "SCANNING: no XYZ breakouts detected"
+    cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": note})
+
+
+if __name__ == "__main__":
+    try:
+        run()
+    except Exception as e:
+        cfg.log(f"CRITICAL ERROR: {e}")
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        cfg.output({"status": "error", "error": str(e)})

--- a/kestrel/scripts/kestrel_config.py
+++ b/kestrel/scripts/kestrel_config.py
@@ -1,0 +1,195 @@
+"""KESTREL v1.0 — XYZ Macro Breakout Rider config helper.
+Self-contained. Standard Senpi skill pattern."""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "kestrel-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "kestrel-config.json"
+STATE_DIR = SKILL_DIR / "state"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def atomic_write(path, data):
+    path = str(path)
+    d = os.path.dirname(path) or "."
+    os.makedirs(d, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=d, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    return {}
+
+
+def get_wallet_and_strategy():
+    w = os.environ.get("KESTREL_WALLET", "")
+    s = os.environ.get("KESTREL_STRATEGY_ID", "")
+    if not w or not s:
+        c = load_config()
+        w = w or c.get("wallet", "")
+        s = s or c.get("strategyId", "")
+    return w, s
+
+
+def load_trade_counter():
+    today = now_date()
+    p = STATE_DIR / "trade-counter.json"
+    default = {"date": today, "entries": 0, "last_entry_ts": 0,
+               "last_win_direction": None, "last_win_ts": 0}
+    if p.exists():
+        try:
+            with open(p) as f:
+                tc = json.load(f)
+            if tc.get("date") != today:
+                tc["date"] = today
+                tc["entries"] = 0
+            for k, v in default.items():
+                if k not in tc:
+                    tc[k] = v
+            return tc
+        except (json.JSONDecodeError, IOError):
+            pass
+    return dict(default)
+
+
+def save_trade_counter(tc):
+    tc["date"] = now_date()
+    atomic_write(str(STATE_DIR / "trade-counter.json"), tc)
+
+
+def is_asset_cooled_down(token, minutes=180):
+    p = STATE_DIR / "cooldowns.json"
+    if not p.exists():
+        return False
+    try:
+        with open(p) as f:
+            cooldowns = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return False
+    entry = cooldowns.get(token)
+    if not entry:
+        return False
+    return time.time() < entry.get("until", 0)
+
+
+def set_asset_cooldown(token, minutes=180, reason="exit"):
+    p = STATE_DIR / "cooldowns.json"
+    cooldowns = {}
+    if p.exists():
+        try:
+            with open(p) as f:
+                cooldowns = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    cooldowns[token] = {"until": time.time() + minutes * 60, "set_at": now_iso(),
+                        "reason": reason}
+    atomic_write(str(p), cooldowns)
+
+
+def mcporter_call(tool, retries=2, timeout=30, **params):
+    args = json.dumps(params) if params else "{}"
+    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
+    for attempt in range(retries):
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            if r.returncode != 0:
+                if attempt < retries - 1:
+                    time.sleep(2)
+                    continue
+                return None
+            raw = json.loads(r.stdout)
+            if isinstance(raw, dict) and "content" in raw:
+                content = raw["content"]
+                if isinstance(content, list) and content:
+                    first = content[0]
+                    if isinstance(first, dict) and "text" in first:
+                        try:
+                            return json.loads(first["text"])
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+            return raw
+        except subprocess.TimeoutExpired:
+            if attempt < retries - 1:
+                time.sleep(2)
+                continue
+            return None
+        except (json.JSONDecodeError, Exception):
+            return None
+    return None
+
+
+def get_positions(wallet=None):
+    if not wallet:
+        wallet, _ = get_wallet_and_strategy()
+    if not wallet:
+        return 0, []
+    ch = mcporter_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+    if not ch or not isinstance(ch, dict):
+        return 0, []
+    data = ch.get("data", ch)
+    positions = []
+    account_value = 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "szi": szi,
+                "size": abs(szi),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "markPrice": float(pos.get("markPx", 0)),
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+            })
+    return account_value, positions
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[KESTREL] {msg}", file=sys.stderr)
+
+
+def now_ts():
+    return time.time()
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+def now_date():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")


### PR DESCRIPTION
## Why a new XYZ agent?

Bald Eagle used SM consensus as the primary signal on XYZ. The SM data on XYZ is thin (26-181 traders vs 300+ on crypto) and lags behind price action. The Iran/oil breakout was missed because SM consensus built too slowly.

## Kestrel's approach

Inverts the signal priority:
- **Price action is the trigger** — detects >1.5% hourly breakouts
- **SM is confirmation only** — checks if smart money is starting to build in the breakout direction
- **Momentum, not contrarian** — commodity macro moves trend, they don't mean-revert

## Asset universe (13 assets)

Commodities: CL, BRENTOIL. Metals: GOLD, SILVER. Indices: SP500, XYZ100. Equities: AAPL, NVDA, GOOGL, TSLA, AMZN, META, MSFT.

## Safety

Market hours only (9:45 AM - 3:30 PM ET), 3-5x leverage, spread gate at 0.2%, 480-min hard timeout.