### PR TITLE
fleet-fix: Dog v2.3 + Vulture v2.2 — funding regime integration

### DIFF
--- a/dog/scripts/dog-scanner.py
+++ b/dog/scripts/dog-scanner.py
@@ -147,6 +147,44 @@ def has_resting_orders(wallet):
         has_fresh = True
     return has_fresh
 
+def _get_funding_regime():
+    """v2.3: market-wide funding regime via new MCP tool."""
+    try:
+        r = cfg.mcporter_call("market_get_funding_regime")
+        if r:
+            return r.get("data", r).get("regime")
+    except Exception:
+        pass
+    return None
+
+
+def _get_funding_history(asset):
+    """v2.3: per-asset persistence + trend via new MCP tool."""
+    try:
+        r = cfg.mcporter_call("market_get_funding_history", asset=asset)
+        if r:
+            data = r.get("data", r)
+            return {
+                "persistence_hours": data.get("persistence_hours"),
+                "trend": data.get("trend"),
+            }
+    except Exception:
+        pass
+    return None
+
+
+def _regime_confirms_fade(fade_direction, regime):
+    """v2.3: fade is confirmed when regime shows crowding in OPPOSITE direction
+    of trade. Dog goes SHORT to fade LONG_CROWDED. Returns True/False/None."""
+    if regime is None or regime == "NEUTRAL":
+        return None  # neutral — neither confirms nor denies
+    if fade_direction == "SHORT" and regime == "LONG_CROWDED":
+        return True
+    if fade_direction == "LONG" and regime == "SHORT_CROWDED":
+        return True
+    return False
+
+
 def evaluate_assets():
     """Score all four assets and return the best candidate above MIN_SCORE."""
     raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
@@ -155,6 +193,9 @@ def evaluate_assets():
     if isinstance(markets, dict): markets = markets.get("markets", markets)
     if isinstance(markets, dict): markets = markets.get("markets", [])
     if not isinstance(markets, list): return None
+
+    # v2.3: fetch market-wide regime once per scan
+    regime = _get_funding_regime()
 
     # Build asset map
     asset_data = {}
@@ -263,6 +304,39 @@ def evaluate_assets():
                     if (d == "SHORT" and funding > 0.0002) or (d == "LONG" and funding < -0.0002):
                         score += 1; reasons.append(f"FUNDING_PAYS {funding*100:.4f}%")
         except: pass
+
+        # ── v2.3: Regime HARD GATE ──
+        # Dog fades SM consensus. Regime confirms crowding in the direction
+        # we're fading. If regime contradicts (says crowd is with our direction),
+        # we're fighting — not fading — and the signal is suspect. Skip.
+        regime_confirms = _regime_confirms_fade(d, regime)
+        if regime_confirms is False:
+            continue  # regime contradicts fade direction — skip
+        if regime_confirms is True:
+            score += 2; reasons.append(f"REGIME_CONFIRMS_{regime}")
+        elif regime is not None:
+            reasons.append(f"REGIME_{regime}")  # neutral, no score change
+
+        # ── v2.3: Persistence + trend via funding_history ──
+        # If SM crowding has been persistent for hours, the fade is mature and
+        # high-conviction. If crowding is still INCREASING, Dog may be early.
+        fh = _get_funding_history(token)
+        if fh:
+            ph = fh.get("persistence_hours")
+            trend = (fh.get("trend") or "").upper()
+            try:
+                ph_val = float(ph) if ph is not None else None
+            except (TypeError, ValueError):
+                ph_val = None
+            if ph_val is not None:
+                if ph_val >= 12:
+                    score += 2; reasons.append(f"MATURE_CROWDING_{ph_val:.0f}h")
+                elif ph_val >= 6:
+                    score += 1; reasons.append(f"STABLE_CROWDING_{ph_val:.0f}h")
+            if trend == "INCREASING":
+                score -= 1; reasons.append("CROWDING_STILL_BUILDING (early fade)")
+            elif trend == "DECREASING":
+                score += 1; reasons.append("CROWDING_UNWINDING (fade confirmed)")
 
         # ── US session bonus (0-1) ──
         hour = datetime.now(timezone.utc).hour

--- a/vulture/scripts/vulture-scanner.py
+++ b/vulture/scripts/vulture-scanner.py
@@ -233,6 +233,32 @@ def has_resting_orders(wallet):
 # SIGNAL SCORING — momentum following (opposite philosophy from Lemon)
 # ═══════════════════════════════════════════════════════════════
 
+def _get_funding_regime():
+    """v2.2: market-wide funding regime via new MCP tool."""
+    try:
+        r = cfg.mcporter_call("market_get_funding_regime")
+        if r:
+            return r.get("data", r).get("regime")
+    except Exception:
+        pass
+    return None
+
+
+def _get_funding_history(asset):
+    """v2.2: per-asset persistence + trend via new MCP tool."""
+    try:
+        r = cfg.mcporter_call("market_get_funding_history", asset=asset)
+        if r:
+            data = r.get("data", r)
+            return {
+                "persistence_hours": data.get("persistence_hours"),
+                "trend": data.get("trend"),
+            }
+    except Exception:
+        pass
+    return None
+
+
 def fetch_sm_data():
     """Get Hyperfeed SM data for all tracked small caps."""
     raw = cfg.mcporter_call("leaderboard_get_markets", limit=100)
@@ -400,6 +426,37 @@ def evaluate_momentum(asset, sm):
         score -= 2
         reasons.append(f"MOVE_EXTENDED {p4h:+.1f}%")
 
+    # ── v2.2: Regime alignment (momentum thesis — not a hard gate) ──
+    # Vulture FOLLOWS momentum. Unlike Dog (which fades crowding),
+    # Vulture wants the macro trend behind it.
+    #   Regime matches direction      → trend has macro backing (+1)
+    #   Regime opposes direction      → fighting the macro tide (-1)
+    #   Regime NEUTRAL / unavailable  → no adjustment
+    regime = evaluate_momentum._regime_cache  # populated by caller per scan
+    if regime == "LONG_CROWDED" and direction == "LONG":
+        score += 1; reasons.append("REGIME_LONG_CROWDED_aligned")
+    elif regime == "SHORT_CROWDED" and direction == "SHORT":
+        score += 1; reasons.append("REGIME_SHORT_CROWDED_aligned")
+    elif regime == "LONG_CROWDED" and direction == "SHORT":
+        score -= 1; reasons.append("REGIME_LONG_CROWDED_fighting")
+    elif regime == "SHORT_CROWDED" and direction == "LONG":
+        score -= 1; reasons.append("REGIME_SHORT_CROWDED_fighting")
+    elif regime is not None:
+        reasons.append(f"REGIME_{regime}")
+
+    # ── v2.2: Persistence validates macro trend durability ──
+    # If funding has been crowded in our direction for hours, the macro
+    # trend is mature — Vulture's momentum ride has runway.
+    fh = evaluate_momentum._fh_cache.get(asset) if hasattr(evaluate_momentum, "_fh_cache") else None
+    if fh:
+        ph = fh.get("persistence_hours")
+        try:
+            ph_val = float(ph) if ph is not None else None
+        except (TypeError, ValueError):
+            ph_val = None
+        if ph_val is not None and ph_val >= 6:
+            score += 1; reasons.append(f"TREND_PERSISTENT_{ph_val:.0f}h")
+
     if score < MIN_SCORE:
         return None
 
@@ -414,6 +471,7 @@ def evaluate_momentum(asset, sm):
         "priceChg4h": p4h,
         "contrib15m": c15m,
         "contrib1h": c1h,
+        "regime": regime,
     }
 
 
@@ -505,6 +563,10 @@ def run():
                     "note": "No SM data on tracked small caps"})
         return
 
+    # v2.2: populate regime + funding_history caches once per scan
+    evaluate_momentum._regime_cache = _get_funding_regime()
+    evaluate_momentum._fh_cache = {}
+
     # Evaluate momentum signals
     signals = []
     rejections = {}
@@ -525,6 +587,9 @@ def run():
         if cfg.is_asset_cooled_down(asset, COOLDOWN_MINUTES):
             rejections[asset] = "cooldown"
             continue
+
+        # v2.2: fetch per-asset funding_history for persistence scoring
+        evaluate_momentum._fh_cache[asset] = _get_funding_history(asset)
 
         result = evaluate_momentum(asset, sm)
         if result:


### PR DESCRIPTION
## Summary

Both agents read the new \`market_get_funding_regime\` and \`market_get_funding_history\` MCP tools, applied differently per their opposite theses.

## Dog v2.3 — Contrarian-exhaustion fader

Dog fades SM consensus at price exhaustion. Regime confirms macro crowding in the fade direction:

- **HARD GATE**: regime must confirm crowding (SHORT when LONG_CROWDED, LONG when SHORT_CROWDED). If regime matches Dog's direction, skip (fighting not fading). NEUTRAL / unavailable passes.
- **+2** when regime explicitly confirms
- **+2** persistence_hours >= 12 (mature crowding, highest-conviction fade)
- **+1** persistence_hours >= 6 (stable crowding)
- **+1** trend DECREASING (crowding unwinding, fade confirmed)
- **-1** trend INCREASING (crowding still building, may be early)

## Vulture v2.2 — Momentum follower

Vulture FOLLOWS SM momentum on small caps. Opposite relationship to regime from Dog — regime is soft scoring, not a hard gate:

- **+1** regime matches direction (macro backing our ride)
- **-1** regime opposes direction (fighting macro tide)
- NEUTRAL / unavailable → no adjustment
- **+1** persistence_hours >= 6 (mature trend, has runway)

No hard gate — Vulture's momentum thesis can work even in NEUTRAL regime on small-cap breakouts.

## Null handling

Both agents treat null \`persistence_hours\` as "insufficient data, no scoring change." Regime None treated as neutral.

## Files

- \`dog/scripts/dog-scanner.py\`: helpers + hard gate + persistence scoring in \`evaluate_assets\`
- \`vulture/scripts/vulture-scanner.py\`: helpers + soft scoring + persistence bonus in \`evaluate_momentum\` with caller-populated caches

🤖 Generated with [Claude Code](https://claude.com/claude-code)