### PR TITLE
[fleet-fix] Contrarian exhaustion gate — Grizzly v4.1, Horribilis v2.1, Dog v2.1

### DIFF
--- a/Grizzly-Horribilis/scripts/grizzly-scanner.py
+++ b/Grizzly-Horribilis/scripts/grizzly-scanner.py
@@ -115,6 +115,16 @@ def evaluate_btc():
 
     if traders < 10: return None
 
+    # CONTRARIAN EXHAUSTION GATE (v2.1)
+    # Fleet analysis April 13: contrarian flips without exhaustion gates
+    # fade accelerating trends instead of exhausted moves. Require 4H price
+    # to have already moved >2.5% in SM direction before fading.
+    MIN_EXHAUSTION_PCT = 2.5
+    if abs(p4h) < MIN_EXHAUSTION_PCT:
+        return None  # Not exhausted yet — don't fight a fresh trend
+    if (d == "LONG" and p4h < 0) or (d == "SHORT" and p4h > 0):
+        return None  # SM direction opposes price — not an exhaustion pattern
+
     funding = 0
     try:
         ad = cfg.mcporter_call("market_get_asset_data", asset=ASSET, candle_intervals=["1h"], include_funding=True)
@@ -326,13 +336,13 @@ def run():
                 "execution": {"asset": ASSET, "direction": thesis["direction"],
                     "leverage": leverage, "margin": margin,
                     "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
-                "result": result, "_horribilis_version": "2.0",
+                "result": result, "_horribilis_version": "2.1",
             })
         else:
             cfg.output({"status": "ok", "action": "ENTRY_FAILED",
                 "signal": {"asset": ASSET, "direction": thesis["direction"],
                     "score": thesis["score"], "reasons": thesis["reasons"]},
-                "error": result, "_horribilis_version": "2.0"})
+                "error": result, "_horribilis_version": "2.1"})
         return
 
     # ── CASE 2: Position exists — evaluate for scale-up ──
@@ -420,13 +430,13 @@ def run():
                 "existingMargin": round(current_margin, 2),
                 "newMargin": scale_margin,
             },
-            "result": result, "_horribilis_version": "2.0",
+            "result": result, "_horribilis_version": "2.1",
         })
     else:
         cfg.output({"status": "ok", "action": "SCALE_UP_FAILED",
             "signal": {"asset": ASSET, "direction": thesis["direction"],
                 "score": thesis["score"], "reasons": thesis["reasons"]},
-            "error": result, "_horribilis_version": "2.0"})
+            "error": result, "_horribilis_version": "2.1"})
 
 
 if __name__ == "__main__":

--- a/dog/scripts/dog-scanner.py
+++ b/dog/scripts/dog-scanner.py
@@ -126,6 +126,17 @@ def evaluate_assets():
         # Hard gate: minimum SM engagement
         if traders < 30: continue
 
+        # CONTRARIAN EXHAUSTION GATE (v2.1)
+        # Fleet analysis April 13: Grizzly v4.0 lost $107 in 15h fading an
+        # accelerating BTC breakout. Contrarian flip without an exhaustion gate
+        # fights live trends instead of exhausted moves.
+        # Require 4H price to have already moved >2.5% in SM direction.
+        MIN_EXHAUSTION_PCT = 2.5
+        if abs(p4h) < MIN_EXHAUSTION_PCT:
+            continue  # Not exhausted yet — don't fight a fresh trend
+        if (d == "LONG" and p4h < 0) or (d == "SHORT" and p4h > 0):
+            continue  # SM direction opposes price — not an exhaustion pattern
+
         score, reasons = 0, []
 
         # ── SM concentration (0-3) ──
@@ -333,12 +344,12 @@ def run():
             "execution": {"asset": best["asset"], "direction": best["direction"],
                 "leverage": leverage, "margin": margin,
                 "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
-            "result": result, "_dog_version": "2.0"})
+            "result": result, "_dog_version": "2.1"})
     else:
         cfg.output({"status": "ok", "action": "ENTRY_FAILED",
             "signal": {"asset": best["asset"], "direction": best["direction"],
                 "score": best["score"], "reasons": best["reasons"]},
-            "error": result, "_dog_version": "2.0"})
+            "error": result, "_dog_version": "2.1"})
 
 if __name__ == "__main__":
     try: run()

--- a/grizzly/scripts/grizzly-scanner.py
+++ b/grizzly/scripts/grizzly-scanner.py
@@ -96,6 +96,21 @@ def evaluate_btc():
 
     if traders < 10: return None
 
+    # CONTRARIAN EXHAUSTION GATE (v4.1)
+    # Fleet analysis April 13: Grizzly v4.0 lost $107 in 15h shorting BTC while
+    # BTC pumped from $72,294 to $74,758 (+3.4%). The contrarian flip was fading
+    # an ACCELERATING breakout, not exhausted consensus.
+    #
+    # Before fading SM, require that the 4H price has already moved significantly
+    # in their direction. If BTC is only up 0.7% and SM is piling in, they might
+    # be early and RIGHT. Only fade when the move is actually exhausted.
+    MIN_EXHAUSTION_PCT = 2.5  # BTC 4H must have moved >2.5% in SM direction
+    if abs(p4h) < MIN_EXHAUSTION_PCT:
+        return None  # Not exhausted yet — don't fight a fresh trend
+    # Must be moving in SM direction (otherwise SM is already wrong)
+    if (d == "LONG" and p4h < 0) or (d == "SHORT" and p4h > 0):
+        return None  # SM direction opposes price — not an exhaustion pattern
+
     funding = 0
     try:
         ad = cfg.mcporter_call("market_get_asset_data", asset=ASSET, candle_intervals=["1h"], include_funding=True)
@@ -251,11 +266,11 @@ def run():
                 "leverage":leverage,"mode":"BTC_HUNTER","reasons":thesis["reasons"]},
             "execution":{"asset":ASSET,"direction":thesis["direction"],"leverage":leverage,
                 "margin":margin,"orderType":"FEE_OPTIMIZED_LIMIT","ensureExecutionAsTaker":False},
-            "result":result,"_grizzly_version":"4.0"})
+            "result":result,"_grizzly_version":"4.1"})
     else:
         cfg.output({"status":"ok","action":"ENTRY_FAILED",
             "signal":{"asset":ASSET,"direction":thesis["direction"],"score":thesis["score"],"reasons":thesis["reasons"]},
-            "error":result,"_grizzly_version":"4.0"})
+            "error":result,"_grizzly_version":"4.1"})
 
 if __name__ == "__main__":
     try: run()


### PR DESCRIPTION
## The bug

Grizzly v4.0 lost \$107 in 15 hours shorting BTC three times while BTC pumped 3.4%. All three trades had the CONTRARIAN_FLIP, positive 15m velocity, and strong SM consensus — the freshness gate was working perfectly, but it was working against the contrarian thesis. When SM is piling in on a live breakout, fading them is suicide.

## Root cause

The 15m freshness gate was designed with strikers in mind: positive 15m = fresh signal = enter. For contrarians, we inverted the interpretation: positive 15m = SM piling in = peak crowding = fade. But this only works if the move is actually exhausted. If it's a fresh breakout, SM is piling in because they're RIGHT.

## The fix

Add a 4H price exhaustion gate. Before fading SM, require the 4H price to have already moved >2.5% in the SM direction. This ensures we're fading AFTER the move has expressed, not BEFORE.

Vulture already has this gate. Grizzly, Horribilis, and Dog didn't. Now they do.