### PR TITLE
Cheetah v7.1.1 — fix positions parser for nested-dict response shape

### DIFF
--- a/cheetah/SKILL.md
+++ b/cheetah/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "7.1.0"
+  version: "7.1.1"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -25,6 +25,24 @@ metadata:
 # 🐆 CHEETAH v7.1.0 — Multi-Signal Confluence Sniper
 
 **SM commits. Quality traders commit. Price confirms. Volume commits. All at once. Cheetah pounces once. The runtime DSL ratchets to lock the win.**
+
+## v7.1.1 (2026-05-11) — positions parser fix (patch)
+
+Live verification of v7.1.0 found `positions_map` was STILL empty even though the widened filter returned the full 25-trader pool. Root cause: `leaderboard_get_trader_positions` actually returns
+
+```
+{ "data": { "positions": { "trader_id": ..., "rank": ..., "positions": [...] } } }
+```
+
+— the per-trader positions array is nested one level deeper than the schema guide documents. The v7.0/v7.1 parser looked at `data.positions` expecting a list, got a dict, hit `if not isinstance(positions, list): continue` and silently skipped every trader.
+
+v7.1.1 parser handles BOTH shapes:
+- list-direct (matches schema guide)
+- nested-dict `{trader_id, rank, positions: [...]}` (actual prod response)
+
+Plus a `POSITIONS_SHAPE_WARN` log line for any future schema drift.
+
+NO change to scoring components, MIN_SCORE, leverage tiers, margin, cooldowns, or DSL. Same thesis. Now the +3 QUALITY_TRADER bonus can actually fire when the per-asset overlap exists.
 
 ## v7.1.0 (2026-05-11) — quality-trader filter widened (patch)
 

--- a/cheetah/scripts/cheetah-producer.py
+++ b/cheetah/scripts/cheetah-producer.py
@@ -125,7 +125,7 @@ import cheetah_config as cfg
 from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "7.1.0"
+VERSION = "7.1.1"
 SCANNER_NAME = "cheetah_signals"  # must match runtime.yaml external_scanner.name
 
 
@@ -563,15 +563,45 @@ def fetch_quality_trader_positions():
                 addresses.append(addr)
 
     positions_map = {}
+    shape_warned = False  # log unexpected response shapes once per refresh
     for addr in addresses:
         data = cfg.mcporter_call("leaderboard_get_trader_positions", trader_id=addr)
         if not data:
             continue
+        # v7.1.1: leaderboard_get_trader_positions actually returns
+        #   { data: { positions: { trader_id, rank, positions: [...] } } }
+        # — the per-trader positions array is nested one level deeper than the
+        # schema guide documents. v7.0/v7.1 parser looked at `data.positions`
+        # expecting a list, got a dict, hit `if not isinstance(positions, list):
+        # continue` and silently skipped every trader → positions_map empty
+        # → +3 QUALITY_TRADER bonus never fires → Cheetah scores cap at 8.
+        # Handle BOTH shapes (list-direct AND nested-dict) so we're resilient
+        # to future schema changes either direction.
         positions = []
         if isinstance(data, dict):
             d = data.get("data", data)
             if isinstance(d, dict):
-                positions = d.get("positions", d.get("top_positions", []))
+                raw_positions = d.get("positions", d.get("top_positions", []))
+                if isinstance(raw_positions, list):
+                    # Old shape (matches the schema guide): direct list
+                    positions = raw_positions
+                elif isinstance(raw_positions, dict):
+                    # Actual shape on prod: { trader_id, rank, positions: [...] }
+                    nested = raw_positions.get("positions", [])
+                    if isinstance(nested, list):
+                        positions = nested
+                    elif not shape_warned:
+                        cfg.log(
+                            f"POSITIONS_SHAPE_WARN unexpected nested dict for {addr[:10]}: "
+                            f"keys={list(raw_positions.keys())[:8]}; treating as empty."
+                        )
+                        shape_warned = True
+                elif not shape_warned:
+                    cfg.log(
+                        f"POSITIONS_SHAPE_WARN unexpected type {type(raw_positions).__name__} "
+                        f"for {addr[:10]}: treating as empty."
+                    )
+                    shape_warned = True
             elif isinstance(d, list):
                 positions = d
         if not isinstance(positions, list):


### PR DESCRIPTION
## Summary

v7.1.0 widened the trader filter correctly (25 traders returned, verified live via SenpiClient directly), but `positions_map` was still empty after first refresh. Live diagnostic via the helpers package found the actual response shape doesn't match the schema guide.

## Evidence (operator's helpers-direct call)

```
=== STEP 1: discovery_get_top_traders ===
traders count: 25 ✓

=== STEP 2: leaderboard_get_trader_positions for first 3 ===
[0] addr=0x8af7... data keys: ['positions']  positions count: NOT A LIST
[1] addr=0xbe19... data keys: ['positions']  positions count: NOT A LIST
[2] addr=0x5d2f... data keys: ['positions']  positions count: NOT A LIST
```

Actual response shape:
```
{
  "data": {
    "positions": {                     ← dict (not list)
      "trader_id": "...",
      "rank": 41,
      "positions": [...]               ← actual list, one level deeper
    }
  }
}
```

The v7.0/v7.1 parser:
```python
positions = d.get("positions", d.get("top_positions", []))
if not isinstance(positions, list): continue  # ← silently skipped every trader
```

## Fix

Parser now handles BOTH shapes:
- list-direct (matches schema guide)
- nested-dict `{trader_id, rank, positions: [...]}` (actual prod)

Plus a `POSITIONS_SHAPE_WARN` log line for future schema drift.

## Unit tests (4 shapes verified)

| Shape | Result |
|---|---|
| `{"data": {"positions": [...]}}` | extracts list ✓ |
| `{"data": {"positions": {"trader_id": ..., "positions": [...]}}}` | extracts nested list ✓ |
| `{"data": {"positions": "garbage"}}` | empty + WARN ✓ |
| `{"data": {"positions": []}}` | empty (clean) ✓ |

## What did NOT change

- Scoring components / weights / MIN_SCORE
- QT filter (the v7.1.0 widening stays)
- Leverage tiers, margin, cooldowns, DSL
- Asset universe / XYZ ban

## Test plan

- [ ] Operator pulls v7.1.1 (no other changes), restarts daemon
- [ ] First quality-cache refresh populates `positions_map` non-empty
- [ ] `QT_POOL_WARN` does NOT fire
- [ ] Within 24h, score distribution shifts to include ≥ 10
- [ ] Trade cadence returns toward pre-migration ~4/day