### PR TITLE
fleet-fix: drop wallet=/scanner= from producer_daemon (host helpers don't support yet)

### DIFF
--- a/cheetah/scripts/cheetah-producer.py
+++ b/cheetah/scripts/cheetah-producer.py
@@ -944,11 +944,18 @@ if __name__ == "__main__":
         if CHEETAH_WALLET
         else "unset"
     )
+    # NOTE: senpi_runtime_helpers.daemon.producer_daemon installed on the
+    # runtime host (Erik's build) does NOT yet accept wallet=/scanner=
+    # kwargs even though the helper-mcp-envelope-aligned branch's source
+    # signature documents them. Caught live on Turbine v3.2 deploy
+    # 2026-05-08: TypeError: unexpected keyword argument 'wallet'.
+    # When the host helpers package is upgraded, add back:
+    #   wallet=CHEETAH_WALLET,
+    #   scanner=SCANNER_NAME,
+    # which enables /state alive_check (auto-terminate on runtime delete).
     producer_daemon(
         fn=main,
         interval_seconds=300,
         name=f"cheetah-producer-{_wallet_lock_id}",
-        wallet=CHEETAH_WALLET,        # enables default /state alive_check
-        scanner=SCANNER_NAME,         # daemon self-terminates if deleted
         tick_timeout=360,
     )

--- a/kodiak/scripts/kodiak-producer.py
+++ b/kodiak/scripts/kodiak-producer.py
@@ -706,11 +706,18 @@ if __name__ == "__main__":
         if KODIAK_WALLET
         else "unset"
     )
+    # NOTE: senpi_runtime_helpers.daemon.producer_daemon installed on the
+    # runtime host (Erik's build) does NOT yet accept wallet=/scanner=
+    # kwargs even though the helper-mcp-envelope-aligned branch's source
+    # signature documents them. Caught live on Turbine v3.2 deploy
+    # 2026-05-08: TypeError: unexpected keyword argument 'wallet'.
+    # When the host helpers package is upgraded, add back:
+    #   wallet=KODIAK_WALLET,
+    #   scanner=SCANNER_NAME,
+    # which enables /state alive_check.
     producer_daemon(
         fn=main,
         interval_seconds=180,           # Kodiak's v6.x cron was every 3 min
         name=f"kodiak-producer-{_wallet_lock_id}",
-        wallet=KODIAK_WALLET,
-        scanner=SCANNER_NAME,
         tick_timeout=240,               # producer's WARN_OVER_180S budget + headroom
     )

--- a/turbine/scripts/turbine-producer.py
+++ b/turbine/scripts/turbine-producer.py
@@ -576,11 +576,18 @@ if __name__ == "__main__":
         if VOLUME_WALLET
         else "unset"
     )
+    # NOTE: senpi_runtime_helpers.daemon.producer_daemon installed on the
+    # runtime host (Erik's build) does NOT yet accept wallet=/scanner=
+    # kwargs even though the helper-mcp-envelope-aligned branch's source
+    # signature documents them. Caught live on Turbine v3.2 deploy
+    # 2026-05-08: TypeError: unexpected keyword argument 'wallet'.
+    # When the host helpers package is upgraded, add back:
+    #   wallet=VOLUME_WALLET,
+    #   scanner=VOLUME_SCANNER_NAME,
+    # which enables /state alive_check on the volume runtime.
     producer_daemon(
         fn=main,
         interval_seconds=60,
         name=f"turbine-producer-{_wallet_lock_id}",
-        wallet=VOLUME_WALLET,
-        scanner=VOLUME_SCANNER_NAME,
         tick_timeout=45,
     )


### PR DESCRIPTION
## Summary

Fix for the bug Turbine operator caught on v3.2 deploy 2026-05-08:

> TypeError: producer_daemon() got an unexpected keyword argument 'wallet'

The host's installed `senpi_runtime_helpers.daemon.producer_daemon` doesn't yet accept `wallet=` / `scanner=` kwargs, even though the `helper-mcp-envelope-aligned` branch's source documents them (daemon.py lines 104-105).

Folding the operator's local patch back into main across all three merged migrations (Cheetah v7.0.0, Turbine v3.2, Kodiak v7.0.0) before the Cheetah / Kodiak operators hit the same boot failure on their deploys.

## What's lost

`/state` alive_check — daemon won't auto-terminate when the runtime is deleted or scanner is renamed. Operator has to kill the daemon manually if they swap runtimes.

## Restoration path

When Erik upgrades the host helpers package to a version that accepts `wallet=` / `scanner=`, the comment block above each `producer_daemon(...)` call documents the exact kwargs to add back. Single-line additions per file.

## Pattern for the 11 remaining migrations

Polar / Wolverine / Grizzly / Scorpion / Vulture / Roach-b / Roach / Pangolin / Jackal / Otter / Spider / Kestrel will all use the post-fix `producer_daemon(...)` shape (just `fn`, `interval_seconds`, `name`, `tick_timeout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)