### PR TITLE
fleet-fix: strip dev / branch references — repo points only at prod / main

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ senpi-skills/
 ├── senpi-trading-runtime/          ╮
 ├── dsl-dynamic-stop-loss/          │
 ├── _helpers/senpi_runtime_helpers/ │ Capabilities (see top of this README)
-│   (on helper-mcp-envelope-aligned)│
+│   
 ├── fee-optimizer/                  │
 ├── shared/                         │
 ├── opportunity-scanner/            │

--- a/cheetah/README.md
+++ b/cheetah/README.md
@@ -64,14 +64,12 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host, shared across all skills)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file (this skill's SKILL.md, README.md, scripts, runtime YAMLs) is on `main` as normal.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers/references
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers/tests
 
 for f in __init__.py _config.py _logging.py cache.py client.py daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```
@@ -215,7 +213,7 @@ cd /data/workspace/skills/cheetah-strategy
 
 # 3. Bump the runtime plugin to >= 2.0.0 if not already on it:
 cat /data/.openclaw/extensions/runtime/package.json | grep version
-# Latest dev tag at the time of v7.0.0:
+# Minimum required version:
 #   1.0.98
 
 # 4. Stop the old producer cron (the v7.0.0 producer is a daemon now):

--- a/cheetah/SKILL.md
+++ b/cheetah/SKILL.md
@@ -18,8 +18,8 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=2.0.0
-    - senpi-runtime-helpers
+    - senpi-trading-runtime>=1.0.98
+    - senpi_runtime_helpers
 ---
 
 # 🐆 CHEETAH v7.1.0 — Multi-Signal Confluence Sniper

--- a/cheetah/scripts/cheetah-producer.py
+++ b/cheetah/scripts/cheetah-producer.py
@@ -10,7 +10,7 @@ v7.0.0 (2026-05-08) — plumbing migration from openclaw-CLI subprocess
 NO thesis change. Scoring tables, scoring components, leverage tiers,
 margin %, asset cooldowns, post-close cooldown, dedup logic are all
 preserved verbatim from v6.1.0. The runtime itself is now on
-senpi-trading-runtime >= 2.0.0 (runtime-phase-2 build) which speaks
+senpi-trading-runtime >= 1.0.98, which speaks
 the new {success,data,error} envelope on /signals + /audit and
 exposes GET /state for daemon liveness probes.
 
@@ -1010,7 +1010,7 @@ if __name__ == "__main__":
     )
     # NOTE: senpi_runtime_helpers.daemon.producer_daemon installed on the
     # runtime host (Erik's build) does NOT yet accept wallet=/scanner=
-    # kwargs even though the helper-mcp-envelope-aligned branch's source
+    # kwargs even though the helpers package's source
     # signature documents them. Caught live on Turbine v3.2 deploy
     # 2026-05-08: TypeError: unexpected keyword argument 'wallet'.
     # When the host helpers package is upgraded, add back:

--- a/grizzly/README.md
+++ b/grizzly/README.md
@@ -133,13 +133,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/grizzly/SKILL.md
+++ b/grizzly/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=2.0.0
-    - senpi-runtime-helpers
+    - senpi-trading-runtime>=1.0.98
+    - senpi_runtime_helpers
 ---
 
 # 🐻 GRIZZLY v7.0.0 — BTC Alpha Hunter (senpi_runtime_helpers)
@@ -260,7 +260,7 @@ get audited.
 
 ## Install
 
-**Prerequisite:** plugin must be on `runtime-phase-2` build. Verify with
+**Prerequisite:** plugin must be `@senpi/runtime` >= 1.0.98. Verify with
 `openclaw senpi external-scanner ingest --help` — should show `--address`
 flag. If not, see README install steps.
 

--- a/jackal/README.md
+++ b/jackal/README.md
@@ -40,13 +40,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package currently lives only on the `helper-mcp-envelope-aligned` branch. Pull from there.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/kestrel/README.md
+++ b/kestrel/README.md
@@ -40,13 +40,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package currently lives only on the `helper-mcp-envelope-aligned` branch. Pull from there.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/kodiak/README.md
+++ b/kodiak/README.md
@@ -74,13 +74,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/kodiak/SKILL.md
+++ b/kodiak/SKILL.md
@@ -18,8 +18,8 @@ metadata:
   exchange: hyperliquid
   base_skill: grizzly-v2.0
   requires:
-    - senpi-trading-runtime>=2.0.0
-    - senpi-runtime-helpers
+    - senpi-trading-runtime>=1.0.98
+    - senpi_runtime_helpers
 ---
 
 # 🐻 KODIAK v7.0.0 — SOL Alpha Hunter

--- a/kodiak/scripts/kodiak-producer.py
+++ b/kodiak/scripts/kodiak-producer.py
@@ -708,7 +708,7 @@ if __name__ == "__main__":
     )
     # NOTE: senpi_runtime_helpers.daemon.producer_daemon installed on the
     # runtime host (Erik's build) does NOT yet accept wallet=/scanner=
-    # kwargs even though the helper-mcp-envelope-aligned branch's source
+    # kwargs even though the helpers package's source
     # signature documents them. Caught live on Turbine v3.2 deploy
     # 2026-05-08: TypeError: unexpected keyword argument 'wallet'.
     # When the host helpers package is upgraded, add back:

--- a/otter/README.md
+++ b/otter/README.md
@@ -40,13 +40,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package currently lives only on the `helper-mcp-envelope-aligned` branch. Pull from there.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/pangolin/README.md
+++ b/pangolin/README.md
@@ -2,7 +2,7 @@
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-**Plumbing-only migration from v2.2.0. NO thesis change.** Pangolin is the canonical reference implementation — its producer was the first to ship the helpers wrapper pattern on `helper-mcp-envelope-aligned`. v3.0.0 ports that to main with fleet-fix #214 (no `wallet=`/`scanner=` daemon kwargs) applied.
+**Plumbing-only migration from v2.2.0. NO thesis change.** Pangolin is the canonical reference implementation — its producer is the helpers wrapper pattern other helpers-native skills copy. v3.0.0 applied fleet-fix #214 (no `wallet=`/`scanner=` daemon kwargs).
 
 ## Install
 
@@ -40,13 +40,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch. Pull from there.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/pangolin/SKILL.md
+++ b/pangolin/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   migration. Plumbing-only flip from openclaw-CLI subprocess + mcporter
   subprocess to in-process SenpiClient. Pangolin is the canonical
   reference implementation — its producer was the first to ship the
-  helpers wrapper pattern on the helper-mcp-envelope-aligned branch;
+  helpers wrapper pattern (now landed on main);
   v3.0.0 ports that to main. Thesis preserved verbatim from v2.2.0:
   funding-fade entries opposite to elevated funding rates (>0.015%/8h
   ≈ 20% annualized), persistence ≥3h, regime confirms or neutral.
@@ -19,8 +19,8 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=2.0.0
-    - senpi-runtime-helpers
+    - senpi-trading-runtime>=1.0.98
+    - senpi_runtime_helpers
 ---
 
 # 🦔 PANGOLIN v3.0.0 — Funding Rate Fader. senpi_runtime_helpers.

--- a/polar/README.md
+++ b/polar/README.md
@@ -55,13 +55,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/polar/SKILL.md
+++ b/polar/SKILL.md
@@ -17,8 +17,8 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=2.0.0
-    - senpi-runtime-helpers
+    - senpi-trading-runtime>=1.0.98
+    - senpi_runtime_helpers
 ---
 
 # 🐻‍❄️ POLAR v5.0.0 — ETH Alpha Hunter (senpi_runtime_helpers)

--- a/roach/README.md
+++ b/roach/README.md
@@ -40,13 +40,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch. Pull from there.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/roach/SKILL.md
+++ b/roach/SKILL.md
@@ -16,8 +16,8 @@ metadata:
   exchange: hyperliquid
   config_source: striker-only-experiment
   requires:
-    - senpi-trading-runtime>=2.0.0
-    - senpi-runtime-helpers
+    - senpi-trading-runtime>=1.0.98
+    - senpi_runtime_helpers
 ---
 
 # 🪳 ROACH v3.0.0 — Striker Only. senpi_runtime_helpers.

--- a/scorpion/README.md
+++ b/scorpion/README.md
@@ -47,13 +47,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/scorpion/SKILL.md
+++ b/scorpion/SKILL.md
@@ -18,8 +18,8 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=2.0.0
-    - senpi-runtime-helpers
+    - senpi-trading-runtime>=1.0.98
+    - senpi_runtime_helpers
 ---
 
 # 🦂 SCORPION v5.0.0 — Multi-Market Active Trader (senpi_runtime_helpers)

--- a/spider/README.md
+++ b/spider/README.md
@@ -40,13 +40,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package currently lives only on the `helper-mcp-envelope-aligned` branch. Pull from there.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/turbine/README.md
+++ b/turbine/README.md
@@ -118,13 +118,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```
@@ -281,7 +279,7 @@ Top up the volume wallet daily-to-weekly to keep 7 slots active. Senpi-side reba
 
 - ❌ **Do NOT** add an openclaw cron — the daemon supervises itself
 - ❌ **Do NOT** set `STRATEGY_ADDRESS`, `TURBINE_WALLET`, or `TURBINE_HUNT_WALLET` env vars — all banned
-- ❌ **Do NOT** point both runtimes at the same wallet — runtime-phase-2 will reject the second install
+- ❌ **Do NOT** point both runtimes at the same wallet — the senpi-trading-runtime plugin rejects a second install on the same wallet
 - ❌ **Do NOT** run Sentinel concurrently — runners mode supersedes it
 - ❌ **Do NOT** delete a runtime while positions are open — orphan-position bug
 

--- a/turbine/SKILL.md
+++ b/turbine/SKILL.md
@@ -18,8 +18,8 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=2.0.0
-    - senpi-runtime-helpers
+    - senpi-trading-runtime>=1.0.98
+    - senpi_runtime_helpers
 ---
 
 # 🌪️ TURBINE v3.2 — Volume Rotation + Runners
@@ -69,7 +69,7 @@ The same rotation alpha goes to both wallets. The runners wallet's DSL gives pos
 
 ## Why two wallets at all
 
-The runtime-phase-2 plugin enforces **one runtime per wallet**. v3.0 attempted to attach two runtimes to a single wallet and got blocked at deploy. v3.1 split into two wallets but rebuilt them with the wrong thesis (HYPE specialist). v3.2 keeps the two-wallet split and rewires both to the right thesis (same volume rotation, different DSL).
+The senpi-trading-runtime plugin enforces **one runtime per wallet**. v3.0 attempted to attach two runtimes to a single wallet and got blocked at deploy. v3.1 split into two wallets but rebuilt them with the wrong thesis (HYPE specialist). v3.2 keeps the two-wallet split and rewires both to the right thesis (same volume rotation, different DSL).
 
 ## Mission
 

--- a/turbine/runtime-runners.yaml
+++ b/turbine/runtime-runners.yaml
@@ -8,7 +8,7 @@ description: >
 
   One of TWO runtimes Turbine v3.2 attaches across two strategy wallets
   (sibling: turbine-volume-tracker on the volume wallet). Each runtime
-  attaches to its OWN wallet — runtime-phase-2 enforces one runtime per
+  attaches to its OWN wallet — the senpi-trading-runtime plugin enforces one runtime per
   wallet, so v3.0's "two runtimes on one wallet" architecture is
   prevented at deploy.
 

--- a/turbine/scripts/turbine-producer.py
+++ b/turbine/scripts/turbine-producer.py
@@ -620,7 +620,7 @@ if __name__ == "__main__":
     )
     # NOTE: senpi_runtime_helpers.daemon.producer_daemon installed on the
     # runtime host (Erik's build) does NOT yet accept wallet=/scanner=
-    # kwargs even though the helper-mcp-envelope-aligned branch's source
+    # kwargs even though the helpers package's source
     # signature documents them. Caught live on Turbine v3.2 deploy
     # 2026-05-08: TypeError: unexpected keyword argument 'wallet'.
     # When the host helpers package is upgraded, add back:

--- a/turbine/scripts/turbine_config.py
+++ b/turbine/scripts/turbine_config.py
@@ -7,7 +7,7 @@ abstraction: ~$2,400 idle 90% of the time, no volume contribution
 from the second wallet. The correct framing (clarified by Jason):
 "run the volume play, but allow winners to run longer."
 
-v3.2 keeps the two-wallet split (runtime-phase-2 still enforces
+v3.2 keeps the two-wallet split (the senpi-trading-runtime plugin enforces
 one runtime per wallet) but rewires it: BOTH wallets run the same
 volume rotation alpha. The wallet boundary just selects DSL
 behavior:
@@ -36,11 +36,6 @@ v3.1 → v3.2 deltas:
   - HYPE-only specialty → general volume rotation on runners wallet
   - hunt_min_score / huntCooldownMin / minHuntWalletBalance dropped
   - Runners get the same scoring path as volume
-
-Helpers-based (matches Cheetah v7.0.0 / Pangolin v2.2 patterns):
-  - SenpiClient via lazy proxy (auth-validated on first use)
-  - mcporter_call() shim for backward-compat call sites
-  - _wrapper_client exposed for direct push_signal access
 
 Helpers-based (matches Cheetah v7.0.0 / Pangolin v2.2 patterns):
   - SenpiClient via lazy proxy (auth-validated on first use)

--- a/vulture/README.md
+++ b/vulture/README.md
@@ -40,13 +40,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch. Pull from there.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/vulture/SKILL.md
+++ b/vulture/SKILL.md
@@ -18,8 +18,8 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=2.0.0
-    - senpi-runtime-helpers
+    - senpi-trading-runtime>=1.0.98
+    - senpi_runtime_helpers
 ---
 
 # 🦅 VULTURE v4.0.0 — Long-Tail Momentum Rider (senpi_runtime_helpers)

--- a/wolverine/README.md
+++ b/wolverine/README.md
@@ -55,13 +55,11 @@ If `curl` returns Connection refused, the plugin still isn't registered — chec
 
 ### Step 1 — Pull the helpers package (one-time per host)
 
-> **Note:** The `_helpers/senpi_runtime_helpers/` package is currently only on the `helper-mcp-envelope-aligned` branch — it has not yet landed on `main`. Pull from that branch until it does. Every other file in this skill is on `main` as normal.
-
 ```bash
 mkdir -p /data/workspace/skills/_helpers/senpi_runtime_helpers
 for f in __init__.py _config.py _logging.py cache.py client.py \
          daemon.py lock.py parallel.py SKILL.md README.md; do
-  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/helper-mcp-envelope-aligned/_helpers/senpi_runtime_helpers/$f" \
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/_helpers/senpi_runtime_helpers/$f" \
     -o "/data/workspace/skills/_helpers/senpi_runtime_helpers/$f"
 done
 ```

--- a/wolverine/SKILL.md
+++ b/wolverine/SKILL.md
@@ -18,8 +18,8 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=2.0.0
-    - senpi-runtime-helpers
+    - senpi-trading-runtime>=1.0.98
+    - senpi_runtime_helpers
 ---
 
 # 🦡 WOLVERINE v5.0.0 — HYPE Alpha Hunter (senpi_runtime_helpers)


### PR DESCRIPTION
## Summary

Runtime 2.0 is now published as `@senpi/runtime` **1.0.98** (in the 1.0.x series for auto-upgrade). Helper-mcp-envelope-aligned branch merged to main via PR #208/#239. Every "pull from this dev branch / install this dev tag / wait for prod release" reference in the repo was stale. This PR strips them.

## Categorical fixes

### 1. Pull URLs — 14 helpers-migrated READMEs
Stripped the "Note: package only on `helper-mcp-envelope-aligned` branch — pull from there" callouts. All `curl` URLs now point at `main` (where the package lives post-merge).

### 2. SKILL.md frontmatter version pins (10 files)
- `senpi-trading-runtime>=2.0.0` → `senpi-trading-runtime>=1.0.98`
- `senpi-runtime-helpers` (hyphens) → `senpi_runtime_helpers` (matches the actual Python module name)

### 3. Cheetah header references
- Producer docstring: `senpi-trading-runtime >= 2.0.0 (runtime-phase-2 build)` → `senpi-trading-runtime >= 1.0.98`
- README comment label: `# Latest dev tag at the time of v7.0.0:` → `# Minimum required version:`

### 4. Grizzly SKILL.md forward-looking prerequisite
`plugin must be on `runtime-phase-2` build` → `plugin must be `@senpi/runtime` >= 1.0.98`

### 5. Turbine forward-looking constraint docs (README, SKILL.md, YAML, config.py)
`runtime-phase-2 enforces one runtime per wallet` → `the senpi-trading-runtime plugin enforces one runtime per wallet` (codename → generic property)

### 6. Top-level README repo layout
Dropped `(on helper-mcp-envelope-aligned)` annotation under `_helpers/senpi_runtime_helpers/`

### 7. Pangolin SKILL.md + README opener
Updated `first to ship on helper-mcp-envelope-aligned branch` historical reference to reflect that the helpers wrapper pattern is on main.

### 8. Producer code comments
`the helper-mcp-envelope-aligned branch's source` → `the helpers package's source` / `the helpers package on main` (cheetah / kodiak / turbine).

### 9. Bonus: duplicate "Helpers-based" block removed
turbine_config.py had a copy-paste artifact (4 duplicate lines).

## What's preserved as historical record

- Turbine SKILL.md changelog entries mentioning `runtime-phase-2 redeploy` / `runtime-phase-2 rollover` in v3.2.x release notes — those describe specific past events at the time they occurred.
- v3.2 internal release-note narratives keep build-name references where they chronicle history.

## What's NOT touched

- Producer logic, scoring, DSL config
- Runtime YAMLs of any agent
- senpi-trading-runtime/SKILL.md (already cleaned in the PR #208 merge)

## Stats

**30 files changed, +47 / −80 (net −33 lines).**

## Test plan

- [ ] CI passes (no producer/scanner code semantics changed)
- [ ] Operator pulling the install instructions from any helpers-migrated skill's README gets URLs that work (point at main, package is there)
- [ ] No reference in main now reads `senpi-trading-runtime >= 2.0.0` or `helper-mcp-envelope-aligned` or `runtime-phase-2 build` as a forward-looking install instruction