### PR TITLE
turbine: pre-ferry cleanup (version alignment, requires bump, strip cross-agent refs)

### DIFF
--- a/turbine/README.md
+++ b/turbine/README.md
@@ -124,7 +124,7 @@ The Python Producer SDK (`senpi_runtime_helpers`) ships inside the senpi-trading
 npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
 ```
 
-Skip if already pulled for Cheetah v7.0.0 or another v3 skill.
+Skip if the senpi-trading-runtime skill is already installed on this host.
 
 ### Step 2 — Pull Turbine v3.2
 

--- a/turbine/SKILL.md
+++ b/turbine/SKILL.md
@@ -14,11 +14,12 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.2.3"
+  version: "3.2.2"
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
 ---
 
 # 🌪️ TURBINE v3.2 — Volume Rotation + Runners
@@ -68,7 +69,7 @@ The same rotation alpha goes to both wallets. The runners wallet's DSL gives pos
 
 ## Why two wallets at all
 
-The the senpi-trading-runtime plugin enforces **one runtime per wallet**. v3.0 attempted to attach two runtimes to a single wallet and got blocked at deploy. v3.1 split into two wallets but rebuilt them with the wrong thesis (HYPE specialist). v3.2 keeps the two-wallet split and rewires both to the right thesis (same volume rotation, different DSL).
+The senpi-trading-runtime plugin enforces **one runtime per wallet**. v3.0 attempted to attach two runtimes to a single wallet and got blocked at deploy. v3.1 split into two wallets but rebuilt them with the wrong thesis (HYPE specialist). v3.2 keeps the two-wallet split and rewires both to the right thesis (same volume rotation, different DSL).
 
 ## Mission
 
@@ -231,7 +232,7 @@ User-conversation Claude sessions MUST NOT call `create_position`, `close_positi
 - ✓ **Wallet-isolated state dirs** (`state/<wallet-hash>/...` per wallet)
 - ✓ **Auto-fallback cycle length** based on rolling maker fill rate
 - ✓ **Auto-downsize on tight margin** — both wallets (graceful slot reduction as wallet bleeds)
-- ✓ **`signal_type=` passed explicitly** per Rachin's review of Cheetah PR #209
+- ✓ **`signal_type=` passed explicitly** to `push_signal()` (avoids relying on the runtime YAML's `defaultSignalType` fallback)
 
 ## Sentinel sunset
 

--- a/turbine/scripts/turbine-producer.py
+++ b/turbine/scripts/turbine-producer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Senpi TURBINE Producer v3.2.0
+# Senpi TURBINE Producer v3.2.2
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
@@ -73,9 +73,10 @@ VERSION = "3.2.2"
 VOLUME_SCANNER_NAME = "turbine_volume_signals"
 RUNNERS_SCANNER_NAME = "turbine_runners_signals"
 
-# Signal types — explicit kwarg to push_signal() (Rachin's review of
-# Cheetah PR #209). Same scoring path on both wallets, but distinct
-# signal_type tags so audit_query splits the two wallets cleanly.
+# Signal types — explicit kwarg to push_signal(). Same scoring path on
+# both wallets, but distinct signal_type tags so audit_query splits the
+# two wallets cleanly. Explicit signal_type avoids relying on the
+# runtime YAML's defaultSignalType fallback.
 VOLUME_SIGNAL_TYPE = "TURBINE_VOLUME_FAST_ROTATION"
 RUNNERS_SIGNAL_TYPE = "TURBINE_VOLUME_PATIENT_ROTATION"
 

--- a/turbine/scripts/turbine_config.py
+++ b/turbine/scripts/turbine_config.py
@@ -37,7 +37,7 @@ v3.1 → v3.2 deltas:
   - hunt_min_score / huntCooldownMin / minHuntWalletBalance dropped
   - Runners get the same scoring path as volume
 
-Helpers-based (matches Cheetah v7.0.0 / Pangolin v2.2 patterns):
+Helpers-native plumbing:
   - SenpiClient via lazy proxy (auth-validated on first use)
   - mcporter_call() shim for backward-compat call sites
   - _wrapper_client exposed for direct push_signal access


### PR DESCRIPTION
Turbine is already on helpers-native (v3.2.2 producer with SDK probe, producer_daemon, dex-aware slot keys, stale-order hygiene). Surface-text cleanup so the github files match what's actually running.

- SKILL.md frontmatter `version: "3.2.3"` → `"3.2.2"` (no v3.2.3 changelog exists; frontmatter was a typo)
- Producer header comment `v3.2.0` → `v3.2.2` (matches VERSION constant)
- `requires:` field → `senpi-trading-runtime>=1.1.0` + `senpi_runtime_helpers`
- Stripped cross-agent refs ("Cheetah PR #209", "matches Cheetah/Pangolin patterns", "Skip if already pulled for Cheetah v7.0.0") — operator agents have strictly local visibility
- Fixed double "the" typo

No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)