### PR TITLE
fleet-fix: Grizzly v5.0 — family alignment (BTC variant of Kodiak)

### DIFF
--- a/grizzly/SKILL.md
+++ b/grizzly/SKILL.md
@@ -1,139 +1,264 @@
 ---
 name: grizzly-strategy
 description: >-
-  GRIZZLY v4.0 — BTC Contrarian (SM Exhaustion Fader). Single-asset BTC
-  scanner that trades AGAINST Smart Money consensus when the move is
-  exhausted. A/B variable vs Grizzly-Horribilis: Grizzly = single entry,
-  Horribilis = pyramids into winners. v4.0 is a direction flip from v3.x
-  after fleet audit found the momentum-following signal was inverted.
+  GRIZZLY v5.0 — BTC Alpha Hunter with Position Lifecycle. Single-asset
+  BTC scanner, trend-following. Family member alongside Kodiak (SOL),
+  Wolverine (HYPE), Polar (ETH) — all four share the same architecture,
+  tuned per asset. v5.0 is a complete rewrite that reverts v4.x contrarian
+  direction flip and ports Kodiak's winning 3-mode lifecycle (HUNTING /
+  RIDING / STALKING) with BTC-specific tuning.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "4.0"
+  version: "5.0"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🐻 GRIZZLY v4.0 — BTC Contrarian
+# 🐻 GRIZZLY v5.0 — BTC Alpha Hunter
 
-Smart money goes one way on BTC. Grizzly goes the other. Single entry, no pyramiding.
+Trend-continuation on BTC. Same architecture as Kodiak / Wolverine / Polar.
+One asset, one scanner, one exit system. No contrarian flips.
+
+---
+
+## ⛔ CRITICAL AGENT RULES
+
+### RULE 1: Install path is `/data/workspace/skills/grizzly-strategy/`
+### RULE 2: THE SCANNER DOES NOT EXIT POSITIONS — DSL only.
+### RULE 3: MAX 1 POSITION (BTC only)
+### RULE 4: Verify runtime on every session start
+### RULE 5: Never modify parameters without family-wide review
+### RULE 6: HARD_STOP circuit breaker triggers at -25% drawdown
+
+---
 
 ## Thesis
 
-BTC is the most-watched asset on Hyperliquid, and when top-trader consensus reaches extreme levels after a significant move, the unwind is typically violent and profitable for counter-trend traders. Grizzly fades the crowd when:
+**Pure trend continuation on BTC, never counter-trend.**
 
-1. **Smart money consensus is strong** on one direction (pct_of_top_traders_gain ≥ threshold, trader count ≥ threshold)
-2. **The 4H move is already extended** in that direction (overextension setup)
-3. **15m velocity is no longer building** (the move is exhausting)
-4. **A consolidation/reversal pattern is forming** on the 1H/4H
+From Kodiak's lifetime top-3 SOL winners (+$133 / +$87 / +$78):
 
-Grizzly then enters in the **OPPOSITE** direction to SM consensus.
+> "The absolute highest predictor of a massive directional swing is when
+> the 4H, 1H, 15m, and 5m price momentum are perfectly unified in a
+> single direction, AND the Smart Money leaderboard is heavily lopsided
+> (>65% directional consensus) in that exact same direction."
 
-## v4.0 — DIRECTION FLIP
+Grizzly v5.0 applies that exact thesis to BTC. BTC is slower and heavier
+than SOL, so thresholds are tightened — but the pattern is identical.
 
-Fleet analysis on 2026-04-10 found that Grizzly's earlier SM-consensus momentum signal was perfectly inverted on BTC. The multi-timeframe confirmation requirement meant the scanner systematically entered AFTER the move was exhausted — buying tops and selling bottoms. An inversion test on 11 trades showed **81.8% win rate if direction were flipped**.
+---
 
-v4.0 embraces that finding:
+## v5.0 — COMPLETE REWRITE
 
-- **Trade OPPOSITE to SM consensus direction** (was: trade with consensus)
-- **Leverage tiers aligned with Grizzly-Horribilis** — 7x base, 10x at score 10+
-- **Added MOVE_EXHAUSTION penalty → bonus** (was missing in v3.x, Horribilis had it)
-- **15m velocity tiers simplified** — less spike-chasing
-- **1h acceleration aligned with Horribilis**
-- **Added same-direction cooldown** — 60 min after any trade to prevent chasing
-- **Fixed resting order filter** — now correctly ignores reduceOnly DSL stops
+v4.x was a contrarian SM-fader. The April 10 inversion test read "if we
+flipped direction we'd win 81.8%" as evidence that SM was broken on BTC.
+The correct read was: the scanner was late, entering *after* the move
+exhausted. Flipping direction made those same late entries profitable
+temporarily, but it also set Grizzly up to fight every real trend.
 
-## A/B vs Grizzly-Horribilis
+v4.x lost $245. Grizzly was the only family member running a direction
+opposite to the family intent.
 
-Both Grizzly and Grizzly-Horribilis are BTC contrarian faders with nearly identical signal logic. The difference:
+v5.0 returns to the family pattern:
 
-| | Grizzly | Grizzly-Horribilis |
+- **REMOVED:** CONTRARIAN_FLIP — Grizzly now trades WITH SM consensus
+- **REMOVED:** CONTRARIAN_EXHAUSTION_GATE — gating contrarian behavior
+- **ADDED:** 3-mode state machine (HUNTING / RIDING / STALKING)
+- **ADDED:** 4-timeframe alignment (5m + 15m + 1h + 4h)
+- **ADDED:** 4TF_aligned bonus scoring
+- **ADDED:** SM strongly tilted bonus (>65% consensus)
+- **ADDED:** SM opposes HARD BLOCK
+- **ADDED:** Move-exhaustion + tiring penalties
+- **ADDED:** RSI filter (70/30 BTC-tuned)
+- **ADDED:** Volume trend + OI-proxy growth signal
+- **ADDED:** STALKING mode — reload on dip after DSL exit
+- **KEPT:** Dynamic daily cap (P&L-aware circuit breaker)
+- **KEPT:** has_resting_orders with auto-cancel stale
+- **KEPT:** 10x MAX_LEVERAGE cap
+
+---
+
+## Hard Gates (all must pass)
+
+1. **4h trend structure ≠ NEUTRAL** (BULLISH or BEARISH, >60% higher-lows or lower-highs)
+2. **1h trend agrees** with 4h direction
+3. **15m momentum confirms** direction (>0.05% in direction)
+4. **SM opposes = HARD BLOCK** (leaderboard_get_markets)
+5. **RSI filter** — LONG requires RSI ≤ 70, SHORT requires RSI ≥ 30
+
+---
+
+## BTC-Specific Tuning vs Kodiak (SOL)
+
+BTC moves ~0.6% in 4h; SOL moves 2–4%. Thresholds tightened ~3x:
+
+| Parameter | Kodiak (SOL) | Grizzly (BTC) | Why |
+|---|---|---|---|
+| min_mom_15m | 0.10% | 0.05% | BTC slower |
+| rsi_max_long | 74 | 70 | BTC rarely pushes 74 |
+| rsi_min_short | 26 | 30 | BTC rarely pushes 26 |
+| move_exhaustion | 4.0% | 2.5% | BTC exhaustion at lower % |
+| move_tiring | 2.5% | 1.5% | |
+| 4h_strong | 4.0% | 2.0% | |
+| vol_ratio_min | 1.2 | 1.1 | BTC volume always deep |
+| funding_extreme | 0.005 | 0.003 | BTC lower-magnitude |
+
+MIN_SCORE = 10 (family standard). Dynamic daily cap same as family.
+
+---
+
+## Scoring (max ~18 pts, MIN_SCORE = 10)
+
+| Signal | Points |
+|---|---:|
+| 4h trend structure | +3 |
+| 1h trend agrees | +2 |
+| 15m momentum strength | +1 |
+| 4TF_aligned (5m agrees) | +1 |
+| SM aligned | +2 |
+| SM strongly tilted (>65%) | +1 |
+| 15m velocity fresh (>0.5) | +1 |
+| 15M_STALE_PENALTY (cc ≤ 0) | -3 |
+| Funding pays direction | +2 |
+| Funding crowded against | -1 |
+| Volume ratio ≥ 1.1x | +1 |
+| Volume rising >15% | +1 |
+| OI growing >10% | +1 |
+| RSI room | +1 |
+| 4h strong (>2%) | +1 |
+| MOVE_EXHAUSTION (>2.5%) | -2 |
+| MOVE_TIRING (>1.5%) | -1 |
+
+---
+
+## Position Sizing
+
+| Score | Leverage | Margin % |
+|---|---:|---:|
+| 10-11 | 10x (clamped to HL max) | 30% |
+| 12-13 | 10x | 37.5% |
+| **14+** | **10x** | **45%** |
+
+Leverage auto-clamped to BTC's Hyperliquid max via `strategy_get_asset_trading_limits`.
+
+---
+
+## Exit (DSL) — BTC-Tuned per RatchetStop Timing Guide
+
+| Mechanism | Value | Why |
 |---|---|---|
-| Entry style | Single full-size entry | Pyramids (scales into winners) |
-| Position complexity | Simpler, one-shot | More complex, multi-leg |
-| Risk profile | Discrete binary bet | Progressive exposure |
-| Best for | Operators who want simple execution | Operators comfortable with pyramid sizing |
+| hard_timeout | 360 min (6h) | BTC trends take time |
+| weak_peak_cut | 120 min @ 2% min | BTC peaks consolidate slowly |
+| dead_weight_cut | 90 min | BTC can sit quietly within a trend |
+| Phase 1 max_loss | 15% | Same as Kodiak |
+| Phase 1 retrace | 8% | |
+| Phase 2 tier 1 | +5% → 25% lock | First profit lock |
+| Phase 2 tier 2 | +10% → 45% | |
+| Phase 2 tier 3 | +15% → 65% | |
+| Phase 2 tier 4 | +20% → 80% | |
+| Phase 2 tier 5 | +30% → 90% | Apex lock |
+| Phase 2 tier 6 | +50% → 94% | Monster winner trail |
 
-Deploy one or the other (or both on separate wallets for A/B comparison), not multiple of the same variant.
+---
 
-## Key settings
+## 3-Mode Lifecycle
 
-| Setting | Value | Why |
-|---|---|---|
-| Asset | BTC | Single-asset focus |
-| Max positions | 1 | No parallel bets |
-| Margin per trade | 50% | High conviction commits high capital |
-| Leverage | 7x base, 10x at score 10+ | Fleet cap (H12 audit) |
-| Min score | 8 | Tunable |
-| Per-asset cooldown | 180 min | Patience between trades |
-| Same-direction cooldown | 60 min | Prevents chasing |
-| Max daily entries | 3 (dynamic cap aware) | Quality over quantity |
+```
+HUNTING → [all gates pass, score >= 10] → ENTER → RIDING
+RIDING  → [DSL closes position]         → STALKING
+STALKING → [reload conditions met]      → RELOAD → RIDING
+STALKING → [kill conditions hit]        → RESET  → HUNTING
+STALKING → [6h timeout]                 → RESET  → HUNTING
+```
 
-## ⛔ Critical agent rules
+**HUNTING:** scanner evaluates BTC every 3 minutes. All hard gates must pass.
 
-1. **Install path** is `/data/workspace/skills/grizzly-strategy/`
-2. **THE SCANNER DOES NOT EXIT POSITIONS** — DSL handles all exits
-3. **MAX 1 POSITION at a time**
-4. **BTC ONLY** — no multi-asset
-5. **Contrarian direction inversion is intentional** — Grizzly trades OPPOSITE to SM by design
-6. **Respect per-asset and same-direction cooldowns**
-7. **Verify runtime on every session start**
+**RIDING:** scanner does NOT re-evaluate the position. DSL manages all exits.
+(Wolverine v1.1 data: 25/27 trades killed by thesis re-evaluation, not DSL.)
 
-## Setup
+**STALKING:** after DSL closes, scanner watches for conditions to reload
+same direction — fresh 5m impulse + volume holding + SM still aligned +
+4h trend intact. Kills if trend reverses, SM flips, funding extremes, or
+OI collapses.
+
+---
+
+## Family Relationship
+
+All four single-asset specialists run the same architecture:
+
+| Agent | Asset | MIN_SCORE | DSL Profile |
+|---|---|---:|---|
+| Kodiak | SOL | 10 | Mid-beta (240/60/90min) |
+| Wolverine | HYPE | 10 | High-beta (180/45/60min) |
+| Polar | ETH | 10 | Mid-beta (240/60/90min) |
+| **Grizzly** | **BTC** | **10** | **Low-beta (360/90/120min)** |
+
+Bug fixes and signal improvements propagate across the family. If one
+member discovers an edge, all four get it. If one has a bleed, all four
+get audited.
+
+---
+
+## Install
 
 ```bash
 mkdir -p /data/workspace/skills/grizzly-strategy/{config,scripts,state}
 
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/runtime.yaml \
-  -o /data/workspace/skills/grizzly-strategy/runtime.yaml
-
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/SKILL.md \
-  -o /data/workspace/skills/grizzly-strategy/SKILL.md
-
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/config/grizzly-config.json \
-  -o /data/workspace/skills/grizzly-strategy/config/grizzly-config.json
-
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/scripts/grizzly-scanner.py \
-  -o /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py
-
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/scripts/grizzly_config.py \
-  -o /data/workspace/skills/grizzly-strategy/scripts/grizzly_config.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/runtime.yaml -o /data/workspace/skills/grizzly-strategy/runtime.yaml
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/SKILL.md -o /data/workspace/skills/grizzly-strategy/SKILL.md
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/config/grizzly-config.json -o /data/workspace/skills/grizzly-strategy/config/grizzly-config.json
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/scripts/grizzly-scanner.py -o /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py
+curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/scripts/grizzly_config.py -o /data/workspace/skills/grizzly-strategy/scripts/grizzly_config.py
 ```
 
-Set wallet and chat ID:
+## Configure
 
 ```bash
 sed -i 's/${WALLET_ADDRESS}/<YOUR_STRATEGY_WALLET>/' /data/workspace/skills/grizzly-strategy/runtime.yaml
 sed -i 's/${TELEGRAM_CHAT_ID}/<YOUR_TELEGRAM_CHAT_ID>/' /data/workspace/skills/grizzly-strategy/runtime.yaml
 ```
 
-Install runtime:
+## Install runtime + create scanner cron
 
 ```bash
 openclaw senpi runtime create --path /data/workspace/skills/grizzly-strategy/runtime.yaml
 openclaw senpi runtime list
+# Create 3-minute cron: python3 /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py
 ```
 
-Verify:
+---
 
-```bash
-python3 /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py
-```
+## Changelog
 
-Run on recurring schedule:
+### v5.0 (2026-04-16) — COMPLETE REWRITE
+- Direction logic flipped back from v4.x contrarian to trend-following
+- Ported Kodiak's full 3-mode state machine (HUNTING/RIDING/STALKING)
+- Added 4-timeframe alignment with 4TF_aligned bonus scoring
+- Added SM-opposes HARD BLOCK
+- Added move-exhaustion + tiring penalties
+- Added RSI filter (70/30 BTC-tuned)
+- Added volume trend + OI-proxy growth signals
+- Added STALKING reload-on-dip mode
+- DSL profile retuned per RatchetStop timing guide for BTC (low-beta)
+- MIN_SCORE raised 8 → 10 (family standard)
+- Margin tiers rebuilt with conviction scaling (30/37.5/45%)
+- Inner-order success validation in execute_entry
+- get_safe_leverage() clamps to BTC's HL max
 
-```bash
-nohup bash -c 'while true; do python3 /data/workspace/skills/grizzly-strategy/scripts/grizzly-scanner.py >> /tmp/grizzly-loop.log 2>&1; sleep 180; done' > /tmp/grizzly-nohup.log 2>&1 &
-```
+### v4.x (deprecated) — contrarian fader
+- Direction-inverted from family intent
+- Lost $245 fighting real trends
+- Replaced by v5.0
 
-## Best for
+### v3.2 — trend-follower (pre-contrarian)
 
-- Operators who want a BTC-only contrarian with simple single-entry execution
-- Counter-trend traders who believe momentum chasing is a losing edge
-- Diversification pair with Grizzly-Horribilis for A/B comparison on pyramiding vs single-entry
+---
 
 ## License
 
-MIT — Copyright 2026 Senpi (https://senpi.ai). BTC Contrarian.
+MIT — Built by Senpi (https://senpi.ai).
+Source: https://github.com/Senpi-ai/senpi-skills

--- a/grizzly/runtime.yaml
+++ b/grizzly/runtime.yaml
@@ -1,10 +1,12 @@
 name: grizzly-tracker
-version: 4.0.0
+version: 5.0.0
 description: >
-  GRIZZLY v4.0 — BTC Contrarian (SM Exhaustion Fader). Single-asset BTC
-  scanner that trades AGAINST Smart Money consensus when the move is
-  exhausted. Single entry (no pyramiding — see Grizzly-Horribilis for
-  the pyramiding variant). Wide DSL lets reversals develop.
+  GRIZZLY v5.0 — BTC Alpha Hunter with Position Lifecycle. Single-asset
+  BTC scanner, trend-following (flipped back from v4.x contrarian).
+  Family member alongside Kodiak (SOL), Wolverine (HYPE), Polar (ETH) —
+  all four share the same architecture, tuned per asset. BTC-specific
+  tuning: tighter momentum thresholds (BTC moves 3x slower than alts),
+  RSI 70/30 extremes, wider DSL timing per RatchetStop guide.
 
 strategy:
   wallet: "${WALLET_ADDRESS}"
@@ -24,34 +26,43 @@ actions:
     decision_mode: rule
     scanners: [position_tracker]
 
-# DSL tuned for BTC contrarian — reversals take time, tight loss floor.
+# ─── EXIT (DSL) — BTC-tuned per RatchetStop timing guide ──────
+# BTC moves 0.6% in 4h. Time-based exits must match asset speed or
+# they'll kill every position before the trend develops.
+#
+#   BTC:      Dead Weight 90min  |  Weak Peak 120min  |  Hard Timeout 360min
+#   ETH/SOL:  Dead Weight 60min  |  Weak Peak 90min   |  Hard Timeout 240min
+#   HYPE:     Dead Weight 30min  |  Weak Peak 60min   |  Hard Timeout 180min
+#
+# Phase 2 tiers calibrated for BTC's slower grinds — first lock at +5%
+# (BTC rarely sees +8% quickly), then escalates.
 exit:
   engine: dsl
   interval_seconds: 30
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 360
+      interval_in_minutes: 360       # 6h — BTC trends take time
     weak_peak_cut:
       enabled: true
-      interval_in_minutes: 90
+      interval_in_minutes: 120        # 2h — BTC peaks consolidate slowly
       min_value: 2.0
     dead_weight_cut:
       enabled: true
-      interval_in_minutes: 30
+      interval_in_minutes: 90         # 90min — BTC can sit quietly in trend
     phase1:
       enabled: true
       max_loss_pct: 15.0
       retrace_threshold: 8
-      consecutive_breaches_required: 3
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,  lock_hw_pct: 20 }
-        - { trigger_pct: 10, lock_hw_pct: 40 }
-        - { trigger_pct: 15, lock_hw_pct: 60 }
-        - { trigger_pct: 20, lock_hw_pct: 75 }
-        - { trigger_pct: 30, lock_hw_pct: 85 }
+        - { trigger_pct: 5,   lock_hw_pct: 25 }   # First profit lock
+        - { trigger_pct: 10,  lock_hw_pct: 45 }
+        - { trigger_pct: 15,  lock_hw_pct: 65 }
+        - { trigger_pct: 20,  lock_hw_pct: 80 }
+        - { trigger_pct: 30,  lock_hw_pct: 90 }   # Apex lock
+        - { trigger_pct: 50,  lock_hw_pct: 94 }   # Monster winner trail
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/grizzly/scripts/grizzly-scanner.py
+++ b/grizzly/scripts/grizzly-scanner.py
@@ -1,97 +1,580 @@
 #!/usr/bin/env python3
-# Senpi GRIZZLY Scanner v3.2
+# Senpi GRIZZLY Scanner v5.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-"""GRIZZLY v4.0 — BTC Contrarian (SM Exhaustion Fader).
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""GRIZZLY v5.0 — BTC Alpha Hunter with Position Lifecycle.
 
-v4.0 — DIRECTION FLIP + A/B alignment with Horribilis.
-Fleet analysis (April 10, 2026) found that the SM consensus signal is
-perfectly inverted on BTC: the multi-timeframe confirmation requirement
-means the scanner enters after the move is exhausted. Inversion test on
-11 trades showed 81.8% WR if direction were flipped.
+v5.0 is a COMPLETE REWRITE. Grizzly is now the BTC variant of the
+Kodiak/Wolverine/Polar single-asset-specialist family. All four agents
+share the same architecture, tuned per asset.
 
-Changes from v3.2:
-- CONTRARIAN FLIP: trade opposite to SM consensus direction
-- Leverage tiers aligned with Horribilis: 7x/10x (was 7x/10x/15x/20x)
-- Added MOVE_EXHAUSTION penalty (was missing, Horribilis had it)
-- 15m velocity tiers aligned with Horribilis (simpler, less spike-chasing)
-- 1h acceleration aligned with Horribilis
-- Added same-direction cooldown (60 min)
-- Fixed resting order filter (now ignores reduceOnly DSL stops)
-- A/B variable vs Horribilis: Grizzly = single entry, Horribilis = pyramids
+v4.x was a contrarian SM-fader — opposite direction to the family intent.
+April 10 inversion test assumed SM was broken on BTC. That was the wrong
+read. Grizzly was bleeding because it was fighting the prevailing trend,
+not because SM was inverted. v5.0 returns to trend-following with the
+full Kodiak architecture.
 
-Uses: leaderboard_get_markets + market_get_asset_data + strategy_get_open_orders
+## Architecture (shared with Kodiak/Wolverine/Polar)
+
+MODE 1 — HUNTING: all signals must align, score >= MIN_SCORE to enter
+MODE 2 — RIDING: position open, DSL manages exit, scanner does NOT re-evaluate
+MODE 3 — STALKING: DSL closed, watch for reload on dip, or reset if thesis dies
+
+## BTC-specific tuning vs Kodiak (SOL)
+
+BTC moves ~0.6% in 4h vs SOL's 2-4%. All momentum thresholds tightened:
+  - min_mom_15m: 0.05 (vs 0.10)
+  - move_exhaustion: 2.5% (vs 4.0%)
+  - move_tiring: 1.5% (vs 2.5%)
+  - rsi_max_long: 70 (vs 74) — BTC rarely pushes that extreme
+  - rsi_min_short: 30 (vs 26)
+  - vol_ratio_min: 1.1 (vs 1.2) — BTC volume is always deep
+  - 4h strong move: 2.0% (vs 4.0%)
+
+BTC SM consensus still works — reuses Kodiak's leaderboard_get_markets
+pattern. SM-opposes is a HARD BLOCK (same as Kodiak).
+
+## v5.0 changes from v4.x
+
+- REMOVED: CONTRARIAN_FLIP — direction flips inverted the family thesis
+- REMOVED: CONTRARIAN_EXHAUSTION_GATE — was gating contrarian behavior
+- ADDED: 3-mode state machine (HUNTING/RIDING/STALKING)
+- ADDED: 4-timeframe alignment (5m + 15m + 1h + 4h)
+- ADDED: 4TF_aligned bonus scoring
+- ADDED: SM strongly tilted bonus (>65% consensus)
+- ADDED: SM opposes HARD BLOCK
+- ADDED: Move-exhaustion + tiring penalties
+- ADDED: RSI filter (70/30 BTC-tuned)
+- ADDED: Volume trend + OI-proxy growth signal
+- ADDED: STALKING mode — reload on dip after DSL exit
+- ADDED: Stalk evaluation kill conditions
+- KEPT:   Dynamic daily cap (P&L-aware circuit breaker)
+- KEPT:   has_resting_orders with auto-cancel stale
+- KEPT:   10x MAX_LEVERAGE cap (fleet-wide learning)
+- KEPT:   Same-direction cooldown (60 min)
+
 Runs every 3 minutes.
 """
 
-import json, sys, os, time
+import sys
+import os
+import time
 from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import grizzly_config as cfg
 
+
+# ═══════════════════════════════════════════════════════════════
+# CONSTANTS — BTC-tuned (vs Kodiak/SOL)
+# ═══════════════════════════════════════════════════════════════
+
 ASSET = "BTC"
 MAX_POSITIONS = 1
-MAX_DAILY_ENTRIES = 2
-
-
-# ═══════════════════════════════════════════════════════════════
-# DYNAMIC DAILY CAP (P&L-aware circuit breaker)
-# ═══════════════════════════════════════════════════════════════
-
-STARTING_BUDGET = 1000.0  # Default starting budget — override per-agent if different
-
-def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
-    """P&L-aware daily entry cap based on drawdown from starting budget.
-
-    Winners get more trades (ride the hot hand).
-    Losers get fewer trades (preserve capital).
-    Catastrophic drawdown triggers HARD STOP (circuit breaker).
-    """
-    if starting_budget <= 0:
-        return 4  # Safe fallback
-    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
-    if pnl_pct >= 5:       return 12   # Hot hand — up >5%
-    elif pnl_pct >= 0:     return 8    # Small win / breakeven
-    elif pnl_pct >= -5:    return 5    # Careful
-    elif pnl_pct >= -15:   return 3    # Defensive
-    elif pnl_pct >= -25:   return 1    # Preserve — only highest conviction
-    else:                  return 0    # HARD STOP — circuit breaker
-
-COOLDOWN_MINUTES = 180
-MARGIN_PCT = 0.50
-MIN_SCORE = 8
-
+MAX_LEVERAGE = 10          # Fleet-wide: 10x is the empirical ceiling
+MIN_LEVERAGE = 5
+MIN_SCORE = 10             # Family standard — was 8 in v4.x
 SAME_DIR_COOLDOWN_MINUTES = 60
+ASSET_COOLDOWN_MINUTES = 60  # Post-exit cooldown on BTC entry
 
-LEVERAGE_TIERS = [
-    {"min_score": 10, "leverage": 10},
-    {"min_score": 8,  "leverage": 7},
-]
-DEFAULT_LEVERAGE = 7
+# BTC-specific momentum thresholds (BTC ~3x slower than SOL)
+MIN_MOM_15M = 0.05         # SOL uses 0.10
+RSI_MAX_LONG = 70          # SOL uses 74
+RSI_MIN_SHORT = 30         # SOL uses 26
+STRONG_4H_PCT = 2.0        # BTC "strong" 4h move (SOL: 4.0)
+MOVE_EXHAUSTION_PCT = 2.5  # SOL: 4.0
+MOVE_TIRING_PCT = 1.5      # SOL: 2.5
+MIN_VOL_RATIO = 1.1        # SOL: 1.2
+FUNDING_EXTREME = 0.0008   # BTC funding is lower magnitude than alts
+FUNDING_CROWDED = 0.003
+
+# Dynamic daily cap
+STARTING_BUDGET = 1000.0
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical Helpers (identical to Kodiak — shared family math)
+# ═══════════════════════════════════════════════════════════════
 
 def safe_float(v, d=0.0):
-    try: return float(v)
-    except: return d
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
 
-def now_date(): return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+def price_momentum(candles, n_bars=1):
+    if len(candles) < n_bars + 1:
+        return 0
+    old = safe_float(candles[-(n_bars + 1)].get("close", candles[-(n_bars + 1)].get("c", 0)))
+    new = safe_float(candles[-1].get("close", candles[-1].get("c", 0)))
+    if old == 0:
+        return 0
+    return ((new - old) / old) * 100
+
+
+def trend_structure(candles, lookback=6):
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [safe_float(c.get("low", c.get("l", 0))) for c in candles[-lookback:]]
+    highs = [safe_float(c.get("high", c.get("h", 0))) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def volume_ratio(candles, lookback=10):
+    if len(candles) < lookback + 1:
+        return 1.0
+    vols = [safe_float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles[-(lookback + 1):-1]]
+    avg = sum(vols) / len(vols) if vols else 1
+    latest = safe_float(candles[-1].get("volume", candles[-1].get("v", candles[-1].get("vlm", 0))))
+    return latest / avg if avg > 0 else 1.0
+
+
+def volume_trend(candles, lookback=6):
+    if len(candles) < lookback + 2:
+        return 0
+    vols = [safe_float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles[-(lookback + 2):]]
+    half = lookback // 2
+    recent = sum(vols[-half:]) / half if half > 0 else 1
+    earlier = sum(vols[:half]) / half if half > 0 else 1
+    if earlier == 0:
+        return 0
+    return ((recent - earlier) / earlier) * 100
+
+
+def calc_rsi(closes, period=14):
+    if len(closes) < period + 1:
+        return 50
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ═══════════════════════════════════════════════════════════════
+# BTC Data
+# ═══════════════════════════════════════════════════════════════
+
+def get_btc_full_picture():
+    """Fetch comprehensive BTC data across all timeframes."""
+    data = cfg.mcporter_call("market_get_asset_data", asset=ASSET,
+                              candle_intervals=["5m", "15m", "1h", "4h"],
+                              include_funding=True, include_order_book=False)
+    if not data or not data.get("success"):
+        return None
+    return data.get("data", data)
+
+
+def get_btc_sm_direction():
+    """Get smart money positioning specifically for BTC.
+    Returns (direction, pct, trader_count, cc_15m)."""
+    data = cfg.mcporter_call("leaderboard_get_markets")
+    if not data:
+        return None, 0, 0, 0
+
+    markets = data.get("data", data)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0, 0, 0
+
+    asset_long_pct = 0
+    asset_short_pct = 0
+    asset_traders = 0
+    btc_cc_15m = 0
+    found = False
+
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = m.get("token", m.get("coin", m.get("asset", "")))
+        if str(token).upper() != ASSET:
+            continue
+        found = True
+        direction = m.get("direction", "").lower()
+        pct = safe_float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        traders = int(m.get("trader_count", m.get("traderCount", 0)) or 0)
+        cc_15m_val = safe_float(m.get("contribution_pct_change_15m", 0))
+        if direction == "long":
+            asset_long_pct = pct
+            asset_traders += traders
+            btc_cc_15m = cc_15m_val
+        elif direction == "short":
+            asset_short_pct = pct
+            asset_traders += traders
+            btc_cc_15m = cc_15m_val
+
+    if not found:
+        return None, 0, 0, 0
+
+    total = asset_long_pct + asset_short_pct
+    if total == 0:
+        return "NEUTRAL", 50, asset_traders, btc_cc_15m
+    long_ratio = (asset_long_pct / total) * 100
+    if long_ratio > 58:
+        return "LONG", long_ratio, asset_traders, btc_cc_15m
+    elif long_ratio < 42:
+        return "SHORT", 100 - long_ratio, asset_traders, btc_cc_15m
+    return "NEUTRAL", 50, asset_traders, btc_cc_15m
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis Builder (BTC)
+# ═══════════════════════════════════════════════════════════════
+
+def build_btc_thesis():
+    """Build a conviction thesis for BTC from every signal source.
+    Mirrors Kodiak's build_sol_thesis. BTC-specific thresholds."""
+
+    btc_data = get_btc_full_picture()
+    if not btc_data:
+        return None
+
+    candles_5m = btc_data.get("candles", {}).get("5m", [])
+    candles_15m = btc_data.get("candles", {}).get("15m", [])
+    candles_1h = btc_data.get("candles", {}).get("1h", [])
+    candles_4h = btc_data.get("candles", {}).get("4h", [])
+    asset_ctx = btc_data.get("asset_context", btc_data.get("assetContext", {}))
+    funding = safe_float(asset_ctx.get("funding", btc_data.get("funding", 0)))
+    oi = safe_float(asset_ctx.get("openInterest", btc_data.get("openInterest", 0)))
+
+    if len(candles_5m) < 12 or len(candles_15m) < 8 or len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+
+    price = safe_float(candles_5m[-1].get("close", candles_5m[-1].get("c", 0)))
+
+    # ── REQUIRED: 4h trend structure (the foundation) ────────
+    trend_4h, trend_strength_4h = trend_structure(candles_4h)
+    if trend_4h == "NEUTRAL":
+        return None  # No conviction without macro structure
+
+    direction = "LONG" if trend_4h == "BULLISH" else "SHORT"
+
+    # ── REQUIRED: 1h trend agrees ─────────────────────────────
+    trend_1h, trend_strength_1h = trend_structure(candles_1h)
+    if trend_1h != trend_4h:
+        return None
+
+    # ── REQUIRED: 15m momentum confirms direction ────────────
+    mom_5m = price_momentum(candles_5m, 1)
+    mom_15m = price_momentum(candles_15m, 1)
+    mom_1h = price_momentum(candles_1h, 2)
+    mom_4h = price_momentum(candles_4h, 1)
+
+    if direction == "LONG" and mom_15m < MIN_MOM_15M:
+        return None
+    if direction == "SHORT" and mom_15m > -MIN_MOM_15M:
+        return None
+
+    # ── SCORING ───────────────────────────────────────────────
+    score = 0
+    reasons = []
+
+    # 4h trend (3 pts — the foundation)
+    score += 3
+    reasons.append(f"4h_{trend_4h.lower()}_{trend_strength_4h:.0%}")
+
+    # 1h trend agreement (2 pts)
+    score += 2
+    reasons.append(f"1h_confirms_{mom_1h:+.2f}%")
+
+    # 15m momentum strength (1 pt if strong)
+    if abs(mom_15m) > MIN_MOM_15M * 2:
+        score += 1
+        reasons.append(f"15m_strong_{mom_15m:+.2f}%")
+    else:
+        reasons.append(f"15m_{mom_15m:+.2f}%")
+
+    # 5m alignment (1 pt — all 4 timeframes agree)
+    if (direction == "LONG" and mom_5m > 0) or (direction == "SHORT" and mom_5m < 0):
+        score += 1
+        reasons.append("4TF_aligned")
+
+    # ── SM positioning (HARD BLOCK if opposed — BTC has strongest SM signal) ─
+    sm_dir, sm_pct, sm_count, sm_cc_15m = get_btc_sm_direction()
+    if sm_dir == direction:
+        score += 2
+        reasons.append(f"sm_aligned_{sm_pct:.0f}%_{sm_count}traders")
+        if sm_pct > 65:
+            score += 1
+            reasons.append("sm_strongly_tilted")
+    elif sm_dir and sm_dir != "NEUTRAL" and sm_dir != direction:
+        # SM opposes — hard block. SM has the best read on BTC.
+        return None
+
+    # ── 15m velocity freshness ────────────────────────────────
+    if sm_cc_15m <= 0:
+        score -= 3
+        reasons.append(f"15M_STALE_PENALTY ({sm_cc_15m:.2f})")
+    elif sm_cc_15m > 0.5:
+        score += 1
+        reasons.append(f"15M_FRESH +{sm_cc_15m:.2f}")
+
+    # ── Funding alignment ─────────────────────────────────────
+    if direction == "LONG" and funding < 0:
+        score += 2
+        reasons.append(f"funding_pays_longs_{funding:+.4f}")
+    elif direction == "SHORT" and funding > 0:
+        score += 2
+        reasons.append(f"funding_pays_shorts_{funding:+.4f}")
+    elif (direction == "LONG" and funding > FUNDING_CROWDED) or \
+         (direction == "SHORT" and funding < -FUNDING_CROWDED):
+        score -= 1
+        reasons.append(f"funding_crowded_{funding:+.4f}")
+
+    # ── Volume confirmation ───────────────────────────────────
+    vol_1h = volume_ratio(candles_1h)
+    if vol_1h >= MIN_VOL_RATIO:
+        score += 1
+        reasons.append(f"vol_{vol_1h:.1f}x")
+    elif vol_1h < 0.7:
+        score -= 1
+        reasons.append("vol_weak")
+
+    vol_trend_1h = volume_trend(candles_1h)
+    if vol_trend_1h > 15:
+        score += 1
+        reasons.append(f"vol_rising_{vol_trend_1h:+.0f}%")
+
+    # ── OI growth proxy (new money entering) ──────────────────
+    vol_recent = sum(safe_float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles_1h[-3:])
+    vol_earlier = sum(safe_float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles_1h[-6:-3])
+    oi_proxy = ((vol_recent - vol_earlier) / vol_earlier * 100) if vol_earlier > 0 else 0
+    if oi_proxy > 10:
+        score += 1
+        reasons.append(f"oi_growing_{oi_proxy:+.0f}%")
+
+    # ── RSI filter (BTC rarely pushes >70 or <30) ─────────────
+    closes_1h = [safe_float(c.get("close", c.get("c", 0))) for c in candles_1h]
+    rsi = calc_rsi(closes_1h)
+    if direction == "LONG" and rsi > RSI_MAX_LONG:
+        return None
+    if direction == "SHORT" and rsi < RSI_MIN_SHORT:
+        return None
+    if (direction == "LONG" and rsi < 55) or (direction == "SHORT" and rsi > 45):
+        score += 1
+        reasons.append(f"rsi_room_{rsi:.0f}")
+
+    # ── 4h momentum strength bonus ────────────────────────────
+    if abs(mom_4h) > STRONG_4H_PCT:
+        score += 1
+        reasons.append(f"4h_strong_{mom_4h:+.1f}%")
+
+    # ── Move-exhaustion penalty ───────────────────────────────
+    if abs(mom_4h) >= MOVE_EXHAUSTION_PCT:
+        if (direction == "LONG" and mom_4h > 0) or (direction == "SHORT" and mom_4h < 0):
+            score -= 2
+            reasons.append(f"MOVE_EXHAUSTION {mom_4h:+.1f}%")
+    elif abs(mom_4h) >= MOVE_TIRING_PCT:
+        if (direction == "LONG" and mom_4h > 0) or (direction == "SHORT" and mom_4h < 0):
+            score -= 1
+            reasons.append(f"MOVE_TIRING {mom_4h:+.1f}%")
+
+    return {
+        "coin": ASSET,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "trend_4h": trend_4h,
+        "trend_1h": trend_1h,
+        "momentum": {"5m": mom_5m, "15m": mom_15m, "1h": mom_1h, "4h": mom_4h},
+        "sm_direction": sm_dir,
+        "sm_pct": sm_pct,
+        "funding": funding,
+        "rsi": rsi,
+        "vol_ratio": vol_1h,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Stalk / Reload Evaluation
+# ═══════════════════════════════════════════════════════════════
+
+def evaluate_reload(exit_state):
+    """After DSL exit, check if conditions are met to reload same direction.
+    Returns (should_reload, reasons). False with kill signals → reset to HUNTING."""
+
+    direction = exit_state.get("exitDirection")
+    exit_ts = exit_state.get("exitTimestamp", 0)
+    exit_vol = exit_state.get("exitEntryVolRatio", 1.0)
+    now = cfg.now_ts()
+    hours_stalking = (now - exit_ts) / 3600
+
+    MAX_STALK_HOURS = 6
+    if hours_stalking > MAX_STALK_HOURS:
+        return False, [f"stalk_timeout_{hours_stalking:.1f}h"]
+
+    btc_data = get_btc_full_picture()
+    if not btc_data:
+        return False, ["data_unavailable"]
+
+    candles_5m = btc_data.get("candles", {}).get("5m", [])
+    candles_1h = btc_data.get("candles", {}).get("1h", [])
+    candles_4h = btc_data.get("candles", {}).get("4h", [])
+    asset_ctx = btc_data.get("asset_context", btc_data.get("assetContext", {}))
+    funding = safe_float(asset_ctx.get("funding", btc_data.get("funding", 0)))
+
+    kill_reasons = []
+    reload_checks = []
+
+    # KILL: 4h trend reversed
+    trend_4h, _ = trend_structure(candles_4h)
+    expected_trend = "BULLISH" if direction == "LONG" else "BEARISH"
+    if trend_4h != expected_trend and trend_4h != "NEUTRAL":
+        kill_reasons.append(f"4h_trend_reversed_{trend_4h}")
+
+    # KILL: SM flipped against
+    sm_dir, sm_pct, _, _ = get_btc_sm_direction()
+    if sm_dir and sm_dir != "NEUTRAL" and sm_dir != direction:
+        kill_reasons.append(f"sm_flipped_{sm_dir}")
+
+    # KILL: Funding spiked into extreme crowding
+    funding_ann = abs(funding) * 8760
+    MAX_FUNDING_ANN_PCT = 80
+    if (direction == "LONG" and funding > 0 and funding_ann > MAX_FUNDING_ANN_PCT) or \
+       (direction == "SHORT" and funding < 0 and funding_ann > MAX_FUNDING_ANN_PCT):
+        kill_reasons.append(f"funding_extreme_{funding_ann:.0f}%ann")
+
+    # KILL: OI collapsed
+    if len(candles_1h) >= 6:
+        recent_vols = [safe_float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles_1h[-3:]]
+        earlier_vols = [safe_float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles_1h[-6:-3]]
+        avg_recent = sum(recent_vols) / len(recent_vols) if recent_vols else 0
+        avg_earlier = sum(earlier_vols) / len(earlier_vols) if earlier_vols else 1
+        if avg_earlier > 0:
+            oi_change = ((avg_recent - avg_earlier) / avg_earlier) * 100
+            if oi_change < -20:
+                kill_reasons.append(f"oi_collapsed_{oi_change:+.0f}%")
+
+    if kill_reasons:
+        return False, kill_reasons
+
+    # Must have been stalking for at least 30 min
+    if hours_stalking < 0.5:
+        reload_checks.append("waiting_for_setup")
+
+    # RELOAD: fresh 5m momentum impulse
+    if len(candles_5m) >= 3:
+        mom_5m_1 = price_momentum(candles_5m, 1)
+        mom_5m_2 = price_momentum(candles_5m[:-1], 1)
+        if direction == "LONG":
+            if mom_5m_1 > 0.10 and mom_5m_1 > mom_5m_2:
+                reload_checks.append(f"fresh_5m_impulse_{mom_5m_1:+.2f}%")
+            else:
+                reload_checks.append("no_5m_impulse")
+        else:
+            if mom_5m_1 < -0.10 and mom_5m_1 < mom_5m_2:
+                reload_checks.append(f"fresh_5m_impulse_{mom_5m_1:+.2f}%")
+            else:
+                reload_checks.append("no_5m_impulse")
+
+    # RELOAD: Volume at least 50% of exit
+    vol = volume_ratio(candles_5m)
+    if vol >= exit_vol * 0.5:
+        reload_checks.append(f"vol_sufficient_{vol:.1f}x")
+    else:
+        reload_checks.append(f"vol_weak_{vol:.1f}x")
+
+    # RELOAD: Funding not crowded
+    if (direction == "LONG" and (funding <= 0 or funding_ann < 50)) or \
+       (direction == "SHORT" and (funding >= 0 or funding_ann < 50)):
+        reload_checks.append("funding_ok")
+    else:
+        reload_checks.append(f"funding_crowded_{funding_ann:.0f}%ann")
+
+    # RELOAD: SM still aligned
+    if sm_dir == direction:
+        reload_checks.append(f"sm_aligned_{sm_pct:.0f}%")
+    elif sm_dir == "NEUTRAL":
+        reload_checks.append("sm_neutral_ok")
+    else:
+        reload_checks.append(f"sm_not_aligned_{sm_dir}")
+
+    # RELOAD: 4h trend intact
+    if trend_4h == expected_trend:
+        reload_checks.append("4h_intact")
+    else:
+        reload_checks.append(f"4h_{trend_4h}")
+
+    fails = [r for r in reload_checks if any(bad in r for bad in
+              ["no_5m", "vol_weak", "funding_crowded",
+               "sm_not_aligned", "waiting_for"])]
+
+    if not fails:
+        return True, reload_checks
+    else:
+        return False, reload_checks
+
+
+# ═══════════════════════════════════════════════════════════════
+# Trading Infrastructure
+# ═══════════════════════════════════════════════════════════════
+
+def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
+    """P&L-aware daily entry cap — hot hand gets more, losers preserve capital."""
+    if starting_budget <= 0:
+        return 4
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
+    if pnl_pct >= 5:       return 12   # Hot hand
+    elif pnl_pct >= 0:     return 8
+    elif pnl_pct >= -5:    return 5
+    elif pnl_pct >= -15:   return 3
+    elif pnl_pct >= -25:   return 1
+    else:                  return 0    # HARD STOP circuit breaker
+
 
 def get_leverage_for_score(score):
-    for tier in LEVERAGE_TIERS:
-        if score >= tier["min_score"]:
-            return tier["leverage"]
-    return DEFAULT_LEVERAGE
+    """Conviction-scaled leverage. Kodiak empirical 10x cap.
+    BTC can safely push to 10x at apex — less wick risk than alts."""
+    if score >= 10:
+        return 10
+    return 7
+
+
+def get_margin_pct(score, base=0.30):
+    """Conviction-scaled margin. Apex setups get bigger allocation."""
+    if score >= 14:
+        return base * 1.5   # 45%
+    elif score >= 12:
+        return base * 1.25  # 37.5%
+    else:
+        return base         # 30%
+
+
+def get_safe_leverage(wallet, coin, desired):
+    """Clamp leverage to per-asset HL max via strategy_get_asset_trading_limits."""
+    try:
+        r = cfg.mcporter_call("strategy_get_asset_trading_limits",
+                              strategy_wallet=wallet, coin=coin)
+        if r:
+            d = r.get("data", r)
+            max_lev = int(d.get("maxLeverage", d.get("max_leverage", MAX_LEVERAGE)))
+            return min(desired, max_lev, MAX_LEVERAGE)
+    except Exception:
+        pass
+    return min(desired, MAX_LEVERAGE)
+
 
 def has_resting_orders(wallet):
-    """Check for non-reduceOnly resting orders, auto-cancelling any older
-    than STALE_ORDER_MAX_AGE_SEC (default 600s / 10 min).
-
-    Without auto-cancel, a maker FEE_OPTIMIZED_LIMIT order that never
-    fills can lock the scanner out of new entries indefinitely, because
-    every subsequent scan sees the stale order and aborts early. Ignores
-    reduceOnly orders (those are DSL exit legs)."""
-    import time as _time
-    STALE_ORDER_MAX_AGE_SEC = 600  # 10 minutes
+    """Non-reduceOnly orders block entry. Auto-cancel stale (>10min) maker orders."""
+    STALE_ORDER_MAX_AGE_SEC = 600
     data = cfg.mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
     if not data:
         return False
@@ -100,7 +583,7 @@ def has_resting_orders(wallet):
         orders = orders.get("orders", orders.get("openOrders", []))
     if not isinstance(orders, list):
         return False
-    now_ms = _time.time() * 1000
+    now_ms = time.time() * 1000
     max_age_ms = STALE_ORDER_MAX_AGE_SEC * 1000
     has_fresh = False
     for o in orders:
@@ -115,123 +598,18 @@ def has_resting_orders(wallet):
             oid = o.get("oid") or o.get("orderId") or o.get("id")
             if oid:
                 try:
-                    cfg.mcporter_call(
-                        "cancel_order",
-                        strategyWalletAddress=wallet,
-                        orderId=int(oid),
-                    )
+                    cfg.mcporter_call("cancel_order",
+                                      strategyWalletAddress=wallet,
+                                      orderId=int(oid))
                 except Exception:
                     pass
-            continue  # Treat cancelled order as gone
+            continue
         has_fresh = True
     return has_fresh
 
 
-def evaluate_btc():
-    raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
-    if not raw: return None
-    markets = raw.get("data", raw)
-    if isinstance(markets, dict): markets = markets.get("markets", markets)
-    if isinstance(markets, dict): markets = markets.get("markets", [])
-
-    btc = None
-    for m in markets:
-        if not isinstance(m, dict): continue
-        if str(m.get("token","")).upper() == ASSET: btc = m; break
-    if not btc: return None
-
-    d = str(btc.get("direction","")).upper()
-    if d not in ("LONG","SHORT"): return None
-    pct = safe_float(btc.get("pct_of_top_traders_gain",0))
-    traders = int(btc.get("trader_count",0))
-    p4h = safe_float(btc.get("token_price_change_pct_4h",0))
-    p1h = safe_float(btc.get("token_price_change_pct_1h", btc.get("price_change_1h",0)))
-    cc = safe_float(btc.get("contribution_pct_change_4h",0))
-    cc_15m = safe_float(btc.get("contribution_pct_change_15m",0))
-    cc_1h_contrib = safe_float(btc.get("contribution_pct_change_1h",0))
-
-    if traders < 10: return None
-
-    # CONTRARIAN EXHAUSTION GATE (v4.1)
-    # Fleet analysis April 13: Grizzly v4.0 lost $107 in 15h shorting BTC while
-    # BTC pumped from $72,294 to $74,758 (+3.4%). The contrarian flip was fading
-    # an ACCELERATING breakout, not exhausted consensus.
-    #
-    # Before fading SM, require that the 4H price has already moved significantly
-    # in their direction. If BTC is only up 0.7% and SM is piling in, they might
-    # be early and RIGHT. Only fade when the move is actually exhausted.
-    MIN_EXHAUSTION_PCT = 2.5  # BTC 4H must have moved >2.5% in SM direction
-    if abs(p4h) < MIN_EXHAUSTION_PCT:
-        return None  # Not exhausted yet — don't fight a fresh trend
-    # Must be moving in SM direction (otherwise SM is already wrong)
-    if (d == "LONG" and p4h < 0) or (d == "SHORT" and p4h > 0):
-        return None  # SM direction opposes price — not an exhaustion pattern
-
-    funding = 0
-    try:
-        ad = cfg.mcporter_call("market_get_asset_data", asset=ASSET, candle_intervals=["1h"], include_funding=True)
-        if ad:
-            ac = ad.get("data",ad).get("asset_context", ad.get("data",ad).get("assetContext",{}))
-            funding = safe_float(ac.get("funding",0))
-    except: pass
-
-    score, reasons = 0, []
-
-    # SM concentration (0-3)
-    if pct >= 15: score += 3; reasons.append(f"DOMINANT_SM {pct:.1f}% ({traders}t)")
-    elif pct >= 10: score += 2; reasons.append(f"STRONG_SM {pct:.1f}% ({traders}t)")
-    elif pct >= 5: score += 1; reasons.append(f"SM_ALIGNED {pct:.1f}% ({traders}t)")
-
-    # 4H price alignment (+/-2)
-    if abs(p4h) >= 2.0:
-        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
-            score += 2; reasons.append(f"STRONG_4H {p4h:+.1f}%")
-        else:
-            score -= 1; reasons.append(f"4H_OPPOSING {p4h:+.1f}%")
-    elif abs(p4h) >= 0.5:
-        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
-            score += 1; reasons.append(f"4H_CONFIRMS {p4h:+.1f}%")
-
-    # 1H momentum (0-1)
-    if (d=="LONG" and p1h>0.2) or (d=="SHORT" and p1h<-0.2):
-        score += 1; reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
-
-    # Move-exhaustion penalty — large existing moves reduce conviction
-    if abs(p4h) >= 4.0:
-        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
-            score -= 2; reasons.append(f"MOVE_EXHAUSTION {p4h:+.1f}%")
-    elif abs(p4h) >= 2.5:
-        if (d == "LONG" and p4h > 0) or (d == "SHORT" and p4h < 0):
-            score -= 1; reasons.append(f"MOVE_TIRING {p4h:+.1f}%")
-
-    # 15m velocity freshness gate — SM must be actively building
-    # For contrarian: we want SM aggressively piling in (high 15m) so we can fade the peak
-    # If SM is already unwinding (15m <= 0), the fade opportunity is passing
-    if cc_15m <= 0:
-        return None  # SM not fresh — stale signal
-
-    # Contribution velocity scoring
-    if cc_15m > 0.5: score += 2; reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
-    elif cc_15m > 0.1: score += 1; reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
-
-    if cc_1h_contrib > 1.0: score += 1; reasons.append(f"1H_ACCEL +{cc_1h_contrib:.2f}")
-
-    if abs(cc)>=5.0: score += 1; reasons.append(f"4H_MAJOR_SHIFT {cc:+.1f}")
-
-    if cc_15m > 0 and cc_1h_contrib > 0 and cc_15m > cc_1h_contrib:
-        score += 1; reasons.append(f"ACCEL_PATTERN 15m({cc_15m:.2f})>1h({cc_1h_contrib:.2f})")
-
-    # Funding alignment (0-1)
-    if (d=="SHORT" and funding>0.0002) or (d=="LONG" and funding<-0.0002):
-        score += 1; reasons.append(f"FUNDING_PAYS {funding*100:.4f}%")
-
-    # Trader depth (0-1)
-    if traders >= 100: score += 1; reasons.append(f"DEEP_CONSENSUS ({traders}t)")
-
-    return {"score":score,"direction":d,"reasons":reasons,"smPct":pct,"smTraders":traders,"priceChg4h":p4h}
-
-
 def execute_entry(wallet, direction, margin, leverage):
+    """Place BTC entry via canonical MCP schema with inner-order validation."""
     result = cfg.mcporter_call(
         "create_position",
         strategyWalletAddress=wallet,
@@ -241,106 +619,236 @@ def execute_entry(wallet, direction, margin, leverage):
             "leverage": leverage,
             "marginAmount": margin,
             "orderType": "FEE_OPTIMIZED_LIMIT",
-            "feeOptimizedLimitOptions": {"ensureExecutionAsTaker": False, "executionTimeoutSeconds": 30},
+            "feeOptimizedLimitOptions": {
+                "ensureExecutionAsTaker": False,
+                "executionTimeoutSeconds": 30,
+            },
         }],
     )
-    if result and result.get("success"): return True, result
-    error = result.get("error", "unknown") if result else "mcporter_call returned None"
-    return False, {"error": error}
+    if not result:
+        return False, {"error": "mcporter_call returned None"}
+
+    # Outer envelope
+    if not result.get("success"):
+        return False, {"error": result.get("error", "outer_envelope_failed"), "raw": result}
+
+    # Inner-order validation — guard against phantom success
+    data = result.get("data", result)
+    orders = data.get("orders", []) if isinstance(data, dict) else []
+    if orders and isinstance(orders, list):
+        first = orders[0] if isinstance(orders[0], dict) else {}
+        if first and not first.get("success", True):
+            return False, {"error": first.get("error", "inner_order_failed"),
+                           "raw": result}
+
+    return True, result
 
 
-def load_tc():
-    p = os.path.join(cfg.STATE_DIR, "trade-counter.json")
-    default = {"date": now_date(), "entries": 0,
-               "last_win_direction": None, "last_win_ts": 0}
-    if os.path.exists(p):
-        try:
-            with open(p) as f: tc = json.load(f)
-            if tc.get("date") != now_date():
-                tc["date"] = now_date()
-                tc["entries"] = 0
-            for k, v in default.items():
-                if k not in tc: tc[k] = v
-            return tc
-        except: pass
-    return dict(default)
-
-def save_tc(tc):
-    tc["date"] = now_date()
-    cfg.atomic_write(os.path.join(cfg.STATE_DIR, "trade-counter.json"), tc)
-
+# ═══════════════════════════════════════════════════════════════
+# Main — 3-Mode State Machine
+# ═══════════════════════════════════════════════════════════════
 
 def run():
-    wallet, sid = cfg.get_wallet_and_strategy()
-    if not wallet: cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"no wallet"}); return
-
-    av, positions = cfg.get_positions(wallet)
-    if av <= 0: cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"cannot read account"}); return
-
-    if has_resting_orders(wallet):
-        cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"RESTING ORDER: BTC limit order pending."}); return
-
-    for p in positions:
-        if p.get("coin","").upper() == ASSET:
-            cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"RIDING: BTC. DSL manages exit.","_v2_no_thesis_exit":True}); return
-
-    tc = load_tc()
-    dynamic_cap = get_dynamic_daily_cap(av)
-    if tc.get("entries", 0) >= dynamic_cap:
-        pnl_pct = ((av - STARTING_BUDGET) / STARTING_BUDGET) * 100
-        cfg.output({"status": "ok", "heartbeat": "NO_REPLY",
-                    "note": f"Daily cap ({dynamic_cap}) reached. Session PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
+    wallet, strategy_id = cfg.get_wallet_and_strategy()
+    if not wallet:
+        cfg.output({"success": True, "heartbeat": "NO_REPLY", "note": "no wallet"})
         return
 
-    if cfg.is_asset_cooled_down(ASSET, COOLDOWN_MINUTES):
-        cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"BTC on cooldown"}); return
+    tc = cfg.load_trade_counter()
+    if tc.get("gate") == "HARD_STOP":
+        cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                    "note": f"gate=HARD_STOP: {tc.get('gateReason', 'circuit breaker')}"})
+        return
 
-    # Same-direction re-entry cooldown after a win
+    account_value, positions = cfg.get_positions(wallet)
+    if account_value <= 0:
+        cfg.output({"success": True, "heartbeat": "NO_REPLY", "note": "cannot read account"})
+        return
+
+    state = cfg.load_state("grizzly-state.json")
+    current_mode = state.get("currentMode", "HUNTING")
+    btc_position = next((p for p in positions if p["coin"].upper() == ASSET), None)
+
+    # ── MODE 2: RIDING ────────────────────────────────────────
+    if btc_position and current_mode in ("RIDING", "HUNTING"):
+        if current_mode != "RIDING":
+            state["currentMode"] = "RIDING"
+            state["lastDirection"] = btc_position["direction"]
+            cfg.save_state(state, "grizzly-state.json")
+        cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                    "note": f"RIDING: BTC {btc_position['direction']} — DSL manages exit. Scanner does NOT re-evaluate.",
+                    "_v2_no_thesis_exit": True})
+        return
+
+    # ── DSL exit detected: was RIDING, now no position ────────
+    if not btc_position and current_mode == "RIDING":
+        btc_data = get_btc_full_picture()
+        exit_vol = 1.0
+        if btc_data:
+            candles_5m = btc_data.get("candles", {}).get("5m", [])
+            exit_vol = volume_ratio(candles_5m) if candles_5m else 1.0
+
+        state["currentMode"] = "STALKING"
+        state["exitState"] = {
+            "exitDirection": state.get("lastDirection", "LONG"),
+            "exitTimestamp": cfg.now_ts(),
+            "exitEntryVolRatio": exit_vol,
+        }
+        cfg.save_state(state, "grizzly-state.json")
+        cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                    "note": "DSL closed position — transitioning to STALKING mode"})
+        return
+
+    # ── MODE 3: STALKING ──────────────────────────────────────
+    if current_mode == "STALKING":
+        exit_state = state.get("exitState", {})
+        if not exit_state:
+            state["currentMode"] = "HUNTING"
+            cfg.save_state(state, "grizzly-state.json")
+        else:
+            should_reload, reasons = evaluate_reload(exit_state)
+
+            if should_reload:
+                direction = exit_state["exitDirection"]
+                leverage = get_safe_leverage(wallet, ASSET, 10)
+                margin = round(account_value * 0.30, 2)  # Reload uses base margin
+
+                state["currentMode"] = "RIDING"
+                state["lastDirection"] = direction
+                state.pop("exitState", None)
+                cfg.save_state(state, "grizzly-state.json")
+
+                success, result = execute_entry(wallet, direction, margin, leverage)
+                if success:
+                    tc["entries"] = tc.get("entries", 0) + 1
+                    tc["last_entry_ts"] = time.time()
+                    cfg.save_trade_counter(tc)
+                    cfg.output({
+                        "success": True,
+                        "action": "RELOAD",
+                        "signal": {"asset": ASSET, "direction": direction,
+                                   "mode": "STALKING_RELOAD", "reasons": reasons},
+                        "execution": {"asset": ASSET, "direction": direction,
+                                      "leverage": leverage, "margin": margin,
+                                      "orderType": "FEE_OPTIMIZED_LIMIT"},
+                        "result": result,
+                        "_grizzly_version": "5.0",
+                    })
+                else:
+                    # Reload failed — back to HUNTING
+                    state["currentMode"] = "HUNTING"
+                    cfg.save_state(state, "grizzly-state.json")
+                    cfg.output({
+                        "success": True, "action": "RELOAD_FAILED",
+                        "signal": {"asset": ASSET, "direction": direction,
+                                   "reasons": reasons},
+                        "error": result, "_grizzly_version": "5.0",
+                    })
+                return
+
+            # Kill conditions → reset to HUNTING
+            kill_signals = [r for r in reasons if any(k in r for k in
+                           ["stalk_timeout", "4h_trend_reversed", "sm_flipped",
+                            "funding_extreme", "oi_collapsed"])]
+
+            if kill_signals:
+                state["currentMode"] = "HUNTING"
+                state.pop("exitState", None)
+                cfg.save_state(state, "grizzly-state.json")
+                cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                            "note": f"STALKING → RESET: {kill_signals[0]}"})
+                return
+
+            # Still stalking
+            hours = (cfg.now_ts() - exit_state.get("exitTimestamp", cfg.now_ts())) / 3600
+            cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                        "note": f"STALKING {hours:.1f}h — waiting for reload conditions"})
+            return
+
+    # ── MODE 1: HUNTING ───────────────────────────────────────
+    # Dynamic daily cap
+    dynamic_cap = get_dynamic_daily_cap(account_value)
+    if tc.get("entries", 0) >= dynamic_cap:
+        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
+        cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                    "note": f"Daily cap ({dynamic_cap}) reached. PnL: {pnl_pct:+.1f}%. Entries: {tc.get('entries', 0)}/{dynamic_cap}"})
+        return
+
+    if cfg.is_asset_cooled_down(ASSET, ASSET_COOLDOWN_MINUTES):
+        cfg.output({"success": True, "heartbeat": "NO_REPLY", "note": "BTC on cooldown"})
+        return
+
+    if has_resting_orders(wallet):
+        cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                    "note": "RESTING ORDER: BTC limit order pending."})
+        return
+
+    # Build thesis
+    thesis = build_btc_thesis()
+    if not thesis:
+        cfg.output({"success": True, "heartbeat": "NO_REPLY", "note": "HUNTING: no BTC thesis"})
+        return
+
+    if thesis["score"] < MIN_SCORE:
+        cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                    "note": f"HUNTING: BTC {thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"})
+        return
+
+    # Same-direction cooldown after a win
     last_win_dir = tc.get("last_win_direction")
     last_win_ts = tc.get("last_win_ts", 0)
-
-    thesis = evaluate_btc()
-    if not thesis:
-        cfg.output({"status":"ok","heartbeat":"NO_REPLY","note":"HUNTING: no BTC thesis"}); return
-    if thesis["score"] < MIN_SCORE:
-        cfg.output({"status":"ok","heartbeat":"NO_REPLY",
-            "note":f"HUNTING: BTC SM={thesis['direction']} score {thesis['score']}<{MIN_SCORE}. {', '.join(thesis['reasons'][:3])}"}); return
-
-    # ── CONTRARIAN FLIP ──
-    # SM says LONG → we go SHORT. SM says SHORT → we go LONG.
-    # The inversion test on 11 trades showed 81.8% WR if flipped.
-    sm_direction = thesis["direction"]
-    thesis["direction"] = "SHORT" if sm_direction == "LONG" else "LONG"
-    thesis["reasons"].insert(0, f"CONTRARIAN_FLIP (SM is {sm_direction})")
-
-    # Same-direction cooldown (post-flip direction)
-    if last_win_dir and last_win_ts:
+    if last_win_dir and last_win_ts and thesis["direction"] == last_win_dir:
         if (time.time() - last_win_ts) < SAME_DIR_COOLDOWN_MINUTES * 60:
-            if thesis["direction"] == last_win_dir:
-                remaining = int((SAME_DIR_COOLDOWN_MINUTES * 60 - (time.time() - last_win_ts)) / 60)
-                cfg.output({"status":"ok","heartbeat":"NO_REPLY",
-                    "note":f"SAME_DIR_COOLDOWN: won {last_win_dir} {remaining}min ago"}); return
+            remaining = int((SAME_DIR_COOLDOWN_MINUTES * 60 - (time.time() - last_win_ts)) / 60)
+            cfg.output({"success": True, "heartbeat": "NO_REPLY",
+                        "note": f"SAME_DIR_COOLDOWN: won {last_win_dir} {remaining}min ago"})
+            return
 
-    leverage = get_leverage_for_score(thesis["score"])
-    margin = round(av * MARGIN_PCT, 2)
+    # Conviction-scaled sizing
+    leverage = get_safe_leverage(wallet, ASSET, get_leverage_for_score(thesis["score"]))
+    margin_pct = get_margin_pct(thesis["score"])
+    margin = round(account_value * margin_pct, 2)
 
+    # Execute
     success, result = execute_entry(wallet, thesis["direction"], margin, leverage)
     if success:
-        tc["entries"] = tc.get("entries",0) + 1
-        save_tc(tc)
-        cfg.output({"status":"ok","action":"ENTRY",
-            "signal":{"asset":ASSET,"direction":thesis["direction"],"score":thesis["score"],
-                "leverage":leverage,"mode":"BTC_HUNTER","reasons":thesis["reasons"]},
-            "execution":{"asset":ASSET,"direction":thesis["direction"],"leverage":leverage,
-                "margin":margin,"orderType":"FEE_OPTIMIZED_LIMIT","ensureExecutionAsTaker":False},
-            "result":result,"_grizzly_version":"4.1"})
+        state["currentMode"] = "RIDING"
+        state["lastDirection"] = thesis["direction"]
+        cfg.save_state(state, "grizzly-state.json")
+
+        tc["entries"] = tc.get("entries", 0) + 1
+        tc["last_entry_ts"] = time.time()
+        cfg.save_trade_counter(tc)
+
+        cfg.output({
+            "success": True,
+            "action": "ENTRY",
+            "signal": thesis,
+            "execution": {
+                "asset": ASSET, "direction": thesis["direction"],
+                "leverage": leverage, "margin": margin,
+                "orderType": "FEE_OPTIMIZED_LIMIT",
+                "ensureExecutionAsTaker": False,
+            },
+            "constraints": {"minLeverage": MIN_LEVERAGE, "maxLeverage": MAX_LEVERAGE},
+            "result": result,
+            "_grizzly_version": "5.0",
+        })
     else:
-        cfg.output({"status":"ok","action":"ENTRY_FAILED",
-            "signal":{"asset":ASSET,"direction":thesis["direction"],"score":thesis["score"],"reasons":thesis["reasons"]},
-            "error":result,"_grizzly_version":"4.1"})
+        cfg.output({
+            "success": True,
+            "action": "ENTRY_FAILED",
+            "signal": {"asset": ASSET, "direction": thesis["direction"],
+                       "score": thesis["score"], "reasons": thesis["reasons"]},
+            "error": result,
+            "_grizzly_version": "5.0",
+        })
+
 
 if __name__ == "__main__":
-    try: run()
+    try:
+        run()
     except Exception as e:
-        import traceback; traceback.print_exc(file=sys.stderr)
-        cfg.output({"status":"error","error":str(e)})
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        cfg.output({"success": False, "error": str(e)})

--- a/grizzly/scripts/grizzly_config.py
+++ b/grizzly/scripts/grizzly_config.py
@@ -61,20 +61,50 @@ def get_wallet_and_strategy():
 def load_trade_counter():
     today = now_date()
     p = STATE_DIR / "trade-counter.json"
+    default = {
+        "date": today, "entries": 0, "realizedPnl": 0,
+        "gate": "OPEN", "gateReason": None, "cooldownUntil": None,
+        "lastResults": [],
+        "last_entry_ts": 0, "last_win_direction": None, "last_win_ts": 0,
+    }
     if p.exists():
         try:
             with open(p) as f:
                 tc = json.load(f)
-            if tc.get("date") == today:
-                return tc
+            if tc.get("date") != today:
+                tc["date"] = today
+                tc["entries"] = 0
+                tc["realizedPnl"] = 0
+                tc["lastResults"] = []
+            for k, v in default.items():
+                if k not in tc:
+                    tc[k] = v
+            return tc
         except (json.JSONDecodeError, IOError):
             pass
-    return {"date": today, "entries": 0}
+    return dict(default)
 
 
 def save_trade_counter(tc):
     tc["date"] = now_date()
     atomic_write(str(STATE_DIR / "trade-counter.json"), tc)
+
+
+# ─── State I/O (v5.0 — 3-mode lifecycle) ─────────────────────
+
+def load_state(filename="grizzly-state.json"):
+    path = STATE_DIR / filename
+    if path.exists():
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            return {}
+    return {}
+
+
+def save_state(data, filename="grizzly-state.json"):
+    atomic_write(str(STATE_DIR / filename), data)
 
 
 def is_asset_cooled_down(asset, cooldown_minutes=180):


### PR DESCRIPTION
## Summary

Grizzly v5.0 is a complete rewrite. Reverts the v4.x contrarian direction flip and ports Kodiak's full 3-mode lifecycle architecture with BTC-specific tuning. All four single-asset specialists — Kodiak (SOL), Wolverine (HYPE), Polar (ETH), Grizzly (BTC) — now share the same architecture.

## Why

v4.x ran a contrarian SM-fader that was direction-inverted from the family intent. The April 10 inversion test concluded "SM is broken on BTC" and flipped direction. The correct read was: scanner was entering late, after the move exhausted. Flipping direction temporarily profited off those late entries but set Grizzly up to fight every real trend. Grizzly bled -$245 in v4.x.

Jason's clarification: *"Grizzly is intended to be the BTC variation of Kodiak, Wolverine, Polar. All of those 4 are supposed to be same family of agents, just trained on a different specific asset."*

## What changed

- **REMOVED**: CONTRARIAN_FLIP direction inversion
- **REMOVED**: CONTRARIAN_EXHAUSTION_GATE
- **ADDED**: 3-mode state machine (HUNTING / RIDING / STALKING)
- **ADDED**: 4-timeframe alignment (5m + 15m + 1h + 4h) with 4TF_aligned bonus
- **ADDED**: SM-opposes HARD BLOCK (from Kodiak)
- **ADDED**: Move-exhaustion + tiring penalties
- **ADDED**: RSI filter (70/30 BTC-tuned vs Kodiak's 74/26 SOL tuning)
- **ADDED**: STALKING mode — reload on dip after DSL exit, kill if trend reverses
- **ADDED**: Volume trend + OI-proxy growth signals
- **MIN_SCORE**: 8 → 10 (family standard)
- **DSL**: retuned per RatchetStop timing guide for BTC (low-beta)
  - hard_timeout: 360min, weak_peak_cut: 120min, dead_weight_cut: 90min
  - 6 Phase-2 tiers (added monster-winner trail at +50%)
- **Margin**: flat 50% → conviction-scaled 30 / 37.5 / 45%
- **Added**: `get_safe_leverage()` clamping, inner-order success validation
- **Added**: `load_state`/`save_state` to grizzly_config.py

## BTC tuning vs Kodiak (SOL)

BTC moves ~3x slower than SOL. Thresholds tightened proportionally:

| Parameter | Kodiak (SOL) | Grizzly (BTC) |
|---|---:|---:|
| min_mom_15m | 0.10% | 0.05% |
| rsi_max_long | 74 | 70 |
| move_exhaustion | 4.0% | 2.5% |
| move_tiring | 2.5% | 1.5% |
| vol_ratio_min | 1.2 | 1.1 |
| DSL hard_timeout | 240min | 360min |
| DSL dead_weight | 60min | 90min |

## Test plan

- [ ] Dry run: `python3 grizzly-scanner.py` — expect HUNTING output with current BTC thesis
- [ ] Verify `grizzly-state.json` created on first run (not found = auto-init)
- [ ] Verify STALKING transition triggers after DSL closes a position
- [ ] Verify SM-opposes HARD BLOCK (feed should produce a skip if SM consensus inverts mid-session)
- [ ] Verify inner-order validation catches MCP phantom-success cases
- [ ] Confirm runtime.yaml version bump 4.0.0 → 5.0.0 reinstalls cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)