### PR TITLE
fleet-fix #2: helpers pull URL → helper-mcp-envelope-aligned branch

### DIFF
--- a/cheetah/README.md
+++ b/cheetah/README.md
@@ -32,12 +32,14 @@ Multi-signal confluence sniper. Refuses to trade unless ALL major signals align:
 
 ### Step 1 — Pull the helpers package (one-time per host, shared across all skills)
 
+> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file (this skill's SKILL.md, README.md, scripts, runtime YAMLs) is on `main` as normal.
+
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers/references
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers/tests
 
 for f in __init__.py _config.py _logging.py cache.py client.py daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/kodiak/README.md
+++ b/kodiak/README.md
@@ -42,11 +42,13 @@ Conviction-tiered leverage:
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
+> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.
+
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/polar/README.md
+++ b/polar/README.md
@@ -23,11 +23,13 @@ ETH single-asset hybrid hunter. Hyperfeed Smart Money gates (pct≥5%, traders�
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
+> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.
+
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/turbine/README.md
+++ b/turbine/README.md
@@ -86,11 +86,13 @@ Create TWO new Senpi strategy wallets:
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
+> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.
+
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```


### PR DESCRIPTION
Caught by Kodiak operator on deploy 2026-05-08: `ImportError: cannot import name 'SenpiClient'` because the helpers files 404'd. The package is only on the `helper-mcp-envelope-aligned` branch, not main. Patched the install URL across all 4 merged migration READMEs (Cheetah, Turbine, Kodiak, Polar) + added explicit caveat note. Pattern for all 11 remaining migrations: README must use the branch URL until helpers lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)