### PR TITLE
Cheetah v7.0.0 — senpi_runtime_helpers migration (reference for fleet rollout)

### DIFF
--- a/cheetah/README.md
+++ b/cheetah/README.md
@@ -1,16 +1,27 @@
-# 🐆 CHEETAH v6.0 — Multi-Signal Confluence Sniper (v2-runtime-native)
+# 🐆 CHEETAH v7.0.0 — Multi-Signal Confluence Sniper (senpi_runtime_helpers)
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-## What changed in v6.0
+## What changed in v7.0.0
 
-- `cheetah-producer.py` (NEW) replaces `cheetah-scanner.py` (DELETED)
+**Plumbing-only migration. NO thesis change.** v6.1's scoring tables, leverage tiers, dedup logic, post-close cooldown, runtime DSL preset are all preserved verbatim.
+
+- `cheetah-producer.py` and `cheetah_config.py` migrate to `senpi_runtime_helpers`:
+  - MCP calls go via `SenpiClient.mcp_call()` (direct HTTPS) instead of `mcporter` subprocess
+  - Signal emission goes via `SenpiClient.push_signal()` (direct HTTP POST) instead of `openclaw senpi external-scanner ingest` subprocess
+  - Reentrancy lock owned by `producer_daemon.scanner_lock` (PID-aliveness auto-recovery) instead of hand-rolled `fcntl`
+  - Tick scheduling owned by `producer_daemon` (long-lived process) instead of openclaw cron + `agentTurn` (per-tick LLM cost)
+- Requires `senpi-trading-runtime >= 2.0.0` (the runtime-phase-2 build with `{success,data,error}` envelope and `GET /state` for daemon liveness probes).
+- `runtime.yaml` unchanged. `external_scanner.name: cheetah_signals` matches the producer's `client.push_signal(scanner=...)`.
+
+## What changed in v6.x (preserved)
+
 - v2-runtime-native: external_scanner + LLM-pass-through gate + native `risk.guard_rails`
 - DSL exits via `FEE_OPTIMIZED_LIMIT` (saves ~0.020-0.030% per maker-filled close)
-- Trade chain DB emits per-trade telemetry — chain DB visibility on Cheetah for the first time
-- **MIN_SCORE 11 → 10** — restores trade flow that produced +$182 in v5.0/v5.1 era
+- Trade chain DB emits per-trade telemetry
+- **MIN_SCORE 10** (v5.2's 11 produced 8 days dormant; restored to 10)
 - Held-asset dedup (3-layer)
-- Post-close cooldown (Pangolin v2.1.2 pattern; backstops the runtime per_asset_cooldown bug)
+- Post-close cooldown (Pangolin v2.1.2 pattern; backstops runtime per_asset_cooldown)
 - All v5.2 scoring + leverage tiers + leverage-safety clamp preserved EXACTLY
 
 ## Thesis (preserved from v5.x)
@@ -19,19 +30,41 @@ Multi-signal confluence sniper. Refuses to trade unless ALL major signals align:
 
 ## Install
 
+### Step 1 — Pull the helpers package (one-time per host, shared across all skills)
+
+```bash
+mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers/references
+mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers/tests
+
+for f in __init__.py _config.py _logging.py cache.py client.py daemon.py lock.py parallel.py SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
+    -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
+done
+```
+
+### Step 2 — Pull the Cheetah skill
+
 ```bash
 mkdir -p /data/workspace/skills/cheetah-strategy/{config,scripts,state}
 
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/runtime.yaml -o /data/workspace/skills/cheetah-strategy/runtime.yaml
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/SKILL.md -o /data/workspace/skills/cheetah-strategy/SKILL.md
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/config/cheetah-config.json -o /data/workspace/skills/cheetah-strategy/config/cheetah-config.json
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/scripts/cheetah-producer.py -o /data/workspace/skills/cheetah-strategy/scripts/cheetah-producer.py
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/scripts/cheetah_config.py -o /data/workspace/skills/cheetah-strategy/scripts/cheetah_config.py
+for f in runtime.yaml SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/$f" \
+    -o "/data/workspace/skills/cheetah-strategy/$f"
+done
+curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/config/cheetah-config.json" \
+  -o "/data/workspace/skills/cheetah-strategy/config/cheetah-config.json"
+for f in cheetah-producer.py cheetah_config.py; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/scripts/$f" \
+    -o "/data/workspace/skills/cheetah-strategy/scripts/$f"
+done
+mkdir -p /data/workspace/skills/cheetah-strategy/references
+curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/references/skill-attribution.md" \
+  -o "/data/workspace/skills/cheetah-strategy/references/skill-attribution.md"
 ```
 
 ## Configure
 
-**Set wallet, strategyId, chatId in `config/cheetah-config.json`** — canonical source. Producer reads from here on every cron tick.
+**Set wallet, strategyId, chatId in `config/cheetah-config.json`** — canonical source.
 
 ```json
 {
@@ -42,24 +75,68 @@ curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cheetah/scr
 }
 ```
 
-LLM model env var (only at runtime-create time):
+### Required env vars
 
-```bash
-export CHEETAH_DECISION_MODEL=gemini-3.1-pro-preview    # bare model name; NO provider prefix
-```
+| Env var | Purpose |
+|---|---|
+| `CHEETAH_WALLET` | Strategy wallet (must match runtime.yaml). Per-agent; no `STRATEGY_ADDRESS` fallback. |
+| `SENPI_AUTH_TOKEN` | Bearer token for MCP + signal POST. |
+| `CHEETAH_DECISION_MODEL` | Bare model name (no provider prefix), e.g. `gemini-3.1-pro-preview`. Set at runtime-create time only. |
 
-## Install runtime + producer cron
+### Optional env vars (sensible defaults)
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `SENPI_MCP_URL` | `https://mcp.prod.senpi.ai/mcp` | Direct MCP endpoint |
+| `SENPI_RUNTIME_API_HOST` | `127.0.0.1` | Runtime signal POST host |
+| `SENPI_RUNTIME_API_PORT` | `8787` | Runtime signal POST port |
+| `OPENCLAW_WORKSPACE` | `/data/workspace` | Skill mount root |
+
+## Install the runtime
 
 ```bash
 openclaw senpi runtime create --path /data/workspace/skills/cheetah-strategy/runtime.yaml
-openclaw senpi runtime list
+openclaw senpi runtime list   # confirm status: ACTIVE
 ```
 
-Cron (3-min cadence, no env vars needed — wallet read from config):
+## Run the producer (long-lived daemon — replaces cron)
 
-```cron
-*/3 * * * * cd /data/workspace/skills/cheetah-strategy && python3 scripts/cheetah-producer.py >> state/producer.log 2>&1
+The v7.0.0 producer is a long-lived daemon. **Do NOT add an openclaw cron entry** — that would spawn duplicate daemons. If you're upgrading from v6.x, delete the existing cheetah-producer cron first:
+
+```bash
+openclaw cron list | grep cheetah
+openclaw cron delete <cheetah-cron-id>
 ```
+
+Start the daemon (pick one supervision style):
+
+```bash
+# Option A — supervised by tini in a docker-managed container:
+exec tini -- python3 -u /data/workspace/skills/cheetah-strategy/scripts/cheetah-producer.py
+
+# Option B — nohup background process (simple, no auto-restart):
+nohup python3 -u /data/workspace/skills/cheetah-strategy/scripts/cheetah-producer.py \
+  > /tmp/cheetah-producer.log 2>&1 &
+```
+
+## Smoke test after deploy
+
+Watch the daemon log for one minute:
+
+```bash
+tail -f /tmp/cheetah-producer.log | jq -c 'select(.event=="daemon_tick_finished")' | head -5
+```
+
+Expected: every line shows `status=ok`.
+
+| Status | Meaning | What to do |
+|---|---|---|
+| `ok` | Tick succeeded | Healthy |
+| `skipped_locked` | Lock collision (likely double-locking) | Confirm no inner `scanner_lock` was added inside `main()` |
+| `error` | `fn` raised | Read the `error` field |
+| `timeout` | `fn` took too long | Tune `tick_timeout` in producer's `__main__` block |
+
+`daemon_self_terminated_no_runtime` is normal when the runtime is deleted.
 
 ## Key parameters
 
@@ -93,29 +170,33 @@ Cron (3-min cadence, no env vars needed — wallet read from config):
 Phase 1: max_loss 15% / retrace 6 / 3 consecutive breaches.
 Time cuts: hard_timeout 720min, weak_peak_cut 90min @ 3.0, dead_weight_cut 60min — all ENABLED (multi-asset rotation has opportunity cost).
 
-## Migrating from v5.2
+## Migrating from v6.x
 
 ```bash
 cd /data/workspace/skills/cheetah-strategy
 
-# DO NOT delete the runtime if any positions are open — orphan-position
-# bug applies (v2 runtime swap leaves baseline positions without DSL).
-# Cheetah has been gate-paused at MIN_SCORE 11 for 8 days — expected
-# state is zero positions.
-openclaw senpi strategy_get_clearinghouse_state --strategy_wallet <wallet>
+# 1. Pull the helpers package (one-time per host) — Step 1 above.
 
-# Pull new files
-rm -f scripts/cheetah-scanner.py                    # replaced by cheetah-producer.py
-# (curl commands above)
+# 2. Pull the new producer + config files (Step 2 above curl block).
 
-# Reload runtime (safe: no positions to orphan)
-openclaw senpi runtime delete <old runtime id>
-openclaw senpi runtime create --path runtime.yaml
+# 3. Bump the runtime plugin to >= 2.0.0 if not already on it:
+cat /data/.openclaw/extensions/runtime/package.json | grep version
+# Latest dev tag at the time of v7.0.0:
+#   2.0.0-dev.runtime-phase-2.20260508133508
 
-# Update cron: replace cheetah-scanner.py with cheetah-producer.py
+# 4. Stop the old producer cron (the v7.0.0 producer is a daemon now):
+openclaw cron list | grep cheetah
+openclaw cron delete <cheetah-cron-id>
+
+# 5. Start the daemon (see "Run the producer" above).
+
+# 6. runtime.yaml unchanged — no need to drop+recreate the runtime.
+#    If you DO recreate it, do so only when there are no open positions
+#    (orphan-position bug: v2 runtime swap can leave baseline positions
+#    without DSL coverage).
 ```
 
-State files (`state/entry-log.jsonl`, `state/scan-history.json`, `state/quality-cache.json`, `state/cooldowns.json`, `state/trade-counter.json`) — the new producer uses wallet-isolated subdirs (`state/<wallet-hash>/`) so v5.2 state files are vestigial. Safe to delete the legacy ones at the top of `state/`.
+State files (`state/entry-log.jsonl`, `state/scan-history.json`, `state/quality-cache.json`, `state/cooldowns.json`, `state/trade-counter.json`) live under `state/<wallet-hash>/` — wallet-isolated. Migration from v6.x preserves these files.
 
 ## License
 

--- a/cheetah/SKILL.md
+++ b/cheetah/SKILL.md
@@ -1,23 +1,28 @@
 ---
 name: cheetah-strategy
 description: >-
-  CHEETAH v6.0 — Multi-signal confluence sniper, v2-runtime-native rewrite.
-  Refuses to trade unless ALL major signals align: SM consensus, velocity,
-  acceleration, dual price confirmation, volume spike, quality-trader
-  alignment, rank climb. Score 10/15 floor with score-scaled leverage
-  (3x/5x/7x/8x). Producer + runtime LLM gate + FEE_OPTIMIZED_LIMIT
-  entries AND exits + held-asset dedup + post-close cooldown.
+  CHEETAH v7.0.0 — Multi-signal confluence sniper, senpi_runtime_helpers
+  migration. Plumbing-only flip from openclaw-CLI subprocess + mcporter
+  subprocess to in-process SenpiClient (direct HTTPS for MCP, direct
+  HTTP POST to runtime /signals, long-lived producer_daemon). Thesis
+  preserved verbatim from v6.1: refuses to trade unless ALL major
+  signals align — SM consensus, velocity, acceleration, dual price
+  confirmation, volume spike, quality-trader alignment, rank climb.
+  Score 10/15 floor, score-scaled leverage (3x/5x/7x/8x),
+  FEE_OPTIMIZED_LIMIT entries AND exits, held-asset dedup, post-close
+  cooldown.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "6.0.0"
+  version: "7.0.0"
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=2.0.0
+    - senpi-runtime-helpers
 ---
 
-# 🐆 CHEETAH v6.0 — Multi-Signal Confluence Sniper
+# 🐆 CHEETAH v7.0.0 — Multi-Signal Confluence Sniper
 
 **SM commits. Quality traders commit. Price confirms. Volume commits. All at once. Cheetah pounces once. The runtime DSL ratchets to lock the win.**
 
@@ -110,9 +115,10 @@ See [README.md](README.md) for fresh-install + migration commands from v5.2.
 - ✓ **Held-asset dedup** (3-layer; v2.1 Pangolin pattern)
 - ✓ **Post-close cooldown** (v2.1.2 Pangolin pattern; runtime cooldown backstop)
 - ✓ **Fleet-standard T0/T1 ladder** (commit 6cad383 pattern)
-- ✓ **Reentrancy lockfile** (fcntl)
+- ✓ **Reentrancy guard** (v7.0.0: producer_daemon scanner_lock with stale-PID auto-recovery; replaces hand-rolled fcntl)
 - ✓ **Wallet-from-config** (no hardcoding; senpi-skills is public)
 - ✓ **drawdown_reset_on_day_rollover: false** (Roach lesson)
+- ✓ **senpi_runtime_helpers** (v7.0.0: in-process MCP + signal POST; replaces mcporter + openclaw-CLI subprocess)
 - ✗ **FP-001 quiet hours** — deferred until fleet telemetry can validate the time-of-day P&L correlation
 
 ## Hard rule for user-conversation Claude sessions
@@ -125,6 +131,10 @@ User-conversation Claude sessions MUST NOT call any of:
 These tools are reserved for the **producer cron** (entry path) and the **DSL ratchet engine** (exit path). User-conversation sessions are **read-only**.
 
 If the user asks a question that implies action ("anything close to triggering?"), respond by reading the current state — DO NOT execute. The producer cron will handle real signals on its next tick.
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.
 
 ## License
 

--- a/cheetah/references/skill-attribution.md
+++ b/cheetah/references/skill-attribution.md
@@ -4,7 +4,7 @@ When calling `strategy_create` or `strategy_create_custom_strategy`, always incl
 
 ```json
 "skill_name": "cheetah",
-"skill_version": "5.0-APEX"
+"skill_version": "7.0.0"
 ```
 
 This is required for attribution and tracking. Example:
@@ -16,7 +16,7 @@ This is required for attribution and tracking. Example:
     "initialBudget": 500,
     "positions": [],
     "skill_name": "cheetah",
-    "skill_version": "5.0-APEX"
+    "skill_version": "7.0.0"
   }
 }
 ```

--- a/cheetah/scripts/cheetah-producer.py
+++ b/cheetah/scripts/cheetah-producer.py
@@ -657,18 +657,29 @@ def score_confluence(market, quality_positions, history):
 # ═══════════════════════════════════════════════════════════════
 
 def build_signal_payload(candidate, leverage, margin_usd, held_assets):
-    """Build the payload matching runtime.yaml's cheetah_signals.config.fields schema.
-    All declared scanner fields go in `data`, NOT `meta`."""
+    """Build the payload that `push_signal()` consumes.
+
+    Returned keys are exactly what `push_signal()` extracts and forwards
+    to the wrapper. The runtime's POST /signals schema declares
+    `additionalProperties: false`, so any other top-level fields would
+    be silently dropped or rejected — and `address`/`scanner` are sourced
+    from module-level constants in `push_signal()`, not from this dict.
+
+    Server-side fields (not sent by the producer):
+      - `address` — passed to push_signal from CHEETAH_WALLET
+      - `scanner` — passed to push_signal from SCANNER_NAME
+      - `timestamp` — set by the runtime receiver
+      - `factors` — set by the runtime receiver to {}
+
+    All scanner-config-validated fields go in `data`. The composite
+    `score` lives there too — it is an unbounded int 0-16, not the
+    schema's 0..1 confidence.
+    """
     held_list = sorted(list(held_assets)) if held_assets else []
     return {
-        "address": CHEETAH_WALLET,
-        "scannerId": SCANNER_NAME,
         "signalType": "CHEETAH_CONFLUENCE",
         "asset": candidate["token"],
         "direction": candidate["direction"],
-        "score": float(candidate["score"]),
-        "timestamp": int(time.time() * 1000),
-        "factors": {},
         "data": {
             "score": candidate["score"],
             "leverage": leverage,
@@ -689,9 +700,6 @@ def build_signal_payload(candidate, leverage, margin_usd, held_assets):
             "qualityAlign": int(candidate.get("quality_align", 0)),
             "rankClimb": int(candidate.get("rank_climb", 0)),
             "heldAssets": held_list,
-        },
-        "meta": {
-            "_cheetah_producer_version": VERSION,
         },
     }
 

--- a/cheetah/scripts/cheetah-producer.py
+++ b/cheetah/scripts/cheetah-producer.py
@@ -703,11 +703,15 @@ def push_signal(payload):
 
     SignalItem field mapping (per references/signal-schema.md and the
     Pangolin TST 2026-05-05 incident):
-      - top-level routing fields: address, scanner, asset, direction
+      - top-level routing fields: address, scanner, asset, direction, signal_type
       - data block: scanner-config-validated fields only
       - score STAYS inside data — Cheetah's composite is unbounded int
         0-16, not 0..1 confidence (different semantics; same Pangolin
         v2.2 reference rationale).
+      - signal_type passed explicitly per signal so the runtime never
+        relies on the scanner's defaultSignalType fallback (cheetah's
+        runtime.yaml does not declare one). Keeps audit logs and the
+        LLM decision context tagged correctly.
 
     Returns True on accepted ingest, False on transport / schema rejection.
     The daemon's per-tick error handler catches anything unhandled here
@@ -722,6 +726,7 @@ def push_signal(payload):
             scanner=SCANNER_NAME,
             asset=payload.get("asset"),
             direction=payload.get("direction"),
+            signal_type=payload.get("signalType"),
             data=payload.get("data"),
         )
         return True

--- a/cheetah/scripts/cheetah-producer.py
+++ b/cheetah/scripts/cheetah-producer.py
@@ -1,9 +1,45 @@
 #!/usr/bin/env python3
-# Senpi CHEETAH Producer v6.1.0
+# Senpi CHEETAH Producer v7.0.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""CHEETAH v6.1 Producer — Multi-signal confluence sniper, v2-runtime-native rewrite.
+"""CHEETAH v7.0.0 Producer — senpi_runtime_helpers migration.
+
+v7.0.0 (2026-05-08) — plumbing migration from openclaw-CLI subprocess
++ mcporter subprocess to senpi_runtime_helpers in-process wrapper.
+NO thesis change. Scoring tables, scoring components, leverage tiers,
+margin %, asset cooldowns, post-close cooldown, dedup logic are all
+preserved verbatim from v6.1.0. The runtime itself is now on
+senpi-trading-runtime >= 2.0.0 (runtime-phase-2 build) which speaks
+the new {success,data,error} envelope on /signals + /audit and
+exposes GET /state for daemon liveness probes.
+
+Six-layer plumbing flip (per migration-cookbook):
+  1. MCP calls: cfg.mcporter_call(...) now delegates to
+     senpi_runtime_helpers.SenpiClient.mcp_call() — direct HTTPS,
+     kills the 6-process tree of mcporter cold-start. Existing call
+     sites continue to call cfg.mcporter_call (backward-compat shim
+     in cheetah_config.py).
+  2. Signal emit: subprocess.run(["openclaw","senpi","external-scanner",
+     "ingest", ...]) replaced by cfg._wrapper_client.push_signal(...).
+     Direct HTTP POST to runtime API on 127.0.0.1:8787/signals.
+     CRITICAL: asset and direction are top-level routing fields;
+     score stays inside data (Cheetah's score is unbounded int 0-16,
+     not 0..1 confidence — same Pangolin reference rationale).
+  3. Reentrancy: hand-rolled fcntl flock dropped. producer_daemon
+     owns the lock per tick via scanner_lock(name) — adds stale-PID
+     auto-recovery via os.kill(pid, 0). Do NOT add an inner
+     scanner_lock inside main() — the daemon already wraps it.
+  4. Tick scheduling: openclaw cron + agentTurn replaced by
+     producer_daemon(fn=main, interval_seconds=300, ...). Long-lived
+     Python process, no per-tick LLM cost.
+  5. Per-tick cache + parallel fan-out NOT adopted in v7.0.0 to match
+     Pangolin reference minimum-change pattern. Future opt-in.
+  6. /state alive_check: producer_daemon self-terminates if the
+     runtime for CHEETAH_WALLET is deleted OR the cheetah_signals
+     scanner is renamed. Default behavior — alive_check left unset.
+
+CHEETAH v6.1 thesis preserved unchanged:
 
 v6.1 (2026-05-05) — Phase 2 T0 ladder calibration. No producer code
 changes. Runtime.yaml only: T0 trigger 5→3, T0 lock 35→40, T1 7/55,
@@ -63,16 +99,19 @@ Environment / config resolution:
   Strategy wallet is read from config/cheetah-config.json (canonical
   source). CHEETAH_WALLET env var supported as optional override.
 
-  CHEETAH_WALLET             — optional override; defaults to config.wallet
-  OPENCLAW_BIN               — optional, default "openclaw"
-  EXTERNAL_SCANNER_NAME      — optional override (default "cheetah_signals")
+  CHEETAH_WALLET             — REQUIRED. Strategy wallet (must match runtime.yaml).
+                              Per Turbine v2.0.9 contamination rule, agent-specific
+                              env var only — do NOT fall back to STRATEGY_ADDRESS.
+  SENPI_MCP_URL              — defaults to https://mcp.prod.senpi.ai/mcp
+  SENPI_AUTH_TOKEN           — REQUIRED. Bearer token for MCP + signal push.
+  SENPI_RUNTIME_API_HOST     — defaults to 127.0.0.1
+  SENPI_RUNTIME_API_PORT     — defaults to 8787
+  OPENCLAW_WORKSPACE         — defaults to /data/workspace
 """
 
-import fcntl
 import hashlib
 import json
 import os
-import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -81,10 +120,13 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import cheetah_config as cfg
 
+# senpi_runtime_helpers (loaded via cfg's sys.path shim) — used here only
+# for SenpiClientError type; the wrapper client lives on cfg.
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
-VERSION = "6.1.0"
-SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "cheetah_signals")
-OPENCLAW_BIN = os.environ.get("OPENCLAW_BIN", "openclaw")
+
+VERSION = "7.0.0"
+SCANNER_NAME = "cheetah_signals"  # must match runtime.yaml external_scanner.name
 
 
 def _resolve_wallet():
@@ -114,7 +156,6 @@ def _wallet_state_dir():
 
 
 _STATE_DIR = _wallet_state_dir()
-_LOCK_PATH = _STATE_DIR / "producer.lock"
 _COOLDOWN_FILE = _STATE_DIR / "asset-cooldowns.json"
 _COUNTER_FILE = _STATE_DIR / "trade-counter.json"
 _LAST_CLOSED_FILE = _STATE_DIR / "last-closed.json"
@@ -123,32 +164,11 @@ _SCAN_HISTORY_FILE = _STATE_DIR / "scan-history.json"
 _QUALITY_CACHE_FILE = _STATE_DIR / "quality-cache.json"
 
 
-# ═══════════════════════════════════════════════════════════════
-# REENTRANCY GUARD (fcntl, fleet-standard)
-# ═══════════════════════════════════════════════════════════════
-
-def acquire_lock():
-    try:
-        f = open(_LOCK_PATH, "w")
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        f.write(f"{os.getpid()} {int(time.time())}\n")
-        f.flush()
-        return f
-    except (IOError, OSError, BlockingIOError):
-        return None
-
-
-def release_lock(lock_file):
-    if lock_file is None:
-        return
-    try:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-    except Exception:
-        pass
-    try:
-        lock_file.close()
-    except Exception:
-        pass
+# Reentrancy guard removed in v7.0.0. producer_daemon owns the per-tick
+# scanner_lock with stale-PID auto-recovery via os.kill(pid, 0). Do NOT
+# add an inner scanner_lock(...) inside main() — fcntl flock is not
+# reentrant; nested call raises BlockingIOError and the daemon logs
+# tick_status=skipped_locked every tick. See migration-cookbook §Step 5.
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -677,33 +697,39 @@ def build_signal_payload(candidate, leverage, margin_usd, held_assets):
 
 
 def push_signal(payload):
-    """Push a signal payload to the runtime via openclaw CLI."""
+    """Push a signal payload to the runtime via senpi_runtime_helpers.
+
+    Direct HTTP POST to runtime API on 127.0.0.1; no subprocess.
+
+    SignalItem field mapping (per references/signal-schema.md and the
+    Pangolin TST 2026-05-05 incident):
+      - top-level routing fields: address, scanner, asset, direction
+      - data block: scanner-config-validated fields only
+      - score STAYS inside data — Cheetah's composite is unbounded int
+        0-16, not 0..1 confidence (different semantics; same Pangolin
+        v2.2 reference rationale).
+
+    Returns True on accepted ingest, False on transport / schema rejection.
+    The daemon's per-tick error handler catches anything unhandled here
+    and continues to the next tick — no half-written caller state.
+    """
     if not CHEETAH_WALLET:
         cfg.log("CHEETAH_WALLET not set; cannot push signal")
         return False
-
-    cmd = [
-        OPENCLAW_BIN, "senpi", "external-scanner", "ingest",
-        "--address", CHEETAH_WALLET,
-        "--scanner", SCANNER_NAME,
-        "--payload", json.dumps(payload),
-    ]
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
-        if r.returncode != 0:
-            cfg.log(f"ingest failed for {payload['asset']} {payload['direction']}: {r.stderr.strip()}")
-            return False
-        if r.stdout.strip():
-            try:
-                response = json.loads(r.stdout)
-                if isinstance(response, dict) and response.get("ok") is False:
-                    cfg.log(f"ingest rejected for {payload['asset']}: {response.get('error')}")
-                    return False
-            except (json.JSONDecodeError, TypeError):
-                pass
+        cfg._wrapper_client.push_signal(
+            address=CHEETAH_WALLET,
+            scanner=SCANNER_NAME,
+            asset=payload.get("asset"),
+            direction=payload.get("direction"),
+            data=payload.get("data"),
+        )
         return True
-    except (subprocess.TimeoutExpired, OSError) as e:
-        cfg.log(f"ingest exception for {payload['asset']}: {e}")
+    except SenpiClientError as e:
+        cfg.log(f"push_signal rejected for {payload.get('asset')} {payload.get('direction')}: {e}")
+        return False
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        cfg.log(f"push_signal exception for {payload.get('asset')}: {type(e).__name__}: {e}")
         return False
 
 
@@ -714,195 +740,202 @@ def push_signal(payload):
 def main():
     run_start = time.time()
 
+    # Fail loud if wallet not configured (Turbine v2.0.9 contamination rule).
     if not CHEETAH_WALLET:
         cfg.output({
             "status": "error",
-            "error": "CHEETAH_WALLET not set. Configure config/cheetah-config.json wallet field.",
+            "error": "CHEETAH_WALLET not set. Set the env var or populate config/cheetah-config.json wallet field.",
             "_cheetah_producer_version": VERSION,
         })
         return
 
-    lock = acquire_lock()
-    if lock is None:
-        print(json.dumps({
-            "status": "skip",
-            "reason": "previous run still active — cron reentrancy guard",
-            "_cheetah_producer_version": VERSION,
-        }))
-        return
+    # NB: no scanner_lock here. producer_daemon owns the per-tick lock.
 
-    try:
-        # ── Account state + held assets ──
-        account_value, pos_count, held_assets = get_account_state()
-        if account_value is None or account_value <= 0:
-            cfg.output({
-                "status": "ok",
-                "note": "cannot read account value; skip tick",
-                "_cheetah_producer_version": VERSION,
-            })
-            return
-
-        # v6.0 close detection: diff held_assets against last tick's held set
-        previously_held = load_previously_held()
-        closed_this_tick = detect_closes(held_assets, previously_held)
-        save_previously_held(held_assets)
-
-        # Max positions guard (Cheetah is 1-slot sniper)
-        if pos_count >= MAX_POSITIONS:
-            cfg.output({
-                "status": "ok",
-                "note": f"riding open position(s): {sorted(list(held_assets))}",
-                "open_positions": pos_count,
-                "_cheetah_producer_version": VERSION,
-            })
-            return
-
-        # ── Fetch SM markets ──
-        markets = fetch_sm_markets()
-        if not markets:
-            cfg.output({
-                "status": "error",
-                "error": "failed to fetch leaderboard_get_markets",
-                "_cheetah_producer_version": VERSION,
-            })
-            return
-
-        # ── Update scan history (for rank-climb scoring) ──
-        history = load_scan_history()
-        history["scans"].append(build_scan_snapshot(markets))
-        save_scan_history(history)
-
-        # ── Quality trader positions (cached) ──
-        quality_positions = fetch_quality_trader_positions()
-
-        # ── Score all markets ──
-        # Filter order: held > post-close-cooldown > emit-cooldown > score.
-        candidates = []
-        all_scored = []
-        skipped_held = 0
-        skipped_post_close = 0
-        post_close_skips = []
-
-        for market in markets:
-            token = market["token"]
-
-            # v6.0 dedup defense layer 1: never emit on held assets
-            if token.upper() in held_assets:
-                skipped_held += 1
-                continue
-
-            # v6.0 post-close cooldown (Pangolin v2.1.2 pattern)
-            if is_in_post_close_cooldown(token):
-                skipped_post_close += 1
-                post_close_skips.append({
-                    "token": token,
-                    "remaining_min": post_close_cooldown_remaining_min(token),
-                })
-                continue
-
-            # Emit cooldown (post-emit, prevents spam re-fires)
-            if is_asset_cooled_down(token):
-                continue
-
-            score, reasons = score_confluence(market, quality_positions, history)
-            if score == 0:
-                continue
-
-            all_scored.append({
-                "token": token,
-                "direction": market["direction"],
-                "score": score,
-            })
-
-            if score >= MIN_SCORE_DEFAULT:
-                # Annotate with extras for telemetry
-                key = f"{token}:{market['direction']}"
-                quality_count = len(quality_positions.get(key, []))
-                rank_climb = get_rank_climb(history, token, market["dex"])
-                candidate = dict(market)
-                candidate["score"] = score
-                candidate["reasons"] = reasons
-                candidate["quality_align"] = quality_count
-                candidate["rank_climb"] = rank_climb
-                candidates.append(candidate)
-
-        if not candidates:
-            top3 = sorted(all_scored, key=lambda s: s["score"], reverse=True)[:3]
-            cfg.output({
-                "status": "ok",
-                "note": f"0 candidates at score >= {MIN_SCORE_DEFAULT} ({len(all_scored)} scored)",
-                "topScored": top3,
-                "skipped_held": skipped_held,
-                "skipped_post_close": skipped_post_close,
-                "post_close_skips": post_close_skips,
-                "closed_this_tick": sorted(list(closed_this_tick)),
-                "held_assets": sorted(list(held_assets)),
-                "_cheetah_producer_version": VERSION,
-            })
-            return
-
-        # ── Pick top candidate, compute sizing + leverage ──
-        candidates.sort(key=lambda c: c["score"], reverse=True)
-        best = candidates[0]
-
-        margin_usd = round(account_value * MARGIN_PCT, 2)
-        requested_leverage = get_leverage_for_score(best["score"])
-        # v5.1.1 leverage clamp preserved
-        leverage = get_safe_leverage(CHEETAH_WALLET, best["token"], requested_leverage)
-
-        # ── Daily counter (best-effort observability; runtime guard_rails
-        #    is the authoritative max_entries_per_day enforcement) ──
-        tc = load_trade_counter()
-
-        # ── Emit signal (only top candidate per tick) ──
-        payload = build_signal_payload(best, leverage, margin_usd, held_assets)
-        pushed = 0
-        if push_signal(payload):
-            pushed += 1
-            mark_asset_emitted(best["token"])
-            tc["entries"] = tc.get("entries", 0) + 1
-            save_trade_counter(tc)
-
-        elapsed = time.time() - run_start
-        warn = "WARN_OVER_120S" if elapsed > 120 else None
+    # ── Account state + held assets ──
+    account_value, pos_count, held_assets = get_account_state()
+    if account_value is None or account_value <= 0:
         cfg.output({
             "status": "ok",
-            "candidates_total": len(candidates),
-            "all_scored": len(all_scored),
+            "note": "cannot read account value; skip tick",
+            "_cheetah_producer_version": VERSION,
+        })
+        return
+
+    # v6.0 close detection: diff held_assets against last tick's held set
+    previously_held = load_previously_held()
+    closed_this_tick = detect_closes(held_assets, previously_held)
+    save_previously_held(held_assets)
+
+    # Max positions guard (Cheetah is 1-slot sniper)
+    if pos_count >= MAX_POSITIONS:
+        cfg.output({
+            "status": "ok",
+            "note": f"riding open position(s): {sorted(list(held_assets))}",
+            "open_positions": pos_count,
+            "_cheetah_producer_version": VERSION,
+        })
+        return
+
+    # ── Fetch SM markets ──
+    markets = fetch_sm_markets()
+    if not markets:
+        cfg.output({
+            "status": "error",
+            "error": "failed to fetch leaderboard_get_markets",
+            "_cheetah_producer_version": VERSION,
+        })
+        return
+
+    # ── Update scan history (for rank-climb scoring) ──
+    history = load_scan_history()
+    history["scans"].append(build_scan_snapshot(markets))
+    save_scan_history(history)
+
+    # ── Quality trader positions (cached) ──
+    quality_positions = fetch_quality_trader_positions()
+
+    # ── Score all markets ──
+    # Filter order: held > post-close-cooldown > emit-cooldown > score.
+    candidates = []
+    all_scored = []
+    skipped_held = 0
+    skipped_post_close = 0
+    post_close_skips = []
+
+    for market in markets:
+        token = market["token"]
+
+        # v6.0 dedup defense layer 1: never emit on held assets
+        if token.upper() in held_assets:
+            skipped_held += 1
+            continue
+
+        # v6.0 post-close cooldown (Pangolin v2.1.2 pattern)
+        if is_in_post_close_cooldown(token):
+            skipped_post_close += 1
+            post_close_skips.append({
+                "token": token,
+                "remaining_min": post_close_cooldown_remaining_min(token),
+            })
+            continue
+
+        # Emit cooldown (post-emit, prevents spam re-fires)
+        if is_asset_cooled_down(token):
+            continue
+
+        score, reasons = score_confluence(market, quality_positions, history)
+        if score == 0:
+            continue
+
+        all_scored.append({
+            "token": token,
+            "direction": market["direction"],
+            "score": score,
+        })
+
+        if score >= MIN_SCORE_DEFAULT:
+            # Annotate with extras for telemetry
+            key = f"{token}:{market['direction']}"
+            quality_count = len(quality_positions.get(key, []))
+            rank_climb = get_rank_climb(history, token, market["dex"])
+            candidate = dict(market)
+            candidate["score"] = score
+            candidate["reasons"] = reasons
+            candidate["quality_align"] = quality_count
+            candidate["rank_climb"] = rank_climb
+            candidates.append(candidate)
+
+    if not candidates:
+        top3 = sorted(all_scored, key=lambda s: s["score"], reverse=True)[:3]
+        cfg.output({
+            "status": "ok",
+            "note": f"0 candidates at score >= {MIN_SCORE_DEFAULT} ({len(all_scored)} scored)",
+            "topScored": top3,
             "skipped_held": skipped_held,
             "skipped_post_close": skipped_post_close,
             "post_close_skips": post_close_skips,
             "closed_this_tick": sorted(list(closed_this_tick)),
             "held_assets": sorted(list(held_assets)),
-            "signals_pushed": pushed,
-            "best_signal": {
-                "asset": best["token"],
-                "direction": best["direction"],
-                "score": best["score"],
-                "leverage": leverage,
-                "marginUsd": margin_usd,
-                "reasons": best["reasons"][:5],
-            } if pushed else None,
-            "account_value": round(account_value, 2),
-            "open_positions": pos_count,
-            "entries_today": tc.get("entries", 0),
-            "elapsed_sec": round(elapsed, 2),
-            "warn": warn,
             "_cheetah_producer_version": VERSION,
         })
-    finally:
-        release_lock(lock)
+        return
+
+    # ── Pick top candidate, compute sizing + leverage ──
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_usd = round(account_value * MARGIN_PCT, 2)
+    requested_leverage = get_leverage_for_score(best["score"])
+    # v5.1.1 leverage clamp preserved
+    leverage = get_safe_leverage(CHEETAH_WALLET, best["token"], requested_leverage)
+
+    # ── Daily counter (best-effort observability; runtime guard_rails
+    #    is the authoritative max_entries_per_day enforcement) ──
+    tc = load_trade_counter()
+
+    # ── Emit signal (only top candidate per tick) ──
+    payload = build_signal_payload(best, leverage, margin_usd, held_assets)
+    pushed = 0
+    if push_signal(payload):
+        pushed += 1
+        mark_asset_emitted(best["token"])
+        tc["entries"] = tc.get("entries", 0) + 1
+        save_trade_counter(tc)
+
+    elapsed = time.time() - run_start
+    warn = "WARN_OVER_120S" if elapsed > 120 else None
+    cfg.output({
+        "status": "ok",
+        "candidates_total": len(candidates),
+        "all_scored": len(all_scored),
+        "skipped_held": skipped_held,
+        "skipped_post_close": skipped_post_close,
+        "post_close_skips": post_close_skips,
+        "closed_this_tick": sorted(list(closed_this_tick)),
+        "held_assets": sorted(list(held_assets)),
+        "signals_pushed": pushed,
+        "best_signal": {
+            "asset": best["token"],
+            "direction": best["direction"],
+            "score": best["score"],
+            "leverage": leverage,
+            "marginUsd": margin_usd,
+            "reasons": best["reasons"][:5],
+        } if pushed else None,
+        "account_value": round(account_value, 2),
+        "open_positions": pos_count,
+        "entries_today": tc.get("entries", 0),
+        "elapsed_sec": round(elapsed, 2),
+        "warn": warn,
+        "_cheetah_producer_version": VERSION,
+    })
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as e:
-        cfg.log(f"CRITICAL ERROR: {e}")
-        import traceback
-        traceback.print_exc(file=sys.stderr)
-        cfg.output({
-            "status": "error",
-            "error": str(e),
-            "_cheetah_producer_version": VERSION,
-        })
+    # v7.0.0 — long-lived daemon. Replaces openclaw cron + agentTurn for
+    # this skill — no LLM coupling, no per-tick CLI cold start.
+    # producer_daemon wraps each tick in scanner_lock so overlap is
+    # skipped cleanly, enforces a 6-min wall-clock per-tick via SIGALRM
+    # (longer than the producer's WARN_OVER_120S budget so the warn
+    # fires before the alarm), and drains gracefully on SIGTERM/SIGINT.
+    #
+    # Lock name is per-wallet so multi-wallet hosts (one daemon per
+    # wallet) don't collide on a single global lock file.
+    #
+    # alive_check is left UNSET (default behavior) — producer_daemon
+    # self-terminates if the runtime for CHEETAH_WALLET is deleted OR
+    # the cheetah_signals scanner is dropped/renamed. Do NOT pass
+    # alive_check=None when wallet= is set.
+    _wallet_lock_id = (
+        hashlib.sha256(CHEETAH_WALLET.lower().encode()).hexdigest()[:12]
+        if CHEETAH_WALLET
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"cheetah-producer-{_wallet_lock_id}",
+        wallet=CHEETAH_WALLET,        # enables default /state alive_check
+        scanner=SCANNER_NAME,         # daemon self-terminates if deleted
+        tick_timeout=360,
+    )

--- a/cheetah/scripts/cheetah_config.py
+++ b/cheetah/scripts/cheetah_config.py
@@ -1,15 +1,19 @@
-"""CHEETAH APEX Strategy — Shared config, MCP helpers, state I/O.
+"""CHEETAH — Shared config, MCP helpers, state I/O.
 
-v5.0 APEX rewrite. Previous versions of this file were a mantis
-copy-paste with broken MANTIS_WALLET env var references.
+v7.0.0: senpi_runtime_helpers migration. mcporter_call now routes
+through SenpiClient.mcp_call() (direct HTTPS) instead of mcporter
+subprocess. _wrapper_client is exposed for the producer's signal
+push (cfg._wrapper_client.push_signal(...)). All other helpers
+(atomic_write, load_config, get_wallet_and_strategy, get_positions,
+output, log, now_*) preserved verbatim.
 """
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
 
+import functools
 import json
 import os
-import subprocess
 import sys
 import tempfile
 import time
@@ -22,6 +26,49 @@ CONFIG_PATH = SKILL_DIR / "config" / "cheetah-config.json"
 STATE_DIR = SKILL_DIR / "state"
 
 STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+# The wrapper is mounted via sys.path at module load, but SenpiClient
+# construction is DEFERRED until first attribute access. Two reasons:
+#   1. Importing cheetah_config from a test, REPL, or sibling helper
+#      shouldn't instantiate a network client or write to stderr.
+#   2. SENPI_AUTH_TOKEN is validated explicitly on first use — a
+#      missing token raises loudly here instead of silently producing
+#      a 401 on the first MCP call.
+# Pattern ported verbatim from pangolin/scripts/pangolin_config.py.
+
+_helpers_path = str(Path(WORKSPACE) / "skills" / "_helpers")
+if _helpers_path not in sys.path:
+    sys.path.insert(0, _helpers_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    """Lazy SenpiClient accessor with explicit auth validation."""
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Cheetah's MCP calls and signal "
+            "POST both require it. Set it on the runtime host (e.g. as a "
+            "Railway service variable) before starting the producer."
+        )
+    client = SenpiClient()
+    log_event("cheetah_wrapper_enabled", helpers_path=_helpers_path)
+    return client
+
+
+class _WrapperClientProxy:
+    """Module-level attribute that defers SenpiClient construction until
+    first attribute access. Preserves the legacy `cfg._wrapper_client.<x>`
+    call shape used by the producer without forcing eager instantiation
+    at import time."""
+
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
 
 
 # ─── Atomic Write ────────────────────────────────────────────
@@ -83,36 +130,26 @@ def save_state(data, filename="state.json"):
 # ─── MCP Helpers ─────────────────────────────────────────────
 
 def mcporter_call(tool, retries=2, timeout=30, **params):
-    """Call a Senpi MCP tool via mcporter. Array syntax, no shell=True."""
-    args = json.dumps(params) if params else "{}"
-    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
-    for attempt in range(retries):
-        try:
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-            if r.returncode != 0:
-                if attempt < retries - 1:
-                    time.sleep(2)
-                    continue
-                return None
-            raw = json.loads(r.stdout)
-            if isinstance(raw, dict) and "content" in raw:
-                content = raw["content"]
-                if isinstance(content, list) and content:
-                    first = content[0]
-                    if isinstance(first, dict) and "text" in first:
-                        try:
-                            return json.loads(first["text"])
-                        except (json.JSONDecodeError, TypeError):
-                            pass
-            return raw
-        except subprocess.TimeoutExpired:
-            if attempt < retries - 1:
-                time.sleep(2)
-                continue
-            return None
-        except (json.JSONDecodeError, Exception):
-            return None
-    return None
+    """Call a Senpi MCP tool via the senpi_runtime_helpers wrapper.
+
+    v7.0.0: routes through SenpiClient.mcp_call() — direct HTTPS, no
+    mcporter subprocess. Returns the unwrapped JSON document on
+    success, or None if the wrapper raised a transport / protocol
+    error. The producer's pre-existing `if not r:` early returns
+    continue to handle the no-data case gracefully.
+
+    `retries` is preserved as a parameter for backward compatibility
+    with existing call sites but is not implemented here — a transient
+    failure is recovered by the daemon's next tick (5 minutes).
+    """
+    try:
+        return _wrapper_client.mcp_call(tool, timeout=timeout, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] cheetah_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
 
 
 def get_positions(wallet=None):


### PR DESCRIPTION
## Summary

First skill in the 15-agent rollout to `senpi_runtime_helpers`. Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess to in-process `SenpiClient` (direct HTTPS for MCP, direct HTTP POST to runtime `/signals`, long-lived `producer_daemon`).

**No thesis change.** Cheetah v6.1's scoring tables, leverage tiers, dedup logic, post-close cooldown, runtime DSL preset, risk gates are all preserved verbatim.

Three commits per the per-skill PR layout:

1. **producer-rewrite** (`73de415`) — `cheetah-producer.py` drops fcntl + subprocess, adds `producer_daemon`, rewrites `push_signal()` to use `cfg._wrapper_client.push_signal(...)`. `score` stays inside `data` (Cheetah's score is unbounded int 0-16, not 0..1 confidence — same Pangolin reference rationale).
2. **config-shim** (`44021bf`) — `cheetah_config.py` adds the lazy `SenpiClient` proxy + delegating `mcporter_call` shim, ported verbatim from `pangolin_config.py`.
3. **doc-bump** (`44f4e57`) — `SKILL.md` (v6.0 → v7.0.0, adds missing `## Skill Attribution` section), `README.md` (helpers install snippet, daemon startup, smoke test, env-var contract), `references/skill-attribution.md` (v5.0-APEX → 7.0.0).

## Compatibility requirements

- `senpi-trading-runtime >= 2.0.0` — the runtime-phase-2 build with the `{success,data,error}` envelope and `GET /state` for daemon liveness probes. Latest dev tag: `2.0.0-dev.runtime-phase-2.20260508133508`.
- `_helpers/senpi_runtime_helpers/` mounted at `${OPENCLAW_WORKSPACE:-/data/workspace}/skills/_helpers/`. One copy per host, shared across skills.
- Required env vars: `CHEETAH_WALLET`, `SENPI_AUTH_TOKEN`. (No `STRATEGY_ADDRESS` fallback per Turbine v2.0.9 contamination rule.)
- The producer is a long-lived daemon now; the v6.x cheetah-producer cron MUST be deleted before starting (would spawn duplicate daemons otherwise).

## Pitfall scan vs Pangolin reference

| Pitfall | Cheetah v7.0.0 | Verdict |
|---|---|---|
| Inner `scanner_lock` inside fn | None | ✅ |
| `alive_check=None` | Not passed (default `/state` probe enabled) | ✅ |
| `STRATEGY_ADDRESS` env var | Not used; `CHEETAH_WALLET` only | ✅ |
| `## Skill Attribution` in SKILL.md | Added (was missing in v6.x) | ✅ |
| Lock name format | `f"cheetah-producer-{sha256(wallet.lower())[:12]}"` | ✅ |
| `score` in `data`, not top-level | Yes (Cheetah's int score, not 0..1 confidence) | ✅ |

## Test plan

- [ ] Operator pulls helpers package + Cheetah v7.0.0 files
- [ ] Verify runtime plugin version: `cat /data/.openclaw/extensions/runtime/package.json | grep version` matches `>= 2.0.0`
- [ ] Delete v6.x cheetah-producer cron
- [ ] Start v7.0.0 daemon (tini or nohup)
- [ ] Smoke test for 1 minute: `tail -f /tmp/cheetah-producer.log | jq -c 'select(.event=="daemon_tick_finished")' | head -5` — every line should show `status=ok`
- [ ] Confirm `[senpi_helpers]` events appear in stderr (proves wrapper is in use)
- [ ] Confirm tick wall-clock drops ~10× vs v6.x cron baseline
- [ ] Watch over the weekend for any signal emission, `daemon_tick_finished status=error`, or `signal_post: ... rejected` log lines

After Cheetah validates, the same 3-commit pattern rolls out to the remaining 14 agents (Scorpion, Vulture, Roach-b, Roach, Pangolin already done, Kodiak, Polar, Turbine, Jackal, Otter, Spider, Kestrel, Wolverine, Grizzly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)