### PR TITLE
Roach v3.0.0 — senpi_runtime_helpers migration

### DIFF
--- a/roach/README.md
+++ b/roach/README.md
@@ -1,6 +1,66 @@
-# 🪳 ROACH v2.0 — Striker Only. v2-Runtime-Native. Maker Exits.
+# 🪳 ROACH v3.0.0 — Striker Only. senpi_runtime_helpers.
 
-Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+**Plumbing-only migration from v2.1.0. NO thesis change.** Producer flips to in-process `SenpiClient` (direct HTTPS for MCP, direct HTTP POST to runtime `/signals`). `producer_daemon` replaces openclaw cron.
+
+## Install
+
+### Step 1 — Pull the helpers package (one-time per host)
+
+> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch. Pull from there.
+
+```bash
+mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
+for f in __init__.py _config.py _logging.py cache.py client.py \
+         daemon.py lock.py parallel.py SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+    -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
+done
+```
+
+### Step 2 — Pull Roach v3.0.0
+
+```bash
+mkdir -p /data/workspace/skills/roach-strategy/{config,scripts,state,references}
+for f in scripts/roach-producer.py scripts/roach_config.py \
+         SKILL.md README.md references/skill-attribution.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/roach/$f" \
+    -o "/data/workspace/skills/roach-strategy/$f"
+done
+```
+
+`runtime.yaml` unchanged from v2.x.
+
+### Step 3 — Required env vars
+
+```bash
+export ROACH_WALLET=<your-roach-wallet>          # NOT STRATEGY_ADDRESS
+export SENPI_AUTH_TOKEN=...
+export ROACH_DECISION_MODEL=gemini-3.1-pro-preview
+```
+
+For **Roach-B** (variant): use the same skill files but set `ROACH_WALLET=<roach-b-wallet>` on that agent's host.
+
+### Step 4 — Stop v2.x cron, start v3.0.0 daemon
+
+```bash
+openclaw cron list | grep roach
+openclaw cron delete <roach-cron-id>
+
+nohup python3 -u /data/workspace/skills/roach-strategy/scripts/roach-producer.py \
+  > /tmp/roach-producer.log 2>&1 &
+```
+
+## Smoke test
+
+```bash
+tail -f /tmp/roach-producer.log | jq -c 'select(.event=="daemon_tick_finished")' | head -3
+```
+
+Expected: `status=ok` every tick (90s interval). Roach is intentionally quiet — heartbeat ticks dominate; Striker fires are rare and that's the design.
+
+---
 
 ## The Strategy
 

--- a/roach/SKILL.md
+++ b/roach/SKILL.md
@@ -1,25 +1,26 @@
 ---
 name: roach-strategy
 description: >-
-  ROACH v2.0 — Striker-only scanner with v2-runtime-native architecture +
-  maker-exit fee recovery. Stalker permanently disabled. Only trades violent
-  FIRST_JUMP / IMMEDIATE_MOVER explosions backed by 1.5x volume, 1h price
-  alignment, and 4h trend agreement. Producer emits signals to the runtime;
-  runtime LLM gates them, executes via FEE_OPTIMIZED_LIMIT (maker-first),
-  and manages DSL exits autonomously. Long stretches of silence are
-  EXPECTED and correct — the patience is the edge.
+  ROACH v3.0.0 — Striker-only scanner, senpi_runtime_helpers migration.
+  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
+  to in-process SenpiClient. Thesis preserved verbatim from v2.1.0:
+  Stalker permanently disabled, only trades violent FIRST_JUMP /
+  IMMEDIATE_MOVER explosions backed by 1.5x volume, 1h price alignment,
+  4h trend agreement. Long stretches of silence are EXPECTED — the
+  patience is the edge.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "2.0"
+  version: "3.0.0"
   platform: senpi
   exchange: hyperliquid
   config_source: striker-only-experiment
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=2.0.0
+    - senpi-runtime-helpers
 ---
 
-# 🪳 ROACH v2.0 — Striker Only. v2-Runtime-Native. Maker Exits.
+# 🪳 ROACH v3.0.0 — Striker Only. senpi_runtime_helpers.
 
 Cockroaches survive anything. ROACH survives by not trading when there's no explosion.
 

--- a/roach/references/skill-attribution.md
+++ b/roach/references/skill-attribution.md
@@ -4,7 +4,7 @@ When calling `strategy_create` or `strategy_create_custom_strategy`, always incl
 
 ```json
 "skill_name": "roach",
-"skill_version": "2.0"
+"skill_version": "3.0.0"
 ```
 
 This is required for attribution and tracking. Example:
@@ -16,7 +16,7 @@ This is required for attribution and tracking. Example:
     "initialBudget": 500,
     "positions": [],
     "skill_name": "roach",
-    "skill_version": "2.0"
+    "skill_version": "3.0.0"
   }
 }
 ```

--- a/roach/scripts/roach-producer.py
+++ b/roach/scripts/roach-producer.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-# Senpi ROACH Producer v2.0
+# Senpi ROACH Producer v3.0.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""ROACH v2.0 Producer — Striker-only signal emitter for v2 runtime.
+"""ROACH v3.0.0 Producer — Striker-only signal emitter for v2 runtime.
 
 Roach v1.x ran as a full-agency Python scanner that:
   - Fetched market concentration + scan history
@@ -51,13 +51,13 @@ Environment variables (standard v2 producer):
   EXTERNAL_SCANNER_NAME — optional override (default "roach_signals")
   ROACH_LEVERAGE    — optional override of default 7
   ROACH_MARGIN_USD  — optional override of default 250
+  SENPI_AUTH_TOKEN  — REQUIRED. Bearer token for MCP + signal POST.
+  ROACH_DECISION_MODEL — bare LLM model name (no provider prefix)
 """
 
-import fcntl
 import hashlib
 import json
 import os
-import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -66,24 +66,22 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import roach_config as cfg
 
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
-# ═══════════════════════════════════════════════════════════════
-# REENTRANCY GUARD
-# ═══════════════════════════════════════════════════════════════
-# Cron fires every 90s. If a run takes longer (MCP latency on
-# market_get_asset_data per candidate × N candidates), the next tick
-# would start a second concurrent run. Two runs racing on
-# scan-history.json would corrupt rank-jump detection.
-# fcntl.LOCK_EX | LOCK_NB is non-blocking: if another run holds the
-# lock, acquire_lock() returns None and we skip this tick cleanly.
-# fcntl locks auto-release when the process dies, so crashes self-heal.
 
-# v2.0.0: Agent-specific wallet env var. NO fallback to STRATEGY_ADDRESS
-# (contamination risk per Turbine v2.0.9 fix — see feedback_mcp_auth_is_fleet_wide.md).
-# Read case-preserved for CLI calls; lowercased separately for stable state-dir hashing.
+# Reentrancy guard removed in v3.0.0. producer_daemon owns the per-tick
+# scanner_lock with stale-PID auto-recovery. Do NOT add an inner
+# scanner_lock(...) inside main().
+
+# v2.0.0: Agent-specific wallet env var. NO fallback to STRATEGY_ADDRESS.
 ROACH_WALLET = os.environ.get("ROACH_WALLET", "")
-SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "roach_signals")
-OPENCLAW_BIN = os.environ.get("OPENCLAW_BIN", "openclaw")
+
+# Hardcoded — must match runtime.yaml external_scanner.name.
+SCANNER_NAME = "roach_signals"
+
+# Signal type passed explicitly to push_signal() per Rachin's review
+# of Cheetah PR #209.
+SIGNAL_TYPE = "ROACH_STRIKER"
 
 # Leverage + margin — operator-tunable, runtime defaults match runtime.yaml
 DEFAULT_LEVERAGE = int(os.environ.get("ROACH_LEVERAGE", "7"))
@@ -107,35 +105,9 @@ def _wallet_state_dir():
 
 
 _STATE_DIR = _wallet_state_dir()
-_LOCK_PATH = _STATE_DIR / "producer.lock"
 _HISTORY_FILE = _STATE_DIR / "scan-history.json"
 _COOLDOWN_FILE = _STATE_DIR / "asset-cooldowns.json"
 _EMITTED_FILE = _STATE_DIR / "last-emitted.json"
-
-
-def acquire_lock():
-    """Non-blocking exclusive lock. Returns file handle or None if held."""
-    try:
-        f = open(_LOCK_PATH, "w")
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        f.write(f"{os.getpid()} {int(time.time())}\n")
-        f.flush()
-        return f
-    except (IOError, OSError, BlockingIOError):
-        return None
-
-
-def release_lock(lock_file):
-    if lock_file is None:
-        return
-    try:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-    except Exception:
-        pass
-    try:
-        lock_file.close()
-    except Exception:
-        pass
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -508,17 +480,10 @@ def detect_striker_signals(current_scan, history):
 # ═══════════════════════════════════════════════════════════════
 
 def build_signal_payload(s):
-    """Build the payload matching runtime.yaml's roach_signals.config.fields schema.
-    All declared scanner fields go in `data`, NOT `meta`. (Turbine v2.0.11 lesson.)"""
+    """v3.0.0: returns only fields push_signal() forwards (asset, direction, data)."""
     return {
-        "address": ROACH_WALLET,
-        "scannerId": SCANNER_NAME,
-        "signalType": "ROACH_STRIKER",
         "asset": s["asset"],
         "direction": s["direction"],
-        "score": float(s["score"]),
-        "timestamp": int(time.time() * 1000),
-        "factors": {},
         "data": {
             "mode": s["mode"],
             "score": s["score"],
@@ -538,40 +503,29 @@ def build_signal_payload(s):
             "leverage": DEFAULT_LEVERAGE,
             "marginUsd": DEFAULT_MARGIN_USD,
         },
-        "meta": {
-            "_roach_producer_version": "2.1.0",
-        },
     }
 
 
 def push_signal(payload):
-    """Push a signal payload to the runtime via CLI."""
+    """Push a signal via senpi_runtime_helpers wrapper (direct HTTP POST)."""
     if not ROACH_WALLET:
         cfg.log("ROACH_WALLET env var not set; cannot push signal")
         return False
-
-    cmd = [
-        OPENCLAW_BIN, "senpi", "external-scanner", "ingest",
-        "--address", ROACH_WALLET,
-        "--scanner", SCANNER_NAME,
-        "--payload", json.dumps(payload),
-    ]
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
-        if r.returncode != 0:
-            cfg.log(f"ingest failed for {payload['asset']} {payload['direction']}: {r.stderr.strip()}")
-            return False
-        if r.stdout.strip():
-            try:
-                response = json.loads(r.stdout)
-                if isinstance(response, dict) and response.get("ok") is False:
-                    cfg.log(f"ingest rejected for {payload['asset']} {payload['direction']}: {response.get('error')}")
-                    return False
-            except (json.JSONDecodeError, TypeError):
-                pass
+        cfg._wrapper_client.push_signal(
+            address=ROACH_WALLET,
+            scanner=SCANNER_NAME,
+            asset=payload.get("asset"),
+            direction=payload.get("direction"),
+            signal_type=SIGNAL_TYPE,
+            data=payload.get("data"),
+        )
         return True
-    except (subprocess.TimeoutExpired, OSError) as e:
-        cfg.log(f"ingest exception for {payload['asset']}: {e}")
+    except SenpiClientError as e:
+        cfg.log(f"push_signal rejected for {payload.get('asset')} {payload.get('direction')}: {e}")
+        return False
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        cfg.log(f"push_signal exception for {payload.get('asset')}: {type(e).__name__}: {e}")
         return False
 
 
@@ -589,84 +543,84 @@ def main():
         cfg.output({
             "status": "error",
             "error": "ROACH_WALLET env var not set. Set it to the Roach strategy wallet (must match runtime.yaml).",
-            "_roach_producer_version": "2.1.0",
+            "_roach_producer_version": "3.0.0",
         })
         return
 
-    lock = acquire_lock()
-    if lock is None:
-        print(json.dumps({
-            "status": "skip",
-            "reason": "previous run still active — cron reentrancy guard",
-            "_roach_producer_version": "2.1.0",
-        }))
+    # Fetch & parse current scan
+    raw = fetch_markets()
+    if raw is None:
+        cfg.output({
+            "status": "error",
+            "error": "failed to fetch markets",
+            "_roach_producer_version": "3.0.0",
+        })
         return
 
-    try:
-        # Fetch & parse current scan
-        raw = fetch_markets()
-        if raw is None:
-            cfg.output({
-                "status": "error",
-                "error": "failed to fetch markets",
-                "_roach_producer_version": "2.1.0",
-            })
-            return
+    current_scan = parse_scan(raw)
 
-        current_scan = parse_scan(raw)
+    # Load history (rank-jump detection requires it)
+    history = load_scan_history()
 
-        # Load history (rank-jump detection requires it)
-        history = load_scan_history()
+    # Detect striker signals
+    striker_signals = detect_striker_signals(current_scan, history)
 
-        # Detect striker signals
-        striker_signals = detect_striker_signals(current_scan, history)
+    # Persist scan history (always, even if no signals)
+    history["scans"].append(current_scan)
+    save_scan_history(history)
 
-        # Persist scan history (always, even if no signals)
-        history["scans"].append(current_scan)
-        save_scan_history(history)
+    # Apply per-asset cooldown (defense-in-depth alongside runtime guard)
+    striker_signals = [s for s in striker_signals
+                       if not is_asset_cooled_down(s["token"])]
 
-        # Apply per-asset cooldown (defense-in-depth alongside runtime guard)
-        striker_signals = [s for s in striker_signals
-                           if not is_asset_cooled_down(s["token"])]
+    # Sort highest score first
+    striker_signals.sort(key=lambda s: s["score"], reverse=True)
 
-        # Sort highest score first
-        striker_signals.sort(key=lambda s: s["score"], reverse=True)
-
-        if not striker_signals:
-            elapsed = time.time() - run_start
-            cfg.output({
-                "status": "ok",
-                "totalMarkets": len(current_scan["markets"]),
-                "scansInHistory": len(history["scans"]),
-                "candidates": 0,
-                "elapsed_sec": round(elapsed, 2),
-                "_roach_producer_version": "2.1.0",
-            })
-            return
-
-        # Emit signals
-        pushed = 0
-        for s in striker_signals:
-            payload = build_signal_payload(s)
-            if push_signal(payload):
-                pushed += 1
-                mark_asset_emitted(s["token"])
-
+    if not striker_signals:
         elapsed = time.time() - run_start
-        warn = "WARN_OVER_90S" if elapsed > 90 else None
         cfg.output({
             "status": "ok",
             "totalMarkets": len(current_scan["markets"]),
             "scansInHistory": len(history["scans"]),
-            "candidates_detected": len(striker_signals),
-            "signals_pushed": pushed,
+            "candidates": 0,
             "elapsed_sec": round(elapsed, 2),
-            "warn": warn,
-            "_roach_producer_version": "2.1.0",
+            "_roach_producer_version": "3.0.0",
         })
-    finally:
-        release_lock(lock)
+        return
+
+    # Emit signals
+    pushed = 0
+    for s in striker_signals:
+        payload = build_signal_payload(s)
+        if push_signal(payload):
+            pushed += 1
+            mark_asset_emitted(s["token"])
+
+    elapsed = time.time() - run_start
+    warn = "WARN_OVER_90S" if elapsed > 90 else None
+    cfg.output({
+        "status": "ok",
+        "totalMarkets": len(current_scan["markets"]),
+        "scansInHistory": len(history["scans"]),
+        "candidates_detected": len(striker_signals),
+        "signals_pushed": pushed,
+        "elapsed_sec": round(elapsed, 2),
+        "warn": warn,
+        "_roach_producer_version": "3.0.0",
+    })
 
 
 if __name__ == "__main__":
-    main()
+    # v3.0.0 — long-lived daemon. NOTE: wallet=/scanner= NOT passed
+    # per fleet-fix #214 (host helpers package doesn't accept yet).
+    _wallet_lock_id = (
+        hashlib.sha256(ROACH_WALLET.lower().encode()).hexdigest()[:12]
+        if ROACH_WALLET
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=90,           # Roach's v2.x cron was every 90s
+        name=f"roach-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/roach/scripts/roach_config.py
+++ b/roach/scripts/roach_config.py
@@ -20,9 +20,9 @@ SKILL_DIR/state/<wallet-hash>/ — see roach-producer.py for the wallet hashing.
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
 
+import functools
 import json
 import os
-import subprocess
 import sys
 import tempfile
 import time
@@ -32,6 +32,33 @@ from pathlib import Path
 WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
 SKILL_DIR = Path(WORKSPACE) / "skills" / "roach-strategy"
 CONFIG_PATH = SKILL_DIR / "config" / "roach-config.json"
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_helpers_path = str(Path(WORKSPACE) / "skills" / "_helpers")
+if _helpers_path not in sys.path:
+    sys.path.insert(0, _helpers_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Roach's MCP calls and signal "
+            "POST both require it."
+        )
+    client = SenpiClient()
+    log_event("roach_wrapper_enabled", helpers_path=_helpers_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
 
 
 # ─── Config ──────────────────────────────────────────────────
@@ -69,36 +96,17 @@ def atomic_write(path, data):
 # ─── MCP Helper ──────────────────────────────────────────────
 
 def mcporter_call(tool, retries=2, timeout=25, **params):
-    """Call a Senpi MCP tool via mcporter. Returns parsed JSON or None on failure."""
-    args = json.dumps(params) if params else "{}"
-    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
-    for attempt in range(retries):
-        try:
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-            if r.returncode != 0:
-                if attempt < retries - 1:
-                    time.sleep(2)
-                    continue
-                return None
-            raw = json.loads(r.stdout)
-            if isinstance(raw, dict) and "content" in raw:
-                content = raw["content"]
-                if isinstance(content, list) and content:
-                    first = content[0]
-                    if isinstance(first, dict) and "text" in first:
-                        try:
-                            return json.loads(first["text"])
-                        except (json.JSONDecodeError, TypeError):
-                            pass
-            return raw
-        except subprocess.TimeoutExpired:
-            if attempt < retries - 1:
-                time.sleep(2)
-                continue
-            return None
-        except (json.JSONDecodeError, Exception):
-            return None
-    return None
+    """v3.0.0: routes through SenpiClient.mcp_call() — direct HTTPS, no
+    mcporter subprocess. Returns the unwrapped JSON document on
+    success, or None if the wrapper raised."""
+    try:
+        return _wrapper_client.mcp_call(tool, timeout=timeout, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] roach_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
 
 
 # ─── Output helpers ──────────────────────────────────────────


### PR DESCRIPTION
Plumbing-only from v2.1.0. NO thesis change. Standard Cheetah-pattern 3-file migration. Operator note: Roach-B is the same skill code with a different ROACH_WALLET — both deployments use these v3.0.0 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)