### PR TITLE
fleet-fix: cheetah v5.1 + dog v2.2 — threshold recalibrations from live data

### DIFF
--- a/cheetah/config/cheetah-config.json
+++ b/cheetah/config/cheetah-config.json
@@ -2,9 +2,9 @@
   "strategyId": "",
   "wallet": "",
   "chatId": "",
-  "_version": "5.0-APEX",
-  "_description": "CHEETAH APEX — Multi-signal confluence sniper purpose-built to win the Senpi Arena. Only fires on score >= 14 (all major signals aligning). Fewer trades, higher conviction, maximum leverage, aggressive profit ratcheting.",
-  "_thesis": "The Arena rewards asymmetric ROE%, not consistency. A sniper that takes 5 high-conviction trades per week with 80% margin and 10x leverage can outperform 200-trade scalpers.",
+  "_version": "5.1-APEX",
+  "_description": "CHEETAH APEX v5.1 — Multi-signal confluence sniper purpose-built to win the Senpi Arena. Score threshold lowered from 14 to 10 based on 24h live data — max observed score was 10 (HYPE LONG), so the 14 gate was mathematically unreachable. Leverage scales by score: 10=7x, 11=8x, 12-13=9x, 14+=10x. Still the tightest gate in the fleet.",
+  "_thesis": "The Arena rewards asymmetric ROE%, not consistency. A sniper that takes 5 high-conviction trades per week with 80% margin and conviction-scaled leverage can outperform 200-trade scalpers.",
   "maxPositions": 1,
   "xyzBanned": true,
   "risk": {
@@ -13,14 +13,16 @@
     "maxDailyLossPct": 12.0
   },
   "leverage": {
-    "default": 8,
+    "default": 7,
     "tiers": [
-      {"minScore": 15, "leverage": 10},
-      {"minScore": 14, "leverage": 8}
+      {"minScore": 14, "leverage": 10},
+      {"minScore": 12, "leverage": 9},
+      {"minScore": 11, "leverage": 8},
+      {"minScore": 10, "leverage": 7}
     ]
   },
   "entry": {
-    "minScore": 14,
+    "minScore": 10,
     "marginPct": 0.80,
     "orderType": "FEE_OPTIMIZED_LIMIT",
     "ensureExecutionAsTaker": true,

--- a/cheetah/scripts/cheetah-scanner.py
+++ b/cheetah/scripts/cheetah-scanner.py
@@ -1,11 +1,30 @@
 #!/usr/bin/env python3
-# Senpi CHEETAH Scanner v5.0-APEX
+# Senpi CHEETAH Scanner v5.1-APEX
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""CHEETAH v5.0 APEX — Multi-signal confluence sniper.
+"""CHEETAH v5.1 APEX — Multi-signal confluence sniper.
 
 Purpose-built to win the Senpi Arena via asymmetric ROE% optimization.
+
+## v5.1 change — threshold recalibration
+
+v5.0 shipped with MIN_SCORE = 14 out of a max possible 15. Live data from
+24h of scanning showed the highest observed score was 10 (HYPE LONG). The
+14 threshold was mathematically unreachable in practice because the
+quality-trader-alignment gate (+3 points) rarely fires — the intersection
+of ELITE/RELIABLE traders with current SM consensus is usually empty.
+
+v5.1 lowers MIN_SCORE from 14 to 10 and introduces score-scaled leverage:
+
+  Score 10 → 7x leverage
+  Score 11 → 8x leverage
+  Score 12-13 → 9x leverage
+  Score 14-15 → 10x leverage
+
+Score 10 is still 2-3 points above the rest of the fleet's gates (most
+are 5-8), so APEX remains the tightest gate in the fleet. It just fires
+occasionally instead of never.
 
 ## Thesis
 
@@ -15,9 +34,9 @@ winning shapes exist: scalpers (100+ trades, tiny edge each) and snipers
 (the fleet is 37 red / 2 green precisely because of this). Sniping works.
 
 APEX takes the sniper path: refuse to trade unless ALL major signals align
-simultaneously (score >= 14 out of 15). 5 target trades per week hits the
-$25k volume floor at 80% margin + 10x leverage. Every trade is maximum
-conviction, maximum size, aggressive profit ratcheting.
+simultaneously (score >= 10 out of 15). 5 target trades per week hits the
+$25k volume floor at 80% margin and score-scaled leverage. Every trade is
+maximum conviction, maximum size, aggressive profit ratcheting.
 
 ## Pipeline
 
@@ -27,11 +46,11 @@ Every 3 minutes:
   3. fetch_quality_trader_positions() - cached 15 min, top 8 ELITE/RELIABLE
   4. For each asset that passes hard gates:
      - score_confluence() - add up all signals
-     - Keep if score >= 14
+     - Keep if score >= 10
   5. Pick highest score, execute via create_position (Wolverine pattern)
   6. Log entry to entry-log.jsonl (survives session clears)
 
-## Scoring (max = 15, threshold = 14)
+## Scoring (max = 15, threshold = 10)
 
   +4  SM_STRONG: pct_of_top_traders_gain >= 10% AND trader_count >= 25
   +2  VELOCITY: 15m contribution >= 1.0 OR 1h contribution >= 3.0
@@ -565,7 +584,7 @@ def run():
         cfg.output({
             "status": "ok", "heartbeat": "NO_REPLY",
             "note": f"RIDING: {coins}. DSL manages exit.",
-            "_cheetah_version": "5.0-APEX",
+            "_cheetah_version": "5.1-APEX",
         })
         return
 
@@ -577,7 +596,7 @@ def run():
         cfg.output({
             "status": "ok", "heartbeat": "NO_REPLY",
             "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%",
-            "_cheetah_version": "5.0-APEX",
+            "_cheetah_version": "5.1-APEX",
         })
         return
 
@@ -585,7 +604,7 @@ def run():
     if has_resting_orders(wallet):
         cfg.output({
             "status": "ok", "heartbeat": "NO_REPLY", "note": "resting order pending",
-            "_cheetah_version": "5.0-APEX",
+            "_cheetah_version": "5.1-APEX",
         })
         return
 
@@ -611,7 +630,7 @@ def run():
     leverage_cfg = config.get("leverage", {})
     cooldown_cfg = config.get("cooldown", {})
     cooldown_min = cooldown_cfg.get("perAssetMinutes", 240)
-    min_score = entry_cfg.get("minScore", 14)
+    min_score = entry_cfg.get("minScore", 10)
 
     candidates = []
     all_scored = []
@@ -651,7 +670,7 @@ def run():
             "status": "ok", "heartbeat": "NO_REPLY",
             "note": f"0 candidates at score >= {min_score} ({len(all_scored)} scored)",
             "topScored": top3,
-            "_cheetah_version": "5.0-APEX",
+            "_cheetah_version": "5.1-APEX",
         })
         return
 
@@ -699,7 +718,7 @@ def run():
                 "orderType": entry_cfg.get("orderType", "FEE_OPTIMIZED_LIMIT"),
             },
             "result": result,
-            "_cheetah_version": "5.0-APEX",
+            "_cheetah_version": "5.1-APEX",
         })
     else:
         error = result.get("error", "unknown") if result else "mcporter_call returned None"
@@ -715,7 +734,7 @@ def run():
             "action": "ENTRY_FAILED",
             "signal": best,
             "error": error,
-            "_cheetah_version": "5.0-APEX",
+            "_cheetah_version": "5.1-APEX",
         })
 
 

--- a/dog/scripts/dog-scanner.py
+++ b/dog/scripts/dog-scanner.py
@@ -2,7 +2,18 @@
 # Senpi DOG Scanner v1.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""DOG v2.0 — The Contrarian Pup (SM Exhaustion Fader).
+"""DOG v2.2 — The Contrarian Pup (SM Exhaustion Fader).
+
+v2.2 — EXHAUSTION GATE WIDENED.
+After v2.1 shipped with a 2.5% exhaustion gate, 24h live data on
+2026-04-15 showed Dog was taking small losses because BTC and HYPE
+trends were blowing through the 2.5% level without reversing.
+Example losses in that window:
+  HYPE SHORT -$28.61, SOL LONG -$47.72, BTC SHORT -$32.58
+The 2.5% gate was insufficient to identify genuine exhaustion in
+trending markets. v2.2 raises the gate to 4.5% — a meaningful
+overextension that requires the market to have genuinely moved too
+far before Dog will fade it.
 
 v2.0 — DIRECTION FLIP.
 Fleet analysis (April 10, 2026) found Dog's signal was perfectly inverted:
@@ -177,12 +188,17 @@ def evaluate_assets():
         # Hard gate: minimum SM engagement
         if traders < 30: continue
 
-        # CONTRARIAN EXHAUSTION GATE (v2.1)
-        # Fleet analysis April 13: Grizzly v4.0 lost $107 in 15h fading an
-        # accelerating BTC breakout. Contrarian flip without an exhaustion gate
-        # fights live trends instead of exhausted moves.
-        # Require 4H price to have already moved >2.5% in SM direction.
-        MIN_EXHAUSTION_PCT = 2.5
+        # CONTRARIAN EXHAUSTION GATE (v2.2 — widened)
+        # v2.1 shipped with 2.5% gate. Dog-reported data on 2026-04-15 showed
+        # BTC and HYPE were "blowing straight through the 2.5% exhaustion
+        # gates" — 4H moves of 2.5-3% in trending markets aren't exhaustion,
+        # they're continuation candles. Dog fires the fade, the trend
+        # continues, DSL SL fires. Result: 10-trade window, -$53 net,
+        # equity at $782 (approaching the -22% HARD STOP threshold).
+        # v2.2 raises the gate to 4.5% — a meaningful overextension in a
+        # trending market. In ranging markets Dog will still fire but on
+        # more meaningful exhaustion signals.
+        MIN_EXHAUSTION_PCT = 4.5
         if abs(p4h) < MIN_EXHAUSTION_PCT:
             continue  # Not exhausted yet — don't fight a fresh trend
         if (d == "LONG" and p4h < 0) or (d == "SHORT" and p4h > 0):
@@ -398,12 +414,12 @@ def run():
             "execution": {"asset": best["asset"], "direction": best["direction"],
                 "leverage": leverage, "margin": margin,
                 "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
-            "result": result, "_dog_version": "2.1"})
+            "result": result, "_dog_version": "2.2"})
     else:
         cfg.output({"status": "ok", "action": "ENTRY_FAILED",
             "signal": {"asset": best["asset"], "direction": best["direction"],
                 "score": best["score"], "reasons": best["reasons"]},
-            "error": result, "_dog_version": "2.1"})
+            "error": result, "_dog_version": "2.2"})
 
 if __name__ == "__main__":
     try: run()


### PR DESCRIPTION
## Summary

Two tightly-scoped single-file threshold recalibrations based on 24h of live fleet data. Both agents were underperforming because their gates were tuned wrong. Live data tells us exactly how wrong and where to re-tune.

## Cheetah APEX v5.1 — MIN_SCORE 14 → 10

**Problem:** v5.0 shipped with MIN_SCORE = 14 out of a max possible 15. Live probe data showed the highest observed score over 24 hours was **10** (HYPE LONG). The 14 threshold was mathematically unreachable because the quality-trader-alignment gate (worth 3 points) rarely fires — the intersection of ELITE/RELIABLE traders with current SM consensus direction is usually empty.

**Fix:** Lower MIN_SCORE to 10 with score-scaled leverage:

| Score | Leverage |
|---|---|
| 10 | 7x |
| 11 | 8x |
| 12-13 | 9x |
| 14-15 | 10x |

**Files changed:**
- \`cheetah/config/cheetah-config.json\` — version 5.0-APEX → 5.1-APEX, minScore 14→10, 4 leverage tiers
- \`cheetah/scripts/cheetah-scanner.py\` — version string updated, docstring documents the v5.1 rationale

**Why selectivity is preserved:** Score 10 is still 2-3 points above the rest of the fleet's MIN_SCORE gates (most agents at 5-8). APEX remains the tightest gate in the fleet; it just fires occasionally instead of never.

## Dog v2.2 — exhaustion gate 2.5% → 4.5%

**Problem:** v2.1 shipped with a 2.5% exhaustion gate (Dog only fires when 4H price has moved >2.5% in SM direction, trying to catch exhausted moves for the contrarian fade). Live data from 24h showed:

- Last 10 trades: 4 winners, 6 losers, **net -\$53**
- Equity dropped from -\$180 to -\$215 overnight (**-\$35**)
- Dog's own diagnosis: *\"the market is blowing straight through the 2.5% exhaustion gates (e.g., BTC pushing past \$74.7k, HYPE pushing past \$44.26)\"*

The 2.5% threshold was too loose for trending markets. 2.5-3% moves in a trending environment are continuation candles, not exhaustion. Dog fires the fade, the trend continues, DSL SL fires.

**Direction inversion confirmed working** — all 10 recent trades had Dog entering opposite to SM direction. The thesis code is correct. The threshold is too loose.

**Fix:** Raise MIN_EXHAUSTION_PCT from 2.5 to 4.5.

4.5% is a meaningful overextension in a trending market. Dog will fire less often but only on genuine exhaustion signals.

**Files changed:**
- \`dog/scripts/dog-scanner.py\` — version 2.1→2.2, MIN_EXHAUSTION_PCT 2.5→4.5, docstring documents v2.2 rationale

## Test plan

- [x] \`ast.parse\` valid on both Python files
- [x] JSON config valid, version string updated
- [x] Leverage tier structure validates (dict: {14→10, 12→9, 11→8, 10→7})
- [x] MIN_EXHAUSTION_PCT = 4.5 verified
- [x] Version strings updated in scanner output (\`_cheetah_version\` = \"5.1-APEX\", \`_dog_version\" = \"2.2\")
- [ ] Agents pull via curl and run scanner, confirm new version in output
- [ ] Cheetah fires at least one trade at score 10-11 within 24h (previously zero trades)
- [ ] Dog fires fewer but higher-quality trades, equity stabilizes

## Deployment

Both agents pull the single file they need from main:

\`\`\`bash
# Cheetah
curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/scripts/cheetah-scanner.py -o /data/workspace/skills/cheetah-strategy/scripts/cheetah-scanner.py
curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/config/cheetah-config.json -o /data/workspace/skills/cheetah-strategy/config/cheetah-config.json

# Dog
curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/dog/scripts/dog-scanner.py -o /data/workspace/skills/dog-strategy/scripts/dog-scanner.py
\`\`\`

No runtime changes needed. No helper module changes. Scanner restart and the next scan cycle will use the new thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)