### PR TITLE
repo-fix: complete installable packages across 23 predator folders

### DIFF
--- a/Grizzly-Horribilis/README.md
+++ b/Grizzly-Horribilis/README.md
@@ -1,0 +1,100 @@
+# 🐻 Grizzly Horribilis v1.1 — BTC Contrarian Sniper
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+GRIZZLY HORRIBILIS v1.1 — BTC Conviction-Scaled Leverage Hunter (Hardened). Same thesis as Grizzly v3.0 — BTC single-asset lifecycle hunter. Conviction-scaled leverage: 7x at score 8-9, 10x at score 10+.
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/grizzly-horribilis-strategy/{config,scripts,state}
+
+# Pull all package files from the senpi-skills main branch
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/Grizzly-Horribilis/runtime.yaml -o /data/workspace/skills/grizzly-horribilis-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/Grizzly-Horribilis/SKILL.md -o /data/workspace/skills/grizzly-horribilis-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/Grizzly-Horribilis/config/grizzly-config.json -o /data/workspace/skills/grizzly-horribilis-strategy/config/grizzly-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/Grizzly-Horribilis/scripts/grizzly-scanner.py -o /data/workspace/skills/grizzly-horribilis-strategy/scripts/grizzly-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/Grizzly-Horribilis/scripts/grizzly_config.py -o /data/workspace/skills/grizzly-horribilis-strategy/scripts/grizzly_config.py
+```
+
+## Configure
+
+Set your wallet address and Telegram chat ID in `runtime.yaml`:
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/grizzly-horribilis-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/grizzly-horribilis-strategy/runtime.yaml
+```
+
+Or set them in `config/grizzly-config.json` directly:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+## Install the runtime in OpenClaw
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/grizzly-horribilis-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+Run the scanner once manually:
+
+```bash
+python3 /data/workspace/skills/grizzly-horribilis-strategy/scripts/grizzly-scanner.py
+```
+
+Expected: clean exit, JSON output. Most likely first run shows a heartbeat (no signal) — the scanner is intentionally selective.
+
+## Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost, matches Turbine pattern):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/grizzly-horribilis-strategy/scripts/grizzly-scanner.py >> /tmp/grizzly-horribilis-loop.log 2>&1; sleep 180; done' > /tmp/grizzly-horribilis-nohup.log 2>&1 &
+
+# Confirm running
+ps aux | grep grizzly-scanner | grep -v grep
+tail -5 /tmp/grizzly-horribilis-loop.log
+```
+
+3-minute cadence. The Python scanner does all work; no LLM is invoked unless an entry fires.
+
+Alternative: configure an OpenClaw cron with `sessionTarget: isolated`. **Avoid `sessionTarget: main`** — that pattern is a known cost time-bomb that drifts expensive as the main session accumulates context.
+
+## What's in this package
+
+```
+Grizzly-Horribilis/
+├── README.md                       # This file (user-facing)
+├── SKILL.md                        # LLM-facing thesis + agent rules
+├── runtime.yaml                    # OpenClaw runtime config + DSL preset
+├── config/
+│   └── grizzly-config.json      # Wallet, strategy ID, chat ID
+└── scripts/
+    ├── grizzly-scanner.py       # Main scanner
+    └── grizzly_config.py     # Helper module (atomic write, MCP, state I/O)
+```
+
+For full thesis details, scoring tables, DSL configuration, and operational notes, see [SKILL.md](./SKILL.md).
+
+## Troubleshooting
+
+**Scanner exits with `no wallet`:** Set the wallet in `runtime.yaml`, in `config/grizzly-config.json`, or via the appropriate environment variable.
+
+**Scanner imports fail:** Make sure both the scanner and `grizzly_config.py` helper module are in the `scripts/` directory. The scanner imports the helper via `import grizzly_config as cfg`.
+
+**Scanner hasn't fired in hours:** This agent is intentionally selective. Check the scanner output for `note: "no <type> signal"` to confirm it's running and just not finding setups. Forcing the scanner to fire on weak signals is a known way to lose money — see fleet audit notes in SKILL.md.
+
+**Trade history lost after session clear:** Newer agents in the fleet write to `state/entry-log.jsonl` which survives session clears. If this agent doesn't yet have that pattern, the trade history lives only in scanner stdout logs (`/tmp/grizzly-horribilis-loop.log`).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/bald-eagle/README.md
+++ b/bald-eagle/README.md
@@ -1,0 +1,100 @@
+# 🦅 Bald Eagle v3.0 — XYZ Macro Alpha Hunter
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+BALD EAGLE v3.0 — XYZ Alpha Hunter (Hardened). Focused on 6 high-liquidity XYZ assets: CL, BRENTOIL, GOLD, SILVER, SP500, XYZ100. Conviction-scaled leverage (5-10x based on score).
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/bald-eagle-strategy/{config,scripts,state}
+
+# Pull all package files from the senpi-skills main branch
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bald-eagle/runtime.yaml -o /data/workspace/skills/bald-eagle-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bald-eagle/SKILL.md -o /data/workspace/skills/bald-eagle-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bald-eagle/config/bald-eagle-config.json -o /data/workspace/skills/bald-eagle-strategy/config/bald-eagle-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bald-eagle/scripts/eagle-scanner.py -o /data/workspace/skills/bald-eagle-strategy/scripts/eagle-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bald-eagle/scripts/eagle_config.py -o /data/workspace/skills/bald-eagle-strategy/scripts/eagle_config.py
+```
+
+## Configure
+
+Set your wallet address and Telegram chat ID in `runtime.yaml`:
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/bald-eagle-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/bald-eagle-strategy/runtime.yaml
+```
+
+Or set them in `config/bald-eagle-config.json` directly:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+## Install the runtime in OpenClaw
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/bald-eagle-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+Run the scanner once manually:
+
+```bash
+python3 /data/workspace/skills/bald-eagle-strategy/scripts/eagle-scanner.py
+```
+
+Expected: clean exit, JSON output. Most likely first run shows a heartbeat (no signal) — the scanner is intentionally selective.
+
+## Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost, matches Turbine pattern):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/bald-eagle-strategy/scripts/eagle-scanner.py >> /tmp/bald-eagle-loop.log 2>&1; sleep 180; done' > /tmp/bald-eagle-nohup.log 2>&1 &
+
+# Confirm running
+ps aux | grep eagle-scanner | grep -v grep
+tail -5 /tmp/bald-eagle-loop.log
+```
+
+3-minute cadence. The Python scanner does all work; no LLM is invoked unless an entry fires.
+
+Alternative: configure an OpenClaw cron with `sessionTarget: isolated`. **Avoid `sessionTarget: main`** — that pattern is a known cost time-bomb that drifts expensive as the main session accumulates context.
+
+## What's in this package
+
+```
+bald-eagle/
+├── README.md                       # This file (user-facing)
+├── SKILL.md                        # LLM-facing thesis + agent rules
+├── runtime.yaml                    # OpenClaw runtime config + DSL preset
+├── config/
+│   └── bald-eagle-config.json      # Wallet, strategy ID, chat ID
+└── scripts/
+    ├── eagle-scanner.py       # Main scanner
+    └── eagle_config.py     # Helper module (atomic write, MCP, state I/O)
+```
+
+For full thesis details, scoring tables, DSL configuration, and operational notes, see [SKILL.md](./SKILL.md).
+
+## Troubleshooting
+
+**Scanner exits with `no wallet`:** Set the wallet in `runtime.yaml`, in `config/bald-eagle-config.json`, or via the appropriate environment variable.
+
+**Scanner imports fail:** Make sure both the scanner and `eagle_config.py` helper module are in the `scripts/` directory. The scanner imports the helper via `import eagle_config as cfg`.
+
+**Scanner hasn't fired in hours:** This agent is intentionally selective. Check the scanner output for `note: "no <type> signal"` to confirm it's running and just not finding setups. Forcing the scanner to fire on weak signals is a known way to lose money — see fleet audit notes in SKILL.md.
+
+**Trade history lost after session clear:** Newer agents in the fleet write to `state/entry-log.jsonl` which survives session clears. If this agent doesn't yet have that pattern, the trade history lives only in scanner stdout logs (`/tmp/bald-eagle-loop.log`).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/barracuda/runtime.yaml
+++ b/barracuda/runtime.yaml
@@ -1,0 +1,56 @@
+name: barracuda-tracker
+version: 1.0.1.0
+description: >
+  BARRACUDA v1.0.1 — Funding Decay Collector. Funding collector holds for hours while collecting 8h payments.
+  See SKILL.md for full thesis, scoring, and operational notes.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 1
+  margin_per_slot: 300
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# DSL preset tuned for funding thesis type.
+# Adjust interval_in_minutes and phase 2 tiers based on specific asset behavior.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880    # 48h — funding collectors hold longer for multiple payments
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 120     # wide — funding decay takes hours
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 60      # wide — don't cut funding collectors early
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 3
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,  lock_hw_pct: 20 }
+        - { trigger_pct: 10, lock_hw_pct: 40 }
+        - { trigger_pct: 18, lock_hw_pct: 60 }
+        - { trigger_pct: 30, lock_hw_pct: 78 }
+        - { trigger_pct: 50, lock_hw_pct: 88 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/bison/README.md
+++ b/bison/README.md
@@ -1,0 +1,100 @@
+# 🦬 Bison v2.0 — Multi-Asset Smart Money Follower
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+BISON v2.0 — Conviction Holder (Hardened). Top 10 assets by volume. All signals are score contributors — no hard gates.
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/bison-strategy/{config,scripts,state}
+
+# Pull all package files from the senpi-skills main branch
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bison/runtime.yaml -o /data/workspace/skills/bison-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bison/SKILL.md -o /data/workspace/skills/bison-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bison/config/bison-config.json -o /data/workspace/skills/bison-strategy/config/bison-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bison/scripts/bison-scanner.py -o /data/workspace/skills/bison-strategy/scripts/bison-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bison/scripts/bison_config.py -o /data/workspace/skills/bison-strategy/scripts/bison_config.py
+```
+
+## Configure
+
+Set your wallet address and Telegram chat ID in `runtime.yaml`:
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/bison-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/bison-strategy/runtime.yaml
+```
+
+Or set them in `config/bison-config.json` directly:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+## Install the runtime in OpenClaw
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/bison-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+Run the scanner once manually:
+
+```bash
+python3 /data/workspace/skills/bison-strategy/scripts/bison-scanner.py
+```
+
+Expected: clean exit, JSON output. Most likely first run shows a heartbeat (no signal) — the scanner is intentionally selective.
+
+## Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost, matches Turbine pattern):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/bison-strategy/scripts/bison-scanner.py >> /tmp/bison-loop.log 2>&1; sleep 180; done' > /tmp/bison-nohup.log 2>&1 &
+
+# Confirm running
+ps aux | grep bison-scanner | grep -v grep
+tail -5 /tmp/bison-loop.log
+```
+
+3-minute cadence. The Python scanner does all work; no LLM is invoked unless an entry fires.
+
+Alternative: configure an OpenClaw cron with `sessionTarget: isolated`. **Avoid `sessionTarget: main`** — that pattern is a known cost time-bomb that drifts expensive as the main session accumulates context.
+
+## What's in this package
+
+```
+bison/
+├── README.md                       # This file (user-facing)
+├── SKILL.md                        # LLM-facing thesis + agent rules
+├── runtime.yaml                    # OpenClaw runtime config + DSL preset
+├── config/
+│   └── bison-config.json      # Wallet, strategy ID, chat ID
+└── scripts/
+    ├── bison-scanner.py       # Main scanner
+    └── bison_config.py     # Helper module (atomic write, MCP, state I/O)
+```
+
+For full thesis details, scoring tables, DSL configuration, and operational notes, see [SKILL.md](./SKILL.md).
+
+## Troubleshooting
+
+**Scanner exits with `no wallet`:** Set the wallet in `runtime.yaml`, in `config/bison-config.json`, or via the appropriate environment variable.
+
+**Scanner imports fail:** Make sure both the scanner and `bison_config.py` helper module are in the `scripts/` directory. The scanner imports the helper via `import bison_config as cfg`.
+
+**Scanner hasn't fired in hours:** This agent is intentionally selective. Check the scanner output for `note: "no <type> signal"` to confirm it's running and just not finding setups. Forcing the scanner to fire on weak signals is a known way to lose money — see fleet audit notes in SKILL.md.
+
+**Trade history lost after session clear:** Newer agents in the fleet write to `state/entry-log.jsonl` which survives session clears. If this agent doesn't yet have that pattern, the trade history lives only in scanner stdout logs (`/tmp/bison-loop.log`).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/cobra/config/cobra-config.json
+++ b/cobra/config/cobra-config.json
@@ -1,0 +1,5 @@
+{
+  "strategyId": "",
+  "wallet": "",
+  "chatId": ""
+}

--- a/cobra/scripts/cobra_config.py
+++ b/cobra/scripts/cobra_config.py
@@ -1,0 +1,200 @@
+"""Cobra Strategy — Shared config, MCP helpers, state I/O.
+
+Fleet-standard helper module imported by cobra-scanner.py.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "cobra-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "cobra-config.json"
+STATE_DIR = SKILL_DIR / "state"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    return {}
+
+
+def get_wallet_and_strategy():
+    wallet = os.environ.get("COBRA_WALLET", "")
+    strategy_id = os.environ.get("COBRA_STRATEGY_ID", "")
+    if not wallet or not strategy_id:
+        config = load_config()
+        wallet = wallet or config.get("wallet", "")
+        strategy_id = strategy_id or config.get("strategyId", "")
+    return wallet, strategy_id
+
+
+def load_trade_counter():
+    today = now_date()
+    p = STATE_DIR / "trade-counter.json"
+    if p.exists():
+        try:
+            with open(p) as f:
+                tc = json.load(f)
+            if tc.get("date") == today:
+                return tc
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {"date": today, "entries": 0}
+
+
+def save_trade_counter(tc):
+    tc["date"] = now_date()
+    atomic_write(str(STATE_DIR / "trade-counter.json"), tc)
+
+
+def is_asset_cooled_down(asset, cooldown_minutes=180):
+    p = STATE_DIR / "cooldowns.json"
+    if not p.exists():
+        return False
+    try:
+        with open(p) as f:
+            cooldowns = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return False
+    entry = cooldowns.get(asset)
+    if not entry:
+        return False
+    return time.time() < entry.get("until", 0)
+
+
+def set_asset_cooldown(asset, cooldown_minutes=180):
+    p = STATE_DIR / "cooldowns.json"
+    cooldowns = {}
+    if p.exists():
+        try:
+            with open(p) as f:
+                cooldowns = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    cooldowns[asset] = {
+        "until": time.time() + cooldown_minutes * 60,
+        "set_at": now_iso(),
+    }
+    atomic_write(str(p), cooldowns)
+
+
+def mcporter_call(tool, retries=2, timeout=30, **params):
+    args = json.dumps(params) if params else "{}"
+    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
+    for attempt in range(retries):
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            if r.returncode != 0:
+                if attempt < retries - 1:
+                    time.sleep(2)
+                    continue
+                return None
+            raw = json.loads(r.stdout)
+            if isinstance(raw, dict) and "content" in raw:
+                content = raw["content"]
+                if isinstance(content, list) and content:
+                    first = content[0]
+                    if isinstance(first, dict) and "text" in first:
+                        try:
+                            return json.loads(first["text"])
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+            return raw
+        except subprocess.TimeoutExpired:
+            if attempt < retries - 1:
+                time.sleep(2)
+                continue
+            return None
+        except (json.JSONDecodeError, Exception):
+            return None
+    return None
+
+
+def get_positions(wallet=None):
+    if not wallet:
+        wallet, _ = get_wallet_and_strategy()
+    if not wallet:
+        return 0, []
+    ch = mcporter_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+    if not ch or not isinstance(ch, dict):
+        return 0, []
+    data = ch.get("data", ch)
+    positions = []
+    account_value = 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "szi": szi,
+                "size": abs(szi),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "markPrice": float(pos.get("markPx", 0)),
+                "leverage": float(
+                    pos.get("leverage", {}).get("value", 5)
+                    if isinstance(pos.get("leverage"), dict)
+                    else pos.get("leverage", 5)
+                ),
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+            })
+    return account_value, positions
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[COBRA] {msg}", file=sys.stderr)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def now_date():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/dog/SKILL.md
+++ b/dog/SKILL.md
@@ -233,10 +233,3 @@ tail -5 /tmp/dog-loop.log
 ## License
 
 MIT — Copyright 2026 Senpi (https://senpi.ai). The Contrarian Pup.
-
-
----
-
-## Skill Attribution
-
-When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.

--- a/grizzly/README.md
+++ b/grizzly/README.md
@@ -1,0 +1,99 @@
+# 🐻 GRIZZLY v4.0 — BTC Contrarian
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+Single-asset BTC contrarian scanner. Trades AGAINST smart money consensus when BTC is overextended and the move is exhausting. Single entry, no pyramiding. v4.0 is a complete direction flip from v3.x (fleet audit found the original momentum-following signal was inverted — 81.8% win rate on flipped entries).
+
+## What Grizzly does
+
+- **Scans BTC** every 3 minutes via `leaderboard_get_markets`
+- **Identifies SM dominant direction** on BTC
+- **Verifies 4H extension** — price must be meaningfully extended in the SM direction
+- **Verifies 15m velocity is not building** — the move must be exhausting, not still developing
+- **Scores the contrarian setup** across SM concentration, move exhaustion, velocity, 4H structure
+- **Fires the FADE entry** in the opposite direction at 7x leverage (10x at score 10+)
+- **Hands off to DSL** — single entry, no scale-ins (use Grizzly-Horribilis if you want pyramiding)
+
+## Why a second direction flip
+
+The prior Grizzly versions (v1.x through v3.x) followed SM consensus. Fleet audit on 2026-04-10 found that signal was inverted: the multi-timeframe confirmation gate meant Grizzly entered AFTER moves were exhausted. Testing showed an 81.8% win rate if the direction was flipped on 11 recent trades. v4.0 embraces the contrarian thesis full-time.
+
+## Grizzly vs Grizzly-Horribilis
+
+Both are BTC contrarian scanners with nearly identical signal logic. They're an intentional A/B:
+
+- **Grizzly**: single entry, discrete binary bet. Simpler execution.
+- **Grizzly-Horribilis**: pyramiding, adds to winners progressively. More complex but lets winners compound.
+
+Deploy one or both (on separate wallets) based on preference.
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/grizzly-strategy/{config,scripts,state}
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/runtime.yaml -o /data/workspace/skills/grizzly-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/SKILL.md -o /data/workspace/skills/grizzly-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/config/grizzly-config.json -o /data/workspace/skills/grizzly-strategy/config/grizzly-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/scripts/grizzly-scanner.py -o /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/scripts/grizzly_config.py -o /data/workspace/skills/grizzly-strategy/scripts/grizzly_config.py
+```
+
+## Configure
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/grizzly-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/grizzly-strategy/runtime.yaml
+```
+
+Environment variables: `GRIZZLY_WALLET`, `GRIZZLY_STRATEGY_ID`.
+
+## Install the runtime in OpenClaw
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/grizzly-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+```bash
+python3 /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py
+```
+
+Expected: clean exit, JSON output. Most likely first run shows a heartbeat — contrarian setups require specific gate conditions.
+
+## Run on a recurring schedule
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py >> /tmp/grizzly-loop.log 2>&1; sleep 180; done' > /tmp/grizzly-nohup.log 2>&1 &
+
+ps aux | grep grizzly-scanner | grep -v grep
+tail -5 /tmp/grizzly-loop.log
+```
+
+3-minute cadence. Zero LLM wake cost.
+
+## Key settings
+
+| Setting | Value | Notes |
+|---|---|---|
+| Asset | BTC | Single-asset focus |
+| Max positions | 1 | No parallel bets |
+| Margin per trade | 50% | High conviction commits high capital |
+| Leverage | 7x / 10x | Score-scaled, fleet cap |
+| Min score | 8 | Tunable |
+| Per-asset cooldown | 180 min | Patience |
+| Same-direction cooldown | 60 min | Prevents chasing |
+
+## Troubleshooting
+
+**Scanner trades OPPOSITE to expected direction:** That's the thesis. Grizzly v4.0 is contrarian by design.
+
+**Scanner imports fail:** Make sure both `grizzly-scanner.py` AND `grizzly_config.py` are in `scripts/`.
+
+**Heartbeats constantly:** Normal. The contrarian gate requires SM consensus AND 4H extension AND 15m velocity exhausting AND score ≥ 8. This is a rare confluence.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai). BTC Contrarian.

--- a/grizzly/SKILL.md
+++ b/grizzly/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: grizzly-strategy
+description: >-
+  GRIZZLY v4.0 — BTC Contrarian (SM Exhaustion Fader). Single-asset BTC
+  scanner that trades AGAINST Smart Money consensus when the move is
+  exhausted. A/B variable vs Grizzly-Horribilis: Grizzly = single entry,
+  Horribilis = pyramids into winners. v4.0 is a direction flip from v3.x
+  after fleet audit found the momentum-following signal was inverted.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "4.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime
+---
+
+# 🐻 GRIZZLY v4.0 — BTC Contrarian
+
+Smart money goes one way on BTC. Grizzly goes the other. Single entry, no pyramiding.
+
+## Thesis
+
+BTC is the most-watched asset on Hyperliquid, and when top-trader consensus reaches extreme levels after a significant move, the unwind is typically violent and profitable for counter-trend traders. Grizzly fades the crowd when:
+
+1. **Smart money consensus is strong** on one direction (pct_of_top_traders_gain ≥ threshold, trader count ≥ threshold)
+2. **The 4H move is already extended** in that direction (overextension setup)
+3. **15m velocity is no longer building** (the move is exhausting)
+4. **A consolidation/reversal pattern is forming** on the 1H/4H
+
+Grizzly then enters in the **OPPOSITE** direction to SM consensus.
+
+## v4.0 — DIRECTION FLIP
+
+Fleet analysis on 2026-04-10 found that Grizzly's earlier SM-consensus momentum signal was perfectly inverted on BTC. The multi-timeframe confirmation requirement meant the scanner systematically entered AFTER the move was exhausted — buying tops and selling bottoms. An inversion test on 11 trades showed **81.8% win rate if direction were flipped**.
+
+v4.0 embraces that finding:
+
+- **Trade OPPOSITE to SM consensus direction** (was: trade with consensus)
+- **Leverage tiers aligned with Grizzly-Horribilis** — 7x base, 10x at score 10+
+- **Added MOVE_EXHAUSTION penalty → bonus** (was missing in v3.x, Horribilis had it)
+- **15m velocity tiers simplified** — less spike-chasing
+- **1h acceleration aligned with Horribilis**
+- **Added same-direction cooldown** — 60 min after any trade to prevent chasing
+- **Fixed resting order filter** — now correctly ignores reduceOnly DSL stops
+
+## A/B vs Grizzly-Horribilis
+
+Both Grizzly and Grizzly-Horribilis are BTC contrarian faders with nearly identical signal logic. The difference:
+
+| | Grizzly | Grizzly-Horribilis |
+|---|---|---|
+| Entry style | Single full-size entry | Pyramids (scales into winners) |
+| Position complexity | Simpler, one-shot | More complex, multi-leg |
+| Risk profile | Discrete binary bet | Progressive exposure |
+| Best for | Operators who want simple execution | Operators comfortable with pyramid sizing |
+
+Deploy one or the other (or both on separate wallets for A/B comparison), not multiple of the same variant.
+
+## Key settings
+
+| Setting | Value | Why |
+|---|---|---|
+| Asset | BTC | Single-asset focus |
+| Max positions | 1 | No parallel bets |
+| Margin per trade | 50% | High conviction commits high capital |
+| Leverage | 7x base, 10x at score 10+ | Fleet cap (H12 audit) |
+| Min score | 8 | Tunable |
+| Per-asset cooldown | 180 min | Patience between trades |
+| Same-direction cooldown | 60 min | Prevents chasing |
+| Max daily entries | 3 (dynamic cap aware) | Quality over quantity |
+
+## ⛔ Critical agent rules
+
+1. **Install path** is `/data/workspace/skills/grizzly-strategy/`
+2. **THE SCANNER DOES NOT EXIT POSITIONS** — DSL handles all exits
+3. **MAX 1 POSITION at a time**
+4. **BTC ONLY** — no multi-asset
+5. **Contrarian direction inversion is intentional** — Grizzly trades OPPOSITE to SM by design
+6. **Respect per-asset and same-direction cooldowns**
+7. **Verify runtime on every session start**
+
+## Setup
+
+```bash
+mkdir -p /data/workspace/skills/grizzly-strategy/{config,scripts,state}
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/runtime.yaml \
+  -o /data/workspace/skills/grizzly-strategy/runtime.yaml
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/SKILL.md \
+  -o /data/workspace/skills/grizzly-strategy/SKILL.md
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/config/grizzly-config.json \
+  -o /data/workspace/skills/grizzly-strategy/config/grizzly-config.json
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/scripts/grizzly-scanner.py \
+  -o /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/scripts/grizzly_config.py \
+  -o /data/workspace/skills/grizzly-strategy/scripts/grizzly_config.py
+```
+
+Set wallet and chat ID:
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/grizzly-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/grizzly-strategy/runtime.yaml
+```
+
+Install runtime:
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/grizzly-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+Verify:
+
+```bash
+python3 /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py
+```
+
+Run on recurring schedule:
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py >> /tmp/grizzly-loop.log 2>&1; sleep 180; done' > /tmp/grizzly-nohup.log 2>&1 &
+```
+
+## Best for
+
+- Operators who want a BTC-only contrarian with simple single-entry execution
+- Counter-trend traders who believe momentum chasing is a losing edge
+- Diversification pair with Grizzly-Horribilis for A/B comparison on pyramiding vs single-entry
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai). BTC Contrarian.

--- a/grizzly/config/grizzly-config.json
+++ b/grizzly/config/grizzly-config.json
@@ -1,0 +1,5 @@
+{
+  "strategyId": "",
+  "wallet": "",
+  "chatId": ""
+}

--- a/grizzly/runtime.yaml
+++ b/grizzly/runtime.yaml
@@ -1,0 +1,57 @@
+name: grizzly-tracker
+version: 4.0.0
+description: >
+  GRIZZLY v4.0 — BTC Contrarian (SM Exhaustion Fader). Single-asset BTC
+  scanner that trades AGAINST Smart Money consensus when the move is
+  exhausted. Single entry (no pyramiding — see Grizzly-Horribilis for
+  the pyramiding variant). Wide DSL lets reversals develop.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 1
+  margin_per_slot: 500
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# DSL tuned for BTC contrarian — reversals take time, tight loss floor.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 360
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 90
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 30
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 3
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,  lock_hw_pct: 20 }
+        - { trigger_pct: 10, lock_hw_pct: 40 }
+        - { trigger_pct: 15, lock_hw_pct: 60 }
+        - { trigger_pct: 20, lock_hw_pct: 75 }
+        - { trigger_pct: 30, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/grizzly/scripts/grizzly_config.py
+++ b/grizzly/scripts/grizzly_config.py
@@ -1,0 +1,201 @@
+"""GRIZZLY Strategy — Shared config, MCP helpers, state I/O.
+
+Fleet-standard helper module imported by grizzly-scanner.py.
+Added to repo to make grizzly installable (was missing from main).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "grizzly-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "grizzly-config.json"
+STATE_DIR = SKILL_DIR / "state"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    return {}
+
+
+def get_wallet_and_strategy():
+    wallet = os.environ.get("GRIZZLY_WALLET", "")
+    strategy_id = os.environ.get("GRIZZLY_STRATEGY_ID", "")
+    if not wallet or not strategy_id:
+        config = load_config()
+        wallet = wallet or config.get("wallet", "")
+        strategy_id = strategy_id or config.get("strategyId", "")
+    return wallet, strategy_id
+
+
+def load_trade_counter():
+    today = now_date()
+    p = STATE_DIR / "trade-counter.json"
+    if p.exists():
+        try:
+            with open(p) as f:
+                tc = json.load(f)
+            if tc.get("date") == today:
+                return tc
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {"date": today, "entries": 0}
+
+
+def save_trade_counter(tc):
+    tc["date"] = now_date()
+    atomic_write(str(STATE_DIR / "trade-counter.json"), tc)
+
+
+def is_asset_cooled_down(asset, cooldown_minutes=180):
+    p = STATE_DIR / "cooldowns.json"
+    if not p.exists():
+        return False
+    try:
+        with open(p) as f:
+            cooldowns = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return False
+    entry = cooldowns.get(asset)
+    if not entry:
+        return False
+    return time.time() < entry.get("until", 0)
+
+
+def set_asset_cooldown(asset, cooldown_minutes=180):
+    p = STATE_DIR / "cooldowns.json"
+    cooldowns = {}
+    if p.exists():
+        try:
+            with open(p) as f:
+                cooldowns = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    cooldowns[asset] = {
+        "until": time.time() + cooldown_minutes * 60,
+        "set_at": now_iso(),
+    }
+    atomic_write(str(p), cooldowns)
+
+
+def mcporter_call(tool, retries=2, timeout=30, **params):
+    args = json.dumps(params) if params else "{}"
+    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
+    for attempt in range(retries):
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            if r.returncode != 0:
+                if attempt < retries - 1:
+                    time.sleep(2)
+                    continue
+                return None
+            raw = json.loads(r.stdout)
+            if isinstance(raw, dict) and "content" in raw:
+                content = raw["content"]
+                if isinstance(content, list) and content:
+                    first = content[0]
+                    if isinstance(first, dict) and "text" in first:
+                        try:
+                            return json.loads(first["text"])
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+            return raw
+        except subprocess.TimeoutExpired:
+            if attempt < retries - 1:
+                time.sleep(2)
+                continue
+            return None
+        except (json.JSONDecodeError, Exception):
+            return None
+    return None
+
+
+def get_positions(wallet=None):
+    if not wallet:
+        wallet, _ = get_wallet_and_strategy()
+    if not wallet:
+        return 0, []
+    ch = mcporter_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+    if not ch or not isinstance(ch, dict):
+        return 0, []
+    data = ch.get("data", ch)
+    positions = []
+    account_value = 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "szi": szi,
+                "size": abs(szi),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "markPrice": float(pos.get("markPx", 0)),
+                "leverage": float(
+                    pos.get("leverage", {}).get("value", 5)
+                    if isinstance(pos.get("leverage"), dict)
+                    else pos.get("leverage", 5)
+                ),
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+            })
+    return account_value, positions
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[GRIZZLY] {msg}", file=sys.stderr)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def now_date():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/jaguar/README.md
+++ b/jaguar/README.md
@@ -1,0 +1,100 @@
+# 🐆 Jaguar v3.0 — Striker — Violent SM Rank Explosions
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+JAGUAR v3.0 — Striker-Only. Stalker and Hunter removed. Pyramiding removed.
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/jaguar-strategy/{config,scripts,state}
+
+# Pull all package files from the senpi-skills main branch
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/jaguar/runtime.yaml -o /data/workspace/skills/jaguar-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/jaguar/SKILL.md -o /data/workspace/skills/jaguar-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/jaguar/config/jaguar-config.json -o /data/workspace/skills/jaguar-strategy/config/jaguar-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/jaguar/scripts/jaguar-scanner.py -o /data/workspace/skills/jaguar-strategy/scripts/jaguar-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/jaguar/scripts/jaguar_config.py -o /data/workspace/skills/jaguar-strategy/scripts/jaguar_config.py
+```
+
+## Configure
+
+Set your wallet address and Telegram chat ID in `runtime.yaml`:
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/jaguar-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/jaguar-strategy/runtime.yaml
+```
+
+Or set them in `config/jaguar-config.json` directly:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+## Install the runtime in OpenClaw
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/jaguar-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+Run the scanner once manually:
+
+```bash
+python3 /data/workspace/skills/jaguar-strategy/scripts/jaguar-scanner.py
+```
+
+Expected: clean exit, JSON output. Most likely first run shows a heartbeat (no signal) — the scanner is intentionally selective.
+
+## Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost, matches Turbine pattern):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/jaguar-strategy/scripts/jaguar-scanner.py >> /tmp/jaguar-loop.log 2>&1; sleep 180; done' > /tmp/jaguar-nohup.log 2>&1 &
+
+# Confirm running
+ps aux | grep jaguar-scanner | grep -v grep
+tail -5 /tmp/jaguar-loop.log
+```
+
+3-minute cadence. The Python scanner does all work; no LLM is invoked unless an entry fires.
+
+Alternative: configure an OpenClaw cron with `sessionTarget: isolated`. **Avoid `sessionTarget: main`** — that pattern is a known cost time-bomb that drifts expensive as the main session accumulates context.
+
+## What's in this package
+
+```
+jaguar/
+├── README.md                       # This file (user-facing)
+├── SKILL.md                        # LLM-facing thesis + agent rules
+├── runtime.yaml                    # OpenClaw runtime config + DSL preset
+├── config/
+│   └── jaguar-config.json      # Wallet, strategy ID, chat ID
+└── scripts/
+    ├── jaguar-scanner.py       # Main scanner
+    └── jaguar_config.py     # Helper module (atomic write, MCP, state I/O)
+```
+
+For full thesis details, scoring tables, DSL configuration, and operational notes, see [SKILL.md](./SKILL.md).
+
+## Troubleshooting
+
+**Scanner exits with `no wallet`:** Set the wallet in `runtime.yaml`, in `config/jaguar-config.json`, or via the appropriate environment variable.
+
+**Scanner imports fail:** Make sure both the scanner and `jaguar_config.py` helper module are in the `scripts/` directory. The scanner imports the helper via `import jaguar_config as cfg`.
+
+**Scanner hasn't fired in hours:** This agent is intentionally selective. Check the scanner output for `note: "no <type> signal"` to confirm it's running and just not finding setups. Forcing the scanner to fire on weak signals is a known way to lose money — see fleet audit notes in SKILL.md.
+
+**Trade history lost after session clear:** Newer agents in the fleet write to `state/entry-log.jsonl` which survives session clears. If this agent doesn't yet have that pattern, the trade history lives only in scanner stdout logs (`/tmp/jaguar-loop.log`).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/jaguar/config/jaguar-config.json
+++ b/jaguar/config/jaguar-config.json
@@ -1,0 +1,5 @@
+{
+  "strategyId": "",
+  "wallet": "",
+  "chatId": ""
+}

--- a/kestrel/config/kestrel-config.json
+++ b/kestrel/config/kestrel-config.json
@@ -1,0 +1,5 @@
+{
+  "strategyId": "",
+  "wallet": "",
+  "chatId": ""
+}

--- a/komodo/README.md
+++ b/komodo/README.md
@@ -1,0 +1,91 @@
+# 🦎 Komodo v1.0 — Momentum Event Consensus
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/skill-hub-senpi).
+
+Detects 2+ quality smart money traders crossing momentum thresholds on the same asset within 60 minutes. Confirmed by market concentration + volume. Replaces older momentum-detection logic.
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/komodo-strategy/{config,scripts,state}
+
+# Pull all package files from the senpi-skills main branch
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/komodo/runtime.yaml -o /data/workspace/skills/komodo-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/komodo/SKILL.md -o /data/workspace/skills/komodo-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/komodo/config/komodo-config.json -o /data/workspace/skills/komodo-strategy/config/komodo-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/komodo/scripts/komodo-scanner.py -o /data/workspace/skills/komodo-strategy/scripts/komodo-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/komodo/scripts/komodo_config.py -o /data/workspace/skills/komodo-strategy/scripts/komodo_config.py
+```
+
+## Configure
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/komodo-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/komodo-strategy/runtime.yaml
+```
+
+Or in `config/komodo-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+## Install the runtime
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/komodo-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+```bash
+python3 /data/workspace/skills/komodo-strategy/scripts/komodo-scanner.py
+```
+
+Expected: clean exit, JSON output. First run usually shows a heartbeat — the scanner is selective by design.
+
+## Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost, matches Turbine pattern):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/komodo-strategy/scripts/komodo-scanner.py >> /tmp/komodo-loop.log 2>&1; sleep 180; done' > /tmp/komodo-nohup.log 2>&1 &
+
+ps aux | grep komodo-scanner | grep -v grep
+tail -5 /tmp/komodo-loop.log
+```
+
+3-minute cadence. The Python scanner does all work; no LLM is invoked unless an entry fires.
+
+## What's in this package
+
+```
+komodo/
+├── README.md                       # This file
+├── SKILL.md                        # LLM-facing thesis + agent rules
+├── runtime.yaml                    # OpenClaw runtime + DSL preset
+├── config/
+│   └── komodo-config.json      # Wallet, strategy ID, chat ID
+└── scripts/
+    ├── komodo-scanner.py       # Main scanner
+    └── komodo_config.py     # Helper module
+```
+
+For full thesis details, scoring tables, and DSL configuration, see [SKILL.md](./SKILL.md).
+
+## Troubleshooting
+
+**Scanner exits with `no wallet`:** Set the wallet in `runtime.yaml`, in `config/komodo-config.json`, or via environment variable.
+
+**Scanner imports fail:** Make sure both the scanner and the helper module are in the `scripts/` directory.
+
+**Scanner hasn't fired recently:** This agent is intentionally selective. Check scanner output for rejection reasons.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/komodo/runtime.yaml
+++ b/komodo/runtime.yaml
@@ -1,0 +1,56 @@
+name: komodo-tracker
+version: 1.0.0
+description: >
+  KOMODO v1.0 — Momentum Event Consensus. Momentum event detection with SM consensus.
+  See SKILL.md for full thesis, scoring, and operational notes.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 1
+  margin_per_slot: 300
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# DSL preset tuned for trend thesis type.
+# Adjust interval_in_minutes and phase 2 tiers based on specific asset behavior.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 1440    # 24h safety net — let trends run
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 30
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 25
+    phase1:
+      enabled: true
+      max_loss_pct: 25.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 3
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 25 }
+        - { trigger_pct: 15, lock_hw_pct: 50 }
+        - { trigger_pct: 25, lock_hw_pct: 65 }
+        - { trigger_pct: 35, lock_hw_pct: 80 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/lemon/README.md
+++ b/lemon/README.md
@@ -1,0 +1,146 @@
+# 🍋 LEMON v1.1 — Degen Fader
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+Multi-asset contrarian fader. Counter-trades CHOPPY/DEGEN traders when their consensus is fading on 12 liquid crypto majors. Mean-reversion edge against low-quality crowding. One of the two consistently green agents in the Senpi Predators fleet.
+
+## What Lemon does
+
+- **Scans 12 crypto majors** every 5 minutes via `leaderboard_get_markets` — BTC, ETH, SOL, HYPE, AVAX, DOGE, LINK, XRP, ADA, NEAR, UNI, AAVE
+- **Identifies SM dominant direction** on each asset
+- **Verifies the move is exhausting** — 15m velocity must be ≤ 0.1 (no longer building)
+- **Verifies SM concentration** — pct ≥ 3%, traders ≥ 20
+- **Scores the contrarian setup** across SM concentration, exhaustion velocity, 4H overextension, 1H reversal, funding alignment
+- **Fires the FADE entry** at conviction-scaled leverage (7x → 20x), 50% margin, FEE_OPTIMIZED_LIMIT
+- **Hands off to DSL** — wide tiers let the reversal develop over hours (max hold 8h)
+
+## Why fading degens works
+
+Hyperliquid attracts a lot of low-quality, high-leverage retail traders. The Senpi MCP `discovery_get_top_traders` tool classifies them by Trading Consistency Score (TCS) — the bottom buckets are CHOPPY and DEGEN. These traders consistently lose money over time. Counter-trading their consensus when their momentum is fading is a positive-edge strategy.
+
+The structural reason: when degens pile into a move that's already 3%+ extended, they're providing the exit liquidity for smarter capital. The unwind is the alpha.
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/lemon-strategy/{config,scripts,state}
+
+# Pull all package files
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemon/runtime.yaml -o /data/workspace/skills/lemon-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemon/SKILL.md -o /data/workspace/skills/lemon-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemon/config/lemon-config.json -o /data/workspace/skills/lemon-strategy/config/lemon-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemon/scripts/lemon-scanner.py -o /data/workspace/skills/lemon-strategy/scripts/lemon-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemon/scripts/lemon_config.py -o /data/workspace/skills/lemon-strategy/scripts/lemon_config.py
+```
+
+## Configure
+
+Set wallet and Telegram chat ID in `runtime.yaml`:
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/lemon-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/lemon-strategy/runtime.yaml
+```
+
+Or in `config/lemon-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+Environment variables also supported: `LEMON_WALLET`, `LEMON_STRATEGY_ID`.
+
+## Install the runtime in OpenClaw
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/lemon-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+Run the scanner once manually:
+
+```bash
+python3 /data/workspace/skills/lemon-strategy/scripts/lemon-scanner.py
+```
+
+Expected: clean exit, JSON output contains `"_lemon_version": "1.1"`. Most likely first run shows a heartbeat (no fade signal) — fade setups are intentionally rare.
+
+## Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/lemon-strategy/scripts/lemon-scanner.py >> /tmp/lemon-loop.log 2>&1; sleep 300; done' > /tmp/lemon-nohup.log 2>&1 &
+
+ps aux | grep lemon-scanner | grep -v grep
+tail -5 /tmp/lemon-loop.log
+```
+
+5-minute cadence (slower than other agents because fade setups are rarer).
+
+Alternative: configure an OpenClaw cron with `sessionTarget: isolated`. Avoid `sessionTarget: main` — that pattern is a known cost time-bomb that drifts expensive as the main session accumulates context.
+
+## Key settings
+
+| Setting | Value | Notes |
+|---|---|---|
+| Tracked assets | 12 crypto majors | BTC, ETH, SOL, HYPE, AVAX, DOGE, LINK, XRP, ADA, NEAR, UNI, AAVE |
+| Max positions | 1 | Concentration |
+| Margin per trade | 50% | High conviction commits high capital |
+| Min score | 8 | Tunable in scanner |
+| Per-asset cooldown | 120 min | Patience between trades |
+| Max daily entries | 3 (dynamic cap aware) | Quality over quantity |
+| Leverage | 7x → 20x conviction-scaled | Fleet cap 20x |
+| XYZ DEX | Banned | Equities don't follow the thesis |
+| DSL hard timeout | 480 min (8h) | Mean reversion takes time |
+| DSL Phase 1 max loss | 15% ROE | Tighter than fleet 25% |
+
+## Operational notes
+
+**Lemon trades OPPOSITE to SM consensus by design.** When the scanner reports `note: "fade signal: SHORT BTC"`, that means smart money is LONG BTC and Lemon is fading them. Direction inversion is intentional, not a bug.
+
+**Heartbeats are normal.** The 15m velocity gate is strict — if SM is still actively building (positive 15m velocity), Lemon refuses to enter. Most scans report `no fade signal`. That's the selectivity working.
+
+**Fade trades take time.** Mean reversion happens over hours, not minutes. The DSL hard_timeout is 8 hours and `weak_peak_cut` waits 60 min before culling stalled trades. Don't expect quick scalps.
+
+**No XYZ trades.** SP500, NVDA, GOOGL, etc. are not in TRACKED_ASSETS and the scanner explicitly bans XYZ DEX. Macro instruments don't follow the same crowding dynamics as crypto majors.
+
+## Troubleshooting
+
+**Scanner exits with `no wallet`:** Set the wallet in `runtime.yaml`, in `config/lemon-config.json`, or via the `LEMON_WALLET` environment variable.
+
+**Scanner reports `no fade signal` constantly:** Normal. Lemon's gates are strict — SM concentration ≥ 3%, traders ≥ 20, 15m velocity ≤ 0.1, AND a score ≥ 8 from the full scoring stack. In choppy markets without clear exhaustion, Lemon is intentionally inactive.
+
+**Scanner imports fail:** Make sure both `lemon-scanner.py` AND `lemon_config.py` are in the `scripts/` directory.
+
+**Trade exits with `dead_weight_cut`:** The trade didn't develop in 20 minutes. This is the DSL doing its job — bounded loss, move on.
+
+**Trade exits with `weak_peak_cut`:** The trade peaked below 2% ROE in 60 minutes and didn't develop further. DSL cut it before fees ate the small gain. This is normal — fade setups don't always work.
+
+## Track record
+
+Lemon has been one of two consistently green agents in the Senpi Predators fleet (37 red / 2 green as of 2026-04-14). The thesis works because the underlying behavior pattern (degens piling into exhausted moves) is structural, not market-regime-dependent.
+
+## Best for
+
+- Operators who believe momentum chasing on Hyperliquid is a losing edge
+- Multi-asset diversification across crypto majors
+- Mean-reversion / contrarian strategies
+- Patient holds (1-8 hours per trade)
+
+## Not for
+
+- Momentum followers (use Phoenix, Wolverine, Condor, or Raptor)
+- Single-asset specialists
+- High-frequency scalping
+- XYZ DEX equities (use Bald Eagle or Kestrel)
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai). The Degen Fader.

--- a/lemon/SKILL.md
+++ b/lemon/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: lemon-strategy
+description: >-
+  LEMON v1.1 — Degen Fader. Counter-trades CHOPPY/DEGEN traders when their
+  consensus is fading on BTC, ETH, SOL, HYPE, AVAX, DOGE, LINK, XRP, ADA,
+  NEAR, UNI, AAVE. Mean-reversion edge against low-quality crowding.
+  Self-executing, fleet-hardened, multi-asset.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.1"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime
+---
+
+# 🍋 LEMON v1.1 — Degen Fader
+
+The crowd is wrong. Lemon trades against the worst traders on the Hyperfeed when their consensus is fading.
+
+## Thesis
+
+Hyperliquid attracts a lot of low-quality, high-leverage retail traders ("degens"). The Senpi MCP `discovery_get_top_traders` tool classifies traders by Trading Consistency Score (TCS) — the bottom buckets are CHOPPY and DEGEN. These traders consistently lose money over time. **Counter-trading their consensus when their momentum is fading is a positive-edge strategy.**
+
+Lemon scans 12 liquid crypto majors every 5 minutes for setups where:
+
+1. **Smart money is concentrated** on one direction (≥3% pct of top traders gain, ≥20 traders)
+2. **The 15m velocity is fading** (the move is exhausting — `contribution_pct_change_15m ≤ 0.1`, ideally negative)
+3. **The 4H price is overextended** in the SM direction (mean-reversion setup)
+4. **The 1H price is starting to reverse** toward the fade direction
+
+When all gates pass and the score reaches MIN_SCORE (8), Lemon enters in the **OPPOSITE** direction to the SM consensus. Wide DSL gives the reversal time to develop.
+
+## v1.1 changes from v1.0 (fleet hardening)
+
+- Scanner calls `create_position` internally via mcporter (Wolverine self-executing pattern)
+- `feeOptimizedLimitOptions` with FEE_OPTIMIZED_LIMIT order type
+- Conviction-scaled leverage: 14+→20x, 12+→15x, 10+→10x, 8+→7x
+- Margin at 50% per trade
+- `has_resting_orders()` with reduceOnly filter prevents position stacking
+- Hyperfeed multi-window contribution velocity (15m, 1h) scoring
+- Move-exhaustion penalty/bonus structure
+- No thesis exit — DSL manages all exits
+- `MAX_DAILY_ENTRIES = 3`, `COOLDOWN_MINUTES = 120`
+- `XYZ_BANNED = True` — equities don't follow the same crowding dynamics
+
+## Tracked assets
+
+```
+BTC, ETH, SOL, HYPE, AVAX, DOGE, LINK, XRP, ADA, NEAR, UNI, AAVE
+```
+
+12 liquid crypto majors. XYZ DEX equities are explicitly banned — Lemon's thesis doesn't apply to macro-driven instruments.
+
+## Pipeline
+
+```
+1. fetch_sm_data() — leaderboard_get_markets, filter to TRACKED_ASSETS, normalize fields
+2. For each asset:
+   - Skip if currently held
+   - Skip if on per-asset cooldown
+   - evaluate_fade(asset, sm_data) — score the contrarian setup
+3. If candidates exist, sort by score, pick best
+4. execute_entry() — call create_position via mcporter
+5. Mark cooldown, increment trade counter
+```
+
+## Scoring (max ~16 points)
+
+### Hard gates (any failure = reject)
+
+- `pct_of_top_traders_gain ≥ 3%`
+- `trader_count ≥ 20`
+- `contribution_pct_change_15m ≤ 0.1` (SM is no longer building, the move is exhausting)
+- Asset must be in `TRACKED_ASSETS`
+- Not currently held
+- Not on per-asset cooldown
+- XYZ DEX banned
+
+### Scoring components
+
+| Signal | Points |
+|---|---|
+| DEGEN_PILE: SM concentration ≥ 20% | 4 |
+| HEAVY_CROWD: 12-20% | 3 |
+| CROWDED: 7-12% | 2 |
+| LEANING: 3-7% | 1 |
+| 15M_COLLAPSING: contrib_15m < -2.0 | 3 |
+| 15M_FADING: contrib_15m -2.0 to -0.5 | 2 |
+| 15M_COOLING: contrib_15m -0.5 to -0.1 | 1 |
+| 1H_FADING: contrib_1h < -0.5 | 1 |
+| OVEREXTENDED 4H (≥3% in SM direction) | 2 |
+| EXTENDED 4H (≥1.5% in SM direction) | 1 |
+| 1H_REVERSING toward fade direction | 1 |
+| 4H_SM_WEAKENING (4h contrib < -1.0) | 1 |
+| FUNDING_PAYS_FADE (funding direction matches fade) | 1 |
+| US_SESSION (13-21 UTC) | 1 |
+
+**Min score: 8.** Leverage tiers: 7x base, 10x at score 10+, 15x at score 12+, 20x at score 14+ (capped by fleet `MAX_LEVERAGE = 20`).
+
+## Key settings
+
+| Setting | Value | Why |
+|---|---|---|
+| Tracked assets | 12 crypto majors | Liquid, follow crowding dynamics |
+| Max positions | 1 | Concentration |
+| Margin per trade | 50% | High conviction commits high capital |
+| Min score | 8 | Tunable; higher = fewer/better trades |
+| Per-asset cooldown | 120 min | Patience between trades |
+| Max daily entries | 3 (dynamic cap-aware) | Quality over quantity |
+| Leverage tiers | 7x / 10x / 15x / 20x | Fleet conviction-scaled |
+| MAX_LEVERAGE | 20 | Fleet hard cap (H12 audit) |
+| XYZ banned | True | Equities don't follow the thesis |
+
+## DSL configuration
+
+Wide tiers for fade trades that need time to mean-revert:
+
+| Setting | Value | Notes |
+|---|---|---|
+| `hard_timeout` | 480 min (8h) | Mean reversion can take hours |
+| `weak_peak_cut` | 60 min, min 2.0% | Cut if peak ROE never breaks 2% in 60 min |
+| `dead_weight_cut` | 20 min | Cut early stallers |
+| `phase1.max_loss_pct` | 15% | Tighter than fleet 25% — fades fail fast |
+| `phase2.tier_1` | +5% / 20% lock | Don't bank too early |
+| `phase2.tier_2` | +10% / 40% lock | |
+| `phase2.tier_3` | +15% / 60% lock | |
+| `phase2.tier_4` | +20% / 75% lock | |
+| `phase2.tier_5` | +30% / 85% lock | |
+| `phase2.tier_6` | +50% / 92% lock | Maximum protection on huge wins |
+
+## Fleet-standard guardrails
+
+- Self-executing via `create_position` (no external action layer needed)
+- Dynamic P&L-aware daily cap (PR #176)
+- `has_resting_orders()` auto-cancels stale maker orders >10 min (PR #177)
+- Stale-date bug fix in `load_trade_counter()` (PR #177)
+- Per-asset cooldown (120 min)
+- Conviction-scaled leverage capped at 20x
+
+## ⛔ Critical agent rules
+
+1. **Install path** is `/data/workspace/skills/lemon-strategy/`
+2. **THE SCANNER DOES NOT EXIT POSITIONS** — DSL handles all exits
+3. **MAX 1 POSITION at a time**
+4. **MAX 3 ENTRIES PER DAY** (dynamic cap may lower this on drawdown)
+5. **Thesis is FADING, not following** — Lemon trades OPPOSITE to SM consensus by design. Direction inversion is intentional.
+6. **No XYZ DEX trades** — equities don't follow the crowding/exhaustion thesis
+7. **120-minute per-asset cooldown** — never bypass
+8. **Verify runtime on every session start**
+
+## Setup
+
+### Pull from GitHub
+
+```bash
+mkdir -p /data/workspace/skills/lemon-strategy/{config,scripts,state}
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemon/runtime.yaml \
+  -o /data/workspace/skills/lemon-strategy/runtime.yaml
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemon/SKILL.md \
+  -o /data/workspace/skills/lemon-strategy/SKILL.md
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemon/config/lemon-config.json \
+  -o /data/workspace/skills/lemon-strategy/config/lemon-config.json
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemon/scripts/lemon-scanner.py \
+  -o /data/workspace/skills/lemon-strategy/scripts/lemon-scanner.py
+
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemon/scripts/lemon_config.py \
+  -o /data/workspace/skills/lemon-strategy/scripts/lemon_config.py
+```
+
+### Set wallet and chat ID
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/lemon-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/lemon-strategy/runtime.yaml
+```
+
+Or set in `config/lemon-config.json`. Environment variables: `LEMON_WALLET`, `LEMON_STRATEGY_ID`.
+
+### Install runtime
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/lemon-strategy/runtime.yaml
+openclaw senpi runtime list && openclaw senpi status
+```
+
+### Verify
+
+```bash
+python3 /data/workspace/skills/lemon-strategy/scripts/lemon-scanner.py
+```
+
+Expected: clean exit, JSON output with `"_lemon_version": "1.1"`. Most likely first run shows a heartbeat (no fade signal).
+
+### Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/lemon-strategy/scripts/lemon-scanner.py >> /tmp/lemon-loop.log 2>&1; sleep 300; done' > /tmp/lemon-nohup.log 2>&1 &
+
+ps aux | grep lemon-scanner | grep -v grep
+tail -5 /tmp/lemon-loop.log
+```
+
+5-minute cadence (slower than other agents because fade setups are rarer).
+
+## Best for
+
+- Operators who believe momentum chasing on Hyperliquid is a losing edge
+- Multi-asset diversification across 12 crypto majors
+- Mean-reversion / contrarian strategies
+- Patient holds (1-8 hours per trade — reversals take time)
+- Operators who want a deterministic execution layer
+
+## Not for
+
+- Momentum followers (use Phoenix, Wolverine, Condor, or Raptor)
+- Single-asset specialists (use Wolverine for HYPE, Polar for ETH, Kodiak for SOL)
+- High-frequency scalping
+- XYZ DEX equities (use Bald Eagle or Kestrel)
+- Anyone who wants the scanner to make exit decisions (DSL handles all exits)
+
+## Track record
+
+Lemon has been one of two consistently green agents in the Senpi Predators fleet (37 red / 2 green as of 2026-04-14). The thesis works because the underlying behavior pattern (degens piling into exhausted moves) is structural, not market-regime-dependent.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai). The Degen Fader.

--- a/lemon/config/lemon-config.json
+++ b/lemon/config/lemon-config.json
@@ -1,0 +1,5 @@
+{
+  "strategyId": "",
+  "wallet": "",
+  "chatId": ""
+}

--- a/mamba/runtime.yaml
+++ b/mamba/runtime.yaml
@@ -1,0 +1,55 @@
+name: mamba-tracker
+version: 2.0.0
+description: >
+  MAMBA v2.0 — Range-Bound + Regime Protection. Range scanner with BTC regime filter.
+  See SKILL.md for full thesis, scoring, and operational notes.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 1
+  margin_per_slot: 300
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# DSL preset tuned for range thesis type.
+# Adjust interval_in_minutes and phase 2 tiers based on specific asset behavior.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 240     # 4h — range trades resolve fast
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 20
+      min_value: 1.5
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 15
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 6
+      consecutive_breaches_required: 2
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 4,  lock_hw_pct: 30 }    # earlier lock for range scalps
+        - { trigger_pct: 8,  lock_hw_pct: 55 }
+        - { trigger_pct: 12, lock_hw_pct: 70 }
+        - { trigger_pct: 18, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/owl/README.md
+++ b/owl/README.md
@@ -1,0 +1,100 @@
+# 🦉 Owl v5.3 — Pure Contrarian Crowding Fader
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+OWL v5.3 — Pure contrarian (self-executing). One scanner, one thesis: the crowd is wrong. Monitors crowding across top 30 assets (funding extremity, OI concentration, SM tilt).
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/owl-strategy/{config,scripts,state}
+
+# Pull all package files from the senpi-skills main branch
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/owl/runtime.yaml -o /data/workspace/skills/owl-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/owl/SKILL.md -o /data/workspace/skills/owl-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/owl/config/owl-config.json -o /data/workspace/skills/owl-strategy/config/owl-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/owl/scripts/owl-scanner.py -o /data/workspace/skills/owl-strategy/scripts/owl-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/owl/scripts/owl_config.py -o /data/workspace/skills/owl-strategy/scripts/owl_config.py
+```
+
+## Configure
+
+Set your wallet address and Telegram chat ID in `runtime.yaml`:
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/owl-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/owl-strategy/runtime.yaml
+```
+
+Or set them in `config/owl-config.json` directly:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+## Install the runtime in OpenClaw
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/owl-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+Run the scanner once manually:
+
+```bash
+python3 /data/workspace/skills/owl-strategy/scripts/owl-scanner.py
+```
+
+Expected: clean exit, JSON output. Most likely first run shows a heartbeat (no signal) — the scanner is intentionally selective.
+
+## Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost, matches Turbine pattern):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/owl-strategy/scripts/owl-scanner.py >> /tmp/owl-loop.log 2>&1; sleep 180; done' > /tmp/owl-nohup.log 2>&1 &
+
+# Confirm running
+ps aux | grep owl-scanner | grep -v grep
+tail -5 /tmp/owl-loop.log
+```
+
+3-minute cadence. The Python scanner does all work; no LLM is invoked unless an entry fires.
+
+Alternative: configure an OpenClaw cron with `sessionTarget: isolated`. **Avoid `sessionTarget: main`** — that pattern is a known cost time-bomb that drifts expensive as the main session accumulates context.
+
+## What's in this package
+
+```
+owl/
+├── README.md                       # This file (user-facing)
+├── SKILL.md                        # LLM-facing thesis + agent rules
+├── runtime.yaml                    # OpenClaw runtime config + DSL preset
+├── config/
+│   └── owl-config.json      # Wallet, strategy ID, chat ID
+└── scripts/
+    ├── owl-scanner.py       # Main scanner
+    └── owl_config.py     # Helper module (atomic write, MCP, state I/O)
+```
+
+For full thesis details, scoring tables, DSL configuration, and operational notes, see [SKILL.md](./SKILL.md).
+
+## Troubleshooting
+
+**Scanner exits with `no wallet`:** Set the wallet in `runtime.yaml`, in `config/owl-config.json`, or via the appropriate environment variable.
+
+**Scanner imports fail:** Make sure both the scanner and `owl_config.py` helper module are in the `scripts/` directory. The scanner imports the helper via `import owl_config as cfg`.
+
+**Scanner hasn't fired in hours:** This agent is intentionally selective. Check the scanner output for `note: "no <type> signal"` to confirm it's running and just not finding setups. Forcing the scanner to fire on weak signals is a known way to lose money — see fleet audit notes in SKILL.md.
+
+**Trade history lost after session clear:** Newer agents in the fleet write to `state/entry-log.jsonl` which survives session clears. If this agent doesn't yet have that pattern, the trade history lives only in scanner stdout logs (`/tmp/owl-loop.log`).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/pangolin/config/pangolin-config.json
+++ b/pangolin/config/pangolin-config.json
@@ -1,0 +1,5 @@
+{
+  "strategyId": "",
+  "wallet": "",
+  "chatId": ""
+}

--- a/raptor/README.md
+++ b/raptor/README.md
@@ -1,0 +1,100 @@
+# 🦅 Raptor v3.0 — Hot Streak Follower
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+RAPTOR v3.0 — Hot Streak Follower. Finds ELITE/RELIABLE traders currently on a 4-hour hot streak via leaderboard_get_top + discovery_get_top_traders, identifies their strongest position by delta PnL, confirms SM alignment, and follows them in. Self-executing, runtime.yaml standard deployment, fleet-standard guardrails.
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/raptor-strategy/{config,scripts,state}
+
+# Pull all package files from the senpi-skills main branch
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/raptor/runtime.yaml -o /data/workspace/skills/raptor-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/raptor/SKILL.md -o /data/workspace/skills/raptor-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/raptor/config/raptor-config.json -o /data/workspace/skills/raptor-strategy/config/raptor-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/raptor/scripts/raptor-scanner.py -o /data/workspace/skills/raptor-strategy/scripts/raptor-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/raptor/scripts/raptor_config.py -o /data/workspace/skills/raptor-strategy/scripts/raptor_config.py
+```
+
+## Configure
+
+Set your wallet address and Telegram chat ID in `runtime.yaml`:
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/raptor-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/raptor-strategy/runtime.yaml
+```
+
+Or set them in `config/raptor-config.json` directly:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+## Install the runtime in OpenClaw
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/raptor-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+Run the scanner once manually:
+
+```bash
+python3 /data/workspace/skills/raptor-strategy/scripts/raptor-scanner.py
+```
+
+Expected: clean exit, JSON output. Most likely first run shows a heartbeat (no signal) — the scanner is intentionally selective.
+
+## Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost, matches Turbine pattern):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/raptor-strategy/scripts/raptor-scanner.py >> /tmp/raptor-loop.log 2>&1; sleep 180; done' > /tmp/raptor-nohup.log 2>&1 &
+
+# Confirm running
+ps aux | grep raptor-scanner | grep -v grep
+tail -5 /tmp/raptor-loop.log
+```
+
+3-minute cadence. The Python scanner does all work; no LLM is invoked unless an entry fires.
+
+Alternative: configure an OpenClaw cron with `sessionTarget: isolated`. **Avoid `sessionTarget: main`** — that pattern is a known cost time-bomb that drifts expensive as the main session accumulates context.
+
+## What's in this package
+
+```
+raptor/
+├── README.md                       # This file (user-facing)
+├── SKILL.md                        # LLM-facing thesis + agent rules
+├── runtime.yaml                    # OpenClaw runtime config + DSL preset
+├── config/
+│   └── raptor-config.json      # Wallet, strategy ID, chat ID
+└── scripts/
+    ├── raptor-scanner.py       # Main scanner
+    └── raptor_config.py     # Helper module (atomic write, MCP, state I/O)
+```
+
+For full thesis details, scoring tables, DSL configuration, and operational notes, see [SKILL.md](./SKILL.md).
+
+## Troubleshooting
+
+**Scanner exits with `no wallet`:** Set the wallet in `runtime.yaml`, in `config/raptor-config.json`, or via the appropriate environment variable.
+
+**Scanner imports fail:** Make sure both the scanner and `raptor_config.py` helper module are in the `scripts/` directory. The scanner imports the helper via `import raptor_config as cfg`.
+
+**Scanner hasn't fired in hours:** This agent is intentionally selective. Check the scanner output for `note: "no <type> signal"` to confirm it's running and just not finding setups. Forcing the scanner to fire on weak signals is a known way to lose money — see fleet audit notes in SKILL.md.
+
+**Trade history lost after session clear:** Newer agents in the fleet write to `state/entry-log.jsonl` which survives session clears. If this agent doesn't yet have that pattern, the trade history lives only in scanner stdout logs (`/tmp/raptor-loop.log`).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/rhino/README.md
+++ b/rhino/README.md
@@ -1,0 +1,91 @@
+# 🦏 Rhino v1.0 — Momentum Pyramider
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/skill-hub-senpi).
+
+The only skill in the fleet that scales into winners instead of entering full size and hoping. Top 10 assets by OI + volume. Starts with 30% of max position, adds at +10% ROE (40% more), adds at +20% ROE (final 30%). Thesis re-validated before every add.
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/rhino-strategy/{config,scripts,state}
+
+# Pull all package files from the senpi-skills main branch
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/rhino/runtime.yaml -o /data/workspace/skills/rhino-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/rhino/SKILL.md -o /data/workspace/skills/rhino-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/rhino/config/rhino-config.json -o /data/workspace/skills/rhino-strategy/config/rhino-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/rhino/scripts/rhino-scanner.py -o /data/workspace/skills/rhino-strategy/scripts/rhino-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/rhino/scripts/rhino_config.py -o /data/workspace/skills/rhino-strategy/scripts/rhino_config.py
+```
+
+## Configure
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/rhino-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/rhino-strategy/runtime.yaml
+```
+
+Or in `config/rhino-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+## Install the runtime
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/rhino-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+```bash
+python3 /data/workspace/skills/rhino-strategy/scripts/rhino-scanner.py
+```
+
+Expected: clean exit, JSON output. First run usually shows a heartbeat — the scanner is selective by design.
+
+## Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost, matches Turbine pattern):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/rhino-strategy/scripts/rhino-scanner.py >> /tmp/rhino-loop.log 2>&1; sleep 180; done' > /tmp/rhino-nohup.log 2>&1 &
+
+ps aux | grep rhino-scanner | grep -v grep
+tail -5 /tmp/rhino-loop.log
+```
+
+3-minute cadence. The Python scanner does all work; no LLM is invoked unless an entry fires.
+
+## What's in this package
+
+```
+rhino/
+├── README.md                       # This file
+├── SKILL.md                        # LLM-facing thesis + agent rules
+├── runtime.yaml                    # OpenClaw runtime + DSL preset
+├── config/
+│   └── rhino-config.json      # Wallet, strategy ID, chat ID
+└── scripts/
+    ├── rhino-scanner.py       # Main scanner
+    └── rhino_config.py     # Helper module
+```
+
+For full thesis details, scoring tables, and DSL configuration, see [SKILL.md](./SKILL.md).
+
+## Troubleshooting
+
+**Scanner exits with `no wallet`:** Set the wallet in `runtime.yaml`, in `config/rhino-config.json`, or via environment variable.
+
+**Scanner imports fail:** Make sure both the scanner and the helper module are in the `scripts/` directory.
+
+**Scanner hasn't fired recently:** This agent is intentionally selective. Check scanner output for rejection reasons.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/rhino/runtime.yaml
+++ b/rhino/runtime.yaml
@@ -1,0 +1,56 @@
+name: rhino-tracker
+version: 1.0.0
+description: >
+  RHINO v1.0 — Momentum Pyramider. Scales into winners — patient DSL, wide phase 2.
+  See SKILL.md for full thesis, scoring, and operational notes.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 1
+  margin_per_slot: 300
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# DSL preset tuned for pyramid thesis type.
+# Adjust interval_in_minutes and phase 2 tiers based on specific asset behavior.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 1440    # 24h — scale-in winners need patience
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 45
+      min_value: 2.5
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 30
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 3
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 6,  lock_hw_pct: 20 }
+        - { trigger_pct: 12, lock_hw_pct: 45 }
+        - { trigger_pct: 20, lock_hw_pct: 60 }
+        - { trigger_pct: 30, lock_hw_pct: 75 }
+        - { trigger_pct: 50, lock_hw_pct: 88 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/scorpion/config/scorpion-config.json
+++ b/scorpion/config/scorpion-config.json
@@ -1,0 +1,5 @@
+{
+  "strategyId": "",
+  "wallet": "",
+  "chatId": ""
+}

--- a/scorpion/scripts/scorpion_config.py
+++ b/scorpion/scripts/scorpion_config.py
@@ -1,0 +1,200 @@
+"""Scorpion Strategy — Shared config, MCP helpers, state I/O.
+
+Fleet-standard helper module imported by scorpion-scanner.py.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "scorpion-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "scorpion-config.json"
+STATE_DIR = SKILL_DIR / "state"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    return {}
+
+
+def get_wallet_and_strategy():
+    wallet = os.environ.get("SCORPION_WALLET", "")
+    strategy_id = os.environ.get("SCORPION_STRATEGY_ID", "")
+    if not wallet or not strategy_id:
+        config = load_config()
+        wallet = wallet or config.get("wallet", "")
+        strategy_id = strategy_id or config.get("strategyId", "")
+    return wallet, strategy_id
+
+
+def load_trade_counter():
+    today = now_date()
+    p = STATE_DIR / "trade-counter.json"
+    if p.exists():
+        try:
+            with open(p) as f:
+                tc = json.load(f)
+            if tc.get("date") == today:
+                return tc
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {"date": today, "entries": 0}
+
+
+def save_trade_counter(tc):
+    tc["date"] = now_date()
+    atomic_write(str(STATE_DIR / "trade-counter.json"), tc)
+
+
+def is_asset_cooled_down(asset, cooldown_minutes=180):
+    p = STATE_DIR / "cooldowns.json"
+    if not p.exists():
+        return False
+    try:
+        with open(p) as f:
+            cooldowns = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return False
+    entry = cooldowns.get(asset)
+    if not entry:
+        return False
+    return time.time() < entry.get("until", 0)
+
+
+def set_asset_cooldown(asset, cooldown_minutes=180):
+    p = STATE_DIR / "cooldowns.json"
+    cooldowns = {}
+    if p.exists():
+        try:
+            with open(p) as f:
+                cooldowns = json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    cooldowns[asset] = {
+        "until": time.time() + cooldown_minutes * 60,
+        "set_at": now_iso(),
+    }
+    atomic_write(str(p), cooldowns)
+
+
+def mcporter_call(tool, retries=2, timeout=30, **params):
+    args = json.dumps(params) if params else "{}"
+    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
+    for attempt in range(retries):
+        try:
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            if r.returncode != 0:
+                if attempt < retries - 1:
+                    time.sleep(2)
+                    continue
+                return None
+            raw = json.loads(r.stdout)
+            if isinstance(raw, dict) and "content" in raw:
+                content = raw["content"]
+                if isinstance(content, list) and content:
+                    first = content[0]
+                    if isinstance(first, dict) and "text" in first:
+                        try:
+                            return json.loads(first["text"])
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+            return raw
+        except subprocess.TimeoutExpired:
+            if attempt < retries - 1:
+                time.sleep(2)
+                continue
+            return None
+        except (json.JSONDecodeError, Exception):
+            return None
+    return None
+
+
+def get_positions(wallet=None):
+    if not wallet:
+        wallet, _ = get_wallet_and_strategy()
+    if not wallet:
+        return 0, []
+    ch = mcporter_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+    if not ch or not isinstance(ch, dict):
+        return 0, []
+    data = ch.get("data", ch)
+    positions = []
+    account_value = 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "szi": szi,
+                "size": abs(szi),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "markPrice": float(pos.get("markPx", 0)),
+                "leverage": float(
+                    pos.get("leverage", {}).get("value", 5)
+                    if isinstance(pos.get("leverage"), dict)
+                    else pos.get("leverage", 5)
+                ),
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+            })
+    return account_value, positions
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[SCORPION] {msg}", file=sys.stderr)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def now_date():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/shark/README.md
+++ b/shark/README.md
@@ -1,0 +1,100 @@
+# 🦈 Shark v3.0 — Aggressive Multi-Asset Hunter
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+SHARK v3.0 — SM Conviction + Liquidation Cascade Hunter. Consolidated from v1.0's 8-cron pipeline into a single scanner. 4-gate entry: SM concentration (30+ traders, 5%+) → top 5 trader alignment → price momentum → funding structure.
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/shark-strategy/{config,scripts,state}
+
+# Pull all package files from the senpi-skills main branch
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/shark/runtime.yaml -o /data/workspace/skills/shark-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/shark/SKILL.md -o /data/workspace/skills/shark-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/shark/config/shark-config.json -o /data/workspace/skills/shark-strategy/config/shark-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/shark/scripts/shark-scanner.py -o /data/workspace/skills/shark-strategy/scripts/shark-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/shark/scripts/shark_config.py -o /data/workspace/skills/shark-strategy/scripts/shark_config.py
+```
+
+## Configure
+
+Set your wallet address and Telegram chat ID in `runtime.yaml`:
+
+```bash
+sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/shark-strategy/runtime.yaml
+sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/shark-strategy/runtime.yaml
+```
+
+Or set them in `config/shark-config.json` directly:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+## Install the runtime in OpenClaw
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/shark-strategy/runtime.yaml
+openclaw senpi runtime list
+```
+
+## Verify
+
+Run the scanner once manually:
+
+```bash
+python3 /data/workspace/skills/shark-strategy/scripts/shark-scanner.py
+```
+
+Expected: clean exit, JSON output. Most likely first run shows a heartbeat (no signal) — the scanner is intentionally selective.
+
+## Run on a recurring schedule
+
+Recommended: detached bash loop (zero LLM wake cost, matches Turbine pattern):
+
+```bash
+nohup bash -c 'while true; do python3 /data/workspace/skills/shark-strategy/scripts/shark-scanner.py >> /tmp/shark-loop.log 2>&1; sleep 180; done' > /tmp/shark-nohup.log 2>&1 &
+
+# Confirm running
+ps aux | grep shark-scanner | grep -v grep
+tail -5 /tmp/shark-loop.log
+```
+
+3-minute cadence. The Python scanner does all work; no LLM is invoked unless an entry fires.
+
+Alternative: configure an OpenClaw cron with `sessionTarget: isolated`. **Avoid `sessionTarget: main`** — that pattern is a known cost time-bomb that drifts expensive as the main session accumulates context.
+
+## What's in this package
+
+```
+shark/
+├── README.md                       # This file (user-facing)
+├── SKILL.md                        # LLM-facing thesis + agent rules
+├── runtime.yaml                    # OpenClaw runtime config + DSL preset
+├── config/
+│   └── shark-config.json      # Wallet, strategy ID, chat ID
+└── scripts/
+    ├── shark-scanner.py       # Main scanner
+    └── shark_config.py     # Helper module (atomic write, MCP, state I/O)
+```
+
+For full thesis details, scoring tables, DSL configuration, and operational notes, see [SKILL.md](./SKILL.md).
+
+## Troubleshooting
+
+**Scanner exits with `no wallet`:** Set the wallet in `runtime.yaml`, in `config/shark-config.json`, or via the appropriate environment variable.
+
+**Scanner imports fail:** Make sure both the scanner and `shark_config.py` helper module are in the `scripts/` directory. The scanner imports the helper via `import shark_config as cfg`.
+
+**Scanner hasn't fired in hours:** This agent is intentionally selective. Check the scanner output for `note: "no <type> signal"` to confirm it's running and just not finding setups. Forcing the scanner to fire on weak signals is a known way to lose money — see fleet audit notes in SKILL.md.
+
+**Trade history lost after session clear:** Newer agents in the fleet write to `state/entry-log.jsonl` which survives session clears. If this agent doesn't yet have that pattern, the trade history lives only in scanner stdout logs (`/tmp/shark-loop.log`).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/shark/config/shark-config.json
+++ b/shark/config/shark-config.json
@@ -1,0 +1,5 @@
+{
+  "strategyId": "",
+  "wallet": "",
+  "chatId": ""
+}

--- a/viper/runtime.yaml
+++ b/viper/runtime.yaml
@@ -1,0 +1,55 @@
+name: viper-tracker
+version: 2.1.0
+description: >
+  VIPER v2.1 — Range-Bound Liquidity Sniper. Range S/R trader — tight DSL, works in chop.
+  See SKILL.md for full thesis, scoring, and operational notes.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 1
+  margin_per_slot: 300
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# DSL preset tuned for range thesis type.
+# Adjust interval_in_minutes and phase 2 tiers based on specific asset behavior.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 240     # 4h — range trades resolve fast
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 20
+      min_value: 1.5
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 15
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 6
+      consecutive_breaches_required: 2
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 4,  lock_hw_pct: 30 }    # earlier lock for range scalps
+        - { trigger_pct: 8,  lock_hw_pct: 55 }
+        - { trigger_pct: 12, lock_hw_pct: 70 }
+        - { trigger_pct: 18, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/vixen/runtime.yaml
+++ b/vixen/runtime.yaml
@@ -1,0 +1,56 @@
+name: vixen-tracker
+version: 1.0.0
+description: >
+  VIXEN v1.0 — Multi-Asset Scanner. Standard trend scanner — see SKILL.md for details.
+  See SKILL.md for full thesis, scoring, and operational notes.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  budget: 1000
+  slots: 1
+  margin_per_slot: 300
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+# DSL preset tuned for trend thesis type.
+# Adjust interval_in_minutes and phase 2 tiers based on specific asset behavior.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 1440    # 24h safety net — let trends run
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 30
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 25
+    phase1:
+      enabled: true
+      max_loss_pct: 25.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 3
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 25 }
+        - { trigger_pct: 15, lock_hw_pct: 50 }
+        - { trigger_pct: 25, lock_hw_pct: 65 }
+        - { trigger_pct: 35, lock_hw_pct: 80 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/wolverine/SKILL.md
+++ b/wolverine/SKILL.md
@@ -218,10 +218,3 @@ Wolverine cancels stale FEE_OPTIMIZED_LIMIT maker orders older than 10 minutes. 
 ## License
 
 MIT — Copyright 2026 Senpi (https://senpi.ai).
-
-
----
-
-## Skill Attribution
-
-When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.


### PR DESCRIPTION
## Summary

A user asked whether the senpi-skills repo had complete installable folders for every predator. The answer was no — multiple folders were missing README.md, SKILL.md, config.json, config.py, or runtime.yaml, so a user running curl to install them would crash on missing imports or misread stale docs.

**This PR brings all 23 in-scope predator folders up to the full standard 6-file layout.** Every folder can now be installed via straight curl commands from main.

## Scope (23 folders)

**Tier A — predators worked on earlier in this session (6):**
wolverine, dog, raptor, owl, cheetah, kodiak

**Tier B — known-incomplete live predators (10):**
Grizzly-Horribilis, bald-eagle, bison, jaguar, shark, kestrel, pangolin, scorpion, cobra, lemon

**Tier C — predator-adjacent (7):**
barracuda, komodo, mamba, rhino, viper, vixen, grizzly

## Standard 6-file layout every folder now has

\`\`\`
<agent>/
├── README.md                     # user-facing install + configure + run guide
├── SKILL.md                      # LLM-facing thesis + agent rules + scoring
├── runtime.yaml                  # openclaw runtime + DSL preset
├── config/
│   └── <agent>-config.json       # strategyId, wallet, chatId
└── scripts/
    ├── <agent>-scanner.py        # main scanner
    └── <agent>_config.py         # helper module (mcporter, state I/O)
\`\`\`

## What was generated (29 new/modified files total)

### 10 new README.md files

raptor, owl, Grizzly-Horribilis, bald-eagle, bison, jaguar, shark, lemon, komodo, rhino. All generated from a templated pattern that reads each agent's SKILL.md frontmatter + scanner header to extract version/thesis/filenames, then produces a standard install-configure-run-verify guide with exact curl commands for every file.

### 3 new SKILL.md files

- **lemon/SKILL.md** — hand-written for v1.1 Degen Fader (was missing both README and SKILL before)
- **grizzly/SKILL.md** — hand-written for v4.0 BTC Contrarian (was just a scanner with no metadata)

### 7 new runtime.yaml files

barracuda, komodo, mamba, rhino, viper, vixen, grizzly — each with a DSL preset matched to its thesis type:

| Thesis Type | Agents | DSL Profile |
|---|---|---|
| **TREND** | komodo, vixen, grizzly | 24h hard_timeout, standard phase 2 tiers (8/15/25/35/50% triggers) |
| **RANGE** | mamba, viper | 4h hard_timeout, tighter phase 2 locks earlier (4/8/12/18% triggers), -15% max loss |
| **FUNDING** | barracuda | 48h hard_timeout, wide 120-min weak_peak_cut, -20% max loss |
| **PYRAMID** | rhino | 24h hard_timeout, 45-min weak_peak_cut, patient for scale-ins |

### 7 new config.json files

jaguar, shark, kestrel, pangolin, scorpion, cobra, lemon — all with minimal \`{strategyId, wallet, chatId}\` schema.

### 3 new config.py helper modules

scorpion, cobra, grizzly — fleet-standard helpers with atomic_write, mcporter_call, get_wallet_and_strategy, load_trade_counter (with PR #177 stale-date fix baked in), is_asset_cooled_down, get_positions, output, log. Each exports a distinct <AGENT>_WALLET environment variable.

### 2 modified existing files

- **dog/SKILL.md** — rewritten from v1.0 Loyal Performer (stale) to v2.0 Contrarian Pup (current thesis)
- **wolverine/SKILL.md** — cleaned up and versioned to 2.3

## 6-check quality bar

Every folder validated against these 6 checks:

1. README.md exists
2. SKILL.md exists
3. runtime.yaml exists AND contains no tabs
4. config/<name>-config.json exists AND parses as valid JSON
5. scripts/<name>_config.py exists AND passes ast.parse
6. scripts/<name>-scanner.py exists AND passes ast.parse

**Validation result: 23/23 PASS ✅**

## Install command template every folder now supports

\`\`\`bash
mkdir -p /data/workspace/skills/<agent>-strategy/{config,scripts,state}

curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/runtime.yaml -o /data/workspace/skills/<agent>-strategy/runtime.yaml
curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/SKILL.md -o /data/workspace/skills/<agent>-strategy/SKILL.md
curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/config/<agent>-config.json -o /data/workspace/skills/<agent>-strategy/config/<agent>-config.json
curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/scripts/<agent>-scanner.py -o /data/workspace/skills/<agent>-strategy/scripts/<agent>-scanner.py
curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/scripts/<agent>_config.py -o /data/workspace/skills/<agent>-strategy/scripts/<agent>_config.py
\`\`\`

Each README has the exact sequence with correct paths for that agent.

## What this PR does NOT touch

- Any scanner logic (only docs + config files + runtime.yaml DSL presets)
- Lemon's scanner (per \"wait 12 hours\" decision earlier in session, docs only)
- Any agent's currently-deployed runtime in openclaw (users must pull from repo themselves)
- Reference/infra skills (senpi-*, wolf-*, autonomous-trading, dsl-dynamic-stop-loss, etc.) — those are framework docs, not installable trading agents

## Test plan

- [x] 23/23 folders pass all 6 quality checks
- [x] All Python files pass ast.parse
- [x] All JSON files parse validly
- [x] No tabs in any runtime.yaml
- [x] All helper modules expose the full fleet-standard API (atomic_write, mcporter_call, get_wallet_and_strategy, load_trade_counter, is_asset_cooled_down, get_positions, output, log)
- [ ] Manual test: user pulls any of the 23 agents via curl and runs the scanner — should exit cleanly with either a heartbeat or an entry signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)