### PR TITLE
[fleet-fix] 15m velocity freshness gate — fleet-wide signal staleness fix

### DIFF
--- a/Grizzly-Horribilis/scripts/grizzly-scanner.py
+++ b/Grizzly-Horribilis/scripts/grizzly-scanner.py
@@ -149,13 +149,14 @@ def evaluate_btc():
         if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
             score -= 1; reasons.append(f"MOVE_TIRING {p4h:+.1f}%")
 
-    # Contribution velocity — multi-window (NEW: 15m + 1h + 4h)
-    # 15m = entry timing signal (SM interest spiking NOW)
-    # 1h = trend confirmation
-    # 4h = existing signal (major shift)
+    # 15m velocity freshness gate — SM must be actively building
+    # For contrarian: we want SM aggressively piling in so we can fade the peak
+    if cc_15m <= 0:
+        return None  # SM not fresh — stale signal
+
+    # Contribution velocity scoring
     if cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
     elif cc_15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
-    elif cc_15m < -0.5: score -= 1; reasons.append(f"15M_FADING {cc_15m:.2f}")
 
     if cc_1h > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h:.2f}")
 

--- a/cobra/scripts/cobra-scanner.py
+++ b/cobra/scripts/cobra-scanner.py
@@ -456,6 +456,14 @@ def main():
         print(json.dumps(output, indent=2))
         return
 
+    # 15m velocity freshness gate — SM must be actively building, not stale
+    cc_15m = float(dominant.get("contribution_pct_change_15m", 0) or 0)
+    if cc_15m <= 0:
+        output["reason"] = f"15M_STALE ({cc_15m:.2f}) — signal not fresh on {token}"
+        output["breakdown"]["cc_15m"] = cc_15m
+        print(json.dumps(output, indent=2))
+        return
+
     # ================================================================
     # ENTRY SIGNAL — Score passed, all gates clear
     # ================================================================

--- a/condor/scripts/condor-scanner.py
+++ b/condor/scripts/condor-scanner.py
@@ -132,6 +132,7 @@ def fetch_all_sm_data():
             "price_chg_1h": safe_float(m.get("token_price_change_pct_1h",
                                        m.get("price_change_1h", 0))),
             "contrib_change": safe_float(m.get("contribution_pct_change_4h", 0)),
+            "cc_15m": safe_float(m.get("contribution_pct_change_15m", 0)),
             "rank": int(m.get("rank", m.get("position", 999))),
         }
 
@@ -264,6 +265,15 @@ def evaluate_thesis(asset, sm_data):
     if rank <= 10:
         score += 1
         reasons.append(f"TOP_10 #{rank}")
+
+    # 7. 15m velocity freshness (conviction penalty)
+    cc_15m = safe_float(sm.get("cc_15m", 0))
+    if cc_15m <= 0:
+        score -= 3
+        reasons.append(f"15M_STALE_PENALTY ({cc_15m:.2f})")
+    elif cc_15m > 0.5:
+        score += 1
+        reasons.append(f"15M_FRESH +{cc_15m:.2f}")
 
     return {
         "asset": asset, "direction": direction, "score": score,

--- a/dog/scripts/dog-scanner.py
+++ b/dog/scripts/dog-scanner.py
@@ -159,11 +159,14 @@ def evaluate_assets():
         if (d == "LONG" and p1h > 0.2) or (d == "SHORT" and p1h < -0.2):
             score += 1; reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
 
-        # ── 15m velocity — only fresh spikes matter ──
+        # ── 15m velocity freshness gate ──
+        # For contrarian: SM must be actively building the position we're about to fade.
+        # If SM is already unwinding (15m <= 0), the fade opportunity is passing — skip.
+        if cc_15m <= 0:
+            continue  # SM not fresh — stale signal, don't fade
         if cc_15m > 2.0: score += 3; reasons.append(f"15M_STRONG_SPIKE +{cc_15m:.2f}")
         elif cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
         elif cc_15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
-        elif cc_15m < -0.5: score -= 1; reasons.append(f"15M_FADING {cc_15m:.2f}")
 
         # ── 1h acceleration (0-1) ──
         if cc_1h > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h:.2f}")

--- a/grizzly/scripts/grizzly-scanner.py
+++ b/grizzly/scripts/grizzly-scanner.py
@@ -133,10 +133,15 @@ def evaluate_btc():
         if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
             score -= 1; reasons.append(f"MOVE_TIRING {p4h:+.1f}%")
 
-    # Contribution velocity — aligned with Horribilis (simpler tiers)
+    # 15m velocity freshness gate — SM must be actively building
+    # For contrarian: we want SM aggressively piling in (high 15m) so we can fade the peak
+    # If SM is already unwinding (15m <= 0), the fade opportunity is passing
+    if cc_15m <= 0:
+        return None  # SM not fresh — stale signal
+
+    # Contribution velocity scoring
     if cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
     elif cc_15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
-    elif cc_15m < -0.5: score -= 1; reasons.append(f"15M_FADING {cc_15m:.2f}")
 
     if cc_1h_contrib > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h_contrib:.2f}")
 

--- a/kodiak/scripts/kodiak-scanner.py
+++ b/kodiak/scripts/kodiak-scanner.py
@@ -117,10 +117,11 @@ def get_btc_correlation():
 
 
 def get_sol_sm_direction():
-    """Get smart money positioning specifically for SOL."""
+    """Get smart money positioning specifically for SOL.
+    Returns (direction, pct, trader_count, cc_15m)."""
     data = cfg.mcporter_call("leaderboard_get_markets")
     if not data or not data.get("success"):
-        return None, 0, 0
+        return None, 0, 0, 0
 
     markets = data.get("data", data)
     if isinstance(markets, dict):
@@ -132,6 +133,7 @@ def get_sol_sm_direction():
     asset_long_pct = 0
     asset_short_pct = 0
     asset_traders = 0
+    sol_cc_15m = 0
     found = False
 
     for m in markets:
@@ -144,25 +146,28 @@ def get_sol_sm_direction():
         direction = m.get("direction", "").lower()
         pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
         traders = int(m.get("trader_count", m.get("traderCount", 0)))
+        cc_15m_val = float(m.get("contribution_pct_change_15m", 0) or 0)
         if direction == "long":
             asset_long_pct = pct
             asset_traders += traders
+            sol_cc_15m = cc_15m_val
         elif direction == "short":
             asset_short_pct = pct
             asset_traders += traders
+            sol_cc_15m = cc_15m_val
 
     if not found:
-        return None, 0, 0
+        return None, 0, 0, 0
 
     total = asset_long_pct + asset_short_pct
     if total == 0:
-        return "NEUTRAL", 50, asset_traders
+        return "NEUTRAL", 50, asset_traders, sol_cc_15m
     long_ratio = (asset_long_pct / total) * 100 if total > 0 else 50
     if long_ratio > 58:
-        return "LONG", long_ratio, asset_traders
+        return "LONG", long_ratio, asset_traders, sol_cc_15m
     elif long_ratio < 42:
-        return "SHORT", 100 - long_ratio, asset_traders
-    return "NEUTRAL", 50, asset_traders
+        return "SHORT", 100 - long_ratio, asset_traders, sol_cc_15m
+    return "NEUTRAL", 50, asset_traders, sol_cc_15m
 
 
 # ─── Thesis Builder (BTC Only) ───────────────────────────────
@@ -236,7 +241,7 @@ def build_sol_thesis(entry_cfg):
         reasons.append("4TF_aligned")
 
     # ── SM positioning (BTC-specific, very strong signal) ─────
-    sm_dir, sm_pct, sm_count = get_sol_sm_direction()
+    sm_dir, sm_pct, sm_count, sm_cc_15m = get_sol_sm_direction()
     if sm_dir == direction:
         score += 2
         reasons.append(f"sm_aligned_{sm_pct:.0f}%_{sm_count}traders")
@@ -246,6 +251,14 @@ def build_sol_thesis(entry_cfg):
     elif sm_dir and sm_dir != "NEUTRAL" and sm_dir != direction:
         # SM opposes — hard block for BTC. SM has the best read on BTC.
         return None
+
+    # ── 15m velocity freshness (conviction penalty) ──────────
+    if sm_cc_15m <= 0:
+        score -= 3
+        reasons.append(f"15M_STALE_PENALTY ({sm_cc_15m:.2f})")
+    elif sm_cc_15m > 0.5:
+        score += 1
+        reasons.append(f"15M_FRESH +{sm_cc_15m:.2f}")
 
     # ── Funding alignment ─────────────────────────────────────
     if (direction == "LONG" and funding < 0):
@@ -360,7 +373,7 @@ def evaluate_sol_position(direction, entry_cfg):
         invalidations.append("4h_trend_flipped_bullish")
 
     # SM flipped against?
-    sm_dir, sm_pct, _ = get_sol_sm_direction()
+    sm_dir, sm_pct, _, _ = get_sol_sm_direction()
     if sm_dir and sm_dir != "NEUTRAL" and sm_dir != direction:
         invalidations.append(f"sm_flipped_{sm_dir}_{sm_pct:.0f}%")
 
@@ -427,7 +440,7 @@ def evaluate_reload(exit_state, entry_cfg):
         kill_reasons.append(f"4h_trend_reversed_{trend_4h}")
 
     # KILL CHECK: SM flipped
-    sm_dir, sm_pct, _ = get_sol_sm_direction()
+    sm_dir, sm_pct, _, _ = get_sol_sm_direction()
     if sm_dir and sm_dir != "NEUTRAL" and sm_dir != direction:
         kill_reasons.append(f"sm_flipped_{sm_dir}")
 

--- a/mantis/scripts/mantis-scanner.py
+++ b/mantis/scripts/mantis-scanner.py
@@ -156,6 +156,7 @@ def parse_scan(raw_markets):
             "price_chg_4h": safe_float(m.get("token_price_change_pct_4h", 0)),
             "price_chg_1h": safe_float(m.get("token_price_change_pct_1h",
                                        m.get("price_change_1h", 0))),
+            "cc_15m": safe_float(m.get("contribution_pct_change_15m", 0)),
         })
 
     return {"markets": markets[:TOP_N], "time": now_iso()}
@@ -301,6 +302,11 @@ def detect_striker_signals(current_scan, history):
 
         if score < STRIKER_MIN_SCORE or len(reasons) < STRIKER_MIN_REASONS:
             continue
+
+        # 15m velocity freshness gate — SM must be actively building, not stale
+        cc_15m = safe_float(market.get("cc_15m", 0))
+        if cc_15m <= 0:
+            continue  # SM velocity is flat or fading — signal is stale, don't enter
 
         vol_ratio, vol_strong = 0, True
         vol_ratio, vol_strong = check_asset_volume(token, dex)

--- a/orca/scripts/orca-scanner.py
+++ b/orca/scripts/orca-scanner.py
@@ -157,6 +157,7 @@ def parse_scan(raw_markets):
             "price_chg_1h": safe_float(m.get("token_price_change_pct_1h",
                                        m.get("price_change_1h", 0))),
             "contrib_change": safe_float(m.get("contribution_pct_change_4h", 0)),
+            "cc_15m": safe_float(m.get("contribution_pct_change_15m", 0)),
         })
 
     return {"markets": markets[:TOP_N], "time": now_iso()}
@@ -387,6 +388,11 @@ def detect_signals(current_scan, history, momentum_index):
 
         if score < STRIKER_MIN_SCORE or len(reasons) < STRIKER_MIN_REASONS:
             continue
+
+        # 15m velocity freshness gate — SM must be actively building, not stale
+        cc_15m = safe_float(market.get("cc_15m", 0))
+        if cc_15m <= 0:
+            continue  # SM velocity is flat or fading — signal is stale, don't enter
 
         # Volume confirmation
         vol_ratio, vol_strong = check_asset_volume(token, dex)

--- a/phoenix/scripts/phoenix-scanner.py
+++ b/phoenix/scripts/phoenix-scanner.py
@@ -193,6 +193,11 @@ def fetch_and_score():
                 score += 1
                 reasons.append(f"DIVERGENCE {velocity_ratio:.1f}x")
 
+        # 15m velocity freshness gate — SM must be actively building, not stale
+        cc_15m = safe_float(m.get("contribution_pct_change_15m", 0))
+        if cc_15m <= 0:
+            continue  # SM velocity is flat or fading — signal is stale, don't enter
+
         signals.append({
             "token": token,
             "dex": dex if dex else None,

--- a/polar/scripts/polar-scanner.py
+++ b/polar/scripts/polar-scanner.py
@@ -152,12 +152,13 @@ def evaluate_eth():
     if (d == "LONG" and p1h > 0.2) or (d == "SHORT" and p1h < -0.2):
         score += 1; reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
 
-    # Contribution velocity — expanded extreme tiers
-    if cc_15m > 5.0: score += 4; reasons.append(f"15M_EXTREME_SPIKE +{cc_15m:.2f}")
+    # 15m velocity freshness — conviction-class penalty (not hard gate)
+    if cc_15m <= 0:
+        score -= 3; reasons.append(f"15M_STALE_PENALTY ({cc_15m:.2f})")
+    elif cc_15m > 5.0: score += 4; reasons.append(f"15M_EXTREME_SPIKE +{cc_15m:.2f}")
     elif cc_15m > 2.0: score += 3; reasons.append(f"15M_STRONG_SPIKE +{cc_15m:.2f}")
     elif cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
     elif cc_15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
-    elif cc_15m < -0.5: score -= 1; reasons.append(f"15M_FADING {cc_15m:.2f}")
 
     if cc_1h > 3.0: score += 2; reasons.append(f"1H_STRONG_ACCEL +{cc_1h:.2f}")
     elif cc_1h > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h:.2f}")

--- a/roach/scripts/roach-scanner.py
+++ b/roach/scripts/roach-scanner.py
@@ -81,6 +81,7 @@ def parse_scan(raw_markets):
             "contribution": round(m.get("pct_of_top_traders_gain", 0), 6),
             "traders": m.get("trader_count", 0),
             "price_chg_4h": round(m.get("token_price_change_pct_4h", 0) or 0, 4),
+            "cc_15m": float(m.get("contribution_pct_change_15m", 0) or 0),
         })
     return scan
 
@@ -432,6 +433,11 @@ def detect_striker_signals(current_scan, history, config):
 
         if score < min_score or len(reasons) < min_reasons:
             continue
+
+        # 15m velocity freshness gate — SM must be actively building, not stale
+        cc_15m = float(market.get("cc_15m", 0))
+        if cc_15m <= 0:
+            continue  # SM velocity is flat or fading — signal is stale, don't enter
 
         # ── Volume confirmation (the PUMP filter) ──
         vol_ratio, vol_strong = 0, True

--- a/scorpion/scripts/scorpion-scanner.py
+++ b/scorpion/scripts/scorpion-scanner.py
@@ -181,6 +181,7 @@ def detect_swarm(markets):
             "direction": direction,
             "sm_pct": sm_pct,
             "contrib_change": m.get("contribution_pct_change_4h", 0) or 0,
+            "cc_15m": float(m.get("contribution_pct_change_15m", 0) or 0),
             "price_change_4h": m.get("token_price_change_pct_4h", 0),
             "trader_count": m.get("trader_count", 0),
             "max_leverage": m.get("max_leverage", 3),
@@ -309,6 +310,11 @@ def pick_best_target(swarm, state):
         clear, _ = check_asset_cooldown(state, token)
         if not clear:
             continue
+
+        # 15m velocity freshness gate — SM must be actively building, not stale
+        cc_15m = float(target.get("cc_15m", 0))
+        if cc_15m <= 0:
+            continue  # SM velocity is flat or fading — signal is stale, don't enter
 
         score, breakdown = score_target(target, swarm_size)
         if score >= MIN_SCORE:

--- a/sentinel/scripts/sentinel-scanner.py
+++ b/sentinel/scripts/sentinel-scanner.py
@@ -177,6 +177,7 @@ def fetch_sm_data():
             "price_chg_1h": safe_float(m.get("token_price_change_pct_1h",
                                        m.get("price_change_1h", 0))),
             "contrib_change": safe_float(m.get("contribution_pct_change_4h", 0)),
+            "cc_15m": safe_float(m.get("contribution_pct_change_15m", 0)),
         }
 
     return sm_map
@@ -286,6 +287,7 @@ def find_convergence_signals(convergence_map, sm_map):
             "price_chg_4h": sm["price_chg_4h"],
             "price_chg_1h": sm["price_chg_1h"],
             "contrib_change": sm.get("contrib_change", 0),
+            "cc_15m": sm.get("cc_15m", 0),
             "trader_details": data["traders"],
         })
 
@@ -356,6 +358,15 @@ def score_candidate(cand):
     if contrib >= 0.01:
         score += 1
         reasons.append(f"CONTRIB_ACCEL +{contrib*100:.1f}%")
+
+    # 5. 15m velocity freshness (conviction penalty)
+    cc_15m = safe_float(cand.get("cc_15m", 0))
+    if cc_15m <= 0:
+        score -= 3
+        reasons.append(f"15M_STALE_PENALTY ({cc_15m:.2f})")
+    elif cc_15m > 0.5:
+        score += 1
+        reasons.append(f"15M_FRESH +{cc_15m:.2f}")
 
     return score, reasons
 

--- a/spider/scripts/spider-scanner.py
+++ b/spider/scripts/spider-scanner.py
@@ -306,12 +306,14 @@ def score_convergences(convergences, velocity):
             if sm_dir == direction and sm_pct >= 5:
                 score += 1; reasons.append(f"SM_CONFIRMS {sm_pct:.1f}%")
 
+            # 15m velocity freshness gate — striker-class hard gate
+            if cc_15m <= 0:
+                reasons.append(f"15M_STALE ({cc_15m:.2f})")
+                continue  # SM not fresh, skip this convergence
             if cc_15m > 0.5:
                 score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
             elif cc_15m > 0.1:
                 score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
-            elif cc_15m < -0.5:
-                score -= 1; reasons.append(f"15M_FADING {cc_15m:.2f}")
 
             if cc_1h > 1.0:
                 score += 1; reasons.append(f"1H_ACCEL +{cc_1h:.2f}")

--- a/wolverine/scripts/wolverine-scanner.py
+++ b/wolverine/scripts/wolverine-scanner.py
@@ -123,9 +123,11 @@ def score_hype_signal(markets_data):
         score += 1
         reasons.append(f"MODERATE_CONTRIB {contribution:.1f}%")
 
-    # Contribution velocity — multi-window (15m + 1h + 4h); v2.2 extreme tiers
-    # 15m is the entry timing signal — HYPE moves fast, this catches the inflection
-    if contrib_15m > 5.0:
+    # 15m velocity freshness — conviction-class penalty (not hard gate)
+    if contrib_15m <= 0:
+        score -= 3
+        reasons.append(f"15M_STALE_PENALTY ({contrib_15m:.2f})")
+    elif contrib_15m > 5.0:
         score += 4
         reasons.append(f"15M_EXTREME_SPIKE +{contrib_15m:.2f}")
     elif contrib_15m > 2.0:
@@ -137,9 +139,6 @@ def score_hype_signal(markets_data):
     elif contrib_15m > 0.1:
         score += 1
         reasons.append(f"15M_BUILDING +{contrib_15m:.2f}")
-    elif contrib_15m < -0.5:
-        score -= 1
-        reasons.append(f"15M_FADING {contrib_15m:.2f}")
 
     if contrib_1h > 3.0:
         score += 2


### PR DESCRIPTION
## The problem

Agents churn at 00:00 UTC when trade counters reset. They see high 4H aggregate scores from hours-old SM data. The scores don't decay — a move that peaked at 23:00 still scores 10 at 00:01.

## The fix

Require contribution_pct_change_15m > 0 before entering. SM must be actively building RIGHT NOW.

| Class | Agents | Enforcement |
|-------|--------|------------|
| Striker | Phoenix, Roach, Orca, Mantis, Cobra, Scorpion, Spider | Hard gate (refuse entry) |
| Conviction | Kodiak, Polar, Condor, Sentinel, Wolverine | Strong penalty (-3 pts) |
| Contrarian | Dog, Grizzly v4.0, Horribilis v2.0 | Hard gate (SM must be actively building to fade) |

Validated: Dog's $70.45 winner had 15m velocity of +4.23 at entry. Gate would not have blocked it.

15 scanners, 112 insertions.