### PR TITLE
Polar v5.0.0 — senpi_runtime_helpers migration

### DIFF
--- a/polar/README.md
+++ b/polar/README.md
@@ -1,31 +1,78 @@
-# 🐻‍❄️ POLAR v4.0.0 — ETH Alpha Hunter (v2-runtime-native)
+# 🐻‍❄️ POLAR v5.0.0 — ETH Alpha Hunter (senpi_runtime_helpers)
 
-Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-## What changed in v4.0
+## What changed in v5.0.0
 
-- `polar-producer.py` (NEW) replaces `polar-scanner.py` (DELETED)
-- v2-runtime-native: external_scanner + LLM-pass-through gate + native `risk.guard_rails`
-- DSL exits via `FEE_OPTIMIZED_LIMIT` (saves ~0.020-0.030% per maker-filled close)
-- Trade chain DB emits `LIFECYCLE_RUNTIME_STARTED → DECISION_EXECUTED → ACTION_RESULT → DSL_CREATED → DSL_CLOSED` for every trade — per-trade telemetry restored
-- v3.x scoring + DSL preset preserved EXACTLY (proved correct on 2026-04-23 ETH Short locking +$71.15 via Phase 2; current live ETH LONG running +$54 unrealized at +5% margin ROE)
-- The Python-state-crash class of bug from v3.x (`load_tc` / `set_cooldown` / `has_resting_orders`) is structurally impossible in v4.0 (state owned by runtime)
+**Plumbing-only migration. NO thesis change.** v4.2.0's scoring tables, leverage tiers, MIN_SCORE 12, quiet hours, DSL preset are all preserved verbatim.
 
-## Thesis (preserved from v3.x)
+- `polar-producer.py` and `polar_config.py` migrate to `senpi_runtime_helpers`:
+  - MCP calls go via `SenpiClient.mcp_call()` (direct HTTPS) instead of `mcporter` subprocess
+  - Signal emission goes via `SenpiClient.push_signal()` (direct HTTP POST) instead of `openclaw senpi external-scanner ingest` subprocess
+  - Reentrancy lock owned by `producer_daemon.scanner_lock` instead of hand-rolled `fcntl`
+  - Tick scheduling owned by `producer_daemon` (long-lived process) instead of openclaw cron + `agentTurn`
+- Requires `senpi-trading-runtime >= 2.0.0`.
+- `runtime.yaml` unchanged. `external_scanner.name: polar_signals` matches the producer's `client.push_signal(scanner=...)`.
+- Per Rachin's review of Cheetah PR #209: dead fields stripped from payload; `signal_type="POLAR_ETH_HYBRID"` passed explicitly.
 
-Single-asset ETH lifecycle hunter. Scores ETH using Hyperfeed Smart Money concentration, multi-timeframe trend structure, candle-based confirmation, and funding/OI/BTC-correlation context. Enters on high conviction (MIN_SCORE 14, scoring max ~17), lets DSL manage all exits via Phase 2 trailing.
+## Thesis (preserved from v4.2.0)
+
+ETH single-asset hybrid hunter. Hyperfeed Smart Money gates (pct≥5%, traders≥30, cc_15m≥0.3 acceleration), structural gates (4h trend != NEUTRAL, 4h-1h-15m alignment, RSI not extreme), multi-factor scoring (~17 max), conviction-tiered leverage (5x/7x/10x), MIN_SCORE 12 floor, FP-001 quiet hours (00-04 UTC unless apex score 17+).
 
 ## Install
 
-```bash
-mkdir -p /data/workspace/skills/polar-strategy/{config,scripts,state}
+### Step 1 — Pull the helpers package (one-time per host)
 
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/polar/runtime.yaml -o /data/workspace/skills/polar-strategy/runtime.yaml
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/polar/SKILL.md -o /data/workspace/skills/polar-strategy/SKILL.md
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/polar/config/polar-config.json -o /data/workspace/skills/polar-strategy/config/polar-config.json
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/polar/scripts/polar-producer.py -o /data/workspace/skills/polar-strategy/scripts/polar-producer.py
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/polar/scripts/polar_config.py -o /data/workspace/skills/polar-strategy/scripts/polar_config.py
+```bash
+mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
+for f in __init__.py _config.py _logging.py cache.py client.py \
+         daemon.py lock.py parallel.py SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
+    -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
+done
 ```
+
+Skip if already pulled for Cheetah / Turbine / Kodiak / another v3 skill.
+
+### Step 2 — Pull Polar v5.0.0
+
+```bash
+mkdir -p /data/workspace/skills/polar-strategy/{config,scripts,state,references}
+for f in scripts/polar-producer.py scripts/polar_config.py \
+         SKILL.md README.md references/skill-attribution.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/polar/$f" \
+    -o "/data/workspace/skills/polar-strategy/$f"
+done
+```
+
+`runtime.yaml` is unchanged from v4.x — don't touch the existing runtime.
+
+### Step 3 — Required env vars
+
+```bash
+export POLAR_WALLET_ADDRESS=<your-polar-wallet>   # NOT STRATEGY_ADDRESS
+export SENPI_AUTH_TOKEN=...
+export POLAR_DECISION_MODEL=gemini-3.1-pro-preview
+```
+
+### Step 4 — Stop the v4.x cron, start the v5.0.0 daemon
+
+```bash
+openclaw cron list | grep polar
+openclaw cron delete <polar-cron-id>
+
+# Start daemon (long-lived, no cron)
+nohup python3 -u /data/workspace/skills/polar-strategy/scripts/polar-producer.py \
+  > /tmp/polar-producer.log 2>&1 &
+```
+
+## Smoke test
+
+```bash
+tail -f /tmp/polar-producer.log | jq -c 'select(.event=="daemon_tick_finished")' | head -3
+```
+
+Expected: `status=ok` every tick (180s interval).
 
 ## Configure
 

--- a/polar/SKILL.md
+++ b/polar/SKILL.md
@@ -1,29 +1,27 @@
 ---
 name: polar-strategy
 description: >-
-  POLAR v4.0.0 — ETH Alpha Hunter, v2-runtime-native rewrite. v3.x was a
-  full-agency scanner (load_tc / has_resting_orders / Python-side cooldowns
-  with the same crash-class bug that bit Vulture v2.x). v4.0 flips to producer
-  + v2 runtime: producer emits ETH signals via external-scanner ingest;
-  runtime LLM gate is pass-through; risk.guard_rails enforces declaratively;
-  DSL uses FEE_OPTIMIZED_LIMIT (saves ~0.020-0.030% per maker-filled exit);
-  trade chain DB emits per-trade telemetry. v3.x scoring + DSL preset
-  preserved exactly (proved correct on 2026-04-23 ETH Short that locked
-  +$71.15 via Phase 2 Tier 1; current live ETH LONG running +$54 unrealized
-  at +5% margin ROE). v3.0.5/v3.0.6 v1-DSL fixes preserved (all time-based
-  cuts disabled — exits 100% price-action via Phase 1 max_loss/retrace +
-  Phase 2 trailing).
+  POLAR v5.0.0 — ETH alpha hunter, senpi_runtime_helpers migration.
+  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
+  to in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST to
+  runtime /signals, long-lived producer_daemon). Thesis preserved
+  verbatim from v4.2.0: ETH single-asset hybrid, hyperfeed SM gates
+  (pct≥5%, traders≥30, cc_15m≥0.3), structural gates (4h trend,
+  1h-4h alignment, 15m momentum, RSI), multi-factor scoring (~17 max),
+  conviction-tiered leverage (5x standard / 7x conviction / 10x apex),
+  MIN_SCORE 12, FP-001 quiet hours (00-04 UTC unless apex score 17+).
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "4.0.0"
+  version: "5.0.0"
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=2.0.0
+    - senpi-runtime-helpers
 ---
 
-# 🐻‍❄️ POLAR v4.0.0 — ETH Alpha Hunter (v2-runtime-native)
+# 🐻‍❄️ POLAR v5.0.0 — ETH Alpha Hunter (senpi_runtime_helpers)
 
 Best gross trader in the fleet. Single asset. Maximum conviction.
 

--- a/polar/references/skill-attribution.md
+++ b/polar/references/skill-attribution.md
@@ -4,7 +4,7 @@ When calling `strategy_create` or `strategy_create_custom_strategy`, always incl
 
 ```json
 "skill_name": "polar",
-"skill_version": "2.3"
+"skill_version": "5.0.0"
 ```
 
 This is required for attribution and tracking. Example:
@@ -16,7 +16,7 @@ This is required for attribution and tracking. Example:
     "initialBudget": 500,
     "positions": [],
     "skill_name": "polar",
-    "skill_version": "2.3"
+    "skill_version": "5.0.0"
   }
 }
 ```

--- a/polar/scripts/polar-producer.py
+++ b/polar/scripts/polar-producer.py
@@ -1,64 +1,43 @@
 #!/usr/bin/env python3
-# Senpi POLAR Producer v4.0.0
+# Senpi POLAR Producer v5.0.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""POLAR v4.0.0 Producer — ETH alpha signal emitter for v2 runtime.
+"""POLAR v5.0.0 Producer — senpi_runtime_helpers migration.
 
-v3.x was a full-agency scanner that called create_position directly,
-maintained Python-side trade counters, cooldowns, and resting-order
-guards. v4.0 flips to producer + v2 runtime (Vulture v3.0 / Scorpion
-v4.x pattern).
+v5.0.0 (2026-05-08) — plumbing migration from openclaw-CLI subprocess
++ mcporter subprocess to senpi_runtime_helpers in-process wrapper.
+NO thesis change. ETH single-asset hybrid, hyperfeed SM gates,
+structural gates, multi-factor scoring (~17 max), conviction-tiered
+leverage (5x/7x/10x), MIN_SCORE 12, FP-001 quiet hours — all
+preserved verbatim from v4.2.0.
 
-ARCHITECTURE CHANGE:
-  - Producer (polar-producer.py) emits signals via
-    `openclaw senpi external-scanner ingest`. NO execution code.
-  - Runtime LLM gate (decision_mode: llm) is pass-through (Roach
-    pattern) — producer has applied every filter; LLM only catches
-    malformed signals.
-  - risk.guard_rails ENFORCES daily caps, drawdown halt, consecutive-
-    loss halt, per-asset cooldown (no Python state to drift / crash).
-  - DSL uses FEE_OPTIMIZED_LIMIT on entries AND exits — saves
-    ~0.020-0.030% per maker-filled close vs v3.x MARKET orders.
-  - Trade chain DB emits LIFECYCLE / DECISION_EXECUTED / ACTION_RESULT
-    / DSL_CREATED / DSL_CLOSED for every trade — telemetry restored.
+Six-layer plumbing flip per migration-cookbook (matches Cheetah v7.0.0
+/ Kodiak v7.0.0 / Pangolin v2.2 patterns):
+  1. MCP calls — cfg.mcporter_call() shim now routes through
+     SenpiClient.mcp_call() (direct HTTPS).
+  2. Signal emit — subprocess.run(["openclaw","senpi","external-scanner",
+     "ingest"...]) replaced by cfg._wrapper_client.push_signal(...).
+     Direct HTTP POST to runtime API on 127.0.0.1:8787/signals.
+     Per Rachin's review of Cheetah PR #209: signal_type passed as
+     explicit kwarg ("POLAR_ETH_HYBRID"), no dead fields in payload.
+  3. Reentrancy — hand-rolled fcntl flock dropped. producer_daemon
+     owns per-tick scanner_lock with stale-PID auto-recovery.
+  4. Tick scheduling — openclaw cron + agentTurn replaced by
+     producer_daemon (long-lived process; zero per-tick LLM cost).
+  5. Per-tick cache + parallel fan-out NOT adopted (matches Pangolin
+     reference minimum-change pattern).
+  6. /state alive_check — wallet=/scanner= kwargs NOT passed to
+     producer_daemon per fleet-fix commit 4f0c15e (host helpers
+     package doesn't accept those kwargs yet). Restoration path
+     documented at the bottom of the file.
 
-WHAT'S PRESERVED FROM v3.0.6:
-  - ETH single-asset thesis
-  - Hyperfeed SM gates (pct≥5%, traders≥30, cc_15m≥0.3 acceleration)
-  - Structural gates (4h trend != NEUTRAL, 4h trend matches SM
-    direction, 1h matches 4h, 15m momentum aligned, RSI not extreme)
-  - Multi-factor scoring (~17 max points across base-tech, SM
-    concentration, SM velocity, SM accelerating, trader depth,
-    funding, OI velocity, BTC correlation, RSI room, 4h momentum,
-    move-exhaustion penalty)
-  - MIN_SCORE = 12 (default; config-overridable). v4.2 restored from
-    v4.0/v4.1's 14 (which silently regressed v3.0's over-strict floor).
-  - Conviction-tiered leverage (5x standard / 7x conviction / 10x apex)
-  - DSL preset: time-cuts disabled, Phase 1 max_loss 25% / retrace 8 /
-    3 breaches, Phase 2 leverage-aware ladder
-
-FLEET PATCHES:
-  - FP-001 quiet hours (00-04 UTC unless apex score 17+)
-  - FP-002 hard rule in SKILL.md (user-conversation Claude sessions
-    are read-only — only producer cron + DSL engine are write paths)
-
-Environment / config resolution:
-  Strategy wallet is read from config/polar-config.json (canonical
-  source). POLAR_WALLET_ADDRESS env var supported as optional
-  override but NOT required for routine cron runs.
-
-  SENPI_API_KEY              — MCP access (required)
-  POLAR_WALLET_ADDRESS       — optional override; defaults to config.wallet
-  SENPI_MCP_URL              — optional, default https://mcp.prod.senpi.ai/mcp
-  OPENCLAW_BIN               — optional, default "openclaw"
-  EXTERNAL_SCANNER_NAME      — optional override (default "polar_signals")
+v4.2.0 thesis preserved unchanged.
 """
 
-import fcntl
+import hashlib
 import json
 import os
-import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -67,43 +46,25 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import polar_config as cfg
 
-
-# ═══════════════════════════════════════════════════════════════
-# REENTRANCY GUARD (fleet-standard fcntl pattern)
-# ═══════════════════════════════════════════════════════════════
-
-_LOCK_DIR = Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "polar-strategy" / "state"
-_LOCK_DIR.mkdir(parents=True, exist_ok=True)
-_LOCK_PATH = _LOCK_DIR / "producer.lock"
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-def acquire_lock():
-    try:
-        f = open(_LOCK_PATH, "w")
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        f.write(f"{os.getpid()} {int(time.time())}\n")
-        f.flush()
-        return f
-    except (IOError, OSError, BlockingIOError):
-        return None
+VERSION = "5.0.0"
+
+# Hardcoded — must match runtime.yaml external_scanner.name. Removing
+# the env var override eliminates a source of mismatch.
+SCANNER_NAME = "polar_signals"
+
+# Signal type passed explicitly to push_signal() per Rachin's review
+# of Cheetah PR #209. Don't rely on scanner's defaultSignalType
+# fallback — runtime YAMLs commonly don't declare one.
+SIGNAL_TYPE = "POLAR_ETH_HYBRID"
 
 
-def release_lock(lock_file):
-    if lock_file is None:
-        return
-    try:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-    except Exception:
-        pass
-    try:
-        lock_file.close()
-    except Exception:
-        pass
-
-
-VERSION = "4.2.0"
-SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "polar_signals")
-OPENCLAW_BIN = os.environ.get("OPENCLAW_BIN", "openclaw")
+# Reentrancy guard removed in v5.0.0. producer_daemon owns the
+# per-tick scanner_lock with stale-PID auto-recovery via os.kill(pid, 0).
+# Do NOT add an inner scanner_lock(...) inside main() — fcntl flock
+# is not reentrant; nested call raises BlockingIOError every tick.
 
 
 def _resolve_wallet():
@@ -582,6 +543,14 @@ def build_eth_thesis():
 # ═══════════════════════════════════════════════════════════════
 
 def push_signal(thesis, held_assets):
+    """Push a signal payload to the runtime via senpi_runtime_helpers.
+
+    Direct HTTP POST to runtime API on 127.0.0.1; no subprocess.
+    asset/direction/signal_type at top-level kwargs (Rachin's PR #209
+    review). Score normalized 0..1 for SignalItem.score (Polar's
+    composite score 0-20 scaled), with raw int score also inside
+    `data` for telemetry.
+    """
     if not STRATEGY_ADDRESS:
         print(
             "ERROR: strategy wallet not resolved — set 'wallet' in "
@@ -598,54 +567,46 @@ def push_signal(thesis, held_assets):
     sm = thesis["sm"]
     mom = thesis["mom"]
 
-    payload = {
-        "asset": ASSET,
-        "direction": thesis["direction"],
-        "score": thesis["score"] / 20.0,  # normalize 0-1 (theoretical max ~20)
-        "signal_type": "POLAR_ETH_HYBRID",
-        "data": {
-            "score": thesis["score"],
-            "tier": tier_label,
-            "leverage": leverage,
-            "reasons": thesis["reasons"],
-            "smPct": sm["pct"],
-            "smTraders": sm["traders"],
-            "smCc15m": sm["cc_15m"],
-            "smCc1h": sm["cc_1h"],
-            "smCc4h": sm["cc_4h"],
-            "trend4h": thesis["trend_4h"],
-            "trendStrength4h": thesis["trend_strength_4h"],
-            "rsi": thesis["rsi"],
-            "funding": thesis["funding"],
-            "oiChange1h": thesis.get("oi_change_1h"),
-            "priceChange5m": mom["5m"],
-            "priceChange15m": mom["15m"],
-            "priceChange1h": mom["1h"],
-            "priceChange4h": mom["4h"],
-            "btcMom15m": thesis.get("btc_mom_15m"),
-            "btcMom1h": thesis.get("btc_mom_1h"),
-            "heldAssets": held_assets,
-        },
+    data_block = {
+        "score": thesis["score"],
+        "tier": tier_label,
+        "leverage": leverage,
+        "reasons": thesis["reasons"],
+        "smPct": sm["pct"],
+        "smTraders": sm["traders"],
+        "smCc15m": sm["cc_15m"],
+        "smCc1h": sm["cc_1h"],
+        "smCc4h": sm["cc_4h"],
+        "trend4h": thesis["trend_4h"],
+        "trendStrength4h": thesis["trend_strength_4h"],
+        "rsi": thesis["rsi"],
+        "funding": thesis["funding"],
+        "oiChange1h": thesis.get("oi_change_1h"),
+        "priceChange5m": mom["5m"],
+        "priceChange15m": mom["15m"],
+        "priceChange1h": mom["1h"],
+        "priceChange4h": mom["4h"],
+        "btcMom15m": thesis.get("btc_mom_15m"),
+        "btcMom1h": thesis.get("btc_mom_1h"),
+        "heldAssets": held_assets,
     }
 
-    cmd = [
-        OPENCLAW_BIN, "senpi", "external-scanner", "ingest",
-        "--address", STRATEGY_ADDRESS,
-        "--scanner", SCANNER_NAME,
-        "--payload", json.dumps(payload),
-    ]
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
-        if result.returncode != 0:
-            print(f"INGEST_FAILED ETH: {result.stderr}", file=sys.stderr)
-            return False
-        response = json.loads(result.stdout) if result.stdout.strip() else {}
-        if not response.get("ok", False):
-            print(f"INGEST_REJECTED ETH: {response.get('error', {})}", file=sys.stderr)
-            return False
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=ASSET,
+            direction=thesis["direction"],
+            score=thesis["score"] / 20.0,   # 0..1 confidence (Polar composite normalized)
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
         return True
-    except Exception as e:
-        print(f"INGEST_EXCEPTION ETH: {e}", file=sys.stderr)
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED ETH {thesis['direction']}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        print(f"INGEST_EXCEPTION ETH {thesis['direction']}: {type(e).__name__}: {e}", file=sys.stderr)
         return False
 
 
@@ -654,76 +615,86 @@ def push_signal(thesis, held_assets):
 # ═══════════════════════════════════════════════════════════════
 
 def main():
+    """Single tick. NO inner scanner_lock — daemon owns it."""
     run_start = time.time()
-    lock = acquire_lock()
-    if lock is None:
+
+    # Build thesis
+    thesis = build_eth_thesis()
+
+    if thesis.get("blocked"):
+        elapsed = time.time() - run_start
         print(json.dumps({
-            "status": "skip",
-            "reason": "previous run still active — cron reentrancy guard",
+            "status": "ok",
+            "heartbeat": "NO_REPLY",
+            "note": f"BLOCKED: {thesis['reason']}",
+            "elapsed_sec": round(elapsed, 2),
             "_polar_producer_version": VERSION,
         }))
         return
 
-    try:
-        # Build thesis
-        thesis = build_eth_thesis()
-
-        if thesis.get("blocked"):
-            elapsed = time.time() - run_start
-            print(json.dumps({
-                "status": "ok",
-                "heartbeat": "NO_REPLY",
-                "note": f"BLOCKED: {thesis['reason']}",
-                "elapsed_sec": round(elapsed, 2),
-                "_polar_producer_version": VERSION,
-            }))
-            return
-
-        # MIN_SCORE check
-        min_score = get_min_score()
-        if thesis["score"] < min_score:
-            print(json.dumps({
-                "status": "ok",
-                "heartbeat": "NO_REPLY",
-                "note": f"score_low {thesis['score']}/{min_score}",
-                "direction": thesis["direction"],
-                "reasons": thesis["reasons"],
-                "_polar_producer_version": VERSION,
-            }))
-            return
-
-        # FP-001 quiet hours (apex-score override)
-        quiet, current_hour, apex_bypass = in_quiet_hours()
-        if quiet and thesis["score"] < apex_bypass:
-            print(json.dumps({
-                "status": "ok",
-                "heartbeat": "NO_REPLY",
-                "note": f"QUIET_HOURS hour={current_hour}_UTC score={thesis['score']}_below_apex_{apex_bypass}",
-                "direction": thesis["direction"],
-                "_polar_producer_version": VERSION,
-            }))
-            return
-
-        # Check held positions — runtime would reject duplicate ETH anyway
-        held_assets = fetch_held_assets()
-
-        pushed = push_signal(thesis, held_assets)
-
-        elapsed = time.time() - run_start
+    # MIN_SCORE check
+    min_score = get_min_score()
+    if thesis["score"] < min_score:
         print(json.dumps({
             "status": "ok",
-            "action": "PUSHED" if pushed else "PUSH_FAILED",
+            "heartbeat": "NO_REPLY",
+            "note": f"score_low {thesis['score']}/{min_score}",
             "direction": thesis["direction"],
-            "score": thesis["score"],
-            "tier": get_leverage_tier(thesis["score"])[1],
-            "reasons": thesis["reasons"][:5],
-            "held_assets": held_assets,
-            "elapsed_sec": round(elapsed, 2),
+            "reasons": thesis["reasons"],
             "_polar_producer_version": VERSION,
         }))
-    finally:
-        release_lock(lock)
+        return
+
+    # FP-001 quiet hours (apex-score override)
+    quiet, current_hour, apex_bypass = in_quiet_hours()
+    if quiet and thesis["score"] < apex_bypass:
+        print(json.dumps({
+            "status": "ok",
+            "heartbeat": "NO_REPLY",
+            "note": f"QUIET_HOURS hour={current_hour}_UTC score={thesis['score']}_below_apex_{apex_bypass}",
+            "direction": thesis["direction"],
+            "_polar_producer_version": VERSION,
+        }))
+        return
+
+    # Check held positions — runtime would reject duplicate ETH anyway
+    held_assets = fetch_held_assets()
+
+    pushed = push_signal(thesis, held_assets)
+
+    elapsed = time.time() - run_start
+    print(json.dumps({
+        "status": "ok",
+        "action": "PUSHED" if pushed else "PUSH_FAILED",
+        "direction": thesis["direction"],
+        "score": thesis["score"],
+        "tier": get_leverage_tier(thesis["score"])[1],
+        "reasons": thesis["reasons"][:5],
+        "held_assets": held_assets,
+        "elapsed_sec": round(elapsed, 2),
+        "_polar_producer_version": VERSION,
+    }))
 
 
 if __name__ == "__main__":
-    main()
+    # v5.0.0 — long-lived daemon. Replaces openclaw cron + agentTurn.
+    # producer_daemon owns the per-tick scanner_lock with stale-PID
+    # auto-recovery.
+    #
+    # NOTE: wallet=/scanner= kwargs NOT passed (host helpers package
+    # doesn't accept yet — see fleet-fix commit 4f0c15e). When Erik
+    # upgrades the host helpers, restore:
+    #   wallet=STRATEGY_ADDRESS,
+    #   scanner=SCANNER_NAME,
+    # to enable /state alive_check (auto-terminate on runtime delete).
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=180,           # Polar's v4.x cron was every 3 min
+        name=f"polar-producer-{_wallet_lock_id}",
+        tick_timeout=240,
+    )

--- a/polar/scripts/polar_config.py
+++ b/polar/scripts/polar_config.py
@@ -1,22 +1,17 @@
-"""POLAR v4.0.0 — Shared MCP helpers + config loader.
+"""POLAR v5.0.0 — Shared config + MCP shim + helpers wrapper.
 
-v4.0 producer responsibilities are narrower than v3.x:
-  - Fetch ETH market data + Hyperfeed SM signal via MCP
-  - Apply scoring + structural/momentum gates
-  - Push signals via `openclaw senpi external-scanner ingest`
-    (runtime owns execution + DSL + risk + counters)
-
-This module is just the MCP call helper + config loader. All state
-(position tracking, trade counters, cooldowns) lives in the runtime,
-not here. v3.x's load_tc / save_tc / has_resting_orders / Polar-
-specific cooldown logic is GONE — runtime.guard_rails replaces it.
+v5.0.0: senpi_runtime_helpers migration. mcporter_call now routes
+through SenpiClient.mcp_call() (direct HTTPS) instead of mcporter
+subprocess. _wrapper_client is exposed for the producer's signal
+push (cfg._wrapper_client.push_signal(...)). All other helpers
+preserved verbatim.
 """
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 
+import functools
 import json
 import os
-import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -25,6 +20,38 @@ from pathlib import Path
 WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
 SKILL_DIR = Path(WORKSPACE) / "skills" / "polar-strategy"
 CONFIG_PATH = SKILL_DIR / "config" / "polar-config.json"
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+# Pattern ported verbatim from pangolin / cheetah_config.py: mount the
+# helpers package at module load, defer SenpiClient construction
+# until first attribute access. SENPI_AUTH_TOKEN validated on first use.
+
+_helpers_path = str(Path(WORKSPACE) / "skills" / "_helpers")
+if _helpers_path not in sys.path:
+    sys.path.insert(0, _helpers_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Polar's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("polar_wrapper_enabled", helpers_path=_helpers_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
 
 
 # ─── Config ──────────────────────────────────────────────────
@@ -42,36 +69,22 @@ def load_config():
 # ─── MCP Helper ──────────────────────────────────────────────
 
 def mcporter_call(tool, retries=2, timeout=30, **params):
-    """Call a Senpi MCP tool via mcporter. Returns parsed JSON or None on failure."""
-    args = json.dumps(params) if params else "{}"
-    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
-    for attempt in range(retries):
-        try:
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-            if r.returncode != 0:
-                if attempt < retries - 1:
-                    time.sleep(2)
-                    continue
-                return None
-            raw = json.loads(r.stdout)
-            if isinstance(raw, dict) and "content" in raw:
-                content = raw["content"]
-                if isinstance(content, list) and content:
-                    first = content[0]
-                    if isinstance(first, dict) and "text" in first:
-                        try:
-                            return json.loads(first["text"])
-                        except (json.JSONDecodeError, TypeError):
-                            pass
-            return raw
-        except subprocess.TimeoutExpired:
-            if attempt < retries - 1:
-                time.sleep(2)
-                continue
-            return None
-        except (json.JSONDecodeError, Exception):
-            return None
-    return None
+    """Call a Senpi MCP tool via the senpi_runtime_helpers wrapper.
+
+    v5.0.0: routes through SenpiClient.mcp_call() — direct HTTPS, no
+    mcporter subprocess. Returns the unwrapped JSON document on
+    success, or None if the wrapper raised. `retries` parameter
+    preserved for call-site compat but not implemented — daemon
+    recovers transient failures on the next tick.
+    """
+    try:
+        return _wrapper_client.mcp_call(tool, timeout=timeout, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] polar_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
 
 
 def output(data):


### PR DESCRIPTION
## Summary

Plumbing-only migration from v4.2.0 to v5.0.0. NO thesis change. ETH single-asset hybrid, hyperfeed SM gates, structural gates, multi-factor scoring (~17 max), conviction-tiered leverage (5x/7x/10x), MIN_SCORE 12, FP-001 quiet hours all preserved verbatim.

Three commits per the per-skill PR layout:

1. **producer-rewrite** (`eec5f39`) — drops fcntl + subprocess, adds `producer_daemon` (no `wallet=`/`scanner=` per fleet-fix #214), rewrites `push_signal()` per Rachin's PR #209 review (dead fields stripped, `signal_type=` passed explicitly).
2. **config-shim** (`f5b4b8d`) — adds the lazy `SenpiClient` proxy + delegating `mcporter_call` shim.
3. **doc-bump** (`31292f4`) — SKILL.md/README.md/skill-attribution.md version sync from v4.0.0 / v2.3 → v5.0.0; README rewritten with full operator install guide.

## Compatibility

- `senpi-trading-runtime >= 2.0.0`
- `_helpers/senpi_runtime_helpers/` mounted on host
- Required env: `POLAR_WALLET_ADDRESS`, `SENPI_AUTH_TOKEN`, `POLAR_DECISION_MODEL`
- `runtime.yaml` UNCHANGED from v4.x

## Pitfall scan

| Pitfall | v5.0.0 | Verdict |
|---|---|---|
| Inner `scanner_lock` inside fn | None | ✅ |
| `wallet=`/`scanner=` on `producer_daemon` | NOT passed (per fleet-fix #214) | ✅ |
| `STRATEGY_ADDRESS` env (banned) | Internal var name only; resolved from per-agent `POLAR_WALLET_ADDRESS` | ✅ |
| `## Skill Attribution` section | Already present in SKILL.md | ✅ |
| `signal_type=` explicit | "POLAR_ETH_HYBRID" passed as kwarg | ✅ |
| Dead fields in payload | Stripped (top-level signal_type/asset/direction/score were duplicated; now only kwargs) | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)