### PR TITLE
fleet-fix: OI velocity scoring in Kodiak family (Kodiak/Polar/Grizzly)

### DIFF
--- a/grizzly/scripts/grizzly-scanner.py
+++ b/grizzly/scripts/grizzly-scanner.py
@@ -352,13 +352,35 @@ def build_btc_thesis():
         score += 1
         reasons.append(f"vol_rising_{vol_trend_1h:+.0f}%")
 
-    # ── OI growth proxy (new money entering) ──────────────────
+    # ── OI growth proxy (legacy, kept as fallback) ────────────
     vol_recent = sum(safe_float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles_1h[-3:])
     vol_earlier = sum(safe_float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles_1h[-6:-3])
     oi_proxy = ((vol_recent - vol_earlier) / vol_earlier * 100) if vol_earlier > 0 else 0
     if oi_proxy > 10:
         score += 1
         reasons.append(f"oi_growing_{oi_proxy:+.0f}%")
+
+    # ── OI velocity (v5.1 — real OI data from new MCP tool) ──
+    # market_get_asset_data now includes oi_velocity (5m/15m/1h/4h).
+    # Accelerating OI in direction = real capital committing → conviction boost.
+    # Null handling: 1h/4h can be null on fresh deploys, treat as insufficient.
+    oi_vel = btc_data.get("oi_velocity", {}) if isinstance(btc_data.get("oi_velocity"), dict) else {}
+    oi_vel_1h = oi_vel.get("1h", {}) if isinstance(oi_vel.get("1h"), dict) else {}
+    oi_vel_change = oi_vel_1h.get("change_pct")
+    if oi_vel_change is not None:
+        try:
+            oi_vel_change = float(oi_vel_change)
+            if oi_vel_change > 5:
+                score += 2
+                reasons.append(f"OI_ACCELERATING_{oi_vel_change:+.1f}%")
+            elif oi_vel_change > 2:
+                score += 1
+                reasons.append(f"OI_rising_{oi_vel_change:+.1f}%")
+            elif oi_vel_change < -3:
+                score -= 1
+                reasons.append(f"OI_draining_{oi_vel_change:+.1f}%")
+        except (TypeError, ValueError):
+            pass
 
     # ── RSI filter (BTC rarely pushes >70 or <30) ─────────────
     closes_1h = [safe_float(c.get("close", c.get("c", 0))) for c in candles_1h]

--- a/kodiak/scripts/kodiak-scanner.py
+++ b/kodiak/scripts/kodiak-scanner.py
@@ -286,13 +286,38 @@ def build_sol_thesis(entry_cfg):
         score += 1
         reasons.append(f"vol_rising_{vol_trend_1h:+.0f}%")
 
-    # ── OI growth (new money entering BTC) ────────────────────
+    # ── OI growth proxy (legacy, kept as fallback) ───────────
     vol_recent = sum(float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles_1h[-3:])
     vol_earlier = sum(float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles_1h[-6:-3])
     oi_proxy = ((vol_recent - vol_earlier) / vol_earlier * 100) if vol_earlier > 0 else 0
     if oi_proxy > 10:
         score += 1
         reasons.append(f"oi_growing_{oi_proxy:+.0f}%")
+
+    # ── OI velocity (v2.1 — real OI data from new MCP tool) ──
+    # market_get_asset_data now includes oi_velocity with 5m/15m/1h/4h windows.
+    # Accelerating OI in direction of trade = real money committing → higher conviction.
+    # Flat OI despite price move = fake breakout → reduced conviction.
+    # Null handling per skill-dev notes: 1h/4h windows return null until poller
+    # has run that long. Treat null as "insufficient data," not zero.
+    oi_vel = sol_data.get("oi_velocity", {}) if isinstance(sol_data.get("oi_velocity"), dict) else {}
+    oi_vel_1h = oi_vel.get("1h", {}) if isinstance(oi_vel.get("1h"), dict) else {}
+    oi_vel_change = oi_vel_1h.get("change_pct")
+    if oi_vel_change is not None:
+        try:
+            oi_vel_change = float(oi_vel_change)
+            # Positive OI change during our direction = capital inflow
+            if oi_vel_change > 5:
+                score += 2
+                reasons.append(f"OI_ACCELERATING_{oi_vel_change:+.1f}%")
+            elif oi_vel_change > 2:
+                score += 1
+                reasons.append(f"OI_rising_{oi_vel_change:+.1f}%")
+            elif oi_vel_change < -3:
+                score -= 1
+                reasons.append(f"OI_draining_{oi_vel_change:+.1f}%")
+        except (TypeError, ValueError):
+            pass  # silently ignore malformed data
 
     # ── BTC correlation confirmation ──────────────────────────
     corr_mom_15m, corr_mom_1h = get_btc_correlation()

--- a/polar/scripts/polar-scanner.py
+++ b/polar/scripts/polar-scanner.py
@@ -187,14 +187,23 @@ def evaluate_eth():
     if traders < 15: return None
 
     funding = 0
+    oi_vel_change = None  # v3.1: OI velocity from new MCP data
     try:
         ad = cfg.mcporter_call("market_get_asset_data", asset=ASSET,
                                 candle_intervals=["1h"], include_funding=True)
         if ad:
-            ac = ad.get("data", ad).get("asset_context",
-                 ad.get("data", ad).get("assetContext", {}))
+            ad_data = ad.get("data", ad)
+            ac = ad_data.get("asset_context", ad_data.get("assetContext", {}))
             if isinstance(ac, dict):
                 funding = safe_float(ac.get("funding", 0))
+            # v3.1: extract oi_velocity from same response (free read)
+            oi_vel = ad_data.get("oi_velocity", {}) if isinstance(ad_data.get("oi_velocity"), dict) else {}
+            oi_vel_1h = oi_vel.get("1h", {}) if isinstance(oi_vel.get("1h"), dict) else {}
+            if oi_vel_1h.get("change_pct") is not None:
+                try:
+                    oi_vel_change = float(oi_vel_1h.get("change_pct"))
+                except (TypeError, ValueError):
+                    oi_vel_change = None
     except: pass
 
     score, reasons = 0, []
@@ -254,6 +263,17 @@ def evaluate_eth():
     # Funding alignment (0-1)
     if (d == "SHORT" and funding > 0.0002) or (d == "LONG" and funding < -0.0002):
         score += 1; reasons.append(f"FUNDING_PAYS {funding*100:.4f}%")
+
+    # v3.1: OI velocity (real OI change from new MCP tool)
+    # Accelerating OI = real capital committing → conviction boost.
+    # Null handling: 1h window can be null until poller has run, treat as insufficient.
+    if oi_vel_change is not None:
+        if oi_vel_change > 5:
+            score += 2; reasons.append(f"OI_ACCELERATING_{oi_vel_change:+.1f}%")
+        elif oi_vel_change > 2:
+            score += 1; reasons.append(f"OI_rising_{oi_vel_change:+.1f}%")
+        elif oi_vel_change < -3:
+            score -= 1; reasons.append(f"OI_draining_{oi_vel_change:+.1f}%")
 
     # US session bonus (0-1)
     hour = datetime.now(timezone.utc).hour


### PR DESCRIPTION
## Summary

Integrates the new \`oi_velocity\` field from \`market_get_asset_data\` into all three Kodiak-family single-asset-specialist scanners.

## Why

Kodiak's diagnostic surfaced that winners have "real money committing" while losers have flat OI during price moves. The scanner had a volume-proxy heuristic for OI growth but it was noisy. The new \`oi_velocity\` field gives precise OI change rates (5m/15m/1h/4h).

## Change

Scoring block added after each scanner's existing OI-proxy block:

- OI 1h change > +5% → **+2** (accelerating, high conviction)
- OI 1h change > +2% → **+1** (rising, modest conviction)
- OI 1h change < -3% → **-1** (draining, fake signal)
- null → **pass** (insufficient data, no penalty)

## Files

- \`kodiak/scripts/kodiak-scanner.py\` — block added in \`build_sol_thesis\`
- \`grizzly/scripts/grizzly-scanner.py\` — block added in \`build_btc_thesis\`
- \`polar/scripts/polar-scanner.py\` — extended existing \`market_get_asset_data\` call to pull oi_velocity, added scoring block after funding alignment

## Null handling (per skill-dev notes)

All three scanners handle null as "insufficient data, no score change" rather than as zero. 1h window returns null until the poller has run that long.

## Wolverine not in this patch

Wolverine's OI velocity integration lands with the v3.0 Kodiak-family port on a separate branch, where it will be part of the full rewrite rather than a patch to the v2.3 scanner scheduled for replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)