### PR TITLE
cheetah: pre-ferry cleanup (requires bump, strip cross-agent refs, cron→daemon wording)

### DIFF
--- a/cheetah/README.md
+++ b/cheetah/README.md
@@ -21,7 +21,7 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 - Trade chain DB emits per-trade telemetry
 - **MIN_SCORE 10** (v5.2's 11 produced 8 days dormant; restored to 10)
 - Held-asset dedup (3-layer)
-- Post-close cooldown (Pangolin v2.1.2 pattern; backstops runtime per_asset_cooldown)
+- Post-close cooldown (producer-side backstop for the runtime `per_asset_cooldown` known-silent-bug)
 - All v5.2 scoring + leverage tiers + leverage-safety clamp preserved EXACTLY
 
 ## Thesis (preserved from v5.x)
@@ -220,7 +220,7 @@ openclaw cron delete <cheetah-cron-id>
 
 # 6. runtime.yaml unchanged — no need to drop+recreate the runtime.
 #    If you DO recreate it, do so only when there are no open positions
-#    (orphan-position bug: v2 runtime swap can leave baseline positions
+#    (orphan-position bug: runtime swap can leave baseline positions
 #    without DSL coverage).
 ```
 

--- a/cheetah/SKILL.md
+++ b/cheetah/SKILL.md
@@ -18,7 +18,8 @@ metadata:
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
 ---
 
 # 🐆 CHEETAH v7.1.0 — Multi-Signal Confluence Sniper
@@ -71,7 +72,7 @@ Refuse to trade unless ALL major signals align simultaneously:
 | Quality trader | ≥ 1 ELITE/RELIABLE positioned same direction | +3 |
 | Rank climb | ≥ 5 positions in last 2 scans, top 15 | +1 |
 
-**Max score: 15. v6.0 floor: 10.** Universe is the top 100 SM leaderboard (`leaderboard_get_markets`), refreshed every cron tick. XYZ permanently banned.
+**Max score: 15. v6.0 floor: 10.** Universe is the top 100 SM leaderboard (`leaderboard_get_markets`), refreshed every producer tick. XYZ permanently banned.
 
 Score-scaled leverage:
 
@@ -101,11 +102,11 @@ v5.x used MARKET (taker) closes. v6.0's DSL fires `FEE_OPTIMIZED_LIMIT` on every
 2. LLM gate hard skip: `heldAssets` array in signal payload, LLM rejects if asset is held
 3. Runtime `per_asset_cooldown_minutes: 240` (known to silently not-enforce; layer 1+2 are the real defense)
 
-### Post-close cooldown (Pangolin v2.1.2 pattern)
+### Post-close cooldown (producer-side backstop)
 Diff `held_assets` across ticks. When asset disappears from held set, record close timestamp. Producer skips emission for 240 min after any close. Backstops the runtime cooldown bug.
 
-### Reentrancy lockfile
-fcntl-based lock at `state/<wallet-hash>/producer.lock`. Prevents two cron runs racing.
+### Reentrancy guard
+`producer_daemon` owns a per-tick `scanner_lock` with stale-PID auto-recovery — replaces v6.x's hand-rolled fcntl lockfile. Prevents two ticks racing.
 
 ## DSL preset (v6.0 — fleet-standard T0/T1 ladder)
 
@@ -143,9 +144,9 @@ See [README.md](README.md) for fresh-install + migration commands from v5.2.
 
 ## Fleet patches incorporated
 
-- ✓ **Held-asset dedup** (3-layer; v2.1 Pangolin pattern)
-- ✓ **Post-close cooldown** (v2.1.2 Pangolin pattern; runtime cooldown backstop)
-- ✓ **Fleet-standard T0/T1 ladder** (commit 6cad383 pattern)
+- ✓ **Held-asset dedup** (3-layer: producer pre-filter, LLM gate, runtime per_asset_cooldown)
+- ✓ **Post-close cooldown** (producer-side backstop for the runtime cooldown silent-enforcement bug)
+- ✓ **Fleet-standard T0/T1 ladder**
 - ✓ **Reentrancy guard** (v7.0.0: producer_daemon scanner_lock with stale-PID auto-recovery; replaces hand-rolled fcntl)
 - ✓ **Wallet-from-config** (no hardcoding; senpi-skills is public)
 - ✓ **drawdown_reset_on_day_rollover: false** (Roach lesson)
@@ -159,9 +160,9 @@ User-conversation Claude sessions MUST NOT call any of:
 `ratchet_stop_add`, `ratchet_stop_edit`, `ratchet_stop_delete`,
 `cancel_order`, `strategy_close`, `strategy_close_positions`.
 
-These tools are reserved for the **producer cron** (entry path) and the **DSL ratchet engine** (exit path). User-conversation sessions are **read-only**.
+These tools are reserved for the **producer daemon** (entry path) and the **DSL ratchet engine** (exit path). User-conversation sessions are **read-only**.
 
-If the user asks a question that implies action ("anything close to triggering?"), respond by reading the current state — DO NOT execute. The producer cron will handle real signals on its next tick.
+If the user asks a question that implies action ("anything close to triggering?"), respond by reading the current state — DO NOT execute. The producer daemon will handle real signals on its next tick.
 
 ## Skill Attribution
 

--- a/cheetah/scripts/cheetah-producer.py
+++ b/cheetah/scripts/cheetah-producer.py
@@ -25,7 +25,9 @@ Six-layer plumbing flip (per migration-cookbook):
      Direct HTTP POST to runtime API on 127.0.0.1:8787/signals.
      CRITICAL: asset and direction are top-level routing fields;
      score stays inside data (Cheetah's score is unbounded int 0-16,
-     not 0..1 confidence — same Pangolin reference rationale).
+     not 0..1 confidence — different semantics than the standard
+     wire-format `score` field, so left in data to preserve the
+     unbounded integer).
   3. Reentrancy: hand-rolled fcntl flock dropped. producer_daemon
      owns the lock per tick via scanner_lock(name) — adds stale-PID
      auto-recovery via os.kill(pid, 0). Do NOT add an inner
@@ -33,8 +35,8 @@ Six-layer plumbing flip (per migration-cookbook):
   4. Tick scheduling: openclaw cron + agentTurn replaced by
      producer_daemon(fn=main, interval_seconds=300, ...). Long-lived
      Python process, no per-tick LLM cost.
-  5. Per-tick cache + parallel fan-out NOT adopted in v7.0.0 to match
-     Pangolin reference minimum-change pattern. Future opt-in.
+  5. Per-tick cache + parallel fan-out NOT adopted in v7.0.0 (kept
+     the minimum-change migration shape; future opt-in).
   6. /state alive_check: producer_daemon self-terminates if the
      runtime for CHEETAH_WALLET is deleted OR the cheetah_signals
      scanner is renamed. Default behavior — alive_check left unset.
@@ -45,22 +47,19 @@ v6.1 (2026-05-05) — Phase 2 T0 ladder calibration. No producer code
 changes. Runtime.yaml only: T0 trigger 5→3, T0 lock 35→40, T1 7/55,
 T2 15/70, T3 30/80, T4 50/90. First post-v6.0 trade (ZEC LONG score
 10, SM 22.85%/210t) peaked at +3.05% margin ROE — old T0 at 5%
-never armed; closed via Phase 1 retrace at -4.09% / -$9.68. Same
-Pangolin v2.2 fix. T0 at 3 captures the typical Cheetah small
-winner at 3x leverage.
+never armed; closed via Phase 1 retrace at -4.09% / -$9.68. T0 at
+3 captures the typical Cheetah small winner at 3x leverage.
 
-v6.0 — full v1 → v2 architecture migration:
-v5.x was a v1 full-agency scanner: scored signals, tracked counters,
+v6.0 — full architecture migration to producer + runtime pattern:
+v5.x was a full-agency scanner: scored signals, tracked counters,
 called create_position directly, maintained Python-side cooldowns and
-resting-order guards. v6.0 flips to producer + v2 runtime (Polar v4.0
-/ Pangolin v2.1 / Vulture v3.0 pattern).
+resting-order guards. v6.0 flips to producer + senpi-trading-runtime.
 
 ARCHITECTURE CHANGE:
   - Producer (cheetah-producer.py) emits signals via
     `SenpiClient.push_signal()` (direct HTTP POST). NO execution code.
-  - Runtime LLM gate (decision_mode: llm) is pass-through (Roach
-    pattern) — producer has applied every filter; LLM only catches
-    malformed signals.
+  - Runtime LLM gate (decision_mode: llm) is pass-through — producer
+    has applied every filter; LLM only catches malformed signals.
   - risk.guard_rails ENFORCES daily caps, drawdown halt, consecutive-
     loss halt, per-asset cooldown (no Python state to drift / crash).
   - DSL uses FEE_OPTIMIZED_LIMIT on entries AND exits — saves
@@ -90,7 +89,7 @@ v6.0 CHANGES vs v5.2:
   - Architecture v1 → v2 (producer + runtime, not full-agency scanner)
   - FEE_OPTIMIZED_LIMIT on EXITS too (v5.2 only used it on entries)
   - Held-asset dedup (3-layer: producer + LLM gate + runtime cooldown)
-  - Post-close cooldown (Pangolin v2.1.2 pattern; backstop for runtime
+  - Post-close cooldown (producer-side backstop for the runtime
     per_asset_cooldown silent enforcement bug)
   - Reentrancy lockfile (fcntl)
   - Wallet from config/cheetah-config.json (canonical source)
@@ -177,8 +176,8 @@ _QUALITY_CACHE_FILE = _STATE_DIR / "quality-cache.json"
 
 MIN_SCORE_DEFAULT = 10                # v6.0 — restored from v5.2's 11
 ASSET_COOLDOWN_MINUTES = 240          # v5.2 carryover, post-emit
-POST_CLOSE_COOLDOWN_MINUTES = 240     # v6.0 — Pangolin v2.1.2 pattern;
-                                      # backstop for runtime per_asset_
+POST_CLOSE_COOLDOWN_MINUTES = 240     # v6.0 — producer-side backstop
+                                      # for the runtime per_asset_
                                       # cooldown_minutes silent non-
                                       # enforcement bug.
 MAX_POSITIONS = 1                     # v5.x carryover — sniper, not scalper
@@ -326,7 +325,7 @@ def save_trade_counter(tc):
 
 
 # ═══════════════════════════════════════════════════════════════
-# v6.0 POST-CLOSE COOLDOWN (Pangolin v2.1.2 pattern)
+# v6.0 POST-CLOSE COOLDOWN (producer-side runtime-cooldown backstop)
 # ═══════════════════════════════════════════════════════════════
 
 def load_last_closed():
@@ -773,13 +772,12 @@ def push_signal(payload):
 
     Direct HTTP POST to runtime API on 127.0.0.1; no subprocess.
 
-    SignalItem field mapping (per references/signal-schema.md and the
-    Pangolin TST 2026-05-05 incident):
+    SignalItem field mapping (per references/signal-schema.md):
       - top-level routing fields: address, scanner, asset, direction, signal_type
       - data block: scanner-config-validated fields only
       - score STAYS inside data — Cheetah's composite is unbounded int
-        0-16, not 0..1 confidence (different semantics; same Pangolin
-        v2.2 reference rationale).
+        0-16, not 0..1 confidence (different semantics than the
+        standard wire-format score field).
       - signal_type passed explicitly per signal so the runtime never
         relies on the scanner's defaultSignalType fallback (cheetah's
         runtime.yaml does not declare one). Keeps audit logs and the
@@ -887,7 +885,7 @@ def main():
             skipped_held += 1
             continue
 
-        # v6.0 post-close cooldown (Pangolin v2.1.2 pattern)
+        # v6.0 post-close cooldown (producer-side runtime-cooldown backstop)
         if is_in_post_close_cooldown(token):
             skipped_post_close += 1
             post_close_skips.append({


### PR DESCRIPTION
Cheetah is already on helpers-native (v7.1.2 producer). Surface-text cleanup so github matches what's running.

- `requires:` → `senpi-trading-runtime>=1.1.0` + `senpi_runtime_helpers`
- "producer cron" → "producer daemon" / "every cron tick" → "every producer tick"
- "fcntl-based lock" reentrancy section updated to describe producer_daemon's scanner_lock
- Stripped cross-agent refs: Pangolin v2.1/v2.1.2/v2.2/TST incident, Polar v4.0, Vulture v3.0, Roach pattern, commit-hash references → generic functional descriptions

No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)