### PR TITLE
Wolverine v5.0.0 — senpi_runtime_helpers migration

### DIFF
--- a/wolverine/README.md
+++ b/wolverine/README.md
@@ -1,31 +1,80 @@
-# 🦡 WOLVERINE v4.0.0 — HYPE Alpha Hunter (v2-runtime-native)
+# 🦡 WOLVERINE v5.0.0 — HYPE Alpha Hunter (senpi_runtime_helpers)
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-## What changed in v4.0
+## What changed in v5.0.0
 
-- `wolverine-producer.py` (NEW) replaces `wolverine-scanner.py` (DELETED)
-- v2-runtime-native: external_scanner + LLM-pass-through gate + native `risk.guard_rails`
-- DSL exits via `FEE_OPTIMIZED_LIMIT` (saves ~0.020-0.030% per maker-filled close)
-- Trade chain DB emits per-trade telemetry — chain DB visibility on Wolverine for the first time
-- v3.0.3 six-gate entry validation preserved EXACTLY (incl. the 4h-magnitude fix that rejects dead-flat chop)
-- v3.0.1/2/4 v1-DSL fixes preserved: time-cuts all disabled, exits 100% price-action
+**Plumbing-only migration. NO thesis change.** v4.2.0's six-gate validation, scoring, leverage tiers, MIN_SCORE 9, quiet hours, DSL preset are all preserved verbatim.
 
-## Thesis (preserved from v3.x)
+- `wolverine-producer.py` and `wolverine_config.py` migrate to `senpi_runtime_helpers`:
+  - MCP calls go via `SenpiClient.mcp_call()` (direct HTTPS) instead of `mcporter` subprocess
+  - Signal emission goes via `SenpiClient.push_signal()` (direct HTTP POST) instead of `openclaw senpi external-scanner ingest` subprocess
+  - Reentrancy lock owned by `producer_daemon.scanner_lock` instead of hand-rolled `fcntl`
+  - Tick scheduling owned by `producer_daemon` (long-lived process) instead of openclaw cron + `agentTurn`
+- Requires `senpi-trading-runtime >= 2.0.0`.
+- `runtime.yaml` unchanged. `external_scanner.name: wolverine_signals` matches the producer's `client.push_signal(scanner=...)`.
+- Per Rachin's review of Cheetah PR #209: dead fields stripped from payload; `signal_type="WOLVERINE_HYPE_HYBRID"` passed explicitly.
 
-Single-asset HYPE alpha hunter. Six-gate entry validation: 4h trend structure, 4h structural strength, 1h confirmation, 15m momentum alignment, base-tech floor, **4h magnitude ≥1.5%** (the v3.0.3 fix). Multi-factor scoring (~17 max points), MIN_SCORE 9, conviction-tiered leverage (3x/5x). DSL Phase 2 trailing owns all winner exits.
+## Thesis (preserved from v4.2.0)
+
+Single-asset HYPE alpha hunter. Six-gate entry validation: 4h trend structure, 4h structural strength ≥0.65, 1h-4h alignment, 15m momentum ≥0.15, base-tech floor, **4h magnitude ≥1.0%**. Multi-factor scoring (~17 max points), MIN_SCORE 9, conviction-tiered leverage (3x standard / 5x apex), FP-001 quiet hours. DSL Phase 2 trailing owns all winner exits.
 
 ## Install
 
-```bash
-mkdir -p /data/workspace/skills/wolverine-strategy/{config,scripts,state}
+### Step 1 — Pull the helpers package (one-time per host)
 
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/wolverine/runtime.yaml -o /data/workspace/skills/wolverine-strategy/runtime.yaml
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/wolverine/SKILL.md -o /data/workspace/skills/wolverine-strategy/SKILL.md
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/wolverine/config/wolverine-config.json -o /data/workspace/skills/wolverine-strategy/config/wolverine-config.json
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/wolverine/scripts/wolverine-producer.py -o /data/workspace/skills/wolverine-strategy/scripts/wolverine-producer.py
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/wolverine/scripts/wolverine_config.py -o /data/workspace/skills/wolverine-strategy/scripts/wolverine_config.py
+> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.
+
+```bash
+mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
+for f in __init__.py _config.py _logging.py cache.py client.py \
+         daemon.py lock.py parallel.py SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+    -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
+done
 ```
+
+Skip if already pulled for Cheetah / Turbine / Kodiak / Polar / another v3 skill.
+
+### Step 2 — Pull Wolverine v5.0.0
+
+```bash
+mkdir -p /data/workspace/skills/wolverine-strategy/{config,scripts,state,references}
+for f in scripts/wolverine-producer.py scripts/wolverine_config.py \
+         SKILL.md README.md references/skill-attribution.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/wolverine/$f" \
+    -o "/data/workspace/skills/wolverine-strategy/$f"
+done
+```
+
+`runtime.yaml` is unchanged from v4.x — don't touch the existing runtime.
+
+### Step 3 — Required env vars
+
+```bash
+export WOLVERINE_WALLET_ADDRESS=<your-wolverine-wallet>
+export SENPI_AUTH_TOKEN=...
+export WOLVERINE_DECISION_MODEL=gemini-3.1-pro-preview
+```
+
+### Step 4 — Stop the v4.x cron, start the v5.0.0 daemon
+
+```bash
+openclaw cron list | grep wolverine
+openclaw cron delete <wolverine-cron-id>
+
+# Start daemon (long-lived, no cron)
+nohup python3 -u /data/workspace/skills/wolverine-strategy/scripts/wolverine-producer.py \
+  > /tmp/wolverine-producer.log 2>&1 &
+```
+
+## Smoke test
+
+```bash
+tail -f /tmp/wolverine-producer.log | jq -c 'select(.event=="daemon_tick_finished")' | head -3
+```
+
+Expected: `status=ok` every tick (180s interval). Tick `duration_ms` should drop from ~30-60s (v4.x mcporter) to ~1-3s.
 
 ## Configure
 

--- a/wolverine/SKILL.md
+++ b/wolverine/SKILL.md
@@ -1,29 +1,28 @@
 ---
 name: wolverine-strategy
 description: >-
-  WOLVERINE v4.0.0 — HYPE Alpha Hunter, v2-runtime-native rewrite. v3.x was
-  a full-agency scanner with Python-side state (load_tc / has_resting_orders
-  / Python cooldowns) — same crash-class bug pattern that bit Vulture v2.x.
-  292 audit entries on M193170 since Apr 15, mostly schema-validation
-  failures. v4.0 flips to producer + v2 runtime: producer emits HYPE
-  signals via external-scanner ingest; runtime LLM gate is pass-through;
-  risk.guard_rails enforces declaratively; DSL uses FEE_OPTIMIZED_LIMIT;
-  trade chain DB emits per-trade telemetry. v3.0.3 six-gate entry
-  validation preserved (incl. the v3.0.3 4h-magnitude fix that rejects
-  dead-flat chop). v3.0.1/2/4 v1-DSL fixes preserved (all time-based cuts
-  disabled — exits 100% price-action via Phase 1 max_loss/retrace +
-  Phase 2 trailing).
+  WOLVERINE v5.0.0 — HYPE alpha hunter, senpi_runtime_helpers migration.
+  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
+  to in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST to
+  runtime /signals, long-lived producer_daemon). Thesis preserved
+  verbatim from v4.2.0: HYPE single-asset hybrid, six-gate entry
+  validation (4h trend, 4h strength ≥0.65, 1h-4h alignment, 15m
+  momentum ≥0.15, base-tech floor, 4h magnitude ≥1.0%), SM hard-block
+  on opposing direction, RSI hard gates (74/26), multi-factor scoring
+  (~17 max), conviction-tiered leverage (3x standard / 5x apex),
+  MIN_SCORE 9, FP-001 quiet hours.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "4.0.0"
+  version: "5.0.0"
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=2.0.0
+    - senpi-runtime-helpers
 ---
 
-# 🦡 WOLVERINE v4.0.0 — HYPE Alpha Hunter (v2-runtime-native)
+# 🦡 WOLVERINE v5.0.0 — HYPE Alpha Hunter (senpi_runtime_helpers)
 
 **v3 → v4 architectural rewrite.** v3.x was a full-agency scanner. v4.0 flips to the standard senpi-trading-runtime v2 pattern: producer emits signals, runtime owns execution + state.
 

--- a/wolverine/references/skill-attribution.md
+++ b/wolverine/references/skill-attribution.md
@@ -4,7 +4,7 @@ When calling `strategy_create` or `strategy_create_custom_strategy`, always incl
 
 ```json
 "skill_name": "wolverine",
-"skill_version": "2.3"
+"skill_version": "5.0.0"
 ```
 
 This is required for attribution and tracking. Example:
@@ -16,7 +16,7 @@ This is required for attribution and tracking. Example:
     "initialBudget": 500,
     "positions": [],
     "skill_name": "wolverine",
-    "skill_version": "2.3"
+    "skill_version": "5.0.0"
   }
 }
 ```

--- a/wolverine/scripts/wolverine-producer.py
+++ b/wolverine/scripts/wolverine-producer.py
@@ -1,60 +1,40 @@
 #!/usr/bin/env python3
-# Senpi WOLVERINE Producer v4.0.0
+# Senpi WOLVERINE Producer v5.0.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""WOLVERINE v4.0.0 Producer — HYPE alpha signal emitter for v2 runtime.
+"""WOLVERINE v5.0.0 Producer — senpi_runtime_helpers migration.
 
-v3.x was a full-agency scanner (load_tc / save_tc / has_resting_orders
-/ Python-side cooldowns / drawdown gate). 292 audit entries on M193170
-since 2026-04-15, mostly schema-validation failures (silent-None bug
-pattern). v4.0 flips to producer + v2 runtime (Polar v4.0 / Vulture
-v3.0 template).
+v5.0.0 (2026-05-08) — plumbing migration. NO thesis change. HYPE
+single-asset hybrid, six-gate entry validation, SM hard-block on
+opposing direction, RSI hard gates (74/26), multi-factor scoring
+(~17 max), conviction-tiered leverage (3x standard / 5x apex),
+MIN_SCORE 9, FP-001 quiet hours — all preserved verbatim from v4.2.0.
 
-ARCHITECTURE CHANGE:
-  - Producer (wolverine-producer.py) emits signals via
-    `openclaw senpi external-scanner ingest`. NO execution code.
-  - Runtime LLM gate is pass-through — producer has applied every
-    filter; LLM only catches malformed signals.
-  - risk.guard_rails ENFORCES daily caps, drawdown halt, consecutive-
-    loss halt, per-asset cooldown. No Python state to drift / crash.
-  - DSL uses FEE_OPTIMIZED_LIMIT on entries AND exits.
-  - Trade chain DB emits per-trade telemetry — chain-DB visibility
-    on Wolverine for the first time.
+Six-layer plumbing flip per migration-cookbook (matches Cheetah v7.0.0
+/ Kodiak v7.0.0 / Polar v5.0.0 patterns):
+  1. MCP calls — cfg.mcporter_call() shim now routes through
+     SenpiClient.mcp_call() (direct HTTPS).
+  2. Signal emit — subprocess.run(["openclaw","senpi","external-scanner",
+     "ingest"...]) replaced by cfg._wrapper_client.push_signal(...).
+     Per Rachin's PR #209 review: signal_type passed as explicit
+     kwarg ("WOLVERINE_HYPE_HYBRID"), no dead fields in payload.
+  3. Reentrancy — hand-rolled fcntl flock dropped. producer_daemon
+     owns per-tick scanner_lock with stale-PID auto-recovery.
+  4. Tick scheduling — openclaw cron + agentTurn replaced by
+     producer_daemon (long-lived process; zero per-tick LLM cost).
+  5. Per-tick cache + parallel fan-out NOT adopted (matches Pangolin
+     reference minimum-change pattern).
+  6. /state alive_check — wallet=/scanner= kwargs NOT passed to
+     producer_daemon per fleet-fix commit 4f0c15e (host helpers
+     package doesn't accept those kwargs yet).
 
-WHAT'S PRESERVED FROM v3.0.3/v3.0.4:
-  - HYPE single-asset thesis
-  - Six-gate entry validation:
-    * GATE 1: 4h trend != NEUTRAL
-    * GATE 2: 4h structural strength ≥ 0.75
-    * GATE 3: 1h matches 4h direction
-    * GATE 4: 15m momentum aligned ≥ MIN_MOM_15M (0.15)
-    * GATE 5: base-tech floor (strong_15m OR aligned_5m)
-    * GATE 6 (v3.0.3): 4h MAGNITUDE >= 1.5% — rejects dead-flat chop
-      that was killing all 6 Week 5 trades on -0.26% 24h HYPE
-  - SM HARD BLOCK if direction opposes
-  - RSI hard gates (74 LONG / 26 SHORT)
-  - Multi-factor scoring (~17 max points)
-  - MIN_SCORE = 9 (config-overridable)
-  - Conviction-tiered leverage: 5x apex (score ≥11), 3x standard (≥9)
-  - DSL preset preserved exactly: time-cuts disabled (v3.0.1/2/4 fixes),
-    Phase 1 max_loss 20% / retrace 8 / 3 breaches, Phase 2 tiers
-    10/15, 20/35, 35/55, 55/70, 80/85
-
-FLEET PATCHES:
-  - FP-001 quiet hours (00-04 UTC unless apex score 11+)
-  - FP-002 hard rule in SKILL.md (user-conversation Claude sessions
-    are read-only — only producer cron + DSL engine are write paths)
-
-Environment / config resolution:
-  Strategy wallet read from config/wolverine-config.json (canonical).
-  WOLVERINE_WALLET_ADDRESS env var supported as optional override.
+v4.2.0 thesis preserved unchanged.
 """
 
-import fcntl
+import hashlib
 import json
 import os
-import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -63,43 +43,23 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import wolverine_config as cfg
 
-
-# ═══════════════════════════════════════════════════════════════
-# REENTRANCY GUARD
-# ═══════════════════════════════════════════════════════════════
-
-_LOCK_DIR = Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "wolverine-strategy" / "state"
-_LOCK_DIR.mkdir(parents=True, exist_ok=True)
-_LOCK_PATH = _LOCK_DIR / "producer.lock"
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-def acquire_lock():
-    try:
-        f = open(_LOCK_PATH, "w")
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        f.write(f"{os.getpid()} {int(time.time())}\n")
-        f.flush()
-        return f
-    except (IOError, OSError, BlockingIOError):
-        return None
+VERSION = "5.0.0"
+
+# Hardcoded — must match runtime.yaml external_scanner.name.
+SCANNER_NAME = "wolverine_signals"
+
+# Signal type passed explicitly to push_signal() per Rachin's review
+# of Cheetah PR #209.
+SIGNAL_TYPE = "WOLVERINE_HYPE_HYBRID"
 
 
-def release_lock(lock_file):
-    if lock_file is None:
-        return
-    try:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-    except Exception:
-        pass
-    try:
-        lock_file.close()
-    except Exception:
-        pass
-
-
-VERSION = "4.2.0"
-SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "wolverine_signals")
-OPENCLAW_BIN = os.environ.get("OPENCLAW_BIN", "openclaw")
+# Reentrancy guard removed in v5.0.0. producer_daemon owns the
+# per-tick scanner_lock with stale-PID auto-recovery. Do NOT add an
+# inner scanner_lock(...) inside main() — fcntl flock is not
+# reentrant; nested call raises BlockingIOError every tick.
 
 
 def _resolve_wallet():
@@ -661,6 +621,14 @@ def build_hype_thesis():
 # ═══════════════════════════════════════════════════════════════
 
 def push_signal(thesis, held_assets):
+    """Push a signal payload to the runtime via senpi_runtime_helpers.
+
+    Direct HTTP POST to runtime API on 127.0.0.1; no subprocess.
+    asset/direction/signal_type at top-level kwargs (Rachin's PR #209
+    review). Score normalized 0..1 for SignalItem.score (Wolverine's
+    composite score 0-17 scaled), with raw int score in `data` for
+    telemetry.
+    """
     if not STRATEGY_ADDRESS:
         print(
             "ERROR: strategy wallet not resolved — set 'wallet' in "
@@ -675,55 +643,47 @@ def push_signal(thesis, held_assets):
     leverage, tier_label = get_leverage_tier(thesis["score"])
     mom = thesis["mom"]
 
-    payload = {
-        "asset": ASSET,
-        "direction": thesis["direction"],
-        "score": thesis["score"] / 17.0,
-        "signal_type": "WOLVERINE_HYPE_HYBRID",
-        "data": {
-            "score": thesis["score"],
-            "tier": tier_label,
-            "leverage": leverage,
-            "reasons": thesis["reasons"],
-            "smPct": thesis["sm_pct"],
-            "smTraders": thesis["sm_traders"],
-            "smCc15m": thesis["sm_cc_15m"],
-            "trend4h": thesis["trend_4h"],
-            "trendStrength4h": thesis["trend_strength_4h"],
-            "rsi": thesis["rsi"],
-            "funding": thesis["funding"],
-            "fundingRegime": thesis.get("regime"),
-            "fundingPersistenceHours": thesis.get("persistence_h"),
-            "oiChange1h": thesis.get("oi_change_1h"),
-            "vol1h": thesis.get("vol_1h"),
-            "priceChange5m": mom["5m"],
-            "priceChange15m": mom["15m"],
-            "priceChange1h": mom["1h"],
-            "priceChange4h": mom["4h"],
-            "btcMom15m": thesis.get("btc_mom_15m"),
-            "btcMom1h": thesis.get("btc_mom_1h"),
-            "heldAssets": held_assets,
-        },
+    data_block = {
+        "score": thesis["score"],
+        "tier": tier_label,
+        "leverage": leverage,
+        "reasons": thesis["reasons"],
+        "smPct": thesis["sm_pct"],
+        "smTraders": thesis["sm_traders"],
+        "smCc15m": thesis["sm_cc_15m"],
+        "trend4h": thesis["trend_4h"],
+        "trendStrength4h": thesis["trend_strength_4h"],
+        "rsi": thesis["rsi"],
+        "funding": thesis["funding"],
+        "fundingRegime": thesis.get("regime"),
+        "fundingPersistenceHours": thesis.get("persistence_h"),
+        "oiChange1h": thesis.get("oi_change_1h"),
+        "vol1h": thesis.get("vol_1h"),
+        "priceChange5m": mom["5m"],
+        "priceChange15m": mom["15m"],
+        "priceChange1h": mom["1h"],
+        "priceChange4h": mom["4h"],
+        "btcMom15m": thesis.get("btc_mom_15m"),
+        "btcMom1h": thesis.get("btc_mom_1h"),
+        "heldAssets": held_assets,
     }
 
-    cmd = [
-        OPENCLAW_BIN, "senpi", "external-scanner", "ingest",
-        "--address", STRATEGY_ADDRESS,
-        "--scanner", SCANNER_NAME,
-        "--payload", json.dumps(payload),
-    ]
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
-        if result.returncode != 0:
-            print(f"INGEST_FAILED HYPE: {result.stderr}", file=sys.stderr)
-            return False
-        response = json.loads(result.stdout) if result.stdout.strip() else {}
-        if not response.get("ok", False):
-            print(f"INGEST_REJECTED HYPE: {response.get('error', {})}", file=sys.stderr)
-            return False
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=ASSET,
+            direction=thesis["direction"],
+            score=thesis["score"] / 17.0,   # 0..1 confidence (Wolverine composite normalized)
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
         return True
-    except Exception as e:
-        print(f"INGEST_EXCEPTION HYPE: {e}", file=sys.stderr)
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED HYPE {thesis['direction']}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        print(f"INGEST_EXCEPTION HYPE {thesis['direction']}: {type(e).__name__}: {e}", file=sys.stderr)
         return False
 
 
@@ -732,72 +692,82 @@ def push_signal(thesis, held_assets):
 # ═══════════════════════════════════════════════════════════════
 
 def main():
+    """Single tick. NO inner scanner_lock — daemon owns it."""
     run_start = time.time()
-    lock = acquire_lock()
-    if lock is None:
+
+    thesis = build_hype_thesis()
+
+    if thesis.get("blocked"):
+        elapsed = time.time() - run_start
         print(json.dumps({
-            "status": "skip",
-            "reason": "previous run still active — cron reentrancy guard",
+            "status": "ok",
+            "heartbeat": "NO_REPLY",
+            "note": f"BLOCKED: {thesis['reason']}",
+            "elapsed_sec": round(elapsed, 2),
             "_wolverine_producer_version": VERSION,
         }))
         return
 
-    try:
-        thesis = build_hype_thesis()
-
-        if thesis.get("blocked"):
-            elapsed = time.time() - run_start
-            print(json.dumps({
-                "status": "ok",
-                "heartbeat": "NO_REPLY",
-                "note": f"BLOCKED: {thesis['reason']}",
-                "elapsed_sec": round(elapsed, 2),
-                "_wolverine_producer_version": VERSION,
-            }))
-            return
-
-        min_score = get_min_score()
-        if thesis["score"] < min_score:
-            print(json.dumps({
-                "status": "ok",
-                "heartbeat": "NO_REPLY",
-                "note": f"score_low {thesis['score']}/{min_score}",
-                "direction": thesis["direction"],
-                "reasons": thesis["reasons"],
-                "_wolverine_producer_version": VERSION,
-            }))
-            return
-
-        # FP-001 quiet hours
-        quiet, current_hour, apex_bypass = in_quiet_hours()
-        if quiet and thesis["score"] < apex_bypass:
-            print(json.dumps({
-                "status": "ok",
-                "heartbeat": "NO_REPLY",
-                "note": f"QUIET_HOURS hour={current_hour}_UTC score={thesis['score']}_below_apex_{apex_bypass}",
-                "direction": thesis["direction"],
-                "_wolverine_producer_version": VERSION,
-            }))
-            return
-
-        held_assets = fetch_held_assets()
-        pushed = push_signal(thesis, held_assets)
-
-        elapsed = time.time() - run_start
+    min_score = get_min_score()
+    if thesis["score"] < min_score:
         print(json.dumps({
             "status": "ok",
-            "action": "PUSHED" if pushed else "PUSH_FAILED",
+            "heartbeat": "NO_REPLY",
+            "note": f"score_low {thesis['score']}/{min_score}",
             "direction": thesis["direction"],
-            "score": thesis["score"],
-            "tier": get_leverage_tier(thesis["score"])[1],
-            "reasons": thesis["reasons"][:5],
-            "held_assets": held_assets,
-            "elapsed_sec": round(elapsed, 2),
+            "reasons": thesis["reasons"],
             "_wolverine_producer_version": VERSION,
         }))
-    finally:
-        release_lock(lock)
+        return
+
+    # FP-001 quiet hours
+    quiet, current_hour, apex_bypass = in_quiet_hours()
+    if quiet and thesis["score"] < apex_bypass:
+        print(json.dumps({
+            "status": "ok",
+            "heartbeat": "NO_REPLY",
+            "note": f"QUIET_HOURS hour={current_hour}_UTC score={thesis['score']}_below_apex_{apex_bypass}",
+            "direction": thesis["direction"],
+            "_wolverine_producer_version": VERSION,
+        }))
+        return
+
+    held_assets = fetch_held_assets()
+    pushed = push_signal(thesis, held_assets)
+
+    elapsed = time.time() - run_start
+    print(json.dumps({
+        "status": "ok",
+        "action": "PUSHED" if pushed else "PUSH_FAILED",
+        "direction": thesis["direction"],
+        "score": thesis["score"],
+        "tier": get_leverage_tier(thesis["score"])[1],
+        "reasons": thesis["reasons"][:5],
+        "held_assets": held_assets,
+        "elapsed_sec": round(elapsed, 2),
+        "_wolverine_producer_version": VERSION,
+    }))
 
 
 if __name__ == "__main__":
-    main()
+    # v5.0.0 — long-lived daemon. Replaces openclaw cron + agentTurn.
+    # producer_daemon owns the per-tick scanner_lock with stale-PID
+    # auto-recovery.
+    #
+    # NOTE: wallet=/scanner= kwargs NOT passed (host helpers package
+    # doesn't accept yet — see fleet-fix commit 4f0c15e). When Erik
+    # upgrades the host helpers, restore:
+    #   wallet=STRATEGY_ADDRESS,
+    #   scanner=SCANNER_NAME,
+    # to enable /state alive_check (auto-terminate on runtime delete).
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=180,           # Wolverine's v4.x cron was every 3 min
+        name=f"wolverine-producer-{_wallet_lock_id}",
+        tick_timeout=240,
+    )

--- a/wolverine/scripts/wolverine_config.py
+++ b/wolverine/scripts/wolverine_config.py
@@ -1,22 +1,17 @@
-"""WOLVERINE v4.0.0 — Shared MCP helpers + config loader.
+"""WOLVERINE v5.0.0 — Shared config + MCP shim + helpers wrapper.
 
-v4.0 producer responsibilities are narrower than v3.x:
-  - Fetch HYPE market data + Hyperfeed SM signal via MCP
-  - Apply scoring + structural/momentum gates (incl. v3.0.3 4h-magnitude)
-  - Push signals via `openclaw senpi external-scanner ingest`
-    (runtime owns execution + DSL + risk + counters)
-
-This module is just the MCP call helper + config loader. All state
-(position tracking, trade counters, cooldowns, drawdown gates) lives
-in the runtime, not here. v3.x's load_tc / save_tc / Python-side
-cooldown logic is GONE — runtime.guard_rails replaces it.
+v5.0.0: senpi_runtime_helpers migration. mcporter_call now routes
+through SenpiClient.mcp_call() (direct HTTPS) instead of mcporter
+subprocess. _wrapper_client is exposed for the producer's signal
+push (cfg._wrapper_client.push_signal(...)). All other helpers
+preserved verbatim.
 """
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 
+import functools
 import json
 import os
-import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -25,6 +20,38 @@ from pathlib import Path
 WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
 SKILL_DIR = Path(WORKSPACE) / "skills" / "wolverine-strategy"
 CONFIG_PATH = SKILL_DIR / "config" / "wolverine-config.json"
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+# Pattern ported verbatim from cheetah/polar/kodiak_config.py: mount
+# the helpers package at module load, defer SenpiClient construction
+# until first attribute access. SENPI_AUTH_TOKEN validated on first use.
+
+_helpers_path = str(Path(WORKSPACE) / "skills" / "_helpers")
+if _helpers_path not in sys.path:
+    sys.path.insert(0, _helpers_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Wolverine's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("wolverine_wrapper_enabled", helpers_path=_helpers_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
 
 
 # ─── Config ──────────────────────────────────────────────────
@@ -42,36 +69,22 @@ def load_config():
 # ─── MCP Helper ──────────────────────────────────────────────
 
 def mcporter_call(tool, retries=2, timeout=30, **params):
-    """Call a Senpi MCP tool via mcporter. Returns parsed JSON or None on failure."""
-    args = json.dumps(params) if params else "{}"
-    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
-    for attempt in range(retries):
-        try:
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-            if r.returncode != 0:
-                if attempt < retries - 1:
-                    time.sleep(2)
-                    continue
-                return None
-            raw = json.loads(r.stdout)
-            if isinstance(raw, dict) and "content" in raw:
-                content = raw["content"]
-                if isinstance(content, list) and content:
-                    first = content[0]
-                    if isinstance(first, dict) and "text" in first:
-                        try:
-                            return json.loads(first["text"])
-                        except (json.JSONDecodeError, TypeError):
-                            pass
-            return raw
-        except subprocess.TimeoutExpired:
-            if attempt < retries - 1:
-                time.sleep(2)
-                continue
-            return None
-        except (json.JSONDecodeError, Exception):
-            return None
-    return None
+    """Call a Senpi MCP tool via the senpi_runtime_helpers wrapper.
+
+    v5.0.0: routes through SenpiClient.mcp_call() — direct HTTPS, no
+    mcporter subprocess. Returns the unwrapped JSON document on
+    success, or None if the wrapper raised. `retries` parameter
+    preserved for call-site compat but not implemented — daemon
+    recovers transient failures on the next tick.
+    """
+    try:
+        return _wrapper_client.mcp_call(tool, timeout=timeout, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] wolverine_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
 
 
 def output(data):


### PR DESCRIPTION
Plumbing-only migration. NO thesis change. v4.2.0 six-gate HYPE entry, scoring, leverage tiers, MIN_SCORE 9, FP-001 quiet hours preserved verbatim.

Three commits per the per-skill PR layout:

1. **producer-rewrite** (`3d76858`) — drops fcntl + subprocess, adds `producer_daemon` (no `wallet=`/`scanner=` per fleet-fix #214), explicit `signal_type="WOLVERINE_HYPE_HYBRID"` per Rachin's PR #209 review.
2. **config-shim** (`7294ce6`) — lazy SenpiClient proxy + delegating `mcporter_call` shim.
3. **doc-bump** — SKILL.md / README.md / skill-attribution.md sync from v4.0.0 / v2.3 → v5.0.0; README updated with `helper-mcp-envelope-aligned` URL per fleet-fix #216.

Compat: senpi-trading-runtime >= 2.0.0 + helpers package on host.
Required env: WOLVERINE_WALLET_ADDRESS, SENPI_AUTH_TOKEN, WOLVERINE_DECISION_MODEL. runtime.yaml unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)