### PR TITLE
fleet-fix: canonical create_position MCP schema across 14 scanners

### DIFF
--- a/Grizzly-Horribilis/scripts/grizzly-scanner.py
+++ b/Grizzly-Horribilis/scripts/grizzly-scanner.py
@@ -257,18 +257,21 @@ def evaluate_btc():
     }
 
 
-def execute_entry(direction, margin, leverage):
+def execute_entry(wallet, direction, margin, leverage):
     result = cfg.mcporter_call(
         "create_position",
-        coin=ASSET,
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 30,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": ASSET,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 30,
+            },
+        }],
     )
     if result and result.get("success"):
         return True, result
@@ -388,7 +391,7 @@ def run():
         leverage = get_leverage_for_score(thesis["score"])
         margin = round(av * INITIAL_MARGIN_PCT, 2)
 
-        success, result = execute_entry(thesis["direction"], margin, leverage)
+        success, result = execute_entry(wallet, thesis["direction"], margin, leverage)
 
         if success:
             tc["entries"] = tc.get("entries", 0) + 1
@@ -473,7 +476,7 @@ def run():
     scale_margin = round(remaining_capital * SCALEUP_MARGIN_PCT, 2)
     leverage = get_leverage_for_score(thesis["score"])
 
-    success, result = execute_entry(thesis["direction"], scale_margin, leverage)
+    success, result = execute_entry(wallet, thesis["direction"], scale_margin, leverage)
 
     if success:
         tc["entries"] = tc.get("entries", 0) + 1

--- a/bald-eagle/scripts/eagle-scanner.py
+++ b/bald-eagle/scripts/eagle-scanner.py
@@ -482,22 +482,25 @@ def build_dsl_state(signal, leverage):
 # EXECUTE TRADE (Wolverine pattern)
 # ═══════════════════════════════════════════════════════════════
 
-def execute_entry(signal, margin, leverage):
+def execute_entry(wallet, signal, margin, leverage):
     """Call create_position directly from the scanner."""
     asset = f"xyz:{signal['token']}"
     direction = signal["direction"]
 
     result = cfg.mcporter_call(
         "create_position",
-        coin=signal["token"],
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 45,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": signal["token"],
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 45,
+            },
+        }],
         dex="xyz",
     )
 
@@ -600,6 +603,7 @@ def run():
 
         # Execute trade directly
         success, result = execute_entry(
+            wallet,
             {"token": token, "direction": fade_direction},
             margin, leverage,
         )

--- a/bison/scripts/bison-scanner.py
+++ b/bison/scripts/bison-scanner.py
@@ -425,15 +425,18 @@ def execute_entry(signal, margin, leverage, wallet, strategy_id):
 
     result = cfg.mcporter_call(
         "create_position",
-        coin=coin,
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 30,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": coin,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 30,
+            },
+        }],
     )
 
     if result and result.get("success"):

--- a/dog/scripts/dog-scanner.py
+++ b/dog/scripts/dog-scanner.py
@@ -280,16 +280,23 @@ def evaluate_assets():
     return candidates
 
 
-def execute_entry(asset, direction, margin, leverage):
+def execute_entry(wallet, asset, direction, margin, leverage):
     """Place maker-only entry."""
     # Clamp leverage to asset max
     asset_max = ASSET_MAX_LEVERAGE.get(asset, 10)
     leverage = min(leverage, asset_max, MAX_LEVERAGE)
 
     result = cfg.mcporter_call(
-        "create_position", coin=asset, direction=direction, leverage=leverage,
-        margin=margin, orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={"ensureExecutionAsTaker": False, "executionTimeoutSeconds": 30},
+        "create_position",
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": asset,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {"ensureExecutionAsTaker": False, "executionTimeoutSeconds": 30},
+        }],
     )
     if result and result.get("success"): return True, result
     error = result.get("error", "unknown") if result else "mcporter_call returned None"
@@ -402,7 +409,7 @@ def run():
             break
     margin = round(av * MARGIN_PCT, 2)
 
-    success, result = execute_entry(best["asset"], best["direction"], margin, leverage)
+    success, result = execute_entry(wallet, best["asset"], best["direction"], margin, leverage)
     if success:
         tc["entries"] = tc.get("entries", 0) + 1
         tc["last_entry_ts"] = time.time()

--- a/grizzly/scripts/grizzly-scanner.py
+++ b/grizzly/scripts/grizzly-scanner.py
@@ -231,11 +231,18 @@ def evaluate_btc():
     return {"score":score,"direction":d,"reasons":reasons,"smPct":pct,"smTraders":traders,"priceChg4h":p4h}
 
 
-def execute_entry(direction, margin, leverage):
+def execute_entry(wallet, direction, margin, leverage):
     result = cfg.mcporter_call(
-        "create_position", coin=ASSET, direction=direction, leverage=leverage,
-        margin=margin, orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={"ensureExecutionAsTaker": False, "executionTimeoutSeconds": 30},
+        "create_position",
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": ASSET,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {"ensureExecutionAsTaker": False, "executionTimeoutSeconds": 30},
+        }],
     )
     if result and result.get("success"): return True, result
     error = result.get("error", "unknown") if result else "mcporter_call returned None"
@@ -317,7 +324,7 @@ def run():
     leverage = get_leverage_for_score(thesis["score"])
     margin = round(av * MARGIN_PCT, 2)
 
-    success, result = execute_entry(thesis["direction"], margin, leverage)
+    success, result = execute_entry(wallet, thesis["direction"], margin, leverage)
     if success:
         tc["entries"] = tc.get("entries",0) + 1
         save_tc(tc)

--- a/jaguar/scripts/jaguar-scanner.py
+++ b/jaguar/scripts/jaguar-scanner.py
@@ -396,19 +396,22 @@ def build_scan_snapshot(markets_data):
 # EXECUTION
 # ═══════════════════════════════════════════════════════════════
 
-def execute_entry(token, direction, leverage, margin):
+def execute_entry(wallet, token, direction, leverage, margin):
     """Call create_position directly via mcporter."""
     result = cfg.mcporter_call(
         "create_position",
-        coin=token,
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 30,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": token,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 30,
+            },
+        }],
     )
     if result and result.get("success"):
         return True, result
@@ -559,7 +562,7 @@ def run():
         leverage = get_leverage_for_score(signal["score"])
         margin = round(account_value * MARGIN_PCT, 2)
 
-        success, result = execute_entry(token, signal["direction"], leverage, margin)
+        success, result = execute_entry(wallet, token, signal["direction"], leverage, margin)
 
         if success:
             tc["entries"] = tc.get("entries", 0) + 1

--- a/kestrel/scripts/kestrel-scanner.py
+++ b/kestrel/scripts/kestrel-scanner.py
@@ -338,18 +338,21 @@ def scan_xyz_breakouts():
     return candidates
 
 
-def execute_entry(token, direction, margin, leverage):
+def execute_entry(wallet, token, direction, margin, leverage):
     result = cfg.mcporter_call(
         "create_position",
-        coin=token,
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 45,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": token,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 45,
+            },
+        }],
         dex="xyz",
     )
     if result and result.get("success"):
@@ -414,7 +417,7 @@ def run():
         leverage = get_leverage_for_score(cand["score"])
         margin = round(account_value * MARGIN_PCT, 2)
 
-        success, result = execute_entry(token, cand["breakout_direction"],
+        success, result = execute_entry(wallet, token, cand["breakout_direction"],
                                          margin, leverage)
 
         if success:

--- a/lemon/scripts/lemon-scanner.py
+++ b/lemon/scripts/lemon-scanner.py
@@ -360,19 +360,22 @@ def evaluate_fade(asset, sm):
 # EXECUTION
 # ═══════════════════════════════════════════════════════════════
 
-def execute_entry(asset, direction, leverage, margin):
+def execute_entry(wallet, asset, direction, leverage, margin):
     """Call create_position directly via mcporter."""
     result = cfg.mcporter_call(
         "create_position",
-        coin=asset,
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 30,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": asset,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 30,
+            },
+        }],
     )
     if result and result.get("success"):
         return True, result
@@ -484,7 +487,7 @@ def run():
     leverage = get_leverage_for_score(best["score"])
     margin = round(account_value * MARGIN_PCT, 2)
 
-    success, result = execute_entry(best["asset"], best["direction"], leverage, margin)
+    success, result = execute_entry(wallet, best["asset"], best["direction"], leverage, margin)
 
     if success:
         tc["entries"] = tc.get("entries", 0) + 1

--- a/pangolin/scripts/pangolin-scanner.py
+++ b/pangolin/scripts/pangolin-scanner.py
@@ -288,18 +288,21 @@ def scan_funding_extremes():
     return candidates
 
 
-def execute_entry(token, direction, margin, leverage):
+def execute_entry(wallet, token, direction, margin, leverage):
     result = cfg.mcporter_call(
         "create_position",
-        coin=token,
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 45,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": token,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 45,
+            },
+        }],
     )
     if result and result.get("success"):
         return True, result
@@ -363,7 +366,7 @@ def run():
         leverage = get_leverage_for_score(cand["score"])
         margin = round(account_value * MARGIN_PCT, 2)
 
-        success, result = execute_entry(token, cand["fade_direction"], margin, leverage)
+        success, result = execute_entry(wallet, token, cand["fade_direction"], margin, leverage)
 
         if success:
             tc["entries"] = tc.get("entries", 0) + 1

--- a/polar/scripts/polar-scanner.py
+++ b/polar/scripts/polar-scanner.py
@@ -256,11 +256,18 @@ def evaluate_eth():
             "smPct": pct, "smTraders": traders, "priceChg4h": p4h}
 
 
-def execute_entry(direction, margin, leverage):
+def execute_entry(wallet, direction, margin, leverage):
     result = cfg.mcporter_call(
-        "create_position", coin=ASSET, direction=direction, leverage=leverage,
-        margin=margin, orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={"ensureExecutionAsTaker": False, "executionTimeoutSeconds": 30},
+        "create_position",
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": ASSET,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {"ensureExecutionAsTaker": False, "executionTimeoutSeconds": 30},
+        }],
     )
     if result and result.get("success"): return True, result
     error = result.get("error", "unknown") if result else "mcporter_call returned None"
@@ -352,7 +359,7 @@ def run():
     leverage = get_leverage_for_score(thesis["score"])
     margin = round(av * MARGIN_PCT, 2)
 
-    success, result = execute_entry(thesis["direction"], margin, leverage)
+    success, result = execute_entry(wallet, thesis["direction"], margin, leverage)
     if success:
         tc["entries"] = tc.get("entries", 0) + 1
         tc["last_entry_ts"] = time.time()

--- a/scorpion/scripts/scorpion-scanner.py
+++ b/scorpion/scripts/scorpion-scanner.py
@@ -287,23 +287,26 @@ def evaluate_markets(held_coins):
     return candidates
 
 
-def execute_entry(token, direction, margin, leverage, is_xyz):
+def execute_entry(wallet, token, direction, margin, leverage, is_xyz):
     """Execute a position entry via mcporter."""
     coin = coin_for_position(token) if is_xyz else token
     lev_type = leverage_type_for(token) if is_xyz else "CROSS"
 
     result = cfg.mcporter_call(
         "create_position",
-        coin=coin,
-        direction=direction,
-        leverage=leverage,
-        leverageType=lev_type,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": True,
-            "executionTimeoutSeconds": 30,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": coin,
+            "direction": direction,
+            "leverage": leverage,
+            "leverageType": lev_type,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": True,
+                "executionTimeoutSeconds": 30,
+            },
+        }],
     )
     if result and result.get("success"):
         return True, result
@@ -375,7 +378,7 @@ def run():
         margin = round(account_value * MARGIN_PCT, 2)
 
         success, result = execute_entry(
-            token, direction, margin, leverage, candidate["is_xyz"]
+            wallet, token, direction, margin, leverage, candidate["is_xyz"]
         )
 
         if success:

--- a/spider/scripts/spider-scanner.py
+++ b/spider/scripts/spider-scanner.py
@@ -397,19 +397,22 @@ def score_convergences(convergences, velocity):
 # EXECUTION
 # ═══════════════════════════════════════════════════════════════
 
-def execute_entry(asset, direction, margin, leverage):
+def execute_entry(wallet, asset, direction, margin, leverage):
     """Call create_position directly via mcporter."""
     result = cfg.mcporter_call(
         "create_position",
-        coin=asset,
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 30,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": asset,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 30,
+            },
+        }],
     )
     if result and result.get("success"):
         return True, result
@@ -526,7 +529,7 @@ def run():
     leverage = get_leverage_for_score(best["score"])
     margin = round(av * MARGIN_PCT, 2)
 
-    success, result = execute_entry(best["asset"], best["direction"], margin, leverage)
+    success, result = execute_entry(wallet, best["asset"], best["direction"], margin, leverage)
 
     if success:
         tc["entries"] = tc.get("entries", 0) + 1

--- a/vulture/scripts/vulture-scanner.py
+++ b/vulture/scripts/vulture-scanner.py
@@ -374,21 +374,24 @@ def evaluate_momentum(asset, sm):
 # EXECUTION
 # ═══════════════════════════════════════════════════════════════
 
-def execute_entry(asset, direction, leverage, margin):
+def execute_entry(wallet, asset, direction, leverage, margin):
     """Call create_position directly via mcporter (Wolverine/Lemon pattern)."""
     # Handle k-prefixed tokens (kBONK, kPEPE) — Hyperliquid expects exact casing
     coin = asset  # TRACKED_ASSETS already preserves case
     result = cfg.mcporter_call(
         "create_position",
-        coin=coin,
-        direction=direction,
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 30,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": coin,
+            "direction": direction,
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 30,
+            },
+        }],
     )
     if result and result.get("success"):
         return True, result
@@ -485,7 +488,7 @@ def run():
     leverage = get_leverage_for_score(best["score"])
     margin = round(account_value * MARGIN_PCT, 2)
 
-    success, result = execute_entry(best["asset"], best["direction"], leverage, margin)
+    success, result = execute_entry(wallet, best["asset"], best["direction"], leverage, margin)
 
     if success:
         tc["entries"] = tc.get("entries", 0) + 1

--- a/wolverine/scripts/wolverine-scanner.py
+++ b/wolverine/scripts/wolverine-scanner.py
@@ -465,19 +465,22 @@ def score_hype_signal(markets_data):
     return score, direction, reasons
 
 
-def execute_entry(direction, margin, leverage):
+def execute_entry(wallet, direction, margin, leverage):
     """Call create_position directly via mcporter."""
     result = cfg.mcporter_call(
         "create_position",
-        coin=ASSET,
-        direction=direction.upper(),
-        leverage=leverage,
-        margin=margin,
-        orderType="FEE_OPTIMIZED_LIMIT",
-        feeOptimizedLimitOptions={
-            "ensureExecutionAsTaker": False,
-            "executionTimeoutSeconds": 30,
-        },
+        strategyWalletAddress=wallet,
+        orders=[{
+            "coin": ASSET,
+            "direction": direction.upper(),
+            "leverage": leverage,
+            "marginAmount": margin,
+            "orderType": "FEE_OPTIMIZED_LIMIT",
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 30,
+            },
+        }],
     )
     if result and result.get("success"):
         return True, result
@@ -599,7 +602,7 @@ def run():
     margin = round(account_value * MARGIN_PCT, 2)
 
     # Execute trade directly
-    success, result = execute_entry(direction, margin, leverage)
+    success, result = execute_entry(wallet, direction, margin, leverage)
 
     if success:
         tc["entries"] = tc.get("entries", 0) + 1


### PR DESCRIPTION
## Summary

**Fleet-wide fix for a silent-failure bug** where \`create_position\` calls using the flat-arg format (coin=, direction=, margin=...) fail in OpenClaw runtime configs without env-var auto-injection of wallet context. Wolverine and Vulture both independently diagnosed this bug — scanners generated valid signals for 16+ hours but executions silently failed.

## The fix

Converts 14 scanners to the canonical MCP schema documented in the \`create_position\` tool signature:

\`\`\`python
cfg.mcporter_call("create_position",
    strategyWalletAddress=wallet,
    orders=[{
        "coin": asset,
        "direction": direction,
        "leverage": leverage,
        "marginAmount": margin,
        "orderType": "FEE_OPTIMIZED_LIMIT",
        "feeOptimizedLimitOptions": {...},
    }])
\`\`\`

### Agents converted (14)
vulture, wolverine, scorpion, polar, Grizzly-Horribilis, grizzly, dog, spider, pangolin, lemon, kestrel, jaguar, bison, bald-eagle

### Already canonical (3 — verified, no changes needed)
owl, cheetah, raptor

### Skipped (2)
- cobra: uses different architecture (\`generate_entry()\` returning DSL state, not direct mcporter call)
- hawk/recipes/hype-sniper: experimental recipe, not fleet-standard

## Validation

**Wolverine manually patched its local scanner to this exact schema and a trade fired immediately** (HYPE SHORT score 14, 10x leverage, $502 margin). This PR formalizes that fix across the fleet.

## Impact on 10-PnL+ weekly mission

Unblocks Wolverine, Vulture, and any other agent that was silently failing executions. Specifically:
- Vulture v2.0 has HYPE at score 11 ready to fire
- Wolverine v2.3 HYPE SHORT score 14 just fired, needs clean execution path for subsequent signals
- Other dormant agents (Dog, GHOR, Polar) will be able to execute when their gates finally trip

## Test plan
- [ ] After merge, verify each agent can pull from main and continue functioning
- [ ] Verify Wolverine/Vulture trades execute cleanly post-merge (eliminate silent failure)
- [ ] Verify already-canonical agents (Owl, Cheetah, Raptor) are unaffected
- [ ] Spot-check lemon/scorpion first trades post-merge (they were working with flat args — canonical should also work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)