### PR TITLE
raptor: v3.0 complete rewrite — fixes zero-trade drought

### DIFF
--- a/raptor/SKILL.md
+++ b/raptor/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: raptor-strategy
+description: >-
+  RAPTOR v3.0 — Hot Streak Follower. Finds ELITE/RELIABLE traders currently
+  on a 4-hour hot streak via leaderboard_get_top + discovery_get_top_traders,
+  identifies their strongest position by delta PnL, confirms SM alignment,
+  and follows them in. Self-executing, runtime.yaml standard deployment,
+  fleet-standard guardrails. 2 positions max. Conviction-scaled leverage 7-10x.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "3.0"
+  platform: senpi
+  exchange: hyperliquid
+---
+
+# RAPTOR v3.0 — Hot Streak Follower
+
+Find traders who are already winning big right now, confirm they're quality (ELITE or RELIABLE on TCS), figure out what bet is driving their streak, check the smart money crowd agrees, and piggyback the same trade.
+
+## v3.0 — why the complete rewrite
+
+**RAPTOR v2.1 traded zero times since deployment.** Root cause:
+
+v2.1 used `leaderboard_get_momentum_events` as the primary signal source and dereferenced three fields on each event — `concentration`, `top_positions`, and `trader_tags`. **All three are `null` on blocked events.** And blocked events are ~100% of tier 2 events in normal market conditions (820/820 tier 2 events over a 44-hour window in one recent sample were all blocked — either `trader_cooldown_active` or `system_cooldown_active`).
+
+Per the senpi guide for `leaderboard_get_momentum_events`:
+> Blocked events are equally valid momentum signals. The blocking only affects notification delivery, not signal quality. Events with `top_positions: null` (blocked events without position data) will not match any asset filter.
+
+v2.1's filter chain silently dropped every blocked event before ever reaching the SM alignment check. Raptor was mathematically incapable of producing a signal regardless of market conditions.
+
+## v3.0 architecture
+
+v3.0 replaces `leaderboard_get_momentum_events` with a multi-step pipeline that uses populated data sources:
+
+```
+1. leaderboard_get_top(limit=30)
+     → top 30 traders by 4h delta PnL (populated data, not blocked)
+
+2. Local filter: delta_pnl ≥ $2M (tier 1 threshold)
+     → narrows to currently active hot streaks
+
+3. discovery_get_top_traders(addresses=[...], consistency=["ELITE","RELIABLE"])
+     → single batch call filters to quality traders and attaches labels
+
+4. Per quality trader: leaderboard_get_trader_positions(address)
+     → per-market delta PnL breakdown with real data
+
+5. Pick the strongest position by |delta_pnl|, compute concentration locally
+
+6. leaderboard_get_markets → SM alignment check on each candidate
+
+7. Score and execute the best candidate via create_position (self-executing)
+```
+
+API cost per scan: 1 (top) + 1 (classify) + up to 10 (positions) + 1 (SM) = ~13 calls/scan. Higher than v2.1's 2 calls/scan, but v2.1 was zero trades/month and v3.0 actually produces signals.
+
+## Scoring model
+
+| Component | Max | Gate |
+|---|---|---|
+| TCS consistency | 3 | ELITE/RELIABLE required |
+| Delta PnL tier | 3 | ≥$2M required |
+| Concentration | 2 | ≥0.40 required |
+| SM alignment strength | 2 | ≥2% SM, ≥10 traders, direction match required |
+| 4h + 1h price confirmation | 2 | — |
+| 15m velocity freshness | +1/-1 | — |
+
+**Hard gates before scoring:** ELITE/RELIABLE consistency, ≥$500k position delta PnL, ≥40% concentration, SM alignment with matching direction.
+
+**Default minScore to trade:** 6. Tunable via `config/raptor-config.json`.
+
+## Leverage tiers
+
+Conviction-scaled:
+- Score 6-7: **7x**
+- Score 8-9: **8x**
+- Score 10+: **10x**
+
+## Fleet-standard guardrails
+
+- **Self-executing** — scanner calls `create_position` directly via mcporter, matching the Wolverine/Phoenix pattern. No external action layer required.
+- **Dynamic daily cap** (fleet PR #176) — P&L-aware entry cap: 12 trades/day if +5% PnL, down to 0 trades (HARD STOP) at -25% drawdown.
+- **Auto-cancel stale resting orders** (fleet PR #177) — `has_resting_orders()` cancels any non-reduceOnly maker order older than 10 minutes so a stuck FEE_OPTIMIZED_LIMIT order never locks the scanner out.
+- **Per-trader event dedupe** — won't re-enter the same (trader, asset) pair within 4 hours.
+- **Per-asset cooldown** — 2-hour cooldown after a trade on any given coin.
+
+## Runtime
+
+- `runtime.yaml` added (was missing in v2.1)
+- Standard Predators deployment: `position_tracker` scanner + rule-based action + DSL engine
+- DSL tuned for follow-the-streak trades: hard_timeout 360 min, wide phase 2 tiers to let winners compound
+
+## Configuration
+
+All thresholds live in `config/raptor-config.json`:
+
+- `hotStreak.minDeltaPnl` — minimum 4h delta PnL to consider a trader (default $2M)
+- `hotStreak.tier2Threshold` / `tier3Threshold` — scoring tier thresholds ($5.5M / $10M)
+- `hotStreak.topTraderLimit` — how many from leaderboard_get_top to pull (default 30)
+- `hotStreak.minConcentration` — minimum position concentration (default 0.40)
+- `smAlignment.minSmPct` / `minSmTraders` — SM consensus strength gates
+- `dedupe.eventDedupeHours` — trader-asset dedupe window (default 4h)
+- `dedupe.perAssetCooldownMinutes` — asset cooldown after any trade (default 120 min)
+- `entry.minScore` — score floor to fire an entry (default 6)
+
+## Deployment
+
+Agents on v2.1 should pull the v3.0 package and restart. The v3.0 repo package includes:
+
+- `raptor/runtime.yaml` (NEW)
+- `raptor/SKILL.md` (NEW)
+- `raptor/config/raptor-config.json` (NEW)
+- `raptor/scripts/raptor_config.py` (NEW — was missing in v2.1 even though scanner imported it)
+- `raptor/scripts/raptor-scanner.py` (REWRITTEN)
+
+Pull command:
+```bash
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/raptor/scripts/raptor-scanner.py -o /data/workspace/skills/raptor-strategy/scripts/raptor-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/raptor/scripts/raptor_config.py -o /data/workspace/skills/raptor-strategy/scripts/raptor_config.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/raptor/config/raptor-config.json -o /data/workspace/skills/raptor-strategy/config/raptor-config.json
+```
+
+Then verify with a single manual run:
+```bash
+python3 /data/workspace/skills/raptor-strategy/scripts/raptor-scanner.py
+```
+
+Expected: clean exit, `_raptor_version: "3.0"` in output JSON. If `leaderboard_get_top` returns data and there's at least one ELITE/RELIABLE hot trader, the scanner may emit a candidate signal or fire a trade on the first run.

--- a/raptor/config/raptor-config.json
+++ b/raptor/config/raptor-config.json
@@ -1,0 +1,48 @@
+{
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "_version": "3.0",
+  "_description": "RAPTOR v3.0 — Hot Streak Follower. Uses leaderboard_get_top + discovery_get_top_traders to find ELITE/RELIABLE traders on active 4h hot streaks, then enters their strongest position with SM alignment confirmation.",
+  "maxPositions": 2,
+  "leverage": {
+    "default": 7,
+    "tiers": [
+      {"minScore": 10, "leverage": 10},
+      {"minScore": 8,  "leverage": 8},
+      {"minScore": 6,  "leverage": 7}
+    ]
+  },
+  "hotStreak": {
+    "minDeltaPnl": 2000000,
+    "tier2Threshold": 5500000,
+    "tier3Threshold": 10000000,
+    "topTraderLimit": 30,
+    "qualityConsistency": ["ELITE", "RELIABLE"],
+    "qualityTimeFrame": "WEEKLY",
+    "minConcentration": 0.40,
+    "minPositionPnl": 500000
+  },
+  "smAlignment": {
+    "minSmPct": 2.0,
+    "minSmTraders": 10,
+    "requireDirectionMatch": true,
+    "xyzBanned": true
+  },
+  "dedupe": {
+    "eventDedupeHours": 4,
+    "perAssetCooldownMinutes": 120
+  },
+  "entry": {
+    "minScore": 6,
+    "marginPctBase": 0.25,
+    "marginPctHighConv": 0.35,
+    "orderType": "FEE_OPTIMIZED_LIMIT",
+    "ensureExecutionAsTaker": true,
+    "executionTimeoutSeconds": 30
+  },
+  "risk": {
+    "startingBudget": 1000,
+    "maxDailyLossPct": 10
+  }
+}

--- a/raptor/runtime.yaml
+++ b/raptor/runtime.yaml
@@ -1,0 +1,59 @@
+name: raptor-strategy
+version: 3.0.0
+description: >
+  RAPTOR v3.0 — Hot Streak Follower. Finds ELITE/RELIABLE traders currently
+  on a 4-hour hot streak via leaderboard_get_top + discovery_get_top_traders,
+  identifies their strongest position by delta PnL, confirms SM alignment,
+  and follows them in. Self-executing. 2 positions max, dynamic daily cap.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 2
+  margin_per_slot: 250
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# Raptor-tuned DSL: follow-the-streak trades need time to play out because
+# they're backed by a quality trader's active run. Wide phase 1, patient
+# phase 2 tiers to let winners compound.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 360
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 60
+      min_value: 2.5
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 40
+    phase1:
+      enabled: true
+      max_loss_pct: 25.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 3
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 25 }
+        - { trigger_pct: 15, lock_hw_pct: 50 }
+        - { trigger_pct: 25, lock_hw_pct: 65 }
+        - { trigger_pct: 40, lock_hw_pct: 80 }
+        - { trigger_pct: 60, lock_hw_pct: 88 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/raptor/scripts/raptor-scanner.py
+++ b/raptor/scripts/raptor-scanner.py
@@ -1,358 +1,776 @@
 #!/usr/bin/env python3
-# Senpi RAPTOR Scanner v2.1
+# Senpi RAPTOR Scanner v3.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""RAPTOR v2.1 — Hot Streak Follower (Hardened).
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""RAPTOR v3.0 — Hot Streak Follower (complete rewrite).
 
-v2.1 changes from fleet audit:
-- Scanner calls create_position internally via mcporter (Wolverine pattern)
-- feeOptimizedLimitOptions with ensureExecutionAsTaker: false
-- Conviction-scaled leverage: score 7-8 → 7x, score 9+ → 10x
-- Margin increased to 50%
-- No thesis exit (unchanged from v2.0)
+v3.0 COMPLETE REWRITE — fixes the zero-trade bug.
 
-Architecture unchanged: event-driven, quality-filtered, SM-confirmed.
-2 API calls: leaderboard_get_momentum_events + leaderboard_get_markets.
+## Why v2.1 never traded
+
+v2.1 used leaderboard_get_momentum_events as the primary signal source and
+filtered on event.concentration, event.top_positions, and event.trader_tags.
+All three of those fields are NULL on blocked momentum events — and 100%
+of tier-2 events in recent windows (820/820 over 44h) are blocked with
+trader_cooldown_active or system_cooldown_active.
+
+Per the senpi guide:
+> Blocked events are equally valid momentum signals. The blocking only
+> affects notification delivery, not signal quality. Events with
+> top_positions: null will not match any asset filter.
+
+Because Raptor's filters dereferenced these null fields, every single
+event was silently dropped before the SM alignment check. Raptor was
+mathematically incapable of producing a signal in any window.
+
+## v3.0 architecture
+
+Instead of momentum_events (mostly blocked with null data), v3.0 uses
+leaderboard_get_top as the primary filter — it returns currently active
+hot traders with populated delta PnL data.
+
+Pipeline:
+  1. leaderboard_get_top(limit=30) → top 30 by 4h delta PnL
+  2. Local filter: delta_pnl >= minDeltaPnl (default $2M = tier 1 threshold)
+  3. discovery_get_top_traders(addresses=[...], consistency=[ELITE,RELIABLE])
+     → filter to quality traders and get their classification labels
+  4. For each quality hot trader: leaderboard_get_trader_positions(address)
+     → per-market delta PnL breakdown (actually populated, unlike blocked
+       momentum events)
+  5. Pick each trader's strongest position by |delta_pnl|, compute
+     concentration locally from the positions list
+  6. leaderboard_get_markets → SM alignment check on each candidate
+  7. Score and execute best candidate via create_position (self-executing)
+
+## Fleet-standard guardrails
+
+- STARTING_BUDGET + get_dynamic_daily_cap (P&L-aware circuit breaker)
+- has_resting_orders() with auto-cancel for stale maker orders >10 min old
+- Per-asset cooldown (2h default)
+- Per-trader event dedupe (4h window)
+- Self-executing via create_position (Wolverine pattern)
+
 Runs every 3 minutes.
 """
 
 import json
-import sys
 import os
+import sys
 import time
 from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import raptor_config as cfg
 
-# Hardcoded constants
 MAX_POSITIONS = 2
-MAX_DAILY_ENTRIES = 4
-
-
-# ═══════════════════════════════════════════════════════════════
-# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
-# ═══════════════════════════════════════════════════════════════
-
-STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
-
-def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
-    """P&L-aware daily entry cap based on drawdown from starting budget.
-
-    Winners get more trades (ride the hot hand).
-    Losers get fewer trades (preserve capital).
-    Catastrophic drawdown triggers HARD STOP (circuit breaker).
-    """
-    if starting_budget <= 0:
-        return 4  # Safe fallback
-    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
-    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
-    elif pnl_pct >= 0:     return 8    # Small win / breakeven
-    elif pnl_pct >= -5:    return 5    # Careful
-    elif pnl_pct >= -15:   return 3    # Defensive
-    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
-    else:                  return 0    # HARD STOP — circuit breaker
-
-COOLDOWN_MINUTES = 120
-MARGIN_PCT = 0.50
-MIN_SCORE = 7
+STARTING_BUDGET = 1000.0
+STALE_ORDER_MAX_AGE_SEC = 600  # 10 min
 XYZ_BANNED = True
 
-LEVERAGE_TIERS = [
-    {"min_score": 9, "leverage": 10},
-    {"min_score": 7, "leverage": 7},
-]
-DEFAULT_LEVERAGE = 7
 
-# Momentum event filters
-MOMENTUM_TIER = 2
-QUALITY_TCS = {"ELITE", "RELIABLE"}
-MIN_CONCENTRATION = 0.5
-MIN_SM_PCT = 3.0
-MIN_SM_TRADERS = 15
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker, fleet standard)
+# ═══════════════════════════════════════════════════════════════
 
-SEEN_EVENTS_FILE = "seen-events.json"
-EVENT_DEDUP_HOURS = 4
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap. Matches fleet PR #176."""
+    if starting_budget <= 0:
+        return 4
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:     return 12  # Hot hand — up >5%
+    elif pnl_pct >= 0:   return 8   # Small win / breakeven
+    elif pnl_pct >= -5:  return 5   # Careful
+    elif pnl_pct >= -15: return 3   # Defensive
+    elif pnl_pct >= -25: return 1   # Preserve
+    else:                return 0   # HARD STOP
 
+
+# ═══════════════════════════════════════════════════════════════
+# HELPERS
+# ═══════════════════════════════════════════════════════════════
 
 def safe_float(val, default=0.0):
-    try: return float(val)
-    except (TypeError, ValueError): return default
-
-def now_date(): return datetime.now(timezone.utc).strftime("%Y-%m-%d")
-def now_iso(): return datetime.now(timezone.utc).isoformat()
-def now_ts(): return time.time()
-
-def get_leverage_for_score(score):
-    for tier in LEVERAGE_TIERS:
-        if score >= tier["min_score"]:
-            return tier["leverage"]
-    return DEFAULT_LEVERAGE
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
 
 
-def fetch_momentum_events():
-    data = cfg.mcporter_call("leaderboard_get_momentum_events", tier=MOMENTUM_TIER, limit=50)
-    if not data: return []
-    events = data.get("events", data.get("data", []))
-    if isinstance(events, dict): events = events.get("events", [])
-    if not isinstance(events, list): return []
-    return events
+def get_leverage_for_score(score, tiers, default_leverage):
+    for tier in sorted(tiers, key=lambda t: t.get("minScore", 0), reverse=True):
+        if score >= tier.get("minScore", 0):
+            return tier.get("leverage", default_leverage)
+    return default_leverage
 
 
-def fetch_sm_data():
+# ═══════════════════════════════════════════════════════════════
+# FLEET-STANDARD: auto-cancel stale resting orders
+# ═══════════════════════════════════════════════════════════════
+
+def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders, auto-cancelling any older
+    than STALE_ORDER_MAX_AGE_SEC. Matches fleet PR #177 pattern."""
+    data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
+    if not data:
+        return False
+    orders = data.get("data", data)
+    if isinstance(orders, dict):
+        orders = orders.get("orders", orders.get("openOrders", []))
+    if not isinstance(orders, list):
+        return False
+    now_ms = time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
+            continue
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
+            continue
+        has_fresh = True
+    return has_fresh
+
+
+# ═══════════════════════════════════════════════════════════════
+# DATA FETCHING (v3.0: leaderboard_get_top, not momentum_events)
+# ═══════════════════════════════════════════════════════════════
+
+def _extract_list(raw, *keys):
+    """Unwrap nested {data: {...: [...]}} API responses to get the inner list."""
+    if raw is None:
+        return []
+    cur = raw
+    if isinstance(cur, dict) and "data" in cur:
+        cur = cur["data"]
+    for k in keys:
+        if isinstance(cur, dict) and k in cur:
+            cur = cur[k]
+    if isinstance(cur, list):
+        return cur
+    return []
+
+
+def fetch_top_traders(limit=30):
+    """Primary signal source: top traders by 4h delta PnL (rolling window).
+    This replaces momentum_events because the latter returns null fields on
+    blocked events (which is 100% of recent events)."""
+    raw = cfg.mcporter_call("leaderboard_get_top", limit=limit)
+    if not raw:
+        return []
+    traders = _extract_list(raw, "traders", "top", "leaderboard")
+    if not traders and isinstance(raw, dict):
+        data = raw.get("data", raw)
+        if isinstance(data, list):
+            traders = data
+    return traders if isinstance(traders, list) else []
+
+
+def fetch_quality_classifications(addresses):
+    """Fetch ELITE/RELIABLE classifications for a batch of addresses in one
+    call via discovery_get_top_traders. Returns a dict: address -> labels."""
+    if not addresses:
+        return {}
+    raw = cfg.mcporter_call(
+        "discovery_get_top_traders",
+        time_frame="WEEKLY",
+        sort_by="PROFIT_AND_LOSS",
+        consistency=["ELITE", "RELIABLE"],
+        addresses=list(addresses),
+        limit=len(addresses),
+    )
+    if not raw:
+        return {}
+    traders = _extract_list(raw, "traders")
+    if not traders and isinstance(raw, dict):
+        data = raw.get("data", raw)
+        if isinstance(data, list):
+            traders = data
+    classifications = {}
+    for t in traders:
+        if not isinstance(t, dict):
+            continue
+        addr = str(t.get("address", t.get("trader_address", ""))).lower()
+        if not addr:
+            continue
+        classifications[addr] = {
+            "consistency": str(t.get("consistency", t.get("consistency_label", ""))).upper(),
+            "activity": str(t.get("activity", t.get("activity_label", ""))).upper(),
+            "risk": str(t.get("risk", t.get("risk_label", ""))).upper(),
+            "roi": safe_float(t.get("roi", t.get("return_on_investment", 0))),
+            "pnl": safe_float(t.get("pnl", t.get("profit_and_loss", 0))),
+            "win_rate": safe_float(t.get("win_rate", 0)),
+        }
+    return classifications
+
+
+def fetch_trader_positions(trader_address):
+    """Get per-market delta PnL breakdown for a single trader. Populated data
+    (unlike blocked momentum event top_positions)."""
+    raw = cfg.mcporter_call("leaderboard_get_trader_positions", trader_id=trader_address)
+    if not raw:
+        return []
+    positions = _extract_list(raw, "positions", "top_positions")
+    if not positions and isinstance(raw, dict):
+        data = raw.get("data", raw)
+        if isinstance(data, dict):
+            positions = data.get("positions", data.get("top_positions", []))
+    return positions if isinstance(positions, list) else []
+
+
+def fetch_sm_map():
+    """Fetch SM leaderboard for alignment checks. Same call most scanners use."""
     raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
-    if not raw: return {}
+    if not raw:
+        return {}
     markets = []
     if isinstance(raw, dict):
-        raw_data = raw.get("data", raw)
-        if isinstance(raw_data, dict):
-            markets = raw_data.get("markets", [])
-            if isinstance(markets, dict): markets = markets.get("markets", [])
-        elif isinstance(raw_data, list): markets = raw_data
-    elif isinstance(raw, list): markets = raw
-
+        data = raw.get("data", raw)
+        if isinstance(data, dict):
+            markets = data.get("markets", [])
+            if isinstance(markets, dict):
+                markets = markets.get("markets", [])
+        elif isinstance(data, list):
+            markets = data
+    elif isinstance(raw, list):
+        markets = raw
     sm_map = {}
     for m in markets:
-        if not isinstance(m, dict): continue
+        if not isinstance(m, dict):
+            continue
         token = str(m.get("token", "")).upper()
         dex = str(m.get("dex", "")).lower()
-        if XYZ_BANNED and dex == "xyz": continue
-        if not token: continue
+        if XYZ_BANNED and dex == "xyz":
+            continue
+        if not token:
+            continue
         sm_map[token] = {
             "direction": str(m.get("direction", "")).upper(),
             "pct": safe_float(m.get("pct_of_top_traders_gain", 0)),
             "traders": int(m.get("trader_count", 0)),
             "price_chg_4h": safe_float(m.get("token_price_change_pct_4h", 0)),
-            "price_chg_1h": safe_float(m.get("token_price_change_pct_1h", m.get("price_change_1h", 0))),
+            "price_chg_1h": safe_float(m.get("token_price_change_pct_1h",
+                                            m.get("price_change_1h", 0))),
             "contrib_15m": safe_float(m.get("contribution_pct_change_15m", 0)),
             "contrib_1h": safe_float(m.get("contribution_pct_change_1h", 0)),
         }
     return sm_map
 
 
+# ═══════════════════════════════════════════════════════════════
+# DEDUPE + COOLDOWN
+# ═══════════════════════════════════════════════════════════════
+
+SEEN_EVENTS_FILE = "seen-events.json"
+
+
 def load_seen_events():
     p = os.path.join(cfg.STATE_DIR, SEEN_EVENTS_FILE)
     if os.path.exists(p):
         try:
-            with open(p) as f: return json.load(f)
-        except: pass
+            with open(p) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
     return {}
 
-def save_seen_events(seen):
-    cutoff = now_ts() - (EVENT_DEDUP_HOURS * 3600)
+
+def save_seen_events(seen, dedupe_hours=4):
+    cutoff = time.time() - (dedupe_hours * 3600)
     cleaned = {k: v for k, v in seen.items() if v > cutoff}
     cfg.atomic_write(os.path.join(cfg.STATE_DIR, SEEN_EVENTS_FILE), cleaned)
 
-def is_event_seen(seen, trader_id, asset): return f"{trader_id}:{asset}" in seen
-def mark_event_seen(seen, trader_id, asset): seen[f"{trader_id}:{asset}"] = now_ts()
+
+def is_event_seen(seen, trader_id, asset, dedupe_hours=4):
+    key = f"{trader_id[:10].lower()}:{asset}"
+    ts = seen.get(key, 0)
+    if ts <= 0:
+        return False
+    return (time.time() - ts) < (dedupe_hours * 3600)
 
 
-def extract_signals(events, sm_map, seen_events):
-    signals = []
-    for event in events:
-        if not isinstance(event, dict): continue
-        trader_id = event.get("trader_id", event.get("address", ""))
-        if not trader_id: continue
-
-        tags = event.get("trader_tags", event.get("tags", {}))
-        if isinstance(tags, str):
-            try: tags = json.loads(tags)
-            except: tags = {}
-        tcs = str(tags.get("TCS", tags.get("tcs", ""))).upper()
-        if tcs not in QUALITY_TCS: continue
-
-        concentration = safe_float(event.get("concentration", 0))
-        if concentration < MIN_CONCENTRATION: continue
-
-        top_positions = event.get("top_positions", [])
-        if isinstance(top_positions, str):
-            try: top_positions = json.loads(top_positions)
-            except: top_positions = []
-        if not top_positions: continue
-
-        best_pos, best_pnl = None, 0
-        for pos in top_positions:
-            if not isinstance(pos, dict): continue
-            asset = str(pos.get("market", pos.get("asset", ""))).upper()
-            direction = str(pos.get("direction", "")).upper()
-            delta_pnl = abs(safe_float(pos.get("delta_pnl", pos.get("deltaPnl", pos.get("pnl", 0)))))
-            if not asset or direction not in ("LONG", "SHORT"): continue
-            if XYZ_BANNED and asset.lower().startswith("xyz"): continue
-            if delta_pnl > best_pnl:
-                best_pnl = delta_pnl
-                best_pos = {"asset": asset, "direction": direction, "delta_pnl": delta_pnl}
-
-        if not best_pos: continue
-        asset, direction = best_pos["asset"], best_pos["direction"]
-        if is_event_seen(seen_events, trader_id, asset): continue
-
-        sm = sm_map.get(asset)
-        if not sm or sm["direction"] != direction: continue
-        if sm["pct"] < MIN_SM_PCT or sm["traders"] < MIN_SM_TRADERS: continue
-
-        score, reasons = 0, []
-        if tcs == "ELITE": score += 2; reasons.append(f"ELITE_STREAK (conc={concentration:.2f})")
-        else: score += 1; reasons.append(f"RELIABLE_STREAK (conc={concentration:.2f})")
-        if concentration >= 0.7: score += 1; reasons.append(f"HIGH_CONVICTION {concentration:.0%}")
-        if sm["pct"] >= 10: score += 2; reasons.append(f"SM_STRONG {sm['pct']:.1f}% ({sm['traders']}t)")
-        elif sm["pct"] >= 5: score += 1; reasons.append(f"SM_ALIGNED {sm['pct']:.1f}% ({sm['traders']}t)")
-
-        p4h, p1h = sm["price_chg_4h"], sm["price_chg_1h"]
-        if (direction == "LONG" and p4h > 0.5) or (direction == "SHORT" and p4h < -0.5):
-            score += 1; reasons.append(f"4H_CONFIRMS {p4h:+.1f}%")
-        if (direction == "LONG" and p1h > 0.2) or (direction == "SHORT" and p1h < -0.2):
-            score += 1; reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
-
-        # Contribution velocity (NEW: 15m + 1h)
-        c15m, c1h = sm.get("contrib_15m", 0), sm.get("contrib_1h", 0)
-        if c15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{c15m:.2f}")
-        elif c15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{c15m:.2f}")
-        if c15m > 0 and c1h > 0 and c15m > c1h:
-            score += 1; reasons.append(f"ACCEL_PATTERN 15m>1h")
-
-        tier = event.get("tier", MOMENTUM_TIER)
-        if tier >= 3: score += 1; reasons.append("TIER_3_EXTREME")
-
-        signals.append({
-            "asset": asset, "direction": direction, "score": score, "mode": "HOT_STREAK",
-            "reasons": reasons, "traderId": trader_id[:10] + "...", "tcs": tcs,
-            "concentration": concentration, "deltaPnl": best_pos["delta_pnl"],
-            "smPct": sm["pct"], "smTraders": sm["traders"], "priceChg4h": p4h, "tier": tier,
-        })
-
-    signals.sort(key=lambda s: s["score"], reverse=True)
-    return signals
+def mark_event_seen(seen, trader_id, asset):
+    key = f"{trader_id[:10].lower()}:{asset}"
+    seen[key] = time.time()
 
 
-def execute_entry(signal, margin, leverage):
-    result = cfg.mcporter_call(
-        "create_position",
-        coin=signal["asset"],
-        direction=signal["direction"],
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 30,
-        },
-    )
-    if result and result.get("success"):
-        return True, result
-    else:
-        error = result.get("error", "unknown") if result else "mcporter_call returned None"
-        return False, {"error": error}
-
-
-def load_trade_counter():
-    p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
-    if os.path.exists(p):
-        try:
-            with open(p) as f: tc = json.load(f)
-            if tc.get("date") == now_date(): return tc
-        except: pass
-    return {"date": now_date(), "entries": 0}
-
-def save_trade_counter(tc):
-    if tc.get("date") != now_date(): tc = {"date": now_date(), "entries": 0}
-    cfg.atomic_write(os.path.join(cfg.STATE_DIR, "trade-counter.json"), tc)
-
-
-def is_on_cooldown(asset):
+def is_on_cooldown(asset, cooldown_minutes=120):
     p = os.path.join(cfg.STATE_DIR, "cooldowns.json")
-    if not os.path.exists(p): return False
+    if not os.path.exists(p):
+        return False
     try:
-        with open(p) as f: cooldowns = json.load(f)
-    except: return False
+        with open(p) as f:
+            cooldowns = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return False
     entry = cooldowns.get(asset)
-    if not entry: return False
+    if not entry:
+        return False
     return time.time() < entry.get("until", 0)
 
 
+def set_cooldown(asset, cooldown_minutes=120):
+    p = os.path.join(cfg.STATE_DIR, "cooldowns.json")
+    cooldowns = {}
+    if os.path.exists(p):
+        try:
+            with open(p) as f:
+                cooldowns = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    cooldowns[asset] = {
+        "until": time.time() + cooldown_minutes * 60,
+        "set_at": cfg.now_iso(),
+    }
+    cfg.atomic_write(p, cooldowns)
+
+
+# ═══════════════════════════════════════════════════════════════
+# TRADE COUNTER
+# ═══════════════════════════════════════════════════════════════
+
+def load_trade_counter():
+    today = cfg.now_date()
+    p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
+    if os.path.exists(p):
+        try:
+            with open(p) as f:
+                tc = json.load(f)
+            if tc.get("date") == today:
+                return tc
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {"date": today, "entries": 0}
+
+
+def save_trade_counter(tc):
+    tc["date"] = cfg.now_date()
+    cfg.atomic_write(os.path.join(cfg.STATE_DIR, "trade-counter.json"), tc)
+
+
+# ═══════════════════════════════════════════════════════════════
+# SIGNAL GENERATION
+# ═══════════════════════════════════════════════════════════════
+
+def build_signal(trader, classification, positions, sm_map, hot_cfg, sm_cfg):
+    """Given a quality hot trader + their positions + SM map, build a signal
+    dict (or return None if the trader doesn't produce a qualifying signal)."""
+    trader_id = str(trader.get("trader_id", trader.get("address", ""))).lower()
+    if not trader_id:
+        return None
+
+    # Pick strongest position by |delta_pnl|
+    best_pos = None
+    best_abs_pnl = 0.0
+    total_abs_pnl = 0.0
+    for pos in positions:
+        if not isinstance(pos, dict):
+            continue
+        asset = str(
+            pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", ""))))
+        ).upper()
+        if not asset:
+            continue
+        if XYZ_BANNED and asset.lower().startswith("xyz:"):
+            continue
+        delta_pnl = safe_float(
+            pos.get("delta_pnl", pos.get("deltaPnl", pos.get("unrealized_pnl", pos.get("pnl", 0))))
+        )
+        direction = str(
+            pos.get("direction", "LONG" if delta_pnl >= 0 else "SHORT")
+        ).upper()
+        if direction not in ("LONG", "SHORT"):
+            continue
+        abs_pnl = abs(delta_pnl)
+        total_abs_pnl += abs_pnl
+        if abs_pnl > best_abs_pnl:
+            best_abs_pnl = abs_pnl
+            best_pos = {
+                "asset": asset,
+                "direction": direction,
+                "delta_pnl": delta_pnl,
+            }
+
+    if not best_pos or best_abs_pnl < hot_cfg.get("minPositionPnl", 500_000):
+        return None
+
+    # Concentration = top position PnL as fraction of total
+    concentration = (best_abs_pnl / total_abs_pnl) if total_abs_pnl > 0 else 0
+    if concentration < hot_cfg.get("minConcentration", 0.40):
+        return None
+
+    # SM alignment check
+    sm = sm_map.get(best_pos["asset"])
+    if not sm:
+        return None
+    if sm_cfg.get("requireDirectionMatch", True) and sm["direction"] != best_pos["direction"]:
+        return None
+    if sm["pct"] < sm_cfg.get("minSmPct", 2.0):
+        return None
+    if sm["traders"] < sm_cfg.get("minSmTraders", 10):
+        return None
+
+    # Scoring
+    score = 0
+    reasons = []
+
+    tcs = classification.get("consistency", "")
+    if tcs == "ELITE":
+        score += 3
+        reasons.append("ELITE")
+    elif tcs == "RELIABLE":
+        score += 2
+        reasons.append("RELIABLE")
+    else:
+        return None  # only ELITE/RELIABLE allowed
+
+    # Delta PnL magnitude tiers
+    trader_delta = safe_float(
+        trader.get("delta_pnl", trader.get("unrealized_pnl", trader.get("pnl", 0)))
+    )
+    if trader_delta >= hot_cfg.get("tier3Threshold", 10_000_000):
+        score += 3
+        reasons.append(f"TIER3_${trader_delta/1e6:.1f}M")
+    elif trader_delta >= hot_cfg.get("tier2Threshold", 5_500_000):
+        score += 2
+        reasons.append(f"TIER2_${trader_delta/1e6:.1f}M")
+    else:
+        score += 1
+        reasons.append(f"TIER1_${trader_delta/1e6:.1f}M")
+
+    # Concentration conviction
+    if concentration >= 0.70:
+        score += 2
+        reasons.append(f"HIGH_CONV_{concentration:.0%}")
+    elif concentration >= 0.55:
+        score += 1
+        reasons.append(f"CONC_{concentration:.0%}")
+
+    # SM strength
+    if sm["pct"] >= 8:
+        score += 2
+        reasons.append(f"SM_STRONG_{sm['pct']:.1f}%")
+    elif sm["pct"] >= 4:
+        score += 1
+        reasons.append(f"SM_ALIGNED_{sm['pct']:.1f}%")
+
+    # Multi-timeframe price confirmation
+    p4h = sm["price_chg_4h"]
+    p1h = sm["price_chg_1h"]
+    if best_pos["direction"] == "LONG":
+        if p4h > 0.5 and p1h > 0.2:
+            score += 2
+            reasons.append(f"4H+1H_CONFIRMS_+{p4h:.1f}/+{p1h:.1f}%")
+        elif p4h > 0.5:
+            score += 1
+            reasons.append(f"4H_CONFIRMS_+{p4h:.1f}%")
+        elif p4h < -2:
+            score -= 1
+            reasons.append(f"4H_OPPOSING_{p4h:.1f}%")
+    else:
+        if p4h < -0.5 and p1h < -0.2:
+            score += 2
+            reasons.append(f"4H+1H_CONFIRMS_{p4h:.1f}/{p1h:.1f}%")
+        elif p4h < -0.5:
+            score += 1
+            reasons.append(f"4H_CONFIRMS_{p4h:.1f}%")
+        elif p4h > 2:
+            score -= 1
+            reasons.append(f"4H_OPPOSING_+{p4h:.1f}%")
+
+    # 15m velocity freshness — fleet-standard penalty
+    c15m = sm.get("contrib_15m", 0)
+    if c15m > 0.5:
+        score += 1
+        reasons.append(f"15M_SPIKE_+{c15m:.2f}")
+    elif c15m <= 0:
+        score -= 1
+        reasons.append(f"15M_STALE_{c15m:.2f}")
+
+    return {
+        "asset": best_pos["asset"],
+        "direction": best_pos["direction"],
+        "score": score,
+        "reasons": reasons,
+        "traderId": trader_id[:10] + "...",
+        "fullTraderId": trader_id,
+        "tcs": tcs,
+        "traderDeltaPnl": trader_delta,
+        "positionDeltaPnl": best_pos["delta_pnl"],
+        "concentration": concentration,
+        "smPct": sm["pct"],
+        "smTraders": sm["traders"],
+        "priceChg4h": p4h,
+        "priceChg1h": p1h,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# EXECUTION
+# ═══════════════════════════════════════════════════════════════
+
+def execute_entry(wallet, signal, account_value, entry_cfg, leverage_cfg):
+    """Self-execute the entry via Senpi MCP create_position.
+    Matches Wolverine/Phoenix pattern."""
+    base_margin_pct = entry_cfg.get("marginPctBase", 0.25)
+    high_conv_pct = entry_cfg.get("marginPctHighConv", 0.35)
+    margin_pct = high_conv_pct if signal["score"] >= 10 else base_margin_pct
+    margin = round(account_value * margin_pct, 2)
+
+    leverage = get_leverage_for_score(
+        signal["score"],
+        leverage_cfg.get("tiers", []),
+        leverage_cfg.get("default", 7),
+    )
+
+    order = {
+        "coin": signal["asset"],
+        "direction": signal["direction"],
+        "leverage": leverage,
+        "marginAmount": margin,
+        "orderType": entry_cfg.get("orderType", "FEE_OPTIMIZED_LIMIT"),
+        "feeOptimizedLimitOptions": {
+            "ensureExecutionAsTaker": entry_cfg.get("ensureExecutionAsTaker", True),
+            "executionTimeoutSeconds": entry_cfg.get("executionTimeoutSeconds", 30),
+        },
+    }
+
+    reason = (
+        f"RAPTOR v3.0 hot streak: {signal['tcs']} trader "
+        f"delta=${signal['traderDeltaPnl']/1e6:.1f}M, "
+        f"conc={signal['concentration']:.0%}, score={signal['score']}"
+    )
+    result = cfg.mcporter_call(
+        "create_position",
+        strategyWalletAddress=wallet,
+        orders=[order],
+        reason=reason,
+    )
+    success = bool(result and result.get("success"))
+    return success, result, margin, leverage
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════
+
 def run():
-    wallet, strategy_id = cfg.get_wallet_and_strategy()
+    config = cfg.load_config()
+    wallet, _ = cfg.get_wallet_and_strategy()
+
     if not wallet:
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "no wallet"}); return
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "no wallet"})
+        return
 
     account_value, positions = cfg.get_positions(wallet)
     if account_value <= 0:
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "cannot read account"}); return
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "cannot read account"})
+        return
 
     if len(positions) >= MAX_POSITIONS:
         coins = [p["coin"] for p in positions]
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                     "note": f"RIDING: {coins}. DSL manages exit.", "_v2_no_thesis_exit": True}); return
+        cfg.output({
+            "status": "ok", "heartbeat": "NO_REPLY",
+            "note": f"RIDING: {coins}. DSL manages exit.",
+            "_raptor_version": "3.0",
+        })
+        return
 
+    # Daily cap (P&L-aware)
     tc = load_trade_counter()
     dynamic_cap = get_dynamic_daily_cap(account_value)
     if tc.get("entries", 0) >= dynamic_cap:
         pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
+        cfg.output({
+            "status": "ok", "heartbeat": "NO_REPLY",
+            "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%.",
+        })
         return
 
-    events = fetch_momentum_events()
-    sm_map = fetch_sm_data()
-    if not events:
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "No Tier 2 momentum events"}); return
+    # Don't stack new entries while a maker order is still resting
+    if has_resting_orders(wallet):
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "resting order pending"})
+        return
+
+    hot_cfg = config.get("hotStreak", {})
+    sm_cfg = config.get("smAlignment", {})
+    dedupe_cfg = config.get("dedupe", {})
+    entry_cfg = config.get("entry", {})
+    leverage_cfg = config.get("leverage", {})
+
+    # ── PHASE 1: Fetch top hot traders by 4h delta PnL ──
+    top_traders = fetch_top_traders(limit=hot_cfg.get("topTraderLimit", 30))
+    if not top_traders:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                    "note": "leaderboard_get_top returned empty"})
+        return
+
+    # Filter to traders above the minimum delta PnL threshold
+    min_delta = hot_cfg.get("minDeltaPnl", 2_000_000)
+    hot_traders = []
+    for t in top_traders:
+        if not isinstance(t, dict):
+            continue
+        delta = safe_float(
+            t.get("delta_pnl", t.get("unrealized_pnl", t.get("pnl", 0)))
+        )
+        if delta >= min_delta:
+            hot_traders.append(t)
+
+    if not hot_traders:
+        cfg.output({
+            "status": "ok", "heartbeat": "NO_REPLY",
+            "note": f"No traders above ${min_delta/1e6:.1f}M delta PnL ({len(top_traders)} scanned)",
+        })
+        return
+
+    # ── PHASE 2: Classify via discovery_get_top_traders (batch, 1 call) ──
+    addresses = [
+        str(t.get("trader_id", t.get("address", ""))).lower()
+        for t in hot_traders
+    ]
+    addresses = [a for a in addresses if a]
+    classifications = fetch_quality_classifications(addresses)
+
+    quality_traders = []
+    for t in hot_traders:
+        addr = str(t.get("trader_id", t.get("address", ""))).lower()
+        cls = classifications.get(addr)
+        if not cls:
+            continue  # not in ELITE/RELIABLE set
+        if cls["consistency"] not in ("ELITE", "RELIABLE"):
+            continue
+        t["_classification"] = cls
+        t["_address"] = addr
+        quality_traders.append(t)
+
+    if not quality_traders:
+        cfg.output({
+            "status": "ok", "heartbeat": "NO_REPLY",
+            "note": f"{len(hot_traders)} hot traders, 0 ELITE/RELIABLE",
+        })
+        return
+
+    # Sort by delta PnL desc so we prioritize the hottest streaks first
+    quality_traders.sort(
+        key=lambda t: safe_float(
+            t.get("delta_pnl", t.get("unrealized_pnl", t.get("pnl", 0)))
+        ),
+        reverse=True,
+    )
+
+    # ── PHASE 3: SM map (1 call) ──
+    sm_map = fetch_sm_map()
     if not sm_map:
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "No SM data"}); return
-
-    seen_events = load_seen_events()
-    signals = extract_signals(events, sm_map, seen_events)
-
-    if not signals:
-        quality_count = sum(1 for e in events
-                           if str((e.get("trader_tags", {}) or {}).get("TCS", "")).upper() in QUALITY_TCS)
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"No hot streak signals. {len(events)} Tier 2 events, {quality_count} quality."}); return
-
-    held_coins = {p["coin"].upper() for p in positions}
-
-    for signal in signals:
-        asset = signal["asset"]
-        if signal["score"] < MIN_SCORE: continue
-        if is_on_cooldown(asset): continue
-        if asset in held_coins: continue
-
-        leverage = get_leverage_for_score(signal["score"])
-        margin = round(account_value * MARGIN_PCT, 2)
-
-        mark_event_seen(seen_events, signal["traderId"], asset)
-        save_seen_events(seen_events)
-
-        success, result = execute_entry(signal, margin, leverage)
-
-        if success:
-            tc["entries"] = tc.get("entries", 0) + 1
-            save_trade_counter(tc)
-            cfg.output({
-                "status": "ok", "action": "ENTRY",
-                "signal": signal,
-                "execution": {"asset": asset, "direction": signal["direction"],
-                              "leverage": leverage, "margin": margin,
-                              "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
-                "result": result,
-                "_raptor_version": "2.1",
-            })
-        else:
-            cfg.output({
-                "status": "ok", "action": "ENTRY_FAILED",
-                "signal": signal, "error": result, "_raptor_version": "2.1",
-            })
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "No SM data"})
         return
 
-    if signals:
-        best = signals[0]
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Best streak: {best['asset']} {best['direction']} score {best['score']}. {', '.join(best['reasons'][:3])}"})
+    # ── PHASE 4: Per-trader position fetch + signal build ──
+    seen_events = load_seen_events()
+    held_coins = {p["coin"].upper() for p in positions}
+    dedupe_hours = dedupe_cfg.get("eventDedupeHours", 4)
+    cooldown_minutes = dedupe_cfg.get("perAssetCooldownMinutes", 120)
+
+    candidates = []
+    scan_limit = min(len(quality_traders), 10)  # cap positions fetch to top 10
+    for t in quality_traders[:scan_limit]:
+        addr = t["_address"]
+        positions_data = fetch_trader_positions(addr)
+        if not positions_data:
+            continue
+
+        signal = build_signal(
+            t, t["_classification"], positions_data, sm_map, hot_cfg, sm_cfg
+        )
+        if not signal:
+            continue
+
+        if is_event_seen(seen_events, addr, signal["asset"], dedupe_hours):
+            continue
+        if is_on_cooldown(signal["asset"], cooldown_minutes):
+            continue
+        if signal["asset"] in held_coins:
+            continue
+
+        candidates.append(signal)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok", "heartbeat": "NO_REPLY",
+            "note": f"{len(quality_traders)} quality traders, 0 candidates passed filters",
+        })
+        return
+
+    candidates.sort(key=lambda s: s["score"], reverse=True)
+    best = candidates[0]
+
+    if best["score"] < entry_cfg.get("minScore", 6):
+        cfg.output({
+            "status": "ok", "heartbeat": "NO_REPLY",
+            "note": f"Best score {best['score']} < {entry_cfg.get('minScore', 6)}. {', '.join(best['reasons'][:3])}",
+            "allCandidates": [
+                {"asset": c["asset"], "dir": c["direction"], "score": c["score"]}
+                for c in candidates[:5]
+            ],
+        })
+        return
+
+    # ── PHASE 5: Execute ──
+    mark_event_seen(seen_events, best["fullTraderId"], best["asset"])
+    save_seen_events(seen_events, dedupe_hours)
+    set_cooldown(best["asset"], cooldown_minutes)
+
+    success, result, margin, leverage = execute_entry(
+        wallet, best, account_value, entry_cfg, leverage_cfg
+    )
+
+    if success:
+        tc["entries"] = tc.get("entries", 0) + 1
+        save_trade_counter(tc)
+        cfg.output({
+            "status": "ok",
+            "action": "ENTRY",
+            "signal": best,
+            "execution": {
+                "asset": best["asset"],
+                "direction": best["direction"],
+                "leverage": leverage,
+                "margin": margin,
+                "orderType": entry_cfg.get("orderType", "FEE_OPTIMIZED_LIMIT"),
+            },
+            "result": result,
+            "_raptor_version": "3.0",
+        })
     else:
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "Momentum events found but no SM alignment"})
+        error = result.get("error", "unknown") if result else "mcporter_call returned None"
+        cfg.output({
+            "status": "ok",
+            "action": "ENTRY_FAILED",
+            "signal": best,
+            "error": error,
+            "_raptor_version": "3.0",
+        })
 
 
 if __name__ == "__main__":
-    try: run()
+    try:
+        run()
     except Exception as e:
         cfg.log(f"CRITICAL ERROR: {e}")
-        import traceback; traceback.print_exc(file=sys.stderr)
+        import traceback
+        traceback.print_exc(file=sys.stderr)
         cfg.output({"status": "error", "error": str(e)})

--- a/raptor/scripts/raptor_config.py
+++ b/raptor/scripts/raptor_config.py
@@ -1,0 +1,177 @@
+"""RAPTOR Strategy — Shared config, MCP helpers, state I/O.
+
+v3.0: added to repo (was previously missing — agents had local copies only).
+Matches fleet-standard pattern from phoenix_config.py / wolverine_config.py.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "raptor-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "raptor-config.json"
+STATE_DIR = SKILL_DIR / "state"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ─── Atomic Write ────────────────────────────────────────────
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    return {}
+
+
+def get_wallet_and_strategy():
+    wallet = os.environ.get("RAPTOR_WALLET", "")
+    strategy_id = os.environ.get("RAPTOR_STRATEGY_ID", "")
+    if not wallet or not strategy_id:
+        config = load_config()
+        wallet = wallet or config.get("wallet", "")
+        strategy_id = strategy_id or config.get("strategyId", "")
+    return wallet, strategy_id
+
+
+# ─── State I/O ───────────────────────────────────────────────
+
+def load_state(filename="state.json"):
+    path = STATE_DIR / filename
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def save_state(data, filename="state.json"):
+    atomic_write(str(STATE_DIR / filename), data)
+
+
+# ─── MCP Helpers ─────────────────────────────────────────────
+
+def mcporter_call(tool, retries=2, timeout=30, **params):
+    """Call a Senpi MCP tool via mcporter. Array syntax, no shell=True."""
+    args = json.dumps(params) if params else "{}"
+    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
+    for attempt in range(retries):
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            if r.returncode != 0:
+                if attempt < retries - 1:
+                    time.sleep(2)
+                    continue
+                return None
+            raw = json.loads(r.stdout)
+            if isinstance(raw, dict) and "content" in raw:
+                content = raw["content"]
+                if isinstance(content, list) and content:
+                    first = content[0]
+                    if isinstance(first, dict) and "text" in first:
+                        try:
+                            return json.loads(first["text"])
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+            return raw
+        except subprocess.TimeoutExpired:
+            if attempt < retries - 1:
+                time.sleep(2)
+                continue
+            return None
+        except (json.JSONDecodeError, Exception):
+            return None
+    return None
+
+
+def get_positions(wallet=None):
+    """Returns (account_value, positions_list)."""
+    if not wallet:
+        wallet, _ = get_wallet_and_strategy()
+    if not wallet:
+        return 0, []
+    ch = mcporter_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+    if not ch or not isinstance(ch, dict):
+        return 0, []
+    data = ch.get("data", ch)
+    positions = []
+    account_value = 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "szi": szi,
+                "size": abs(szi),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "markPrice": float(pos.get("markPx", 0)),
+                "leverage": float(
+                    pos.get("leverage", {}).get("value", 5)
+                    if isinstance(pos.get("leverage"), dict)
+                    else pos.get("leverage", 5)
+                ),
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+            })
+    return account_value, positions
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[RAPTOR] {msg}", file=sys.stderr)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def now_date():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")


### PR DESCRIPTION
## Summary

Raptor v2.1 had **traded zero times since deployment**. v3.0 is a complete rewrite that fixes the root cause: the primary data source (leaderboard_get_momentum_events) returns null fields on ~100% of events in normal conditions.

## Root cause

v2.1 used \`leaderboard_get_momentum_events\` as the primary signal source and dereferenced three fields on each event — \`concentration\`, \`top_positions\`, and \`trader_tags\`. **All three are \`null\` on blocked events.** And blocked events are ~100% of tier-2 events in normal market conditions (820/820 tier-2 events over a 44-hour window in one recent sample were all blocked — either \`trader_cooldown_active\` or \`system_cooldown_active\`).

Per the senpi guide: *"Blocked events are equally valid momentum signals. The blocking only affects notification delivery, not signal quality. Events with top_positions: null will not match any asset filter."*

v2.1's filter chain silently dropped every blocked event before ever reaching the SM alignment check.

## v3.0 architecture

Replaces \`leaderboard_get_momentum_events\` with a multi-step pipeline using populated data sources:

1. \`leaderboard_get_top(limit=30)\` → top 30 traders by 4h delta PnL
2. Local filter: delta_pnl ≥ \$2M (tier 1 threshold)
3. \`discovery_get_top_traders(addresses=[...], consistency=[ELITE,RELIABLE])\` → batch classification
4. \`leaderboard_get_trader_positions(address)\` per quality trader → per-market delta PnL
5. Pick strongest position, compute concentration locally, check SM alignment
6. Score and execute via \`create_position\` (self-executing)

## Added missing files

The v2.1 repo package was incomplete — only had \`raptor-scanner.py\`, missing runtime.yaml, SKILL.md, raptor_config.py (even though imported), and raptor-config.json. v3.0 adds the full standard Predators package:

- \`raptor/runtime.yaml\` (NEW)
- \`raptor/SKILL.md\` (NEW)
- \`raptor/config/raptor-config.json\` (NEW)
- \`raptor/scripts/raptor_config.py\` (NEW)
- \`raptor/scripts/raptor-scanner.py\` (REWRITTEN)

## Fleet-standard guardrails

All present: dynamic P&L-aware daily cap (PR #176), auto-cancel stale resting orders (PR #177), self-execution (Wolverine pattern), per-trader dedupe, per-asset cooldown, conviction-scaled leverage (7x/8x/10x).

## Test plan

- [x] \`ast.parse\` valid on both Python files
- [x] \`runtime.yaml\` no tabs, valid structure
- [x] \`raptor-config.json\` valid JSON
- [ ] Pull new package on live Raptor agent and run manual scan
- [ ] Verify \`_raptor_version: "3.0"\` in output JSON
- [ ] First trade within 1-3 scan cycles assuming leaderboard_get_top has any ELITE/RELIABLE hot trader

🤖 Generated with [Claude Code](https://claude.com/claude-code)