### PR TITLE
fleet-fix: Scorpion v3.0 — Multi-Market Active Trader (Arena winner A/B Variant B)

### DIFF
--- a/scorpion/README.md
+++ b/scorpion/README.md
@@ -1,27 +1,27 @@
-# 🦂 SCORPION v2.0 — Altcoin Swarm Hunter
+# SCORPION v3.0 — Multi-Market Active Trader
 
-**The swarm forms. Scorpion picks the weakest prey.**
+**The only predator that hunts across both crypto and commodities.**
 
-Scorpion detects coordinated altcoin risk-off events and trades the highest-conviction target.
+Scorpion trades BOTH the main Hyperliquid DEX (crypto) and the XYZ DEX (commodities/indices) using SM concentration + 4H price trend alignment. Arena winner #2/#3 playbook.
 
 ## Quick Stats
-- **Strategy**: Detect altcoin swarms (5+ alts with SM >2%), trade the best one
-- **Margin**: $350 per trade (35% of $1K budget)
-- **Leverage**: 5x (altcoin typical), up to 10x on select mid-caps
-- **Entry threshold**: Swarm confirmed + Score 5/8
-- **Max positions**: 1 at a time
-- **Timeout**: 240 minutes (altcoin trends develop slowly)
-- **Daily cap**: 3 entries, 90-min cooldown
-- **Order type**: FEE_OPTIMIZED_LIMIT (maker first)
+- **Strategy**: SM trend-following across crypto + XYZ DEX
+- **Universe**: BTC, ETH, SOL, HYPE, ZEC, LIT, GRASS, FARTCOIN, TAO, ONDO, SUI, ARB, WLD, DOGE, AVAX + xyz:CL, xyz:BRENTOIL, xyz:GOLD, xyz:SPX
+- **Margin**: 30% per position (3 x 30% = 90% max exposure)
+- **Leverage**: 5-10x (score-scaled)
+- **Entry threshold**: Score 6+ (SM + trend + velocity + depth)
+- **Max positions**: 3 concurrent
+- **Hard timeout**: 720 minutes (12 hours)
+- **Daily cap**: 6 entries, 120-min per-asset cooldown
+- **Order type**: FEE_OPTIMIZED_LIMIT with ensureExecutionAsTaker
 
-## The Swarm Signal
-When 5+ non-major altcoins simultaneously attract SM SHORT concentration >2%, something systemic is happening. This coordinated pattern is higher conviction than any single asset signal.
+## What Makes This Different
+No other Senpi predator trades XYZ DEX assets. Scorpion v3.0 trades crude oil, Brent, gold, and SPX alongside crypto — capturing opportunities across uncorrelated markets.
 
-## What It Trades
-Assets that no other Predator touches: LIT, TAO, MON, FARTCOIN, VVV, ZRO, CC, AVAX, XMR, PUMP, and more. These are the altcoins generating the most SM PnL on Hyperliquid.
-
-## Complementary to Cobra
-Cobra trades the #1 SM asset (usually BTC/ETH/HYPE). Scorpion trades the #1 altcoin within a confirmed swarm. They never overlap and can run simultaneously.
+## XYZ DEX Handling
+- XYZ assets use `xyz:` prefix in create_position calls (e.g., `coin="xyz:CL"`)
+- XYZ assets require `leverageType="ISOLATED"`
+- XYZ price thresholds are lower (commodities move 0.5-3% in 4h vs 1-5% for crypto)
 
 ## Install
 See [SKILL.md](SKILL.md) for full setup instructions.

--- a/scorpion/SKILL.md
+++ b/scorpion/SKILL.md
@@ -1,128 +1,96 @@
 ---
 name: scorpion-strategy
 description: >-
-  SCORPION v2.0 — Altcoin Swarm Hunter. Detects coordinated risk-off
-  events where 5+ altcoins simultaneously attract SM concentration,
-  then trades the highest-conviction target within the swarm.
+  SCORPION v3.0 — Multi-Market Active Trader. Trades BOTH crypto AND XYZ
+  DEX commodities/indices using SM concentration + 4H trend alignment.
+  Up to 3 concurrent positions, short holds, Arena winner playbook.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "2.0"
+  version: "3.0"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🦂 SCORPION v2.0 — Altcoin Swarm Hunter
+# SCORPION v3.0 — Multi-Market Active Trader
 
-The swarm forms. Scorpion picks the weakest prey.
+The only predator that hunts across both crypto and commodities.
 
 ## The Thesis
 
-When SM goes risk-off, altcoins dump in a correlated swarm. The top traders
-on Hyperliquid make their biggest returns not on BTC/ETH, but on altcoin
-SHORTs: LIT, TAO, MON, FARTCOIN, VVV, ZRO, CC.
+Arena winners #2 and #3 share a playbook: trade across BOTH the main Hyperliquid
+DEX (crypto) AND the XYZ DEX (commodities, indices), follow SM direction with 4H
+price trend confirmation, hold for hours not days, and run multiple positions
+simultaneously.
 
-On April 3, 2026, trader 0x039c was up **99.8% in 4 hours** with 33 positions.
-Biggest winners were all altcoin SHORTs: LIT +$11.6K, FARTCOIN +$6.3K,
-TAO +$4.9K. The same day, the SM leaderboard showed 7+ altcoins simultaneously
-at >2% SM SHORT concentration — a clear coordinated swarm.
+No other Senpi predator trades both markets. Scorpion v3.0 fills that gap.
 
-**No current agent detects this pattern.** Our agents evaluate assets individually.
-Scorpion detects the *meta-pattern* first — then picks the best target.
+### Universe
 
-### The Data Advantage
+| Market | Assets |
+|---|---|
+| Crypto majors | BTC, ETH, SOL, HYPE |
+| Crypto mid-caps | ZEC, LIT, GRASS, FARTCOIN, TAO, ONDO, SUI, ARB, WLD, DOGE, AVAX |
+| XYZ commodities | CL (crude oil), BRENTOIL, GOLD |
+| XYZ indices | SPX |
 
-| Signal | What it means | Who uses it |
+### What Makes This Different
+
+| Feature | Most Predators | Scorpion v3.0 |
 |---|---|---|
-| SM concentration on BTC | Smart money is trading BTC | Grizzly, Cobra |
-| SM concentration on HYPE | Smart money is trading HYPE | Cheetah |
-| SM concentration on ETH | Smart money is trading ETH | Polar |
-| **5+ altcoins all SM SHORT** | **Coordinated risk-off event** | **Only Scorpion** |
+| Markets | Crypto only | Crypto + XYZ DEX |
+| Max positions | 1 | 3 concurrent |
+| Hold time | Hours to days | Hours (12h max) |
+| Daily entries | 2-4 | Up to 6 |
+| Direction | Fixed or contrarian | Signal-driven both ways |
 
-## ⛔ CRITICAL AGENT RULES
+## CRITICAL AGENT RULES
 ### RULE 1: Install path is `/data/workspace/skills/scorpion-strategy/`
 ### RULE 2: THE SCANNER DOES NOT EXIT POSITIONS — DSL only.
-### RULE 3: MAX 1 POSITION at a time.
-### RULE 4: MAX 3 ENTRIES PER DAY. 90-minute cooldown. 120-minute per-asset cooldown.
-### RULE 5: Must detect swarm (5+ altcoins) BEFORE evaluating individual targets.
-### RULE 6: XYZ equities are BANNED from trading.
-### RULE 7: Major assets (BTC, ETH, SOL, HYPE) are EXCLUDED — those are Cobra's territory.
-### RULE 8: USE FEE_OPTIMIZED_LIMIT for all entries.
+### RULE 3: MAX 3 POSITIONS at a time.
+### RULE 4: MAX 6 ENTRIES PER DAY. 120-minute per-asset cooldown.
+### RULE 5: XYZ assets use "xyz:" prefix for create_position (e.g. coin="xyz:CL").
+### RULE 6: XYZ assets require leverageType="ISOLATED".
+### RULE 7: USE FEE_OPTIMIZED_LIMIT for all entries with ensureExecutionAsTaker=true.
 
 ## Scanner Logic (1 API call)
 
 ```
 1. leaderboard_get_markets (limit=100)
 
-STEP 1 — SWARM DETECTION:
-   → Count non-major, non-XYZ altcoins with SM >2% in each direction
-   → If SHORT count >= 5: SHORT swarm confirmed
-   → If LONG count >= 5: LONG swarm confirmed
-   → If neither: NO TRADE (no coordinated event)
+For each asset in the universe (crypto + XYZ):
+  - Check SM direction and concentration
+  - Check 4H price alignment with SM direction
+    (crypto: >= 1.0%, XYZ: >= 0.5%)
+  - Score: SM concentration + 4H trend + 15m velocity +
+           1H acceleration + trader depth + 4H conviction
+  - MIN_SCORE: 6
 
-STEP 2 — TARGET SELECTION (only if swarm confirmed):
-   → Score each altcoin in the swarm:
-     - Swarm Size: >=7 = +2, >=5 = +1
-     - SM Concentration: >10% = +2, >5% = +1
-     - Price Confirmation: >1% in direction = +2, >0.5% = +1
-     - Trader Count: >=50 = +1
-     - Contribution Velocity: >3% = +1
-
-   MIN_SCORE: 5/8
-
-   → Pick highest-scoring target
-   → ENTER with $350 margin, 5x leverage, FEE_OPTIMIZED_LIMIT
+Pick up to (3 - current_positions) best candidates.
+Enter with 30% margin, 5-10x leverage (score-scaled).
 ```
 
-## DSL Configuration (Altcoin-Optimized)
-
-Altcoins are more volatile than majors. They need wider stops and more time.
+## DSL Configuration (Short-Hold Profile)
 
 **Phase 1 (Loss Protection):**
-- Max loss: -20% (wider than Cobra's -15% — alts bounce harder)
-- Retrace from high water: 10% (alts retrace 5-8% before continuing)
+- Max loss: -15%
+- Retrace from high water: 8%
 - 3 consecutive breaches required
-- Phase 1 max time: 45 minutes
 
-**Phase 2 (Profit Locking — let altcoin trends develop):**
-- +5% → lock 20% (very loose — let it run)
-- +10% → lock 40%
-- +15% → lock 55%
-- +20% → lock 70%
-- +30% → lock 82%
-- +50% → lock 90% (huge winners get maximum room)
+**Phase 2 (Profit Locking):**
+- +5% -> lock 20%
+- +10% -> lock 40%
+- +15% -> lock 60%
+- +20% -> lock 75%
+- +30% -> lock 85%
+- +50% -> lock 90%
 
 **Timeouts:**
-- Hard timeout: 240 minutes (4 hours — altcoin moves are slower to develop)
-- Weak peak cut: 90 minutes at +3% minimum
-- Dead weight cut: 45 minutes
-
-## Why This Works
-
-1. **Pattern detection > single-asset detection.** When 7 altcoins simultaneously
-   attract SM SHORT concentration, something systemic is happening. Individual
-   signals might be noise. Correlated signals are conviction.
-
-2. **Untapped altcoin alpha.** No other Predator agent trades LIT, TAO, MON,
-   FARTCOIN, VVV, ZRO, or CC. These are the assets generating the most SM PnL
-   right now. We're leaving the highest-ROE trades on the table.
-
-3. **Higher move magnitude.** BTC moves 0.2% in 4 hours. LIT moves 3.1%. At the
-   same leverage, the altcoin trade has 15x the ROE impact.
-
-4. **Complementary to Cobra.** Cobra trades the #1 SM asset (usually a major).
-   Scorpion trades the #1 altcoin within a confirmed swarm. They never overlap.
-
-## ROE Math
-
-$350 margin × 5x leverage = $1,750 notional position
-LIT drops 3% (today's actual move): $1,750 × 0.03 = $52.50 profit
-$52.50 / $1,000 account = **5.25% ROE per trade**
-
-With 3 entries/day over 5 remaining Arena days = 15 potential trades.
-Need 4 winners at 5%+ each = **+20% weekly ROE** with room for losers.
+- Hard timeout: 720 minutes (12 hours)
+- Weak peak cut: 60 minutes at +3% minimum
+- Dead weight cut: 30 minutes
 
 ## Runtime Setup
 ```bash
@@ -136,7 +104,7 @@ openclaw senpi runtime list && openclaw senpi status
 Verify runtime + status + scanner cron (90s, main).
 CRITICAL: The cron must be configured to call `create_position` via Senpi MCP
 when the scanner outputs a signal with an entry block.
-Send: "🦂 SCORPION v2.0 online. Swarm hunter. Watching for coordinated altcoin risk-off."
+Send: "SCORPION v3.0 online. Multi-market active trader. Hunting crypto + XYZ."
 
 ## License
 MIT — Built by Senpi (https://senpi.ai).

--- a/scorpion/config/scorpion-state.json
+++ b/scorpion/config/scorpion-state.json
@@ -1,10 +1,8 @@
 {
-  "date": "2026-04-03",
-  "entries_today": 1,
-  "last_entry_time": "2026-04-03T20:02:40.635254+00:00",
-  "last_asset": "LIT",
-  "last_direction": "SHORT",
-  "asset_cooldowns": {
-    "LIT": "2026-04-03T20:02:40.635254+00:00"
-  }
+  "date": "",
+  "entries_today": 0,
+  "last_entry_time": null,
+  "last_asset": null,
+  "last_direction": null,
+  "asset_cooldowns": {}
 }

--- a/scorpion/references/skill-attribution.md
+++ b/scorpion/references/skill-attribution.md
@@ -4,7 +4,7 @@ When calling `strategy_create` or `strategy_create_custom_strategy`, always incl
 
 ```json
 "skill_name": "scorpion",
-"skill_version": "2.0"
+"skill_version": "3.0"
 ```
 
 This is required for attribution and tracking. Example:
@@ -13,10 +13,10 @@ This is required for attribution and tracking. Example:
 {
   "tool": "strategy_create_custom_strategy",
   "args": {
-    "initialBudget": 500,
+    "initialBudget": 1000,
     "positions": [],
     "skill_name": "scorpion",
-    "skill_version": "2.0"
+    "skill_version": "3.0"
   }
 }
 ```

--- a/scorpion/runtime.yaml
+++ b/scorpion/runtime.yaml
@@ -1,65 +1,68 @@
 name: scorpion-tracker
-version: 1.0.0
+version: 3.0.0
 description: >
-  SCORPION v2.0 — Altcoin Swarm Hunter. Detects coordinated risk-off
-  events where 5+ altcoins simultaneously attract SM SHORT concentration,
-  then trades the highest-conviction target. Wide DSL for volatile alts.
+  SCORPION v3.0 — Multi-Market Active Trader. Trades BOTH crypto AND XYZ
+  DEX commodities/indices using SM concentration + 4H trend alignment.
+  Up to 3 concurrent positions, 5-10x leverage, 12-hour max hold.
+  Arena winner #2/#3 playbook.
 
+# -- STRATEGY --
 strategy:
   wallet: "${WALLET_ADDRESS}"
   budget: 1000
-  slots: 1
-  margin_per_slot: 350
+  slots: 3
+  margin_per_slot: 300
   enabled: true
 
+# -- SCANNERS --
 scanners:
   - name: position_tracker
     type: position_tracker
     interval: 10s
 
+# -- ACTIONS --
 actions:
   - name: position_tracker_action
     action_type: POSITION_TRACKER
     decision_mode: rule
     scanners: [position_tracker]
 
-# DSL: Extra-wide for altcoin volatility
-# Altcoins move 3-10% in 4 hours — need room to breathe
-# Phase 1 retrace 10% because alts bounce hard before continuing
-# Phase 2 starts at +5% and lets massive winners run to +50%
-# 240min (4 hour) timeout — altcoin trends develop slower than majors
-#
-# NOTE: FEE_OPTIMIZED_LIMIT is specified in the scanner entry block.
-# The agent must pass orderType: FEE_OPTIMIZED_LIMIT when calling
-# create_position.
+# -- EXIT (DSL) --
+# Short-hold profile for active multi-market trading.
+# Dead weight cut at 30 min — kill losers fast, free up slots.
+# Weak peak cut at 60 min — don't let small winners decay.
+# Hard timeout at 720 min (12h) — forced rotation, not a buy-and-hold.
+# Phase 1 max loss 15% — standard fleet tightness.
+# Phase 2 starts at +5% with standard tier progression.
 exit:
   engine: dsl
   interval_seconds: 30
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 240
+      interval_in_minutes: 720
     weak_peak_cut:
       enabled: true
-      interval_in_minutes: 90
+      interval_in_minutes: 60
       min_value: 3.0
     dead_weight_cut:
       enabled: true
-      interval_in_minutes: 45
+      interval_in_minutes: 30
     phase1:
       enabled: true
-      max_loss_pct: 20.0
-      retrace_threshold: 10
+      max_loss_pct: 15.0
+      retrace_threshold: 8
       consecutive_breaches_required: 3
     phase2:
       enabled: true
       tiers:
         - { trigger_pct: 5,  lock_hw_pct: 20 }
         - { trigger_pct: 10, lock_hw_pct: 40 }
-        - { trigger_pct: 15, lock_hw_pct: 55 }
-        - { trigger_pct: 20, lock_hw_pct: 70 }
-        - { trigger_pct: 30, lock_hw_pct: 82 }
+        - { trigger_pct: 15, lock_hw_pct: 60 }
+        - { trigger_pct: 20, lock_hw_pct: 75 }
+        - { trigger_pct: 30, lock_hw_pct: 85 }
         - { trigger_pct: 50, lock_hw_pct: 90 }
 
+# -- NOTIFICATIONS --
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/scorpion/scripts/scorpion-scanner.py
+++ b/scorpion/scripts/scorpion-scanner.py
@@ -1,558 +1,431 @@
 #!/usr/bin/env python3
-"""
-SCORPION v2.0 — Altcoin Swarm Hunter
+# Senpi SCORPION Scanner v3.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""SCORPION v3.0 — Multi-Market Active Trader.
 
-PURPOSE: Detect coordinated altcoin risk-off events (swarms) where 5+
-non-major altcoins simultaneously attract SM SHORT concentration, then
-trade the highest-conviction target within the swarm.
+Arena winner #2/#3 playbook: trade BOTH crypto AND XYZ DEX commodities,
+signal-driven LONG and SHORT, up to 3 concurrent positions, short holds.
 
-THESIS: When SM goes risk-off, altcoins dump in a correlated swarm.
-Top SM traders make the most money on altcoin SHORTs (LIT, TAO, MON,
-FARTCOIN, VVV, ZRO), not on BTC/ETH. No current agent detects the
-*pattern* of simultaneous altcoin SM convergence. That pattern is the
-highest-conviction signal in the Hyperfeed.
+This is the only Senpi predator that trades both markets simultaneously.
+Crypto majors + mid-caps + XYZ commodities/indices in one universe.
 
-Evidence from April 3, 2026: Trader 0x039c was up 99.8% in 4 hours
-with 33 positions, biggest winners all altcoin SHORTs: LIT +$11.6K,
-SOL +$10K, FARTCOIN +$6.3K, TAO +$4.9K.
+Universe:
+  Crypto: BTC, ETH, SOL, HYPE, ZEC, LIT, GRASS, FARTCOIN, TAO, ONDO,
+          SUI, ARB, WLD, DOGE, AVAX
+  XYZ:    CL (crude oil), BRENTOIL, GOLD, SPX
 
-DESIGN PRINCIPLES:
-1. Detect the SWARM first — count altcoins with SM SHORT/LONG >2%
-2. Only enter when swarm count >= 5 (correlated risk event confirmed)
-3. Pick the BEST target from the swarm (highest SM + price confirmation)
-4. ONE position at a time, $350 margin, 5x leverage (altcoin max)
-5. FEE_OPTIMIZED_LIMIT orders, wide DSL, let positions breathe
-6. 3 entries per day, 90-min cooldown, 120-min per-asset cooldown
+Direction: Signal-driven, BOTH long and short based on SM direction + 4H
+           price trend alignment.
 
-WHAT MAKES THIS DIFFERENT FROM COBRA:
-- Cobra trades the #1 SM asset (usually a major like BTC/ETH/HYPE)
-- Scorpion trades the #1 ALTCOIN within a confirmed swarm pattern
-- Scorpion requires a meta-signal (swarm detection) before evaluating
-  individual assets — this filters out noise and only trades during
-  genuine coordinated risk events
+Design:
+  - MAX 3 concurrent positions (30% margin each = 90% max exposure)
+  - Leverage 5-10x, score-scaled
+  - MIN_SCORE 6 (lower bar, broader universe, faster cadence)
+  - 120-min per-asset cooldown, 6 entries/day
+  - Short hold profile: hard_timeout=720min (12h), dead_weight_cut=30min
+  - Self-executing: calls create_position directly via mcporter
+  - _v2_no_thesis_exit: scanner enters, DSL exits, scanner NEVER exits
 
-SIGNALS (1 API call):
-1. leaderboard_get_markets (limit=100) → Full market scan
-   - Count altcoins with SM concentration >2% in same direction
-   - If swarm count >= 5: score individual targets
-   - Pick best target by combined SM + price + trader count
+XYZ handling:
+  - XYZ assets use "xyz:" prefix for create_position (e.g. coin="xyz:CL")
+  - XYZ assets require leverageType="ISOLATED"
+  - XYZ assets have different price thresholds (commodities move less)
+  - leaderboard_get_markets returns XYZ assets with dex="xyz" — we INCLUDE them
 
-SCORING (max 8 points):
-- Swarm Size: >=7 alts = +2, >=5 = +1 (meta-signal)
-- SM Concentration: >10% = +2, >5% = +1, >2% = +0
-- Price Confirmation: >1% in direction = +2, >0.5% = +1
-- Trader Count: >=50 = +1
-- Contribution Velocity: >3% = +1
-
-MIN_SCORE: 5 (requires swarm + strong individual signal)
+Runs every 3 minutes.
 """
 
 import json
 import sys
 import os
+import time
 from datetime import datetime, timezone
 
-# ============================================================
-# CONFIGURATION
-# ============================================================
-MAX_ENTRIES_PER_DAY = 3
-COOLDOWN_MINUTES = 90
-PER_ASSET_COOLDOWN_MINUTES = 120
-MIN_SCORE = 5
-MARGIN_AMOUNT = 350
-MAX_POSITIONS = 1
-LEVERAGE = 5  # Altcoins typically max at 3-5x
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import scorpion_config as cfg
 
-# Major assets — EXCLUDED from swarm detection (Cobra's territory)
-MAJOR_ASSETS = {"BTC", "ETH", "SOL", "HYPE"}
-
-# Minimum SM concentration for an altcoin to count as part of the swarm
-MIN_SWARM_SM_PCT = 2.0
-
-# Minimum number of altcoins in swarm to confirm a coordinated event
-MIN_SWARM_COUNT = 5
-
-# XYZ equities banned from trading (but counted in swarm for context)
-XYZ_BANNED_TRADING = True
-
-# Low-liquidity assets blacklisted from TRADING (still counted in swarm detection).
-# XPL: -$52.89 single trade loss, violent wicks through DSL floors.
-# LIT: -$42.97 single trade loss (pre-margin-scaling-fix), erratic price action.
-# FARTCOIN: -$9.87, insufficient book depth for reliable execution.
-BLACKLISTED_ASSETS = {"XPL", "LIT", "FARTCOIN"}
-
-# State file
-STATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                          "..", "config", "scorpion-state.json")
-
-# Leverage overrides for specific altcoins with higher max leverage
-LEVERAGE_OVERRIDES = {
-    "AVAX": 10, "DOGE": 10, "LINK": 10, "XRP": 10,
-    "ADA": 10, "NEAR": 10, "DOT": 10, "UNI": 10,
-    "AAVE": 10, "kPEPE": 10, "FARTCOIN": 10, "LTC": 10,
+# ── CONFIGURATION ──
+CRYPTO_ASSETS = {
+    "BTC", "ETH", "SOL", "HYPE", "ZEC", "LIT", "GRASS", "FARTCOIN",
+    "TAO", "ONDO", "SUI", "ARB", "WLD", "DOGE", "AVAX",
 }
+XYZ_ASSETS = {"CL", "BRENTOIL", "GOLD", "SPX"}
+
+MAX_POSITIONS = 3
+MAX_DAILY_ENTRIES = 6
+
+# ═══════════════════════════════════════════════════════════════
+# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
+# ═══════════════════════════════════════════════════════════════
+
+STARTING_BUDGET = 1000.0
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap. Winners get more trades, losers fewer."""
+    if starting_budget <= 0:
+        return 6
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand
+    elif pnl_pct >= 0:     return 8    # Breakeven+
+    elif pnl_pct >= -5:    return 6    # Careful
+    elif pnl_pct >= -15:   return 4    # Defensive
+    elif pnl_pct >= -25:   return 2    # Preserve
+    else:                  return 0    # HARD STOP — circuit breaker
 
 
-def load_state():
+COOLDOWN_MINUTES = 120
+MARGIN_PCT = 0.30
+MIN_SCORE = 6
+
+# 4H price alignment thresholds — XYZ assets move less than crypto
+MIN_4H_ALIGNED_PCT_CRYPTO = 1.0
+MIN_4H_ALIGNED_PCT_XYZ = 0.5
+
+LEVERAGE_TIERS = [
+    {"min_score": 10, "leverage": 10},
+    {"min_score": 8,  "leverage": 7},
+    {"min_score": 6,  "leverage": 5},
+]
+DEFAULT_LEVERAGE = 5
+
+
+def safe_float(v, d=0.0):
     try:
-        with open(STATE_FILE, "r") as f:
-            state = json.load(f)
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        if state.get("date") != today:
-            state["date"] = today
-            state["entries_today"] = 0
-        return state
-    except (FileNotFoundError, json.JSONDecodeError):
-        return {
-            "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-            "entries_today": 0,
-            "last_entry_time": None,
-            "last_asset": None,
-            "last_direction": None,
-            "asset_cooldowns": {}
-        }
+        return float(v)
+    except (TypeError, ValueError):
+        return d
 
 
-def save_state(state):
-    os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
-    with open(STATE_FILE, "w") as f:
-        json.dump(state, f, indent=2)
+def is_xyz(token):
+    """Check if a token is an XYZ DEX asset."""
+    return token in XYZ_ASSETS
 
 
-def check_cooldown(state, cooldown_min):
-    last_time = state.get("last_entry_time")
-    if not last_time:
-        return True, 0
-    try:
-        last_dt = datetime.fromisoformat(last_time)
-        now = datetime.now(timezone.utc)
-        elapsed = (now - last_dt).total_seconds() / 60
-        remaining = max(0, cooldown_min - elapsed)
-        return elapsed >= cooldown_min, round(remaining, 1)
-    except (ValueError, TypeError):
-        return True, 0
+def coin_for_position(token):
+    """Return the coin string for create_position — XYZ assets need 'xyz:' prefix."""
+    if is_xyz(token):
+        return f"xyz:{token}"
+    return token
 
 
-def check_asset_cooldown(state, asset):
-    cooldowns = state.get("asset_cooldowns", {})
-    last_time = cooldowns.get(asset)
-    if not last_time:
-        return True, 0
-    try:
-        last_dt = datetime.fromisoformat(last_time)
-        now = datetime.now(timezone.utc)
-        elapsed = (now - last_dt).total_seconds() / 60
-        remaining = max(0, PER_ASSET_COOLDOWN_MINUTES - elapsed)
-        return elapsed >= PER_ASSET_COOLDOWN_MINUTES, round(remaining, 1)
-    except (ValueError, TypeError):
-        return True, 0
+def leverage_type_for(token):
+    """XYZ assets require ISOLATED, crypto can use CROSS."""
+    if is_xyz(token):
+        return "ISOLATED"
+    return "CROSS"
 
 
-def detect_swarm(markets):
-    """
-    Detect coordinated altcoin swarm events.
+def get_leverage_for_score(score):
+    for tier in LEVERAGE_TIERS:
+        if score >= tier["min_score"]:
+            return tier["leverage"]
+    return DEFAULT_LEVERAGE
 
-    Scans all non-major assets for SM concentration >2%.
-    Groups by dominant direction (SHORT vs LONG).
-    Returns the swarm info if count >= MIN_SWARM_COUNT.
-    """
-    short_swarm = []
-    long_swarm = []
 
-    for m in markets:
-        token = m.get("token", "")
-        dex = m.get("dex", "")
-        direction = m.get("direction", "")
-        sm_pct = m.get("pct_of_top_traders_gain", 0)
-
-        # Skip majors — those are Cobra's territory
-        if token in MAJOR_ASSETS:
+def has_resting_orders(wallet):
+    """Check for non-reduceOnly resting orders, auto-cancelling stale ones >10min."""
+    import time as _time
+    STALE_ORDER_MAX_AGE_SEC = 600
+    data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
+    if not data:
+        return False
+    orders = data.get("data", data)
+    if isinstance(orders, dict):
+        orders = orders.get("orders", orders.get("openOrders", []))
+    if not isinstance(orders, list):
+        return False
+    now_ms = _time.time() * 1000
+    max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
+    has_fresh = False
+    for o in orders:
+        if o.get("reduceOnly", False):
             continue
-
-        # Skip XYZ for swarm counting too — we want crypto altcoins
-        if dex == "xyz":
+        ts_raw = o.get("timestamp", 0) or 0
+        try:
+            ts = float(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0.0
+        if ts > 0 and (now_ms - ts) > max_age_ms:
+            oid = o.get("oid") or o.get("orderId") or o.get("id")
+            if oid:
+                try:
+                    cfg.mcporter_call(
+                        "cancel_order",
+                        strategyWalletAddress=wallet,
+                        orderId=int(oid),
+                    )
+                except Exception:
+                    pass
             continue
-
-        if sm_pct < MIN_SWARM_SM_PCT:
-            continue
-
-        entry = {
-            "token": token,
-            "direction": direction,
-            "sm_pct": sm_pct,
-            "contrib_change": m.get("contribution_pct_change_4h", 0) or 0,
-            "cc_15m": float(m.get("contribution_pct_change_15m", 0) or 0),
-            "price_change_4h": m.get("token_price_change_pct_4h", 0),
-            "trader_count": m.get("trader_count", 0),
-            "max_leverage": m.get("max_leverage", 3),
-        }
-
-        if direction == "short":
-            short_swarm.append(entry)
-        else:
-            long_swarm.append(entry)
-
-    # Pick the dominant swarm direction
-    if len(short_swarm) >= len(long_swarm) and len(short_swarm) >= MIN_SWARM_COUNT:
-        return "SHORT", short_swarm
-    elif len(long_swarm) >= MIN_SWARM_COUNT:
-        return "LONG", long_swarm
-    else:
-        return None, []
+        has_fresh = True
+    return has_fresh
 
 
-def score_target(target, swarm_size):
+def evaluate_markets(held_coins):
+    """Score all allowed assets for trend-following opportunities.
+
+    Returns a list of candidates sorted by score (best first).
+    Excludes assets we already hold positions in.
     """
-    Score an individual altcoin target within a confirmed swarm.
+    raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
+    if not raw:
+        return []
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
 
-    Args:
-        target: dict with token info from swarm detection
-        swarm_size: number of altcoins in the swarm
-
-    Returns: (score, breakdown)
-    """
-    token = target["token"]
-    direction = target["direction"]
-    sm_pct = target["sm_pct"]
-    contrib = target["contrib_change"]
-    price_4h = target["price_change_4h"]
-    trader_count = target["trader_count"]
-
-    score = 0
-    breakdown = {
-        "token": token,
-        "direction": direction.upper(),
-        "sm_pct": round(sm_pct, 2),
-        "contrib_change": round(contrib, 2),
-        "price_change_4h": round(price_4h, 3),
-        "trader_count": trader_count,
-        "swarm_size": swarm_size,
-    }
-
-    # 1. Swarm Size meta-signal (max 2 pts)
-    if swarm_size >= 7:
-        score += 2
-        breakdown["swarm_score"] = f"+2 (MASSIVE swarm: {swarm_size} altcoins)"
-    elif swarm_size >= 5:
-        score += 1
-        breakdown["swarm_score"] = f"+1 (CONFIRMED swarm: {swarm_size} altcoins)"
-
-    # 2. SM Concentration on this target (max 2 pts)
-    if sm_pct >= 10:
-        score += 2
-        breakdown["sm_score"] = f"+2 (DOMINANT {sm_pct:.1f}%)"
-    elif sm_pct >= 5:
-        score += 1
-        breakdown["sm_score"] = f"+1 (STRONG {sm_pct:.1f}%)"
-    else:
-        breakdown["sm_score"] = f"+0 (IN SWARM {sm_pct:.1f}%)"
-
-    # 3. Price Confirmation in direction (max 2 pts)
-    confirms = False
-    if direction == "short" and price_4h < -1.0:
-        score += 2
-        confirms = True
-        breakdown["price_score"] = f"+2 (STRONG CONFIRM {price_4h:+.2f}%)"
-    elif direction == "short" and price_4h < -0.5:
-        score += 1
-        confirms = True
-        breakdown["price_score"] = f"+1 (CONFIRMS {price_4h:+.2f}%)"
-    elif direction == "long" and price_4h > 1.0:
-        score += 2
-        confirms = True
-        breakdown["price_score"] = f"+2 (STRONG CONFIRM {price_4h:+.2f}%)"
-    elif direction == "long" and price_4h > 0.5:
-        score += 1
-        confirms = True
-        breakdown["price_score"] = f"+1 (CONFIRMS {price_4h:+.2f}%)"
-    else:
-        breakdown["price_score"] = f"+0 (NOT CONFIRMING {price_4h:+.2f}%)"
-
-    # 4. Trader Count depth (1 pt)
-    if trader_count >= 50:
-        score += 1
-        breakdown["depth_score"] = f"+1 (DEEP: {trader_count} traders)"
-    else:
-        breakdown["depth_score"] = f"+0 ({trader_count} traders, need 50)"
-
-    # 5. Contribution Velocity (1 pt)
-    abs_contrib = abs(contrib)
-    if abs_contrib >= 3:
-        score += 1
-        breakdown["contrib_score"] = f"+1 (VELOCITY {contrib:+.1f}%)"
-    else:
-        breakdown["contrib_score"] = f"+0 (SLOW {contrib:+.1f}%)"
-
-    breakdown["total_score"] = score
-    breakdown["min_score"] = MIN_SCORE
-    breakdown["passes"] = score >= MIN_SCORE
-
-    return score, breakdown
-
-
-def pick_best_target(swarm, state):
-    """
-    From a confirmed swarm, pick the best tradeable target.
-    Scores all candidates and returns the highest-scoring one
-    that isn't on per-asset cooldown.
-    """
-    swarm_size = len(swarm)
     candidates = []
 
-    for target in swarm:
-        token = target["token"]
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", "")).upper()
+        dex = str(m.get("dex", "")).lower()
 
-        # Skip blacklisted low-liquidity assets
-        if token in BLACKLISTED_ASSETS:
+        # Determine if this is an allowed asset
+        is_xyz_asset = (dex == "xyz" and token in XYZ_ASSETS)
+        is_crypto_asset = (dex != "xyz" and token in CRYPTO_ASSETS)
+
+        if not is_xyz_asset and not is_crypto_asset:
             continue
 
-        # Check per-asset cooldown
-        clear, _ = check_asset_cooldown(state, token)
-        if not clear:
+        # Skip assets we already hold
+        coin_key = coin_for_position(token) if is_xyz_asset else token
+        if coin_key in held_coins or token in held_coins:
             continue
 
-        # 15m velocity freshness gate — SM must be actively building, not stale
-        cc_15m = float(target.get("cc_15m", 0))
-        if cc_15m <= 0:
-            continue  # SM velocity is flat or fading — signal is stale, don't enter
+        sm_direction = str(m.get("direction", "")).upper()
+        if sm_direction not in ("LONG", "SHORT"):
+            continue
 
-        score, breakdown = score_target(target, swarm_size)
+        pct = safe_float(m.get("pct_of_top_traders_gain", 0))
+        traders = int(m.get("trader_count", 0))
+        p4h = safe_float(m.get("token_price_change_pct_4h", 0))
+        p1h = safe_float(m.get("token_price_change_pct_1h",
+                         m.get("price_change_1h", 0)))
+        cc_15m = safe_float(m.get("contribution_pct_change_15m", 0))
+        cc_1h = safe_float(m.get("contribution_pct_change_1h", 0))
+        cc_4h = safe_float(m.get("contribution_pct_change_4h", 0))
+
+        if traders < 5:
+            continue
+
+        # 4H price alignment gate — SM direction must match price trend
+        min_4h = MIN_4H_ALIGNED_PCT_XYZ if is_xyz_asset else MIN_4H_ALIGNED_PCT_CRYPTO
+        price_aligned = (sm_direction == "LONG" and p4h >= min_4h) or \
+                        (sm_direction == "SHORT" and p4h <= -min_4h)
+        if not price_aligned:
+            continue
+
+        score = 0
+        reasons = []
+        asset_label = f"xyz:{token}" if is_xyz_asset else token
+
+        # SM concentration (0-3)
+        if pct >= 15:
+            score += 3; reasons.append(f"DOMINANT_SM {pct:.1f}% ({traders}t)")
+        elif pct >= 10:
+            score += 2; reasons.append(f"STRONG_SM {pct:.1f}% ({traders}t)")
+        elif pct >= 5:
+            score += 1; reasons.append(f"SM_PRESENT {pct:.1f}% ({traders}t)")
+
+        # 4H price alignment (0-3) — bigger move = stronger trend
+        big_move = 3.0 if is_xyz_asset else 5.0
+        med_move = 1.5 if is_xyz_asset else 3.0
+        if abs(p4h) >= big_move:
+            score += 3; reasons.append(f"STRONG_TREND {p4h:+.1f}%")
+        elif abs(p4h) >= med_move:
+            score += 2; reasons.append(f"TREND {p4h:+.1f}%")
+        elif abs(p4h) >= min_4h:
+            score += 1; reasons.append(f"ALIGNED {p4h:+.1f}%")
+
+        # 15m SM velocity (0-2) — is SM actively building?
+        if cc_15m > 1.0:
+            score += 2; reasons.append(f"15M_SM_BUILDING {cc_15m:+.2f}")
+        elif cc_15m > 0.3:
+            score += 1; reasons.append(f"15M_SM_FRESH {cc_15m:+.2f}")
+        elif cc_15m < -0.5:
+            score -= 1; reasons.append(f"15M_SM_FADING {cc_15m:+.2f}")
+
+        # 1H acceleration (0-1) — is the move accelerating?
+        if sm_direction == "LONG":
+            if p1h > 0.5:
+                score += 1; reasons.append(f"1H_ACCEL {p1h:+.2f}%")
+        else:
+            if p1h < -0.5:
+                score += 1; reasons.append(f"1H_ACCEL {p1h:+.2f}%")
+
+        # Trader depth (0-1)
+        if traders >= 50:
+            score += 1; reasons.append(f"DEEP_SM ({traders}t)")
+
+        # 4H contribution shift (0-1) — conviction building over hours
+        if abs(cc_4h) >= 5.0:
+            score += 1; reasons.append(f"4H_CONVICTION {cc_4h:+.1f}")
+
         if score >= MIN_SCORE:
+            reasons.insert(0, f"TREND_FOLLOW {asset_label} {sm_direction}")
             candidates.append({
-                "target": target,
+                "token": token,
+                "is_xyz": is_xyz_asset,
                 "score": score,
-                "breakdown": breakdown,
+                "direction": sm_direction,
+                "reasons": reasons,
+                "p4h": p4h,
+                "smPct": pct,
+                "smTraders": traders,
             })
 
     if not candidates:
-        return None
+        return []
 
-    # Sort by score descending, then by SM concentration as tiebreaker
-    candidates.sort(key=lambda c: (c["score"], c["target"]["sm_pct"]),
-                    reverse=True)
-    return candidates[0]
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    return candidates
 
 
-def generate_entry(token, direction, leverage, margin):
-    return {
-        "coin": token,
-        "direction": direction.upper(),
-        "leverage": leverage,
-        "leverageType": "CROSS",
-        "marginAmount": margin,
-        "orderType": "FEE_OPTIMIZED_LIMIT",
-        "ensureExecutionAsTaker": True,
-        "executionTimeoutSeconds": 30,
-    }
+def execute_entry(token, direction, margin, leverage, is_xyz):
+    """Execute a position entry via mcporter."""
+    coin = coin_for_position(token) if is_xyz else token
+    lev_type = leverage_type_for(token) if is_xyz else "CROSS"
 
-
-def generate_dsl_state(token, direction, leverage):
-    return {
-        "coin": token,
-        "direction": direction.upper(),
-        "leverage": leverage,
-        "leverageType": "CROSS",
-        "absoluteFloorRoe": None,
-        "highWaterRoe": None,
-        "highWaterPrice": None,
-        "currentTier": 0,
-        "consecutiveBreaches": 0,
-        "consecutiveBreachesRequired": 3,
-        "phase1MaxMinutes": 45,
-        "deadWeightCutMin": 45,
-        "phase1": {
-            "maxLossPct": 20.0,
-            "retraceThreshold": 10,
-            "enabled": True
+    result = cfg.mcporter_call(
+        "create_position",
+        coin=coin,
+        direction=direction,
+        leverage=leverage,
+        leverageType=lev_type,
+        margin=margin,
+        orderType="FEE_OPTIMIZED_LIMIT",
+        feeOptimizedLimitOptions={
+            "ensureExecutionAsTaker": True,
+            "executionTimeoutSeconds": 30,
         },
-        "phase2": {
-            "enabled": True,
-            "tiers": [
-                {"triggerPct": 5, "lockHwPct": 20},
-                {"triggerPct": 10, "lockHwPct": 40},
-                {"triggerPct": 15, "lockHwPct": 55},
-                {"triggerPct": 20, "lockHwPct": 70},
-                {"triggerPct": 30, "lockHwPct": 82},
-                {"triggerPct": 50, "lockHwPct": 90}
-            ]
-        },
-        "hardTimeout": {
-            "enabled": True,
-            "intervalInMinutes": 240
-        },
-        "weakPeakCut": {
-            "enabled": True,
-            "intervalInMinutes": 90,
-            "minValue": 3.0
-        },
-        "deadWeightCut": {
-            "enabled": True,
-            "intervalInMinutes": 45
-        }
-    }
-
-
-def main():
-    state = load_state()
-    now = datetime.now(timezone.utc)
-
-    output = {
-        "scanner": "scorpion",
-        "version": "2.0",
-        "timestamp": now.isoformat(),
-        "action": "NONE",
-        "reason": "",
-        "score": 0,
-        "swarm": {},
-        "breakdown": {},
-        "entry": None,
-        "dsl_state": None,
-        "status": {
-            "entries_today": state["entries_today"],
-            "max_entries": MAX_ENTRIES_PER_DAY,
-            "last_asset": state.get("last_asset"),
-        }
-    }
-
-    # Gate 1: Daily cap
-    if state["entries_today"] >= MAX_ENTRIES_PER_DAY:
-        output["reason"] = f"Daily cap reached ({state['entries_today']}/{MAX_ENTRIES_PER_DAY})"
-        print(json.dumps(output, indent=2))
-        return
-
-    # Gate 2: Global cooldown
-    clear, remaining = check_cooldown(state, COOLDOWN_MINUTES)
-    if not clear:
-        output["reason"] = f"Global cooldown: {remaining} min remaining"
-        print(json.dumps(output, indent=2))
-        return
-
-    # Parse input
-    try:
-        if not sys.stdin.isatty():
-            input_data = json.load(sys.stdin)
-        else:
-            output["reason"] = "AWAITING_DATA"
-            output["instructions"] = [
-                "1. Call senpi:leaderboard_get_markets with limit=100",
-                "2. Pipe the full JSON to this scanner via stdin",
-                "3. Scanner detects altcoin swarm patterns and scores targets",
-                "4. If action=ENTER, call senpi:create_position with the entry block"
-            ]
-            print(json.dumps(output, indent=2))
-            return
-    except json.JSONDecodeError:
-        output["reason"] = "Invalid JSON input"
-        print(json.dumps(output, indent=2))
-        return
-
-    # Extract market data
-    data = input_data.get("data", input_data) if "data" in input_data else input_data
-    markets_list = data.get("markets", {}).get("markets", [])
-    if not markets_list:
-        output["reason"] = "No market data in input"
-        print(json.dumps(output, indent=2))
-        return
-
-    # ================================================================
-    # SWARM DETECTION
-    # ================================================================
-    swarm_direction, swarm = detect_swarm(markets_list)
-
-    if swarm_direction is None:
-        # Count what we found for diagnostics
-        short_count = sum(1 for m in markets_list
-                         if m.get("token") not in MAJOR_ASSETS
-                         and m.get("dex", "") != "xyz"
-                         and m.get("direction") == "short"
-                         and m.get("pct_of_top_traders_gain", 0) >= MIN_SWARM_SM_PCT)
-        long_count = sum(1 for m in markets_list
-                        if m.get("token") not in MAJOR_ASSETS
-                        and m.get("dex", "") != "xyz"
-                        and m.get("direction") == "long"
-                        and m.get("pct_of_top_traders_gain", 0) >= MIN_SWARM_SM_PCT)
-
-        output["reason"] = (
-            f"No swarm detected. SHORT alts: {short_count}, "
-            f"LONG alts: {long_count} (need {MIN_SWARM_COUNT}+)"
-        )
-        output["swarm"] = {
-            "detected": False,
-            "short_count": short_count,
-            "long_count": long_count,
-            "min_required": MIN_SWARM_COUNT,
-        }
-        print(json.dumps(output, indent=2))
-        return
-
-    # Swarm confirmed
-    swarm_tokens = [s["token"] for s in swarm[:10]]
-    output["swarm"] = {
-        "detected": True,
-        "direction": swarm_direction,
-        "count": len(swarm),
-        "top_tokens": swarm_tokens,
-    }
-
-    # ================================================================
-    # TARGET SELECTION
-    # ================================================================
-    best = pick_best_target(swarm, state)
-
-    if best is None:
-        output["reason"] = (
-            f"Swarm detected ({len(swarm)} {swarm_direction} alts) "
-            f"but no target reached MIN_SCORE {MIN_SCORE} or all on cooldown"
-        )
-        # Show top 3 candidates for diagnostics
-        swarm_size = len(swarm)
-        diagnostics = []
-        for t in swarm[:3]:
-            s, b = score_target(t, swarm_size)
-            diagnostics.append({
-                "token": t["token"],
-                "score": s,
-                "sm_pct": round(t["sm_pct"], 2),
-                "price_4h": round(t["price_change_4h"], 2),
-            })
-        output["swarm"]["top_candidates"] = diagnostics
-        print(json.dumps(output, indent=2))
-        return
-
-    # ================================================================
-    # ENTRY SIGNAL
-    # ================================================================
-    target = best["target"]
-    token = target["token"]
-    direction = target["direction"].upper()
-    leverage = LEVERAGE_OVERRIDES.get(token, min(LEVERAGE, target["max_leverage"]))
-
-    entry = generate_entry(token, direction, leverage, MARGIN_AMOUNT)
-    dsl_state = generate_dsl_state(token, direction, leverage)
-
-    output["action"] = "ENTER"
-    output["score"] = best["score"]
-    output["breakdown"] = best["breakdown"]
-    output["reason"] = (
-        f"SCORPION STRIKES — {swarm_direction} swarm ({len(swarm)} alts). "
-        f"Best target: {token} {direction} at {leverage}x, $350 margin. "
-        f"Score {best['score']}/{MIN_SCORE}. SM {target['sm_pct']:.1f}%."
     )
-    output["entry"] = entry
-    output["dsl_state"] = dsl_state
+    if result and result.get("success"):
+        return True, result
+    error = result.get("error", "unknown") if result else "mcporter_call returned None"
+    return False, {"error": error}
 
-    # Update state
-    state["entries_today"] += 1
-    state["last_entry_time"] = now.isoformat()
-    state["last_asset"] = token
-    state["last_direction"] = direction
-    if "asset_cooldowns" not in state:
-        state["asset_cooldowns"] = {}
-    state["asset_cooldowns"][token] = now.isoformat()
-    save_state(state)
 
-    print(json.dumps(output, indent=2))
+def run():
+    wallet, sid = cfg.get_wallet_and_strategy()
+    if not wallet:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY", "note": "no wallet"})
+        return
+
+    account_value, positions = cfg.get_positions(wallet)
+    if account_value <= 0:
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": "cannot read account"})
+        return
+
+    # Check for resting orders
+    if has_resting_orders(wallet):
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": "RESTING ORDER: limit order pending."})
+        return
+
+    # Check existing positions — DSL manages all exits
+    held_coins = set()
+    for p in positions:
+        held_coins.add(p["coin"])
+    pos_count = len(positions)
+
+    if pos_count >= MAX_POSITIONS:
+        pos_desc = ", ".join(f"{p['coin']} {p['direction']}" for p in positions)
+        cfg.output({
+            "status": "ok", "heartbeat": "NO_REPLY",
+            "note": f"MAX_POSITIONS ({MAX_POSITIONS}): {pos_desc}. DSL manages exits.",
+            "_v2_no_thesis_exit": True,
+        })
+        return
+
+    # Daily limits
+    tc = cfg.load_trade_counter()
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    effective_cap = min(dynamic_cap, MAX_DAILY_ENTRIES)
+    if tc.get("entries", 0) >= effective_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                    "note": f"Daily cap ({effective_cap}) reached. PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{effective_cap}"})
+        return
+
+    # Evaluate all allowed assets
+    candidates = evaluate_markets(held_coins)
+    if not candidates:
+        pos_desc = ", ".join(f"{p['coin']} {p['direction']}" for p in positions) if positions else "none"
+        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                     "note": f"SCANNING: no qualifying signal across crypto+XYZ universe. Holding: {pos_desc}"})
+        return
+
+    # Try candidates in order until one passes cooldown and executes
+    for candidate in candidates:
+        token = candidate["token"]
+        direction = candidate["direction"]
+
+        # Per-asset cooldown
+        if cfg.is_asset_cooled_down(token, COOLDOWN_MINUTES):
+            continue
+
+        leverage = get_leverage_for_score(candidate["score"])
+        margin = round(account_value * MARGIN_PCT, 2)
+
+        success, result = execute_entry(
+            token, direction, margin, leverage, candidate["is_xyz"]
+        )
+
+        if success:
+            tc["entries"] = tc.get("entries", 0) + 1
+            cfg.save_trade_counter(tc)
+            cfg.set_asset_cooldown(token, COOLDOWN_MINUTES, reason="entry")
+
+            coin_label = coin_for_position(token) if candidate["is_xyz"] else token
+            cfg.output({
+                "status": "ok",
+                "action": "ENTRY",
+                "signal": {
+                    "asset": coin_label,
+                    "direction": direction,
+                    "score": candidate["score"],
+                    "leverage": leverage,
+                    "p4h": candidate["p4h"],
+                    "is_xyz": candidate["is_xyz"],
+                    "mode": "MULTI_MARKET_TREND",
+                    "reasons": candidate["reasons"],
+                },
+                "execution": {
+                    "coin": coin_label,
+                    "direction": direction,
+                    "leverage": leverage,
+                    "leverageType": leverage_type_for(token) if candidate["is_xyz"] else "CROSS",
+                    "margin": margin,
+                    "orderType": "FEE_OPTIMIZED_LIMIT",
+                    "ensureExecutionAsTaker": True,
+                },
+                "result": result,
+                "positions_held": pos_count + 1,
+                "max_positions": MAX_POSITIONS,
+                "_scorpion_version": "3.0",
+            })
+            return
+        else:
+            cfg.log(f"Entry failed for {token}: {result}")
+            continue
+
+    # All candidates either on cooldown or failed
+    cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
+                "note": "All qualifying candidates on cooldown or entry failed."})
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        run()
+    except Exception as e:
+        cfg.log(f"CRITICAL ERROR: {e}")
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        cfg.output({"status": "error", "error": str(e)})

--- a/scorpion/scripts/scorpion_config.py
+++ b/scorpion/scripts/scorpion_config.py
@@ -1,4 +1,4 @@
-"""Scorpion Strategy — Shared config, MCP helpers, state I/O.
+"""Scorpion v3.0 Multi-Market Active Trader — Shared config, MCP helpers, state I/O.
 
 Fleet-standard helper module imported by scorpion-scanner.py.
 """
@@ -91,7 +91,7 @@ def is_asset_cooled_down(asset, cooldown_minutes=180):
     return time.time() < entry.get("until", 0)
 
 
-def set_asset_cooldown(asset, cooldown_minutes=180):
+def set_asset_cooldown(asset, cooldown_minutes=180, reason="exit"):
     p = STATE_DIR / "cooldowns.json"
     cooldowns = {}
     if p.exists():
@@ -103,6 +103,7 @@ def set_asset_cooldown(asset, cooldown_minutes=180):
     cooldowns[asset] = {
         "until": time.time() + cooldown_minutes * 60,
         "set_at": now_iso(),
+        "reason": reason,
     }
     atomic_write(str(p), cooldowns)
 


### PR DESCRIPTION
## Summary

**Variant B of the Arena-winner A/B experiment.** Complete rewrite of Scorpion from Altcoin Swarm Hunter to Multi-Market Active Trader, based on Arena winner #2/#3 (0xschelling) playbook.

### Before state
Scorpion v2.0: -11.6% / 185 trades. "Altcoin Swarm Hunter" requiring 5+ altcoins in coordinated risk-off — too rare AND too noisy.

### v3.0 — Arena winner #2/#3 playbook
- **Universe: crypto + XYZ DEX commodities** (xyz:CL, xyz:BRENTOIL, xyz:GOLD, xyz:SPX) — **first predator to trade both crypto and commodities in the same scanner**
- **3 concurrent positions** (was 1) — matches #2/#3's multi-position pattern
- **Signal-driven LONG + SHORT** — mixed directions based on SM + 4h trend
- **Shorter holds:** hard_timeout=720min (12h), dead_weight_cut=30min — faster than Vulture's 7-day profile
- XYZ assets use `xyz:` prefix and `ISOLATED` leverage mode
- Leverage: 5-10x score-scaled, 30% margin per position
- MIN_SCORE=6, up to 6 entries/day, 120min per-asset cooldown

### The A/B experiment

| | Variant A (PR #189, merged) | Variant B (this PR) |
|---|---|---|
| Agent | Vulture v2.0 | Scorpion v3.0 |
| Archetype | Long-Tail Rider | Multi-Market Active |
| Universe | 25 small-cap alts | Majors + alts + XYZ commodities |
| Hold profile | 7 days | 12 hours |
| Max positions | 2 | 3 |
| Arena winner source | #1 (small-cap rider) | #2/#3 (0xschelling, multi-market) |

**Both test:** Can we replicate Arena winner playbooks? Different signal architectures, different hold profiles, different asset universes.

### External usability
All 7 files updated. External users can curl install from main.

## Test plan
- [ ] Verify Scorpion enters at least 1 trade within 24h (any entry is progress vs swarm-gated v2.0)
- [ ] Verify XYZ assets (xyz:CL, xyz:BRENTOIL) are correctly handled with xyz: prefix + ISOLATED leverage
- [ ] Verify 3 concurrent positions can coexist without state conflicts
- [ ] Compare ROE trajectory to Arena winner #2/#3 baseline at 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)