### PR TITLE
skill update checker: optional github api auth

### DIFF
--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -12,7 +12,7 @@ license: Apache-2.0
 compatibility: "Node.js, shell, Python 3, OpenClaw (optional — Step 5 cron)"
 metadata:
   author: Senpi
-  version: "1.2.2"
+  version: "1.2.3"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -36,6 +36,7 @@ steps.
 |---|---|---|
 | `SENPI_MCP_ENDPOINT` | `{{SENPI_MCP_ENDPOINT}}` | `https://mcp.prod.senpi.ai` |
 | `REFERRAL_CODE` | `{{REFERRAL_CODE}}` | _(empty — optional)_ |
+| `GH_TOKEN` / `GITHUB_TOKEN` / `SENPI_GITHUB_TOKEN` | _(none)_ | _(optional — skill update checker uses the first set value to authenticate GitHub REST calls; avoids shared-IP rate limit exhaustion)_ |
 
 If a placeholder appears as a literal `{{...}}` string (not substituted),
 use the default value from the table above.

--- a/senpi-entrypoint/references/skill-update-checker.md
+++ b/senpi-entrypoint/references/skill-update-checker.md
@@ -18,6 +18,22 @@ rendering. If it is heartbeat/empty, continue to normal response flow.
 
 ---
 
+## GitHub API rate limits (skill update checker)
+
+`scripts/check-skill-updates.py` calls the GitHub REST API once per run (repo
+root listing). Unauthenticated access is limited to roughly **60 requests per
+hour per IP**. On a shared network or with frequent manual runs, that ceiling
+can be hit; the script then exits with a heartbeat and **does not surface
+updates**.
+
+Set **`GH_TOKEN`**, **`GITHUB_TOKEN`**, or **`SENPI_GITHUB_TOKEN`** to a
+personal access token with `public_repo` (or classic `repo` if you use private
+forks). The script picks the first of these variables that is non-empty.
+Authenticated requests get a much higher quota and are less likely to fail on
+busy IPs.
+
+---
+
 ## Output Handling
 
 At session startup the entrypoint reads

--- a/senpi-entrypoint/scripts/check-skill-updates.py
+++ b/senpi-entrypoint/scripts/check-skill-updates.py
@@ -7,6 +7,11 @@ all installed Senpi skills, then checks GitHub for:
   - Version bumps (hash change in skill folder + version field changed in SKILL.md)
   - New skills added to the repo that the user has never been shown
 
+GitHub REST calls use optional auth from `GH_TOKEN`, `GITHUB_TOKEN`, or
+`SENPI_GITHUB_TOKEN` (first set wins). Without a token, unauthenticated API
+access is capped at about 60 requests/hour per IP — shared NAT or tight cron
+intervals can exhaust that and skip updates silently.
+
 Uses `$SENPI_STATE_DIR/pending-skill-updates.json` (default:
 `~/.config/senpi/pending-skill-updates.json` if `SENPI_STATE_DIR` is unset)
 to track last-known versions and which skills have already been surfaced to the user.
@@ -47,6 +52,26 @@ NON_SKILL_DIRS = {
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def github_api_token():
+    """Return a PAT for api.github.com if any supported env var is set."""
+    for key in ("GH_TOKEN", "GITHUB_TOKEN", "SENPI_GITHUB_TOKEN"):
+        val = os.environ.get(key)
+        if val and val.strip():
+            return val.strip()
+    return None
+
+
+def github_api_request_headers():
+    headers = {
+        "User-Agent": "senpi-skill-update-checker/1.0",
+        "Accept": "application/vnd.github+json",
+    }
+    token = github_api_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
 
 def load_json(path, default=None):
     try:
@@ -172,10 +197,7 @@ def apply_pending_to_catalog(known_versions, seen_available, pending_result):
 
 def github_get(url, max_attempts=3, delay=3):
     """GET a GitHub API URL. Returns parsed JSON or None after all retries fail."""
-    req = urllib.request.Request(
-        url,
-        headers={"User-Agent": "senpi-skill-update-checker/1.0"},
-    )
+    req = urllib.request.Request(url, headers=github_api_request_headers())
     for attempt in range(max_attempts):
         try:
             with urllib.request.urlopen(req, timeout=15) as resp:


### PR DESCRIPTION
## problem

`check-skill-updates.py` calls the GitHub REST API once per run (repo root listing). Unauthenticated requests are limited to about 60 requests per hour per IP. Agents or crons behind shared NAT can hit that limit; the script then returns only a heartbeat and users never see new or updated skills.

## change

- Read optional `GH_TOKEN`, `GITHUB_TOKEN`, or `SENPI_GITHUB_TOKEN` (first non-empty wins) and send `Authorization: Bearer` on GitHub API requests.
- Document the behavior in `senpi-entrypoint/SKILL.md`, `references/skill-update-checker.md`, and the script docstring.
- Bump `senpi-entrypoint` metadata version to 1.2.3.

No change to raw.githubusercontent.com fetches (still unauthenticated; public repo).
