### PR TITLE
[fleet-fix] Add Wolverine runtime.yaml — permanent DSL config

### DIFF
--- a/wolverine/runtime.yaml
+++ b/wolverine/runtime.yaml
@@ -1,0 +1,58 @@
+name: wolverine-tracker
+version: 1.0.0
+description: >
+  WOLVERINE v2.2 — HYPE Alpha Hunter. SM conviction + 15m/1h momentum
+  on HYPE. Conviction-scaled leverage 7x/10x. DSL time cuts tuned for
+  HYPE volatility — winners need 2-4 hours to play out fully.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 1
+  margin_per_slot: 500
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# HYPE-specific DSL — wide for volatility, patient for trends.
+# Wolverine's two biggest winners held for 251 min (+$146) and 268 min (+$88).
+# Winners need 2-4 hours. Losers get cut fast by weak_peak_cut and dead_weight_cut.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 240
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 25
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 35
+    phase1:
+      enabled: true
+      max_loss_pct: 25.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 3
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 25 }
+        - { trigger_pct: 15, lock_hw_pct: 50 }
+        - { trigger_pct: 25, lock_hw_pct: 65 }
+        - { trigger_pct: 35, lock_hw_pct: 80 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"


### PR DESCRIPTION
Wolverine had no runtime.yaml in the repo. DSL was managed at deploy time, meaning users deploying Wolverine got no exit configuration.

Settings based on live data:
- hard_timeout: 240 min (winners held 251 min for +$146 and 268 min for +$88)
- weak_peak_cut: 25 min (kills dead trades fast)
- dead_weight_cut: 35 min
- Phase 2 tiers wide for HYPE volatility

Initial 60-min hard_timeout was too tight — nearly killed a +$67 winner at 57 min.