### PR TITLE
Turbine v3.2.1 — stale-order hygiene (orphan ALO sweep)

### DIFF
--- a/turbine/SKILL.md
+++ b/turbine/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.2.0"
+  version: "3.2.1"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -25,6 +25,14 @@ metadata:
 # 🌪️ TURBINE v3.2 — Volume Rotation + Runners
 
 **Run the volume play. Let winners run.**
+
+## What changed in v3.2.1 vs v3.2.0 (patch — 2026-05-09)
+
+**Stale-order hygiene.** The producer now sweeps non-reduce-only ALO orders older than 300s before computing `held_keys`. Each runtime swap (helpers migration, runtime-phase-2 redeploy, daemon restart) leaves resting maker orders behind that the new runtime instance does not own; the producer's ghost-trade fix (v2.0.4) correctly counts those orphans as slot occupiers, which means orphans can starve real fills until cleared. The runtime's own `execution_timeout_seconds: 180` cancels orders it placed — anything still resting well past that is by definition abandoned.
+
+NO change to maker/taker placement. NO change to fee economics. NO change to YAMLs. Cancellation is free; HL only charges on fills. Symptom in v3.2.0: volume wallet showed `slots_held = 6/7` while `clearinghouse` only reported 4 actual positions, throttling emissions to 1 signal/tick instead of 3-4.
+
+Tick output now includes `volume.stale_swept[]` and `runners.stale_swept[]` arrays for telemetry — empty list = no orphans on this tick.
 
 ## What changed in v3.2 vs v3.1
 

--- a/turbine/scripts/turbine-producer.py
+++ b/turbine/scripts/turbine-producer.py
@@ -67,7 +67,7 @@ import turbine_config as cfg
 from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "3.2.0"
+VERSION = "3.2.1"
 
 # Scanner names — must match runtime YAMLs
 VOLUME_SCANNER_NAME = "turbine_volume_signals"
@@ -139,6 +139,25 @@ def _runtime_config():
         "spread_xyz_bps": float(spread.get("xyzBps", 10)),
         "xyz_weight": float(c.get("xyzWeight", 0.80)),
     }
+
+
+# ═══════════════════════════════════════════════════════════════
+# STALE-ORDER HYGIENE
+# ═══════════════════════════════════════════════════════════════
+# Each runtime restart / swap (helpers migration, runtime-phase-2
+# rollover, daemon redeploy) leaves resting ALO orders that the new
+# runtime instance does not own. The runtime's own
+# `execution_timeout_seconds` (180s on FEE_OPTIMIZED_LIMIT) cancels
+# the orders it placed — anything still resting well past that is
+# by definition abandoned. The producer's `held_keys` set treats
+# every non-reduceOnly resting order as a slot occupier (v2.0.4
+# ghost-trade fix), so orphans starve real fills until cleared.
+#
+# We sweep BEFORE computing held_keys so the fresh slot count
+# reflects only live positions + actively-managed resting orders.
+# Maker-vs-taker placement is unchanged — cancellation has no fee
+# impact; HL only charges on fills.
+STALE_ORDER_MAX_AGE_SECONDS = 300
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -437,6 +456,17 @@ def main():
         })
         return
 
+    # Sweep orphaned ALOs (left behind by previous runtime swaps) BEFORE
+    # computing held_keys. Anything still resting > STALE_ORDER_MAX_AGE_SECONDS
+    # (5 min) past the runtime's own 180s execution_timeout has been
+    # abandoned — clear it so the slot is honestly counted as free.
+    volume_swept = cfg.sweep_stale_resting_orders(
+        VOLUME_WALLET, volume_resting, STALE_ORDER_MAX_AGE_SECONDS, label="volume",
+    )
+    if volume_swept:
+        # Refetch so held_keys doesn't double-count just-cancelled orders.
+        volume_resting = cfg.get_resting_orders(VOLUME_WALLET)
+
     volume_held_keys = {cfg.normalize_coin_key(p["coin"]) for p in volume_positions}
     volume_held_keys.update(cfg.normalize_coin_key(o["coin"]) for o in volume_resting)
 
@@ -463,10 +493,20 @@ def main():
     free_runners = 0
     closed_runners = set()
     last_runners_closed = {}
+    runners_swept = []
     if RUNNERS_ENABLED:
         runners_positions = cfg.get_open_positions(RUNNERS_WALLET)
         runners_resting = cfg.get_resting_orders(RUNNERS_WALLET)
         runners_account_value = cfg.get_account_value(RUNNERS_WALLET) or 0.0
+
+        # Same orphan sweep as volume wallet — see comment above.
+        runners_swept = cfg.sweep_stale_resting_orders(
+            RUNNERS_WALLET, runners_resting, STALE_ORDER_MAX_AGE_SECONDS,
+            label="runners",
+        )
+        if runners_swept:
+            runners_resting = cfg.get_resting_orders(RUNNERS_WALLET)
+
         runners_held_keys = {cfg.normalize_coin_key(p["coin"]) for p in runners_positions}
         runners_held_keys.update(cfg.normalize_coin_key(o["coin"]) for o in runners_resting)
 
@@ -533,6 +573,7 @@ def main():
             "account_value": round(volume_account_value, 2),
             "open_positions": len(volume_positions),
             "resting_orders": len(volume_resting),
+            "stale_swept": volume_swept,
             "slots_max": rt["volume_slots"],
             "slots_effective": eff_volume,
             "slots_held": len(volume_held_keys),
@@ -545,6 +586,7 @@ def main():
             "account_value": round(runners_account_value, 2),
             "open_positions": len(runners_positions),
             "resting_orders": len(runners_resting),
+            "stale_swept": runners_swept,
             "slots_max": rt["runners_slots"],
             "slots_effective": eff_runners,
             "slots_held": len(runners_held_keys),

--- a/turbine/scripts/turbine_config.py
+++ b/turbine/scripts/turbine_config.py
@@ -264,7 +264,19 @@ def get_account_value(wallet):
 
 def get_resting_orders(wallet):
     """Open (resting / ALO) non-reduceOnly orders. Reduce-only orders
-    are DSL exit legs — not slot occupiers."""
+    are DSL exit legs — not slot occupiers.
+
+    Each entry includes:
+      - coin, direction, limit_price, oid (legacy fields)
+      - timestamp_ms — HL order placement time (epoch ms)
+      - age_seconds — wall-clock age vs now()
+      - is_trigger — true for stop-limit orders (we never count those)
+
+    `age_seconds` lets the caller distinguish freshly-placed maker orders
+    (the runtime is still working them) from orphaned ALOs left behind
+    by previous runtime instances after a swap/restart. The producer's
+    stale-order hygiene sweep uses this field.
+    """
     if not wallet:
         return []
     data = mcporter_call("strategy_get_open_orders", strategy_wallet=wallet)
@@ -275,23 +287,99 @@ def get_resting_orders(wallet):
         orders = orders.get("orders", orders.get("openOrders", []))
     if not isinstance(orders, list):
         return []
+    now_ms = time.time() * 1000.0
     out = []
     for o in orders:
         if not isinstance(o, dict):
             continue
         if o.get("reduceOnly"):
             continue
+        if o.get("isTrigger"):
+            # Stop-limit / take-profit triggers are exit-only; never count
+            # as slot occupiers and never sweep.
+            continue
         coin = o.get("coin") or o.get("asset", "")
         if not coin:
             continue
         side = (o.get("side") or "").upper()
+        ts_ms = safe_float(o.get("timestamp", 0))
+        age_sec = max(0.0, (now_ms - ts_ms) / 1000.0) if ts_ms > 0 else None
         out.append({
             "coin": coin,
             "direction": "LONG" if side in ("B", "BUY") else "SHORT",
             "limit_price": safe_float(o.get("limitPx") or o.get("price")),
             "oid": o.get("oid"),
+            "timestamp_ms": ts_ms if ts_ms > 0 else None,
+            "age_seconds": age_sec,
         })
     return out
+
+
+def cancel_order(wallet, order_id, coin=None, reason=None):
+    """Cancel a single resting order via the cancel_order MCP. Returns
+    True on success (or wasAlreadyCancelled), False on failure. Uses
+    the same SenpiClient session as every other MCP call.
+
+    Idempotent: HL returns success with wasAlreadyCancelled=true when
+    the order is already filled/cancelled — we treat both as success.
+    """
+    if not wallet or not order_id:
+        return False
+    params = {"strategyWalletAddress": wallet, "orderId": int(order_id)}
+    if coin:
+        params["coin"] = coin
+    if reason:
+        params["reason"] = reason
+    res = mcporter_call("cancel_order", **params)
+    if not res:
+        return False
+    if isinstance(res, dict):
+        if res.get("success") is False:
+            return False
+    return True
+
+
+def sweep_stale_resting_orders(wallet, resting_orders, max_age_seconds,
+                                label="wallet"):
+    """Cancel non-reduceOnly resting orders older than `max_age_seconds`.
+
+    These are orphans left behind by previous runtime instances (each
+    runtime swap / restart leaves resting ALOs the new runtime doesn't
+    own). The active runtime's own FEE_OPTIMIZED_LIMIT timeout is
+    180s — anything still resting well past that is by definition
+    abandoned. The producer's `held_keys` set treats every non-reduce-only
+    resting order as a slot occupier (v2.0.4 ghost-trade fix), so
+    orphans starve real-slot fills until cleared.
+
+    Returns list of {oid, coin, age_seconds, status} for telemetry.
+    Maker-vs-taker order placement is unchanged — cancellation is free.
+    """
+    swept = []
+    if not wallet or not resting_orders:
+        return swept
+    for o in resting_orders:
+        age = o.get("age_seconds")
+        if age is None or age < max_age_seconds:
+            continue
+        oid = o.get("oid")
+        if not oid:
+            continue
+        coin = o.get("coin")
+        ok = cancel_order(
+            wallet=wallet,
+            order_id=oid,
+            coin=coin,
+            reason=f"turbine_producer_stale_sweep label={label} age={int(age)}s",
+        )
+        swept.append({
+            "oid": oid,
+            "coin": coin,
+            "age_seconds": int(age),
+            "status": "cancelled" if ok else "cancel_failed",
+        })
+        log(f"stale_sweep {label} oid={oid} coin={coin} "
+            f"age={int(age)}s status={'ok' if ok else 'fail'}")
+    return swept
 
 
 # ─── Output / log ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Volume bottleneck this morning was **orphaned non-reduceOnly ALO orders left on HL by yesterday's v3.0/v3.1/v3.2/helpers runtime swaps** — they were being counted as slot occupiers by the v2.0.4 ghost-trade fix, blocking real-slot fills. NOT a maker/taker fee issue, NOT a YAML path issue.

Concrete evidence (this morning's `strategy_get_open_orders`):
- volume xyz: BRENTOIL ALO non-reduce-only, **16h old**, partial-filled (5.24/25.62)
- volume main: SOL ALO non-reduce-only, **13h old**, never filled

While these were resting, the producer counted BRENTOIL/SOL as held → emitted 1 signal/tick instead of 3-4 → volume came in at $500k/12h (10× under target).

## What changed

**`turbine_config.py`**
- `get_resting_orders()` returns `timestamp_ms` and `age_seconds`; filters `isTrigger` (DSL stops are never slot occupiers)
- New `cancel_order(wallet, oid, coin, reason)` helper wraps the `cancel_order` MCP
- New `sweep_stale_resting_orders(wallet, resting, max_age, label)` cancels non-reduceOnly ALOs older than `max_age` seconds; returns telemetry list

**`turbine-producer.py`**
- New `STALE_ORDER_MAX_AGE_SECONDS = 300` (5 min — well past the runtime's own 180s `execution_timeout_seconds` so an actively-managed order is never touched)
- `main()` calls the sweep on **both** volume + runners wallets BEFORE computing `held_keys`; refetches resting orders if any swept
- Tick output now includes `volume.stale_swept[]` + `runners.stale_swept[]` for telemetry

**Docs**
- SKILL.md frontmatter v3.2.0 → v3.2.1
- v3.2.1 patch note added explaining the symptom + fix

## What did NOT change

- ❌ NO YAML changes (the agent's repeated sed edits caused the divergences in the first place — leaving runtime YAMLs alone)
- ❌ NO change to maker/taker placement (`ensure_execution_as_taker: false` stays — Jason was right that taker = pure 4x cost, no offset from builder fees)
- ❌ NO change to scoring, signal payload structure, decision_prompt, or DSL config
- ❌ NO change to producer cadence or signal generation logic

Cancellation is free — HL only charges on fills. The sweep just stops orphans from accumulating across future restarts.

## Test plan

- [ ] Operator pulls v3.2.1, restarts daemon
- [ ] First tick log shows `volume.stale_swept[]` populated with the 13h SOL + 16h BRENTOIL orphans (then empty on subsequent ticks)
- [ ] `volume.slots_held` drops from 6/7 to 4/7 (matching real position count)
- [ ] `volume.slots_free` grows to 3, `volume.emitted` per tick climbs to 3-4
- [ ] 24h volume target: ≥ $5M (was $500k/12h on v3.2.0)
- [ ] Maker fill rate stays 100% — no taker fees in the dashboard
- [ ] If it works, same pattern can be backported to other helpers-migrated agents that show similar slot-starvation