### PR TITLE
fleet-fix batch5: universe expansion + Raptor entry-discipline + Spider leverage safety

### DIFF
--- a/owl/README.md
+++ b/owl/README.md
@@ -1,8 +1,8 @@
-# 🦉 Owl v6.0 — Pure Contrarian Crowding Fader (gate recalibration)
+# 🦉 Owl v6.1 — Pure Contrarian Crowding Fader (universe expansion)
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-OWL v6.0 — Pure contrarian. One scanner, one thesis: the crowd is wrong. Monitors crowding across top 30 assets (funding extremity, OI concentration, SM tilt). **v6.0 fleet-fix:** minPersistHours reduced 4→1, entry.minScore reduced 14→12, DSL Phase 2 first tier tightened 10%→5% trigger. Diagnosis: only 7 trades in 30 days on v5.3 → over-gated. Re-crowding exit preserved (dormant, safe — 0 fires in 14 days).
+OWL v6.1 — Pure contrarian. Monitors crowding across **ALL assets with OI > $3M** (v6.1 — was top-30 only in v6.0). **v6.1 fleet-fix:** Removed the top-30 OI truncation that was blinding Owl to mid-cap extreme-funding setups. ZEC/MON/LIT hit >1000% annualized funding at probe time but were filtered out. **v6.0:** minPersistHours 4→1, entry.minScore 14→12, DSL Phase 2 first tier 10%→5%.
 
 ## Install
 

--- a/owl/SKILL.md
+++ b/owl/SKILL.md
@@ -1,23 +1,24 @@
 ---
 name: owl-strategy
 description: >-
-  OWL v6.0 — Pure contrarian (gate recalibration). One scanner, one thesis: the crowd
-  is wrong. Monitors crowding across top 30 assets (funding extremity, OI concentration,
-  SM tilt). When crowding persists 1+ hour AND exhaustion signals fire (volume declining,
+  OWL v6.1 — Pure contrarian (universe expansion). One scanner, one thesis: the crowd
+  is wrong. Monitors crowding across ALL assets with OI > $3M (v6.1 — was top 30 only
+  in v6.0). When crowding persists 1+ hour AND exhaustion signals fire (volume declining,
   price stalling, RSI divergence), enters AGAINST the crowd to ride the liquidation
-  unwind. v6.0 fleet-fix: minPersistHours reduced 4→1 and entry.minScore reduced 14→12
-  after fleet analysis found Owl only traded 7 times in 30 days due to unreachable gate
-  combination. DSL Phase 2 first tier tightened 10%→5% trigger (Lemon-pattern learning).
-  Re-crowding exit preserved (dormant, not harmful — 0 fires in 14 days).
+  unwind. v6.1 removes the top-30 OI truncation that was blinding Owl to mid-cap extreme-
+  funding setups — per Owl's own diagnosis, the most violent unwinds happen on assets
+  ranked 30-60 in OI (ZEC/MON/LIT hit >1000% annualized at probe time). v6.0 fleet-fix:
+  minPersistHours reduced 4→1 and entry.minScore reduced 14→12. DSL Phase 2 locks first
+  leg at 5% ROE (Lemon-pattern learning).
 license: Apache-2.0
 metadata:
   author: jason-goldberg
-  version: "6.0"
+  version: "6.1"
   platform: senpi
   exchange: hyperliquid
 ---
 
-# OWL v6.0 — Pure Contrarian (gate recalibration)
+# OWL v6.1 — Pure Contrarian (universe expansion)
 
 Wait for the crowd to overcommit. Wait for them to exhaust. Then eat their liquidations.
 

--- a/owl/runtime.yaml
+++ b/owl/runtime.yaml
@@ -1,15 +1,16 @@
 name: owl-strategy
-version: 6.0.0
+version: 6.1.0
 description: >
-  OWL v6.0 — Pure Contrarian (gate recalibration). Monitors crowding across
-  top 30 assets (funding extremity + SM tilt + OI concentration). When
-  crowding persists 1+ hour AND exhaustion signals fire (volume declining,
-  price stalling, RSI divergence), enters AGAINST the crowd to ride the
-  liquidation unwind. v6.0 fixes the over-gated Owl: minPersistHours
-  reduced 4→1 and entry.minScore reduced 14→12 after fleet analysis found
-  Owl only traded 7 times in 30 days due to unreachable gate combination.
-  Re-crowding exit preserved (dormant, not harmful — 0 fires in 14 days).
-  DSL Phase 2 tightened to lock first leg at 5% ROE (Lemon-pattern learning).
+  OWL v6.1 — Pure Contrarian (universe expansion). Monitors crowding across
+  ALL assets with OI > $3M (v6.1 — was top 30 only in v6.0). Funding
+  extremity + SM tilt + OI concentration signals. When crowding persists
+  1+ hour AND exhaustion signals fire (volume declining, price stalling,
+  RSI divergence), enters AGAINST the crowd to ride the liquidation unwind.
+  v6.1 removes the top-30 OI truncation that was blinding Owl to mid-cap
+  extreme-funding setups (ZEC/MON/LIT hit >1000% annualized at probe time
+  but were filtered out). v6.0 fixed the over-gated Owl: minPersistHours
+  reduced 4→1 and entry.minScore reduced 14→12. DSL Phase 2 locks first
+  leg at 5% ROE (Lemon-pattern learning).
 
 strategy:
   wallet: "${WALLET_ADDRESS}"

--- a/owl/scripts/owl-scanner.py
+++ b/owl/scripts/owl-scanner.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
-# Senpi OWL Scanner v6.0
+# Senpi OWL Scanner v6.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under Apache-2.0 — attribution required for derivative works
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""OWL v6.0 — Pure Contrarian (gate recalibration).
+"""OWL v6.1 — Pure Contrarian (universe expansion).
 
 One scanner. One thesis: the crowd is wrong.
+
+v6.1 changes (2026-04-16 — per Owl's self-diagnosis):
+  - REMOVED top-30 OI truncation in get_all_assets(). Owl was blinded
+    to mid-cap extreme-funding setups ranked 30-60 in OI — exactly
+    where the most violent liquidation unwinds happen. ZEC, MON, LIT
+    hit >1000% annualized funding at probe time but were filtered out.
+    $3M OI minimum remains as the sole liquidity gate.
 
 v6.0 changes (fleet-fix: only 7 trades in 30 days → over-gated):
   - minPersistHours reduced 4 → 1 in owl-config.json. The 4-hour persistence
@@ -182,7 +189,7 @@ def execute_entry(wallet, signal, account_value, entry_cfg, leverage_cfg):
     }
 
     reason = (
-        f"OWL v6.0 contrarian fade: score={signal['score']}, "
+        f"OWL v6.1 contrarian fade: score={signal['score']}, "
         f"crowd={signal['crowdDirection']}, "
         f"persist={signal['persistHours']:.1f}h"
     )
@@ -200,7 +207,16 @@ def execute_entry(wallet, signal, account_value, entry_cfg, leverage_cfg):
 # ─── Crowding Analysis ────────────────────────────────────────
 
 def get_all_assets():
-    """Top 30 assets by OI for crowding scan."""
+    """All assets with OI > $3M for crowding scan.
+
+    v6.1 — UNIVERSE EXPANSION. Previously truncated to top 30 by OI,
+    which blinded Owl to mid-cap extreme-funding setups. Owl's self-
+    diagnosis (2026-04-16): "The most violent unwinds (extreme funding
+    + heavy tilt) are on assets ranked 30-60 in OI. ZEC, MON, LIT hit
+    >1000% annualized funding but get filtered out by the top-30 cap."
+    The $3M OI minimum IS the real liquidity gate — the 30-cap was
+    redundant and actively harmful.
+    """
     data = cfg.mcporter_call("market_list_instruments")
     if not data or not data.get("success"):
         return []
@@ -222,7 +238,7 @@ def get_all_assets():
                 "price": mark_px, "funding": funding,
             })
     assets.sort(key=lambda x: x["oi_usd"], reverse=True)
-    return assets[:30]
+    return assets  # v6.1: no truncation
 
 
 def get_sm_positioning(coin):

--- a/pangolin/README.md
+++ b/pangolin/README.md
@@ -1,10 +1,14 @@
-# 🦔 PANGOLIN v1.1 — Extreme Funding Rate Fader
+# 🦔 PANGOLIN v1.2 — Extreme Funding Rate Fader (universe expansion)
 
 Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Thesis
 
-When funding rates are elevated (>20% annualized), the crowd is paying to hold their position. Pangolin enters opposite to the funding direction — collecting funding every 8 hours while waiting for the crowded side to capitulate. Conservative 3-5x leverage, very wide DSL (12-hour hard timeout), top 20 crypto assets by volume.
+When funding rates are elevated (>20% annualized), the crowd is paying to hold their position. Pangolin enters opposite to the funding direction — collecting funding every 8 hours while waiting for the crowded side to capitulate. Conservative 3-5x leverage, very wide DSL (12-hour hard timeout). **Scans every Hyperliquid perp with OI > $3M** (~60 assets, post-v1.2 expansion).
+
+## v1.2 Changelog (2026-04-16)
+
+- **UNIVERSE EXPANSION.** Removed hardcoded top-20 `ALLOWED_ASSETS` whitelist. Pangolin now scans every instrument with OI > $3M — ~60 assets instead of 20. Addresses Owl's diagnostic finding that extreme funding signals on mid-caps (ZEC/MON/LIT hit >1000% annualized at probe time) were being filtered out.
 
 ## v1.1 Changelog
 

--- a/pangolin/SKILL.md
+++ b/pangolin/SKILL.md
@@ -1,25 +1,36 @@
 ---
 name: pangolin-strategy
 description: >-
-  PANGOLIN v1.1 — Extreme Funding Rate Fader. Enters opposite to elevated
-  funding rates (>0.015%/8h = ~20% annualized, recalibrated down from
-  the v1.0 40% threshold that never fired in the current market regime),
+  PANGOLIN v1.2 — Extreme Funding Rate Fader (universe expansion).
+  Enters opposite to elevated funding rates (>0.015%/8h = ~20% annualized),
   collecting funding while waiting for crowded positions to mean-revert.
-  Conservative 3-5x leverage, very wide DSL (12h hard timeout). Top 20
-  crypto assets by volume.
+  Conservative 3-5x leverage, very wide DSL (12h hard timeout). v1.2
+  replaces the hardcoded top-20 ALLOWED_ASSETS whitelist with a dynamic
+  liquidity floor (OI > $3M) — now scans ~60 assets instead of 20,
+  unlocking mid-cap unwind setups (ZEC/MON/LIT hit >1000% annualized
+  at probe time but were filtered out pre-v1.2).
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "1.1"
+  version: "1.2"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🦔 PANGOLIN v1.1 — Extreme Funding Rate Fader
+# 🦔 PANGOLIN v1.2 — Extreme Funding Rate Fader (universe expansion)
 
 An entirely new strategy archetype for the Predators fleet. No other agent trades on funding rate signals.
+
+## v1.2 changelog (fleet-fix batch 5, 2026-04-16)
+
+- **UNIVERSE EXPANSION.** Removed the hardcoded `ALLOWED_ASSETS` set
+  of 20 top-volume majors. Now scans every instrument with OI > $3M
+  (~60 assets). This addresses Owl's diagnostic finding that extreme
+  funding signals (>1000% annualized on ZEC/MON/LIT at probe time)
+  were happening on mid-cap assets Pangolin was filtering out.
+- XYZ DEX remains banned.
 
 ## v1.1 changelog (fleet-fix batch 4)
 

--- a/pangolin/scripts/pangolin-scanner.py
+++ b/pangolin/scripts/pangolin-scanner.py
@@ -1,9 +1,24 @@
 #!/usr/bin/env python3
-# Senpi PANGOLIN Scanner v1.1
+# Senpi PANGOLIN Scanner v1.2
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""PANGOLIN v1.1 — Extreme Funding Rate Fader (threshold recalibrated).
+"""PANGOLIN v1.2 — Extreme Funding Rate Fader (universe expansion).
+
+## v1.2 change — universe expansion (2026-04-16)
+
+Owl's diagnostic revealed that extreme funding signals DO exist in
+current market conditions — just not in Pangolin's universe. ZEC, MON,
+and LIT all hit >1000% annualized funding at probe time, but Pangolin's
+hardcoded ALLOWED_ASSETS set (top-20 by volume: BTC, ETH, SOL, HYPE,
+DOGE, XRP, AVAX, LINK, ADA, DOT, NEAR, UNI, LTC, BCH, TAO, INJ, AAVE,
+ZEC, WIF, PEPE) filtered them out. ZEC was the only overlap — the
+most extreme funding on mid-caps was invisible.
+
+v1.2 replaces the brand whitelist with a liquidity floor: any asset
+with OI > $3M qualifies. XYZ DEX remains banned. This expands the
+scannable universe from ~20 to ~60 assets and unlocks the exact
+unwind setups Pangolin was designed for.
 
 ## v1.1 change — threshold recalibration
 
@@ -93,12 +108,13 @@ LEVERAGE_TIERS = [
 ]
 DEFAULT_LEVERAGE = 3
 
-# Top assets by volume — only trade liquid markets
-ALLOWED_ASSETS = {
-    "BTC", "ETH", "SOL", "HYPE", "DOGE", "XRP", "AVAX", "LINK",
-    "ADA", "DOT", "NEAR", "UNI", "LTC", "BCH", "TAO", "INJ",
-    "AAVE", "ZEC", "WIF", "PEPE",
-}
+# v1.2: UNIVERSE EXPANSION. Previously ALLOWED_ASSETS was a hardcoded set
+# of 20 top-volume majors. Per Owl's 2026-04-16 diagnosis: the most
+# extreme funding unwinds happen on mid-cap assets (ZEC, MON, LIT —
+# >1000% annualized funding at probe time) that weren't in the top-20
+# by volume. Now any asset with sufficient OI liquidity ($3M minimum)
+# qualifies — the liquidity floor replaces the brand-whitelist.
+MIN_OI_USD = 3_000_000          # v1.2: liquidity gate (replaces ALLOWED_ASSETS)
 
 
 def safe_float(v, d=0.0):
@@ -197,7 +213,17 @@ def scan_funding_extremes():
             continue
 
         name = str(inst.get("name", inst.get("coin", ""))).upper()
-        if name not in ALLOWED_ASSETS:
+        dex = str(inst.get("dex", "")).lower()
+
+        # v1.2: XYZ filter (banned)
+        if XYZ_BANNED and dex == "xyz":
+            continue
+
+        # v1.2: liquidity gate — replaces old ALLOWED_ASSETS hardcoded set
+        oi = safe_float(inst.get("openInterest", 0))
+        mark_px = safe_float(inst.get("markPx", inst.get("midPx", 0)))
+        oi_usd = oi * mark_px if mark_px > 0 else 0
+        if oi_usd < MIN_OI_USD:
             continue
 
         funding = safe_float(inst.get("funding", 0))
@@ -405,7 +431,7 @@ def run():
                     "ensureExecutionAsTaker": False,
                 },
                 "result": result,
-                "_pangolin_version": "1.1",
+                "_pangolin_version": "1.2",
             })
             return
         else:
@@ -415,7 +441,7 @@ def run():
                 "signal": {"asset": token, "score": cand["score"],
                            "reasons": cand["reasons"]},
                 "error": result,
-                "_pangolin_version": "1.1",
+                "_pangolin_version": "1.2",
             })
             return
 

--- a/raptor/README.md
+++ b/raptor/README.md
@@ -1,8 +1,8 @@
-# 🦅 Raptor v3.0 — Hot Streak Follower
+# 🦅 Raptor v3.2 — Hot Streak Follower (whale entry-price discipline)
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-RAPTOR v3.0 — Hot Streak Follower. Finds ELITE/RELIABLE traders currently on a 4-hour hot streak via leaderboard_get_top + discovery_get_top_traders, identifies their strongest position by delta PnL, confirms SM alignment, and follows them in. Self-executing, runtime.yaml standard deployment, fleet-standard guardrails.
+RAPTOR v3.2 — Hot Streak Follower. Finds ELITE/RELIABLE traders on a 4-hour hot streak, identifies their strongest position by delta PnL, confirms SM alignment, and piggybacks — **but only if we get a better fill than the whale did**. **v3.2** adds entry-discipline: skip if the asset has run 20%+ in the whale's favor since their entry (we'd be buying their top). Bonus +1/+2 score if we're getting a better fill than the whale. Addresses Raptor's own self-diagnosis that v3.1 spiraled -$60 by buying the tops of whales' bags.
 
 ## Install
 

--- a/raptor/SKILL.md
+++ b/raptor/SKILL.md
@@ -1,20 +1,26 @@
 ---
 name: raptor-strategy
 description: >-
-  RAPTOR v3.0 — Hot Streak Follower. Finds ELITE/RELIABLE traders currently
-  on a 4-hour hot streak via leaderboard_get_top + discovery_get_top_traders,
-  identifies their strongest position by delta PnL, confirms SM alignment,
-  and follows them in. Self-executing, runtime.yaml standard deployment,
-  fleet-standard guardrails. 2 positions max. Conviction-scaled leverage 7-10x.
+  RAPTOR v3.2 — Hot Streak Follower (whale entry-price discipline).
+  Finds ELITE/RELIABLE traders currently on a 4-hour hot streak via
+  leaderboard_get_top + discovery_get_top_traders, identifies their
+  strongest position, confirms SM alignment, and piggybacks — but
+  ONLY if we get a fill at a better price than the whale did.
+  v3.2 (2026-04-16) adds entry-discipline: fetch current price vs
+  whale's entryPx; if asset has run 20%+ in whale's favor post-entry,
+  SKIP (we'd be buying their top). Bonus +1/+2 points if we're
+  getting a better fill than the whale. Prior v3.1 spiral (-$60 in
+  16h) was caused by re-entering whales' positions at worse prices
+  than they originally filled.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0"
+  version: "3.2"
   platform: senpi
   exchange: hyperliquid
 ---
 
-# RAPTOR v3.0 — Hot Streak Follower
+# RAPTOR v3.2 — Hot Streak Follower (entry-price discipline)
 
 Find traders who are already winning big right now, confirm they're quality (ELITE or RELIABLE on TCS), figure out what bet is driving their streak, check the smart money crowd agrees, and piggyback the same trade.
 

--- a/raptor/scripts/raptor-scanner.py
+++ b/raptor/scripts/raptor-scanner.py
@@ -1,9 +1,32 @@
 #!/usr/bin/env python3
-# Senpi RAPTOR Scanner v3.1
+# Senpi RAPTOR Scanner v3.2
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""RAPTOR v3.1 — Hot Streak Follower (quality-first architecture).
+"""RAPTOR v3.2 — Hot Streak Follower (whale entry-price discipline).
+
+## v3.2 changes from v3.1 (2026-04-16)
+
+Raptor's self-diagnosis identified the core failure mode: "We are buying
+the top of the whale's bags. High-tier traders often sit in underwater or
+flat positions for days, averaging down. Following them blindly without
+knowing their entry price means we assume all their risk without their
+padding."
+
+v3.2 adds an entry-discipline check:
+  1. Extract `entryPx` from each whale position (the whale's average entry).
+  2. Fetch current market price via `market_get_prices`.
+  3. HARD GATE: if current price has run >20% in the whale's favor from
+     their entry, SKIP the trade — we'd be buying their top. For a LONG
+     whale at $100, if current is >$120, skip. For a SHORT whale at $100,
+     if current is <$80, skip.
+  4. SCORE BONUS: if current price is WORSE than whale's entry (we'd get
+     a better fill than the whale did), add +1 or +2 points to the score.
+     This rewards trades where we're piggybacking but at a discount.
+
+This directly addresses why Raptor v3.1 spiraled from +$50 unrealized
+to -$60 realized: it kept re-entering the same assets where whales had
+already made their money, buying the tops and shorting the bottoms.
 
 ## v3.1 changes from v3.0
 
@@ -479,6 +502,15 @@ def build_signal(trader, positions, sm_map, hot_cfg, sm_cfg):
         ).upper()
         if direction not in ("LONG", "SHORT"):
             continue
+        # v3.2: capture whale entry price for entry-discipline check
+        whale_entry_px = safe_float(
+            pos.get("entryPx",
+                    pos.get("entry_px",
+                            pos.get("entryPrice",
+                                    pos.get("entry_price",
+                                            pos.get("avgEntryPx",
+                                                    pos.get("avg_entry_px", 0))))))
+        )
         position_count += 1
         abs_pnl = abs(delta_pnl)
         total_abs_pnl += abs_pnl
@@ -488,6 +520,7 @@ def build_signal(trader, positions, sm_map, hot_cfg, sm_cfg):
                 "asset": asset,
                 "direction": direction,
                 "delta_pnl": delta_pnl,
+                "whale_entry_px": whale_entry_px,  # v3.2: track for entry discipline
             }
 
     if not best_pos or best_abs_pnl < hot_cfg.get("minPositionPnl", 100_000):
@@ -508,6 +541,50 @@ def build_signal(trader, positions, sm_map, hot_cfg, sm_cfg):
         return None
     if sm["traders"] < sm_cfg.get("minSmTraders", 10):
         return None
+
+    # ─────────────────────────────────────────────────────────────
+    # v3.2 ENTRY DISCIPLINE: don't buy the top of the whale's bag
+    # ─────────────────────────────────────────────────────────────
+    # Raptor's 2026-04-16 self-diagnosis: "Elite traders often sit in
+    # underwater or flat positions for days, averaging down. Following
+    # them blindly without knowing their entry price means we assume all
+    # their risk without their padding. We are buying the top of their bags."
+    #
+    # Fix: compare current market price to whale's entryPx.
+    # - If current price is WORSE than whale's entry (asset moved against
+    #   their position post-entry), we get a BETTER fill than the whale did
+    #   → take the trade.
+    # - If current price has run 20%+ FROM whale's entry in their favor,
+    #   we'd be buying their top → skip.
+    MAX_PRICE_RUN_PCT_FROM_WHALE_ENTRY = 20.0
+    whale_entry_px = best_pos.get("whale_entry_px", 0)
+    if whale_entry_px > 0:
+        # Get current price — prefer market_get_prices (fresh) but fall
+        # back to any price hint in sm_map if the MCP call fails.
+        current_px = 0
+        try:
+            px_raw = cfg.mcporter_call("market_get_prices",
+                                        assets=[best_pos["asset"]])
+            if px_raw:
+                data = px_raw.get("data", px_raw)
+                if isinstance(data, dict):
+                    current_px = safe_float(data.get(best_pos["asset"], 0))
+        except Exception:
+            current_px = 0
+
+        if current_px > 0:
+            if best_pos["direction"] == "LONG":
+                # Whale is long. We want to enter at entryPx or better
+                # (lower). If current > entry * 1.20, we're late.
+                run_pct = ((current_px - whale_entry_px) / whale_entry_px) * 100
+                if run_pct > MAX_PRICE_RUN_PCT_FROM_WHALE_ENTRY:
+                    return None  # Buying their top
+            else:  # SHORT
+                # Whale is short. We want to enter at entryPx or better
+                # (higher). If current < entry * 0.80, we're late.
+                run_pct = ((whale_entry_px - current_px) / whale_entry_px) * 100
+                if run_pct > MAX_PRICE_RUN_PCT_FROM_WHALE_ENTRY:
+                    return None  # Shorting their bottom (they've already made the money)
 
     # Scoring
     score = 0
@@ -590,6 +667,23 @@ def build_signal(trader, positions, sm_map, hot_cfg, sm_cfg):
         score -= 1
         reasons.append(f"15M_STALE_{c15m:.2f}")
 
+    # v3.2: ENTRY_DISCIPLINE bonus — reward trades where we're getting
+    # a better fill than the whale (their position is underwater post-entry).
+    if whale_entry_px > 0 and current_px > 0:
+        if best_pos["direction"] == "LONG":
+            edge_pct = ((whale_entry_px - current_px) / whale_entry_px) * 100
+        else:
+            edge_pct = ((current_px - whale_entry_px) / whale_entry_px) * 100
+        if edge_pct >= 5:
+            score += 2
+            reasons.append(f"BETTER_THAN_WHALE_+{edge_pct:.1f}%")
+        elif edge_pct >= 2:
+            score += 1
+            reasons.append(f"EDGE_VS_WHALE_+{edge_pct:.1f}%")
+        elif edge_pct < -10:
+            # We're far worse than whale's entry but still under the 20% skip gate
+            reasons.append(f"LATE_VS_WHALE_{edge_pct:.1f}%")
+
     return {
         "asset": best_pos["asset"],
         "direction": best_pos["direction"],
@@ -605,6 +699,8 @@ def build_signal(trader, positions, sm_map, hot_cfg, sm_cfg):
         "smTraders": sm["traders"],
         "priceChg4h": p4h,
         "priceChg1h": p1h,
+        "whaleEntryPx": whale_entry_px if whale_entry_px > 0 else None,  # v3.2
+        "currentPx": current_px if (whale_entry_px > 0 and current_px > 0) else None,  # v3.2
     }
 
 
@@ -715,7 +811,7 @@ def run():
         cfg.output({
             "status": "ok", "heartbeat": "NO_REPLY",
             "note": f"RIDING: {coins}. DSL manages exit.",
-            "_raptor_version": "3.1",
+            "_raptor_version": "3.2",
         })
         return
 
@@ -835,7 +931,7 @@ def run():
                 "orderType": entry_cfg.get("orderType", "FEE_OPTIMIZED_LIMIT"),
             },
             "result": result,
-            "_raptor_version": "3.1",
+            "_raptor_version": "3.2",
         })
     else:
         error = result.get("error", "unknown") if result else "mcporter_call returned None"
@@ -844,7 +940,7 @@ def run():
             "action": "ENTRY_FAILED",
             "signal": best,
             "error": error,
-            "_raptor_version": "3.1",
+            "_raptor_version": "3.2",
         })
 
 

--- a/spider/scripts/spider-scanner.py
+++ b/spider/scripts/spider-scanner.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python3
-# Senpi SPIDER Scanner v1.0
+# Senpi SPIDER Scanner v1.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""SPIDER v1.0 — Elite Convergence Scanner.
+"""SPIDER v1.1 — Elite Convergence Scanner (leverage safety added).
+
+v1.1 (2026-04-16 — fleet-fix batch 5): Adds get_safe_leverage() helper
+and inner-order success validation. Spider was missed from batch 4's
+fleet-wide canonical-schema fix, so the phantom-trade bug (where
+CREATE_INVALID_LEVERAGE errors returned outer success=true but inner
+success=false) was still active here. Spider self-flagged this in
+the fleet broadcast response. Fixed now.
+
+Original v1.0 logic:
 
 THESIS: When 2+ independently-operating ELITE/RELIABLE traders with
 SNIPER/AGGRESSIVE risk profiles converge on the same asset and direction,
@@ -397,15 +406,49 @@ def score_convergences(convergences, velocity):
 # EXECUTION
 # ═══════════════════════════════════════════════════════════════
 
+def get_safe_leverage(wallet, asset, requested_leverage):
+    """Clamp leverage to asset's max allowed on Hyperliquid.
+
+    Fleet-fix batch 5 addition (was missed in batch 4 broadcast).
+    Prevents the CREATE_INVALID_LEVERAGE phantom-trade bug that
+    silently failed Cheetah's MON LONG (MON max 5x, requested 7x).
+    """
+    try:
+        limits = cfg.mcporter_call(
+            "strategy_get_asset_trading_limits",
+            strategy_wallet=wallet,
+            coin=asset,
+        )
+        if limits:
+            data = limits.get("data", limits)
+            if isinstance(data, dict):
+                lev = data.get("leverage", {})
+                if isinstance(lev, dict):
+                    max_lev = int(float(lev.get("value", 20)))
+                    return min(requested_leverage, max_lev)
+                elif isinstance(lev, (int, float)):
+                    return min(requested_leverage, int(lev))
+    except Exception:
+        pass
+    return requested_leverage  # fallback
+
+
 def execute_entry(wallet, asset, direction, margin, leverage):
-    """Call create_position directly via mcporter."""
+    """Call create_position directly via mcporter.
+
+    Fleet-fix batch 5: added inner-order success validation to catch
+    the phantom-trade bug where the outer MCP envelope returns
+    success=true but the inner exchange order was rejected.
+    """
+    # Clamp leverage to asset max before sending
+    safe_lev = get_safe_leverage(wallet, asset, leverage)
     result = cfg.mcporter_call(
         "create_position",
         strategyWalletAddress=wallet,
         orders=[{
             "coin": asset,
             "direction": direction,
-            "leverage": leverage,
+            "leverage": safe_lev,
             "marginAmount": margin,
             "orderType": "FEE_OPTIMIZED_LIMIT",
             "feeOptimizedLimitOptions": {
@@ -415,6 +458,15 @@ def execute_entry(wallet, asset, direction, margin, leverage):
         }],
     )
     if result and result.get("success"):
+        # Validate inner order success (phantom-trade guard)
+        data = result.get("data", {})
+        if isinstance(data, dict):
+            orders_result = data.get("orders", data.get("results", []))
+            if isinstance(orders_result, list) and orders_result:
+                inner = orders_result[0]
+                if isinstance(inner, dict) and inner.get("success") is False:
+                    err = inner.get("error", "inner order failed")
+                    return False, {"error": f"INNER_FAILURE: {err}"}
         return True, result
     else:
         error = result.get("error", "unknown") if result else "mcporter_call returned None"
@@ -560,14 +612,14 @@ def run():
                 "ensureExecutionAsTaker": False,
             },
             "result": result,
-            "_spider_version": "1.0",
+            "_spider_version": "1.1",
         })
     else:
         cfg.output({
             "status": "ok", "action": "ENTRY_FAILED",
             "signal": {"asset": best["asset"], "direction": best["direction"],
                 "score": best["score"], "reasons": best["reasons"]},
-            "error": result, "_spider_version": "1.0",
+            "error": result, "_spider_version": "1.1",
         })
 
 


### PR DESCRIPTION
## Summary

Ships 4 targeted improvements based on live agent diagnostics from 2026-04-16.

### Changes

**🦉 Owl v6.1** — removed top-30 OI truncation. ZEC/MON/LIT >1000% annualized funding signals were being filtered out. $3M OI minimum remains as sole liquidity gate.

**🛡️ Pangolin v1.2** — removed hardcoded ALLOWED_ASSETS top-20 whitelist. Liquidity floor (OI > $3M) replaces it. Universe: 20 → 60 assets.

**🦅 Raptor v3.2** — entry-price discipline. Per Raptor's own diagnosis ("we are buying the top of their bags"), now:
- Extracts whale's `entryPx` from position data
- Fetches current market price via `market_get_prices`
- Hard gate: skip if asset has run >20% in whale's favor since their entry
- Score bonus: +2 if getting 5%+ better fill, +1 if 2%+ better

**🕷️ Spider v1.1** — leverage safety (missed from batch 4). Spider itself flagged the omission. Added `get_safe_leverage()` + inner-order success validation.

### Part of 10-PnL+ mission
End of Arena Week 4 (Wednesday Apr 22) deadline. Current green count: 2 defended + 2-3 live positions running (Wolverine +6.62% HYPE SHORT, Kodiak SOL LONG Phase 2, Phoenix SOL LONG fresh). Batch 5 unlocks Owl/Pangolin from regime-dormancy and makes Raptor/Spider less self-destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)