### PR TITLE
Grizzly v7.0.0 — senpi_runtime_helpers migration

### DIFF
--- a/grizzly/README.md
+++ b/grizzly/README.md
@@ -1,8 +1,21 @@
-# 🐻 GRIZZLY v6.0.0 — BTC Alpha Hunter (v2-runtime-native)
+# 🐻 GRIZZLY v7.0.0 — BTC Alpha Hunter (senpi_runtime_helpers)
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 Single-asset BTC trend-following scanner. Trades **WITH** smart money consensus when BTC's multi-timeframe momentum aligns. Same Kodiak-family pattern as Wolverine (HYPE), Polar (ETH), and Kodiak (SOL) — tuned for BTC's slower cadence.
+
+## What changed in v7.0.0
+
+**Plumbing-only migration. NO thesis change.** v6.0.0's six-gate validation, scoring, leverage tiers, MIN_SCORE 12, FP-001 quiet hours, FP-003 requireAllConfirmations gate are all preserved verbatim.
+
+- `grizzly-producer.py` and `grizzly_config.py` migrate to `senpi_runtime_helpers`:
+  - MCP calls go via `SenpiClient.mcp_call()` (direct HTTPS) instead of `mcporter` subprocess
+  - Signal emission goes via `SenpiClient.push_signal()` (direct HTTP POST) instead of `openclaw senpi external-scanner ingest` subprocess
+  - Reentrancy lock owned by `producer_daemon.scanner_lock` instead of hand-rolled `fcntl`
+  - Tick scheduling owned by `producer_daemon` (long-lived process) instead of openclaw cron + `agentTurn`
+- Requires `senpi-trading-runtime >= 2.0.0`.
+- `runtime.yaml` unchanged from v6.x.
+- Per Rachin's review of Cheetah PR #209: dead fields stripped from payload; `signal_type="GRIZZLY_BTC_TREND"` passed explicitly.
 
 ## What Grizzly does
 
@@ -84,35 +97,62 @@ Time-cuts ALL DISABLED — single-asset family pattern. Phase 1 + Phase 2 own al
 - **FP-002 hard rule** — user-conversation Claude sessions are read-only. Only the producer cron and DSL engine are write paths.
 - **FP-003 require-all-confirmations** — every soft confirmation (4TF + SM + Funding + Volume + OI) must fire, not just summed score.
 
-## Install (operator path)
+## Install
 
-**Prerequisite — verify your plugin is on `runtime-phase-2`:**
+### Step 1 — Pull the helpers package (one-time per host)
 
-```bash
-openclaw senpi external-scanner ingest --help
-```
-
-Should show `--address`, `--scanner`, `--payload` flags. If not, you're on stable v1.0.97 which lacks v2 architecture. Install the phase-2 build first:
+> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.
 
 ```bash
-cd /tmp && rm -rf senpi-trading-runtime
-git clone -b runtime-phase-2 https://github.com/Senpi-ai/senpi-trading-runtime.git
-cd senpi-trading-runtime && npm run build
-openclaw plugins uninstall runtime
-openclaw plugins install ./
+mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
+for f in __init__.py _config.py _logging.py cache.py client.py \
+         daemon.py lock.py parallel.py SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+    -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
+done
 ```
 
-**Then install the skill:**
+Skip if already pulled for Cheetah / Turbine / Kodiak / Polar / Wolverine / another v3 skill.
+
+### Step 2 — Pull Grizzly v7.0.0
 
 ```bash
-mkdir -p /data/workspace/skills/grizzly-strategy/{config,scripts,state}
-
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/runtime.yaml -o /data/workspace/skills/grizzly-strategy/runtime.yaml
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/SKILL.md -o /data/workspace/skills/grizzly-strategy/SKILL.md
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/config/grizzly-config.json -o /data/workspace/skills/grizzly-strategy/config/grizzly-config.json
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/scripts/grizzly-producer.py -o /data/workspace/skills/grizzly-strategy/scripts/grizzly-producer.py
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/scripts/grizzly_config.py -o /data/workspace/skills/grizzly-strategy/scripts/grizzly_config.py
+mkdir -p /data/workspace/skills/grizzly-strategy/{config,scripts,state,references}
+for f in scripts/grizzly-producer.py scripts/grizzly_config.py \
+         SKILL.md README.md references/skill-attribution.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/grizzly/$f" \
+    -o "/data/workspace/skills/grizzly-strategy/$f"
+done
 ```
+
+`runtime.yaml` is unchanged from v6.x — don't touch the existing runtime.
+
+### Step 3 — Required env vars
+
+```bash
+export GRIZZLY_WALLET_ADDRESS=<your-grizzly-wallet>
+export SENPI_AUTH_TOKEN=...
+export GRIZZLY_DECISION_MODEL=gemini-3.1-pro-preview
+```
+
+### Step 4 — Stop the v6.x cron, start the v7.0.0 daemon
+
+```bash
+openclaw cron list | grep grizzly
+openclaw cron delete <grizzly-cron-id>
+
+# Start daemon (long-lived, no cron)
+nohup python3 -u /data/workspace/skills/grizzly-strategy/scripts/grizzly-producer.py \
+  > /tmp/grizzly-producer.log 2>&1 &
+```
+
+## Smoke test
+
+```bash
+tail -f /tmp/grizzly-producer.log | jq -c 'select(.event=="daemon_tick_finished")' | head -3
+```
+
+Expected: `status=ok` every tick (180s interval). Tick `duration_ms` should drop from ~30-60s (v6.x mcporter) to ~1-3s.
 
 ## Configure
 

--- a/grizzly/SKILL.md
+++ b/grizzly/SKILL.md
@@ -1,35 +1,30 @@
 ---
 name: grizzly-strategy
 description: >-
-  GRIZZLY v6.0.0 — BTC Alpha Hunter, v2-runtime-native rewrite.
-  v5.x was a 1073-line full-agency Python scanner with a 3-mode state
-  machine and direct create_position calls. The Apr 30 BTC LONG ran
-  +33% peak ROE through Tier 5 cleanly for +$76.36 / +29.9% realized —
-  proves the scoring works. v6.0 flips to producer + v2 runtime
-  (Wolverine v4 / Cheetah v6 / Vulture v3 template): producer emits
-  signals via openclaw external-scanner ingest, runtime LLM gate is
-  pass-through, risk.guard_rails enforces daily caps + drawdown halt
-  + cooldowns, DSL uses FEE_OPTIMIZED_LIMIT on entries AND exits, and
-  trade chain DB telemetry comes online for the first time. ALL gates
-  and scoring preserved verbatim from v5.8: six entry gates (4h trend
-  != NEUTRAL, 4h structural strength ≥ 0.75, 1h matches 4h, 15m
-  momentum aligned, base-tech floor, v5.5 macro V-recovery gate),
-  SM hard block, RSI hard gates (70/30), MIN_SCORE 12, BTC-tuned
-  thresholds, conviction-scaled leverage (10x apex/conviction), DSL
-  preset (time-cuts disabled, Phase 2 v5.9 ratchet ladder T0/T1
-  patch). Trades WITH SM consensus and trend, NOT contrarian.
-  Family member alongside Kodiak (SOL), Wolverine (HYPE), Polar (ETH).
+  GRIZZLY v7.0.0 — BTC alpha hunter, senpi_runtime_helpers migration.
+  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
+  to in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST to
+  runtime /signals, long-lived producer_daemon). Thesis preserved
+  verbatim from v6.0.0: BTC single-asset trend hunter, six-gate entry
+  validation including v5.5 macro V-recovery gate (block fades within
+  1.25% of 24h extreme), RSI hard gates (70/30 — BTC-tuned),
+  multi-factor scoring (~17 max), conviction-scaled leverage (7x
+  default / 10x conviction / 10x apex), MIN_SCORE 12, FP-001 quiet
+  hours, FP-003 requireAllConfirmations gate. Trades WITH SM consensus
+  and trend, NOT contrarian. Family member alongside Kodiak (SOL),
+  Wolverine (HYPE), Polar (ETH).
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "6.0.0"
+  version: "7.0.0"
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=2.0.0
+    - senpi-runtime-helpers
 ---
 
-# 🐻 GRIZZLY v6.0.0 — BTC Alpha Hunter
+# 🐻 GRIZZLY v7.0.0 — BTC Alpha Hunter (senpi_runtime_helpers)
 
 Trend-continuation on BTC, v2-runtime-native. Same Kodiak-family
 architecture as Wolverine / Polar / Kodiak. Producer emits signals,
@@ -338,6 +333,10 @@ openclaw cron add \
 ### v3.2 — trend-follower (pre-contrarian)
 
 ---
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.
 
 ## License
 

--- a/grizzly/references/skill-attribution.md
+++ b/grizzly/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "grizzly",
+"skill_version": "7.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "grizzly",
+    "skill_version": "7.0.0"
+  }
+}
+```

--- a/grizzly/scripts/grizzly-producer.py
+++ b/grizzly/scripts/grizzly-producer.py
@@ -1,9 +1,36 @@
 #!/usr/bin/env python3
-# Senpi GRIZZLY Producer v6.0.0
+# Senpi GRIZZLY Producer v7.0.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""GRIZZLY v6.0.0 Producer — BTC alpha signal emitter for v2 runtime.
+"""GRIZZLY v7.0.0 Producer — senpi_runtime_helpers migration.
+
+v7.0.0 (2026-05-08) — plumbing migration. NO thesis change. BTC
+single-asset alpha hunter, six-gate entry validation, v5.5 macro
+V-recovery gate, RSI hard gates, multi-factor scoring (~17 max),
+conviction-scaled leverage (7x default / 10x conviction / 10x apex),
+MIN_SCORE 12, FP-001 quiet hours, FP-003 requireAllConfirmations
+gate — all preserved verbatim from v6.0.0.
+
+Six-layer plumbing flip per migration-cookbook (matches Cheetah
+v7.0.0 / Kodiak v7.0.0 / Polar v5.0.0 / Wolverine v5.0.0 patterns):
+  1. MCP calls — cfg.mcporter_call() shim now routes through
+     SenpiClient.mcp_call() (direct HTTPS).
+  2. Signal emit — subprocess.run(["openclaw","senpi","external-scanner",
+     "ingest"...]) replaced by cfg._wrapper_client.push_signal(...).
+     Per Rachin's PR #209 review: signal_type passed as explicit
+     kwarg ("GRIZZLY_BTC_TREND"), no dead fields in payload.
+  3. Reentrancy — hand-rolled fcntl flock dropped. producer_daemon
+     owns per-tick scanner_lock.
+  4. Tick scheduling — openclaw cron + agentTurn replaced by
+     producer_daemon (long-lived process; zero per-tick LLM cost).
+  5. Per-tick cache + parallel fan-out NOT adopted.
+  6. /state alive_check — wallet=/scanner= NOT passed per fleet-fix
+     #214 (host helpers package doesn't accept yet).
+
+v6.0.0 thesis preserved unchanged.
+
+Original v6.0.0 docstring (preserved for context):
 
 v5.x was a full-agency scanner: 1073 lines with a 3-mode state machine
 (HUNTING/RIDING/STALKING), Python-side cooldowns + dynamic daily caps,
@@ -62,10 +89,9 @@ Environment / config resolution:
   GRIZZLY_WALLET_ADDRESS env var supported as optional override.
 """
 
-import fcntl
+import hashlib
 import json
 import os
-import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -74,43 +100,23 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import grizzly_config as cfg
 
-
-# ═══════════════════════════════════════════════════════════════
-# REENTRANCY GUARD
-# ═══════════════════════════════════════════════════════════════
-
-_LOCK_DIR = Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "grizzly-strategy" / "state"
-_LOCK_DIR.mkdir(parents=True, exist_ok=True)
-_LOCK_PATH = _LOCK_DIR / "producer.lock"
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-def acquire_lock():
-    try:
-        f = open(_LOCK_PATH, "w")
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        f.write(f"{os.getpid()} {int(time.time())}\n")
-        f.flush()
-        return f
-    except (IOError, OSError, BlockingIOError):
-        return None
+VERSION = "7.0.0"
+
+# Hardcoded — must match runtime.yaml external_scanner.name.
+SCANNER_NAME = "grizzly_signals"
+
+# Signal type passed explicitly to push_signal() per Rachin's review
+# of Cheetah PR #209.
+SIGNAL_TYPE = "GRIZZLY_BTC_TREND"
 
 
-def release_lock(lock_file):
-    if lock_file is None:
-        return
-    try:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-    except Exception:
-        pass
-    try:
-        lock_file.close()
-    except Exception:
-        pass
-
-
-VERSION = "6.0.0"
-SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "grizzly_signals")
-OPENCLAW_BIN = os.environ.get("OPENCLAW_BIN", "openclaw")
+# Reentrancy guard removed in v7.0.0. producer_daemon owns the
+# per-tick scanner_lock with stale-PID auto-recovery via os.kill(pid, 0).
+# Do NOT add an inner scanner_lock(...) inside main() — fcntl flock
+# is not reentrant; nested call raises BlockingIOError every tick.
 
 
 def _resolve_wallet():
@@ -701,6 +707,13 @@ def build_btc_thesis():
 # ═══════════════════════════════════════════════════════════════
 
 def push_signal(thesis, held_assets):
+    """Push a signal payload to the runtime via senpi_runtime_helpers.
+
+    Direct HTTP POST to runtime API on 127.0.0.1; no subprocess.
+    asset/direction/signal_type at top-level kwargs (Rachin's PR #209
+    review). Score normalized 0..1 for SignalItem.score (Grizzly's
+    composite 0-17 scaled), with raw int score in `data` for telemetry.
+    """
     if not STRATEGY_ADDRESS:
         print(
             "ERROR: strategy wallet not resolved — set 'wallet' in "
@@ -715,69 +728,45 @@ def push_signal(thesis, held_assets):
     leverage, tier_label = get_leverage_tier(thesis["score"])
     mom = thesis["mom"]
 
-    payload = {
-        "asset": ASSET,
-        "direction": thesis["direction"],
-        "score": thesis["score"] / 17.0,  # normalize 0-1 (theoretical max ~17)
-        "signal_type": "GRIZZLY_BTC_TREND",
-        "data": {
-            "score": thesis["score"],
-            "tier": tier_label,
-            "leverage": leverage,
-            "reasons": thesis["reasons"],
-            "smPct": thesis["sm_pct"],
-            "smTraders": thesis["sm_traders"],
-            "smCc15m": thesis["sm_cc_15m"],
-            "trend4h": thesis["trend_4h"],
-            "trendStrength4h": thesis["trend_strength_4h"],
-            "rsi": thesis["rsi"],
-            "funding": thesis["funding"],
-            "fundingRegime": thesis.get("regime"),
-            "fundingPersistenceHours": thesis.get("persistence_h"),
-            "oiChange1h": thesis.get("oi_change_1h"),
-            "vol1h": thesis.get("vol_1h"),
-            "priceChange5m": mom["5m"],
-            "priceChange15m": mom["15m"],
-            "priceChange1h": mom["1h"],
-            "priceChange4h": mom["4h"],
-            "heldAssets": held_assets,
-        },
+    data_block = {
+        "score": thesis["score"],
+        "tier": tier_label,
+        "leverage": leverage,
+        "reasons": thesis["reasons"],
+        "smPct": thesis["sm_pct"],
+        "smTraders": thesis["sm_traders"],
+        "smCc15m": thesis["sm_cc_15m"],
+        "trend4h": thesis["trend_4h"],
+        "trendStrength4h": thesis["trend_strength_4h"],
+        "rsi": thesis["rsi"],
+        "funding": thesis["funding"],
+        "fundingRegime": thesis.get("regime"),
+        "fundingPersistenceHours": thesis.get("persistence_h"),
+        "oiChange1h": thesis.get("oi_change_1h"),
+        "vol1h": thesis.get("vol_1h"),
+        "priceChange5m": mom["5m"],
+        "priceChange15m": mom["15m"],
+        "priceChange1h": mom["1h"],
+        "priceChange4h": mom["4h"],
+        "heldAssets": held_assets,
     }
 
-    cmd = [
-        OPENCLAW_BIN, "senpi", "external-scanner", "ingest",
-        "--address", STRATEGY_ADDRESS,
-        "--scanner", SCANNER_NAME,
-        "--payload", json.dumps(payload),
-    ]
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
-        if result.returncode != 0:
-            # Forensic logging (Vulture v3.1.1 pattern) — capture rc + both
-            # stderr and stdout + payload, so any future ingest failure is
-            # self-diagnosing from the producer log alone.
-            print(
-                f"INGEST_FAILED BTC: rc={result.returncode} "
-                f"stderr={result.stderr.strip()!r} "
-                f"stdout={result.stdout.strip()!r} "
-                f"payload={json.dumps(payload)}",
-                file=sys.stderr,
-            )
-            return False
-        response = json.loads(result.stdout) if result.stdout.strip() else {}
-        if not response.get("ok", False):
-            print(
-                f"INGEST_REJECTED BTC: error={response.get('error', {})} "
-                f"payload={json.dumps(payload)}",
-                file=sys.stderr,
-            )
-            return False
-        return True
-    except Exception as e:
-        print(
-            f"INGEST_EXCEPTION BTC: {e!r} payload={json.dumps(payload)}",
-            file=sys.stderr,
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=ASSET,
+            direction=thesis["direction"],
+            score=thesis["score"] / 17.0,   # 0..1 confidence (Grizzly composite normalized)
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
         )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED BTC {thesis['direction']}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        print(f"INGEST_EXCEPTION BTC {thesis['direction']}: {type(e).__name__}: {e}", file=sys.stderr)
         return False
 
 
@@ -786,86 +775,96 @@ def push_signal(thesis, held_assets):
 # ═══════════════════════════════════════════════════════════════
 
 def main():
+    """Single tick. NO inner scanner_lock — daemon owns it."""
     run_start = time.time()
-    lock = acquire_lock()
-    if lock is None:
+
+    thesis = build_btc_thesis()
+
+    if thesis.get("blocked"):
+        elapsed = time.time() - run_start
         print(json.dumps({
-            "status": "skip",
-            "reason": "previous run still active — cron reentrancy guard",
+            "status": "ok",
+            "heartbeat": "NO_REPLY",
+            "note": f"BLOCKED: {thesis['reason']}",
+            "elapsed_sec": round(elapsed, 2),
             "_grizzly_producer_version": VERSION,
         }))
         return
 
-    try:
-        thesis = build_btc_thesis()
+    min_score = get_min_score()
+    if thesis["score"] < min_score:
+        print(json.dumps({
+            "status": "ok",
+            "heartbeat": "NO_REPLY",
+            "note": f"score_low {thesis['score']}/{min_score}",
+            "direction": thesis["direction"],
+            "reasons": thesis["reasons"],
+            "_grizzly_producer_version": VERSION,
+        }))
+        return
 
-        if thesis.get("blocked"):
-            elapsed = time.time() - run_start
+    # FP-001 quiet hours
+    quiet, current_hour, apex_bypass = in_quiet_hours()
+    if quiet and thesis["score"] < apex_bypass:
+        print(json.dumps({
+            "status": "ok",
+            "heartbeat": "NO_REPLY",
+            "note": f"QUIET_HOURS hour={current_hour}_UTC score={thesis['score']}_below_apex_{apex_bypass}",
+            "direction": thesis["direction"],
+            "_grizzly_producer_version": VERSION,
+        }))
+        return
+
+    # FP-003 require-all-confirmations
+    if require_all_confirmations_enabled():
+        ok, missing = all_confirmations_present(thesis)
+        if not ok:
             print(json.dumps({
                 "status": "ok",
                 "heartbeat": "NO_REPLY",
-                "note": f"BLOCKED: {thesis['reason']}",
-                "elapsed_sec": round(elapsed, 2),
-                "_grizzly_producer_version": VERSION,
-            }))
-            return
-
-        min_score = get_min_score()
-        if thesis["score"] < min_score:
-            print(json.dumps({
-                "status": "ok",
-                "heartbeat": "NO_REPLY",
-                "note": f"score_low {thesis['score']}/{min_score}",
+                "note": f"MISSING_CONFIRMATIONS {missing} score={thesis['score']}",
                 "direction": thesis["direction"],
                 "reasons": thesis["reasons"],
                 "_grizzly_producer_version": VERSION,
             }))
             return
 
-        # FP-001 quiet hours
-        quiet, current_hour, apex_bypass = in_quiet_hours()
-        if quiet and thesis["score"] < apex_bypass:
-            print(json.dumps({
-                "status": "ok",
-                "heartbeat": "NO_REPLY",
-                "note": f"QUIET_HOURS hour={current_hour}_UTC score={thesis['score']}_below_apex_{apex_bypass}",
-                "direction": thesis["direction"],
-                "_grizzly_producer_version": VERSION,
-            }))
-            return
+    held_assets = fetch_held_assets()
+    pushed = push_signal(thesis, held_assets)
 
-        # FP-003 require-all-confirmations
-        if require_all_confirmations_enabled():
-            ok, missing = all_confirmations_present(thesis)
-            if not ok:
-                print(json.dumps({
-                    "status": "ok",
-                    "heartbeat": "NO_REPLY",
-                    "note": f"MISSING_CONFIRMATIONS {missing} score={thesis['score']}",
-                    "direction": thesis["direction"],
-                    "reasons": thesis["reasons"],
-                    "_grizzly_producer_version": VERSION,
-                }))
-                return
-
-        held_assets = fetch_held_assets()
-        pushed = push_signal(thesis, held_assets)
-
-        elapsed = time.time() - run_start
-        print(json.dumps({
-            "status": "ok",
-            "action": "PUSHED" if pushed else "PUSH_FAILED",
-            "direction": thesis["direction"],
-            "score": thesis["score"],
-            "tier": get_leverage_tier(thesis["score"])[1],
-            "reasons": thesis["reasons"][:5],
-            "held_assets": held_assets,
-            "elapsed_sec": round(elapsed, 2),
-            "_grizzly_producer_version": VERSION,
-        }))
-    finally:
-        release_lock(lock)
+    elapsed = time.time() - run_start
+    print(json.dumps({
+        "status": "ok",
+        "action": "PUSHED" if pushed else "PUSH_FAILED",
+        "direction": thesis["direction"],
+        "score": thesis["score"],
+        "tier": get_leverage_tier(thesis["score"])[1],
+        "reasons": thesis["reasons"][:5],
+        "held_assets": held_assets,
+        "elapsed_sec": round(elapsed, 2),
+        "_grizzly_producer_version": VERSION,
+    }))
 
 
 if __name__ == "__main__":
-    main()
+    # v7.0.0 — long-lived daemon. Replaces openclaw cron + agentTurn.
+    # producer_daemon owns the per-tick scanner_lock with stale-PID
+    # auto-recovery.
+    #
+    # NOTE: wallet=/scanner= kwargs NOT passed (host helpers package
+    # doesn't accept yet — see fleet-fix commit 4f0c15e). When Erik
+    # upgrades the host helpers, restore:
+    #   wallet=STRATEGY_ADDRESS,
+    #   scanner=SCANNER_NAME,
+    # to enable /state alive_check (auto-terminate on runtime delete).
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=180,           # Grizzly's v6.x cron was every 3 min
+        name=f"grizzly-producer-{_wallet_lock_id}",
+        tick_timeout=240,
+    )

--- a/grizzly/scripts/grizzly_config.py
+++ b/grizzly/scripts/grizzly_config.py
@@ -1,15 +1,19 @@
-"""GRIZZLY Strategy — Shared config, MCP helpers, state I/O.
+"""GRIZZLY v7.0.0 — Shared config + MCP shim + helpers wrapper.
 
-Fleet-standard helper module imported by grizzly-scanner.py.
-Added to repo to make grizzly installable (was missing from main).
+v7.0.0: senpi_runtime_helpers migration. mcporter_call now routes
+through SenpiClient.mcp_call() (direct HTTPS) instead of mcporter
+subprocess. _wrapper_client is exposed for the producer's signal
+push (cfg._wrapper_client.push_signal(...)). All other helpers
+(atomic_write, load_config, get_wallet_and_strategy, get_positions,
+trade-counter I/O, output/log) preserved verbatim.
 """
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
 
+import functools
 import json
 import os
-import subprocess
 import sys
 import tempfile
 import time
@@ -22,6 +26,38 @@ CONFIG_PATH = SKILL_DIR / "config" / "grizzly-config.json"
 STATE_DIR = SKILL_DIR / "state"
 
 STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+# Pattern ported verbatim from cheetah/polar/wolverine/kodiak_config.py:
+# mount the helpers package at module load, defer SenpiClient
+# construction until first attribute access.
+
+_helpers_path = str(Path(WORKSPACE) / "skills" / "_helpers")
+if _helpers_path not in sys.path:
+    sys.path.insert(0, _helpers_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Grizzly's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("grizzly_wrapper_enabled", helpers_path=_helpers_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
 
 
 def atomic_write(path, data):
@@ -139,35 +175,22 @@ def set_asset_cooldown(asset, cooldown_minutes=180):
 
 
 def mcporter_call(tool, retries=2, timeout=30, **params):
-    args = json.dumps(params) if params else "{}"
-    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
-    for attempt in range(retries):
-        try:
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-            if r.returncode != 0:
-                if attempt < retries - 1:
-                    time.sleep(2)
-                    continue
-                return None
-            raw = json.loads(r.stdout)
-            if isinstance(raw, dict) and "content" in raw:
-                content = raw["content"]
-                if isinstance(content, list) and content:
-                    first = content[0]
-                    if isinstance(first, dict) and "text" in first:
-                        try:
-                            return json.loads(first["text"])
-                        except (json.JSONDecodeError, TypeError):
-                            pass
-            return raw
-        except subprocess.TimeoutExpired:
-            if attempt < retries - 1:
-                time.sleep(2)
-                continue
-            return None
-        except (json.JSONDecodeError, Exception):
-            return None
-    return None
+    """Call a Senpi MCP tool via the senpi_runtime_helpers wrapper.
+
+    v7.0.0: routes through SenpiClient.mcp_call() — direct HTTPS, no
+    mcporter subprocess. Returns the unwrapped JSON document on
+    success, or None if the wrapper raised. `retries` parameter
+    preserved for call-site compat but not implemented — daemon
+    recovers transient failures on the next tick.
+    """
+    try:
+        return _wrapper_client.mcp_call(tool, timeout=timeout, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] grizzly_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
 
 
 def get_positions(wallet=None):


### PR DESCRIPTION
Plumbing-only migration from v6.0.0. NO thesis change. v6.0.0 six-gate BTC validation, v5.5 macro V-recovery gate, scoring, leverage tiers preserved verbatim. Three commits (`5f65d17` producer-rewrite, `02e9ed8` config-shim, doc-bump). Pattern matches Cheetah/Kodiak/Polar/Wolverine.

Note: Grizzly was missing `references/skill-attribution.md` AND the `## Skill Attribution` section in SKILL.md (regression vs Pangolin reference). Both added in doc-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)