### PR TITLE
[fleet-fix] Fix Cheetah runtime.yaml version field

### DIFF
--- a/cheetah/runtime.yaml
+++ b/cheetah/runtime.yaml
@@ -1,5 +1,5 @@
 name: cheetah-tracker
-version: 4.0.0
+version: 1.0.0
 description: >
   CHEETAH v4.0 — HYPE Funding Rate + Crowding Fader. Enters opposite to
   extreme HYPE funding rates, collecting funding while waiting for crowded


### PR DESCRIPTION
Cheetah v4.0 reported that version: 4.0.0 in runtime.yaml broke the Senpi runtime engine. Fixed to 1.0.0.