### PR TITLE
fleet-fix batch6: Scorpion v3.1 scalp re-entry + Vulture v2.1 wider DSL

### DIFF
--- a/scorpion/scripts/scorpion-scanner.py
+++ b/scorpion/scripts/scorpion-scanner.py
@@ -1,9 +1,40 @@
 #!/usr/bin/env python3
-# Senpi SCORPION Scanner v3.0
+# Senpi SCORPION Scanner v3.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""SCORPION v3.0 — Multi-Market Active Trader.
+"""SCORPION v3.1 — Multi-Market Active Trader (scalp re-entry).
+
+## v3.1 changes (2026-04-16)
+
+Inspired by pr0br000's 3-week Arena sweep: 21 fills on $HEMI in Week 2,
+33 fills in Week 3, total 369 fills across 22 assets. The pattern: exit
+on any meaningful wick, re-enter fast when thesis is still intact. We're
+matching that behavior.
+
+Critical context: Senpi runtime no longer supports multi-breach DSL
+(orders placed onchain → single-breach is enforced). Every DSL exit is
+final. The ONLY way to capture more of a trending move is to re-enter
+cleanly after an exit.
+
+v3.1 adds SCALP RE-ENTRY logic:
+- SCALP_WINDOW_MINUTES = 60: if last entry on an asset was within 60 min,
+  treat next entry as a scalp re-entry rather than a fresh entry.
+- SCALP_COOLDOWN_MINUTES = 15: short cooldown on scalp re-entries vs the
+  120-min standard fresh-entry cooldown.
+- MAX_REENTRIES_PER_ASSET = 10: daily cap per asset prevents death-
+  spiral re-entry on a breaking thesis. After 10 entries on same asset
+  in one day, lockout for 24h.
+- Scalp re-entries BYPASS the overall daily cap (they continue a position
+  the scanner already validated rather than opening a new thesis).
+- Fresh entries still use 120-min cooldown and count against daily cap.
+
+Target behavior: when SCORPION enters $HEMI at 10am and DSL exits at
+10:30am with +2% realized PnL, the scanner can re-enter HEMI at 10:45am
+(past the 15-min scalp cooldown) if the signal still fires. Instead of
+1 entry per day, SCORPION gets 5-10 fills per asset when the move runs.
+
+## v3.0 changes
 
 Arena winner #2/#3 playbook: trade BOTH crypto AND XYZ DEX commodities,
 signal-driven LONG and SHORT, up to 3 concurrent positions, short holds.
@@ -75,7 +106,10 @@ def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
     else:                  return 0    # HARD STOP — circuit breaker
 
 
-COOLDOWN_MINUTES = 120
+COOLDOWN_MINUTES = 120          # Fresh-entry cooldown (different asset, or >60 min since last entry on same asset)
+SCALP_COOLDOWN_MINUTES = 15     # v3.1: short cooldown for scalp re-entries on recently-active assets
+SCALP_WINDOW_MINUTES = 60       # v3.1: within this window of last entry, asset is a scalp candidate
+MAX_REENTRIES_PER_ASSET = 10    # v3.1: cap per-asset daily entries to prevent death spiral
 MARGIN_PCT = 0.30
 MIN_SCORE = 6
 
@@ -385,15 +419,11 @@ def run():
         })
         return
 
-    # Daily limits
+    # Daily limits — note: scalp re-entries bypass the overall daily cap (v3.1)
     tc = cfg.load_trade_counter()
     dynamic_cap = get_dynamic_daily_cap(account_value)
     effective_cap = min(dynamic_cap, MAX_DAILY_ENTRIES)
-    if tc.get("entries", 0) >= effective_cap:
-        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily cap ({effective_cap}) reached. PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{effective_cap}"})
-        return
+    # We'll check the daily cap PER-CANDIDATE below based on scalp vs fresh.
 
     # Evaluate all allowed assets
     candidates = evaluate_markets(held_coins)
@@ -403,18 +433,47 @@ def run():
                      "note": f"SCANNING: no qualifying signal across crypto+XYZ universe. Holding: {pos_desc}"})
         return
 
+    # v3.1: ensure asset_entries dict exists in trade counter
+    if "asset_entries" not in tc:
+        tc["asset_entries"] = {}
+
+    now_ts = time.time()
+
     # Try candidates in order until one passes cooldown and executes
     for candidate in candidates:
         token = candidate["token"]
         direction = candidate["direction"]
 
-        # Per-asset cooldown
-        if cfg.is_asset_cooled_down(token, COOLDOWN_MINUTES):
+        # ─── v3.1 SCALP RE-ENTRY LOGIC ──────────────────────────────
+        # Determine if this is a scalp candidate (recently active asset)
+        # or a fresh entry. Scalp re-entries use a 15-min cooldown and
+        # BYPASS the overall daily cap. Fresh entries use 120-min
+        # cooldown and count against the daily cap.
+        asset_state = tc["asset_entries"].get(token, {})
+        last_entry_ts = asset_state.get("last_entry_ts", 0)
+        entries_today_for_asset = asset_state.get("entries_today", 0)
+        seconds_since_last = now_ts - last_entry_ts if last_entry_ts > 0 else float('inf')
+
+        # Per-asset daily cap (prevents death-spiral re-entry on a breaking thesis)
+        if entries_today_for_asset >= MAX_REENTRIES_PER_ASSET:
             continue
 
+        is_scalp_candidate = seconds_since_last < SCALP_WINDOW_MINUTES * 60
+
+        if is_scalp_candidate:
+            # Scalp re-entry path: check short cooldown only
+            if seconds_since_last < SCALP_COOLDOWN_MINUTES * 60:
+                continue  # Still within scalp cooldown
+            entry_type = "scalp_reentry"
+        else:
+            # Fresh entry path: check standard cooldown + daily cap
+            if cfg.is_asset_cooled_down(token, COOLDOWN_MINUTES):
+                continue
+            if tc.get("entries", 0) >= effective_cap:
+                continue  # Daily cap blocks fresh entries (scalps bypass)
+            entry_type = "fresh_entry"
+
         requested_leverage = get_leverage_for_score(candidate["score"])
-        # Fleet-wide batch-4 leverage safety: clamp to asset max. Pass the
-        # coin string that will actually be submitted (xyz: prefix for XYZ).
         coin_for_clamp = coin_for_position(token) if candidate["is_xyz"] else token
         leverage = get_safe_leverage(wallet, coin_for_clamp, requested_leverage)
         margin = round(account_value * MARGIN_PCT, 2)
@@ -424,14 +483,28 @@ def run():
         )
 
         if success:
-            tc["entries"] = tc.get("entries", 0) + 1
+            # v3.1: update per-asset tracker
+            tc["asset_entries"][token] = {
+                "last_entry_ts": now_ts,
+                "entries_today": entries_today_for_asset + 1,
+            }
+            # Only fresh entries count against overall daily cap
+            if entry_type == "fresh_entry":
+                tc["entries"] = tc.get("entries", 0) + 1
             cfg.save_trade_counter(tc)
-            cfg.set_asset_cooldown(token, COOLDOWN_MINUTES, reason="entry")
+
+            # Set cooldown: short for scalp, long for fresh
+            if entry_type == "scalp_reentry":
+                cfg.set_asset_cooldown(token, SCALP_COOLDOWN_MINUTES, reason="scalp_reentry")
+            else:
+                cfg.set_asset_cooldown(token, COOLDOWN_MINUTES, reason="fresh_entry")
 
             coin_label = coin_for_position(token) if candidate["is_xyz"] else token
             cfg.output({
                 "status": "ok",
                 "action": "ENTRY",
+                "entry_type": entry_type,  # v3.1: expose scalp vs fresh
+                "asset_entries_today": entries_today_for_asset + 1,
                 "signal": {
                     "asset": coin_label,
                     "direction": direction,
@@ -454,7 +527,7 @@ def run():
                 "result": result,
                 "positions_held": pos_count + 1,
                 "max_positions": MAX_POSITIONS,
-                "_scorpion_version": "3.0",
+                "_scorpion_version": "3.1",
             })
             return
         else:

--- a/vulture/runtime.yaml
+++ b/vulture/runtime.yaml
@@ -1,15 +1,15 @@
 name: vulture-tracker
-version: 2.0.0
+version: 2.1.0
 description: >
-  VULTURE v2.0 — Long-Tail Momentum Rider. COMPLETE REWRITE from v1.0's
-  contrarian fader thesis. Scans 25+ small/mid-cap Hyperliquid perps
-  (HEMI, WLD, MON, XPL, AIXBT, ARB, ASTER, ZEC, LIT, TAO, etc.) that
-  no other Senpi predator covers. Follows SM direction when confluence
-  is strong (heavy flow + aligned 4h trend + 15m velocity accelerating).
-  Built from the #1 Arena winner's playbook (3-week champion, 38.6% win
-  rate, 6.15x profit factor, hold times 24h to 8 days). Max 2 positions,
-  5-7x leverage (small caps can't handle 20x — slippage). Signal-driven
-  direction, NOT long-only bias.
+  VULTURE v2.1 — Long-Tail Momentum Rider (wider small-cap DSL).
+  v2.1 widens the DSL tier curve after fleet analysis found that Senpi's
+  onchain DSL now enforces SINGLE-BREACH exits (consecutive-breach
+  tolerance is no longer supported at runtime). Narrow floors designed
+  for 3-breach protection were exiting on normal small-cap wicks. v2.1
+  pushes Phase 2 tier locks wider so normal 3-8% wicks don't breach.
+  Scans 25+ small/mid-cap Hyperliquid perps (HEMI, WLD, MON, XPL,
+  AIXBT, ARB, ASTER, ZEC, LIT, TAO, etc.). Built from the #1 Arena
+  winner's playbook. Max 2 positions, 5-7x leverage.
 
 # ── STRATEGY ──
 strategy:
@@ -32,21 +32,15 @@ actions:
     decision_mode: rule
     scanners: [position_tracker]
 
-# ── EXIT (DSL) — Long-Tail Rider profile ──
-# Winners need DAYS to develop. Arena winner #1 held HEMI for 8 days,
-# WLD for 4 days, MON for 5 days. Losers need to be cut FAST because
-# small caps don't retrace kindly — once a momentum signal fails, the
-# asset usually keeps falling.
+# ── EXIT (DSL) — v2.1 WIDER small-cap profile ──────────────────────
+# CRITICAL: Senpi runtime now enforces single-breach exits (orders on-
+# chain). `consecutive_breaches_required` fields are no-ops. We adapt
+# by setting floors wide enough that normal small-cap wicks (3-8%)
+# don't breach them in the first place.
 #
-#   hard_timeout: 10080 min (7 days) — let winners run a full week
-#   dead_weight_cut: 60 min — loser exit, faster than Owl's 90 but
-#     slower than Lemon's 20 because small-cap wicks are deeper
-#   weak_peak_cut: 120 min @ 2% min — catch fades that stalled
-#   Phase 1 max_loss_pct: 20% — wider than Lemon's 15% because
-#     small caps retrace harder, but tighter than Owl's 35% because
-#     we're following momentum, not fading
-#   Phase 2: start locking at 5% (Lemon-pattern learning — capture
-#     the first leg of the trend before it reverses)
+# Target: Winning moves on HEMI/WLD/MON can wick back 5-8% from peak
+# without exiting. We accept giving back more on true reversals; net
+# EV wins because the wicks-that-continue-trending dominate the sample.
 exit:
   engine: dsl
   interval_seconds: 30
@@ -56,26 +50,27 @@ exit:
       interval_in_minutes: 10080    # 7 days — let momentum runners run
     weak_peak_cut:
       enabled: true
-      interval_in_minutes: 120
+      interval_in_minutes: 180       # v2.1: 120 → 180 (more patience on small-cap flats)
       min_value: 2.0
     dead_weight_cut:
       enabled: true
-      interval_in_minutes: 60       # 60 min loser cut — small-cap wick tolerance
+      interval_in_minutes: 90        # v2.1: 60 → 90 (looser loser cut)
     phase1:
       enabled: true
-      max_loss_pct: 20.0            # Wider than Lemon's 15%, tighter than Owl's 35%
-      retrace_threshold: 10
-      consecutive_breaches_required: 3
+      max_loss_pct: 25.0             # v2.1: 20 → 25 (small caps retrace harder)
+      retrace_threshold: 15          # v2.1: 10 → 15
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,  lock_hw_pct: 20 }     # Lock first leg at 5%
-        - { trigger_pct: 10, lock_hw_pct: 35 }
-        - { trigger_pct: 20, lock_hw_pct: 55 }
-        - { trigger_pct: 35, lock_hw_pct: 70 }
-        - { trigger_pct: 50, lock_hw_pct: 80 }
-        - { trigger_pct: 75, lock_hw_pct: 88 }
-        - { trigger_pct: 100, lock_hw_pct: 92 }    # Infinite trail on massive winners
+        # v2.1: WIDER tiers — single-breach runtime requires floors that
+        # survive 3-8% wicks. At +15% peak, floor is +3%. At +30% peak,
+        # floor is +12%. At +50%, +30% — hard to breach on noise.
+        - { trigger_pct: 15, lock_hw_pct: 20 }   # v2.1: was 5/20 — don't lock until +15% peak
+        - { trigger_pct: 30, lock_hw_pct: 40 }   # v2.1: was 10/35
+        - { trigger_pct: 50, lock_hw_pct: 60 }   # v2.1: was 20/55
+        - { trigger_pct: 75, lock_hw_pct: 75 }   # v2.1: was 35/70
+        - { trigger_pct: 100, lock_hw_pct: 85 }  # v2.1: was 50/80
+        - { trigger_pct: 150, lock_hw_pct: 92 }  # Infinite trail on monster winners
 
 # ── NOTIFICATIONS ──
 notifications:

--- a/vulture/scripts/vulture-scanner.py
+++ b/vulture/scripts/vulture-scanner.py
@@ -1,9 +1,27 @@
 #!/usr/bin/env python3
-# Senpi VULTURE Scanner v2.0
+# Senpi VULTURE Scanner v2.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""VULTURE v2.0 — Long-Tail Momentum Rider.
+"""VULTURE v2.1 — Long-Tail Momentum Rider (wider DSL).
+
+## v2.1 changes (2026-04-16)
+
+Senpi runtime now enforces single-breach DSL exits (orders onchain).
+v2.0's Phase 2 floors (5%/20%) were exiting on normal small-cap wicks.
+v2.1 widens Phase 2 tiers so floors survive normal volatility:
+
+  +15% peak → +3% floor (was +1% floor on a +7% peak in v2.0)
+  +30% peak → +12% floor
+  +50% peak → +30% floor
+
+Also: Phase 1 max_loss 20→25%, retrace 10→15%; dead_weight_cut 60→90 min;
+weak_peak_cut 120→180 min. Scanner logic unchanged — only DSL widened.
+
+Complements Scorpion v3.1's scalp re-entry approach: VULTURE tries to
+hold THROUGH wicks; SCORPION tries to re-enter AFTER exits. A/B test.
+
+## v2.0 scanner logic (unchanged in v2.1)
 
 COMPLETE REWRITE. v1.0 was a contrarian SM-exhaustion fader on 4 crypto majors
 (BTC/ETH/SOL/HYPE) gated at MIN_4H_MOVE_PCT=3.0, which made the entry gate
@@ -461,7 +479,7 @@ def run():
             "status": "ok", "heartbeat": "NO_REPLY",
             "note": f"RIDING: {coins}. DSL manages exit.",
             "_v2_no_thesis_exit": True,
-            "_vulture_version": "2.0",
+            "_vulture_version": "2.1",
         })
         return
 
@@ -557,7 +575,7 @@ def run():
                 {"asset": s["asset"], "direction": s["direction"], "score": s["score"]}
                 for s in signals[:5]
             ],
-            "_vulture_version": "2.0",
+            "_vulture_version": "2.1",
         })
     else:
         cfg.output({
@@ -565,7 +583,7 @@ def run():
             "action": "ENTRY_FAILED",
             "signal": best,
             "error": result,
-            "_vulture_version": "2.0",
+            "_vulture_version": "2.1",
         })
 
 


### PR DESCRIPTION
## Summary

Two parallel experiments to capture more of pr0br000's 12.86:1 win/loss asymmetry on small-cap trending moves.

### Context
Senpi runtime now enforces single-breach DSL (orders onchain). Agents designed for 3-breach wick tolerance exit on the first wick, clipping winners at 1-5% when the underlying move runs 15-30%+.

### Variant A: 🦅 Vulture v2.1 — wider DSL
- Phase 2 tier 1 widened to **trigger 15% / lock 20%** (was 5/20)
- Subsequent tiers widened proportionally
- Phase 1 max_loss 20→25%, retrace 10→15%
- dead_weight_cut 60→90 min; weak_peak_cut 120→180 min
- Target: hold through normal small-cap 3-8% wicks

### Variant B: 🦂 Scorpion v3.1 — scalp re-entry
- Per-asset tracking: last_entry_ts + entries_today
- 60-min window defines "scalp candidate" vs "fresh entry"
- Scalp re-entries: 15 min cooldown, BYPASS daily cap
- Fresh entries: 120 min cooldown, count against daily cap
- Max 10 entries per asset per day (death-spiral guard)
- Target: 20-30 fills/week on a trending asset

### Test plan
Evaluate at end of Arena Week 4:
- Scorpion fires 10+ fills on any single asset in 24h window (scalp working)
- Vulture holds a position past 15% peak without DSL exit (wider DSL working)
- Which strategy produces larger avg winners

🤖 Generated with [Claude Code](https://claude.com/claude-code)