### PR TITLE
Spider v4.0.0 — senpi_runtime_helpers migration (plumbing-only)

### DIFF
--- a/spider/README.md
+++ b/spider/README.md
@@ -1,22 +1,62 @@
-# 🕷️ SPIDER v3.0 — Patient Anchor Sniper (v2-runtime-native)
+# 🕷️ SPIDER v4.0.0 — Patient Anchor Sniper. senpi_runtime_helpers.
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-## What changed in v3.0
+**Plumbing-only migration from v3.0.2. NO thesis change. NO scoring change. NO threshold change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry. Fleet-fix #214 applied (no `wallet=`/`scanner=` daemon kwargs). v2.0.9 contamination rule applied: `SPIDER_WALLET` is the canonical env var (with `STRATEGY_ADDRESS` deprecation fallback).
 
-- `spider-producer.py` (NEW) replaces the v2.0 simulated-runtime cron-prompt approach
-- `spider-rationale-log.py` (DELETED) — chain DB telemetry replaces it
-- v2-runtime-native: external_scanner + LLM-pass-through gate + native `risk.guard_rails` + standard `OPEN_POSITION` action
-- DSL exits via `FEE_OPTIMIZED_LIMIT` (entries already on FEE_OPTIMIZED_LIMIT)
-- Trade chain DB emits per-trade telemetry — chain DB visibility for the first time
-- **Single-leg anchor only** — basket leg dropped (no native portfolio runtime support); revisit when `dsl_portfolio` ships
-- All v2.0 anchor scoring logic preserved (arena 0.40 + SM 0.30 + funding 0.15 + relstr 0.15)
+## Install
 
-## Why the redesign
+### Step 1 — Pull the helpers package (one-time per host)
 
-v2.0 was specced with custom runtime types (`composite_score`, `portfolio_snapshot`, `predators_position_aggregator`, `LLM_PORTFOLIO_DECISION`) that the senpi-trading-runtime doesn't implement. The runtime silently dropped the unsupported types; the operator agent simulated the missing engine via cron text prompts. **Spider v2.0 never made a real trade in 30+ days of "operation."**
+> **Note:** The `_helpers/senpi_runtime_helpers/` package currently lives only on the `helper-mcp-envelope-aligned` branch. Pull from there.
 
-v3.0 trade-off: drop the basket leg + portfolio-level coordination to use ONLY runtime primitives that exist today. Single high-conviction long anchor, 7-day minimum hold, fee-aware. The thesis (patience > frequency) survives intact.
+```bash
+mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
+for f in __init__.py _config.py _logging.py cache.py client.py \
+         daemon.py lock.py parallel.py SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+    -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
+done
+```
+
+### Step 2 — Pull Spider v4.0.0
+
+```bash
+mkdir -p /data/workspace/skills/spider-strategy/{config,scripts,state,references}
+for f in scripts/spider-producer.py scripts/spider_config.py \
+         runtime.yaml SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/spider/$f" \
+    -o "/data/workspace/skills/spider-strategy/$f"
+done
+```
+
+### Step 3 — Required env vars
+
+```bash
+export SPIDER_WALLET=<your-spider-wallet>      # or set wallet field in config/spider-config.json
+export SENPI_AUTH_TOKEN=...
+export SPIDER_DECISION_MODEL=gemini-2.5-pro    # or any model the runtime supports
+```
+
+### Step 4 — Stop v3.x cron, start v4.0.0 daemon
+
+```bash
+openclaw cron list | grep spider
+openclaw cron delete <spider-cron-id>
+
+nohup python3 -u /data/workspace/skills/spider-strategy/scripts/spider-producer.py \
+  > /tmp/spider-producer.log 2>&1 &
+```
+
+## Smoke test
+
+```bash
+tail -f /tmp/spider-producer.log | jq -c 'select(.event=="daemon_tick_finished")' | head -3
+```
+
+Expected: `status=ok` every tick (3600s interval — Spider's hourly cadence reflects the 7-day-min-hold thesis horizon).
+
+---
 
 ## Thesis
 
@@ -29,56 +69,6 @@ Hold one high-conviction long anchor for at least 7 days. Generate edge from:
 
 While 95% of the fleet churns daily on noise, Spider sits with a single position. **Patience is the edge.**
 
-## Install
-
-```bash
-mkdir -p /data/workspace/skills/spider-strategy/{config,scripts,state}
-
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/spider/runtime.yaml -o /data/workspace/skills/spider-strategy/runtime.yaml
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/spider/SKILL.md -o /data/workspace/skills/spider-strategy/SKILL.md
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/spider/config/spider-config.json -o /data/workspace/skills/spider-strategy/config/spider-config.json
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/spider/scripts/spider-producer.py -o /data/workspace/skills/spider-strategy/scripts/spider-producer.py
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/spider/scripts/spider_config.py -o /data/workspace/skills/spider-strategy/scripts/spider_config.py
-```
-
-## Configure
-
-**Set wallet, strategyId, chatId in `config/spider-config.json`** — canonical source. Producer reads from here on every cron tick.
-
-```json
-{
-  "strategyId": "your-strategy-id",
-  "wallet": "0xYourStrategyWallet",
-  "chatId": "YourTelegramChatId",
-  "minScore": 7.0
-}
-```
-
-LLM model env var (only at runtime-create time):
-
-```bash
-export SPIDER_DECISION_MODEL=gemini-3.1-pro-preview    # bare model name; NO provider prefix
-```
-
-## Install runtime + producer cron
-
-```bash
-openclaw senpi runtime create --path /data/workspace/skills/spider-strategy/runtime.yaml
-openclaw senpi runtime list
-```
-
-Cron (hourly, no env vars needed — wallet read from config). Spider's producer self-skips when riding an anchor with held_days < 7, so hourly cadence is safe and catches faster regime shifts than daily would.
-
-```cron
-0 * * * * cd /data/workspace/skills/spider-strategy && python3 scripts/spider-producer.py >> state/producer.log 2>&1
-```
-
-If you prefer the v2.0 daily 13:00 UTC cadence:
-
-```cron
-0 13 * * * cd /data/workspace/skills/spider-strategy && python3 scripts/spider-producer.py >> state/producer.log 2>&1
-```
-
 ## Key parameters
 
 | Parameter | Value |
@@ -87,18 +77,16 @@ If you prefer the v2.0 daily 13:00 UTC cadence:
 | Max positions | 1 (anchor only) |
 | Margin per slot | $1000 (100% of equity, single anchor) |
 | Leverage | 1x / 2x / 3x (score-tiered, capped at 3x) |
-| **MIN_SCORE** | **7.0** |
+| **MIN_SCORE** | **5.5** (v3.0.2 calibration; preserved in v4.0.0) |
 | Min hold | 7 days |
 | Post-close cooldown | 7 days (matches min-hold) |
-| Daily entry cap | 2 |
 | Daily loss limit | 12% |
 | Drawdown halt | 25% |
-| drawdown_reset_on_day_rollover | false |
 | per_asset_cooldown | 10080 min (7d) |
 | Entry order type | FEE_OPTIMIZED_LIMIT |
 | Exit order type | FEE_OPTIMIZED_LIMIT |
 
-## DSL Phase 2 ladder (v3.0 — patience-tuned, wider than active agents)
+## DSL Phase 2 ladder (patience-tuned, wider than active agents)
 
 | Tier | Trigger (margin ROE) | Lock (% of HW) |
 |---|---|---|
@@ -110,37 +98,6 @@ If you prefer the v2.0 daily 13:00 UTC cadence:
 
 Phase 1: max_loss 12% / retrace 8 / 3 consecutive breaches.
 Time cuts: hard_timeout 30d (43200 min) — fail-safe only. weak_peak_cut and dead_weight_cut DISABLED — patience agent.
-
-## Migrating from v2.0
-
-```bash
-cd /data/workspace/skills/spider-strategy
-
-# v2.0 had no real positions (it never traded). Safe to delete + recreate.
-rm -f scripts/spider_rationale_log.py     # replaced by chain DB
-# (curl commands above for new files)
-
-# Reload runtime
-openclaw senpi runtime delete <old runtime id>
-openclaw senpi runtime create --path runtime.yaml
-
-# Update cron to point at spider-producer.py
-```
-
-State files from v2.0 (`spider-log.jsonl`, `paper-positions.json`, etc.) are vestigial — chain DB owns telemetry now. Safe to archive or delete.
-
-## What's deferred for later
-
-- **Basket leg** — when the runtime ships `dsl_portfolio` and supports multi-leg coordinated entry/exit, basket-of-shorts can be re-added. For now, anchor only.
-- **Fleet concentration overlay** — leverage modifier from peer-position aggregator. Producer can simulate this via `discovery_get_top_strategies`, but skipped in v3.0 to ship.
-- **Funding harvest from coordinated shorts** — partially captured via the funding-favorability score component on the anchor.
-
-## Operator checklist for the first 7 days
-
-- **Day 1:** confirm `state/producer.log` accumulating one JSON-per-tick. Look for `_spider_producer_version: "3.0.0"` in output.
-- **Day 1-2:** if anchor opens, verify chain DB emits CREATED + DECISION + ACTION_RESULT events (via `trade_chains_get`)
-- **Day 2-7:** producer should output `note: "riding anchor day X.Y/7 min hold"` on every tick. No new emissions.
-- **Day 7+:** anchor can close via DSL Phase 1 max_loss OR Phase 2 trailing. After close, 7-day post-close cooldown blocks re-entry on same asset.
 
 ## License
 

--- a/spider/SKILL.md
+++ b/spider/SKILL.md
@@ -1,21 +1,24 @@
 ---
 name: spider-strategy
 description: >-
-  SPIDER v3.0 — Single-leg patient anchor sniper. Holds one
-  high-conviction long for 7+ days. Scored on arena leader alignment +
-  SM consensus + funding favorability + 30d relative strength. LLM
-  regime-aware gate vetoes during BTC catastrophe / vol expansion /
-  funding flipping. v2-runtime-native. Trade-off vs v2.0 design:
-  drops basket leg (no portfolio runtime support) to gain actually
-  trading.
+  SPIDER v4.0.0 — Single-leg patient anchor sniper
+  (senpi_runtime_helpers migration). Plumbing-only port from v3.0.2.
+  NO thesis change. NO scoring change. NO threshold change. Producer
+  ports onto `senpi_runtime_helpers` (in-process SenpiClient + direct
+  HTTP POST to runtime /signals + producer_daemon long-lived loop).
+  Holds one high-conviction long for 7+ days. Scored on arena leader
+  alignment + SM consensus + funding favorability + 30d relative
+  strength. LLM regime-aware gate vetoes during BTC catastrophe / vol
+  expansion / funding flipping.
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0.0"
+  version: "4.0.0"
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime@v2
+    - senpi_runtime_helpers
 ---
 
 # 🕷️ SPIDER v3.0 — Patient Anchor Sniper

--- a/spider/scripts/spider-producer.py
+++ b/spider/scripts/spider-producer.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
-# Senpi SPIDER Producer v3.0.0
+# Senpi SPIDER Producer v4.0.0
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""SPIDER v3.0.2 Producer — Single-leg patient anchor sniper, v2-runtime-native.
+"""SPIDER v4.0.0 Producer — Single-leg patient anchor sniper.
+
+PLUMBING-ONLY MIGRATION from v3.0.2. NO thesis change. NO scoring change.
+NO threshold change. Producer ports onto senpi_runtime_helpers (in-process
+SenpiClient + direct HTTP POST to runtime /signals + producer_daemon
+long-lived loop replacing the openclaw cron entry).
 
 v3.0.2 (2026-05-04 — calibration relax):
   Diagnostic of first 3 hourly scans showed arena=0.0 in every scan
@@ -75,11 +80,9 @@ Environment / config resolution:
   EXTERNAL_SCANNER_NAME      — optional override (default "spider_signals")
 """
 
-import fcntl
 import hashlib
 import json
 import os
-import subprocess
 import sys
 import time
 from datetime import datetime, timezone
@@ -88,21 +91,36 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import spider_config as cfg
 
+_helpers_path = str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace"))
+                    / "skills" / "_helpers")
+if _helpers_path not in sys.path:
+    sys.path.insert(0, _helpers_path)
+from senpi_runtime_helpers import producer_daemon  # type: ignore  # noqa: E402
 
-VERSION = "3.0.2"
+
+VERSION = "4.0.0"
 SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "spider_signals")
-OPENCLAW_BIN = os.environ.get("OPENCLAW_BIN", "openclaw")
+SIGNAL_TYPE = "SPIDER_ANCHOR"
 
 
 def _resolve_wallet():
-    env_wallet = os.environ.get("SPIDER_WALLET", "").strip()
+    env_wallet = (os.environ.get("SPIDER_WALLET") or "").strip()
     if env_wallet:
         return env_wallet
+    legacy = (os.environ.get("STRATEGY_ADDRESS") or "").strip()
+    if legacy:
+        sys.stderr.write(
+            "[spider v4.0.0] DEPRECATION: STRATEGY_ADDRESS env var is BANNED "
+            "by v2.0.9 contamination rule. Set SPIDER_WALLET instead. "
+            "Honoring legacy value for this run only.\n"
+        )
+        return legacy
     config = cfg.load_config()
     return (config.get("wallet") or "").strip()
 
 
 SPIDER_WALLET = _resolve_wallet()
+STRATEGY_ADDRESS = SPIDER_WALLET  # alias used by signal payload
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -120,39 +138,12 @@ def _wallet_state_dir():
 
 
 _STATE_DIR = _wallet_state_dir()
-_LOCK_PATH = _STATE_DIR / "producer.lock"
 _LAST_CLOSED_FILE = _STATE_DIR / "last-closed.json"
 _PREV_HELD_FILE = _STATE_DIR / "previously-held.json"
 _ANCHOR_HISTORY_FILE = _STATE_DIR / "anchor-history.json"
 _COOLDOWN_FILE = _STATE_DIR / "asset-cooldowns.json"
-
-
-# ═══════════════════════════════════════════════════════════════
-# REENTRANCY GUARD
-# ═══════════════════════════════════════════════════════════════
-
-def acquire_lock():
-    try:
-        f = open(_LOCK_PATH, "w")
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        f.write(f"{os.getpid()} {int(time.time())}\n")
-        f.flush()
-        return f
-    except (IOError, OSError, BlockingIOError):
-        return None
-
-
-def release_lock(lock_file):
-    if lock_file is None:
-        return
-    try:
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-    except Exception:
-        pass
-    try:
-        lock_file.close()
-    except Exception:
-        pass
+_wallet_lock_id = (hashlib.sha256(SPIDER_WALLET.lower().encode()).hexdigest()[:8]
+                   if SPIDER_WALLET else "unset")
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -677,68 +668,51 @@ def score_anchor(market, arena_long_exposure):
 # SIGNAL EMISSION
 # ═══════════════════════════════════════════════════════════════
 
-def build_signal_payload(candidate, leverage, margin_usd, held_assets, breakdown):
+def build_signal_data(candidate, leverage, margin_usd, held_assets, breakdown):
+    """v4.0.0: helpers `push_signal()` takes asset/direction/signal_type/score
+    as top-level kwargs. Everything else goes in `data`."""
     held_list = sorted(list(held_assets)) if held_assets else []
     return {
-        "address": SPIDER_WALLET,
-        "scannerId": SCANNER_NAME,
-        "signalType": "SPIDER_ANCHOR",
-        "asset": candidate["token"],
-        "direction": "LONG",
-        "score": float(candidate["score"]),
-        "timestamp": int(time.time() * 1000),
-        "factors": {},
-        "data": {
-            "score": candidate["score"],
-            "leverage": leverage,
-            "marginUsd": margin_usd,
-            "reasons": " | ".join(candidate["reasons"]),
-            "smPct": float(candidate["pct"]),
-            "smTraders": int(candidate["traders"]),
-            "rank": int(candidate["rank"]),
-            "arenaScore": breakdown.get("arena", 0),
-            "smScore": breakdown.get("sm", 0),
-            "fundingScore": breakdown.get("funding", 0),
-            "relstrScore": breakdown.get("relstr", 0),
-            "fundingRate": float(candidate["funding_rate"]),
-            "priceChg30d": float(candidate["price_chg_30d"]),
-            "priceChg7d": float(candidate["price_chg_7d"]),
-            "priceChg24h": float(candidate["price_chg_24h"]),
-            "heldAssets": held_list,
-        },
-        "meta": {
-            "_spider_producer_version": VERSION,
-        },
+        "score": candidate["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "reasons": " | ".join(candidate["reasons"]),
+        "smPct": float(candidate["pct"]),
+        "smTraders": int(candidate["traders"]),
+        "rank": int(candidate["rank"]),
+        "arenaScore": breakdown.get("arena", 0),
+        "smScore": breakdown.get("sm", 0),
+        "fundingScore": breakdown.get("funding", 0),
+        "relstrScore": breakdown.get("relstr", 0),
+        "fundingRate": float(candidate["funding_rate"]),
+        "priceChg30d": float(candidate["price_chg_30d"]),
+        "priceChg7d": float(candidate["price_chg_7d"]),
+        "priceChg24h": float(candidate["price_chg_24h"]),
+        "heldAssets": held_list,
+        "_spider_producer_version": VERSION,
     }
 
 
-def push_signal(payload):
-    if not SPIDER_WALLET:
+def push_signal(candidate, leverage, margin_usd, held_assets, breakdown):
+    """v4.0.0: direct POST to runtime /signals via helpers SenpiClient."""
+    if not STRATEGY_ADDRESS:
         cfg.log("SPIDER_WALLET not set; cannot push signal")
         return False
-
-    cmd = [
-        OPENCLAW_BIN, "senpi", "external-scanner", "ingest",
-        "--address", SPIDER_WALLET,
-        "--scanner", SCANNER_NAME,
-        "--payload", json.dumps(payload),
-    ]
+    data_block = build_signal_data(candidate, leverage, margin_usd, held_assets, breakdown)
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
-        if r.returncode != 0:
-            cfg.log(f"ingest failed for {payload['asset']}: {r.stderr.strip()}")
-            return False
-        if r.stdout.strip():
-            try:
-                response = json.loads(r.stdout)
-                if isinstance(response, dict) and response.get("ok") is False:
-                    cfg.log(f"ingest rejected for {payload['asset']}: {response.get('error')}")
-                    return False
-            except (json.JSONDecodeError, TypeError):
-                pass
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=candidate["token"],
+            direction="LONG",
+            signal_type=SIGNAL_TYPE,
+            score=float(candidate["score"]),
+            data=data_block,
+        )
         return True
-    except (subprocess.TimeoutExpired, OSError) as e:
-        cfg.log(f"ingest exception for {payload['asset']}: {e}")
+    except Exception as e:  # noqa: BLE001
+        cfg.log(f"push_signal failed for {candidate['token']}: "
+                f"{type(e).__name__}: {e}")
         return False
 
 
@@ -757,186 +731,166 @@ def main():
         })
         return
 
-    lock = acquire_lock()
-    if lock is None:
-        print(json.dumps({
-            "status": "skip",
-            "reason": "previous run still active — cron reentrancy guard",
-            "_spider_producer_version": VERSION,
-        }))
-        return
-
-    try:
-        # ── Account + held assets + oldest open position age ──
-        account_value, pos_count, held_assets, oldest_age_sec = get_account_state()
-        if account_value is None or account_value <= 0:
-            cfg.output({
-                "status": "ok",
-                "note": "cannot read account value; skip tick",
-                "_spider_producer_version": VERSION,
-            })
-            return
-
-        # ── Detect closes vs last tick ──
-        previously_held = load_previously_held()
-        closed_this_tick = detect_closes(held_assets, previously_held)
-        save_previously_held(held_assets)
-
-        # ── Fallback hold-time check via anchor-history.json ──
-        fallback_age_sec = get_oldest_anchor_age_seconds(held_assets)
-        effective_age_sec = oldest_age_sec or fallback_age_sec
-
-        # ── Single-leg max positions guard + 7-day min-hold gate ──
-        if pos_count >= MAX_POSITIONS:
-            held_days = (effective_age_sec / 86400.0) if effective_age_sec else None
-            if held_days is not None and held_days < MIN_HOLD_DAYS:
-                cfg.output({
-                    "status": "ok",
-                    "note": f"riding anchor day {held_days:.1f}/{MIN_HOLD_DAYS} min hold",
-                    "held_assets": sorted(list(held_assets)),
-                    "_spider_producer_version": VERSION,
-                })
-                return
-            # Past min-hold — agent could rotate. v3.0 MVP: still don't emit
-            # while position open. DSL Phase 1 / Phase 2 owns exits.
-            cfg.output({
-                "status": "ok",
-                "note": (f"riding anchor (past min hold {held_days:.1f}d)"
-                         if held_days is not None
-                         else "riding anchor (hold-time unknown, conservative skip)"),
-                "held_assets": sorted(list(held_assets)),
-                "_spider_producer_version": VERSION,
-            })
-            return
-
-        # ── Fetch top-15 SM markets (LONG-only, XYZ banned) ──
-        markets = fetch_sm_markets()
-        if not markets:
-            cfg.output({
-                "status": "ok",
-                "note": "no LONG markets returned by leaderboard_get_markets",
-                "_spider_producer_version": VERSION,
-            })
-            return
-
-        # ── Fetch arena top-10 long exposure ──
-        arena_long_exposure = fetch_arena_long_exposure()
-
-        # ── Score candidates ──
-        candidates = []
-        all_scored = []
-        skipped_held = 0
-        skipped_post_close = 0
-        post_close_skips = []
-
-        for market in markets:
-            token = market["token"]
-
-            if token.upper() in held_assets:
-                skipped_held += 1
-                continue
-
-            if is_in_post_close_cooldown(token):
-                skipped_post_close += 1
-                post_close_skips.append({
-                    "token": token,
-                    "remaining_min": post_close_cooldown_remaining_min(token),
-                })
-                continue
-
-            if is_asset_cooled_down(token):
-                continue
-
-            score, reasons, breakdown = score_anchor(market, arena_long_exposure)
-            if score == 0:
-                continue
-
-            all_scored.append({
-                "token": token,
-                "score": round(score, 2),
-                "breakdown": breakdown,
-            })
-
-            if score >= MIN_SCORE_DEFAULT:
-                candidate = dict(market)
-                candidate["score"] = score
-                candidate["reasons"] = reasons
-                candidate["breakdown"] = breakdown
-                candidates.append(candidate)
-
-        if not candidates:
-            top3 = sorted(all_scored, key=lambda s: s["score"], reverse=True)[:3]
-            cfg.output({
-                "status": "ok",
-                "note": f"0 anchor candidates at score >= {MIN_SCORE_DEFAULT} ({len(all_scored)} scored)",
-                "topScored": top3,
-                "skipped_held": skipped_held,
-                "skipped_post_close": skipped_post_close,
-                "post_close_skips": post_close_skips,
-                "closed_this_tick": sorted(list(closed_this_tick)),
-                "held_assets": sorted(list(held_assets)),
-                "_spider_producer_version": VERSION,
-            })
-            return
-
-        # ── Pick highest-scoring anchor candidate ──
-        candidates.sort(key=lambda c: c["score"], reverse=True)
-        best = candidates[0]
-
-        margin_usd = round(account_value * MARGIN_PCT, 2)
-        requested_leverage = get_anchor_leverage_for_score(best["score"])
-        leverage = get_safe_leverage(SPIDER_WALLET, best["token"], requested_leverage)
-
-        # ── Emit signal ──
-        payload = build_signal_payload(
-            best, leverage, margin_usd, held_assets, best["breakdown"],
-        )
-        pushed = 0
-        if push_signal(payload):
-            pushed += 1
-            mark_asset_emitted(best["token"])
-            record_anchor_open(best["token"], best["score"])
-
-        elapsed = time.time() - run_start
-        warn = "WARN_OVER_120S" if elapsed > 120 else None
+    # ── Account + held assets + oldest open position age ──
+    account_value, pos_count, held_assets, oldest_age_sec = get_account_state()
+    if account_value is None or account_value <= 0:
         cfg.output({
             "status": "ok",
-            "candidates_total": len(candidates),
-            "all_scored": len(all_scored),
+            "note": "cannot read account value; skip tick",
+            "_spider_producer_version": VERSION,
+        })
+        return
+
+    # ── Detect closes vs last tick ──
+    previously_held = load_previously_held()
+    closed_this_tick = detect_closes(held_assets, previously_held)
+    save_previously_held(held_assets)
+
+    # ── Fallback hold-time check via anchor-history.json ──
+    fallback_age_sec = get_oldest_anchor_age_seconds(held_assets)
+    effective_age_sec = oldest_age_sec or fallback_age_sec
+
+    # ── Single-leg max positions guard + 7-day min-hold gate ──
+    if pos_count >= MAX_POSITIONS:
+        held_days = (effective_age_sec / 86400.0) if effective_age_sec else None
+        if held_days is not None and held_days < MIN_HOLD_DAYS:
+            cfg.output({
+                "status": "ok",
+                "note": f"riding anchor day {held_days:.1f}/{MIN_HOLD_DAYS} min hold",
+                "held_assets": sorted(list(held_assets)),
+                "_spider_producer_version": VERSION,
+            })
+            return
+        # Past min-hold — agent could rotate. v3.0 MVP: still don't emit
+        # while position open. DSL Phase 1 / Phase 2 owns exits.
+        cfg.output({
+            "status": "ok",
+            "note": (f"riding anchor (past min hold {held_days:.1f}d)"
+                     if held_days is not None
+                     else "riding anchor (hold-time unknown, conservative skip)"),
+            "held_assets": sorted(list(held_assets)),
+            "_spider_producer_version": VERSION,
+        })
+        return
+
+    # ── Fetch top-15 SM markets (LONG-only, XYZ banned) ──
+    markets = fetch_sm_markets()
+    if not markets:
+        cfg.output({
+            "status": "ok",
+            "note": "no LONG markets returned by leaderboard_get_markets",
+            "_spider_producer_version": VERSION,
+        })
+        return
+
+    # ── Fetch arena top-10 long exposure ──
+    arena_long_exposure = fetch_arena_long_exposure()
+
+    # ── Score candidates ──
+    candidates = []
+    all_scored = []
+    skipped_held = 0
+    skipped_post_close = 0
+    post_close_skips = []
+
+    for market in markets:
+        token = market["token"]
+
+        if token.upper() in held_assets:
+            skipped_held += 1
+            continue
+
+        if is_in_post_close_cooldown(token):
+            skipped_post_close += 1
+            post_close_skips.append({
+                "token": token,
+                "remaining_min": post_close_cooldown_remaining_min(token),
+            })
+            continue
+
+        if is_asset_cooled_down(token):
+            continue
+
+        score, reasons, breakdown = score_anchor(market, arena_long_exposure)
+        if score == 0:
+            continue
+
+        all_scored.append({
+            "token": token,
+            "score": round(score, 2),
+            "breakdown": breakdown,
+        })
+
+        if score >= MIN_SCORE_DEFAULT:
+            candidate = dict(market)
+            candidate["score"] = score
+            candidate["reasons"] = reasons
+            candidate["breakdown"] = breakdown
+            candidates.append(candidate)
+
+    if not candidates:
+        top3 = sorted(all_scored, key=lambda s: s["score"], reverse=True)[:3]
+        cfg.output({
+            "status": "ok",
+            "note": f"0 anchor candidates at score >= {MIN_SCORE_DEFAULT} ({len(all_scored)} scored)",
+            "topScored": top3,
             "skipped_held": skipped_held,
             "skipped_post_close": skipped_post_close,
             "post_close_skips": post_close_skips,
             "closed_this_tick": sorted(list(closed_this_tick)),
             "held_assets": sorted(list(held_assets)),
-            "signals_pushed": pushed,
-            "best_signal": {
-                "asset": best["token"],
-                "direction": "LONG",
-                "score": round(best["score"], 2),
-                "leverage": leverage,
-                "marginUsd": margin_usd,
-                "breakdown": best["breakdown"],
-                "reasons": best["reasons"][:6],
-            } if pushed else None,
-            "account_value": round(account_value, 2),
-            "open_positions": pos_count,
-            "elapsed_sec": round(elapsed, 2),
-            "warn": warn,
             "_spider_producer_version": VERSION,
         })
-    finally:
-        release_lock(lock)
+        return
+
+    # ── Pick highest-scoring anchor candidate ──
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_usd = round(account_value * MARGIN_PCT, 2)
+    requested_leverage = get_anchor_leverage_for_score(best["score"])
+    leverage = get_safe_leverage(SPIDER_WALLET, best["token"], requested_leverage)
+
+    # ── Emit signal ──
+    pushed = 0
+    if push_signal(best, leverage, margin_usd, held_assets, best["breakdown"]):
+        pushed += 1
+        mark_asset_emitted(best["token"])
+        record_anchor_open(best["token"], best["score"])
+
+    elapsed = time.time() - run_start
+    warn = "WARN_OVER_120S" if elapsed > 120 else None
+    cfg.output({
+        "status": "ok",
+        "candidates_total": len(candidates),
+        "all_scored": len(all_scored),
+        "skipped_held": skipped_held,
+        "skipped_post_close": skipped_post_close,
+        "post_close_skips": post_close_skips,
+        "closed_this_tick": sorted(list(closed_this_tick)),
+        "held_assets": sorted(list(held_assets)),
+        "signals_pushed": pushed,
+        "best_signal": {
+            "asset": best["token"],
+            "direction": "LONG",
+            "score": round(best["score"], 2),
+            "leverage": leverage,
+            "marginUsd": margin_usd,
+            "breakdown": best["breakdown"],
+            "reasons": best["reasons"][:6],
+        } if pushed else None,
+        "account_value": round(account_value, 2),
+        "open_positions": pos_count,
+        "elapsed_sec": round(elapsed, 2),
+        "warn": warn,
+        "_spider_producer_version": VERSION,
+    })
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as e:
-        cfg.log(f"CRITICAL ERROR: {e}")
-        import traceback
-        traceback.print_exc(file=sys.stderr)
-        cfg.output({
-            "status": "error",
-            "error": str(e),
-            "_spider_producer_version": VERSION,
-        })
+    producer_daemon(
+        fn=main,
+        interval_seconds=3600,
+        name=f"spider-producer-{_wallet_lock_id}",
+        tick_timeout=240,
+    )

--- a/spider/scripts/spider_config.py
+++ b/spider/scripts/spider_config.py
@@ -1,26 +1,19 @@
-"""SPIDER v3.0 — Shared MCP helpers + config loader.
+"""SPIDER v4.0.0 — Shared MCP helpers + config loader.
 
-v3.0 producer responsibilities:
-  - Fetch top-15 SM leaderboard markets via MCP
-  - Score each candidate on 4 components (arena alignment, SM strength,
-    funding favorability, relative strength)
-  - Apply hold-time gate (don't emit while holding < 7 days)
-  - Push qualifying signals via `openclaw senpi external-scanner ingest`
-    (runtime owns execution + DSL + risk + counters)
+Plumbing-only migration from v3.0.2. Routes MCP calls + signal POSTs
+through `senpi_runtime_helpers.SenpiClient` (in-process, direct HTTPS).
+No mcporter / openclaw subprocesses.
 
 This module is the MCP call helper + config loader. All state
 (position tracking, post-close cooldown, anchor history) lives in
 state/<wallet-hash>/ JSON files.
-
-v2.0's elaborate spider_rationale_log + simulated runtime is GONE —
-chain DB telemetry replaces it.
 """
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 
+import functools
 import json
 import os
-import subprocess
 import sys
 import tempfile
 import time
@@ -30,6 +23,33 @@ from pathlib import Path
 WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
 SKILL_DIR = Path(WORKSPACE) / "skills" / "spider-strategy"
 CONFIG_PATH = SKILL_DIR / "config" / "spider-config.json"
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_helpers_path = str(Path(WORKSPACE) / "skills" / "_helpers")
+if _helpers_path not in sys.path:
+    sys.path.insert(0, _helpers_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Spider's MCP calls and signal "
+            "POST both require it."
+        )
+    client = SenpiClient()
+    log_event("spider_wrapper_enabled", helpers_path=_helpers_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
 
 
 # ─── Atomic Write ────────────────────────────────────────────
@@ -67,36 +87,17 @@ def load_config():
 # ─── MCP Helper ──────────────────────────────────────────────
 
 def mcporter_call(tool, retries=2, timeout=30, **params):
-    """Call a Senpi MCP tool via mcporter. Returns parsed JSON or None on failure."""
-    args = json.dumps(params) if params else "{}"
-    cmd = ["mcporter", "call", "senpi", tool, "--args", args]
-    for attempt in range(retries):
-        try:
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-            if r.returncode != 0:
-                if attempt < retries - 1:
-                    time.sleep(2)
-                    continue
-                return None
-            raw = json.loads(r.stdout)
-            if isinstance(raw, dict) and "content" in raw:
-                content = raw["content"]
-                if isinstance(content, list) and content:
-                    first = content[0]
-                    if isinstance(first, dict) and "text" in first:
-                        try:
-                            return json.loads(first["text"])
-                        except (json.JSONDecodeError, TypeError):
-                            pass
-            return raw
-        except subprocess.TimeoutExpired:
-            if attempt < retries - 1:
-                time.sleep(2)
-                continue
-            return None
-        except (json.JSONDecodeError, Exception):
-            return None
-    return None
+    """v4.0.0: routes through SenpiClient.mcp_call() — direct HTTPS, no
+    mcporter subprocess. Returns the unwrapped JSON document on
+    success, or None if the wrapper raised."""
+    try:
+        return _wrapper_client.mcp_call(tool, timeout=timeout, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] spider_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
 
 
 def output(data):
@@ -105,7 +106,7 @@ def output(data):
 
 
 def log(msg):
-    print(f"[SPIDER-v3] {msg}", file=sys.stderr)
+    print(f"[SPIDER-v4] {msg}", file=sys.stderr)
 
 
 def now_ts():


### PR DESCRIPTION
## Summary

Plumbing-only migration of Spider from v3.0.2 (mcporter subprocess + openclaw cron + manual fcntl lock) to v4.0.0 (in-process `senpi_runtime_helpers.SenpiClient` + long-lived `producer_daemon` with built-in reentrancy). NO thesis change. NO scoring change. NO threshold change.

## What changed

**Producer (`scripts/spider-producer.py`)**
- Drop subprocess + manual fcntl lock
- Direct POST via `_wrapper_client.push_signal(...)` with `signal_type="SPIDER_ANCHOR"` passed explicitly
- `producer_daemon(fn=main, interval_seconds=3600, name=..., tick_timeout=240)` replaces openclaw cron entry; fleet-fix #214 applied
- v2.0.9 contamination fix: `SPIDER_WALLET` stays canonical, `STRATEGY_ADDRESS` deprecation fallback

**Config-shim (`scripts/spider_config.py`)**
- Drop `subprocess` import, add `functools`
- Lazy `SenpiClient` proxy
- `mcporter_call()` body now delegates to `_wrapper_client.mcp_call()`

**Docs**
- SKILL.md frontmatter v3.0.0 → v4.0.0; `requires` includes `senpi_runtime_helpers`
- README retitled, helpers install steps 1-4 added

## Test plan

- [ ] Operator pulls v4.0.0 + helpers package per README
- [ ] `SPIDER_WALLET` and `SENPI_AUTH_TOKEN` set in env
- [ ] Old openclaw cron deleted
- [ ] Daemon launched as nohup background process
- [ ] First `daemon_tick_finished status=ok` observed in `/tmp/spider-producer.log`
- [ ] If anchor open: producer outputs "riding anchor day X.Y/7 min hold"
- [ ] If no anchor + qualifying signal: signal POSTs to runtime /signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)