### PR TITLE
Fleet fix: stale-date bug + auto-cancel stale resting orders

### DIFF
--- a/Grizzly-Horribilis/scripts/grizzly-scanner.py
+++ b/Grizzly-Horribilis/scripts/grizzly-scanner.py
@@ -100,18 +100,48 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 
 def evaluate_btc():

--- a/bald-eagle/scripts/eagle_config.py
+++ b/bald-eagle/scripts/eagle_config.py
@@ -85,14 +85,20 @@ def is_market_hours():
 # --- Trade Counter ---
 
 def load_trade_counter():
+    # v1.0.1: fleet-wide stale date fix. Without the date check, an agent that
+    # doesn't trade for a day (e.g. capped out on old day) stays locked forever
+    # because load returns stale data and the rollover only ran on save.
+    today = now_date()
     p = STATE_DIR / "trade-counter.json"
     if p.exists():
         try:
             with open(p) as f:
-                return json.load(f)
+                tc = json.load(f)
+            if tc.get("date") == today:
+                return tc
         except (json.JSONDecodeError, IOError):
             pass
-    return {"date": now_date(), "entries": 0}
+    return {"date": today, "entries": 0}
 
 
 def save_trade_counter(tc):

--- a/cheetah/scripts/cheetah-scanner.py
+++ b/cheetah/scripts/cheetah-scanner.py
@@ -105,17 +105,48 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 
 def evaluate_hype_funding():

--- a/condor/scripts/condor-scanner.py
+++ b/condor/scripts/condor-scanner.py
@@ -110,22 +110,48 @@ def now_iso():
 
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
-    if not data: return False
+    if not data:
+        return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
-
-
-# ═══════════════════════════════════════════════════════════════
-# DATA FETCHING
-# ═══════════════════════════════════════════════════════════════
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 def fetch_all_sm_data():
     """Get SM data for all tracked assets from one API call."""

--- a/dog/scripts/dog-scanner.py
+++ b/dog/scripts/dog-scanner.py
@@ -93,22 +93,48 @@ def now_iso(): return datetime.now(timezone.utc).isoformat()
 
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
-    if not data: return False
+    if not data:
+        return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
-
-
-# ═══════════════════════════════════════════════════════════════
-# SCORING — Tight, focused, consistency-oriented
-# ═══════════════════════════════════════════════════════════════
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 def evaluate_assets():
     """Score all four assets and return the best candidate above MIN_SCORE."""

--- a/grizzly/scripts/grizzly-scanner.py
+++ b/grizzly/scripts/grizzly-scanner.py
@@ -83,17 +83,48 @@ def get_leverage_for_score(score):
     return DEFAULT_LEVERAGE
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
-    if not data: return False
+    if not data:
+        return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 
 def evaluate_btc():

--- a/hydra/scripts/hydra-scanner.py
+++ b/hydra/scripts/hydra-scanner.py
@@ -346,14 +346,20 @@ def score_squeeze(cand):
 # ═══════════════════════════════════════════════════════════════
 
 def load_trade_counter():
+    # Fleet-wide stale date fix. Without the date check, an agent that
+    # doesn't trade for a day stays locked forever because load returns
+    # stale data and the rollover only ran on save.
+    today = now_date()
     p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
     if os.path.exists(p):
         try:
             with open(p) as f:
-                return json.load(f)
+                tc = json.load(f)
+            if tc.get("date") == today:
+                return tc
         except (json.JSONDecodeError, IOError):
             pass
-    return {"date": now_date(), "entries": 0}
+    return {"date": today, "entries": 0}
 
 
 def save_trade_counter(tc):

--- a/jaguar/scripts/jaguar-scanner.py
+++ b/jaguar/scripts/jaguar-scanner.py
@@ -118,18 +118,48 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 
 def check_4h_alignment(direction, price_chg_4h):

--- a/kestrel/scripts/kestrel-scanner.py
+++ b/kestrel/scripts/kestrel-scanner.py
@@ -115,17 +115,48 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 
 def scan_xyz_breakouts():

--- a/kodiak/scripts/kodiak-scanner.py
+++ b/kodiak/scripts/kodiak-scanner.py
@@ -547,21 +547,48 @@ SAME_DIR_COOLDOWN_MINUTES = 60
 
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
-
-
-# ─── Main ─────────────────────────────────────────────────────
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 def run():
     config = cfg.load_config()

--- a/lemon/scripts/lemon-scanner.py
+++ b/lemon/scripts/lemon-scanner.py
@@ -135,23 +135,48 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
-
-
-# ═══════════════════════════════════════════════════════════════
-# FADE SIGNAL DETECTION
-# ═══════════════════════════════════════════════════════════════
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 def fetch_sm_data():
     """Get SM data for tracked assets."""

--- a/orca/scripts/orca-scanner.py
+++ b/orca/scripts/orca-scanner.py
@@ -539,14 +539,20 @@ def run():
 
 
 def load_trade_counter():
+    # Fleet-wide stale date fix. Without the date check, an agent that
+    # doesn't trade for a day stays locked forever because load returns
+    # stale data and the rollover only ran on save.
+    today = now_date()
     p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
     if os.path.exists(p):
         try:
             with open(p) as f:
-                return json.load(f)
+                tc = json.load(f)
+            if tc.get("date") == today:
+                return tc
         except (json.JSONDecodeError, IOError):
             pass
-    return {"date": now_date(), "entries": 0}
+    return {"date": today, "entries": 0}
 
 
 def save_trade_counter(tc):

--- a/pangolin/scripts/pangolin-scanner.py
+++ b/pangolin/scripts/pangolin-scanner.py
@@ -107,17 +107,48 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 
 def scan_funding_extremes():

--- a/polar/scripts/polar-scanner.py
+++ b/polar/scripts/polar-scanner.py
@@ -93,17 +93,48 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
-    if not data: return False
+    if not data:
+        return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 
 def evaluate_eth():

--- a/sentinel/scripts/sentinel-scanner.py
+++ b/sentinel/scripts/sentinel-scanner.py
@@ -127,22 +127,48 @@ def now_iso():
 
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
-    if not data: return False
+    if not data:
+        return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
-
-
-# ═══════════════════════════════════════════════════════════════
-# DATA FETCHING
-# ═══════════════════════════════════════════════════════════════
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 def fetch_quality_traders():
     """Get top ELITE + RELIABLE traders with open positions."""

--- a/spider/scripts/spider-scanner.py
+++ b/spider/scripts/spider-scanner.py
@@ -129,22 +129,48 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
-    if not data: return False
+    if not data:
+        return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
-
-
-# ═══════════════════════════════════════════════════════════════
-# PHASE 1: BUILD CONVERGENCE MAP (every 5 min)
-# ═══════════════════════════════════════════════════════════════
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 def fetch_elite_traders():
     """Get weekly top ELITE/RELIABLE + SNIPER/AGGRESSIVE traders with open positions."""

--- a/vulture/scripts/vulture-scanner.py
+++ b/vulture/scripts/vulture-scanner.py
@@ -92,18 +92,48 @@ def get_leverage_for_score(score):
 
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders. Ignores DSL stop-losses."""
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
+
+    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
+    fills can lock the scanner out of new entries indefinitely, because
+    every subsequent scan sees the stale order and aborts early. Ignores
+    reduceOnly orders (those are DSL exit legs)."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
     orders = data.get("data", data)
     if isinstance(orders, dict):
         orders = orders.get("orders", orders.get("openOrders", []))
-    if isinstance(orders, list):
-        for o in orders:
-            if not o.get("reduceOnly", False):
-                return True
-    return False
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue  # Treat cancelled order as gone
+        has_fresh = True
+    return has_fresh
 
 
 def evaluate_markets():


### PR DESCRIPTION
## Summary

Two mechanical fleet-wide fixes that unblock agents silently getting stuck.

### Fix 1: Stale-date bug in load_trade_counter (3 files)

Without a date check on load, an agent that doesn't trade for a day stays locked forever — load returns stale data and the rollover only runs on save. Symptom: Wolverine was stuck on April 7, Lemon on April 6 (manual resets unblocked them).

Fixed in:
- bald-eagle/scripts/eagle_config.py
- hydra/scripts/hydra-scanner.py
- orca/scripts/orca-scanner.py

All now follow the Phoenix/Lemon pattern — if stored date != today, return fresh {today, 0} dict.

### Fix 2: has_resting_orders auto-cancel (14 files)

When a FEE_OPTIMIZED_LIMIT maker order doesn't fill, it sits on the book. Every subsequent scan sees it, aborts early, and locks the agent out of new entries until DSL or a human cancels.

All 14 impls now auto-cancel non-reduceOnly resting orders older than 600s (10 min) via `cfg.mcporter_call("cancel_order", ...)` before returning. Orders younger than 10 min still block. Reduce-only orders (DSL exit legs) are still ignored.

Files patched: Grizzly-Horribilis, cheetah, condor, dog, grizzly, jaguar, kestrel, kodiak, lemon, pangolin, polar, sentinel, spider, vulture.

## Test plan
- [x] All 17 touched files pass `ast.parse`
- [ ] Agents pull from GitHub and verify `has_resting_orders` no longer locks on stale maker orders
- [ ] Agents verify `load_trade_counter` rolls over across midnight without a trade firing
- [ ] Monitor Wolverine/Lemon/Grizzly-Horribilis/Polar for false-positive cancels

🤖 Generated with [Claude Code](https://claude.com/claude-code)