### PR TITLE
Turbine v3.1 — two-wallet rewrite (runtime-phase-2 constraint)

### DIFF
--- a/turbine/README.md
+++ b/turbine/README.md
@@ -1,40 +1,37 @@
-# 🌪️ Turbine v3.0 — Volume Engine + HYPE Hunt
+# 🌪️ Turbine v3.1 — Volume Engine + HYPE Hunt (two wallets)
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-**Single producer, two runtimes, one wallet.** Combines a 7-slot volume engine (10-min rotation, funding-fade direction, 80% XYZ weighted for the lower fee floor) with a 2-slot HYPE 4H momentum hunt (Phase 2 ratchet exit). Targets **$5M/day volume at <$100 net cost per $1M** while opportunistically scooping HYPE breakouts.
+**ONE producer daemon manages TWO Senpi strategy wallets, each with its own runtime.** This is required because the runtime-phase-2 plugin enforces one runtime per wallet — v3.0's "two runtimes on one wallet" architecture got blocked at deploy and was rewritten as v3.1.
 
-This is a **complete rewrite from v2.0.x** — not a migration. The rebuild lands on a fresh strategy wallet with clean state. Legacy Turbine MUST be paused before v3.0 deploys.
+The wallet boundary IS the mode boundary. Volume wallet runs the rotation engine; hunt wallet rides HYPE 4H momentum. Single producer reads both, emits to both. `audit_query` filters per-wallet for clean P&L attribution.
 
-## What changed in v3.0
+## What changed in v3.1 (from v3.0)
 
-- **Two runtimes on one wallet** (`turbine-volume-tracker` + `turbine-hunt-tracker`) — gives mode-distinct DSL profiles without losing slot-pool fungibility.
-- **9 total slots** (7 volume + 2 hunt). New funding requirement: **$6,000**.
-- **Volume cycle 10 min default** with auto-fallback to 12 min when realized maker fill rate drops below 85%. Was fixed 15 min in v2.0.x.
-- **Tighter spread gates** — main 5→3 bps, XYZ 15→10 bps.
-- **Tighter universe** — dropped TSLA/NVDA from XYZ pool. 80/20 XYZ/main weighting (was 70/30).
-- **HYPE hunt mode** — multi-axis 4H breakout score (max 15, floor 10) on 2 dedicated slots.
-- **Sentinel sunset** — hunt slots take over with explicit slot accounting.
-- **`senpi_runtime_helpers` integration** — no `mcporter` / `openclaw` subprocess. Long-lived `producer_daemon`.
-- **`STRATEGY_ADDRESS` env var BANNED** — only `TURBINE_WALLET` honored per v2.0.9 rule.
+- **Two strategy wallets** instead of one — runtime-phase-2 plugin enforces one runtime per wallet
+- **Funding split** — Volume wallet $3,500 (7 × $500) + Hunt wallet $2,400 (2 × $1,200) = $5,900 total
+- **Env var schema** — `TURBINE_VOLUME_WALLET` + `TURBINE_HUNT_WALLET` (split from v3.0's single `TURBINE_WALLET`)
+- **Config schema** — `volume.{wallet,strategyId}` + `hunt.{wallet,strategyId}` (was flat `wallet`/`strategyId`)
+- **Slot-mode tracker dropped** — wallet boundary makes it redundant
+- **Hunt is optional** — leave `TURBINE_HUNT_WALLET` unset to run a pure volume engine
 
 ## Mission targets
 
-| Metric | v2.0.x | v3.0 |
+| Metric | v2.0.x | v3.1 |
 |---|---|---|
 | Daily volume | ~$2-3M | $5M |
 | Net cost per $1M volume | $200 | <$100 |
-| Total slots | 3 | 9 |
+| Total slots | 3 | 9 (7 vol + 2 hunt) |
 | Volume cycle | 15 min | 10 min |
-| Funding | $1,500 | $6,000 |
+| Total funding | $1,500 | **$5,900** ($3,500 vol + $2,400 hunt) |
 
 See [SKILL.md](SKILL.md) for the full thesis, scoring tables, DSL presets, and risk-gate breakdown.
 
 ---
 
-## Sunset sequence (BEFORE deploying v3.0)
+## Sunset sequence (BEFORE deploying v3.1)
 
-**Critical: legacy Turbine v2.0.x and Sentinel both write to the SAME wallet.** Both must be stopped before v3.0 deploys to a fresh wallet.
+If Turbine v2.0.x or Sentinel are still running on the legacy wallet, stop them first.
 
 ```bash
 # 1. Confirm what's running
@@ -46,14 +43,28 @@ openclaw cron delete <turbine-v2-cron-id>
 openclaw cron delete <sentinel-cron-id>     # if exists
 
 # 3. Wait for or close any open positions on the legacy wallet
-openclaw senpi strategy_get_clearinghouse_state --strategy_wallet <legacy-wallet>
+mcp__senpi-prod__strategy_get_clearinghouse_state \
+  --strategy_wallet <legacy-wallet>
 
-# 4. Delete the legacy runtimes
+# 4. Delete the legacy runtime(s)
 openclaw senpi runtime delete <turbine-tracker-id>
 openclaw senpi runtime delete <sentinel-tracker-id>     # if exists
 
-# 5. Withdraw funds (or leave them; v3.0 uses a NEW wallet)
+# 5. Withdraw funds (or leave; v3.1 uses TWO new wallets)
 ```
+
+---
+
+## Provision two strategy wallets
+
+Create TWO new Senpi strategy wallets:
+
+| Wallet | Purpose | Funding |
+|---|---|---|
+| `<volume-wallet>` | Volume engine runtime | $3,500 USDC on HL perps |
+| `<hunt-wallet>` | HYPE momentum runtime | $2,400 USDC on HL perps |
+
+If you want a pure volume engine without hunt mode, provision only the volume wallet and leave hunt unset.
 
 ---
 
@@ -62,16 +73,17 @@ openclaw senpi runtime delete <sentinel-tracker-id>     # if exists
 ### Step 1 — Pull the helpers package (one-time per host)
 
 ```bash
-mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers/references
-mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers/tests
-
-for f in __init__.py _config.py _logging.py cache.py client.py daemon.py lock.py parallel.py SKILL.md README.md; do
+mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
+for f in __init__.py _config.py _logging.py cache.py client.py \
+         daemon.py lock.py parallel.py SKILL.md README.md; do
   curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```
 
-### Step 2 — Pull Turbine v3.0
+Skip if already pulled for Cheetah v7.0.0 or another v3 skill.
+
+### Step 2 — Pull Turbine v3.1
 
 ```bash
 mkdir -p /data/workspace/skills/turbine-strategy/{config,scripts,state,references}
@@ -92,34 +104,67 @@ curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/turbine
 
 ### Step 3 — Configure
 
-Set `wallet`, `strategyId`, `chatId` in `config/turbine-config.json`.
+Edit `config/turbine-config.json`:
+
+```json
+{
+  "volume": {
+    "wallet": "0xVolumeWallet...",
+    "strategyId": "volume-strategy-id"
+  },
+  "hunt": {
+    "wallet": "0xHuntWallet...",
+    "strategyId": "hunt-strategy-id"
+  },
+  "chatId": "your-telegram-chat-id"
+}
+```
+
+Leave the other defaults (`slots`, `margin`, `cycle`, `spread`, etc.) alone unless instructed.
 
 ### Step 4 — Required env vars
 
 ```bash
-export TURBINE_WALLET=0xYourFreshTurbineWallet
+export TURBINE_VOLUME_WALLET=0xVolumeWallet
+export TURBINE_HUNT_WALLET=0xHuntWallet                # omit to disable hunt
 export SENPI_AUTH_TOKEN=...
 export TURBINE_VOLUME_DECISION_MODEL=gemini-3.1-pro-preview
 export TURBINE_HUNT_DECISION_MODEL=gemini-3.1-pro-preview
+
+# OpenClaw runtime substitution
+export TELEGRAM_CHAT_ID=<your-chat-id>
 ```
 
-Optional: `SENPI_MCP_URL`, `SENPI_RUNTIME_API_HOST`, `SENPI_RUNTIME_API_PORT`, `OPENCLAW_WORKSPACE` — sensible defaults.
+❌ Do NOT set `STRATEGY_ADDRESS` (banned per v2.0.9) or `TURBINE_WALLET` (legacy v3.0 var; v3.1 ignores it).
 
-### Step 5 — Fund the wallet
+### Step 5 — Fund both wallets
 
-Fund the new strategy wallet with **$6,000** in USDC (Hyperliquid perps account).
+| Wallet | Amount |
+|---|---|
+| Volume | $3,500 USDC on HL perps |
+| Hunt | $2,400 USDC on HL perps |
 
 ### Step 6 — Install BOTH runtimes
 
+Each runtime points to its own wallet via `${TURBINE_VOLUME_WALLET}` / `${TURBINE_HUNT_WALLET}`:
+
 ```bash
-openclaw senpi runtime create --path /data/workspace/skills/turbine-strategy/runtime-volume.yaml
-openclaw senpi runtime create --path /data/workspace/skills/turbine-strategy/runtime-hunt.yaml
-openclaw senpi runtime list   # confirm BOTH ACTIVE
+# Volume runtime
+openclaw senpi runtime create \
+  --path /data/workspace/skills/turbine-strategy/runtime-volume.yaml
+
+# Hunt runtime (skip if running pure volume engine)
+openclaw senpi runtime create \
+  --path /data/workspace/skills/turbine-strategy/runtime-hunt.yaml
+
+openclaw senpi runtime list   # confirm both ACTIVE
 ```
+
+Each runtime attaches to its OWN wallet, so the runtime-phase-2 "one runtime per wallet" rule is satisfied.
 
 ### Step 7 — Start the producer daemon
 
-The v3.0 producer is a long-lived daemon. **Do NOT add an openclaw cron entry.**
+The v3.1 producer is a long-lived daemon. **Do NOT add an openclaw cron entry.**
 
 ```bash
 # Option A — supervised by tini:
@@ -140,45 +185,52 @@ tail -f /tmp/turbine-producer.log | jq -c 'select(.event=="daemon_tick_finished"
 
 Every line should show `status=ok`.
 
-| Status | Meaning | What to do |
-|---|---|---|
-| `ok` | Tick succeeded | Healthy |
-| `skipped_locked` | Lock collision | Confirm no inner `scanner_lock` was added inside `main()` |
-| `error` | `fn` raised | Read the `error` field |
-| `timeout` | `fn` took > 45s | Tune `tick_timeout` or check MCP latency |
+| Status | Meaning |
+|---|---|
+| `ok` | Tick succeeded |
+| `skipped_locked` | Lock collision (likely double-locking) |
+| `error` | `fn` raised |
+| `timeout` | `fn` took > 45s |
 
-`daemon_self_terminated_no_runtime` is normal when the volume runtime is deleted.
+`daemon_self_terminated_no_runtime` is normal when the volume runtime is deleted (the daemon's alive_check tracks the volume runtime; hunt can be deleted independently without stopping the daemon).
 
-## Verify volume + hunt are firing
+## Verify both wallets are firing
 
 ```bash
-tail -50 /tmp/turbine-producer.log | grep -v '"event"' | jq '.slots, .volume_emitted, .hunt_emitted, .current_cycle_min'
+tail -50 /tmp/turbine-producer.log | grep -v '"event"' | jq '
+  .volume_wallet, .volume_account_value, .slots,
+  .hunt_enabled, .hunt_wallet, .hunt_account_value,
+  .volume_emitted, .hunt_emitted, .current_cycle_min'
 ```
 
 Expected first 5 minutes:
-- `volume_emitted` populating with funding-fade signals
+- `volume_account_value` ≈ $3,500
+- `hunt_account_value` ≈ $2,400 (or `null` if hunt disabled)
 - `slots.volume.held` climbing toward 7
-- `hunt_emitted` typically empty (HYPE 4H breakouts are rare)
-- `current_cycle_min == 10` (or 12 if fill rate is low)
+- `slots.hunt.held` typically 0 (HYPE 4H breakouts are rare)
+- `volume_emitted` populating with funding-fade signals
+- `hunt_emitted` typically empty
+- `current_cycle_min == 10`
 
 ## What NOT to do
 
-- ❌ **Do NOT** add a second openclaw cron — the daemon supervises itself
-- ❌ **Do NOT** set `STRATEGY_ADDRESS` env var — banned per v2.0.9
+- ❌ **Do NOT** add an openclaw cron — the daemon supervises itself
+- ❌ **Do NOT** set `STRATEGY_ADDRESS` or `TURBINE_WALLET` env vars — both banned
+- ❌ **Do NOT** point both runtimes at the same wallet — runtime-phase-2 will reject the second install
 - ❌ **Do NOT** run Sentinel concurrently — hunt mode supersedes it
-- ❌ **Do NOT** lower `huntMinScore` below 10 without changing the scoring system
+- ❌ **Do NOT** lower `huntMinScore` below 10 — admits noise
 - ❌ **Do NOT** delete a runtime while positions are open — orphan-position bug
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Producer exits with `TURBINE_WALLET not set` | Env var missing | Export `TURBINE_WALLET` (NOT `STRATEGY_ADDRESS`) |
-| `volume push_signal rejected ... INVALID_REQUEST` | Scanner schema mismatch | Confirm runtime-volume.yaml is latest from main |
-| `volume push_signal rejected ... NOT_FOUND` | Volume runtime not registered | `openclaw senpi runtime list` |
-| Volume slots never fill past 3-4 | Spread gates too tight, fill rate low | Check `current_cycle_min` and per-asset spread distribution |
-| Hunt never fires | Score floor 10 is selective by design | Watch `state/<wallet-hash>/hunt-history.json` |
-| Account drops below `minAccountValueForHunt` | Volume side ate a drawdown | Hunt auto-pauses; volume continues. Top up OR lower the floor. |
+| Producer exits with `TURBINE_VOLUME_WALLET not set` | Env var missing | Export `TURBINE_VOLUME_WALLET` (NOT `TURBINE_WALLET`) |
+| Hunt slots never fire | `TURBINE_HUNT_WALLET` not set OR score floor 10 is selective | Check daemon's per-tick `hunt_enabled` field; check `hunt_skipped_reason` |
+| `volume push_signal rejected ... NOT_FOUND` | Volume runtime not registered to the volume wallet | `openclaw senpi runtime list`; confirm `external_scanner.name: turbine_volume_signals` matches producer |
+| `runtime for wallet X already running` on install | Volume + hunt runtime YAMLs both pointing at the same wallet | Confirm `${TURBINE_VOLUME_WALLET}` ≠ `${TURBINE_HUNT_WALLET}`; rerun env exports |
+| Volume slots never fill past 3-4 | Spread gates too tight, fill rate low | Check `current_cycle_min`; check per-asset spread distribution |
+| Account drops below `minHuntWalletBalance` | Hunt wallet ate a drawdown | Hunt auto-pauses; volume continues. Top up hunt wallet OR lower `minHuntWalletBalance`. |
 
 ## License
 

--- a/turbine/SKILL.md
+++ b/turbine/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: turbine-strategy
 description: >-
-  TURBINE v3.0 — two-mode signal emitter. One producer + two runtimes
-  on a single wallet. VOLUME (7 slots × 10-min funding-fade rotation,
-  XYZ-weighted 80/20) is a builder-fee-recycling volume engine on
-  Hyperliquid: pure breakeven trading P&L target, alpha is the net
-  spread between Senpi's builder-fee recycling (~3.5 bps RT) and HL
-  maker fees (~1.2-1.4 bps RT main, ~0.6 bps XYZ). HUNT (2 slots ×
-  HYPE 4H momentum, ratchet exit) rides directional moves with
-  score-gated entries (>=10 floor on multi-axis confluence). Single
-  long-lived producer_daemon + senpi_runtime_helpers in-process
-  wrapper (no mcporter / openclaw subprocess). Sentinel sunset —
-  hunt slots take over with explicit slot accounting.
+  TURBINE v3.1 — two-wallet, two-runtime, single-producer architecture.
+  ONE producer daemon manages BOTH wallets. The wallet boundary IS the
+  mode boundary, which gives clean per-mode P&L attribution at the
+  account level (no slot-mode tagging needed). VOLUME wallet (7 slots
+  × 10-min funding-fade rotation, XYZ-weighted 80/20) is a builder-fee-
+  recycling volume engine — pure breakeven trading P&L target, alpha
+  is the spread between Senpi's builder-fee recycling (~3.5 bps RT)
+  and HL maker fees (~1.2-1.4 bps RT main, ~0.6 bps XYZ). HUNT wallet
+  (2 slots × HYPE 4H momentum, ratchet exit) rides directional moves
+  with score-gated entries (>=10 floor on multi-axis confluence).
+  Hunt is optional — leave TURBINE_HUNT_WALLET unset to run a pure
+  volume engine. Sentinel sunset.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0.0"
+  version: "3.1.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -23,44 +24,60 @@ metadata:
     - senpi-runtime-helpers
 ---
 
-# 🌪️ TURBINE v3.0 — Volume Engine + HYPE Hunt
+# 🌪️ TURBINE v3.1 — Volume Engine + HYPE Hunt (two wallets)
 
-**The bot prints volume. Senpi prints rebates. Hunt slots scoop alpha when HYPE breaks.**
+**The bot prints volume. Senpi prints rebates. Hunt slots scoop alpha when HYPE breaks. Two wallets keep the books clean.**
+
+## Why two wallets
+
+The runtime-phase-2 plugin enforces **one runtime per wallet**. v3.0 attempted to attach `turbine-volume-tracker` AND `turbine-hunt-tracker` to a single wallet and got blocked at deploy. v3.1 splits cleanly:
+
+| Wallet | Runtime | Funding | Slots |
+|---|---|---|---|
+| Volume | `turbine-volume-tracker` | $3,500 | 7 × $500 |
+| Hunt | `turbine-hunt-tracker` | $2,400 | 2 × $1,200 |
+| **Total** | | **$5,900** | 9 |
+
+The wallet boundary is the mode boundary. `audit_query` filters per-wallet without needing a `signalType` join. HL margin is wallet-isolated, so volume side can't bleed into hunt and vice-versa — that's a feature, not a bug.
 
 ## Mission
 
-Hit **$5M/day in notional volume on Hyperliquid at <$100 net cost per $1M** while running 2 additional slots that take directional HYPE 4H momentum trades for upside.
+Hit **$5M/day in notional volume on Hyperliquid at <$100 net cost per $1M** while running 2 dedicated slots that take directional HYPE 4H momentum trades for upside.
 
-| Metric | v2.0.x baseline | v3.0 target |
+| Metric | v2.0.x baseline | v3.1 target |
 |---|---|---|
 | Daily volume | ~$2-3M | $5M |
 | Net cost per $1M volume | $200 | <$100 |
-| Total slots | 3 (volume only) | 9 (7 volume + 2 hunt) |
+| Total slots | 3 | 9 (7 vol + 2 hunt) |
 | Volume cycle | 15 min | 10 min (auto-fallback to 12 min) |
-| Funding | $1,500 | $6,000 |
+| Total funding | $1,500 | $5,900 |
 
 ## Architecture
 
-**Single producer, two runtimes, one wallet.**
-
 ```
-                 turbine-producer.py (long-lived daemon)
-                       │
-            ┌──────────┴──────────┐
-            │                     │
-   turbine_volume_signals    turbine_hunt_signals
-            │                     │
-   turbine-volume-tracker    turbine-hunt-tracker
-   (runtime-volume.yaml)    (runtime-hunt.yaml)
-            │                     │
-            └──────────┬──────────┘
-                       │
-                  Strategy wallet
+              turbine-producer.py (long-lived daemon)
+                     │
+            ┌────────┴────────┐
+            │                 │
+     reads volume       reads hunt
+       wallet            wallet
+            │                 │
+            ▼                 ▼
+     emits to:         emits to:
+   turbine_volume     turbine_hunt
+     _signals          _signals
+            │                 │
+   turbine-volume-     turbine-hunt-
+        tracker           tracker
+            │                 │
+            ▼                 ▼
+      VOLUME WALLET     HUNT WALLET
+      ($3,500)          ($2,400)
 ```
 
-The producer manages slot accounting (which positions are VOLUME vs HUNT), enforces post-close cooldowns, and emits to the appropriate scanner. Each runtime's DSL only manages positions it opened.
+ONE producer, TWO `cfg.get_*_wallet_and_strategy()` calls per tick, TWO independent slot accountings. Each wallet has its own runtime; each runtime's DSL only manages its own positions.
 
-## VOLUME mode — the volume engine
+## VOLUME mode
 
 ### Universe (tightened from v2.0.x)
 
@@ -81,7 +98,7 @@ NEUTRAL/FLAT  → alternate vs last_direction for this asset
 
 ### Spread gates (tightened)
 
-| DEX | v2.0.x | v3.0 |
+| DEX | v2.0.x | v3.1 |
 |---|---|---|
 | main | 5 bps | **3 bps** |
 | xyz | 15 bps | **10 bps** |
@@ -96,9 +113,9 @@ If realized maker fill rate (last 20 entries) < 85%:
 Fall back to 12 min until rate recovers
 ```
 
-State tracked in `state/<wallet-hash>/cycle-stats.json`. Operator overrides via `cycle.*` keys in `turbine-config.json`.
+State tracked in `state/<volume-wallet-hash>/cycle-stats.json`. Operator overrides via `cycle.*` keys in `turbine-config.json`.
 
-### Volume cost math (target)
+### Volume cost math
 
 ```
 Theoretical (perfect maker on both legs):
@@ -109,7 +126,7 @@ Theoretical (perfect maker on both legs):
 Weighted (80% XYZ / 20% main): +2.7 bps net positive theoretical
 ```
 
-Real-world cost includes spread crossings, taker fallthrough, and funding paid during 10-min holds. v3.0 targets **<$100/$1M actual** via tighter spread gates + 80/20 XYZ + maker-only ALO.
+Real-world cost includes spread crossings, taker fallthrough, and funding paid during 10-min holds. v3.1 targets **<$100/$1M actual** via tighter spread gates + 80/20 XYZ + maker-only ALO.
 
 ### Volume DSL preset (`runtime-volume.yaml`)
 
@@ -123,7 +140,7 @@ Real-world cost includes spread crossings, taker fallthrough, and funding paid d
 | Entry + exit order type | FEE_OPTIMIZED_LIMIT | Maker-only |
 | `ensure_execution_as_taker` | **false** | The strategy IS maker fills — taker fallback would invert the alpha |
 
-## HUNT mode — HYPE 4H momentum
+## HUNT mode
 
 ### Why HYPE only
 
@@ -155,11 +172,21 @@ Floor 10/15 means 4-5 components must fire — meaningful conviction, not first-
 | `phase1.max_loss_pct` | 30% (6% price move at 5x) |
 | `phase2 tiers` | 5/0, 10/35, 20/55, 35/75, 50/85 |
 
-### Hunt safety floor
+### Hunt safety
 
-- Per-asset cooldown: 60 min post-exit (producer mirrors runtime gate)
-- Account-equity floor: hunt slots blocked when account_value < $5,500 (preserves volume capital)
-- Daily entry cap: 6 (runtime guard rail)
+- **Per-asset cooldown:** 60 min post-exit (producer mirrors runtime gate)
+- **Hunt wallet balance floor:** $2,000 default. Producer skips hunt emission if hunt wallet's own balance falls below this. Volume capital is naturally protected by the wallet boundary — no need for the cross-mode equity floor v3.0 had.
+- **Daily entry cap:** 6 (runtime guard rail)
+
+## Hunt is optional
+
+If `TURBINE_HUNT_WALLET` is unset, hunt mode is disabled gracefully:
+
+- Producer only queries volume wallet
+- Producer only emits volume signals
+- Operator runs a pure volume engine with $5,900 in one wallet (or whatever they fund volume with)
+
+This is the simplest deploy path for operators who only want the volume engine.
 
 ## Risk gates summary
 
@@ -176,11 +203,17 @@ Floor 10/15 means 4-5 components must fire — meaningful conviction, not first-
 
 ```json
 {
-  "wallet": "0x...",
-  "strategyId": "...",
+  "volume": {
+    "wallet": "0xVolumeWallet...",
+    "strategyId": "volume-strategy-id"
+  },
+  "hunt": {
+    "wallet": "0xHuntWallet...",
+    "strategyId": "hunt-strategy-id"
+  },
   "chatId": "...",
   "slots":    { "volume": 7, "hunt": 2 },
-  "margin":   { "volume": 500, "hunt": 1250 },
+  "margin":   { "volume": 500, "hunt": 1200 },
   "leverage": { "volume": 5, "hunt": 5 },
   "cycle":    {
     "volumeDefaultMin": 10,
@@ -192,18 +225,23 @@ Floor 10/15 means 4-5 components must fire — meaningful conviction, not first-
   "spread":   { "mainBps": 3, "xyzBps": 10 },
   "xyzWeight": 0.80,
   "huntMinScore": 10,
-  "minAccountValueForHunt": 5500.0
+  "minHuntWalletBalance": 2000.0
 }
 ```
+
+To run pure volume engine (no hunt), leave `hunt.wallet` and `hunt.strategyId` empty strings, and don't export `TURBINE_HUNT_WALLET`.
 
 ## Required env vars
 
 | Var | Purpose |
 |---|---|
-| `TURBINE_WALLET` | Strategy wallet (must match BOTH runtime YAMLs). **STRATEGY_ADDRESS is BANNED** per v2.0.9 contamination rule. |
+| `TURBINE_VOLUME_WALLET` | Volume strategy wallet (REQUIRED). |
+| `TURBINE_HUNT_WALLET` | Hunt strategy wallet (optional; omit to disable hunt mode). |
 | `SENPI_AUTH_TOKEN` | Bearer token for MCP + signal POST. |
 | `TURBINE_VOLUME_DECISION_MODEL` | Bare LLM model name (no provider prefix) for volume gate. |
-| `TURBINE_HUNT_DECISION_MODEL` | Bare LLM model name for hunt gate. (Can be same as volume.) |
+| `TURBINE_HUNT_DECISION_MODEL` | Bare LLM model name for hunt gate. (Only used if hunt wallet set.) |
+
+**`STRATEGY_ADDRESS` and `TURBINE_WALLET` are BANNED.** STRATEGY_ADDRESS per the v2.0.9 contamination rule (a generic env var is a fleet-wide vector). TURBINE_WALLET was v3.0's single-wallet env var; v3.1 splits it explicitly. If you have either set from older testing, unset.
 
 ## Hard rule for user-conversation Claude sessions
 
@@ -213,18 +251,19 @@ User-conversation Claude sessions MUST NOT call `create_position`, `close_positi
 
 - ✓ **senpi_runtime_helpers** (in-process MCP + signal POST)
 - ✓ **producer_daemon scanner_lock** (PID-aliveness auto-recovery)
-- ✓ **TURBINE_WALLET only** (no STRATEGY_ADDRESS fallback per v2.0.9 rule)
+- ✓ **Per-wallet env vars** (TURBINE_VOLUME_WALLET / TURBINE_HUNT_WALLET; STRATEGY_ADDRESS + TURBINE_WALLET BANNED per v2.0.9 rule)
 - ✓ **Wallet-from-config** (no hardcoding; senpi-skills is public)
 - ✓ **drawdown_reset_on_day_rollover: false** on hunt runtime (Roach lesson)
-- ✓ **Slot-mode tracker** in `state/<wallet-hash>/slot-mode.json` — explicit per-position mode tagging
-- ✓ **Auto-fallback cycle length** based on rolling maker fill rate
-- ✓ **Account-equity hunt floor** ($5,500 default — preserves volume capital after drawdown)
+- ✓ **Wallet-isolated state dirs** (`state/<wallet-hash>/...` per wallet)
+- ✓ **Auto-fallback cycle length** based on rolling maker fill rate (volume side)
+- ✓ **Hunt wallet balance floor** (pauses hunt emission if hunt wallet draws down)
+- ✓ **`signal_type=` passed explicitly** per Rachin's review of Cheetah PR #209
 
 ## Sentinel sunset
 
-Sentinel previously ran on the same Turbine wallet, allocating $200 per slot for "convergence-based momentum trades using leftover margin." The blended-PnL problem made it impossible to attribute performance. v3.0's HUNT mode replaces it with explicit slot accounting and clean per-mode telemetry via `audit_query`.
+Sentinel previously co-ran on the legacy Turbine wallet, allocating $200 per slot for "convergence-based momentum trades using leftover margin." The blended-PnL problem made attribution impossible. v3.1's HUNT mode with its own wallet replaces it cleanly.
 
-Sentinel should be paused or retired before Turbine v3.0 deploys.
+Sentinel should be paused or retired before Turbine v3.1 deploys.
 
 ## Operator install
 

--- a/turbine/config/turbine-config.json
+++ b/turbine/config/turbine-config.json
@@ -1,6 +1,14 @@
 {
-  "wallet": "",
-  "strategyId": "",
+  "volume": {
+    "wallet": "",
+    "strategyId": ""
+  },
+
+  "hunt": {
+    "wallet": "",
+    "strategyId": ""
+  },
+
   "chatId": "",
 
   "slots": {
@@ -10,7 +18,7 @@
 
   "margin": {
     "volume": 500,
-    "hunt": 1250
+    "hunt": 1200
   },
 
   "leverage": {
@@ -34,5 +42,5 @@
 
   "xyzWeight": 0.80,
   "huntMinScore": 10,
-  "minAccountValueForHunt": 5500.0
+  "minHuntWalletBalance": 2000.0
 }

--- a/turbine/references/skill-attribution.md
+++ b/turbine/references/skill-attribution.md
@@ -4,7 +4,7 @@ When calling `strategy_create` or `strategy_create_custom_strategy`, always incl
 
 ```json
 "skill_name": "turbine",
-"skill_version": "3.0.0"
+"skill_version": "3.1.0"
 ```
 
 Required for attribution and tracking. Example:
@@ -16,7 +16,7 @@ Required for attribution and tracking. Example:
     "initialBudget": 6000,
     "positions": [],
     "skill_name": "turbine",
-    "skill_version": "3.0.0"
+    "skill_version": "3.1.0"
   }
 }
 ```

--- a/turbine/runtime-hunt.yaml
+++ b/turbine/runtime-hunt.yaml
@@ -12,10 +12,10 @@ description: >
   explicit slot accounting in the producer.
 
 strategy:
-  wallet: "${TURBINE_WALLET}"
-  budget: 6000
+  wallet: "${TURBINE_HUNT_WALLET}"
+  budget: 2400
   slots: 2
-  margin_per_slot: 1250
+  margin_per_slot: 1200
   trading_risk: balanced
   default_leverage: 5
   enabled: true

--- a/turbine/runtime-volume.yaml
+++ b/turbine/runtime-volume.yaml
@@ -9,8 +9,8 @@ description: >
   Trading P&L target: pure breakeven.
 
 strategy:
-  wallet: "${TURBINE_WALLET}"
-  budget: 6000
+  wallet: "${TURBINE_VOLUME_WALLET}"
+  budget: 3500
   slots: 7
   margin_per_slot: 500
   trading_risk: aggressive

--- a/turbine/scripts/turbine-producer.py
+++ b/turbine/scripts/turbine-producer.py
@@ -1,52 +1,68 @@
 #!/usr/bin/env python3
-# Senpi TURBINE Producer v3.0.0
+# Senpi TURBINE Producer v3.1.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-# Source: https://github.com/Senpi-ai/senpi-skills
-"""TURBINE v3.0 Producer — two-mode signal emitter.
+# Source: https://github.com/Senpi-ai/skills
+"""TURBINE v3.1 Producer — two-wallet, two-runtime, single daemon.
 
-VOLUME mode (7 slots, 10-min rotation):
-  Volume engine. Funding-fade direction. XYZ-heavy rotation (80/20)
-  for the lower fee floor. FEE_OPTIMIZED_LIMIT entries with
+v3.1 (2026-05-08) — two-wallet rewrite.
+
+The runtime-phase-2 plugin enforces ONE RUNTIME PER WALLET. v3.0
+attempted "two runtimes on one wallet" and got blocked at deploy
+when the second runtime install failed with "A runtime for wallet
+X is already running." v3.1 splits the architecture cleanly:
+
+  Wallet A (volume):  own runtime turbine-volume-tracker
+                      $3,500 funding ($500 × 7 slots)
+                      Funding-fade rotation, 10-min cycle, 80/20 XYZ/main
+
+  Wallet B (hunt):    own runtime turbine-hunt-tracker
+                      $2,400 funding ($1,200 × 2 slots)
+                      HYPE 4H momentum, score >= 10 floor, ratchet exit
+
+  ONE producer daemon reads both wallets and emits to both runtimes.
+  The wallet boundary IS the mode boundary — no more slot-mode
+  tagging needed. audit_query splits per-wallet trivially.
+
+VOLUME mode (Wallet A, 7 slots, 10-min rotation):
+  Volume engine. Funding-fade direction. XYZ-heavy 80/20 for the
+  lower fee floor. FEE_OPTIMIZED_LIMIT entries with
   ensure_execution_as_taker: false. DSL hard_timeout: 10min owns
-  the exit. No Phase 2. Pure breakeven thesis — profit comes from
-  Senpi's builder-fee recycling vs HL maker fee differential.
+  the exit. No Phase 2. Pure breakeven thesis — alpha is Senpi
+  builder-fee recycling vs HL maker fee differential.
 
-HUNT mode (2 slots, HYPE-only momentum):
-  HYPE 4H breakout rider. Score >= 10 floor on multi-axis confluence.
-  5x leverage, $1,250 margin. DSL Phase 2 ratchet enabled with
-  HYPE-tuned ladder. Up to 4h hold. Fills the gap left by Wolverine
-  v3.0 spec. Distinct asset + distinct timescale from VOLUME = clean
-  per-mode P&L attribution.
+HUNT mode (Wallet B, 2 slots, HYPE-only momentum):
+  HYPE 4H breakout rider. Score >= 10 floor on multi-axis
+  confluence. 5x leverage, $1,200 margin. DSL Phase 2 ratchet
+  enabled with HYPE-tuned ladder. Up to 4h hold. Distinct asset
+  + distinct timescale + distinct WALLET from VOLUME = clean P&L
+  attribution at the wallet level.
 
-Architecture: ONE producer + TWO runtimes on the same wallet:
-  - turbine-volume-tracker  — DSL: hard_timeout 10min, no Phase 2
-  - turbine-hunt-tracker    — DSL: hard_timeout 240min, Phase 2 ratchet
-
-v3.0 changes vs v2.0.x:
-  - senpi_runtime_helpers integration (no subprocess for MCP / signals)
-  - Long-lived producer_daemon replaces openclaw cron + agentTurn
-  - 3 → 9 slots (7 volume + 2 hunt). $6k funding requirement.
-  - Cycle 15min → 10min default; auto-fallback to 12min when realized
-    maker fill rate drops below 85%.
-  - Spread gates tightened: main 5→3 bps, XYZ 15→10 bps.
-  - Universe tightened: dropped TSLA + NVDA (wider spreads off-hours).
-  - 70/30 → 80/20 XYZ/main weighting.
-  - Sentinel sunset: hunt slots take over with explicit slot accounting.
-  - STRATEGY_ADDRESS env var REMOVED — only TURBINE_WALLET (per v2.0.9
-    contamination rule). Fail loud when missing.
+If TURBINE_HUNT_WALLET is unset, hunt mode is disabled gracefully
+— producer only emits volume signals. Lets operators run a pure
+volume engine without provisioning a second wallet.
 
 Required env vars:
-  TURBINE_WALLET                   — strategy wallet (must match runtimes)
+  TURBINE_VOLUME_WALLET            — volume strategy wallet (REQUIRED)
+  TURBINE_HUNT_WALLET              — hunt strategy wallet (optional;
+                                      omit to disable hunt mode)
   SENPI_AUTH_TOKEN                 — Bearer token for MCP + signal POST
   TURBINE_VOLUME_DECISION_MODEL    — bare model name for volume LLM gate
   TURBINE_HUNT_DECISION_MODEL      — bare model name for hunt LLM gate
+                                     (only used if hunt wallet set)
 
 Optional env vars (sensible defaults):
   SENPI_MCP_URL                    — default https://mcp.prod.senpi.ai/mcp
   SENPI_RUNTIME_API_HOST           — default 127.0.0.1
   SENPI_RUNTIME_API_PORT           — default 8787
   OPENCLAW_WORKSPACE               — default /data/workspace
+
+Banned env vars (per v2.0.9 contamination rule):
+  STRATEGY_ADDRESS  — generic env var; agent-specific vars only.
+  TURBINE_WALLET    — was v3.0's single-wallet env var; v3.1 splits
+                      it into TURBINE_VOLUME_WALLET + TURBINE_HUNT_WALLET.
+                      If you have TURBINE_WALLET exported from v3.0
+                      testing, unset it — v3.1 ignores it.
 """
 
 import hashlib
@@ -64,57 +80,51 @@ import turbine_config as cfg
 from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "3.0.0"
+VERSION = "3.1.0"
 
 # Scanner names — must match runtime-volume.yaml + runtime-hunt.yaml
 VOLUME_SCANNER_NAME = "turbine_volume_signals"
 HUNT_SCANNER_NAME = "turbine_hunt_signals"
 
 # Signal types — passed explicitly to push_signal() per Rachin's review
-# of Cheetah v7.0.0 (PR #209). Don't rely on scanner's defaultSignalType
-# fallback — runtime YAMLs here don't declare one. Distinct types per
-# mode also give audit_query a clean filter for per-mode P&L
-# attribution, which was a v3.0 design goal vs v2.0.x's blended numbers.
+# of Cheetah PR #209. The wrapper only forwards declared kwargs;
+# defaultSignalType in scanner config isn't reliable. Distinct types
+# per mode also give audit_query a free filter for per-mode P&L.
 VOLUME_SIGNAL_TYPE = "TURBINE_VOLUME_ROTATION"
 HUNT_SIGNAL_TYPE = "TURBINE_HUNT_HYPE_MOMENTUM"
 
 
 # ═══════════════════════════════════════════════════════════════
-# WALLET RESOLUTION (TURBINE_WALLET only — no STRATEGY_ADDRESS fallback)
+# WALLET RESOLUTION — two wallets, hunt is optional
 # ═══════════════════════════════════════════════════════════════
 
-def _resolve_wallet():
-    env = os.environ.get("TURBINE_WALLET", "").strip()
-    if env:
-        return env
-    return (cfg.load_config().get("wallet") or "").strip()
-
-
-TURBINE_WALLET = _resolve_wallet()
+VOLUME_WALLET, VOLUME_STRATEGY_ID = cfg.get_volume_wallet_and_strategy()
+HUNT_WALLET, HUNT_STRATEGY_ID = cfg.get_hunt_wallet_and_strategy()
+HUNT_ENABLED = bool(HUNT_WALLET)
 
 
 # ═══════════════════════════════════════════════════════════════
-# WALLET-ISOLATED STATE DIR
+# WALLET-ISOLATED STATE DIRS — one per wallet
 # ═══════════════════════════════════════════════════════════════
 
-def _wallet_state_dir():
-    h = (
-        hashlib.sha256(TURBINE_WALLET.lower().encode()).hexdigest()[:12]
-        if TURBINE_WALLET
-        else "unset"
-    )
+def _wallet_state_dir(wallet):
+    h = hashlib.sha256(wallet.lower().encode()).hexdigest()[:12] if wallet else "unset"
     d = cfg.SKILL_DIR / "state" / h
     d.mkdir(parents=True, exist_ok=True)
     return d
 
 
-_STATE_DIR = _wallet_state_dir()
-_SLOT_MODE_FILE = _STATE_DIR / "slot-mode.json"
-_PREV_HELD_FILE = _STATE_DIR / "prev-held.json"
-_LAST_CLOSED_FILE = _STATE_DIR / "last-closed.json"
-_CYCLE_STATS_FILE = _STATE_DIR / "cycle-stats.json"
-_HUNT_HISTORY_FILE = _STATE_DIR / "hunt-history.json"
-_ROTATION_INDEX_FILE = _STATE_DIR / "rotation-index.json"
+_VOLUME_STATE_DIR = _wallet_state_dir(VOLUME_WALLET)
+_VOLUME_LAST_CLOSED_FILE = _VOLUME_STATE_DIR / "last-closed.json"
+_VOLUME_PREV_HELD_FILE = _VOLUME_STATE_DIR / "prev-held.json"
+_VOLUME_CYCLE_STATS_FILE = _VOLUME_STATE_DIR / "cycle-stats.json"
+_VOLUME_ROTATION_INDEX_FILE = _VOLUME_STATE_DIR / "rotation-index.json"
+
+if HUNT_ENABLED:
+    _HUNT_STATE_DIR = _wallet_state_dir(HUNT_WALLET)
+    _HUNT_LAST_CLOSED_FILE = _HUNT_STATE_DIR / "last-closed.json"
+    _HUNT_PREV_HELD_FILE = _HUNT_STATE_DIR / "prev-held.json"
+    _HUNT_HISTORY_FILE = _HUNT_STATE_DIR / "hunt-history.json"
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -132,7 +142,7 @@ def _runtime_config():
         "volume_slots": int(slots.get("volume", 7)),
         "hunt_slots": int(slots.get("hunt", 2)),
         "volume_margin": float(margin.get("volume", 500)),
-        "hunt_margin": float(margin.get("hunt", 1250)),
+        "hunt_margin": float(margin.get("hunt", 1200)),
         "volume_leverage": float(leverage.get("volume", 5)),
         "hunt_leverage": float(leverage.get("hunt", 5)),
         "volume_cycle_default_min": float(cycle.get("volumeDefaultMin", 10)),
@@ -145,19 +155,20 @@ def _runtime_config():
         "spread_xyz_bps": float(spread.get("xyzBps", 10)),
         "xyz_weight": float(c.get("xyzWeight", 0.80)),
         "hunt_min_score": int(c.get("huntMinScore", 10)),
-        "min_account_value_for_hunt": float(c.get("minAccountValueForHunt", 5500.0)),
+        # Hunt wallet's own balance floor — pauses hunt emission if
+        # the hunt wallet itself draws down. Wallet boundary means
+        # volume capital is naturally protected; this just protects
+        # the hunt wallet from over-cycling after a bad streak.
+        "min_hunt_wallet_balance": float(c.get("minHuntWalletBalance", 2000.0)),
     }
 
 
 # ═══════════════════════════════════════════════════════════════
-# UNIVERSE (tightened from v2.0.x)
+# UNIVERSE
 # ═══════════════════════════════════════════════════════════════
 
-# Volume universe — only assets with deep books + tight spreads.
 VOLUME_XYZ = ["xyz:BRENTOIL", "xyz:GOLD", "xyz:SPX"]
 VOLUME_MAIN = ["BTC", "ETH", "SOL", "HYPE"]
-
-# Hunt universe — HYPE only.
 HUNT_ASSETS = ["HYPE"]
 
 
@@ -179,54 +190,76 @@ def _load_json(path, default):
         return default
 
 
-def load_slot_mode():
-    data = _load_json(_SLOT_MODE_FILE, {})
-    return data if isinstance(data, dict) else {}
+# Volume state
+def load_volume_prev_held():
+    return set(_load_json(_VOLUME_PREV_HELD_FILE, {"assets": []}).get("assets", []))
 
 
-def save_slot_mode(d):
-    cfg.atomic_write(str(_SLOT_MODE_FILE), d)
+def save_volume_prev_held(held):
+    cfg.atomic_write(str(_VOLUME_PREV_HELD_FILE),
+                     {"assets": sorted(list(held)), "updatedAt": cfg.now_iso()})
 
 
-def load_prev_held():
-    data = _load_json(_PREV_HELD_FILE, {"assets": []})
-    return set(data.get("assets", []))
+def load_volume_last_closed():
+    return _load_json(_VOLUME_LAST_CLOSED_FILE, {})
 
 
-def save_prev_held(held):
-    cfg.atomic_write(str(_PREV_HELD_FILE), {"assets": sorted(list(held)), "updatedAt": cfg.now_iso()})
-
-
-def load_last_closed():
-    return _load_json(_LAST_CLOSED_FILE, {})
-
-
-def save_last_closed(d):
-    cfg.atomic_write(str(_LAST_CLOSED_FILE), d)
+def save_volume_last_closed(d):
+    cfg.atomic_write(str(_VOLUME_LAST_CLOSED_FILE), d)
 
 
 def load_cycle_stats():
-    return _load_json(_CYCLE_STATS_FILE, {"window": []})
+    return _load_json(_VOLUME_CYCLE_STATS_FILE, {"window": []})
 
 
 def save_cycle_stats(d):
-    cfg.atomic_write(str(_CYCLE_STATS_FILE), d)
+    cfg.atomic_write(str(_VOLUME_CYCLE_STATS_FILE), d)
+
+
+def load_rotation_index():
+    return _load_json(_VOLUME_ROTATION_INDEX_FILE, {"index": 0})
+
+
+def save_rotation_index(d):
+    cfg.atomic_write(str(_VOLUME_ROTATION_INDEX_FILE), d)
+
+
+# Hunt state (only initialized if HUNT_ENABLED)
+def load_hunt_prev_held():
+    if not HUNT_ENABLED:
+        return set()
+    return set(_load_json(_HUNT_PREV_HELD_FILE, {"assets": []}).get("assets", []))
+
+
+def save_hunt_prev_held(held):
+    if not HUNT_ENABLED:
+        return
+    cfg.atomic_write(str(_HUNT_PREV_HELD_FILE),
+                     {"assets": sorted(list(held)), "updatedAt": cfg.now_iso()})
+
+
+def load_hunt_last_closed():
+    if not HUNT_ENABLED:
+        return {}
+    return _load_json(_HUNT_LAST_CLOSED_FILE, {})
+
+
+def save_hunt_last_closed(d):
+    if not HUNT_ENABLED:
+        return
+    cfg.atomic_write(str(_HUNT_LAST_CLOSED_FILE), d)
 
 
 def load_hunt_history():
+    if not HUNT_ENABLED:
+        return {"last_emitted_ts": 0, "scores": []}
     return _load_json(_HUNT_HISTORY_FILE, {"last_emitted_ts": 0, "scores": []})
 
 
 def save_hunt_history(d):
+    if not HUNT_ENABLED:
+        return
     cfg.atomic_write(str(_HUNT_HISTORY_FILE), d)
-
-
-def load_rotation_index():
-    return _load_json(_ROTATION_INDEX_FILE, {"index": 0})
-
-
-def save_rotation_index(d):
-    cfg.atomic_write(str(_ROTATION_INDEX_FILE), d)
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -234,7 +267,7 @@ def save_rotation_index(d):
 # ═══════════════════════════════════════════════════════════════
 
 def query_asset_data(asset):
-    """Spread + funding regime + candles for one asset. Returns dict or None."""
+    """Spread + funding regime + candles for one asset."""
     params = {
         "asset": asset,
         "candle_intervals": [],
@@ -303,9 +336,9 @@ def choose_volume_direction(regime, last_direction):
     return "LONG", "alternate_neutral"
 
 
-def pick_volume_asset(rot_idx, xyz_weight, held_set, slot_mode_map, last_closed):
-    """Pick next volume asset. Probabilistic XYZ/main weighting + deterministic
-    rotation index inside each pool. Skips held + post-close cooldown."""
+def pick_volume_asset(rot_idx, xyz_weight, held_set, last_closed):
+    """Pick next volume asset. Probabilistic XYZ/main weighting +
+    deterministic rotation index inside each pool."""
     use_xyz = random.random() < xyz_weight
     pool = VOLUME_XYZ if use_xyz else VOLUME_MAIN
     n = len(pool)
@@ -336,8 +369,8 @@ def pick_volume_asset(rot_idx, xyz_weight, held_set, slot_mode_map, last_closed)
 
 def emit_volume_signal(asset, direction, thesis, ad, slot_index,
                        leverage, margin_usd, current_cycle_min):
-    if not TURBINE_WALLET:
-        cfg.log("TURBINE_WALLET not set; cannot emit volume signal")
+    if not VOLUME_WALLET:
+        cfg.log("TURBINE_VOLUME_WALLET not set; cannot emit volume signal")
         return False
     data_block = {
         "mode": "VOLUME",
@@ -351,13 +384,9 @@ def emit_volume_signal(asset, direction, thesis, ad, slot_index,
         "isXyz": is_xyz(asset),
         "cycleMin": float(current_cycle_min),
     }
-    # signal_type explicit — per Rachin's review of Cheetah PR #209.
-    # The wrapper only forwards declared kwargs; anything else in the
-    # payload dict is dead weight, and the scanner has no
-    # defaultSignalType fallback declared in runtime-volume.yaml.
     try:
         cfg._wrapper_client.push_signal(
-            address=TURBINE_WALLET,
+            address=VOLUME_WALLET,
             scanner=VOLUME_SCANNER_NAME,
             asset=asset,
             direction=direction,
@@ -457,8 +486,8 @@ def score_hype_momentum(ad):
 
 
 def emit_hunt_signal(asset, direction, score, reasons, ad, leverage, margin_usd):
-    if not TURBINE_WALLET:
-        cfg.log("TURBINE_WALLET not set; cannot emit hunt signal")
+    if not HUNT_WALLET:
+        cfg.log("TURBINE_HUNT_WALLET not set; cannot emit hunt signal")
         return False
     data_block = {
         "mode": "HUNT",
@@ -472,7 +501,7 @@ def emit_hunt_signal(asset, direction, score, reasons, ad, leverage, margin_usd)
     }
     try:
         cfg._wrapper_client.push_signal(
-            address=TURBINE_WALLET,
+            address=HUNT_WALLET,
             scanner=HUNT_SCANNER_NAME,
             asset=asset,
             direction=direction,
@@ -486,18 +515,6 @@ def emit_hunt_signal(asset, direction, score, reasons, ad, leverage, margin_usd)
     except Exception as e:  # noqa: BLE001
         cfg.log(f"hunt push_signal exception for {asset} {direction}: {type(e).__name__}: {e}")
         return False
-
-
-# ═══════════════════════════════════════════════════════════════
-# SLOT MODE RECONCILIATION
-# ═══════════════════════════════════════════════════════════════
-
-def reconcile_slot_mode(slot_mode, current_held):
-    return {k: v for k, v in slot_mode.items() if k in current_held}
-
-
-def detect_closes(prev_held, current_held):
-    return prev_held - current_held
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -524,47 +541,68 @@ def main():
     """Single tick. NO inner scanner_lock — daemon owns it."""
     run_start = time.time()
 
-    if not TURBINE_WALLET:
+    if not VOLUME_WALLET:
         cfg.output({
             "status": "error",
-            "error": "TURBINE_WALLET not set. Set the env var or populate config/turbine-config.json wallet field. STRATEGY_ADDRESS is BANNED.",
+            "error": ("TURBINE_VOLUME_WALLET not set. Set the env var or "
+                      "populate config/turbine-config.json volume.wallet field. "
+                      "STRATEGY_ADDRESS and TURBINE_WALLET are BANNED."),
             "_turbine_producer_version": VERSION,
         })
         return
 
     rt = _runtime_config()
 
-    open_positions = cfg.get_open_positions(TURBINE_WALLET)
-    resting_orders = cfg.get_resting_orders(TURBINE_WALLET)
-    account_value = cfg.get_account_value(TURBINE_WALLET)
-    if account_value is None or account_value <= 0:
+    # ── VOLUME WALLET state ──
+    volume_positions = cfg.get_open_positions(VOLUME_WALLET)
+    volume_resting = cfg.get_resting_orders(VOLUME_WALLET)
+    volume_account_value = cfg.get_account_value(VOLUME_WALLET)
+    if volume_account_value is None or volume_account_value <= 0:
         cfg.output({
             "status": "ok",
-            "note": "cannot read account value; skip tick",
+            "note": "cannot read volume wallet account value; skip tick",
             "_turbine_producer_version": VERSION,
         })
         return
 
-    held_keys = {cfg.normalize_coin_key(p["coin"]) for p in open_positions}
-    held_keys.update(cfg.normalize_coin_key(o["coin"]) for o in resting_orders)
+    volume_held_keys = {cfg.normalize_coin_key(p["coin"]) for p in volume_positions}
+    volume_held_keys.update(cfg.normalize_coin_key(o["coin"]) for o in volume_resting)
+    free_volume = max(0, rt["volume_slots"] - len(volume_held_keys))
 
-    slot_mode = load_slot_mode()
-    slot_mode = reconcile_slot_mode(slot_mode, held_keys)
-
-    volume_held = sum(1 for v in slot_mode.values() if v.get("mode") == "VOLUME")
-    hunt_held = sum(1 for v in slot_mode.values() if v.get("mode") == "HUNT")
-    free_volume = max(0, rt["volume_slots"] - volume_held)
-    free_hunt = max(0, rt["hunt_slots"] - hunt_held)
-
-    prev_held = load_prev_held()
-    closed_keys = detect_closes(prev_held, held_keys)
-    if closed_keys:
-        last_closed = load_last_closed()
-        for k in closed_keys:
+    # Detect closes on volume wallet
+    prev_volume = load_volume_prev_held()
+    closed_volume = prev_volume - volume_held_keys
+    if closed_volume:
+        last_closed = load_volume_last_closed()
+        for k in closed_volume:
             last_closed[k] = {"ts": time.time(), "iso": cfg.now_iso()}
-        save_last_closed(last_closed)
-    save_prev_held(held_keys)
-    last_closed = load_last_closed()
+        save_volume_last_closed(last_closed)
+    save_volume_prev_held(volume_held_keys)
+    last_volume_closed = load_volume_last_closed()
+
+    # ── HUNT WALLET state (if enabled) ──
+    hunt_positions = []
+    hunt_resting = []
+    hunt_account_value = 0.0
+    hunt_held_keys = set()
+    free_hunt = 0
+    closed_hunt = set()
+    if HUNT_ENABLED:
+        hunt_positions = cfg.get_open_positions(HUNT_WALLET)
+        hunt_resting = cfg.get_resting_orders(HUNT_WALLET)
+        hunt_account_value = cfg.get_account_value(HUNT_WALLET) or 0.0
+        hunt_held_keys = {cfg.normalize_coin_key(p["coin"]) for p in hunt_positions}
+        hunt_held_keys.update(cfg.normalize_coin_key(o["coin"]) for o in hunt_resting)
+        free_hunt = max(0, rt["hunt_slots"] - len(hunt_held_keys))
+
+        prev_hunt = load_hunt_prev_held()
+        closed_hunt = prev_hunt - hunt_held_keys
+        if closed_hunt:
+            last_closed = load_hunt_last_closed()
+            for k in closed_hunt:
+                last_closed[k] = {"ts": time.time(), "iso": cfg.now_iso()}
+            save_hunt_last_closed(last_closed)
+        save_hunt_prev_held(hunt_held_keys)
 
     # ── VOLUME emission ──
     cycle_stats = load_cycle_stats()
@@ -576,7 +614,7 @@ def main():
     if free_volume > 0:
         for slot_idx in range(free_volume):
             asset, rot_idx = pick_volume_asset(
-                rot_idx, rt["xyz_weight"], held_keys, slot_mode, last_closed
+                rot_idx, rt["xyz_weight"], volume_held_keys, last_volume_closed
             )
             if asset is None:
                 break
@@ -586,32 +624,26 @@ def main():
             max_spread = rt["spread_xyz_bps"] if is_xyz(asset) else rt["spread_main_bps"]
             if ad["spread_bps"] > max_spread:
                 continue
-            coin_key = cfg.normalize_coin_key(asset)
-            last_dir = (slot_mode.get(coin_key, {}) or {}).get("last_direction", "")
-            direction, thesis = choose_volume_direction(ad["funding_regime"], last_dir)
+            direction, thesis = choose_volume_direction(ad["funding_regime"], "")
             if emit_volume_signal(
                 asset, direction, thesis, ad,
                 slot_idx, rt["volume_leverage"], rt["volume_margin"],
                 current_cycle_min,
             ):
                 volume_emitted.append({"asset": asset, "direction": direction, "thesis": thesis})
-                slot_mode[coin_key] = {
-                    "mode": "VOLUME",
-                    "entered_at": cfg.now_iso(),
-                    "last_direction": direction,
-                }
-                held_keys.add(coin_key)
+                # Mark as held for this tick to avoid double-emit
+                volume_held_keys.add(cfg.normalize_coin_key(asset))
 
     save_rotation_index({"index": rot_idx})
 
-    # ── HUNT emission ──
+    # ── HUNT emission (if enabled) ──
     hunt_emitted = []
     hunt_skipped_reason = None
-    if free_hunt > 0:
-        if account_value < rt["min_account_value_for_hunt"]:
+    if HUNT_ENABLED and free_hunt > 0:
+        if hunt_account_value < rt["min_hunt_wallet_balance"]:
             hunt_skipped_reason = (
-                f"account_value {account_value:.2f} < hunt_floor "
-                f"{rt['min_account_value_for_hunt']:.2f}"
+                f"hunt wallet balance {hunt_account_value:.2f} < floor "
+                f"{rt['min_hunt_wallet_balance']:.2f}"
             )
         else:
             hh = load_hunt_history()
@@ -624,8 +656,8 @@ def main():
             else:
                 for asset in HUNT_ASSETS:
                     coin_key = cfg.normalize_coin_key(asset)
-                    if coin_key in held_keys:
-                        hunt_skipped_reason = f"{coin_key} already held"
+                    if coin_key in hunt_held_keys:
+                        hunt_skipped_reason = f"{coin_key} already held on hunt wallet"
                         continue
                     ad = query_asset_data(asset)
                     if ad is None:
@@ -650,34 +682,36 @@ def main():
                             "asset": asset, "direction": direction,
                             "score": score, "reasons": reasons,
                         })
-                        slot_mode[coin_key] = {
-                            "mode": "HUNT",
-                            "entered_at": cfg.now_iso(),
-                            "score": score,
-                            "direction": direction,
-                        }
-                        held_keys.add(coin_key)
+                        hunt_held_keys.add(coin_key)
                         hh["last_emitted_ts"] = time.time()
                 hh["scores"] = hh.get("scores", [])[-50:]
                 save_hunt_history(hh)
 
-    save_slot_mode(slot_mode)
-
     elapsed = time.time() - run_start
     cfg.output({
         "status": "ok",
-        "account_value": round(account_value, 2),
-        "open_positions": len(open_positions),
-        "resting_orders": len(resting_orders),
+        "volume_wallet": VOLUME_WALLET[:10] + "...",
+        "volume_account_value": round(volume_account_value, 2),
+        "volume_positions": len(volume_positions),
+        "volume_resting": len(volume_resting),
+        "hunt_enabled": HUNT_ENABLED,
+        "hunt_wallet": HUNT_WALLET[:10] + "..." if HUNT_ENABLED else None,
+        "hunt_account_value": round(hunt_account_value, 2) if HUNT_ENABLED else None,
+        "hunt_positions": len(hunt_positions),
+        "hunt_resting": len(hunt_resting),
         "slots": {
-            "volume": {"max": rt["volume_slots"], "held": volume_held, "free": free_volume},
-            "hunt":   {"max": rt["hunt_slots"],   "held": hunt_held,   "free": free_hunt},
+            "volume": {"max": rt["volume_slots"], "held": len(volume_held_keys), "free": free_volume},
+            "hunt":   {"max": rt["hunt_slots"] if HUNT_ENABLED else 0,
+                       "held": len(hunt_held_keys), "free": free_hunt},
         },
         "current_cycle_min": current_cycle_min,
         "volume_emitted": volume_emitted,
         "hunt_emitted": hunt_emitted,
         "hunt_skipped_reason": hunt_skipped_reason,
-        "closed_this_tick": sorted(list(closed_keys)),
+        "closed_this_tick": {
+            "volume": sorted(list(closed_volume)),
+            "hunt": sorted(list(closed_hunt)),
+        },
         "elapsed_sec": round(elapsed, 2),
         "_turbine_producer_version": VERSION,
     })
@@ -686,18 +720,30 @@ def main():
 # ═══════════════════════════════════════════════════════════════
 # DAEMON ENTRYPOINT
 # ═══════════════════════════════════════════════════════════════
+#
+# Single daemon manages BOTH wallets. Lock name uses VOLUME_WALLET
+# hash since volume is the operationally-critical mission.
+#
+# alive_check is configured for the volume wallet's runtime — if
+# turbine-volume-tracker is deleted OR the volume scanner is renamed,
+# the daemon self-terminates. Hunt runtime can be deleted independently
+# without affecting the daemon (operator notices via failed
+# push_signal logs and decides to restart manually if needed).
+#
+# Do NOT add an inner scanner_lock(...) inside main() — fcntl flock
+# is not reentrant; nested call raises BlockingIOError every tick.
 
 if __name__ == "__main__":
     _wallet_lock_id = (
-        hashlib.sha256(TURBINE_WALLET.lower().encode()).hexdigest()[:12]
-        if TURBINE_WALLET
+        hashlib.sha256(VOLUME_WALLET.lower().encode()).hexdigest()[:12]
+        if VOLUME_WALLET
         else "unset"
     )
     producer_daemon(
         fn=main,
         interval_seconds=60,
         name=f"turbine-producer-{_wallet_lock_id}",
-        wallet=TURBINE_WALLET,
+        wallet=VOLUME_WALLET,                # volume runtime is alive-check'd
         scanner=VOLUME_SCANNER_NAME,
         tick_timeout=45,
     )

--- a/turbine/scripts/turbine_config.py
+++ b/turbine/scripts/turbine_config.py
@@ -1,17 +1,28 @@
-"""TURBINE v3.0 — Shared config + state I/O + helpers wrapper.
+"""TURBINE v3.1 — Shared config + state I/O + helpers wrapper.
 
-v3.0 (2026-05-08) — full rewrite. Volume-engine + HYPE-momentum hunt.
-Helpers-based (matches Pangolin v2.2 / Cheetah v7.0.0 patterns):
+v3.1 (2026-05-08) — two-wallet rewrite. The runtime-phase-2 plugin
+enforces one runtime per wallet, so v3.0's "two runtimes on one
+wallet" architecture won't deploy. v3.1 splits into TWO Senpi
+strategy wallets — each with its own runtime — managed by ONE
+producer daemon. The wallet boundary is the mode boundary, which
+ends up cleaner than v3.0's slot-mode tagging.
+
+  Wallet A (volume): own runtime turbine-volume-tracker, $3,500
+                     ($500 × 7 slots), funding-fade rotation.
+  Wallet B (hunt):   own runtime turbine-hunt-tracker,   $2,400
+                     ($1,200 × 2 slots), HYPE 4H momentum.
+
+Helpers-based (matches Cheetah v7.0.0 / Pangolin v2.2 patterns):
   - SenpiClient via lazy proxy (auth-validated on first use)
-  - mcporter_call() shim for backward-compat call sites in producer
+  - mcporter_call() shim for backward-compat call sites
   - _wrapper_client exposed for direct push_signal access
 
-Per-wallet state under SKILL_DIR/state/<wallet-hash>/:
-  - slot-mode.json    — {coin: "VOLUME"|"HUNT", entered_at, slot_id}
+Per-wallet state lives under SKILL_DIR/state/<wallet-hash>/:
   - last-closed.json  — close timestamps (post-close cooldown)
   - prev-held.json    — previous-tick held set (close detection)
-  - cycle-stats.json  — rolling fill-rate window (auto-fallback gate)
-  - hunt-history.json — HYPE 4H breakout score history
+  - cycle-stats.json  — rolling fill-rate window (volume only)
+  - hunt-history.json — HYPE 4H breakout score history (hunt only)
+  - rotation-index.json — volume rotation pointer
 """
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
@@ -90,17 +101,37 @@ def load_config():
     return {}
 
 
-def get_wallet_and_strategy():
-    """Resolve wallet + strategyId from env (preferred) → config (fallback).
-    TURBINE_WALLET only — STRATEGY_ADDRESS is BANNED per v2.0.9 contamination
-    rule."""
-    wallet = os.environ.get("TURBINE_WALLET", "").strip()
-    strategy_id = os.environ.get("TURBINE_STRATEGY_ID", "").strip()
+def get_volume_wallet_and_strategy():
+    """Resolve VOLUME wallet + strategyId. Env (TURBINE_VOLUME_WALLET /
+    TURBINE_VOLUME_STRATEGY_ID) preferred → config.volume.{wallet,strategyId}
+    fallback. STRATEGY_ADDRESS is BANNED per v2.0.9 contamination rule."""
+    wallet = os.environ.get("TURBINE_VOLUME_WALLET", "").strip()
+    strategy_id = os.environ.get("TURBINE_VOLUME_STRATEGY_ID", "").strip()
     if not wallet or not strategy_id:
-        c = load_config()
+        c = load_config().get("volume", {}) or {}
         wallet = wallet or (c.get("wallet") or "").strip()
         strategy_id = strategy_id or (c.get("strategyId") or "").strip()
     return wallet, strategy_id
+
+
+def get_hunt_wallet_and_strategy():
+    """Resolve HUNT wallet + strategyId. Env (TURBINE_HUNT_WALLET /
+    TURBINE_HUNT_STRATEGY_ID) preferred → config.hunt.{wallet,strategyId}
+    fallback. Empty wallet means hunt mode is disabled — producer
+    only emits volume signals (graceful degradation)."""
+    wallet = os.environ.get("TURBINE_HUNT_WALLET", "").strip()
+    strategy_id = os.environ.get("TURBINE_HUNT_STRATEGY_ID", "").strip()
+    if not wallet or not strategy_id:
+        c = load_config().get("hunt", {}) or {}
+        wallet = wallet or (c.get("wallet") or "").strip()
+        strategy_id = strategy_id or (c.get("strategyId") or "").strip()
+    return wallet, strategy_id
+
+
+def get_wallet_and_strategy():
+    """Backward-compat shim: returns the volume wallet. Existing call
+    sites that ask for "the" wallet are operating on volume mode."""
+    return get_volume_wallet_and_strategy()
 
 
 # ─── MCP wrapper shim ─────────────────────────────────────


### PR DESCRIPTION
## Summary

v3.0 deploy hit a hard blocker: the runtime-phase-2 plugin enforces **one runtime per wallet**. v3.0 attempted to attach `turbine-volume-tracker` AND `turbine-hunt-tracker` to a single wallet and got rejected on the second install:

> Error: A runtime for wallet 0xbcb3... is already running (runtime turbine-volume-tracker-b3c7). Stop it first.

v3.1 splits cleanly into TWO Senpi strategy wallets, each with its own runtime, managed by ONE producer daemon. The wallet boundary IS the mode boundary.

## Architecture

| Wallet | Runtime | Funding | Slots |
|---|---|---|---|
| Volume | `turbine-volume-tracker` | $3,500 | 7 × $500 |
| Hunt | `turbine-hunt-tracker` | $2,400 | 2 × $1,200 |
| **Total** | | **$5,900** | 9 |

Single producer reads both wallets, emits to both runtimes. Each runtime attaches to its own wallet (constraint satisfied). `audit_query` filters per-wallet for free P&L attribution.

## Key changes vs v3.0

**Config schema** (turbine-config.json):
- `wallet`/`strategyId` → `volume.{wallet,strategyId}` + `hunt.{wallet,strategyId}`
- Empty hunt wallet → hunt mode disabled gracefully (operator can run pure volume engine)
- `minAccountValueForHunt` (cross-mode floor, no longer needed) → `minHuntWalletBalance` (hunt wallet's own floor)
- Hunt margin default $1,250 → $1,200 (matches $5,900 = 7×$500 + 2×$1,200 exact)

**Env vars:**
- `TURBINE_WALLET` (BANNED) → `TURBINE_VOLUME_WALLET` (REQUIRED) + `TURBINE_HUNT_WALLET` (optional)
- `STRATEGY_ADDRESS` still BANNED per v2.0.9 contamination rule

**Producer:**
- Two `get_*_wallet_and_strategy()` helpers
- Two account-state queries per tick (one per wallet)
- Slot-mode tracker dropped (wallet IS the mode)
- Per-wallet state dirs (`state/<volume-hash>/`, `state/<hunt-hash>/`)
- Hunt-disabled graceful degradation when `TURBINE_HUNT_WALLET` unset
- Daemon `alive_check` tracks volume runtime (operationally critical); hunt can be deleted independently

**Runtimes:**
- `runtime-volume.yaml`: wallet `${TURBINE_VOLUME_WALLET}`, budget 3500
- `runtime-hunt.yaml`: wallet `${TURBINE_HUNT_WALLET}`, budget 2400

## Pure-volume mode (hunt optional)

Operators who only want the volume engine can:
- Provision only the volume wallet, fund $5,900 in it
- Leave `hunt.wallet` empty in config + don't export `TURBINE_HUNT_WALLET`
- Don't install runtime-hunt.yaml
- Producer skips hunt emission silently each tick

This is the simplest deploy path.

## Operator deploy notes

Provisioning sequence:
1. Sunset legacy Turbine v2.0.x + Sentinel
2. **Provision TWO Senpi strategy wallets** — volume + hunt
3. Fund each separately: $3,500 to volume wallet, $2,400 to hunt wallet
4. Pull helpers package (one-time per host)
5. Pull Turbine v3.1 files
6. Configure `volume.{wallet,strategyId}` + `hunt.{wallet,strategyId}` in config.json
7. Export `TURBINE_VOLUME_WALLET` + `TURBINE_HUNT_WALLET` (NOT `TURBINE_WALLET`)
8. Install BOTH runtimes — each attaches to its own wallet
9. Start single daemon
10. Smoke test

Full sequence in README.md.

## Pitfall scan

| Pitfall | v3.1 | Verdict |
|---|---|---|
| Inner `scanner_lock` inside fn | None — daemon owns the lock | ✅ |
| `alive_check=None` | Not passed (default `/state` probe via volume wallet+scanner) | ✅ |
| `STRATEGY_ADDRESS` env | BANNED + checked | ✅ |
| `TURBINE_WALLET` (legacy v3.0) | BANNED + checked; producer ignores it | ✅ |
| `## Skill Attribution` section | Present + skill-attribution.md updated to 3.1.0 | ✅ |
| Lock name format | `f"turbine-producer-{sha256(volume_wallet.lower())[:12]}"` | ✅ |
| `score` placement | Inside `data` block | ✅ |
| `asset`/`direction`/`signal_type` placement | Top-level on `push_signal()` (Rachin's fix from PR #209) | ✅ |
| Two runtimes on one wallet | Architecturally prevented (separate wallet env vars) | ✅ |

## Test plan

### Pre-deploy
- [ ] Confirm legacy Turbine v2.0.x + Sentinel both stopped
- [ ] Provision two new Senpi strategy wallets (capture both addresses + strategyIds)
- [ ] Fund volume wallet $3,500 USDC
- [ ] Fund hunt wallet $2,400 USDC
- [ ] Verify runtime plugin >= 2.0.0
- [ ] Edit config/turbine-config.json with both wallets
- [ ] Export TURBINE_VOLUME_WALLET + TURBINE_HUNT_WALLET (NOT TURBINE_WALLET)

### Deploy
- [ ] Pull helpers package
- [ ] Pull Turbine v3.1 files
- [ ] Install volume runtime: `openclaw senpi runtime create --path runtime-volume.yaml`
- [ ] Confirm volume runtime ACTIVE
- [ ] Install hunt runtime: `openclaw senpi runtime create --path runtime-hunt.yaml`
- [ ] Confirm hunt runtime ACTIVE (the second install was the v3.0 blocker; should succeed now since hunt has its own wallet)
- [ ] Start daemon
- [ ] Smoke test: daemon_tick_finished status=ok every 60s

### Smoke test
- [ ] Per-tick output shows both `volume_wallet` and `hunt_wallet` populated
- [ ] `volume_account_value` ≈ $3,500
- [ ] `hunt_account_value` ≈ $2,400
- [ ] `slots.volume.held` climbing toward 7
- [ ] `current_cycle_min == 10`
- [ ] No `signal_post: ... INVALID_REQUEST` rejections
- [ ] No `signal_post: ... NOT_FOUND` rejections (would indicate runtime mismatch)

### Weekend run
- [ ] Daily volume on track to \$5M (672 round-trips/day at 10-min × 7 slots × \$5K)
- [ ] Net cost per \$1M after first 24h
- [ ] Hunt mode: 1-3 HYPE breakouts/day max expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)