### PR TITLE
fleet-fix: README Step 0 — register runtime plugin in openclaw.json

### DIFF
--- a/cheetah/README.md
+++ b/cheetah/README.md
@@ -30,6 +30,38 @@ Multi-signal confluence sniper. Refuses to trade unless ALL major signals align:
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host, shared across all skills)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file (this skill's SKILL.md, README.md, scripts, runtime YAMLs) is on `main` as normal.

--- a/grizzly/README.md
+++ b/grizzly/README.md
@@ -99,6 +99,38 @@ Time-cuts ALL DISABLED — single-asset family pattern. Phase 1 + Phase 2 own al
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.

--- a/jackal/README.md
+++ b/jackal/README.md
@@ -6,6 +6,38 @@ Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package currently lives only on the `helper-mcp-envelope-aligned` branch. Pull from there.

--- a/kestrel/README.md
+++ b/kestrel/README.md
@@ -6,6 +6,38 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package currently lives only on the `helper-mcp-envelope-aligned` branch. Pull from there.

--- a/kodiak/README.md
+++ b/kodiak/README.md
@@ -40,6 +40,38 @@ Conviction-tiered leverage:
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.

--- a/otter/README.md
+++ b/otter/README.md
@@ -6,6 +6,38 @@ Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package currently lives only on the `helper-mcp-envelope-aligned` branch. Pull from there.

--- a/pangolin/README.md
+++ b/pangolin/README.md
@@ -6,6 +6,38 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch. Pull from there.

--- a/polar/README.md
+++ b/polar/README.md
@@ -21,6 +21,38 @@ ETH single-asset hybrid hunter. Hyperfeed Smart Money gates (pct≥5%, traders�
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.

--- a/roach/README.md
+++ b/roach/README.md
@@ -6,6 +6,38 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch. Pull from there.

--- a/scorpion/README.md
+++ b/scorpion/README.md
@@ -13,6 +13,38 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does.

--- a/spider/README.md
+++ b/spider/README.md
@@ -6,6 +6,38 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package currently lives only on the `helper-mcp-envelope-aligned` branch. Pull from there.

--- a/turbine/README.md
+++ b/turbine/README.md
@@ -84,6 +84,38 @@ Create TWO new Senpi strategy wallets:
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.

--- a/vulture/README.md
+++ b/vulture/README.md
@@ -6,6 +6,38 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch. Pull from there.

--- a/wolverine/README.md
+++ b/wolverine/README.md
@@ -21,6 +21,38 @@ Single-asset HYPE alpha hunter. Six-gate entry validation: 4h trend structure, 4
 
 ## Install
 
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+If `curl` returns Connection refused, the plugin still isn't registered — check `openclaw plugin list` shows the runtime entry as loaded and re-verify the JSON.
+
 ### Step 1 — Pull the helpers package (one-time per host)
 
 > **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.


### PR DESCRIPTION
## Summary

Root-causes today's Vulture / Kestrel / Pangolin / Jackal "Connection refused on signal_post" stall. The `@senpi/runtime` plugin silently refuses to bind port 8787 unless `plugins.entries.runtime` is configured in `/data/.openclaw/openclaw.json`. Plugin logs `No plugin config found — skipping registration` when missing; producer daemon gets Errno 111 Connection refused on every signal_post.

Confirmed via Cheetah operator's working host today.

## Canonical config

```json
{
  "plugins": {
    "entries": {
      "runtime": {
        "enabled": true,
        "config": {
          "stateDir": "/data/.openclaw/senpi-state",
          "apiKey": "<SENPI_AUTH_TOKEN>",
          "autoUpdate": { "enabled": false }
        }
      }
    }
  }
}
```

## What changed

New `### Step 0 — Register the runtime plugin in openclaw.json` section inserted ABOVE the existing `### Step 1 — Pull the helpers package` anchor in 14 helpers-migrated agent READMEs:

- cheetah, kodiak, polar, wolverine, grizzly, scorpion, vulture, roach, pangolin, jackal, otter, spider, kestrel, turbine

Step 0 includes:
- The full JSON snippet
- A `gateway restart` + `curl /state` verification
- A failure-mode pointer (Connection refused → re-check the JSON)

## Why this matters

Pre-existing hosts (Cheetah, Kodiak, Grizzly, Polar, Turbine) had this configured from earlier setup and traded through the migration without issue. Fresh hosts (Vulture, Kestrel, Pangolin, Jackal operators) hit the gap and went dark for days. **Skill code was always fine; the gap was deployment prerequisite.**

Note: plugin's npm scope is `@senpi/runtime` (single segment). The plugin's export ID is `@senpi-ai/runtime` which generates a cosmetic "plugin id mismatch" warning — that's a red herring.

## Test plan

- [ ] Vulture + Kestrel operators apply Step 0 from their respective READMEs
- [ ] After gateway restart, `curl /state` returns 200 with runtimes array
- [ ] `signal_post` events in producer log start showing `"status": "ok"` instead of `"network_error"`
- [ ] Next tick produces actual trades