### PR TITLE
fleet-fix: context-nesting bug across 4 more scanners (Owl, Bison, Viper, Mamba)

### DIFF
--- a/bison/scripts/bison-scanner.py
+++ b/bison/scripts/bison-scanner.py
@@ -151,8 +151,12 @@ def get_top_assets(n=10):
         if not isinstance(inst, dict):
             continue
         coin = inst.get("coin") or inst.get("name", "")
-        vol = float(inst.get("dayNtlVlm", inst.get("volume24h", 0)))
-        mark_px = float(inst.get("markPx", inst.get("midPx", 0)))
+        # CRITICAL FIX (2026-04-16): volume/price nested in context
+        ctx = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        vol = float(ctx.get("dayNtlVlm", ctx.get("volume24h",
+                             inst.get("dayNtlVlm", inst.get("volume24h", 0)))) or 0)
+        mark_px = float(ctx.get("markPx", ctx.get("midPx",
+                                 inst.get("markPx", inst.get("midPx", 0)))) or 0)
         if coin and vol > 0:
             assets.append({"coin": coin, "volume": vol, "price": mark_px})
     assets.sort(key=lambda x: x["volume"], reverse=True)

--- a/mamba/scripts/mamba-scanner.py
+++ b/mamba/scripts/mamba-scanner.py
@@ -176,8 +176,11 @@ def get_scan_candidates(entry_cfg):
         # Gate: ban XYZ equities
         if any(coin.lower().startswith(p) for p in banned):
             continue
-        oi = float(inst.get("openInterest", 0))
-        mark_px = float(inst.get("markPx", inst.get("midPx", 0)))
+        # CRITICAL FIX (2026-04-16): OI/price nested in context
+        ctx = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        oi = float(ctx.get("openInterest", inst.get("openInterest", 0)) or 0)
+        mark_px = float(ctx.get("markPx", ctx.get("midPx",
+                                 inst.get("markPx", inst.get("midPx", 0)))) or 0)
         oi_usd = oi * mark_px if mark_px > 0 else 0
         if coin and oi_usd > min_oi_usd:
             candidates.append({"coin": coin, "oi": oi, "oi_usd": oi_usd, "price": mark_px})

--- a/owl/scripts/owl-scanner.py
+++ b/owl/scripts/owl-scanner.py
@@ -228,9 +228,17 @@ def get_all_assets():
         if not isinstance(inst, dict):
             continue
         coin = inst.get("coin") or inst.get("name", "")
-        oi = float(inst.get("openInterest", 0))
-        mark_px = float(inst.get("markPx", inst.get("midPx", 0)))
-        funding = float(inst.get("funding", 0))
+        # CRITICAL FIX (2026-04-16): funding/OI/price are nested inside
+        # the `context` sub-object on market_list_instruments response,
+        # NOT top-level. Pre-fix, every asset had oi=0 and funding=0
+        # here, which meant Owl's universe was empty. With v6.1
+        # universe expansion this bug was hidden because the $3M check
+        # was the gate that always rejected everything.
+        ctx = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        oi = float(ctx.get("openInterest", inst.get("openInterest", 0)) or 0)
+        mark_px = float(ctx.get("markPx", ctx.get("midPx",
+                                 inst.get("markPx", inst.get("midPx", 0)))) or 0)
+        funding = float(ctx.get("funding", inst.get("funding", 0)) or 0)
         oi_usd = oi * mark_px if mark_px > 0 else 0
         if coin and oi_usd > 3_000_000:
             assets.append({

--- a/viper/scripts/viper-scanner.py
+++ b/viper/scripts/viper-scanner.py
@@ -90,8 +90,11 @@ def get_scan_candidates(entry_cfg):
     min_oi_usd = entry_cfg.get("minOiUsd", 5_000_000)
     for inst in instruments:
         coin = inst.get("coin") or inst.get("name", "")
-        oi = float(inst.get("openInterest", 0))
-        mark_px = float(inst.get("markPx", inst.get("midPx", 0)))
+        # CRITICAL FIX (2026-04-16): OI/price nested in context
+        ctx = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        oi = float(ctx.get("openInterest", inst.get("openInterest", 0)) or 0)
+        mark_px = float(ctx.get("markPx", ctx.get("midPx",
+                                 inst.get("markPx", inst.get("midPx", 0)))) or 0)
         oi_usd = oi * mark_px if mark_px > 0 else 0
         if coin and oi_usd > min_oi_usd:
             candidates.append({"coin": coin, "oi": oi, "oi_usd": oi_usd, "price": mark_px})


### PR DESCRIPTION
Companion to PR #195. `market_list_instruments` returns funding/OI/price/volume nested inside `context`, not top-level. 5 scanners had this bug (Pangolin already fixed). This PR fixes the remaining 4.

Rhino was already correct.

Owl especially was silently broken — universe was effectively empty because every asset failed the $3M OI gate (read as 0 due to the bug). The v6.1 universe expansion was a no-op.

🤖 Generated with Claude Code