### PR TITLE
fleet-fix: nested-dict positions parser (Spider v4.0.1 + Raptor v3.4)

### DIFF
--- a/raptor/SKILL.md
+++ b/raptor/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.2"
+  version: "3.4"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/raptor/scripts/raptor-scanner.py
+++ b/raptor/scripts/raptor-scanner.py
@@ -317,14 +317,26 @@ def fetch_quality_hot_traders(limit=20, min_delta_usd=500_000):
 
 
 def fetch_trader_positions(trader_address):
-    """Get per-market delta PnL breakdown for a single trader."""
+    """Get per-market delta PnL breakdown for a single trader.
+
+    v3.4: leaderboard_get_trader_positions actually returns
+      { data: { positions: { trader_id, rank, positions: [...] } } }
+    — the per-trader positions array is nested one level deeper than the
+    schema guide documents. v3.3 `_extract_list` walked `data.positions`
+    expecting a list, got a dict, fell through silently. Now try the
+    nested path first, then fall back to the documented flat shape.
+    Same bug pattern caught + fixed in Cheetah v7.1.1 and Spider v4.0.1.
+    """
     raw = cfg.mcporter_call("leaderboard_get_trader_positions", trader_id=trader_address)
     if not raw:
         return []
-    # Try common nested paths
+    # Try common nested paths — nested-dict shape first since it's the
+    # actual production response shape.
     positions = _extract_list(
         raw,
-        ("data", "positions"),
+        ("data", "positions", "positions"),  # nested-dict shape (actual prod)
+        ("data", "top_positions", "positions"),
+        ("data", "positions"),  # flat list shape (schema guide)
         ("data", "top_positions"),
         ("positions",),
         ("top_positions",),

--- a/spider/SKILL.md
+++ b/spider/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "4.0.0"
+  version: "4.0.1"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/spider/scripts/spider-producer.py
+++ b/spider/scripts/spider-producer.py
@@ -98,7 +98,7 @@ if _helpers_path not in sys.path:
 from senpi_runtime_helpers import producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "4.0.0"
+VERSION = "4.0.1"
 SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "spider_signals")
 SIGNAL_TYPE = "SPIDER_ANCHOR"
 
@@ -557,6 +557,7 @@ def fetch_arena_long_exposure():
     # Step 3: for each user, fetch positions across their strategies.
     # Track per-user asset-direction sets to dedupe (one count per user).
     long_count = {}
+    shape_warned = False
     for uid in user_ids:
         wallets = user_to_wallets.get(uid, [])
         if not wallets:
@@ -568,11 +569,37 @@ def fetch_arena_long_exposure():
             )
             if not positions_data:
                 continue
+            # v4.0.1: leaderboard_get_trader_positions actually returns
+            #   { data: { positions: { trader_id, rank, positions: [...] } } }
+            # — the per-trader positions array is nested one level deeper
+            # than the schema guide documents. Pre-v4.0.1 parser expected
+            # a list at `data.positions`, got a dict, silently skipped every
+            # trader → arena_long_exposure empty → W_ARENA component (4pts)
+            # never fired → Spider candidates capped below MIN_SCORE.
+            # Same bug pattern caught and fixed in Cheetah v7.1.1.
             positions = []
             if isinstance(positions_data, dict):
                 d = positions_data.get("data", positions_data)
                 if isinstance(d, dict):
-                    positions = d.get("positions", d.get("top_positions", []))
+                    raw_positions = d.get("positions", d.get("top_positions", []))
+                    if isinstance(raw_positions, list):
+                        positions = raw_positions
+                    elif isinstance(raw_positions, dict):
+                        nested = raw_positions.get("positions", [])
+                        if isinstance(nested, list):
+                            positions = nested
+                        elif not shape_warned:
+                            cfg.log(
+                                f"POSITIONS_SHAPE_WARN nested non-list for {wallet[:10]}: "
+                                f"keys={list(raw_positions.keys())[:8]}"
+                            )
+                            shape_warned = True
+                    elif not shape_warned:
+                        cfg.log(
+                            f"POSITIONS_SHAPE_WARN unexpected type "
+                            f"{type(raw_positions).__name__} for {wallet[:10]}"
+                        )
+                        shape_warned = True
                 elif isinstance(d, list):
                     positions = d
             if not isinstance(positions, list):


### PR DESCRIPTION
## Summary

Same bug pattern caught + fixed in Cheetah v7.1.1 today (PR #235), spotted in 2 other agents via grep. Fleet-wide consistency fix.

`leaderboard_get_trader_positions` actually returns:
```
{ "data": { "positions": { "trader_id": "...", "rank": ..., "positions": [...] } } }
```

The per-trader positions array is nested one level deeper than the schema guide documents. Spider and Raptor's parsers expected a list at `data.positions`, got a dict, silently skipped every trader.

## Impact verified via Cheetah's live test today

Cheetah went from `positions_map: {}` (no QUALITY_TRADER bonus ever fires) to a working signal pipeline within 1 hour of v7.1.1 deploy. First trade post-fix: SOL LONG score 11 with `QUALITY_ALIGN 2_traders` (+3 bonus that had been dormant).

Spider's symptoms align: 2 trades total since 4/23, +$0.88, $3.4k volume. The `W_ARENA` (4pt) component depended on this data and was always 0.

## Fixes

| Agent | Path | Before | After |
|---|---|---|---|
| Spider v4.0.1 | `spider-producer.py` (fetch_arena_long_exposure) | Walks `data.positions` expecting list, hits `if not isinstance(positions, list): continue` | Handles both list-direct and nested-dict shapes; logs `POSITIONS_SHAPE_WARN` on unknown shapes |
| Raptor v3.4 | `raptor-scanner.py` (fetch_trader_positions) | `_extract_list` walks `data.positions` expecting list, returns [] | Walks nested path FIRST, flat path as fallback |

## Survey

Grepped for `leaderboard_get_trader_positions` across all skills:

| Agent | Status |
|---|---|
| Cheetah | Fixed in PR #235 (v7.1.1) |
| Spider | Fixed here (v4.0.1) |
| Raptor | Fixed here (v3.4) |
| Shark | Already handles nested via `pos_data.get("positions",{}).get("positions",[])` — no change |

## What did NOT change

- Scoring components, weights, MIN_SCORE
- Leverage tiers, margin, cooldowns
- DSL config
- Asset universe / XYZ ban
- Thesis or trade selection logic

Same producers, same logic. Now with the data they were always trying to read.

## Test plan

- [ ] Operators pull v4.0.1 (Spider) / v3.4 (Raptor), restart daemons
- [ ] Wipe stale state cache: `rm -f state/*/quality-cache.json` (or equivalent for Raptor)
- [ ] Within 1 hour, candidate scores climb (Spider: arena bonus 0→4; Raptor: trader concentration scoring restored)
- [ ] Trade frequency returns toward design expectation