### PR TITLE
docs: add Senpi MCP tool reference table to top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Skills are versioned and MIT-licensed. Anyone can fork a skill, modify it, or bu
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │                       SENPI PLATFORM                          │
-│  Hyperfeed data layer · Top-trader scoring · 48 MCP tools     │
+│  Hyperfeed data layer · Top-trader scoring · 65+ MCP tools    │
 └────────────────────────────────┬─────────────────────────────┘
                                  │
 ┌────────────────────────────────▼─────────────────────────────┐
@@ -129,6 +129,154 @@ Per-asset rollup of top-trader notional positioning. Useful as a confluence inpu
 ## `autonomous-trading/` — Budget/Target/Deadline Orchestrator
 
 Gives an agent a budget, a target, and a deadline; orchestrates DSL + Opportunity Scanner + Emerging Movers into a full lifecycle. Higher-level than any individual strategy skill.
+
+---
+
+# Senpi MCP — Tool Reference
+
+Every capability and strategy skill in this repo ultimately calls into the **Senpi MCP** server. The MCP exposes ~65 tools that handle everything from trader discovery to position lifecycle to Arena standings.
+
+Each tool's full schema (params, types, response shape) is in the MCP server itself — load it via your MCP client, or call `list_senpi_guides` / `read_senpi_guide` for the curated reference docs.
+
+### Discovery — find traders and strategies worth copying
+
+| Tool | Purpose |
+|---|---|
+| `discovery_get_top_traders` | Rank top traders across TAS / TCS / TRP composite scores; filter by win rate, ROI, trade volume |
+| `discovery_get_top_strategies` | Top-performing strategies (mirror + custom) by ROE / PnL / volume |
+| `discovery_get_trader_state` | Open positions, current PnL, recent activity for a specific trader |
+| `discovery_get_trader_history` | Closed-position history with realized PnL, leverage, fees per trade |
+| `discovery_get_open_position_realized_pnl` | Realized PnL on currently-open positions (closed legs of partial exits) |
+
+### Hyperfeed — top-trader leaderboard data layer
+
+| Tool | Purpose |
+|---|---|
+| `leaderboard_get_top` | Top-N traders ranked by delta PnL over a rolling window |
+| `leaderboard_get_trader` | Single trader's PnL breakdown, position metrics, freshness tier |
+| `leaderboard_get_trader_positions` | Position-level delta PnL for one trader |
+| `leaderboard_get_markets` | Per-asset market concentration — which assets the top cohort is piling into |
+| `leaderboard_get_momentum_events` | Tier-classified momentum events (entries, scaling, exits) with behavioral tags |
+| `leaderboard_get_status` | System health + window mechanics for the Hyperfeed data layer |
+
+### Strategy lifecycle — create, top-up, pause, close
+
+| Tool | Purpose |
+|---|---|
+| `strategy_list` | Filterable list of user's strategies (by status, type, trader, ID) |
+| `strategy_get` | Detailed config + performance for one strategy by ID |
+| `strategy_create` | Create a **mirror** strategy that copies a trader (async lifecycle: subscribe → fund → init → active) |
+| `strategy_create_custom_strategy` | Create a **custom** strategy with operator-defined positions / budget |
+| `strategy_update` | Edit slippage, SL/TP, mirror multiplier on an active strategy |
+| `strategy_top_up` | Add capital to a running strategy (multi-chain funding supported) |
+| `strategy_pause` | Pause a strategy (note: pause is one-way — no resume) |
+| `strategy_close` | Irreversible closure — closes positions, withdraws to source wallet |
+| `strategy_close_positions` | Close specific position(s) without closing the whole strategy |
+| `strategy_withdraw_funds` | Withdraw idle USDC from a strategy wallet |
+| `strategy_bridge_funds_from_hyperliquid_to_evm` | Bridge USDC from HL back to an EVM chain |
+| `estimate_custom_strategy_positions_opening` | Preview what a custom strategy would actually open at current prices (OG + MANUAL modes) |
+
+### Strategy state — wallet inspection (read-only)
+
+| Tool | Purpose |
+|---|---|
+| `strategy_get_clearinghouse_state` | Full HL perp account state (positions, margin, withdrawable) across main + xyz subaccounts |
+| `strategy_get_open_orders` | Resting limit / stop-limit orders by wallet |
+| `strategy_get_asset_trading_limits` | Per-asset max position size, available margin, mark price |
+| `strategy_get_pnl_and_account_value_history` | Time-series of PnL + account value (for charts) |
+
+### Position lifecycle — direct order placement
+
+| Tool | Purpose |
+|---|---|
+| `create_position` | Open a position on a strategy wallet (MARKET / LIMIT, optional SL/TP attached) |
+| `edit_position` | Resize an existing position by target amount (handles flips) |
+| `close_position` | Full close — cleans up SL/TP attachments automatically |
+| `cancel_order` | Cancel a resting order (idempotent; returns wasAlreadyCancelled if filled/cancelled) |
+
+### Execution — pre-trade estimation + post-trade inspection
+
+| Tool | Purpose |
+|---|---|
+| `execution_estimate_position_opening` | Copy-trading preview — what would mirroring a specific trade open, with skip categorization |
+| `execution_get_open_position_details` | Detailed live position state (entry, mark, funding accrued, unrealized PnL) |
+| `execution_get_closed_position_details` | Historical closed-trade fields with net-PnL breakdown |
+| `execution_get_order_status` | Status of a specific order ID (filled / resting / canceled) |
+
+### Market data
+
+| Tool | Purpose |
+|---|---|
+| `market_list_instruments` | All Hyperliquid perp instruments (main + xyz HIP-3 dex) |
+| `market_get_asset_data` | Per-asset candles + order book + funding context — primary scanner input |
+| `market_get_prices` | Batch price snapshot across multiple assets |
+| `market_get_funding_history` | Historical funding rates per asset |
+| `market_get_funding_regime` | Classified funding regime (LONG_CROWDED / SHORT_CROWDED / NEUTRAL) |
+| `market_get_cross_asset_flows` | Detects BTC-led moves and which alts haven't caught up yet |
+
+### DSL / Ratchet Stop — position protection engine
+
+| Tool | Purpose |
+|---|---|
+| `ratchet_stop_add` | Attach a ratchet stop to a position with tiered ROE thresholds |
+| `ratchet_stop_edit` | Update tier thresholds / lock fractions on an existing ratchet config |
+| `ratchet_stop_delete` | Remove the ratchet config (does not close the position) |
+| `ratchet_stop_get` | Read current ratchet config + state for one position |
+| `ratchet_stop_list` | Ratchet configs across all strategies (or one) |
+| `ratchet_stop_events` | Event log — tier triggers, locks taken, exit fires |
+
+### Arena — weekly + monthly competition
+
+| Tool | Purpose |
+|---|---|
+| `arena_leaderboard` | Rankings (weekly or monthly) by ROE %, with qualification flags |
+| `arena_pool` | Current prize pool size for the active period |
+| `arena_prizes` | Historical prize payouts |
+| `arena_roe_chart` | ROE time-series for an Arena participant |
+| `arena_week_prizes` | Prize distribution detail for a specific week |
+
+### Audit — full action history with reasoning
+
+| Tool | Purpose |
+|---|---|
+| `audit_get_recent_actions` | Most recent agent actions (create / update / close / etc.) |
+| `audit_get_strategy_history` | Mutation timeline for one strategy with AI reasoning per action |
+| `audit_query` | Advanced query — filter by user / tool / type / time / duration |
+
+### Account & portfolio
+
+| Tool | Purpose |
+|---|---|
+| `account_get_portfolio` | Total user balances by category (idle, in-strategy, in-position) |
+| `account_get_historical_info` | PnL and balance time-series with configurable buckets |
+
+### Treasury & transfers
+
+| Tool | Purpose |
+|---|---|
+| `send_usdc` | Send USDC to a recipient (multi-chain routing) |
+| `transfer_spot_to_perps` | Move USDC from Hyperliquid Spot wallet to Perps wallet |
+
+### User identity & rewards
+
+| Tool | Purpose |
+|---|---|
+| `user_get_me` | Authenticated user profile (ID, embedded wallet, referral code) |
+| `user_get_senpi_points` | Points balance, season info, loyalty tier multiplier |
+| `user_get_senpi_points_leaderboard` | Global points leaderboard |
+| `user_get_referral_rewards` | Accumulated referral rewards balance (25% of builder fees from referees) |
+| `user_claim_referral_rewards` | Claim accumulated rewards to USDC |
+| `get_loyalty_tiers` | Loyalty tier definitions + fee discounts |
+| `get_share_your_wins` | Recently closed winning positions worth sharing |
+
+### Documentation
+
+| Tool | Purpose |
+|---|---|
+| `list_senpi_guides` | Enumerate all Senpi reference guides (load first if unsure which guide is relevant) |
+| `read_senpi_guide` | Fetch the full text of one guide by `senpi://` URI |
+
+> Guides cover parameter semantics, calculation methodology, workflow patterns, and gotchas for the most-used tools — especially `discovery_get_top_traders`, `leaderboard_get_*`, `strategy_create*`, `create_position`, `audit_*`, and the Arena rules. Load `senpi://guides/senpi-overview` first if you're new to the platform.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a comprehensive **Senpi MCP — Tool Reference** section to the top-level README, placed between Capabilities and Trading Strategy Skills.

68 tools enumerated across 13 functional categories with a one-line purpose for each. Operators landing on GitHub can now see the full Senpi surface area on one page without leaving for separate docs.

## Categories

| Section | Tools |
|---|---:|
| Discovery — find traders/strategies worth copying | 5 |
| Hyperfeed — top-trader leaderboard data layer | 6 |
| Strategy lifecycle — create, top-up, pause, close | 12 |
| Strategy state — wallet inspection (read-only) | 4 |
| Position lifecycle — direct order placement | 4 |
| Execution — pre-trade estimation + post-trade inspection | 4 |
| Market data | 6 |
| DSL / Ratchet Stop — position protection engine | 6 |
| Arena — weekly + monthly competition | 5 |
| Audit — full action history with reasoning | 3 |
| Account & portfolio | 2 |
| Treasury & transfers | 2 |
| User identity & rewards | 7 |
| Documentation | 2 |
| **Total** | **68** |

Bottom note points operators at `senpi://guides/senpi-overview` as the first read and at the per-tool curated guides for parameter semantics + calculation methodology.

## Also

- Architecture diagram updated: `48 MCP tools` → `65+ MCP tools` (the original count was stale)

## Diff

149 insertions, 1 deletion. Pure addition to the README — no other files touched.