### PR TITLE
roach: pre-ferry cleanup (stale v2 wording, requires bump, dedupe install)

### DIFF
--- a/roach/README.md
+++ b/roach/README.md
@@ -99,7 +99,7 @@ ROACH will be quiet. Days with zero trades are expected and correct. Striker sig
 
 | Layer | v1.x | v2.0 |
 |---|---|---|
-| Trading loop | Agent runs scanner + calls `create_position` | Producer pushes signals via `external-scanner ingest`; runtime owns execution |
+| Trading loop | Agent runs scanner + calls `create_position` | Producer pushes signals via `SenpiClient.push_signal()` direct HTTP POST; runtime owns execution |
 | Entry gate | Agent decides | LLM pass-through gate (producer already filtered) |
 | Exit | DSL + MARKET orders | DSL + **FEE_OPTIMIZED_LIMIT** (maker-first, 60s, taker fallback) |
 | Risk gates | Agent enforces in scanner code | Declarative `runtime.risk.guard_rails` |

--- a/roach/SKILL.md
+++ b/roach/SKILL.md
@@ -16,7 +16,8 @@ metadata:
   exchange: hyperliquid
   config_source: striker-only-experiment
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
 ---
 
 # 🪳 ROACH v3.0.0 — Striker Only. senpi_runtime_helpers.
@@ -47,7 +48,7 @@ Cockroaches survive anything. ROACH survives by not trading when there's no expl
 
 | File | Purpose |
 |---|---|
-| `runtime.yaml` | v2 runtime spec (scanners, actions, exit DSL, guard_rails) |
+| `runtime.yaml` | senpi-trading-runtime spec (scanners, actions, exit DSL, guard_rails) |
 | `scripts/roach-producer.py` | Cron-driven producer — emits Striker signals to runtime |
 | `scripts/roach_config.py` | Shared MCP helper + atomic state I/O |
 | `config/roach-config.json` | Operator-tunable defaults (informational; producer constants WIN) |
@@ -56,7 +57,7 @@ Cockroaches survive anything. ROACH survives by not trading when there's no expl
 
 ## Producer behavior
 
-Runs every 90s via cron. On each tick:
+Runs every 90s as a long-lived daemon (via `producer_daemon`; scanner_lock with stale-PID auto-recovery is owned by the daemon). On each tick:
 
 1. **Reentrancy guard:** acquires `state/<wallet-hash>/producer.lock`. If a prior run hasn't released it (cron faster than MCP latency), this run skips cleanly.
 2. **Fetch markets:** `leaderboard_get_markets` (top 50, XYZ filtered out at parse time).
@@ -113,55 +114,24 @@ The producer reads:
 
 ## Producer install (on OpenClaw host)
 
-Source path in the senpi-skills repo: `roach/`. Install destination on the
-OpenClaw host: `/data/workspace/skills/roach-strategy/`. The two names
-differ — repo uses `roach`, install dir uses the SKILL.md `name` field
-(`roach-strategy`).
+Source path in the senpi-skills repo: `roach/`. Install destination on the OpenClaw host: `/data/workspace/skills/roach-strategy/`. The two names differ — repo uses `roach`, install dir uses the SKILL.md `name` field (`roach-strategy`).
+
+Full operator-facing install runbook lives in [`README.md`](README.md) — five-step flow (openclaw.json plugin registration → install senpi-trading-runtime skill → pull Roach files → env vars → recreate runtime + launch daemon → smoke test).
+
+After install, manage the daemon via the `senpi-helpers` CLI:
 
 ```bash
-# 1. Pull the skill files (source: senpi-skills/main/roach/)
-mkdir -p /data/workspace/skills/roach-strategy/scripts
-mkdir -p /data/workspace/skills/roach-strategy/config
+senpi-helpers list                                  # daemons visible with recent LAST_TICK
+senpi-helpers health roach-<wallet-suffix>          # exit 0 = healthy
+senpi-helpers stats roach-<wallet-suffix> --hours 1 # signals posted + error histogram
+senpi-helpers restart roach-<wallet-suffix>         # stop + re-exec from boot.json
+```
 
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/roach/runtime.yaml \
-  -o /data/workspace/skills/roach-strategy/runtime.yaml
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/roach/scripts/roach-producer.py \
-  -o /data/workspace/skills/roach-strategy/scripts/roach-producer.py
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/roach/scripts/roach_config.py \
-  -o /data/workspace/skills/roach-strategy/scripts/roach_config.py
-curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/roach/config/roach-config.json \
-  -o /data/workspace/skills/roach-strategy/config/roach-config.json
+Inspect producer state (per-wallet scan history):
 
-# Remove the v1 scanner if it's still there from a prior install
-rm -f /data/workspace/skills/roach-strategy/scripts/roach-scanner.py
-
-# 2. Install the runtime
-# ROACH_DECISION_MODEL is REQUIRED — pick any model supported by the runtime's
-# model registry. Examples: gemini-3.1-pro-preview, claude-sonnet-4-20250514.
-# Pass BARE model name only — NO provider prefix (OpenClaw double-prefixes).
-WALLET_ADDRESS=0x... \
-TELEGRAM_CHAT_ID=... \
-ROACH_DECISION_MODEL=gemini-3.1-pro-preview \
-  openclaw senpi runtime create --path /data/workspace/skills/roach-strategy/runtime.yaml
-
-# 3. Launch the producer daemon (90s tick).
-# ROACH_WALLET (NOT generic STRATEGY_ADDRESS) is required by the producer.
-# Producer fails loud at startup if not set — misconfig is visible immediately.
-SENPI_AUTH_TOKEN=<your-token> \
-ROACH_WALLET=0x... \
-  nohup python3 -u /data/workspace/skills/roach-strategy/scripts/roach-producer.py \
-  > /tmp/roach-producer.log 2>&1 &
-
-# 4. Verify
-openclaw senpi runtime list                            # expect: roach-tracker running
-openclaw senpi status --runtime roach-tracker
-senpi-helpers list                                     # daemon visible with recent LAST_TICK
-senpi-helpers health roach-<wallet-suffix>             # exit 0 = healthy
-senpi-helpers stats roach-<wallet-suffix> --hours 1    # signals posted + error histogram
-
-# Inspect producer state (per-wallet scan history):
+```bash
 ls -la /data/workspace/skills/roach-strategy/state/<wallet-hash>/
-# Expect: producer.lock + scan-history.json with mtime in last few minutes.
+# Expect: scan-history.json with mtime in last few minutes.
 # A fresh scan-history.json (mtime < 5 min) confirms the daemon is ticking.
 ```
 

--- a/roach/scripts/roach-producer.py
+++ b/roach/scripts/roach-producer.py
@@ -3,19 +3,20 @@
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""ROACH v3.0.0 Producer — Striker-only signal emitter for v2 runtime.
+"""ROACH v3.0.0 Producer — Striker-only signal emitter, helpers-native.
 
 Roach v1.x ran as a full-agency Python scanner that:
   - Fetched market concentration + scan history
   - Detected Striker signals (FIRST_JUMP / IMMEDIATE_MOVER + volume)
   - Returned them as JSON for the agent to act on via create_position
 
-v2.0 splits that into two parts:
-  1. This producer (cron, 90s): emits candidate signals only.
-  2. Runtime (senpi-trading-runtime): receives signals via
-     external_scanner ingest, LLM-gates them (pass-through), executes
-     with FEE_OPTIMIZED_LIMIT (maker-first + 60s + taker fallback),
-     and manages DSL exits autonomously.
+v3.0 splits that into two parts:
+  1. This producer (long-lived daemon, 90s tick): emits candidate
+     signals via client.push_signal() direct HTTP POST.
+  2. Runtime (senpi-trading-runtime): receives signals at /signals,
+     LLM-gates them (pass-through), executes with FEE_OPTIMIZED_LIMIT
+     (maker-first + 60s + taker fallback), and manages DSL exits
+     autonomously.
 
 The producer's single responsibility: detect Striker signals and push
 them to the runtime via `SenpiClient.push_signal()` (direct HTTP POST).
@@ -36,9 +37,9 @@ Striker detection logic preserved verbatim from v1.2 scanner:
   - XYZ banned at scan level
   - Per-asset 120min cooldown
 
-Environment variables (standard v2 producer):
+Environment variables:
   SENPI_API_KEY     — for MCP access
-  ROACH_WALLET      — Roach v2 wallet (must match runtime YAML's wallet).
+  ROACH_WALLET      — Roach strategy wallet (must match runtime YAML's wallet).
                       AGENT-SPECIFIC env var by design — do NOT fall back
                       to a generic STRATEGY_ADDRESS. Per Turbine v2.0.9
                       contamination fix: a shared env var is a fleet-wide

--- a/roach/scripts/roach_config.py
+++ b/roach/scripts/roach_config.py
@@ -1,8 +1,13 @@
-"""ROACH v2 — Shared MCP helpers + config loader + atomic state I/O.
+"""ROACH v3.0.0 — Shared MCP helpers + config loader + atomic state I/O.
 
-v2 producer responsibilities are narrower than v1:
+v3 producer responsibilities are narrower than v1:
   - Fetch market concentration via MCP (leaderboard_get_markets, market_get_asset_data)
   - Push signals via `SenpiClient.push_signal()` direct HTTP POST (runtime owns execution)
+
+v3.0.0 plumbing flip from v2.x: mcporter subprocess → SenpiClient.mcp_call()
+in-process HTTPS. Bash cron + sleep loop → producer_daemon long-lived process.
+SDK probe points at the senpi-trading-runtime skill's bundled
+senpi_runtime_helpers package (~/.openclaw/skills/senpi-trading-runtime/).
 
 Runtime handles: position tracking, DSL exits, risk guardrails, trade counting,
 asset cooldowns. All of that state lives in the runtime's state dir, not here.
@@ -128,7 +133,7 @@ def output(data):
 
 
 def log(msg):
-    print(f"[ROACH-v2] {msg}", file=sys.stderr)
+    print(f"[ROACH-v3] {msg}", file=sys.stderr)
 
 
 def now_ts():


### PR DESCRIPTION
Roach is already on the helpers-native architecture (v3.0.0 producer with SDK probe + producer_daemon). This commit cleans up the surface text so a fresh-eyes operator reading the github files lands on a self-consistent v3 story matching what's actually running.

- Frontmatter `requires:` → `senpi-trading-runtime>=1.1.0` + `senpi_runtime_helpers`
- SKILL.md install section → pointer to README's canonical 5-step install (was the old 4-step duplicate; README is now SSOT)
- `Runs every 90s via cron` → `Runs every 90s as a long-lived daemon`
- `external-scanner ingest` → `SenpiClient.push_signal() direct HTTP POST` (CLI ingest path dropped in plumbing flip)
- `[ROACH-v2]` log prefix → `[ROACH-v3]`; docstring v2 → v3.0.0

No code or behavior change. Documentation alignment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)