### PR TITLE
Turbine v3.2.2 — dex-aware slot keys (fix held_keys collision)

### DIFF
--- a/turbine/SKILL.md
+++ b/turbine/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.2.1"
+  version: "3.2.2"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -25,6 +25,14 @@ metadata:
 # 🌪️ TURBINE v3.2 — Volume Rotation + Runners
 
 **Run the volume play. Let winners run.**
+
+## What changed in v3.2.2 vs v3.2.1 (patch — 2026-05-09)
+
+**Dex-aware slot keys.** `normalize_coin_key()` previously stripped the `xyz:` prefix from coin names, collapsing main and xyz versions of the same symbol into one held_keys entry. When a main position and an xyz resting order on the same symbol both existed (or vice versa), the producer undercounted slots → over-emitted signals → runtime rejected the surplus on margin. v3.2.2 preserves the prefix: `main:HYPE` and `xyz:HYPE` are now distinct keys.
+
+Symptom in v3.2.1 (verified from operator's tick logs): `slots_held = 4` while `positions + resting = 5` on ticks where main and xyz versions of the same coin coexisted. Producer over-emitted by 1 on those ticks.
+
+NO change to maker/taker placement. NO change to fee economics. NO change to YAMLs. One-time minor regression: 90s post-close cooldown skipped for the first 1-2 cycles after upgrade as `last_closed` repopulates with new-format keys. Trivial impact.
 
 ## What changed in v3.2.1 vs v3.2.0 (patch — 2026-05-09)
 

--- a/turbine/scripts/turbine-producer.py
+++ b/turbine/scripts/turbine-producer.py
@@ -67,7 +67,7 @@ import turbine_config as cfg
 from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "3.2.1"
+VERSION = "3.2.2"
 
 # Scanner names — must match runtime YAMLs
 VOLUME_SCANNER_NAME = "turbine_volume_signals"

--- a/turbine/scripts/turbine_config.py
+++ b/turbine/scripts/turbine_config.py
@@ -201,10 +201,26 @@ def safe_float(v, d=0.0):
 
 
 def normalize_coin_key(coin):
-    """Map 'xyz:GOLD' and 'GOLD' to the same canonical key."""
+    """Canonicalize a coin string for use in held_keys sets.
+
+    v3.2.2 (2026-05-09): preserve the xyz: prefix so that main:HYPE and
+    xyz:HYPE are distinct slot occupiers. Previously this function
+    stripped the prefix, which caused held_keys to collapse a main
+    position and an xyz resting order on the same coin into one entry,
+    undercounting slots. Producer would then over-emit signals which
+    the runtime rejected when actual margin couldn't accommodate them.
+
+    Hyperliquid's coin field is already canonical (HYPE / xyz:HYPE), so
+    we only need to lowercase the prefix and uppercase the symbol for
+    deterministic comparison across feeds.
+    """
     if not coin:
         return ""
-    return coin.split(":")[-1].upper()
+    s = coin.strip()
+    if ":" in s:
+        prefix, _, symbol = s.partition(":")
+        return f"{prefix.lower()}:{symbol.upper()}"
+    return s.upper()
 
 
 def get_open_positions(wallet):


### PR DESCRIPTION
## Summary

Fix the slot-accounting collision verified in operator's v3.2.1 tick logs: `held_keys` collapses main and xyz versions of the same coin to one entry, undercounting slots → producer over-emits → runtime rejects surplus on margin.

## Evidence (operator's diagnostic on v3.2.1)

```
{"v_pos":3,"v_rest":2,"v_held":4,"v_emit":0}   # 5 raw items → 4 keys = 1 collision
{"v_pos":3,"v_rest":2,"v_held":6,"v_emit":2}   # correct: 5 + 2 emits = 7 raw → 6 keys (1 collision in batch)
{"v_pos":5,"v_rest":0,"v_held":6,"v_emit":1}   # correct: 5 + 1 emit = 6
```

The "overcount" cases above are not bugs — they're the post-emit `held_keys` reflecting just-emitted signals (which become resting orders next tick). The **undercount** is the real bug.

## What changed

`turbine_config.py` — `normalize_coin_key()` now preserves the `xyz:` prefix:

| Input | Before | After |
|---|---|---|
| `BTC` | `BTC` | `BTC` |
| `xyz:GOLD` | `GOLD` | `xyz:GOLD` |
| `XYZ:gold` | `GOLD` | `xyz:GOLD` |
| `hype` | `HYPE` | `HYPE` |
| `xyz:BRENTOIL` | `BRENTOIL` | `xyz:BRENTOIL` |

`turbine-producer.py` — version bump 3.2.1 → 3.2.2 (no other code changes; all call sites for `normalize_coin_key` already pass the full coin string from clearinghouse data).

`SKILL.md` — frontmatter version bump + v3.2.2 patch note.

## What did NOT change

- ❌ NO YAML changes
- ❌ NO maker/taker placement change
- ❌ NO scoring / signal payload / decision_prompt change
- ❌ NO new MCP calls

## Operator regression

One-time, trivial: the 90s post-close cooldown is skipped for the first 1-2 cycles after upgrade because `last_closed` file holds old-format keys (e.g. `GOLD` instead of `xyz:GOLD`). Producer rebuilds with new keys naturally and cooldown resumes.

## Test plan

- [ ] Operator pulls v3.2.2 + restarts daemon (no YAML edits, no rebuilds)
- [ ] First 30 ticks show `v_held == v_pos + v_rest + v_emit` consistently
- [ ] Volume throughput continues at ~24 closes / 30min cadence (or better)
- [ ] If volume DROPS, the over-emission was actually generating useful real fills (unlikely, but worth watching)