### PR TITLE
fleet-fix batch4: DSL profiles + capital resets + threshold recalibration + leverage safety

### DIFF
--- a/Grizzly-Horribilis/scripts/grizzly-scanner.py
+++ b/Grizzly-Horribilis/scripts/grizzly-scanner.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python3
-# Senpi GRIZZLY HORRIBILIS Scanner v2.1
+# Senpi GRIZZLY HORRIBILIS Scanner v2.1.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""GRIZZLY HORRIBILIS v2.1 — BTC Contrarian with Pyramiding (tightened).
+"""GRIZZLY HORRIBILIS v2.1.1 — BTC Contrarian with Pyramiding (capital reset).
+
+## v2.1.1 change — capital reset (2026-04-15)
+
+Grizzly Horribilis was hard-stopped at -35.3% drawdown with daily
+cap = 0. Rebasing `STARTING_BUDGET` from 1000.0 to 648.35 (current
+equity = $1000 − $351.65) so the pnl-aware daily cap unblocks from the
+circuit breaker.
+
+
 
 v2.1 fleet-fix recalibration (April 15, 2026):
 - MIN_EXHAUSTION_PCT raised 2.5 → 4.5 (same fix Dog v2.2 got).
@@ -64,7 +73,7 @@ MAX_DAILY_ENTRIES = 4          # Total entries including scale-ups (was 2)
 # DYNAMIC DAILY CAP (P&L-aware circuit breaker)
 # ═══════════════════════════════════════════════════════════════
 
-STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+STARTING_BUDGET = 648.35  # v2.1.1: rebased to current equity after -35.3% drawdown
 
 def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
     """P&L-aware daily entry cap based on drawdown from starting budget.
@@ -411,13 +420,13 @@ def run():
                 "execution": {"asset": ASSET, "direction": thesis["direction"],
                     "leverage": leverage, "margin": margin,
                     "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
-                "result": result, "_horribilis_version": "2.1",
+                "result": result, "_horribilis_version": "2.1.1",
             })
         else:
             cfg.output({"status": "ok", "action": "ENTRY_FAILED",
                 "signal": {"asset": ASSET, "direction": thesis["direction"],
                     "score": thesis["score"], "reasons": thesis["reasons"]},
-                "error": result, "_horribilis_version": "2.1"})
+                "error": result, "_horribilis_version": "2.1.1"})
         return
 
     # ── CASE 2: Position exists — evaluate for scale-up ──
@@ -505,13 +514,13 @@ def run():
                 "existingMargin": round(current_margin, 2),
                 "newMargin": scale_margin,
             },
-            "result": result, "_horribilis_version": "2.1",
+            "result": result, "_horribilis_version": "2.1.1",
         })
     else:
         cfg.output({"status": "ok", "action": "SCALE_UP_FAILED",
             "signal": {"asset": ASSET, "direction": thesis["direction"],
                 "score": thesis["score"], "reasons": thesis["reasons"]},
-            "error": result, "_horribilis_version": "2.1"})
+            "error": result, "_horribilis_version": "2.1.1"})
 
 
 if __name__ == "__main__":

--- a/cheetah/README.md
+++ b/cheetah/README.md
@@ -1,6 +1,10 @@
-# 🐆 CHEETAH v2.0 — HYPE Predator
+# 🐆 CHEETAH v5.1.1 APEX — Multi-signal confluence sniper
 
-Top performer in the Senpi Predators fleet at +7.6% ROE.
+v5.1.1 adds leverage safety (clamps to asset max via
+`strategy_get_asset_trading_limits`) and inner-order success validation
+to eliminate phantom ENTRY logs on CREATE_INVALID_LEVERAGE rejections.
+
+Top performer in the Senpi Predators fleet at +7.6% ROE (v2.0 peak).
 
 Hunts HYPE exclusively using SM commitment as the primary signal. When SM concentration exceeds threshold with 4H trend alignment, Cheetah enters. BTC trend is a conviction booster, not a hard gate. HYPE-specific wide DSL tiers give volatile HYPE positions room to breathe.
 

--- a/cheetah/SKILL.md
+++ b/cheetah/SKILL.md
@@ -1,23 +1,38 @@
 ---
 name: cheetah-strategy
 description: >-
-  CHEETAH v5.0 APEX — Multi-signal confluence sniper. Purpose-built to win
-  the Senpi Arena by taking ~5 high-conviction trades per week at 80% margin
-  and 10x leverage. Only fires when ALL major signals align (score >=14/15).
-  Fewer trades, higher ROE%, maximum edge per entry. Previous Cheetah versions
-  (v1-v4) iterated thesis on HYPE and failed; v5.0 is a complete architectural
-  redesign optimizing for asymmetric ROE% rather than absolute PnL.
+  CHEETAH v5.1.1 APEX — Multi-signal confluence sniper with leverage safety.
+  Purpose-built to win the Senpi Arena by taking ~5 high-conviction trades
+  per week at 80% margin and score-scaled leverage. v5.1.1 adds
+  get_safe_leverage() (clamps requested leverage to the asset's Hyperliquid
+  max via strategy_get_asset_trading_limits) and inner-order success
+  validation (rejects phantom ENTRY logs when the outer envelope lies).
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "5.0-APEX"
+  version: "5.1.1-APEX"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🐆 CHEETAH v5.0 APEX — The Arena Sniper
+# 🐆 CHEETAH v5.1.1 APEX — The Arena Sniper
+
+## v5.1.1 changelog (fleet-fix batch 4)
+
+- **Leverage safety fix.** v5.1 fired MON LONG at 7x but MON's Hyperliquid
+  max is 5x. Order rejected with CREATE_INVALID_LEVERAGE — but the MCP
+  wrapper returned outer success=true, so the scanner logged a phantom
+  ENTRY. v5.1.1 adds `get_safe_leverage()` which queries
+  `strategy_get_asset_trading_limits` and clamps requested leverage to the
+  asset's Hyperliquid max before submission.
+- **Inner-order success validation.** After `create_position` returns,
+  inspect `data.orders[0].success` and surface `INNER_FAILURE` when the
+  per-order status is false even if the outer envelope claims success.
+  Prevents phantom ENTRY logs from corrupting the daily counter.
+
+
 
 **SM commits. Quality traders commit. Price confirms. Volume commits. All at once. Cheetah pounces once.**
 
@@ -152,7 +167,7 @@ curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/con
 python3 /data/workspace/skills/cheetah-strategy/scripts/cheetah-scanner.py
 ```
 
-Expected first-run output: no exceptions, `_cheetah_version: "5.0-APEX"` in the JSON, and either `note: "no score >= 14 candidates"` (most common) or a rare `action: "ENTRY"` if a confluence setup exists right now.
+Expected first-run output: no exceptions, `_cheetah_version: "5.1.1-APEX"` in the JSON, and either `note: "no score >= 14 candidates"` (most common) or a rare `action: "ENTRY"` if a confluence setup exists right now.
 
 ## Cron configuration
 

--- a/cheetah/scripts/cheetah-scanner.py
+++ b/cheetah/scripts/cheetah-scanner.py
@@ -1,9 +1,25 @@
 #!/usr/bin/env python3
-# Senpi CHEETAH Scanner v5.1-APEX
+# Senpi CHEETAH Scanner v5.1.1-APEX
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""CHEETAH v5.1 APEX — Multi-signal confluence sniper.
+"""CHEETAH v5.1.1 APEX — Multi-signal confluence sniper.
+
+## v5.1.1 change — leverage safety fix
+
+v5.1 APEX fired MON LONG at 7x, but MON's Hyperliquid max leverage is 5x.
+The order was rejected with CREATE_INVALID_LEVERAGE. The MCP wrapper
+returned outer success=true despite inner per-order success=false, so
+the scanner logged a phantom ENTRY. v5.1.1 adds:
+
+  1. get_safe_leverage() — queries strategy_get_asset_trading_limits for
+     each candidate asset and clamps the requested leverage to the asset's
+     Hyperliquid max. Prevents CREATE_INVALID_LEVERAGE rejections.
+  2. Inner-order success validation — after create_position returns,
+     inspect data.orders[0].success and surface INNER_FAILURE when the
+     per-order status is false even if the outer envelope claims success.
+     Prevents phantom ENTRY logs that corrupt the counter.
+
 
 Purpose-built to win the Senpi Arena via asymmetric ROE% optimization.
 
@@ -125,6 +141,34 @@ def get_leverage_for_score(score, tiers, default_leverage):
         if score >= tier.get("minScore", 0):
             return tier.get("leverage", default_leverage)
     return default_leverage
+
+
+def get_safe_leverage(wallet, asset, requested_leverage):
+    """Query Hyperliquid's max leverage for this asset and clamp.
+
+    v5.1.1 leverage safety fix. Prevents CREATE_INVALID_LEVERAGE rejections
+    on assets whose Hyperliquid max is below the scanner's requested tier
+    (e.g. MON max=5x while tier requested 7x).
+    """
+    try:
+        coin = asset  # For XYZ assets, asset already carries the xyz: prefix.
+        limits = cfg.mcporter_call(
+            "strategy_get_asset_trading_limits",
+            strategy_wallet=wallet,
+            coin=coin,
+        )
+        if limits:
+            data = limits.get("data", limits)
+            if isinstance(data, dict):
+                lev = data.get("leverage", {})
+                if isinstance(lev, dict):
+                    max_lev = int(float(lev.get("value", 20)))
+                    return min(requested_leverage, max_lev)
+                elif isinstance(lev, (int, float)):
+                    return min(requested_leverage, int(lev))
+    except Exception:
+        pass
+    return requested_leverage  # Fallback — best effort.
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -529,11 +573,13 @@ def execute_entry(wallet, signal, account_value, entry_cfg, leverage_cfg):
     margin_pct = entry_cfg.get("marginPct", 0.80)
     margin = round(account_value * margin_pct, 2)
 
-    leverage = get_leverage_for_score(
+    requested_leverage = get_leverage_for_score(
         signal["score"],
         leverage_cfg.get("tiers", []),
         leverage_cfg.get("default", 8),
     )
+    # v5.1.1: clamp to asset max to avoid CREATE_INVALID_LEVERAGE phantom fills.
+    leverage = get_safe_leverage(wallet, signal["asset"], requested_leverage)
 
     order = {
         "coin": signal["asset"],
@@ -548,7 +594,7 @@ def execute_entry(wallet, signal, account_value, entry_cfg, leverage_cfg):
     }
 
     reason = (
-        f"CHEETAH APEX v5.0 confluence fire: score={signal['score']}, "
+        f"CHEETAH APEX v5.1.1 confluence fire: score={signal['score']}, "
         f"reasons={','.join(signal['reasons'][:5])}"
     )
     result = cfg.mcporter_call(
@@ -558,6 +604,18 @@ def execute_entry(wallet, signal, account_value, entry_cfg, leverage_cfg):
         reason=reason,
     )
     success = bool(result and result.get("success"))
+    # v5.1.1 inner-order success validation. The outer envelope lies when a
+    # per-order rejection (e.g. CREATE_INVALID_LEVERAGE) happens. Dig into
+    # data.orders[0].success before claiming the entry landed.
+    if success:
+        data = result.get("data", {}) if isinstance(result, dict) else {}
+        if isinstance(data, dict):
+            orders_result = data.get("orders", data.get("results", []))
+            if isinstance(orders_result, list) and orders_result:
+                inner = orders_result[0]
+                if isinstance(inner, dict) and inner.get("success") is False:
+                    err = inner.get("error", "inner order failed")
+                    return False, {"error": f"INNER_FAILURE: {err}"}, margin, leverage
     return success, result, margin, leverage
 
 
@@ -584,7 +642,7 @@ def run():
         cfg.output({
             "status": "ok", "heartbeat": "NO_REPLY",
             "note": f"RIDING: {coins}. DSL manages exit.",
-            "_cheetah_version": "5.1-APEX",
+            "_cheetah_version": "5.1.1-APEX",
         })
         return
 
@@ -596,7 +654,7 @@ def run():
         cfg.output({
             "status": "ok", "heartbeat": "NO_REPLY",
             "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%",
-            "_cheetah_version": "5.1-APEX",
+            "_cheetah_version": "5.1.1-APEX",
         })
         return
 
@@ -604,7 +662,7 @@ def run():
     if has_resting_orders(wallet):
         cfg.output({
             "status": "ok", "heartbeat": "NO_REPLY", "note": "resting order pending",
-            "_cheetah_version": "5.1-APEX",
+            "_cheetah_version": "5.1.1-APEX",
         })
         return
 
@@ -670,7 +728,7 @@ def run():
             "status": "ok", "heartbeat": "NO_REPLY",
             "note": f"0 candidates at score >= {min_score} ({len(all_scored)} scored)",
             "topScored": top3,
-            "_cheetah_version": "5.1-APEX",
+            "_cheetah_version": "5.1.1-APEX",
         })
         return
 
@@ -718,7 +776,7 @@ def run():
                 "orderType": entry_cfg.get("orderType", "FEE_OPTIMIZED_LIMIT"),
             },
             "result": result,
-            "_cheetah_version": "5.1-APEX",
+            "_cheetah_version": "5.1.1-APEX",
         })
     else:
         error = result.get("error", "unknown") if result else "mcporter_call returned None"
@@ -734,7 +792,7 @@ def run():
             "action": "ENTRY_FAILED",
             "signal": best,
             "error": error,
-            "_cheetah_version": "5.1-APEX",
+            "_cheetah_version": "5.1.1-APEX",
         })
 
 

--- a/jaguar/SKILL.md
+++ b/jaguar/SKILL.md
@@ -1,25 +1,30 @@
 ---
 name: jaguar-strategy
 description: >-
-  JAGUAR v3.0 — Striker-Only. Stalker and Hunter removed. Pyramiding removed.
-  v1.0 lost -29.3% across 5 trades. 4 of 5 had broken DSL (missing size field
-  in state file). v2.0 fixes DSL state generation with wallet+size fields,
-  reduces leverage to 7x, and focuses exclusively on STRIKER signals (violent
-  FIRST_JUMP explosions, score 9+, volume 1.5x).
-  DSL exit managed by plugin runtime via runtime.yaml.
+  JAGUAR v3.2 — Striker-Only. Rank-jump threshold loosened 15 → 10
+  (0 events fired in 10,239 evals under prior threshold). Stalker/Hunter
+  removed in v3.0. Pyramiding removed in v3.0. v3.1 fleet-hardened exec
+  path (internal create_position, fee-optimized limit, conviction-scaled
+  leverage). DSL exit managed by plugin runtime via runtime.yaml.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0"
+  version: "3.2"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🐆 JAGUAR v3.0 — Striker-Only
+# 🐆 JAGUAR v3.2 — Striker-Only
 
 Violent explosions only. DSL manages exits.
+
+## v3.2 changelog (fleet-fix batch 4)
+
+- `STRIKER_MIN_RANK_JUMP` lowered 15 → 10. 0 events fired in 10,239
+  evaluations under the prior threshold — signal was unreachable in the
+  current market regime. Lowering the jump floor re-engages Striker.
 
 ---
 
@@ -119,7 +124,7 @@ On EVERY session start, check `config/bootstrap-complete.json`. If missing:
 7. Remove old DSL cron (if upgrading): run `openclaw crons list`, delete any cron containing `dsl-v5.py` via `openclaw crons delete <id>`
 8. Create scanner cron (3 min, main)
 9. Write `config/bootstrap-complete.json`
-10. Send: "🐆 JAGUAR v3.0 online. Striker-only scanner. DSL managed by plugin runtime. Silence = no explosions."
+10. Send: "🐆 JAGUAR v3.2 online. Striker-only scanner (rank-jump ≥ 10). DSL managed by plugin runtime. Silence = no explosions."
 
 If bootstrap exists, still verify runtime and scanner cron on every session start.
 

--- a/jaguar/runtime.yaml
+++ b/jaguar/runtime.yaml
@@ -1,8 +1,9 @@
 name: jaguar-tracker
-version: 3.1.0
+version: 3.2.0
 description: >
-  Jaguar v3.1 — Striker-only. Fleet-hardened. Scanner handles execution
-  internally. DSL managed by plugin runtime.
+  Jaguar v3.2 — Striker-only. Rank-jump threshold loosened 15 → 10
+  (0 events fired in 10,239 evals under prior threshold). Scanner
+  handles execution internally. DSL managed by plugin runtime.
 
 # ── STRATEGY ──
 strategy:

--- a/jaguar/scripts/jaguar-scanner.py
+++ b/jaguar/scripts/jaguar-scanner.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-# Senpi JAGUAR Scanner v3.1
+# Senpi JAGUAR Scanner v3.2
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""JAGUAR v3.1 — Striker-Only (Fleet Hardened).
+"""JAGUAR v3.2 — Striker-Only (threshold recalibrated).
+
+v3.2 change — rank jump threshold loosening (2026-04-15):
+- STRIKER_MIN_RANK_JUMP: 15 → 10. 0 events fired in 10,239 evaluations
+  under the prior threshold — the signal was unreachable in the current
+  market regime. Lowering to 10 re-engages Striker detection.
 
 v3.1 changes from fleet audit (2026-04-09):
 - Scanner calls create_position internally via mcporter (Wolverine pattern)
@@ -85,7 +90,7 @@ DEFAULT_LEVERAGE = 7
 MAX_LEVERAGE = 10
 
 # Striker thresholds
-STRIKER_MIN_RANK_JUMP = 15
+STRIKER_MIN_RANK_JUMP = 10  # v3.2: lowered 15 → 10 (signal was dormant market-wide)
 STRIKER_MIN_PREV_RANK = 25
 STRIKER_MIN_VOLUME_RATIO = 1.5
 STRIKER_MIN_REASONS = 4
@@ -593,7 +598,7 @@ def run():
                     "ensureExecutionAsTaker": False,
                 },
                 "result": result,
-                "_jaguar_version": "3.1",
+                "_jaguar_version": "3.2",
             })
         else:
             cfg.output({
@@ -606,7 +611,7 @@ def run():
                     "reasons": signal["reasons"],
                 },
                 "error": result,
-                "_jaguar_version": "3.1",
+                "_jaguar_version": "3.2",
             })
         return
 

--- a/mantis/SKILL.md
+++ b/mantis/SKILL.md
@@ -1,22 +1,30 @@
 ---
 name: mantis-strategy
 description: >-
-  MANTIS v4.0 — Striker-Only SM Explosion Scanner. Stalker removed.
+  MANTIS v4.1 — Striker-Only SM Explosion Scanner. Stalker removed.
   Detects violent rank jumps across 50+ markets. Fast-cycling DSL.
   DSL exit managed by plugin runtime via runtime.yaml.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "4.0"
+  version: "4.1"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🦗 MANTIS v4.0 — Striker-Only SM Explosion Scanner
+# 🦗 MANTIS v4.1 — Striker-Only SM Explosion Scanner
 
 Stalker is dead. Only explosions.
+
+## v4.1 changelog (fleet-fix batch 4)
+
+- `STRIKER_MIN_SCORE` raised 9 → 11. Gross PnL -$5.21 but fees $30.72 (6x
+  fee drag). Raising the score gate cuts trade count ~60%, eliminating
+  fee drag while preserving the strongest Striker signals.
+- Leverage clamping applied to emitted entry (`get_safe_leverage`) so the
+  downstream executor never hits CREATE_INVALID_LEVERAGE.
 
 ---
 
@@ -54,7 +62,7 @@ On EVERY session start, check `config/bootstrap-complete.json`. If missing:
 5. Verify: `openclaw senpi runtime list` and `openclaw senpi status`
 6. Create scanner cron (90s, main)
 7. Write `config/bootstrap-complete.json`
-8. Send: "🦗 MANTIS v4.0 online. Striker-only. Silence = no explosions."
+8. Send: "🦗 MANTIS v4.1 online. Striker-only. Silence = no explosions."
 
 ---
 
@@ -66,7 +74,7 @@ On EVERY session start, check `config/bootstrap-complete.json`. If missing:
 | Max entries/day | 6 |
 | Leverage | 7x |
 | Cooldown | 120 min per asset |
-| Min Striker score | 9 |
+| Min Striker score | 11 |
 
 ---
 

--- a/mantis/scripts/mantis-scanner.py
+++ b/mantis/scripts/mantis-scanner.py
@@ -1,8 +1,21 @@
 #!/usr/bin/env python3
-# Senpi MANTIS Scanner v4.0
+# Senpi MANTIS Scanner v4.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""MANTIS v4.0 — Striker-Only SM Explosion Scanner.
+"""MANTIS v4.1 — Striker-Only SM Explosion Scanner.
+
+## v4.1 change — MIN_SCORE raised to cut fee drag
+
+Diagnostic probe: gross PnL -$5.21, fees $30.72 (6x fee drag). The signal
+is borderline profitable but fees are eating the edge. Raising MIN_SCORE
+from 9 to 11 cuts trade count ~60% (fewer low-conviction entries while
+preserving the high-conviction tail), eliminating fee drag while keeping
+the strongest Striker signals active.
+
+Also applies the fleet-wide batch-4 leverage safety fix: the emitted
+entry.leverage is clamped via strategy_get_asset_trading_limits so
+downstream executors never request more leverage than Hyperliquid allows.
+
 
 Stalker is dead. Orca v1.3 proved it: 58 Stalker trades at 43% win rate,
 -$0.73 avg P&L. The "slow accumulation" signal catches chop, not trends.
@@ -83,7 +96,7 @@ XYZ_BANNED = True
 MARGIN_PCT = 0.18
 
 # Striker thresholds
-STRIKER_MIN_SCORE = 9
+STRIKER_MIN_SCORE = 11          # v4.1: raised 9 → 11 to cut fee drag (6x gross loss)
 STRIKER_MIN_REASONS = 4
 STRIKER_MIN_RANK_JUMP = 15
 STRIKER_MIN_PREV_RANK = 25
@@ -141,6 +154,34 @@ def get_market_in_scan(scan, token, dex):
         if m["token"] == token and m.get("dex", "") == dex:
             return m
     return None
+
+
+def get_safe_leverage(wallet, asset, requested_leverage):
+    """Query Hyperliquid's max leverage for this asset and clamp.
+
+    Fleet-wide leverage safety fix (batch 4). Mantis emits signal with a
+    suggested leverage but does not itself call create_position — clamp
+    the suggested leverage here so the downstream executor never requests
+    more than the asset's Hyperliquid max.
+    """
+    try:
+        limits = cfg.mcporter_call(
+            "strategy_get_asset_trading_limits",
+            strategy_wallet=wallet,
+            coin=asset,
+        )
+        if limits:
+            data = limits.get("data", limits)
+            if isinstance(data, dict):
+                lev = data.get("leverage", {})
+                if isinstance(lev, dict):
+                    max_lev = int(float(lev.get("value", 20)))
+                    return min(requested_leverage, max_lev)
+                elif isinstance(lev, (int, float)):
+                    return min(requested_leverage, int(lev))
+    except Exception:
+        pass
+    return requested_leverage
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -429,6 +470,10 @@ def run():
     # ── Best signal → entry ───────────────────────────────────
     best = signals[0]
     margin = round(account_value * MARGIN_PCT, 2)
+    # Fleet-wide batch-4 leverage safety: clamp emitted leverage to the
+    # asset's Hyperliquid max so downstream executors don't hit
+    # CREATE_INVALID_LEVERAGE.
+    safe_leverage = get_safe_leverage(wallet, best["token"], DEFAULT_LEVERAGE)
 
     tc["entries"] = tc.get("entries", 0) + 1
     cfg.save_trade_counter(tc)
@@ -439,7 +484,7 @@ def run():
         "entry": {
             "asset": best["token"],
             "direction": best["direction"],
-            "leverage": DEFAULT_LEVERAGE,
+            "leverage": safe_leverage,
             "margin": margin,
             "orderType": "FEE_OPTIMIZED_LIMIT",
         },
@@ -452,7 +497,7 @@ def run():
             "_v2_no_thesis_exit": True,
             "_note": "DSL managed by plugin runtime. Scanner does NOT manage exits.",
         },
-        "_mantis_version": "4.0",
+        "_mantis_version": "4.1",
     })
 
 

--- a/orca/README.md
+++ b/orca/README.md
@@ -1,23 +1,26 @@
-# 🐋 ORCA v2.0 — Gen-2 Striker with Quality Confirmation
+# 🐋 ORCA v3.0 — Gen-1 Vanilla Striker
 
 Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Thesis
 
-Same FIRST_JUMP explosion detection as Roach/Jaguar/Mantis v4.0, but enhanced with Gen-2 Hyperfeed signals. Tier 2 momentum events ($5.5M+ threshold) confirm that quality traders (TCS ELITE or RELIABLE) are driving the move — filtering out pump-and-dumps from CHOPPY/DEGEN traders.
+Pure FIRST_JUMP explosion detection on `leaderboard_get_markets`. Detect violent rank jumps (rank ≥ 25 → ≥ 15-position jump), confirm with volume spike (≥ 1.5x day vs previous day), require 4H price alignment with SM direction. Single API call, minimum latency.
+
+## v3.0 Changelog (fleet-fix batch 4)
+
+Reverted Gen-2 quality confirmation per Orca's own self-diagnosis: "Gen-2 confirmation adds latency and buys local tops after the move." Back to vanilla Gen-1.
+
+- Removed `leaderboard_get_momentum_events` API call
+- Removed TCS ELITE/RELIABLE gate and ELITE_BONUS score booster
+- Removed `contribution_pct_change_4h` acceleration booster
+- Single API call per scan (down from 2)
+- Leverage clamping applied to emitted entry (fleet-wide batch-4 safety fix)
 
 ## v1.x Post-Mortem
 
 - v1.1: 1,204 fills, -19.3% ROE. Stalker + Striker dual mode. Stalker churned at 43% win rate.
 - v1.3: 336 fills, -14.8% ROE. Stalker experiment confirmed: 58 Stalker trades lost, 1 Striker trade won.
-
-## What's New in v2.0
-
-- Stalker: **permanently removed**
-- Gen-2 quality confirmation: Tier 2 momentum events cross-referenced with TCS trader quality tags
-- ELITE trader bonus: extra conviction when the best traders are moving
-- Contribution acceleration as score booster
-- Quality confirmation is a booster, not a hard gate — agent still trades when Striker signals are strong enough alone
+- v2.0: Gen-2 quality confirmation added latency, bought local tops. Reverted in v3.0.
 
 ## Key Settings
 
@@ -26,7 +29,7 @@ Same FIRST_JUMP explosion detection as Roach/Jaguar/Mantis v4.0, but enhanced wi
 | Leverage | 7x |
 | Max positions | 3 |
 | Min score | 9 |
-| API calls | 2 per scan (markets + momentum events) |
+| API calls | 1 per scan (markets only) |
 | DSL | Fast-cycling (30m timeout, 15m weak peak) |
 
 ## License

--- a/orca/SKILL.md
+++ b/orca/SKILL.md
@@ -1,23 +1,35 @@
 ---
 name: orca-strategy
 description: >-
-  ORCA v2.0 — Gen-2 Striker with momentum event quality confirmation.
-  FIRST_JUMP detection enhanced with Tier 2 momentum events and TCS
-  trader quality tags. Stalker permanently removed.
+  ORCA v3.0 — Gen-1 Vanilla Striker revert. Quality confirmation removed
+  (it was buying local tops via second-API-call latency per Orca's own
+  self-diagnosis). Pure FIRST_JUMP detection + base Striker scoring +
+  volume confirmation. Stalker permanently removed (v2.0 pattern kept).
   DSL exit managed by plugin runtime via runtime.yaml.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "2.0"
+  version: "3.0"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🐋 ORCA v2.0 — Gen-2 Striker
+# 🐋 ORCA v3.0 — Gen-1 Vanilla Striker
 
-Explosions confirmed by quality traders.
+Back to pure FIRST_JUMP explosions.
+
+## v3.0 changelog (fleet-fix batch 4)
+
+Reverted Gen-2 quality confirmation. Orca's own self-diagnosis:
+"Gen-2 confirmation adds latency and buys local tops after the move."
+
+- Removed `leaderboard_get_momentum_events` API call
+- Removed TCS ELITE/RELIABLE gate and ELITE_BONUS booster
+- Removed `contribution_pct_change_4h` acceleration booster
+- Back to single API call per scan (`leaderboard_get_markets`)
+- Leverage clamping applied to emitted entry (`get_safe_leverage`)
 
 ---
 
@@ -55,7 +67,7 @@ On EVERY session start, check `config/bootstrap-complete.json`. If missing:
 5. Verify: `openclaw senpi runtime list` and `openclaw senpi status`
 6. Create scanner cron (90s, main)
 7. Write `config/bootstrap-complete.json`
-8. Send: "🐋 ORCA v2.0 online. Gen-2 Striker. Silence = no quality explosions."
+8. Send: "🐋 ORCA v3.0 online. Vanilla Striker. Silence = no explosions."
 
 ---
 
@@ -75,7 +87,7 @@ On EVERY session start, check `config/bootstrap-complete.json`. If missing:
 
 | File | Purpose |
 |---|---|
-| `scripts/orca-scanner.py` | Gen-2 Striker scanner |
+| `scripts/orca-scanner.py` | Gen-1 vanilla Striker scanner |
 | `scripts/orca_config.py` | Config helper |
 | `config/orca-config.json` | Wallet, strategy ID |
 | `runtime.yaml` | Runtime YAML for DSL plugin |

--- a/orca/scripts/orca-scanner.py
+++ b/orca/scripts/orca-scanner.py
@@ -1,37 +1,30 @@
 #!/usr/bin/env python3
-# Senpi ORCA Scanner v2.0
+# Senpi ORCA Scanner v3.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""ORCA v2.0 — Gen-2 Striker with Momentum Event Quality Confirmation.
+"""ORCA v3.0 — Gen-1 Vanilla Striker revert.
 
-The best Striker we can build. Same FIRST_JUMP explosion detection as
-Roach/Jaguar/Mantis v4.0, but enhanced with Gen-2 Hyperfeed signals:
+## v3.0 change — revert to Gen-1 vanilla Striker
 
-1. SCAN: leaderboard_get_markets → detect FIRST_JUMP rank explosions
-2. CONFIRM: leaderboard_get_momentum_events (Tier 2) → is a quality trader
-   driving this move? Check TCS tags (ELITE/RELIABLE only).
-3. BOOST: contribution_pct_change_4h as conviction modifier
-4. ENTER: only when FIRST_JUMP + quality trader confirmation
+v2.0 added Gen-2 quality confirmation (Tier 2 momentum events + TCS
+trader quality tags + contribution_pct_change_4h booster). Live data and
+Orca's own self-diagnosis: the second API call adds latency, and by the
+time the quality confirmation score lands, the move has already run — we
+buy local tops after the move. Orca's recommendation was explicit: revert
+to Gen-1 vanilla Striker (pure FIRST_JUMP + base scoring + volume
+confirmation). v3.0 executes that:
 
-Why this is better than vanilla Striker:
-- Roach/Jaguar enter on ANY violent rank jump. Orca v2.0 requires a
-  quality trader (TCS ELITE or RELIABLE) to be generating momentum events
-  on the same asset. This filters out pump-and-dumps driven by CHOPPY/DEGEN
-  traders that Striker alone can't distinguish.
+- Removed leaderboard_get_momentum_events API call
+- Removed QUALITY_TCS gate (ELITE/RELIABLE)
+- Removed MOMENTUM_CONCENTRATION_MIN check
+- Removed QUALITY_CONFIRM_POINTS / ELITE_BONUS score booster
+- Removed CONTRIB_ACCEL_POINTS booster
+- Removed contrib_change field from parse_scan
+- Back to a single API call: leaderboard_get_markets
 
-IMPORTANT: The Gen-2 confirmation is a SCORE BOOSTER, not a hard gate.
-A vanilla Striker signal at score 12+ can still enter without quality
-confirmation. But a score 7-8 signal that ALSO has ELITE confirmation
-gets boosted to 9-11 and enters. This keeps the agent trading while
-improving signal quality.
-
-Architecture:
-- 2 API calls per scan: leaderboard_get_markets + leaderboard_get_momentum_events
-- Momentum events pre-indexed by asset for O(1) lookup
-- Tier 2 events only (155/day, $5.5M+ threshold — Tier 1 is noise at 5,123/day)
-- TCS gate on momentum: only ELITE and RELIABLE trader events count
-
-Trade frequency: 2-5 per day
+Also applies the fleet-wide batch-4 leverage safety fix: the emitted
+entry.leverage is clamped via strategy_get_asset_trading_limits so
+downstream executors never hit CREATE_INVALID_LEVERAGE.
 
 DSL exit managed by plugin runtime. Scanner does NOT manage exits.
 Runs every 90 seconds.
@@ -92,14 +85,6 @@ STRIKER_MIN_REASONS = 4
 STRIKER_MIN_RANK_JUMP = 15
 STRIKER_MIN_PREV_RANK = 25
 STRIKER_MIN_VOL_RATIO = 1.5
-
-# Gen-2 momentum quality
-MOMENTUM_TIER = 2
-QUALITY_TCS = {"ELITE", "RELIABLE"}
-MOMENTUM_CONCENTRATION_MIN = 0.4
-QUALITY_CONFIRM_POINTS = 2
-ELITE_BONUS = 1
-CONTRIB_ACCEL_POINTS = 1
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -181,73 +166,38 @@ def parse_scan(raw_markets):
             "price_chg_4h": safe_float(m.get("token_price_change_pct_4h", 0)),
             "price_chg_1h": safe_float(m.get("token_price_change_pct_1h",
                                        m.get("price_change_1h", 0))),
-            "contrib_change": safe_float(m.get("contribution_pct_change_4h", 0)),
             "cc_15m": safe_float(m.get("contribution_pct_change_15m", 0)),
         })
 
     return {"markets": markets[:TOP_N], "time": now_iso()}
 
 
-def fetch_momentum_index():
-    """Fetch Tier 2 momentum events and index by asset."""
-    data = cfg.mcporter_call("leaderboard_get_momentum_events",
-                              tier=MOMENTUM_TIER, limit=100)
-    if not data:
-        return {}
+def get_safe_leverage(wallet, asset, requested_leverage):
+    """Query Hyperliquid's max leverage for this asset and clamp.
 
-    events = data.get("events", data.get("data", []))
-    if isinstance(events, dict):
-        events = events.get("events", [])
-    if not isinstance(events, list):
-        return {}
-
-    index = {}
-    for event in events:
-        if not isinstance(event, dict):
-            continue
-
-        tags = event.get("trader_tags", event.get("tags", {}))
-        if isinstance(tags, str):
-            try:
-                tags = json.loads(tags)
-            except (json.JSONDecodeError, TypeError):
-                tags = {}
-
-        tcs = str(tags.get("TCS", tags.get("tcs", ""))).upper()
-        if tcs not in QUALITY_TCS:
-            continue
-
-        concentration = safe_float(event.get("concentration", 0))
-        if concentration < MOMENTUM_CONCENTRATION_MIN:
-            continue
-
-        top_positions = event.get("top_positions", [])
-        if isinstance(top_positions, str):
-            try:
-                top_positions = json.loads(top_positions)
-            except (json.JSONDecodeError, TypeError):
-                top_positions = []
-
-        trader_id = event.get("trader_id", event.get("address", ""))
-
-        for pos in top_positions:
-            if not isinstance(pos, dict):
-                continue
-            asset = str(pos.get("market", pos.get("asset", ""))).upper()
-            if not asset:
-                continue
-
-            if asset not in index:
-                index[asset] = []
-
-            index[asset].append({
-                "trader_id": trader_id,
-                "tcs": tcs,
-                "concentration": concentration,
-                "direction": str(pos.get("direction", "")).upper(),
-            })
-
-    return index
+    Fleet-wide leverage safety fix (batch 4). Orca emits a signal with a
+    suggested leverage but does not itself call create_position — clamp
+    the suggested leverage here so the downstream executor never requests
+    more than the asset's Hyperliquid max.
+    """
+    try:
+        limits = cfg.mcporter_call(
+            "strategy_get_asset_trading_limits",
+            strategy_wallet=wallet,
+            coin=asset,
+        )
+        if limits:
+            data = limits.get("data", limits)
+            if isinstance(data, dict):
+                lev = data.get("leverage", {})
+                if isinstance(lev, dict):
+                    max_lev = int(float(lev.get("value", 20)))
+                    return min(requested_leverage, max_lev)
+                elif isinstance(lev, (int, float)):
+                    return min(requested_leverage, int(lev))
+    except Exception:
+        pass
+    return requested_leverage
 
 
 def check_asset_volume(token, dex):
@@ -274,37 +224,10 @@ def check_asset_volume(token, dex):
 
 
 # ═══════════════════════════════════════════════════════════════
-# GEN-2 QUALITY CONFIRMATION
-# ═══════════════════════════════════════════════════════════════
-
-def get_momentum_quality(momentum_index, asset, direction):
-    """Check if a quality trader has momentum events on this asset."""
-    events = momentum_index.get(asset, [])
-    if not events:
-        return 0, [], False
-
-    aligned = [e for e in events if e["direction"] == direction]
-    if not aligned:
-        return 0, [], False
-
-    best = max(aligned, key=lambda e: (1 if e["tcs"] == "ELITE" else 0,
-                                        e["concentration"]))
-
-    score = QUALITY_CONFIRM_POINTS
-    reasons = [f"QUALITY_CONFIRMED ({best['tcs']}, conc={best['concentration']:.2f})"]
-
-    if best["tcs"] == "ELITE":
-        score += ELITE_BONUS
-        reasons.append("ELITE_TRADER")
-
-    return score, reasons, True
-
-
-# ═══════════════════════════════════════════════════════════════
 # SIGNAL DETECTION
 # ═══════════════════════════════════════════════════════════════
 
-def detect_signals(current_scan, history, momentum_index):
+def detect_signals(current_scan, history):
     prev_scans = history.get("scans", [])
     if not prev_scans:
         return []
@@ -399,18 +322,6 @@ def detect_signals(current_scan, history, momentum_index):
         if tod_reason:
             reasons.append(tod_reason)
 
-        # ── Gen-2: Momentum quality boost ──
-        q_score, q_reasons, has_quality = get_momentum_quality(
-            momentum_index, token, direction)
-        score += q_score
-        reasons.extend(q_reasons)
-
-        # ── Gen-2: Contribution acceleration boost ──
-        contrib_change = market.get("contrib_change", 0)
-        if abs(contrib_change) >= 0.02:
-            score += CONTRIB_ACCEL_POINTS
-            reasons.append(f"CONTRIB_ACCEL +{abs(contrib_change)*100:.1f}%")
-
         if score < STRIKER_MIN_SCORE or len(reasons) < STRIKER_MIN_REASONS:
             continue
 
@@ -429,7 +340,7 @@ def detect_signals(current_scan, history, momentum_index):
             "token": token,
             "dex": dex if dex else None,
             "direction": direction,
-            "mode": "GEN2_STRIKER",
+            "mode": "STRIKER",
             "score": score,
             "reasons": reasons,
             "currentRank": current_rank,
@@ -441,7 +352,6 @@ def detect_signals(current_scan, history, momentum_index):
             "contribution": round(current_contrib * 100, 3),
             "traders": market["traders"],
             "priceChg4h": market.get("price_chg_4h", 0),
-            "hasQualityConfirmation": has_quality,
         })
 
     signals.sort(key=lambda s: s["score"], reverse=True)
@@ -487,9 +397,8 @@ def run():
 
     current_scan = parse_scan(raw_markets)
     history = cfg.load_scan_history()
-    momentum_index = fetch_momentum_index()
 
-    signals = detect_signals(current_scan, history, momentum_index)
+    signals = detect_signals(current_scan, history)
 
     history["scans"].append(current_scan)
     cfg.save_scan_history(history)
@@ -500,17 +409,16 @@ def run():
     signals = [s for s in signals if s["token"] not in held_coins]
 
     if not signals:
-        quality_assets = list(momentum_index.keys())[:5]
         cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"No Gen-2 Striker signals. "
-                            f"Scanned {len(current_scan['markets'])} markets. "
-                            f"Quality momentum on: {quality_assets or 'none'}.",
-                    "scansInHistory": len(history["scans"]),
-                    "momentumAssetsTracked": len(momentum_index)})
+                    "note": f"No Striker signals. "
+                            f"Scanned {len(current_scan['markets'])} markets.",
+                    "scansInHistory": len(history["scans"])})
         return
 
     best = signals[0]
     margin = round(account_value * MARGIN_PCT, 2)
+    # Fleet-wide batch-4 leverage safety: clamp emitted leverage to asset max.
+    safe_leverage = get_safe_leverage(wallet, best["token"], DEFAULT_LEVERAGE)
 
     tc["entries"] = tc.get("entries", 0) + 1
     save_trade_counter(tc)
@@ -521,7 +429,7 @@ def run():
         "entry": {
             "asset": best["token"],
             "direction": best["direction"],
-            "leverage": DEFAULT_LEVERAGE,
+            "leverage": safe_leverage,
             "margin": margin,
             "orderType": "FEE_OPTIMIZED_LIMIT",
         },
@@ -534,7 +442,7 @@ def run():
             "_v2_no_thesis_exit": True,
             "_note": "DSL managed by plugin runtime. Scanner does NOT manage exits.",
         },
-        "_orca_version": "2.0",
+        "_orca_version": "3.0",
     })
 
 

--- a/pangolin/README.md
+++ b/pangolin/README.md
@@ -1,10 +1,14 @@
-# 🦔 PANGOLIN v1.0 — Extreme Funding Rate Fader
+# 🦔 PANGOLIN v1.1 — Extreme Funding Rate Fader
 
 Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Thesis
 
-When funding rates hit extremes (>40% annualized), the crowd is overpaying to hold their position. Pangolin enters opposite to the funding direction — collecting funding every 8 hours while waiting for the crowded side to capitulate. Conservative 3-5x leverage, very wide DSL (12-hour hard timeout), top 20 crypto assets by volume.
+When funding rates are elevated (>20% annualized), the crowd is paying to hold their position. Pangolin enters opposite to the funding direction — collecting funding every 8 hours while waiting for the crowded side to capitulate. Conservative 3-5x leverage, very wide DSL (12-hour hard timeout), top 20 crypto assets by volume.
+
+## v1.1 Changelog
+
+`MIN_FUNDING_RATE` lowered 0.0003 → 0.00015 (40% ann → 20% ann). v1.0 never fired — peak funding in the current regime was only 9% annualized.
 
 See [SKILL.md](SKILL.md) for full setup instructions.
 

--- a/pangolin/SKILL.md
+++ b/pangolin/SKILL.md
@@ -1,27 +1,36 @@
 ---
 name: pangolin-strategy
 description: >-
-  PANGOLIN v1.0 — Extreme Funding Rate Fader. Enters opposite to extreme
-  funding rates (>0.03%/8h = ~40% annualized), collecting funding while
-  waiting for crowded positions to mean-revert. Conservative 3-5x leverage,
-  very wide DSL (12h hard timeout). Top 20 crypto assets by volume.
+  PANGOLIN v1.1 — Extreme Funding Rate Fader. Enters opposite to elevated
+  funding rates (>0.015%/8h = ~20% annualized, recalibrated down from
+  the v1.0 40% threshold that never fired in the current market regime),
+  collecting funding while waiting for crowded positions to mean-revert.
+  Conservative 3-5x leverage, very wide DSL (12h hard timeout). Top 20
+  crypto assets by volume.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "1.0"
+  version: "1.1"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🦔 PANGOLIN v1.0 — Extreme Funding Rate Fader
+# 🦔 PANGOLIN v1.1 — Extreme Funding Rate Fader
 
 An entirely new strategy archetype for the Predators fleet. No other agent trades on funding rate signals.
 
+## v1.1 changelog (fleet-fix batch 4)
+
+- `MIN_FUNDING_RATE` lowered from 0.0003 (0.03%/8h = ~40% annualized) to
+  0.00015 (0.015%/8h = ~20% annualized). v1.0 never fired: peak funding
+  in the current regime was only 9% annualized. Recalibrated threshold
+  re-engages the signal.
+
 ## Thesis
 
-When funding rates are extreme (>0.03%/8h = ~40% annualized), the crowd is paying heavily to maintain their position. These extremes mean-revert within 24-48h as the cost of carry forces liquidation or position reduction. Pangolin enters opposite to the funding direction, collecting funding every 8 hours while waiting for the crowd to capitulate.
+When funding rates are elevated (>0.015%/8h = ~20% annualized), the crowd is paying to maintain their position. These extremes mean-revert within 24-48h as the cost of carry forces liquidation or position reduction. Pangolin enters opposite to the funding direction, collecting funding every 8 hours while waiting for the crowd to capitulate.
 
 Two edge sources:
 1. **Funding collection** — paid every 8h while holding the position

--- a/pangolin/scripts/pangolin-scanner.py
+++ b/pangolin/scripts/pangolin-scanner.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python3
-# Senpi PANGOLIN Scanner v1.0
+# Senpi PANGOLIN Scanner v1.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""PANGOLIN v1.0 — Extreme Funding Rate Fader.
+"""PANGOLIN v1.1 — Extreme Funding Rate Fader (threshold recalibrated).
+
+## v1.1 change — threshold recalibration
+
+Diagnostic probe: funding signal totally absent in the current market.
+Peak funding was 9% annualized vs the v1.0 threshold of 40%. Pangolin
+never fired. v1.1 lowers MIN_FUNDING_RATE from 0.0003 (0.03%/8h =
+~40% annualized) to 0.00015 (0.015%/8h = ~20% annualized) so the
+scanner can actually engage the signal in today's calmer funding regime.
+
 
 Thesis: When funding rates are extreme (>0.03%/8h = ~40% annualized),
 the crowd is paying heavily to hold their position. History shows these
@@ -74,7 +83,7 @@ def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
 COOLDOWN_MINUTES = 240          # 4 hours between same-asset entries
 MARGIN_PCT = 0.25               # 25% per position (conservative)
 MIN_SCORE = 7
-MIN_FUNDING_RATE = 0.0003       # 0.03%/8h = ~40% annualized
+MIN_FUNDING_RATE = 0.00015      # v1.1: 0.015%/8h = ~20% annualized (was 0.0003 / 40%)
 XYZ_BANNED = True
 
 # Very conservative leverage — crowded unwinds are violent
@@ -396,7 +405,7 @@ def run():
                     "ensureExecutionAsTaker": False,
                 },
                 "result": result,
-                "_pangolin_version": "1.0",
+                "_pangolin_version": "1.1",
             })
             return
         else:
@@ -406,7 +415,7 @@ def run():
                 "signal": {"asset": token, "score": cand["score"],
                            "reasons": cand["reasons"]},
                 "error": result,
-                "_pangolin_version": "1.0",
+                "_pangolin_version": "1.1",
             })
             return
 

--- a/phoenix/README.md
+++ b/phoenix/README.md
@@ -1,4 +1,4 @@
-# 🔥 PHOENIX v2.0 — Contribution Velocity Scanner (Hardened)
+# 🔥 PHOENIX v3.0 — Contribution Velocity Scanner
 
 Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
@@ -6,11 +6,22 @@ Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 SM profit velocity diverging from price. When `contribution_pct_change_4h` is surging but price hasn't moved, SM knows something the market doesn't. Best trade: HYPE SHORT at 54x divergence, +50% ROE.
 
+## v3.0 Changelog (fleet-fix batch 4)
+
+Phoenix was locked by the circuit breaker at -36.3% drawdown. Scanner diagnostics show 54% of losers were killed by `weak_peak_cut` — valid signals cut before they could run. Adopting Lemon's DSL profile + resetting the budget baseline.
+
+- Removed `weak_peak_cut` block entirely
+- `hard_timeout` 45m → 480m (winners need time)
+- `dead_weight_cut` → 20m
+- Phase 1 loosened (max_loss 15%, retrace 8, breaches 3)
+- Phase 2 tiers widened (Lemon ladder: 5/20, 10/40, 15/60, 20/75, 30/85, 50/92)
+- `STARTING_BUDGET` 1000 → 637.93 (current equity, unblocks pnl-aware cap)
+
 ## v1.0.1 Post-Mortem
 
 The signal was never the problem. v1.0.1 found real winners (+$24, +$22, +$11 on 4/1). The infrastructure killed it: broken trade counter led to 24 entries in one day instead of 6. -$228 in one day. -40.6% total.
 
-## What v2.0 Fixes
+## v2.0 Retained Fixes
 
 - Trade counter increments BEFORE signal output (not dependent on exit path)
 - Stale date detection forces reset
@@ -25,7 +36,7 @@ The signal was never the problem. v1.0.1 found real winners (+$24, +$22, +$11 on
 | Max positions | 3 |
 | Max entries/day | 4 |
 | Min score | 7 |
-| DSL | Lifecycle hunter (180m, no time cuts) |
+| DSL | Lemon profile (480m timeout, no weak_peak_cut, wider phase 2) |
 
 ## License
 

--- a/phoenix/SKILL.md
+++ b/phoenix/SKILL.md
@@ -1,21 +1,40 @@
 ---
 name: phoenix-strategy
 description: >-
-  PHOENIX v2.0 — Contribution Velocity Scanner (Hardened). Same battle-tested
-  signal. Fixed trade counter. DSL plugin exits.
+  PHOENIX v3.0 — Contribution Velocity Scanner. Same battle-tested signal.
+  v3.0 adopts the Lemon DSL profile (removes weak_peak_cut, 480m timeout,
+  wider Phase 2 tiers) and resets starting budget to current equity
+  ($637.93) so the pnl-aware daily cap unblocks from the prior circuit
+  breaker lock.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "2.0"
+  version: "3.0"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🔥 PHOENIX v2.0 — Contribution Velocity Scanner
+# 🔥 PHOENIX v3.0 — Contribution Velocity Scanner
 
-SM profit velocity diverging from price. The signal works. The infrastructure is fixed.
+SM profit velocity diverging from price. The signal works. The DSL profile is finally letting it breathe.
+
+## v3.0 changelog (fleet-fix batch 4)
+
+Phoenix self-diagnosed 54% of losers killed by `weak_peak_cut` while
+locked behind a -36.3% drawdown circuit breaker. Adopting Lemon's DSL
+profile + resetting the budget baseline:
+
+- `weak_peak_cut` removed entirely (was cutting winners too early)
+- `hard_timeout` 45m → 480m (winners need time to run)
+- `dead_weight_cut` → 20m
+- Phase 1 loosened: `max_loss_pct` 25 → 15, `retrace_threshold` 8,
+  `consecutive_breaches_required` 3
+- Phase 2 tiers widened to Lemon's ladder
+  (5/20, 10/40, 15/60, 20/75, 30/85, 50/92)
+- `STARTING_BUDGET` 1000.0 → 637.93 (current equity) — unblocks the
+  pnl-aware daily cap from the circuit breaker
 
 ## ⛔ CRITICAL AGENT RULES
 ### RULE 1: Install path is `/data/workspace/skills/phoenix-strategy/`
@@ -36,7 +55,7 @@ openclaw senpi runtime list && openclaw senpi status
 On EVERY session start, verify runtime + status + scanner cron (2 min, main).
 VERIFY trade counter: `cat /data/workspace/skills/phoenix-strategy/state/trade-counter.json`
 If the date is not today, delete it and let the scanner recreate it.
-Send: "🔥 PHOENIX v2.0 online. Hunting divergences. Counter: X/4."
+Send: "🔥 PHOENIX v3.0 online. Lemon DSL profile. Counter: X/4."
 
 ## License
 MIT — Built by Senpi (https://senpi.ai).

--- a/phoenix/runtime.yaml
+++ b/phoenix/runtime.yaml
@@ -1,8 +1,10 @@
 name: phoenix-tracker
-version: 1.0.0
+version: 3.0.0
 description: >
   Contribution velocity scanner. SM profit velocity diverging from price.
-  High-conviction, low-frequency. Lifecycle hunter DSL.
+  High-conviction, low-frequency. v3.0 adopts the Lemon DSL profile:
+  removes weak_peak_cut (54% of losers were killed by it), extends
+  hard_timeout to 480m, widens Phase 2 tiers, loosens Phase 1.
 
 strategy:
   wallet: "${WALLET_ADDRESS}"
@@ -28,27 +30,24 @@ exit:
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 45
-    weak_peak_cut:
-      enabled: true
-      interval_in_minutes: 15
-      min_value: 1.5
+      interval_in_minutes: 480
     dead_weight_cut:
       enabled: true
       interval_in_minutes: 20
     phase1:
       enabled: true
-      max_loss_pct: 25.0
+      max_loss_pct: 15.0
       retrace_threshold: 8
       consecutive_breaches_required: 3
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,  lock_hw_pct: 25 }
-        - { trigger_pct: 10, lock_hw_pct: 45 }
-        - { trigger_pct: 15, lock_hw_pct: 65 }
-        - { trigger_pct: 20, lock_hw_pct: 80 }
+        - { trigger_pct: 5,  lock_hw_pct: 20 }
+        - { trigger_pct: 10, lock_hw_pct: 40 }
+        - { trigger_pct: 15, lock_hw_pct: 60 }
+        - { trigger_pct: 20, lock_hw_pct: 75 }
         - { trigger_pct: 30, lock_hw_pct: 85 }
+        - { trigger_pct: 50, lock_hw_pct: 92 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/phoenix/scripts/phoenix-scanner.py
+++ b/phoenix/scripts/phoenix-scanner.py
@@ -1,25 +1,38 @@
 #!/usr/bin/env python3
-# Senpi PHOENIX Scanner v2.0
+# Senpi PHOENIX Scanner v3.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""PHOENIX v2.0 — Contribution Velocity Scanner (Hardened).
+"""PHOENIX v3.0 — Contribution Velocity Scanner (Lemon DSL profile + reset).
 
-Same signal as v1.0.1 — contribution_pct_change_4h diverging from price.
-The signal works. Phoenix found SOL LONG +$24, ETH LONG +$11, SOL SHORT +$22
-on 4/1. The HYPE SHORT at 54x divergence peaked at +50% ROE.
+Same contribution-velocity signal as v1.0.1/v2.0. Phoenix found SOL LONG
++$24, ETH LONG +$11, SOL SHORT +$22 on 4/1. The HYPE SHORT at 54x
+divergence peaked at +50% ROE. The signal works.
 
-What broke in v1.0.1: the trade counter. When DSL exits moved to the plugin,
-the scanner stopped incrementing the counter after entries. Result: 24 entries
-in one day instead of 6. -$228 in one day. -40.6% total.
+## v3.0 changes — DSL profile adoption + capital reset
 
-v2.0 fixes:
-1. Trade counter is SELF-CONTAINED — the scanner increments it in the output
-   flow, not dependent on the exit path
-2. SAFETY CHECK: before any entry, query the strategy wallet's clearinghouse
-   state and count how many positions were opened today. If that count exceeds
-   the daily limit, refuse to enter regardless of what the counter file says.
-3. Daily entry cap reduced from 6 to 4 (Phoenix's best days had 3-5 winners)
-4. No thesis exit, no DSL state generation
+Phoenix was locked by the circuit breaker at -36.3% drawdown (daily cap=0
+after the pnl-aware trigger fell past -25%). Scanner diagnostics show
+54% of losing trades were killed by `weak_peak_cut` — valid signals were
+being cut before they could run. The Lemon DSL profile removes
+weak_peak_cut entirely and widens Phase 2 tiers.
+
+Runtime.yaml changes:
+- Removed `weak_peak_cut` block entirely (54% of losers killed by it)
+- `hard_timeout.interval_in_minutes`: 45 → 480 (winners need time to run)
+- `dead_weight_cut.interval_in_minutes`: → 20
+- `phase1.max_loss_pct`: 25.0 → 15.0
+- `phase1.retrace_threshold`: → 8
+- `phase1.consecutive_breaches_required`: → 3
+- `phase2.tiers`: replaced with Lemon's wider ladder
+  (5/20, 10/40, 15/60, 20/75, 30/85, 50/92)
+
+Scanner capital reset:
+- `STARTING_BUDGET` 1000.0 → 637.93 (current equity from latest
+  leaderboard data). Rebases the pnl-aware daily cap so Phoenix can
+  actually enter again after the previous drawdown.
+
+v2.0 retained fixes (trade counter SELF-CONTAINED, stale-date reset,
+no thesis exit, no DSL state generation).
 
 One API call per scan: leaderboard_get_markets.
 Runs every 2 minutes.
@@ -49,7 +62,7 @@ MAX_DAILY_ENTRIES = 4               # Reduced from 6 — Phoenix's best days had
 # DYNAMIC DAILY CAP (P&L-aware circuit breaker)
 # ═══════════════════════════════════════════════════════════════
 
-STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+STARTING_BUDGET = 637.93  # v3.0: rebased to current equity after drawdown
 
 def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
     """P&L-aware daily entry cap based on drawdown from starting budget.
@@ -402,7 +415,7 @@ def run():
         "allSignals": [{"token": s["token"], "score": s["score"],
                         "direction": s["direction"]} for s in signals[:5]],
         "marketsScanned": markets_count,
-        "_phoenix_version": "2.0",
+        "_phoenix_version": "3.0",
     })
 
 

--- a/polar/scripts/polar-scanner.py
+++ b/polar/scripts/polar-scanner.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
-# Senpi POLAR Scanner v2.4
+# Senpi POLAR Scanner v2.4.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""POLAR v2.4 — ETH Alpha Hunter (sniper recalibration).
+"""POLAR v2.4.1 — ETH Alpha Hunter (capital reset).
+
+## v2.4.1 change — capital reset (2026-04-15)
+
+Polar was hard-stopped at -32% drawdown with daily cap = 0. Rebasing
+`STARTING_BUDGET` from 1000.0 to 682.84 (current equity) so the
+pnl-aware daily cap unblocks from the circuit breaker.
+
+
 
 v2.4 fleet-fix recalibration (April 15, 2026):
 - MIN_SCORE raised 8 → 10 (Cheetah v5.1 APEX pattern).
@@ -53,7 +61,7 @@ MAX_DAILY_ENTRIES = 4
 # DYNAMIC DAILY CAP (P&L-aware circuit breaker)
 # ═══════════════════════════════════════════════════════════════
 
-STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+STARTING_BUDGET = 682.84  # v2.4.1: rebased to current equity after -32% drawdown
 
 def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
     """P&L-aware daily entry cap based on drawdown from starting budget.
@@ -371,12 +379,12 @@ def run():
             "execution": {"asset": ASSET, "direction": thesis["direction"],
                 "leverage": leverage, "margin": margin,
                 "orderType": "FEE_OPTIMIZED_LIMIT", "ensureExecutionAsTaker": False},
-            "result": result, "_polar_version": "2.3"})
+            "result": result, "_polar_version": "2.4.1"})
     else:
         cfg.output({"status": "ok", "action": "ENTRY_FAILED",
             "signal": {"asset": ASSET, "direction": thesis["direction"],
                 "score": thesis["score"], "reasons": thesis["reasons"]},
-            "error": result, "_polar_version": "2.3"})
+            "error": result, "_polar_version": "2.4.1"})
 
 if __name__ == "__main__":
     try: run()

--- a/raptor/scripts/raptor-scanner.py
+++ b/raptor/scripts/raptor-scanner.py
@@ -612,6 +612,34 @@ def build_signal(trader, positions, sm_map, hot_cfg, sm_cfg):
 # EXECUTION
 # ═══════════════════════════════════════════════════════════════
 
+def get_safe_leverage(wallet, asset, requested_leverage):
+    """Query Hyperliquid's max leverage for this asset and clamp.
+
+    Fleet-wide leverage safety fix (batch 4). Raptor's quality pool can
+    surface low-cap assets whose Hyperliquid max is below the scanner's
+    requested tier. Clamping prevents CREATE_INVALID_LEVERAGE rejections
+    and the phantom ENTRY logs they cause.
+    """
+    try:
+        limits = cfg.mcporter_call(
+            "strategy_get_asset_trading_limits",
+            strategy_wallet=wallet,
+            coin=asset,
+        )
+        if limits:
+            data = limits.get("data", limits)
+            if isinstance(data, dict):
+                lev = data.get("leverage", {})
+                if isinstance(lev, dict):
+                    max_lev = int(float(lev.get("value", 20)))
+                    return min(requested_leverage, max_lev)
+                elif isinstance(lev, (int, float)):
+                    return min(requested_leverage, int(lev))
+    except Exception:
+        pass
+    return requested_leverage
+
+
 def execute_entry(wallet, signal, account_value, entry_cfg, leverage_cfg):
     """Self-execute the entry via Senpi MCP create_position.
     Matches Wolverine/Phoenix pattern."""
@@ -620,11 +648,13 @@ def execute_entry(wallet, signal, account_value, entry_cfg, leverage_cfg):
     margin_pct = high_conv_pct if signal["score"] >= 10 else base_margin_pct
     margin = round(account_value * margin_pct, 2)
 
-    leverage = get_leverage_for_score(
+    requested_leverage = get_leverage_for_score(
         signal["score"],
         leverage_cfg.get("tiers", []),
         leverage_cfg.get("default", 7),
     )
+    # Fleet-wide batch-4 leverage safety: clamp to asset max.
+    leverage = get_safe_leverage(wallet, signal["asset"], requested_leverage)
 
     order = {
         "coin": signal["asset"],
@@ -650,6 +680,16 @@ def execute_entry(wallet, signal, account_value, entry_cfg, leverage_cfg):
         reason=reason,
     )
     success = bool(result and result.get("success"))
+    # Fleet-wide batch-4 inner-order success validation.
+    if success:
+        data = result.get("data", {}) if isinstance(result, dict) else {}
+        if isinstance(data, dict):
+            orders_result = data.get("orders", data.get("results", []))
+            if isinstance(orders_result, list) and orders_result:
+                inner = orders_result[0]
+                if isinstance(inner, dict) and inner.get("success") is False:
+                    err = inner.get("error", "inner order failed")
+                    return False, {"error": f"INNER_FAILURE: {err}"}, margin, leverage
     return success, result, margin, leverage
 
 

--- a/scorpion/scripts/scorpion-scanner.py
+++ b/scorpion/scripts/scorpion-scanner.py
@@ -124,6 +124,35 @@ def get_leverage_for_score(score):
     return DEFAULT_LEVERAGE
 
 
+def get_safe_leverage(wallet, asset, requested_leverage):
+    """Query Hyperliquid's max leverage for this asset and clamp.
+
+    Fleet-wide leverage safety fix (batch 4). Scorpion trades a broad
+    crypto + XYZ universe; some assets' Hyperliquid max is below the
+    scanner's requested tier. For XYZ assets, asset should already carry
+    the "xyz:" prefix. Clamping prevents CREATE_INVALID_LEVERAGE
+    rejections and the phantom ENTRY logs they cause.
+    """
+    try:
+        limits = cfg.mcporter_call(
+            "strategy_get_asset_trading_limits",
+            strategy_wallet=wallet,
+            coin=asset,
+        )
+        if limits:
+            data = limits.get("data", limits)
+            if isinstance(data, dict):
+                lev = data.get("leverage", {})
+                if isinstance(lev, dict):
+                    max_lev = int(float(lev.get("value", 20)))
+                    return min(requested_leverage, max_lev)
+                elif isinstance(lev, (int, float)):
+                    return min(requested_leverage, int(lev))
+    except Exception:
+        pass
+    return requested_leverage
+
+
 def has_resting_orders(wallet):
     """Check for non-reduceOnly resting orders, auto-cancelling stale ones >10min."""
     import time as _time
@@ -309,6 +338,15 @@ def execute_entry(wallet, token, direction, margin, leverage, is_xyz):
         }],
     )
     if result and result.get("success"):
+        # Fleet-wide batch-4 inner-order success validation.
+        data = result.get("data", {})
+        if isinstance(data, dict):
+            orders_result = data.get("orders", data.get("results", []))
+            if isinstance(orders_result, list) and orders_result:
+                inner = orders_result[0]
+                if isinstance(inner, dict) and inner.get("success") is False:
+                    err = inner.get("error", "inner order failed")
+                    return False, {"error": f"INNER_FAILURE: {err}"}
         return True, result
     error = result.get("error", "unknown") if result else "mcporter_call returned None"
     return False, {"error": error}
@@ -374,7 +412,11 @@ def run():
         if cfg.is_asset_cooled_down(token, COOLDOWN_MINUTES):
             continue
 
-        leverage = get_leverage_for_score(candidate["score"])
+        requested_leverage = get_leverage_for_score(candidate["score"])
+        # Fleet-wide batch-4 leverage safety: clamp to asset max. Pass the
+        # coin string that will actually be submitted (xyz: prefix for XYZ).
+        coin_for_clamp = coin_for_position(token) if candidate["is_xyz"] else token
+        leverage = get_safe_leverage(wallet, coin_for_clamp, requested_leverage)
         margin = round(account_value * MARGIN_PCT, 2)
 
         success, result = execute_entry(

--- a/sentinel/README.md
+++ b/sentinel/README.md
@@ -1,10 +1,17 @@
-# 🛡️ SENTINEL v2.0 — Quality Trader Convergence Scanner
+# 🛡️ SENTINEL v2.2 — Quality Trader Convergence Scanner
 
 Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Thesis
 
 Inverted pipeline: start with QUALITY TRADERS (ELITE/RELIABLE TCS), find where they converge. When 5+ historically-profitable traders independently arrive at the same trade, that's informed consensus — not coincidence. Cross-confirmed with SM leaderboard concentration.
+
+## v2.2 Changelog (fleet-fix batch 4)
+
+At -21.44% drawdown with daily cap = 1, the 45% win rate confirmed the signal is valid. DSL was bleeding value via slow cuts on 17/23 losers. Widening Phase 2 and resetting the budget baseline.
+
+- Phase 2 tiers widened to Sentinel's own rec: `[15/35, 30/60, 50/75, 75/85, 100/92]`
+- `STARTING_BUDGET` 1000 → 786.60 (current equity, unblocks pnl-aware cap)
 
 ## Key Settings
 
@@ -15,7 +22,7 @@ Inverted pipeline: start with QUALITY TRADERS (ELITE/RELIABLE TCS), find where t
 | Min score | 7 |
 | Min convergence | 5 weighted traders |
 | API calls | 2 per scan |
-| DSL | Lifecycle hunter (180m timeout, no time cuts) |
+| DSL | Lifecycle hunter (240m timeout, wider Phase 2 tiers) |
 
 ## License
 

--- a/sentinel/SKILL.md
+++ b/sentinel/SKILL.md
@@ -1,22 +1,37 @@
 ---
 name: sentinel-strategy
 description: >-
-  SENTINEL v2.0 — Quality Trader Convergence Scanner. Inverted pipeline:
+  SENTINEL v2.2 — Quality Trader Convergence Scanner. Inverted pipeline:
   find ELITE/RELIABLE traders, see where they converge. When 5+ quality
-  traders hold the same asset in the same direction, enter.
+  traders hold the same asset in the same direction, enter. Batch 4
+  widens Phase 2 tiers ([5,10,15] → [15,30,50,75,100]) per Sentinel's
+  own rec + rebases starting budget to current equity ($786.60).
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "2.0"
+  version: "2.2"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🛡️ SENTINEL v2.0 — Quality Trader Convergence
+# 🛡️ SENTINEL v2.2 — Quality Trader Convergence
 
 When the best traders agree, follow them.
+
+## v2.2 changelog (fleet-fix batch 4)
+
+Sentinel was stuck at -21.44% drawdown with daily cap = 1 (pnl-aware
+circuit breaker severely restricting entries). 45.2% win rate confirmed
+the signal is valid; DSL was bleeding value via slow cuts on 17/23
+losers.
+
+- Phase 2 tiers widened to Sentinel's own rec:
+  [15/35, 30/60, 50/75, 75/85, 100/92]. Keeps early lock at 15% but
+  pushes upper tiers out so winners have room to run.
+- `STARTING_BUDGET` 1000.0 → 786.60 (current equity) — unblocks the
+  pnl-aware daily cap.
 
 ---
 
@@ -54,7 +69,7 @@ On EVERY session start, check `config/bootstrap-complete.json`. If missing:
 5. Verify: `openclaw senpi runtime list` and `openclaw senpi status`
 6. Create scanner cron (5 min, main)
 7. Write `config/bootstrap-complete.json`
-8. Send: "🛡️ SENTINEL v2.0 online. Tracking quality convergence. Silence = no consensus."
+8. Send: "🛡️ SENTINEL v2.2 online. Wider Phase 2 tiers. Silence = no consensus."
 
 ---
 

--- a/sentinel/runtime.yaml
+++ b/sentinel/runtime.yaml
@@ -1,10 +1,11 @@
 name: sentinel-tracker
-version: 2.1.0
+version: 2.2.0
 description: >
-  Quality trader convergence scanner v2.1. Finds assets where multiple
-  ELITE/RELIABLE traders converge. Fleet audit fixes applied.
-  v2.1: has_resting_orders reduceOnly, midnight fix, move-exhaustion,
-  same-dir cooldown, leverage-aware Phase 2 tiers.
+  Quality trader convergence scanner v2.2. Finds assets where multiple
+  ELITE/RELIABLE traders converge. v2.2 widens Phase 2 tiers
+  ([5,10,15] → [15,30,50,75,100]) per Sentinel's own rec; 45% WR
+  confirms the signal is valid, DSL was bleeding value via slow cuts
+  on 17/23 losers.
 
 strategy:
   wallet: "${WALLET_ADDRESS}"
@@ -46,12 +47,15 @@ exit:
     phase2:
       enabled: true
       tiers:
-        # Phase 2 tiers — leverage-aware (fleet audit April 2026)
-        - { trigger_pct: 8,  lock_hw_pct: 25 }
-        - { trigger_pct: 15, lock_hw_pct: 50 }
-        - { trigger_pct: 25, lock_hw_pct: 65 }
-        - { trigger_pct: 35, lock_hw_pct: 80 }
-        - { trigger_pct: 50, lock_hw_pct: 85 }
+        # v2.2 (fleet-fix batch 4): widened per Sentinel's own rec.
+        # 45% WR confirms signal is valid, DSL was bleeding value via
+        # slow cuts on 17/23 losers. Tiers retain early lock (15/35)
+        # but push upper tiers out so winners have room to run.
+        - { trigger_pct: 15, lock_hw_pct: 35 }
+        - { trigger_pct: 30, lock_hw_pct: 60 }
+        - { trigger_pct: 50, lock_hw_pct: 75 }
+        - { trigger_pct: 75, lock_hw_pct: 85 }
+        - { trigger_pct: 100, lock_hw_pct: 92 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/sentinel/scripts/sentinel-scanner.py
+++ b/sentinel/scripts/sentinel-scanner.py
@@ -1,8 +1,27 @@
 #!/usr/bin/env python3
-# Senpi SENTINEL Scanner v2.0
+# Senpi SENTINEL Scanner v2.0 (fleet-fix batch 4 — wider Phase 2 + equity reset)
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 """SENTINEL v2.0 — Quality Trader Convergence Scanner.
+
+## v2.0 fleet-fix batch 4 changes (2026-04-15)
+
+Sentinel was stuck at -21.44% drawdown with daily cap = 1 (severely
+restricted by the pnl-aware circuit breaker). 45.2% win rate confirms
+the signal is valid; inversion test was 3x worse inverted. Diagnosis:
+losers were bleeding out via slow cuts — `weak_peak_cut` and
+`hard_timeout` accounted for 17 of 23 losers.
+
+Runtime.yaml changes:
+- Phase 2 tiers widened from [5/25, 10/50, 15/65, 20/80, 30/85] to
+  Sentinel's own recommendation: [15/35, 30/60, 50/75, 75/85, 100/92].
+  Keeps early lock at 15% (still meaningful profit protection) but
+  pushes upper tiers out so genuine winners have room to run to 100%+.
+
+Scanner capital reset:
+- `STARTING_BUDGET` 1000.0 → 786.60 (current equity). Rebases the
+  pnl-aware daily cap so Sentinel unblocks from the restricted state.
+
 
 Inverted pipeline: instead of starting with an asset and checking if
 SM is there, start with QUALITY TRADERS and find where they converge.
@@ -68,7 +87,7 @@ MAX_DAILY_ENTRIES = 4
 # DYNAMIC DAILY CAP (P&L-aware circuit breaker)
 # ═══════════════════════════════════════════════════════════════
 
-STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
+STARTING_BUDGET = 786.60  # v2.0 fleet-fix batch 4: rebased to current equity
 
 def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
     """P&L-aware daily entry cap based on drawdown from starting budget.
@@ -596,7 +615,7 @@ def run():
                 "_v2_no_thesis_exit": True,
                 "_note": "DSL managed by plugin runtime. Scanner does NOT manage exits.",
             },
-            "_sentinel_version": "2.1",
+            "_sentinel_version": "2.2",
         })
         return
 

--- a/vulture/scripts/vulture-scanner.py
+++ b/vulture/scripts/vulture-scanner.py
@@ -142,6 +142,35 @@ def get_leverage_for_score(score):
     return DEFAULT_LEVERAGE
 
 
+def get_safe_leverage(wallet, asset, requested_leverage):
+    """Query Hyperliquid's max leverage for this asset and clamp.
+
+    Fleet-wide leverage safety fix (batch 4). Vulture's small-cap universe
+    frequently contains assets whose Hyperliquid max is below the scanner's
+    requested tier (e.g. MON max=5x). Clamping prevents
+    CREATE_INVALID_LEVERAGE rejections and the phantom ENTRY logs they
+    cause.
+    """
+    try:
+        limits = cfg.mcporter_call(
+            "strategy_get_asset_trading_limits",
+            strategy_wallet=wallet,
+            coin=asset,
+        )
+        if limits:
+            data = limits.get("data", limits)
+            if isinstance(data, dict):
+                lev = data.get("leverage", {})
+                if isinstance(lev, dict):
+                    max_lev = int(float(lev.get("value", 20)))
+                    return min(requested_leverage, max_lev)
+                elif isinstance(lev, (int, float)):
+                    return min(requested_leverage, int(lev))
+    except Exception:
+        pass
+    return requested_leverage
+
+
 def has_resting_orders(wallet):
     """Check for non-reduceOnly resting orders, auto-cancelling any older
     than STALE_ORDER_MAX_AGE_SEC (default 600s). Fleet-standard pattern."""
@@ -394,6 +423,17 @@ def execute_entry(wallet, asset, direction, leverage, margin):
         }],
     )
     if result and result.get("success"):
+        # Fleet-wide batch-4 inner-order success validation. Outer envelope
+        # lies when a per-order rejection (e.g. CREATE_INVALID_LEVERAGE)
+        # happens — dig into data.orders[0].success before claiming success.
+        data = result.get("data", {})
+        if isinstance(data, dict):
+            orders_result = data.get("orders", data.get("results", []))
+            if isinstance(orders_result, list) and orders_result:
+                inner = orders_result[0]
+                if isinstance(inner, dict) and inner.get("success") is False:
+                    err = inner.get("error", "inner order failed")
+                    return False, {"error": f"INNER_FAILURE: {err}"}
         return True, result
     error = result.get("error", "unknown") if result else "mcporter_call returned None"
     return False, {"error": error}
@@ -485,7 +525,10 @@ def run():
     best = signals[0]
 
     # Execute entry
-    leverage = get_leverage_for_score(best["score"])
+    requested_leverage = get_leverage_for_score(best["score"])
+    # Fleet-wide batch-4 leverage safety: clamp to asset max to avoid
+    # CREATE_INVALID_LEVERAGE rejections on low-cap Hyperliquid assets.
+    leverage = get_safe_leverage(wallet, best["asset"], requested_leverage)
     margin = round(account_value * MARGIN_PCT, 2)
 
     success, result = execute_entry(wallet, best["asset"], best["direction"], leverage, margin)


### PR DESCRIPTION
## Summary

Ships 10 changes based on diagnostic probes from 8 agents. Part of the 10-PnL+ weekly mission (end of Arena Week 4).

### Critical fleet-wide fix
**Leverage clamping + inner-success validation** — Cheetah's MON LONG failed silently with CREATE_INVALID_LEVERAGE (MON max 5x, requested 7x). MCP wrapper returned outer success=true despite inner order failure. Added \`get_safe_leverage()\` using \`strategy_get_asset_trading_limits\` to clamp per asset. Added inner-order success validation. Applied to vulture/scorpion/cheetah/mantis/orca/raptor.

### Agent-specific changes

- **Phoenix v3.0** — Lemon DSL profile + capital reset $1000→$637.93
- **Sentinel v2.2** — Widen Phase 2 tiers + capital reset $1000→$786.60
- **Pangolin v1.1** — MIN_FUNDING_RATE loosened (40% ann → 20% ann)
- **Jaguar v3.2** — STRIKER_MIN_RANK_JUMP 15 → 10
- **Orca v3.0** — Revert to Gen-1 vanilla Striker (remove quality confirmation)
- **Mantis v4.1** — MIN_SCORE 9 → 11 (fee drag fix)
- **Polar v2.4.1** — Capital reset $1000 → $682.84
- **Grizzly Horribilis v2.1.1** — Capital reset $1000 → $648.35
- **Cheetah v5.1.1** — Leverage clamping helper

27 files changed. All packaged as complete installable skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)