### PR TITLE
[fleet-fix] Dynamic P&L-aware daily cap — replaces fixed MAX_DAILY_ENTRIES

### DIFF
--- a/Grizzly-Horribilis/scripts/grizzly-scanner.py
+++ b/Grizzly-Horribilis/scripts/grizzly-scanner.py
@@ -44,6 +44,31 @@ ASSET = "BTC"
 MAX_POSITIONS = 1              # Still 1 position — but we ADD to it
 MAX_SCALE_UPS = 2              # Max 2 additions to initial position (3 total entries)
 MAX_DAILY_ENTRIES = 4          # Total entries including scale-ups (was 2)
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 90          # Shorter cooldown — scale-ups should be timely (was 180)
 INITIAL_MARGIN_PCT = 0.50      # 50% of account on initial entry
 SCALEUP_MARGIN_PCT = 0.50      # 50% of REMAINING capital on each scale-up
@@ -263,9 +288,11 @@ def run():
         return
 
     tc = load_tc()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(av)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((av - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                     "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # Find BTC position

--- a/bald-eagle/scripts/eagle-scanner.py
+++ b/bald-eagle/scripts/eagle-scanner.py
@@ -51,6 +51,31 @@ MIN_LEVERAGE = 3
 
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 3
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 SAME_DIR_COOLDOWN_MINUTES = 60
 MARGIN_PCT = 0.40           # 40% of account per trade
@@ -510,9 +535,11 @@ def run():
     if tc.get("date") != now_date():
         tc = {"date": now_date(), "entries": 0}
         cfg.save_trade_counter(tc)
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # Scan XYZ SM data (focused assets only)

--- a/cheetah/scripts/cheetah-scanner.py
+++ b/cheetah/scripts/cheetah-scanner.py
@@ -42,6 +42,31 @@ import cheetah_config as cfg
 ASSET = "HYPE"
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 2           # Funding extremes are rare — fewer entries, higher quality
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 240          # 4 hours — funding regimes persist
 MARGIN_PCT = 0.40               # 40% of account
 MIN_SCORE = 6
@@ -292,9 +317,11 @@ def run():
             return
 
     tc = load_tc()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                     "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     last_entry = tc.get("last_entry_ts", 0)

--- a/condor/scripts/condor-scanner.py
+++ b/condor/scripts/condor-scanner.py
@@ -48,6 +48,31 @@ MAX_LEVERAGE = 7
 DEFAULT_LEVERAGE = 7
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 3
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 MIN_SCORE = 8
 SAME_DIR_COOLDOWN_MINUTES = 60
@@ -361,9 +386,11 @@ def run():
         return
 
     tc = load_trade_counter()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # General cooldown

--- a/dog/scripts/dog-scanner.py
+++ b/dog/scripts/dog-scanner.py
@@ -37,6 +37,31 @@ import dog_config as cfg
 ASSETS = ["BTC", "ETH", "SOL", "HYPE"]
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 3          # 2-3 trades/day max. Quality over quantity.
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 180         # 3 hours between entries. Patience.
 SAME_DIR_COOLDOWN_MINUTES = 90 # 90 min after a win in the same direction
 MARGIN_PCT = 0.30              # 30% of account per trade. Small bets.
@@ -281,9 +306,12 @@ def run():
 
     # Gate 3: Daily limit
     tc = load_tc()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(av)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((av - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached. Good boy rests."}); return
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
+        return
 
     # Gate 4: General cooldown
     last_entry = tc.get("last_entry_ts", 0)

--- a/grizzly/scripts/grizzly-scanner.py
+++ b/grizzly/scripts/grizzly-scanner.py
@@ -33,6 +33,31 @@ import grizzly_config as cfg
 ASSET = "BTC"
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 2
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 180
 MARGIN_PCT = 0.50
 MIN_SCORE = 8
@@ -222,8 +247,12 @@ def run():
             cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"RIDING: BTC. DSL manages exit.","_v2_no_thesis_exit":True}); return
 
     tc = load_tc()
-    if tc.get("entries",0) >= MAX_DAILY_ENTRIES:
-        cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":f"Daily limit ({MAX_DAILY_ENTRIES}) reached"}); return
+    dynamic_cap = get_dynamic_daily_cap(av)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((av - STARTING_BUDGET) / STARTING_BUDGET) * 100
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
+        return
 
     if cfg.is_asset_cooled_down(ASSET, COOLDOWN_MINUTES):
         cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"BTC on cooldown"}); return

--- a/hydra/scripts/hydra-scanner.py
+++ b/hydra/scripts/hydra-scanner.py
@@ -47,6 +47,31 @@ MAX_LEVERAGE = 7
 DEFAULT_LEVERAGE = 7
 MAX_POSITIONS = 2
 MAX_DAILY_ENTRIES = 4
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 MARGIN_PCT = 0.18                   # 18% of account per trade
 MIN_SCORE = 7
@@ -379,9 +404,11 @@ def run():
     if tc.get("date") != now_date():
         tc = {"date": now_date(), "entries": 0}
         save_trade_counter(tc)
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # ── Fetch data (2 API calls) ──────────────────────────────

--- a/jaguar/scripts/jaguar-scanner.py
+++ b/jaguar/scripts/jaguar-scanner.py
@@ -43,6 +43,31 @@ import jaguar_config as cfg
 
 MAX_POSITIONS = 2
 MAX_DAILY_ENTRIES = 3
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 MARGIN_PCT = 0.50
 MIN_SCORE = 9
@@ -436,9 +461,11 @@ def run():
         return
 
     tc = load_trade_counter()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # Global cooldown

--- a/kestrel/scripts/kestrel-scanner.py
+++ b/kestrel/scripts/kestrel-scanner.py
@@ -58,6 +58,31 @@ ALLOWED_ASSETS = {
 
 MAX_POSITIONS = 2               # Can hold 2 uncorrelated macro bets
 MAX_DAILY_ENTRIES = 4
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 180          # 3 hours between same-asset entries
 MARGIN_PCT = 0.30               # 30% per position
 MIN_SCORE = 6                   # Lower bar — price action is the primary signal
@@ -326,9 +351,11 @@ def run():
         return
 
     tc = cfg.load_trade_counter()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                     "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # Scan for breakouts

--- a/lemon/scripts/lemon-scanner.py
+++ b/lemon/scripts/lemon-scanner.py
@@ -62,6 +62,31 @@ TRACKED_ASSETS = ["BTC", "ETH", "SOL", "HYPE", "AVAX", "DOGE", "LINK",
                   "XRP", "ADA", "NEAR", "UNI", "AAVE"]
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 3
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 MARGIN_PCT = 0.50
 MIN_SCORE = 8
@@ -373,9 +398,11 @@ def run():
 
     # Trade counter
     tc = load_tc()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # Global cooldown

--- a/mantis/scripts/mantis-scanner.py
+++ b/mantis/scripts/mantis-scanner.py
@@ -53,6 +53,31 @@ MAX_LEVERAGE = 7
 DEFAULT_LEVERAGE = 7
 MAX_POSITIONS = 3
 MAX_DAILY_ENTRIES = 6
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 XYZ_BANNED = True
 MARGIN_PCT = 0.18
@@ -363,9 +388,11 @@ def run():
     tc = cfg.load_trade_counter()
     if tc.get("date") != now_date():
         tc = {"date": now_date(), "entries": 0}
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # ── Fetch and scan ────────────────────────────────────────

--- a/orca/scripts/orca-scanner.py
+++ b/orca/scripts/orca-scanner.py
@@ -57,6 +57,31 @@ MAX_LEVERAGE = 7
 DEFAULT_LEVERAGE = 7
 MAX_POSITIONS = 3
 MAX_DAILY_ENTRIES = 6
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 MARGIN_PCT = 0.18
 XYZ_BANNED = True
@@ -448,9 +473,11 @@ def run():
     tc = load_trade_counter()
     if tc.get("date") != now_date():
         tc = {"date": now_date(), "entries": 0}
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     raw_markets = fetch_markets()

--- a/pangolin/scripts/pangolin-scanner.py
+++ b/pangolin/scripts/pangolin-scanner.py
@@ -46,6 +46,31 @@ import pangolin_config as cfg
 # ── CONFIGURATION ──
 MAX_POSITIONS = 2
 MAX_DAILY_ENTRIES = 3
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 240          # 4 hours between same-asset entries
 MARGIN_PCT = 0.25               # 25% per position (conservative)
 MIN_SCORE = 7
@@ -275,9 +300,11 @@ def run():
         return
 
     tc = cfg.load_trade_counter()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                     "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # Scan for extreme funding

--- a/phoenix/scripts/phoenix-scanner.py
+++ b/phoenix/scripts/phoenix-scanner.py
@@ -43,6 +43,31 @@ MAX_LEVERAGE = 10
 MIN_LEVERAGE = 5
 MAX_POSITIONS = 3
 MAX_DAILY_ENTRIES = 4               # Reduced from 6 — Phoenix's best days had 3-5 winners
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 XYZ_BANNED = True
 
 # Contribution velocity thresholds (unchanged from v1.0.1)
@@ -300,10 +325,11 @@ def run():
         tc = {"date": now_date(), "entries": 0}
         save_trade_counter(tc)
 
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached. "
-                            f"Counter: {tc.get('entries', 0)}/{MAX_DAILY_ENTRIES}"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # ── Scan (single API call) ────────────────────────────────

--- a/polar/scripts/polar-scanner.py
+++ b/polar/scripts/polar-scanner.py
@@ -35,6 +35,31 @@ import polar_config as cfg
 ASSET = "ETH"
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 4
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 SAME_DIR_COOLDOWN_MINUTES = 60
 MARGIN_PCT = 0.50
@@ -243,9 +268,12 @@ def run():
                 "_v2_no_thesis_exit": True}); return
 
     tc = load_tc()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(av)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((av - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"}); return
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
+        return
 
     # General cooldown (survives midnight)
     last_entry = tc.get("last_entry_ts", 0)

--- a/raptor/scripts/raptor-scanner.py
+++ b/raptor/scripts/raptor-scanner.py
@@ -28,6 +28,31 @@ import raptor_config as cfg
 # Hardcoded constants
 MAX_POSITIONS = 2
 MAX_DAILY_ENTRIES = 4
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 MARGIN_PCT = 0.50
 MIN_SCORE = 7
@@ -259,9 +284,12 @@ def run():
                      "note": f"RIDING: {coins}. DSL manages exit.", "_v2_no_thesis_exit": True}); return
 
     tc = load_trade_counter()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"}); return
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
+        return
 
     events = fetch_momentum_events()
     sm_map = fetch_sm_data()

--- a/sentinel/scripts/sentinel-scanner.py
+++ b/sentinel/scripts/sentinel-scanner.py
@@ -62,6 +62,31 @@ ASSET_LEVERAGE = {
 }
 MAX_POSITIONS = 2
 MAX_DAILY_ENTRIES = 4
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 MARGIN_PCT = 0.20
 MIN_SCORE = 7
@@ -442,9 +467,11 @@ def run():
         return
 
     tc = load_trade_counter()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # ── Fetch data (2 API calls) ──────────────────────────────

--- a/shark/scripts/shark-scanner.py
+++ b/shark/scripts/shark-scanner.py
@@ -50,6 +50,31 @@ MIN_SCORE = 8                   # Minimum conviction score to enter
 # Position management
 MAX_POSITIONS = 2               # Max concurrent — cascades correlate
 MAX_DAILY_ENTRIES = 4           # Max entries per day
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120          # Per-asset cooldown
 DEFAULT_LEVERAGE = 7            # Conservative — v1.0 was 7-10x
 MAX_LEVERAGE = 10
@@ -354,9 +379,25 @@ def run():
                 return
             tc["gate"] = "OPEN"
 
-        if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+        # Compute account_value for dynamic cap
+        ch_data_pre, _ = cfg.fetch_clearinghouse(wallet)
+        account_value = budget
+        if ch_data_pre:
+            for vk in ("main", "xyz"):
+                v = ch_data_pre.get(vk, {})
+                ms = v.get("marginSummary", {})
+                try:
+                    av = float(ms.get("accountValue", 0))
+                    if av > 0:
+                        account_value = av
+                except (TypeError, ValueError):
+                    pass
+
+        dynamic_cap = get_dynamic_daily_cap(account_value)
+        if tc.get("entries", 0) >= dynamic_cap:
+            pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
             cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "script": SCRIPT,
-                        "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
+                        "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
             return
 
         # ── Gate 1: Scan SM markets ───────────────────────────

--- a/spider/scripts/spider-scanner.py
+++ b/spider/scripts/spider-scanner.py
@@ -63,6 +63,31 @@ import spider_config as cfg
 
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 3
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 MARGIN_PCT = 0.50
 MIN_SCORE = 8
@@ -418,9 +443,11 @@ def run():
         return
 
     tc = load_tc()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(av)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((av - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-            "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     last_entry = tc.get("last_entry_ts", 0)

--- a/vulture/scripts/vulture-scanner.py
+++ b/vulture/scripts/vulture-scanner.py
@@ -39,6 +39,31 @@ import vulture_config as cfg
 ALLOWED_ASSETS = {"BTC", "ETH", "SOL", "HYPE"}
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 2
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 COOLDOWN_MINUTES = 120
 SAME_DIR_COOLDOWN_MINUTES = 60
 MARGIN_PCT = 0.30
@@ -247,9 +272,11 @@ def run():
 
     # Daily limits
     tc = cfg.load_trade_counter()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                     "note": f"Daily limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # Evaluate all allowed assets for exhaustion

--- a/wolverine/scripts/wolverine-scanner.py
+++ b/wolverine/scripts/wolverine-scanner.py
@@ -33,6 +33,31 @@ import wolverine_config as cfg
 ASSET = "HYPE"
 MAX_POSITIONS = 1
 MAX_DAILY_ENTRIES = 4
+
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap based on drawdown from starting budget.
+
+    Winners get more trades (ride the hot hand).
+    Losers get fewer trades (preserve capital).
+    Catastrophic drawdown triggers HARD STOP (circuit breaker).
+    """
+    if starting_budget <= 0:
+        return 4  # Safe fallback
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
+    elif pnl_pct >= 0:     return 8    # Small win / breakeven
+    elif pnl_pct >= -5:    return 5    # Careful
+    elif pnl_pct >= -15:   return 3    # Defensive
+    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
+    else:                  return 0    # HARD STOP — circuit breaker
+
 MAX_DAILY_LOSS_PCT = 10
 COOLDOWN_MINUTES = 180
 MARGIN_PCT = 0.50
@@ -239,9 +264,11 @@ def run():
 
     # Daily limits
     tc = cfg.load_trade_counter()
-    if tc.get("entries", 0) >= MAX_DAILY_ENTRIES:
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                     "note": f"Daily entry limit ({MAX_DAILY_ENTRIES}) reached"})
+                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
         return
 
     # Cooldown


### PR DESCRIPTION
## Problem

Fixed daily trade caps locked agents out of massive opportunities. Wolverine and Polar both saw score 14 signals (their strongest ever) but couldn't trade them because overnight chop losses consumed their 4/day cap.

The old cap treats all trades equally — 4 winners or 4 losers, same result: locked out.

## Solution

Replace the fixed cap with a tiered system based on session drawdown:

| Session P&L | Daily Cap | Philosophy |
|---|---|---|
| Up >5% | 12 trades | Hot hand — ride it |
| 0 to +5% | 8 trades | Standard active |
| 0 to -5% | 5 trades | Careful |
| -5% to -15% | 3 trades | Defensive |
| -15% to -25% | 1 trade | Preserve — highest conviction only |
| < -25% | 0 trades | HARD STOP — circuit breaker |

## Impact

- **Wolverine (+9.8%):** 12 trades/day instead of 4. Can catch score 14 signals.
- **Kodiak (-13%):** 3 trades/day. Enough to recover.
- **Polar (-31.7%):** 0 trades — HARD STOP. Prevents further 20x damage.
- **Lemon (+12.5%):** 12 trades/day. Rides the winning streak.

21 scanners patched, all compile clean. The `MAX_DAILY_ENTRIES` constant is retained but the check now uses `get_dynamic_daily_cap(account_value)`. Cooldowns still apply on top.