### PR TITLE
Post-merge review fixes from PR #244

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Used by every active trading skill in the repo.
 
 ## `senpi_runtime_helpers` — Python Producer SDK (ships with `senpi-trading-runtime`)
 
-The Python SDK every Runtime 2.0 producer imports. Ships inside the `senpi-trading-runtime` skill (`senpi-trading-runtime/senpi_runtime_helpers/`) — installing the runtime skill installs the SDK.
+The Python SDK every helpers-native producer imports. Ships inside the `senpi-trading-runtime` skill (`senpi-trading-runtime/senpi_runtime_helpers/`) — installing the runtime skill installs the SDK.
 
 - `SenpiClient` — direct HTTPS to MCP (no `mcporter` / `openclaw` subprocess shell-out) and direct POST to runtime `/signals`.
 - `producer_daemon(fn, interval_seconds, name, tick_timeout)` — long-lived loop with built-in fcntl reentrancy guard, structured tick telemetry, signal-handled graceful shutdown.

--- a/jackal/README.md
+++ b/jackal/README.md
@@ -2,7 +2,7 @@
 
 Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-**Plumbing-only migration from v2.0. NO thesis change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry. Fleet-fix #214 applied (no `wallet=`/`scanner=` daemon kwargs). v2.0.9 contamination rule applied: `JACKAL_WALLET` replaces generic `STRATEGY_ADDRESS`.
+**Plumbing-only migration from v2.0. NO thesis change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry. v2.0.9 contamination rule applied: `JACKAL_WALLET` replaces generic `STRATEGY_ADDRESS`.
 
 ## Install
 

--- a/kestrel/README.md
+++ b/kestrel/README.md
@@ -2,7 +2,7 @@
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-**Plumbing-only migration from v2.0. NO thesis change. NO scoring change. NO threshold change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry. Fleet-fix #214 applied (no `wallet=`/`scanner=` daemon kwargs). v2.0.9 contamination rule applied: `KESTREL_WALLET` is the canonical env var (with `STRATEGY_ADDRESS` deprecation fallback).
+**Plumbing-only migration from v2.0. NO thesis change. NO scoring change. NO threshold change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry. v2.0.9 contamination rule applied: `KESTREL_WALLET` is the canonical env var (with `STRATEGY_ADDRESS` deprecation fallback).
 
 ## Install
 

--- a/otter/README.md
+++ b/otter/README.md
@@ -2,7 +2,7 @@
 
 Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-**Plumbing-only migration from v1.0. NO thesis change. NO scoring change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry. Fleet-fix #214 applied (no `wallet=`/`scanner=` daemon kwargs).
+**Plumbing-only migration from v1.0. NO thesis change. NO scoring change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry.
 
 ## Install
 

--- a/pangolin/README.md
+++ b/pangolin/README.md
@@ -2,7 +2,7 @@
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-**Plumbing-only migration from v2.2.0. NO thesis change.** Pangolin is the canonical reference producer for the `senpi_runtime_helpers` SDK wrapper pattern. v3.0.0 is on `main` with fleet-fix #214 (no `wallet=`/`scanner=` daemon kwargs) applied.
+**Plumbing-only migration from v2.2.0. NO thesis change.** Pangolin is the canonical reference producer for the `senpi_runtime_helpers` SDK wrapper pattern.
 
 ## Install
 

--- a/senpi-trading-runtime/references/python-producer-sdk.md
+++ b/senpi-trading-runtime/references/python-producer-sdk.md
@@ -126,7 +126,7 @@ ch_ok, ch = results[0]
 |---|---|
 | `signal_post: … code=INVALID_REQUEST` | Most common: `asset`/`direction` inside `data`. Move to top-level kwargs; verify `data` keys against `runtime.yaml` `config.fields`. |
 | `signal_post: … code=NOT_FOUND` | Verify runtime install (`openclaw senpi runtime list`); confirm `scanner` matches `runtime.yaml`. |
-| `signal_post: unexpected envelope shape` | Runtime is on the legacy envelope; bump the `runtime` plugin to `>= 1.1.0`. |
+| `signal_post: unexpected envelope shape` | Runtime is on the legacy envelope; bump the runtime plugin (id: `runtime`, npm package: `@senpi/runtime`) to `>= 1.1.0`. |
 | `signal_post: HTTP 400 … Exceeded api.maxItemsPerSignalsRequest=10` | Batch too large; split batch (default cap 10). |
 | `MCP error: …` from `mcp_call` | Check tool name + arguments against `senpi-hyperliquid-mcp` schema. |
 | `lock_recovered_after_crash` | Previous holder crashed; auto-recovered — no action needed. |

--- a/senpi-trading-runtime/references/python-producer-sdk.md
+++ b/senpi-trading-runtime/references/python-producer-sdk.md
@@ -126,7 +126,7 @@ ch_ok, ch = results[0]
 |---|---|
 | `signal_post: … code=INVALID_REQUEST` | Most common: `asset`/`direction` inside `data`. Move to top-level kwargs; verify `data` keys against `runtime.yaml` `config.fields`. |
 | `signal_post: … code=NOT_FOUND` | Verify runtime install (`openclaw senpi runtime list`); confirm `scanner` matches `runtime.yaml`. |
-| `signal_post: unexpected envelope shape` | Runtime is on the legacy 1.x envelope; bump runtime to a build that returns `{success, data, error}`. |
+| `signal_post: unexpected envelope shape` | Runtime is on the legacy envelope; bump the runtime plugin (`@senpi/runtime`) to `>= 1.1.0`. |
 | `signal_post: HTTP 400 … Exceeded api.maxItemsPerSignalsRequest=10` | Batch too large; split batch (default cap 10). |
 | `MCP error: …` from `mcp_call` | Check tool name + arguments against `senpi-hyperliquid-mcp` schema. |
 | `lock_recovered_after_crash` | Previous holder crashed; auto-recovered — no action needed. |

--- a/senpi-trading-runtime/references/python-producer-sdk.md
+++ b/senpi-trading-runtime/references/python-producer-sdk.md
@@ -126,7 +126,7 @@ ch_ok, ch = results[0]
 |---|---|
 | `signal_post: … code=INVALID_REQUEST` | Most common: `asset`/`direction` inside `data`. Move to top-level kwargs; verify `data` keys against `runtime.yaml` `config.fields`. |
 | `signal_post: … code=NOT_FOUND` | Verify runtime install (`openclaw senpi runtime list`); confirm `scanner` matches `runtime.yaml`. |
-| `signal_post: unexpected envelope shape` | Runtime is on the legacy envelope; bump the runtime plugin (`@senpi/runtime`) to `>= 1.1.0`. |
+| `signal_post: unexpected envelope shape` | Runtime is on the legacy envelope; bump the `runtime` plugin to `>= 1.1.0`. |
 | `signal_post: HTTP 400 … Exceeded api.maxItemsPerSignalsRequest=10` | Batch too large; split batch (default cap 10). |
 | `MCP error: …` from `mcp_call` | Check tool name + arguments against `senpi-hyperliquid-mcp` schema. |
 | `lock_recovered_after_crash` | Previous holder crashed; auto-recovered — no action needed. |

--- a/spider/README.md
+++ b/spider/README.md
@@ -2,7 +2,7 @@
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-**Plumbing-only migration from v3.0.2. NO thesis change. NO scoring change. NO threshold change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry. Fleet-fix #214 applied (no `wallet=`/`scanner=` daemon kwargs). v2.0.9 contamination rule applied: `SPIDER_WALLET` is the canonical env var (with `STRATEGY_ADDRESS` deprecation fallback).
+**Plumbing-only migration from v3.0.2. NO thesis change. NO scoring change. NO threshold change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry. v2.0.9 contamination rule applied: `SPIDER_WALLET` is the canonical env var (with `STRATEGY_ADDRESS` deprecation fallback).
 
 ## Install
 


### PR DESCRIPTION
## Summary

Three review comments from PR #244 landed after the merge and weren't yet addressed on `main`. This PR catches them up.

- **Q1** (`README.md:131`): top-level README still said "every Runtime 2.0 producer imports". Main's `e69c473` stripped all "Runtime 2.0" phrasings; this one slipped through the merge. Now reads "every helpers-native producer".
- **Q2** (5 producer READMEs): pangolin, otter, kestrel, spider, jackal all carried a "fleet-fix #214 (no \`wallet=\`/\`scanner=\` daemon kwargs) applied" sentence. PR #244 commit `55a6e25` reversed that fix — the kwargs are now passed by all 13 producers (\`/state\` alive_check is enabled). The README sentence actively misdescribed current behavior. Removed.
- **Q7** (`senpi-trading-runtime/references/python-producer-sdk.md`): error row for "unexpected envelope shape" said "bump runtime to a build that returns \`{success, data, error}\`." Replaced with the specific, actionable version — and disambiguated plugin from skill: "bump the runtime plugin (\`@senpi/runtime\`) to \`>= 1.1.0\`."

Other review items intentionally not actioned here:
- **Q3**: concern was reasonable but already fixed in commit \`687485c\` on the previous PR.
- **Q5**: SKILL.md secret-read carve-out is appropriately scoped — kept as-is.
- **Q6**: description field length stays per earlier directive.
- **Q4**: deferred per request.

## Test plan

- [x] Repo-wide grep for \`Runtime 2.0\` and \`fleet-fix #214\` returns zero hits outside legitimate code
- [x] SDK tests pass (202)
- [x] No behavior change — docs only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only edits that clarify SDK/runtime terminology and remove outdated operational notes; no code or behavior changes.
> 
> **Overview**
> Updates documentation to reflect current `senpi_runtime_helpers` usage and runtime plugin behavior.
> 
> Top-level `README.md` rephrases the Python SDK description to “helpers-native” producers, several strategy READMEs drop an outdated “fleet-fix #214” note, and the Python Producer SDK reference replaces a vague “unexpected envelope shape” fix with an explicit requirement to upgrade the `@senpi/runtime` plugin to `>= 1.1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c41d146b03be44c3460ad4712e6117a108d92b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->