### PR TITLE
Kodiak v7.0.0 — senpi_runtime_helpers migration

### DIFF
--- a/kodiak/README.md
+++ b/kodiak/README.md
@@ -1,29 +1,142 @@
-# 🐻 KODIAK v2.0 — SOL Alpha Hunter
+# 🐻 KODIAK v7.0.0 — SOL Alpha Hunter (senpi_runtime_helpers)
 
-Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-## Thesis
+SOL-only alpha hunter. Single-asset focus. Multi-factor scoring (SM consensus + trend structure + momentum + funding + OI + BTC correlation + RSI). Conviction-tiered leverage (5x default, 6x at score 11+, 7x apex at score 13+).
 
-SOL-only lifecycle hunter. Three modes: HUNT (scan for entry) → RIDE (DSL trails) → STALK (watch for reload). Based on Grizzly's BTC lifecycle, adapted for SOL's volatility.
+## What changed in v7.0.0
 
-## v2.0 Highlights
+**Plumbing-only migration. NO thesis change.** v6.0.1's scoring tables, leverage tiers, asset cooldown, base-tech-score floor are all preserved verbatim.
 
-- **+$134 on a single SOL SHORT** — DSL trailed to Tier 4, locked 85% of peak
-- Thesis exit removed — DSL manages all exits
-- DSL state includes wallet + size (fixes the bug that left positions unprotected)
-- Leverage capped at 7x (was 10-12x)
-- Retrace widened to 0.08 (positions hold through normal SOL oscillation)
+- `kodiak-producer.py` and `kodiak_config.py` migrate to `senpi_runtime_helpers`:
+  - MCP calls go via `SenpiClient.mcp_call()` (direct HTTPS) instead of `mcporter` subprocess
+  - Signal emission goes via `SenpiClient.push_signal()` (direct HTTP POST) instead of `openclaw senpi external-scanner ingest` subprocess
+  - Reentrancy lock owned by `producer_daemon.scanner_lock` (PID-aliveness auto-recovery) instead of hand-rolled `fcntl`
+  - Tick scheduling owned by `producer_daemon` (long-lived process) instead of openclaw cron + `agentTurn`
+- Requires `senpi-trading-runtime >= 2.0.0` (the runtime-phase-2 build).
+- `runtime.yaml` unchanged. `external_scanner.name: kodiak_signals` matches the producer's `client.push_signal(scanner=...)`.
+- Per Rachin's review of Cheetah PR #209: dead fields stripped from `build_signal_payload`; `signal_type="KODIAK_SOL_THESIS"` passed explicitly.
 
-## Key Settings
+## Thesis (preserved from v6.0.1)
+
+SOL alpha hunter. Single-asset focus. v5.1 base-tech-score floor:
+
+| Component | Threshold | Note |
+|---|---|---|
+| MIN_SCORE | 10 | Multi-factor composite |
+| MIN_MOM_15M_PCT | 0.1% | 15-min momentum floor |
+| MIN_TREND_STRENGTH_4H | 0.75 | 4 of 5 higher-lows / lower-highs |
+| RSI_LONG_MAX | 72 | Don't chase overbought |
+| RSI_SHORT_MIN | 28 | Don't chase oversold |
+| ASSET_COOLDOWN_MINUTES | 240 | 4h post-emit cooldown |
+
+Conviction-tiered leverage:
+
+| Score | Leverage | Label |
+|---|---|---|
+| 13+ | 7x | apex |
+| 11-12 | 6x | conviction |
+| 10 | 5x | standard |
+
+## Install
+
+### Step 1 — Pull the helpers package (one-time per host)
+
+```bash
+mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
+for f in __init__.py _config.py _logging.py cache.py client.py \
+         daemon.py lock.py parallel.py SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
+    -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
+done
+```
+
+Skip if already pulled for Cheetah v7.0.0 / Turbine v3.2 / another v3 skill.
+
+### Step 2 — Pull Kodiak v7.0.0
+
+```bash
+mkdir -p /data/workspace/skills/kodiak-strategy/{config,scripts,state,references}
+
+for f in scripts/kodiak-producer.py scripts/kodiak_config.py \
+         SKILL.md README.md references/skill-attribution.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/kodiak/$f" \
+    -o "/data/workspace/skills/kodiak-strategy/$f"
+done
+```
+
+`runtime.yaml` is unchanged from v6.x — don't touch the existing runtime.
+
+### Step 3 — Required env vars
+
+```bash
+export KODIAK_WALLET=<your-kodiak-wallet>       # NOT STRATEGY_ADDRESS
+export SENPI_AUTH_TOKEN=...
+export KODIAK_DECISION_MODEL=gemini-3.1-pro-preview   # bare model name
+```
+
+Optional (sensible defaults):
+
+| Env var | Default |
+|---|---|
+| `SENPI_MCP_URL` | `https://mcp.prod.senpi.ai/mcp` |
+| `SENPI_RUNTIME_API_HOST` | `127.0.0.1` |
+| `SENPI_RUNTIME_API_PORT` | `8787` |
+| `OPENCLAW_WORKSPACE` | `/data/workspace` |
+| `KODIAK_MARGIN_PCT` | `0.20` |
+
+### Step 4 — Stop the v6.x cron, start the v7.0.0 daemon
+
+```bash
+# Find and delete the v6.x cron
+openclaw cron list | grep kodiak
+openclaw cron delete <kodiak-cron-id>
+```
+
+Start the daemon (long-lived process, no cron):
+
+```bash
+# Option A — supervised by tini:
+exec tini -- python3 -u /data/workspace/skills/kodiak-strategy/scripts/kodiak-producer.py
+
+# Option B — nohup:
+nohup python3 -u /data/workspace/skills/kodiak-strategy/scripts/kodiak-producer.py \
+  > /tmp/kodiak-producer.log 2>&1 &
+```
+
+## Smoke test after deploy
+
+```bash
+tail -f /tmp/kodiak-producer.log | jq -c 'select(.event=="daemon_tick_finished")' | head -3
+```
+
+Expected: every line shows `status=ok`. Kodiak's tick interval is 180s (3 min) so the first tick fires shortly after startup.
+
+| Status | Meaning | What to do |
+|---|---|---|
+| `ok` | Tick succeeded | Healthy |
+| `skipped_locked` | Lock collision | Confirm no inner `scanner_lock` was added |
+| `error` | `fn` raised | Read the `error` field |
+| `timeout` | `fn` took > 240s | Check MCP latency |
+
+`daemon_self_terminated_no_runtime` is normal when the runtime is deleted.
+
+## Key parameters
 
 | Setting | Value |
 |---|---|
 | Asset | SOL only |
-| Leverage | 7x max |
+| Leverage | 5x / 6x / 7x (score-tiered) |
 | Max positions | 1 |
-| Entry score | 10+ |
-| DSL retrace | 0.08 |
-| Trailing tiers | 7%/40%, 12%/55%, 15%/75%, 20%/85% |
+| MIN_SCORE | 10 |
+| Asset cooldown | 240 min |
+| Margin per trade | 20% of account value |
+
+## What NOT to do
+
+- ❌ **Do NOT** add an openclaw cron — the daemon supervises itself
+- ❌ **Do NOT** set `STRATEGY_ADDRESS` env var — banned per v2.0.9
+- ❌ **Do NOT** delete the runtime — runtime.yaml unchanged from v6.x; orphan-position bug applies if positions are open
 
 ## License
 

--- a/kodiak/SKILL.md
+++ b/kodiak/SKILL.md
@@ -1,23 +1,28 @@
 ---
 name: kodiak-strategy
 description: >-
-  KODIAK v2.0 — SOL alpha hunter with position lifecycle. Thesis exit removed.
-  DSL manages all exits. Leverage capped at 7x. Retrace widened to 0.08.
-  v1.1.1's SOL SHORT ran 13 hours unprotected due to missing wallet fields —
-  v2.0 prevents this.
-  DSL exit managed by plugin runtime via runtime.yaml.
+  KODIAK v7.0.0 — SOL alpha hunter, senpi_runtime_helpers migration.
+  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
+  to in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST to
+  runtime /signals, long-lived producer_daemon). Thesis preserved
+  verbatim from v6.0.1: SOL alpha hunter, single-asset focus, v5.1
+  base-tech-score floor with multi-factor scoring (SM consensus,
+  trend structure, momentum, funding, OI, BTC correlation, RSI),
+  conviction-tiered leverage (5x default, 6x conviction at score 11+,
+  7x apex at score 13+), 240-min asset cooldown.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "2.0"
+  version: "7.0.0"
   platform: senpi
   exchange: hyperliquid
   base_skill: grizzly-v2.0
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=2.0.0
+    - senpi-runtime-helpers
 ---
 
-# 🐻 KODIAK v2.0 — SOL Alpha Hunter
+# 🐻 KODIAK v7.0.0 — SOL Alpha Hunter
 
 One asset. Every signal. Scanner enters. DSL exits.
 

--- a/kodiak/references/skill-attribution.md
+++ b/kodiak/references/skill-attribution.md
@@ -4,7 +4,7 @@ When calling `strategy_create` or `strategy_create_custom_strategy`, always incl
 
 ```json
 "skill_name": "kodiak",
-"skill_version": "2.0"
+"skill_version": "7.0.0"
 ```
 
 This is required for attribution and tracking. Example:
@@ -16,7 +16,7 @@ This is required for attribution and tracking. Example:
     "initialBudget": 500,
     "positions": [],
     "skill_name": "kodiak",
-    "skill_version": "2.0"
+    "skill_version": "7.0.0"
   }
 }
 ```

--- a/kodiak/scripts/kodiak-producer.py
+++ b/kodiak/scripts/kodiak-producer.py
@@ -1,30 +1,41 @@
 #!/usr/bin/env python3
-# Senpi KODIAK Producer v6.0.1
+# Senpi KODIAK Producer v7.0.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
-# Source: https://github.com/Senpi-ai/skills
-"""KODIAK v6.0.1 Producer — SOL Alpha Hunter (v2-runtime-native + 5x lev fix).
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""KODIAK v7.0.0 Producer — senpi_runtime_helpers migration.
 
-v6.0.1 (2026-05-04 hot-patch — runtime.yaml only):
-  Entry-side ensure_execution_as_taker false → true. v6.0 shipped
-  with the value as `false` intending "cancel-and-skip" semantics,
-  but runtime behavior diverged: order rests on book indefinitely,
-  action marked SKIPPED but order eventually fills via natural
-  price action, producing realized PnL with broken telemetry.
-  Forces taker fallback after 60s ALO timeout. Producer code
-  unchanged from v6.0.0.
+v7.0.0 (2026-05-08) — plumbing migration. NO thesis change. SOL
+alpha hunter logic, v5.1 base-tech-score floor, multi-factor scoring,
+5x leverage default — all preserved verbatim from v6.0.1.
 
-v6.0 — full v1 → v2 architecture migration. SOL alpha hunter.
-Single-asset focus. v5.1 base-tech-score floor + multi-factor
-scoring preserved. Leverage default dropped 10x → 5x (v5.1's 10x
-on SOL chop = -17.8% ROE / -$178 over 26 trades).
+Six-layer plumbing flip per migration-cookbook (matches Cheetah v7.0.0
+/ Pangolin v2.2 patterns):
+  1. MCP calls — cfg.mcporter_call() shim now routes through
+     SenpiClient.mcp_call() (direct HTTPS, no mcporter subprocess).
+     Existing call sites unchanged.
+  2. Signal emit — subprocess.run(["openclaw","senpi","external-scanner",
+     "ingest"...]) replaced by cfg._wrapper_client.push_signal(...).
+     Direct HTTP POST to runtime API on 127.0.0.1:8787/signals.
+     CRITICAL: asset/direction/signal_type at top-level kwargs (Rachin's
+     review on Cheetah PR #209 — dead fields in payload dict are NOT
+     forwarded to the wire).
+  3. Reentrancy — hand-rolled fcntl flock dropped. producer_daemon
+     owns per-tick scanner_lock with stale-PID auto-recovery.
+  4. Tick scheduling — openclaw cron + agentTurn replaced by
+     producer_daemon (long-lived process; zero per-tick LLM cost).
+  5. Per-tick cache + parallel fan-out NOT adopted (matches Pangolin
+     reference minimum-change pattern).
+  6. /state alive_check — daemon self-terminates if runtime deleted
+     or scanner renamed.
+
+v6.0.1 thesis preserved unchanged (SOL alpha hunter, single-asset focus,
+v5.1 base-tech-score floor, leverage default 5x).
 """
 
-import fcntl
 import hashlib
 import json
 import os
-import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -33,13 +44,24 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import kodiak_config as cfg
 
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
-VERSION = "6.0.0"   # producer code unchanged in v6.0.1 (runtime.yaml only)
+
+VERSION = "7.0.0"
+
+# Hardcoded — must match runtime.yaml external_scanner.name. Removing the
+# env var override eliminates a source of mismatch (Cheetah v7.0.0 pattern).
+SCANNER_NAME = "kodiak_signals"
+
+# Signal type passed explicitly to push_signal() per Rachin's review of
+# Cheetah PR #209. Don't rely on scanner's defaultSignalType fallback —
+# many runtime YAMLs (including Kodiak's) don't declare one.
+SIGNAL_TYPE = "KODIAK_SOL_THESIS"
 
 # v6.0: Agent-specific wallet env var. NO fallback to STRATEGY_ADDRESS
+# (banned per Turbine v2.0.9 contamination rule — a generic env var is
+# a fleet-wide vector if a sibling agent on the same host sets it).
 KODIAK_WALLET = os.environ.get("KODIAK_WALLET", "")
-SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "kodiak_signals")
-OPENCLAW_BIN = os.environ.get("OPENCLAW_BIN", "openclaw")
 MARGIN_PCT = float(os.environ.get("KODIAK_MARGIN_PCT", "0.20"))
 
 ASSET = "SOL"
@@ -60,36 +82,13 @@ def _wallet_state_dir():
 
 
 _STATE_DIR = _wallet_state_dir()
-_LOCK_PATH = _STATE_DIR / "producer.lock"
 _COOLDOWN_FILE = _STATE_DIR / "asset-cooldowns.json"
 
 
-# ═══════════════════════════════════════════════════════════════
-# REENTRANCY GUARD
-# ═══════════════════════════════════════════════════════════════
-
-def acquire_lock():
-    try:
-        f = open(_LOCK_PATH, "w")
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        f.write(f"{os.getpid()} {int(time.time())}\n")
-        f.flush()
-        return f
-    except (IOError, OSError, BlockingIOError):
-        return None
-
-
-def release_lock(lock_file):
-    if lock_file is None:
-        return
-    try:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-    except Exception:
-        pass
-    try:
-        lock_file.close()
-    except Exception:
-        pass
+# Reentrancy guard removed in v7.0.0. producer_daemon owns the per-tick
+# scanner_lock with stale-PID auto-recovery via os.kill(pid, 0). Do NOT
+# add an inner scanner_lock(...) inside main() — fcntl flock is not
+# reentrant; nested call raises BlockingIOError.
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -540,17 +539,23 @@ def build_sol_thesis():
 # ═══════════════════════════════════════════════════════════════
 
 def build_signal_payload(thesis, leverage, margin_usd):
-    """All declared scanner fields go in `data`, NOT `meta`. (Turbine v2.0.11.)"""
+    """v7.0.0: returns only the fields push_signal() actually forwards.
+
+    Per Rachin's review of Cheetah PR #209: the wrapper-era push_signal()
+    only passes declared kwargs (address, scanner, asset, direction,
+    score, signal_type, data) to the wire. Everything else in a payload
+    dict is dead weight at best, schema-rejected at worst. Strip them.
+
+    asset / direction → top-level kwargs on push_signal() (routing)
+    Everything else → goes inside `data` block (validated against
+                       runtime.yaml external_scanner.config.fields).
+    score stays inside data — Kodiak's composite is unbounded int 0-20,
+    not 0..1 confidence (matches Cheetah/Pangolin reference rationale).
+    """
     sm = thesis.get("sm", {}) or {}
     return {
-        "address": KODIAK_WALLET,
-        "scannerId": SCANNER_NAME,
-        "signalType": "KODIAK_SOL_THESIS",
         "asset": thesis["asset"],
         "direction": thesis["direction"],
-        "score": float(thesis["score"]),
-        "timestamp": int(time.time() * 1000),
-        "factors": {},
         "data": {
             "score": thesis["score"],
             "leverage": leverage,
@@ -571,39 +576,35 @@ def build_signal_payload(thesis, leverage, margin_usd):
             "rsi": thesis["rsi"],
             "reasons": " | ".join(thesis.get("reasons", [])),
         },
-        "meta": {
-            "_kodiak_producer_version": VERSION,
-        },
     }
 
 
 def push_signal(payload):
+    """Push a signal payload to the runtime via senpi_runtime_helpers.
+
+    Direct HTTP POST to runtime API on 127.0.0.1; no subprocess.
+    asset/direction/signal_type at top-level kwargs; data block carries
+    scanner-config-validated fields only. Returns True on accepted
+    ingest, False on transport / schema rejection.
+    """
     if not KODIAK_WALLET:
         cfg.log("KODIAK_WALLET env var not set; cannot push signal")
         return False
-
-    cmd = [
-        OPENCLAW_BIN, "senpi", "external-scanner", "ingest",
-        "--address", KODIAK_WALLET,
-        "--scanner", SCANNER_NAME,
-        "--payload", json.dumps(payload),
-    ]
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
-        if r.returncode != 0:
-            cfg.log(f"ingest failed for {payload['asset']} {payload['direction']}: {r.stderr.strip()}")
-            return False
-        if r.stdout.strip():
-            try:
-                response = json.loads(r.stdout)
-                if isinstance(response, dict) and response.get("ok") is False:
-                    cfg.log(f"ingest rejected: {response.get('error')}")
-                    return False
-            except (json.JSONDecodeError, TypeError):
-                pass
+        cfg._wrapper_client.push_signal(
+            address=KODIAK_WALLET,
+            scanner=SCANNER_NAME,
+            asset=payload.get("asset"),
+            direction=payload.get("direction"),
+            signal_type=SIGNAL_TYPE,
+            data=payload.get("data"),
+        )
         return True
-    except (subprocess.TimeoutExpired, OSError) as e:
-        cfg.log(f"ingest exception for {payload['asset']}: {e}")
+    except SenpiClientError as e:
+        cfg.log(f"push_signal rejected for {payload.get('asset')} {payload.get('direction')}: {e}")
+        return False
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        cfg.log(f"push_signal exception for {payload.get('asset')}: {type(e).__name__}: {e}")
         return False
 
 
@@ -617,98 +618,99 @@ def main():
     if not KODIAK_WALLET:
         cfg.output({
             "status": "error",
-            "error": "KODIAK_WALLET env var not set. Set it to the Kodiak strategy wallet (must match runtime.yaml).",
+            "error": "KODIAK_WALLET env var not set. Set it to the Kodiak strategy wallet (must match runtime.yaml). STRATEGY_ADDRESS is BANNED.",
             "_kodiak_producer_version": VERSION,
         })
         return
 
-    lock = acquire_lock()
-    if lock is None:
-        print(json.dumps({
-            "status": "skip",
-            "reason": "previous run still active — cron reentrancy guard",
-            "_kodiak_producer_version": VERSION,
-        }))
-        return
+    # NB: no scanner_lock here. producer_daemon owns the per-tick lock.
 
-    try:
-        # 1. Read account value for sizing
-        account_value, pos_count = get_account_value()
-        if account_value is None or account_value <= 0:
-            cfg.output({
-                "status": "ok",
-                "note": "cannot read account value; skip tick",
-                "_kodiak_producer_version": VERSION,
-            })
-            return
-
-        # 2. Per-asset cooldown (defense-in-depth alongside runtime guard)
-        if is_asset_cooled_down(ASSET):
-            cfg.output({
-                "status": "ok",
-                "note": f"{ASSET} in 240min cooldown",
-                "_kodiak_producer_version": VERSION,
-            })
-            return
-
-        # 3. Build thesis (v5.1 logic preserved)
-        thesis = build_sol_thesis()
-
-        if thesis.get("blocked"):
-            cfg.output({
-                "status": "ok",
-                "note": f"thesis_blocked: {thesis['reason']}",
-                "_kodiak_producer_version": VERSION,
-            })
-            return
-
-        # 4. MIN_SCORE gate
-        if thesis["score"] < MIN_SCORE:
-            cfg.output({
-                "status": "ok",
-                "note": f"score_below_min: {thesis['score']} < {MIN_SCORE}",
-                "thesis_direction": thesis["direction"],
-                "reasons_preview": thesis["reasons"][:3],
-                "_kodiak_producer_version": VERSION,
-            })
-            return
-
-        # 5. Compute sizing + leverage
-        leverage, lev_label = get_leverage_for_score(thesis["score"])
-        margin_usd = round(account_value * MARGIN_PCT, 2)
-
-        # 6. Emit
-        payload = build_signal_payload(thesis, leverage, margin_usd)
-        pushed = 1 if push_signal(payload) else 0
-        if pushed:
-            mark_asset_emitted(ASSET)
-
-        elapsed = time.time() - run_start
-        warn = "WARN_OVER_180S" if elapsed > 180 else None
+    # 1. Read account value for sizing
+    account_value, pos_count = get_account_value()
+    if account_value is None or account_value <= 0:
         cfg.output({
             "status": "ok",
-            "asset": ASSET,
-            "direction": thesis["direction"],
-            "score": thesis["score"],
-            "leverage": leverage,
-            "lev_label": lev_label,
-            "margin_usd": margin_usd,
-            "signals_pushed": pushed,
-            "account_value": round(account_value, 2),
-            "open_positions": pos_count,
-            "elapsed_sec": round(elapsed, 2),
-            "warn": warn,
+            "note": "cannot read account value; skip tick",
             "_kodiak_producer_version": VERSION,
         })
-    finally:
-        release_lock(lock)
+        return
+
+    # 2. Per-asset cooldown (defense-in-depth alongside runtime guard)
+    if is_asset_cooled_down(ASSET):
+        cfg.output({
+            "status": "ok",
+            "note": f"{ASSET} in 240min cooldown",
+            "_kodiak_producer_version": VERSION,
+        })
+        return
+
+    # 3. Build thesis (v5.1 logic preserved)
+    thesis = build_sol_thesis()
+
+    if thesis.get("blocked"):
+        cfg.output({
+            "status": "ok",
+            "note": f"thesis_blocked: {thesis['reason']}",
+            "_kodiak_producer_version": VERSION,
+        })
+        return
+
+    # 4. MIN_SCORE gate
+    if thesis["score"] < MIN_SCORE:
+        cfg.output({
+            "status": "ok",
+            "note": f"score_below_min: {thesis['score']} < {MIN_SCORE}",
+            "thesis_direction": thesis["direction"],
+            "reasons_preview": thesis["reasons"][:3],
+            "_kodiak_producer_version": VERSION,
+        })
+        return
+
+    # 5. Compute sizing + leverage
+    leverage, lev_label = get_leverage_for_score(thesis["score"])
+    margin_usd = round(account_value * MARGIN_PCT, 2)
+
+    # 6. Emit
+    payload = build_signal_payload(thesis, leverage, margin_usd)
+    pushed = 1 if push_signal(payload) else 0
+    if pushed:
+        mark_asset_emitted(ASSET)
+
+    elapsed = time.time() - run_start
+    warn = "WARN_OVER_180S" if elapsed > 180 else None
+    cfg.output({
+        "status": "ok",
+        "asset": ASSET,
+        "direction": thesis["direction"],
+        "score": thesis["score"],
+        "leverage": leverage,
+        "lev_label": lev_label,
+        "margin_usd": margin_usd,
+        "signals_pushed": pushed,
+        "account_value": round(account_value, 2),
+        "open_positions": pos_count,
+        "elapsed_sec": round(elapsed, 2),
+        "warn": warn,
+        "_kodiak_producer_version": VERSION,
+    })
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as e:
-        cfg.log(f"CRITICAL ERROR: {e}")
-        import traceback
-        traceback.print_exc(file=sys.stderr)
-        cfg.output({"status": "error", "error": str(e)})
+    # v7.0.0 — long-lived daemon. Replaces openclaw cron + agentTurn.
+    # producer_daemon owns the per-tick scanner_lock with stale-PID
+    # auto-recovery. alive_check left UNSET (default) — daemon
+    # self-terminates if the runtime for KODIAK_WALLET is deleted OR
+    # the kodiak_signals scanner is renamed.
+    _wallet_lock_id = (
+        hashlib.sha256(KODIAK_WALLET.lower().encode()).hexdigest()[:12]
+        if KODIAK_WALLET
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=180,           # Kodiak's v6.x cron was every 3 min
+        name=f"kodiak-producer-{_wallet_lock_id}",
+        wallet=KODIAK_WALLET,
+        scanner=SCANNER_NAME,
+        tick_timeout=240,               # producer's WARN_OVER_180S budget + headroom
+    )

--- a/kodiak/scripts/kodiak_config.py
+++ b/kodiak/scripts/kodiak_config.py
@@ -1,20 +1,17 @@
-"""KODIAK v6 — Shared MCP helper + atomic state I/O + output helpers.
+"""KODIAK v7.0.0 — Shared config + MCP shim + state I/O + output helpers.
 
-v6.0 producer responsibilities are narrower than v5.x:
-  - Fetch market data via MCP (market_get_asset_data,
-    leaderboard_get_markets, strategy_get_clearinghouse_state)
-  - Push signals via `openclaw senpi external-scanner ingest`
-    (runtime owns execution)
-
-This module is the MCP call helper + state I/O atomic write helper.
-All state lives in state/<wallet-hash>/ JSON files.
+v7.0.0: senpi_runtime_helpers migration. mcporter_call now routes
+through SenpiClient.mcp_call() (direct HTTPS) instead of mcporter
+subprocess. _wrapper_client is exposed for the producer's signal
+push (cfg._wrapper_client.push_signal(...)). All other helpers
+preserved verbatim.
 """
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 
+import functools
 import json
 import os
-import subprocess
 import sys
 import tempfile
 import time
@@ -24,6 +21,40 @@ from pathlib import Path
 WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
 SKILL_DIR = Path(WORKSPACE) / "skills" / "kodiak-strategy"
 CONFIG_PATH = SKILL_DIR / "config" / "kodiak-config.json"
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+# Pattern ported verbatim from pangolin/cheetah_config.py: mount the
+# helpers package at module load, defer SenpiClient construction
+# until first attribute access. SENPI_AUTH_TOKEN validated explicitly
+# on first use — missing token raises a loud RuntimeError instead of
+# silently 401-ing on the first MCP call.
+
+_helpers_path = str(Path(WORKSPACE) / "skills" / "_helpers")
+if _helpers_path not in sys.path:
+    sys.path.insert(0, _helpers_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Kodiak's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("kodiak_wrapper_enabled", helpers_path=_helpers_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
 
 
 # ─── Config ──────────────────────────────────────────────────
@@ -61,36 +92,22 @@ def atomic_write(path, data):
 # ─── MCP Helper ──────────────────────────────────────────────
 
 def mcporter_call(tool, retries=2, timeout=25, **params):
-    """Call a Senpi MCP tool via mcporter. Returns parsed JSON or None on failure."""
-    args = json.dumps(params) if params else "{}"
-    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
-    for attempt in range(retries):
-        try:
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-            if r.returncode != 0:
-                if attempt < retries - 1:
-                    time.sleep(2)
-                    continue
-                return None
-            raw = json.loads(r.stdout)
-            if isinstance(raw, dict) and "content" in raw:
-                content = raw["content"]
-                if isinstance(content, list) and content:
-                    first = content[0]
-                    if isinstance(first, dict) and "text" in first:
-                        try:
-                            return json.loads(first["text"])
-                        except (json.JSONDecodeError, TypeError):
-                            pass
-            return raw
-        except subprocess.TimeoutExpired:
-            if attempt < retries - 1:
-                time.sleep(2)
-                continue
-            return None
-        except (json.JSONDecodeError, Exception):
-            return None
-    return None
+    """Call a Senpi MCP tool via the senpi_runtime_helpers wrapper.
+
+    v7.0.0: routes through SenpiClient.mcp_call() — direct HTTPS, no
+    mcporter subprocess. Returns the unwrapped JSON document on
+    success, or None if the wrapper raised. `retries` parameter
+    preserved for call-site compat but not implemented — daemon
+    recovers transient failures on the next tick (3 min).
+    """
+    try:
+        return _wrapper_client.mcp_call(tool, timeout=timeout, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] kodiak_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
 
 
 def output(data):


### PR DESCRIPTION
## Summary

Plumbing-only migration from v6.0.1 to v7.0.0. NO thesis change. SOL alpha hunter logic, multi-factor scoring, conviction-tiered leverage (5x/6x/7x), 240-min asset cooldown all preserved verbatim.

Three commits per the per-skill PR layout:

1. **producer-rewrite** (`be7b765`) — drops fcntl + subprocess, adds `producer_daemon`, rewrites `push_signal()` and `build_signal_payload()` per Rachin's PR #209 review (dead fields stripped, `signal_type=` passed explicitly).
2. **config-shim** (`b8ed95c`) — adds the lazy `SenpiClient` proxy + delegating `mcporter_call` shim, ported verbatim from `pangolin_config.py`.
3. **doc-bump** (`b791e5f`) — SKILL.md/README.md/skill-attribution.md version sync from v2.0 → v7.0.0 (was 5+ majors behind), README rewritten with full operator install guide.

## Compatibility

- `senpi-trading-runtime >= 2.0.0`
- `_helpers/senpi_runtime_helpers/` mounted on host
- Required env: `KODIAK_WALLET`, `SENPI_AUTH_TOKEN`, `KODIAK_DECISION_MODEL`
- `STRATEGY_ADDRESS` BANNED per Turbine v2.0.9 contamination rule
- `runtime.yaml` UNCHANGED from v6.x (no need to drop+recreate runtime)

## Pitfall scan

| Pitfall | v7.0.0 | Verdict |
|---|---|---|
| Inner `scanner_lock` inside fn | None | ✅ |
| `alive_check=None` | Not passed | ✅ |
| `STRATEGY_ADDRESS` env | Not used; `KODIAK_WALLET` only | ✅ |
| `## Skill Attribution` section | Already present in SKILL.md | ✅ |
| `signal_type=` explicit | "KODIAK_SOL_THESIS" passed as kwarg | ✅ |
| Dead fields in build_signal_payload | Stripped (was building address/scannerId/timestamp/factors/meta) | ✅ |
| Lock name format | `f"kodiak-producer-{sha256(wallet.lower())[:12]}"` | ✅ |

## Test plan

- [ ] Operator pulls helpers package (skip if already present)
- [ ] Operator pulls Kodiak v7.0.0 producer + config + docs
- [ ] Operator stops v6.x cron
- [ ] Operator starts v7.0.0 daemon (tini or nohup)
- [ ] `daemon_tick_finished status=ok` every 3 min
- [ ] `[senpi_helpers]` events appear in stderr
- [ ] Tick `duration_ms` drops to ~1-3s typical (was 30-60s under mcporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)