### PR TITLE
fleet-fix: align runtime references to @senpi/runtime 1.1.0

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -214,7 +214,7 @@ if __name__ == "__main__":
                     wallet=wallet, scanner="<skill>_signals")
 ```
 
-**What the wrapper gives you** (full breakdown: `docs/runtime-v2-fixes/runtime-2-performance-findings.md` in the `senpi-trading-runtime` repo):
+**What the wrapper gives you** (full breakdown in the `senpi-trading-runtime` repo's performance-findings docs):
 
 - A persistent HTTPS keep-alive client to MCP — ~280 ms per call. The legacy `mcporter` subprocess spawned a 6-process tree (gateway → sh → python → mcporter → npm → mcp-remote) at 2.5–5 s and 250–300 MB transient RSS per call.
 - Direct POST to the runtime's `/signals` endpoint via `push_signal(...)`. The legacy `openclaw senpi external-scanner ingest` cold-started the openclaw CLI at 5–8 s per emit.

--- a/Grizzly-Horribilis/README.md
+++ b/Grizzly-Horribilis/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Skills are versioned and MIT-licensed. Anyone can fork a skill, modify it, or bu
 ┌──────────────────────────────────▼───────────────────────────────────────┐
 │                        CAPABILITIES (this repo)                           │
 │                                                                            │
-│   senpi-trading-runtime  ─── @senpi/runtime plugin (>= v1.0.98)           │
+│   senpi-trading-runtime  ─── @senpi/runtime plugin (>= v1.1.0)            │
 │                              Consumes: Strategy state, Position,           │
 │                              Execution, Audit MCP categories               │
 │                                                                            │
@@ -108,9 +108,9 @@ Detail on each capability follows. The full tool surface is enumerated in the **
 
 ## `senpi-trading-runtime/` — Plugin Runtime
 
-The OpenClaw plugin (`@senpi/runtime`, currently published as `1.0.98+`) that owns the trading loop. Auto-upgrades on operator hosts via standard OpenClaw plugin install.
+The OpenClaw plugin (`@senpi/runtime`, currently published as `1.1.0`) that owns the trading loop. Auto-upgrades on operator hosts via standard OpenClaw plugin install.
 
-> Internally the architecture is sometimes called "runtime 2.0" because it's a major rewrite from the legacy Python DSL cron model — in-process producer daemon, direct HTTPS to MCP, declarative `risk.guard_rails`, native FEE_OPTIMIZED_LIMIT entries + exits, trade-chain DB telemetry, GET `/state` for daemon liveness. The npm version stays in the `1.0.x` series so existing operator hosts auto-upgrade without manual major-version opt-in.
+> The current generation of the runtime is a major rewrite from the legacy Python DSL cron model — in-process producer daemon, direct HTTPS to MCP, declarative `risk.guard_rails`, native FEE_OPTIMIZED_LIMIT entries + exits, trade-chain DB telemetry, GET `/state` for daemon liveness.
 
 Two skill architecture patterns exist; a skill targets one via its `runtime.yaml`:
 
@@ -502,7 +502,7 @@ Each strategy directory contains:
 
 1. Deploy an [OpenClaw](https://openclaw.ai) agent and configure Senpi MCP access.
 2. Pick a strategy skill from the buckets above. Read its `README.md`.
-3. Install the `@senpi/runtime` plugin (>= 1.0.98) per standard `openclaw plugin install`. Helpers-native skills additionally need the `_helpers/senpi_runtime_helpers/` package pulled from `main` into `${OPENCLAW_WORKSPACE}/skills/_helpers/`.
+3. Install the `@senpi/runtime` plugin (>= 1.1.0) per standard `openclaw plugin install`. Helpers-native skills additionally need the `_helpers/senpi_runtime_helpers/` package pulled from `main` into `${OPENCLAW_WORKSPACE}/skills/_helpers/`.
 4. Pull the skill's scripts + `runtime.yaml` from main into your host workspace.
 5. Set the required env vars (`<SKILL>_WALLET`, `SENPI_AUTH_TOKEN`, and optionally a `<SKILL>_DECISION_MODEL` for LLM-gated actions).
 6. Start the producer per the skill's README — helpers-native skills launch a long-lived `producer_daemon` (manage via `senpi-helpers` CLI); legacy skills run via openclaw cron.
@@ -517,7 +517,7 @@ Each strategy directory contains:
 
 Each skill is self-contained. To build a new one:
 
-1. Start from a runtime-2 skill (`kodiak/`, `cheetah/`, or `roach/`) as a template.
+1. Start from a helpers-native skill (`kodiak/`, `cheetah/`, or `roach/`) as a template.
 2. Replace the producer's signal-generation logic with your thesis.
 3. Tune `runtime.yaml` — universe, score thresholds, DSL config, risk guard-rails.
 4. Document in `SKILL.md` (frontmatter) and `README.md` (operator-facing).

--- a/_helpers/senpi_runtime_helpers/SKILL.md
+++ b/_helpers/senpi_runtime_helpers/SKILL.md
@@ -8,13 +8,13 @@ description: >-
 
   Triggers: producer authoring, scanner authoring, mcporter, mcporter_call,
   external-scanner ingest, push_signal, SenpiClientError, scanner_lock,
-  tick_cache, parallel MCP, producer_daemon, runtime-2 migration.
+  tick_cache, parallel MCP, producer_daemon, helpers-native migration.
 license: MIT
 compatibility: >-
-  Python 3.10+. Stdlib only. Requires senpi-trading-runtime >= 1.0.98
-  (uses the 2.0 senpi-stack `{success, data, error}` envelope on /signals
-  and GET /state for liveness — neither shipped in the 1.x line). Loaded
-  from `${OPENCLAW_WORKSPACE:-/data/workspace}/skills/_helpers/`.
+  Python 3.10+. Stdlib only. Requires senpi-trading-runtime >= 1.1.0
+  (uses the senpi-stack `{success, data, error}` envelope on /signals
+  and GET /state for liveness). Loaded from
+  `${OPENCLAW_WORKSPACE:-/data/workspace}/skills/_helpers/`.
 metadata:
   author: senpi
   version: "1.0"
@@ -285,7 +285,7 @@ restarts.
 |---|---|---|
 | `signal_post: response body was empty` | Proxy/sidecar stripped body | Check container network, `SENPI_RUNTIME_API_HOST/PORT` |
 | `signal_post: response not valid JSON` | Mid-stream truncation | Network instability; retry on next tick |
-| `signal_post: unexpected envelope shape` | Runtime is on the legacy 1.x envelope | Bump runtime to `>= 2.0.0` |
+| `signal_post: unexpected envelope shape` | Runtime is on the legacy 1.0.x envelope | Bump runtime to `>= 1.1.0` |
 | `signal_post: … code=INVALID_REQUEST` | Per-item schema violation. Most common: `asset`/`direction` inside `data` | Move to top-level kwargs; verify `data` keys against `runtime.yaml` `config.fields` |
 | `signal_post: … code=NOT_FOUND` | No runtime for wallet, or scanner name unknown | Verify runtime install (`openclaw senpi runtime list`); confirm `scanner` matches `runtime.yaml` |
 | `signal_post: HTTP 400 … Exceeded api.maxItemsPerSignalsRequest=10` | Batch too large | Split batch (default cap 10) |

--- a/barracuda/README.md
+++ b/barracuda/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/bison/README.md
+++ b/bison/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/cheetah/README.md
+++ b/cheetah/README.md
@@ -11,7 +11,7 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
   - Signal emission goes via `SenpiClient.push_signal()` (direct HTTP POST) instead of `openclaw senpi external-scanner ingest` subprocess
   - Reentrancy lock owned by `producer_daemon.scanner_lock` (PID-aliveness auto-recovery) instead of hand-rolled `fcntl`
   - Tick scheduling owned by `producer_daemon` (long-lived process) instead of openclaw cron + `agentTurn` (per-tick LLM cost)
-- Requires `senpi-trading-runtime >= 1.0.98` .
+- Requires `senpi-trading-runtime >= 1.1.0` .
 - `runtime.yaml` unchanged. `external_scanner.name: cheetah_signals` matches the producer's `client.push_signal(scanner=...)`.
 
 ## What changed in v6.x (preserved)
@@ -211,10 +211,10 @@ cd /data/workspace/skills/cheetah-strategy
 
 # 2. Pull the new producer + config files (Step 2 above curl block).
 
-# 3. Bump the runtime plugin to >= 2.0.0 if not already on it:
+# 3. Bump the runtime plugin to >= 1.1.0 if not already on it:
 cat /data/.openclaw/extensions/runtime/package.json | grep version
 # Minimum required version:
-#   1.0.98
+#   1.1.0
 
 # 4. Stop the old producer cron (the v7.0.0 producer is a daemon now):
 openclaw cron list | grep cheetah

--- a/cheetah/SKILL.md
+++ b/cheetah/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=1.0.98
+    - senpi-trading-runtime>=1.1.0
     - senpi_runtime_helpers
 ---
 

--- a/cheetah/scripts/cheetah-producer.py
+++ b/cheetah/scripts/cheetah-producer.py
@@ -10,7 +10,7 @@ v7.0.0 (2026-05-08) — plumbing migration from openclaw-CLI subprocess
 NO thesis change. Scoring tables, scoring components, leverage tiers,
 margin %, asset cooldowns, post-close cooldown, dedup logic are all
 preserved verbatim from v6.1.0. The runtime itself is now on
-senpi-trading-runtime >= 1.0.98, which speaks
+senpi-trading-runtime >= 1.1.0, which speaks
 the new {success,data,error} envelope on /signals + /audit and
 exposes GET /state for daemon liveness probes.
 

--- a/cobra/README.md
+++ b/cobra/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/condor/README.md
+++ b/condor/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/dire/README.md
+++ b/dire/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/dog/README.md
+++ b/dog/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/grizzly/README.md
+++ b/grizzly/README.md
@@ -13,7 +13,7 @@ Single-asset BTC trend-following scanner. Trades **WITH** smart money consensus 
   - Signal emission goes via `SenpiClient.push_signal()` (direct HTTP POST) instead of `openclaw senpi external-scanner ingest` subprocess
   - Reentrancy lock owned by `producer_daemon.scanner_lock` instead of hand-rolled `fcntl`
   - Tick scheduling owned by `producer_daemon` (long-lived process) instead of openclaw cron + `agentTurn`
-- Requires `senpi-trading-runtime >= 1.0.98`.
+- Requires `senpi-trading-runtime >= 1.1.0`.
 - `runtime.yaml` unchanged from v6.x.
 - Per Rachin's review of Cheetah PR #209: dead fields stripped from payload; `signal_type="GRIZZLY_BTC_TREND"` passed explicitly.
 

--- a/grizzly/SKILL.md
+++ b/grizzly/SKILL.md
@@ -20,7 +20,7 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=1.0.98
+    - senpi-trading-runtime>=1.1.0
     - senpi_runtime_helpers
 ---
 
@@ -260,7 +260,7 @@ get audited.
 
 ## Install
 
-**Prerequisite:** plugin must be `@senpi/runtime` >= 1.0.98. Verify with
+**Prerequisite:** plugin must be `@senpi/runtime` >= 1.1.0. Verify with
 `openclaw senpi external-scanner ingest --help` — should show `--address`
 flag. If not, see README install steps.
 

--- a/hydra/README.md
+++ b/hydra/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/jackal/SKILL.md
+++ b/jackal/SKILL.md
@@ -254,7 +254,7 @@ context is too strict.
 - NO thesis change. NO decision-prompt change. NO DSL change.
 
 ### v2.0 (2026-04-23) — V2-RUNTIME-NATIVE REWRITE
-- First fleet agent on senpi-trading-runtime v2
+- First fleet agent on senpi-trading-runtime
 - Producer-only Python (400 lines vs v1's 760 line scanner)
 - LLM `decision_mode: llm` replaces hardcoded score thresholds
 - `risk.guard_rails` YAML replaces Python risk code

--- a/jackal/runtime.yaml
+++ b/jackal/runtime.yaml
@@ -21,7 +21,7 @@ description: >
   Scorpion v4.0.2 maker-exit fix.
 
   JACKAL v2.0 — The Smart Stalker (v2-runtime-native rewrite).
-  First fleet agent built on the senpi-trading-runtime v2 architecture:
+  First fleet agent built on the senpi-trading-runtime architecture:
   pure producer + external_scanner + LLM-gated OPEN_POSITION action +
   declarative risk guardrails + runtime-managed DSL.
 
@@ -211,7 +211,7 @@ exit:
   # Wide Phase 1 (22% max_loss), loose early Phase 2 locks (preserve
   # the gold-signal case: newly-promoted source + 2+ existing consensus).
   # Hard timeout 72h lets multi-day holds breathe. No dead_weight_cut
-  # (v1 had it; runtime v2 disables time cuts once Phase 2 reached
+  # (v1 had it; runtime disables time cuts once Phase 2 reached
   # automatically — preserving the patience philosophy).
   dsl_preset:
     hard_timeout:

--- a/jackal/scripts/jackal-producer.py
+++ b/jackal/scripts/jackal-producer.py
@@ -13,7 +13,7 @@ Jackal v1.1 (the scanner) ran as a full-agency Python scanner that:
 
 v2.0 splits that into two parts:
   1. This producer (runs on cron, 60s): emits candidate signals only
-  2. Runtime (senpi-trading-runtime v2): receives signals via
+  2. Runtime (senpi-trading-runtime): receives signals via
      external_scanner ingest, gates through LLM decision_prompt,
      executes, and manages DSL autonomously.
 

--- a/jaguar/README.md
+++ b/jaguar/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/kodiak/README.md
+++ b/kodiak/README.md
@@ -13,7 +13,7 @@ SOL-only alpha hunter. Single-asset focus. Multi-factor scoring (SM consensus + 
   - Signal emission goes via `SenpiClient.push_signal()` (direct HTTP POST) instead of `openclaw senpi external-scanner ingest` subprocess
   - Reentrancy lock owned by `producer_daemon.scanner_lock` (PID-aliveness auto-recovery) instead of hand-rolled `fcntl`
   - Tick scheduling owned by `producer_daemon` (long-lived process) instead of openclaw cron + `agentTurn`
-- Requires `senpi-trading-runtime >= 1.0.98` .
+- Requires `senpi-trading-runtime >= 1.1.0` .
 - `runtime.yaml` unchanged. `external_scanner.name: kodiak_signals` matches the producer's `client.push_signal(scanner=...)`.
 - Per Rachin's review of Cheetah PR #209: dead fields stripped from `build_signal_payload`; `signal_type="KODIAK_SOL_THESIS"` passed explicitly.
 

--- a/kodiak/SKILL.md
+++ b/kodiak/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   exchange: hyperliquid
   base_skill: grizzly-v2.0
   requires:
-    - senpi-trading-runtime>=1.0.98
+    - senpi-trading-runtime>=1.1.0
     - senpi_runtime_helpers
 ---
 

--- a/komodo/README.md
+++ b/komodo/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/lemon/README.md
+++ b/lemon/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/mamba/README.md
+++ b/mamba/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/mantis/README.md
+++ b/mantis/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/orca/README.md
+++ b/orca/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/otter/scripts/otter-producer.py
+++ b/otter/scripts/otter-producer.py
@@ -20,7 +20,7 @@ with directional conviction. Otter rides for 1-3 hours.
 
 Architecture (v2-native, matches Roach v2 / Pangolin v2 / Jackal v2):
   1. This producer (cron, 5min): emits flow-detected signals only.
-  2. Runtime (senpi-trading-runtime v2): receives signals via
+  2. Runtime (senpi-trading-runtime): receives signals via
      external_scanner ingest, LLM-gates them (pass-through), executes
      with FEE_OPTIMIZED_LIMIT (entries: maker-only; exits: maker-first
      + taker fallback), and manages DSL exits autonomously.

--- a/owl/README.md
+++ b/owl/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/owl/scripts/owl-producer.py
+++ b/owl/scripts/owl-producer.py
@@ -32,7 +32,7 @@ Owl v6.x was a v1-architecture self-executing scanner that:
 
 v7.0 splits that into two parts:
   1. This producer (cron, 15min): emits contrarian signals only.
-  2. Runtime (senpi-trading-runtime v2): receives signals via
+  2. Runtime (senpi-trading-runtime): receives signals via
      external_scanner ingest, LLM-gates them (pass-through), executes
      with FEE_OPTIMIZED_LIMIT (entries: maker-only; exits: maker-first
      + taker fallback as safety), and manages DSL exits autonomously.

--- a/pangolin/SKILL.md
+++ b/pangolin/SKILL.md
@@ -19,7 +19,7 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=1.0.98
+    - senpi-trading-runtime>=1.1.0
     - senpi_runtime_helpers
 ---
 

--- a/pangolin/scripts/pangolin-producer.py
+++ b/pangolin/scripts/pangolin-producer.py
@@ -74,7 +74,7 @@ Pangolin v1.x ran as a full-agency Python scanner that:
 
 v2.0 splits that into two parts:
   1. This producer (cron, 5min): emits candidate signals only.
-  2. Runtime (senpi-trading-runtime v2): receives signals via
+  2. Runtime (senpi-trading-runtime): receives signals via
      external_scanner ingest, LLM-gates them (pass-through),
      executes with FEE_OPTIMIZED_LIMIT (maker-first, 60s, no taker
      fallback on entries — preserve v1 patience), and manages DSL

--- a/phoenix/README.md
+++ b/phoenix/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/polar/README.md
+++ b/polar/README.md
@@ -11,7 +11,7 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
   - Signal emission goes via `SenpiClient.push_signal()` (direct HTTP POST) instead of `openclaw senpi external-scanner ingest` subprocess
   - Reentrancy lock owned by `producer_daemon.scanner_lock` instead of hand-rolled `fcntl`
   - Tick scheduling owned by `producer_daemon` (long-lived process) instead of openclaw cron + `agentTurn`
-- Requires `senpi-trading-runtime >= 1.0.98`.
+- Requires `senpi-trading-runtime >= 1.1.0`.
 - `runtime.yaml` unchanged. `external_scanner.name: polar_signals` matches the producer's `client.push_signal(scanner=...)`.
 - Per Rachin's review of Cheetah PR #209: dead fields stripped from payload; `signal_type="POLAR_ETH_HYBRID"` passed explicitly.
 

--- a/polar/SKILL.md
+++ b/polar/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=1.0.98
+    - senpi-trading-runtime>=1.1.0
     - senpi_runtime_helpers
 ---
 
@@ -25,7 +25,7 @@ metadata:
 
 Best gross trader in the fleet. Single asset. Maximum conviction.
 
-**v3 → v4 architectural rewrite.** v3.x was a full-agency scanner that called create_position directly and tracked state in Python. v4.0 flips to the standard senpi-trading-runtime v2 pattern: producer emits signals, runtime owns execution + state.
+**v3 → v4 architectural rewrite.** v3.x was a full-agency scanner that called create_position directly and tracked state in Python. v4.0 flips to the standard senpi-trading-runtime pattern: producer emits signals, runtime owns execution + state.
 
 **What changed structurally:**
 - `polar-producer.py` (NEW) replaces `polar-scanner.py` (DELETED). Pure producer — no execution, no counters, no cooldowns, no resting-order guards.

--- a/python/README.md
+++ b/python/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/raptor/README.md
+++ b/raptor/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/rhino/README.md
+++ b/rhino/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/roach/SKILL.md
+++ b/roach/SKILL.md
@@ -16,7 +16,7 @@ metadata:
   exchange: hyperliquid
   config_source: striker-only-experiment
   requires:
-    - senpi-trading-runtime>=1.0.98
+    - senpi-trading-runtime>=1.1.0
     - senpi_runtime_helpers
 ---
 

--- a/roach/scripts/roach-producer.py
+++ b/roach/scripts/roach-producer.py
@@ -12,7 +12,7 @@ Roach v1.x ran as a full-agency Python scanner that:
 
 v2.0 splits that into two parts:
   1. This producer (cron, 90s): emits candidate signals only.
-  2. Runtime (senpi-trading-runtime v2): receives signals via
+  2. Runtime (senpi-trading-runtime): receives signals via
      external_scanner ingest, LLM-gates them (pass-through), executes
      with FEE_OPTIMIZED_LIMIT (maker-first + 60s + taker fallback),
      and manages DSL exits autonomously.

--- a/scorpion/SKILL.md
+++ b/scorpion/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=1.0.98
+    - senpi-trading-runtime>=1.1.0
     - senpi_runtime_helpers
 ---
 
@@ -196,7 +196,7 @@ A healthy Scorpion v4 shows:
 ## Changelog
 
 ### v4.0 (2026-04-23) — V2-RUNTIME-NATIVE REWRITE
-- First multi-asset agent on senpi-trading-runtime v2
+- First multi-asset agent on senpi-trading-runtime
 - Producer-only Python (280 lines vs v3.x's 549-line scanner)
 - LLM `decision_mode: llm` replaces hardcoded score thresholds
 - `risk.guard_rails` YAML replaces Python risk code — no more silent counter leaks

--- a/scorpion/runtime.yaml
+++ b/scorpion/runtime.yaml
@@ -77,7 +77,7 @@ description: >
   requiring an engine change (reprice-ladder), not a config fix.
 
   SCORPION v4.0 — Multi-Market Active Trader (v2-runtime-native rewrite).
-  First multi-asset agent on senpi-trading-runtime v2. Replaces v3.2
+  First multi-asset agent on senpi-trading-runtime. Replaces v3.2
   which logged 43 fills / 18h / -$79.84 in Arena Week 5 despite
   MAX_DAILY_ENTRIES=3 — the scalp re-entry bypass logic and in-Python
   trade counter were silently leaking. v4.0 removes all that

--- a/sentinel/README.md
+++ b/sentinel/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/shark/README.md
+++ b/shark/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/turbine/SKILL.md
+++ b/turbine/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=1.0.98
+    - senpi-trading-runtime>=1.1.0
     - senpi_runtime_helpers
 ---
 
@@ -36,7 +36,7 @@ NO change to maker/taker placement. NO change to fee economics. NO change to YAM
 
 ## What changed in v3.2.1 vs v3.2.0 (patch — 2026-05-09)
 
-**Stale-order hygiene.** The producer now sweeps non-reduce-only ALO orders older than 300s before computing `held_keys`. Each runtime swap (helpers migration, runtime-phase-2 redeploy, daemon restart) leaves resting maker orders behind that the new runtime instance does not own; the producer's ghost-trade fix (v2.0.4) correctly counts those orphans as slot occupiers, which means orphans can starve real fills until cleared. The runtime's own `execution_timeout_seconds: 180` cancels orders it placed — anything still resting well past that is by definition abandoned.
+**Stale-order hygiene.** The producer now sweeps non-reduce-only ALO orders older than 300s before computing `held_keys`. Each runtime swap (helpers migration, runtime redeploy, daemon restart) leaves resting maker orders behind that the new runtime instance does not own; the producer's ghost-trade fix (v2.0.4) correctly counts those orphans as slot occupiers, which means orphans can starve real fills until cleared. The runtime's own `execution_timeout_seconds: 180` cancels orders it placed — anything still resting well past that is by definition abandoned.
 
 NO change to maker/taker placement. NO change to fee economics. NO change to YAMLs. Cancellation is free; HL only charges on fills. Symptom in v3.2.0: volume wallet showed `slots_held = 6/7` while `clearinghouse` only reported 4 actual positions, throttling emissions to 1 signal/tick instead of 3-4.
 

--- a/turbine/scripts/turbine-producer.py
+++ b/turbine/scripts/turbine-producer.py
@@ -12,8 +12,9 @@ v3.1's hunt-mode-as-HYPE-specialist was the wrong abstraction:
 wallet. The correct framing: "run the volume play, but allow winners
 to run longer."
 
-v3.2 keeps the two-wallet split (runtime-phase-2 enforces one runtime
-per wallet) and rewires both wallets to receive the SAME volume-rotation
+v3.2 keeps the two-wallet split (the senpi-trading-runtime plugin
+enforces one runtime per wallet) and rewires both wallets to receive
+the SAME volume-rotation
 alpha. The wallet boundary selects DSL behavior:
 
   VOLUME WALLET  ($4,000, 7 slots × $500):
@@ -144,8 +145,8 @@ def _runtime_config():
 # ═══════════════════════════════════════════════════════════════
 # STALE-ORDER HYGIENE
 # ═══════════════════════════════════════════════════════════════
-# Each runtime restart / swap (helpers migration, runtime-phase-2
-# rollover, daemon redeploy) leaves resting ALO orders that the new
+# Each runtime restart / swap (helpers migration, runtime rollover,
+# daemon redeploy) leaves resting ALO orders that the new
 # runtime instance does not own. The runtime's own
 # `execution_timeout_seconds` (180s on FEE_OPTIMIZED_LIMIT) cancels
 # the orders it placed — anything still resting well past that is

--- a/viper/README.md
+++ b/viper/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/vixen/README.md
+++ b/vixen/README.md
@@ -22,7 +22,7 @@ Defined in the producer/scanner. See `runtime.yaml` `scanner:` section and the p
 
 - Standard fleet drawdown gate.
 - Fee budget tracking via shared infra.
-- Producer reentrancy guard via fcntl lockfile (Runtime 2.0 only).
+- Producer reentrancy guard via fcntl lockfile.
 
 ## Configuration
 

--- a/vulture/SKILL.md
+++ b/vulture/SKILL.md
@@ -18,13 +18,13 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=1.0.98
+    - senpi-trading-runtime>=1.1.0
     - senpi_runtime_helpers
 ---
 
 # 🦅 VULTURE v4.0.0 — Long-Tail Momentum Rider (senpi_runtime_helpers)
 
-**v2 → v3 architectural rewrite.** v2.x was a full-agency scanner that called create_position directly and tracked state in Python. v3.0 flips to the standard senpi-trading-runtime v2 pattern: producer emits signals, runtime owns execution + state.
+**v2 → v3 architectural rewrite.** v2.x was a full-agency scanner that called create_position directly and tracked state in Python. v3.0 flips to the standard senpi-trading-runtime pattern: producer emits signals, runtime owns execution + state.
 
 **What changed structurally:**
 - `vulture-producer.py` (NEW) replaces `vulture-scanner.py` (DELETED). Pure producer — no execution, no counters, no cooldowns, no dynamic-slot bookkeeping.

--- a/wolverine/README.md
+++ b/wolverine/README.md
@@ -11,7 +11,7 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
   - Signal emission goes via `SenpiClient.push_signal()` (direct HTTP POST) instead of `openclaw senpi external-scanner ingest` subprocess
   - Reentrancy lock owned by `producer_daemon.scanner_lock` instead of hand-rolled `fcntl`
   - Tick scheduling owned by `producer_daemon` (long-lived process) instead of openclaw cron + `agentTurn`
-- Requires `senpi-trading-runtime >= 1.0.98`.
+- Requires `senpi-trading-runtime >= 1.1.0`.
 - `runtime.yaml` unchanged. `external_scanner.name: wolverine_signals` matches the producer's `client.push_signal(scanner=...)`.
 - Per Rachin's review of Cheetah PR #209: dead fields stripped from payload; `signal_type="WOLVERINE_HYPE_HYBRID"` passed explicitly.
 

--- a/wolverine/SKILL.md
+++ b/wolverine/SKILL.md
@@ -18,13 +18,13 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime>=1.0.98
+    - senpi-trading-runtime>=1.1.0
     - senpi_runtime_helpers
 ---
 
 # 🦡 WOLVERINE v5.0.0 — HYPE Alpha Hunter (senpi_runtime_helpers)
 
-**v3 → v4 architectural rewrite.** v3.x was a full-agency scanner. v4.0 flips to the standard senpi-trading-runtime v2 pattern: producer emits signals, runtime owns execution + state.
+**v3 → v4 architectural rewrite.** v3.x was a full-agency scanner. v4.0 flips to the standard senpi-trading-runtime pattern: producer emits signals, runtime owns execution + state.
 
 **What changed structurally:**
 - `wolverine-producer.py` (NEW) replaces `wolverine-scanner.py` (DELETED)


### PR DESCRIPTION
## Summary

Senpi runtime 1.1.0 is now the published prod release. Strip internal "Runtime 2.0" / "runtime-2" / "senpi-trading-runtime v2" / "runtime-phase-2" phrasings and bump every `>=1.0.98` reference to `>=1.1.0` across the repo.

- 24 agent READMEs: drop the "(Runtime 2.0 only)" parenthetical from the reentrancy-guard line.
- Agent SKILL.md frontmatter `requires:` + README "Requires …" lines bumped to `senpi-trading-runtime >= 1.1.0`.
- Producer script docstrings, runtime.yaml descriptions, and Turbine's stale-order-hygiene narrative degenericized away from "v2 pattern" / "runtime-phase-2".
- `_helpers/senpi_runtime_helpers/SKILL.md` compatibility + error table updated.
- Top-level README plugin-version block and "build from a runtime-2 skill" language replaced.

No code or behavior change. Documentation alignment only.

## Test plan

- [x] `grep -rni "runtime 2\.0\|runtime-2\|runtime-phase\|senpi-trading-runtime v2\|1\.0\.98"` returns empty across `.md` / `.yaml` / `.yml` / `.py` / `.json`
- [x] `git diff --stat` shows 51 files, 73/72 insertions/deletions — small, mechanical
- [ ] Visual spot-check on top-level README, `_helpers/SKILL.md`, and Turbine producer post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)