### PR TITLE
jackal + spider: pre-ferry cleanup (version + requires + strip cross-agent refs)

### DIFF
--- a/jackal/SKILL.md
+++ b/jackal/SKILL.md
@@ -14,11 +14,12 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0.1"
+  version: "3.0.0"
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
 ---
 
 # 🐺 JACKAL v2.0 — The Smart Stalker (v2-native)
@@ -26,9 +27,10 @@ metadata:
 The jackal watches bigger predators hunt. v2 splits the hunt into two
 processes that can't step on each other:
 
-- **The producer** runs on a cron, builds the trader pool, detects new
-  entries, enriches with context, and pushes candidate signals. Nothing
-  else. No execution, no DSL, no risk code.
+- **The producer** runs as a long-lived daemon (`producer_daemon`),
+  builds the trader pool, detects new entries, enriches with context,
+  and pushes candidate signals. Nothing else. No execution, no DSL,
+  no risk code.
 - **The runtime** receives signals, gates each through an LLM decision
   prompt with `min_confidence: 7`. The model is required at deploy
   time via the `$JACKAL_DECISION_MODEL` env var (no default by design
@@ -156,7 +158,7 @@ Jackal's v1 patience profile survives:
 |---|---|---|
 | hard_timeout | 72h | 72h |
 | weak_peak_cut | 8h @ 3% | 4h @ 3% (tightened — v1 was too forgiving on fade) |
-| dead_weight_cut | 4h | **disabled** (v2 runtime auto-disables once Phase 2 reached; single-decision thesis doesn't benefit from time-based loss cuts) |
+| dead_weight_cut | 4h | **disabled** (runtime auto-disables once Phase 2 reached; single-decision thesis doesn't benefit from time-based loss cuts) |
 | Phase 1 max_loss | 22% | 22% |
 | Phase 2 tiers | 6 tiers | 6 tiers (same ladder) |
 

--- a/jackal/scripts/jackal-producer.py
+++ b/jackal/scripts/jackal-producer.py
@@ -3,7 +3,7 @@
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""JACKAL v3.0.0 Producer — Smart-Stalker signal emitter for v2 runtime.
+"""JACKAL v3.0.0 Producer — Smart-Stalker signal emitter, helpers-native.
 
 Jackal v1.1 (the scanner) ran as a full-agency Python scanner that:
   - Maintained a two-tier pool (watchlist + active)
@@ -11,11 +11,12 @@ Jackal v1.1 (the scanner) ran as a full-agency Python scanner that:
   - Scored them via its own heuristics
   - Called create_position + ratchet_stop_add directly
 
-v2.0 splits that into two parts:
-  1. This producer (runs on cron, 60s): emits candidate signals only
-  2. Runtime (senpi-trading-runtime): receives signals via
-     external_scanner ingest, gates through LLM decision_prompt,
-     executes, and manages DSL autonomously.
+v2.0+ splits that into two parts:
+  1. This producer (long-lived daemon, 60s tick): emits candidate
+     signals via client.push_signal() direct HTTP POST.
+  2. Runtime (senpi-trading-runtime): receives signals at /signals,
+     gates through LLM decision_prompt, executes, and manages DSL
+     autonomously.
 
 The producer's single responsibility: fetch the active trader pool,
 detect new entries, enrich with consensus + TA + funding regime
@@ -60,7 +61,9 @@ VERSION = "3.0.0"
 # Hardcoded — must match runtime.yaml external_scanner.name.
 SCANNER_NAME = "jackal_signals"
 
-# Signal type passed explicitly per Rachin's PR #209 review.
+# Signal type passed explicitly to push_signal(). Don't rely on the
+# scanner's defaultSignalType fallback — runtime YAMLs commonly don't
+# declare one, and missing tags break audit-log filtering.
 # (Preserved from v2.x payload — don't change without coordinating
 # with audit_query consumers that filter on this value.)
 SIGNAL_TYPE = "JACKAL_COPY_ENTRY"
@@ -93,8 +96,8 @@ STRATEGY_ADDRESS = _resolve_wallet()
 # ═══════════════════════════════════════════════════════════════
 
 # Smaller, sharper pool than v1. Top-ROI monthly with win-rate + age
-# filters. Pool refreshes daily (run cron once at 00:00 UTC with
-# REFRESH_POOL=true env var, or it rebuilds on first run of the day).
+# filters. Pool refreshes daily (the producer rebuilds it on first
+# tick of each UTC day; REFRESH_POOL=true env var forces a rebuild).
 POOL_SIZE = 25
 POOL_MIN_WIN_RATE = 0.50
 POOL_MIN_TRADER_AGE_DAYS = 14
@@ -380,8 +383,8 @@ def enrich_with_ta(candidate, funding_regime):
 
     Takes pre-fetched funding_regime as arg — do NOT call
     market_get_funding_regime here; it's a global per-run state and
-    calling it per-candidate wastes 1 MCP call × N candidates per cron
-    tick (Daniel's review, 2026-04-23).
+    calling it per-candidate wastes 1 MCP call × N candidates per
+    producer tick.
     """
     coin = candidate["coin"]
     out = {
@@ -501,7 +504,8 @@ def push_signal(payload):
 
 def build_signal_payload(candidate, ta, btc_macro):
     """Build the payload. push_signal extracts asset/direction/score/data
-    as kwargs; signal_type is the SIGNAL_TYPE constant (Rachin's PR #209)."""
+    as kwargs; signal_type is the SIGNAL_TYPE constant (passed explicitly
+    to avoid the runtime YAML's defaultSignalType fallback)."""
     trader = candidate["trader"]
     return {
         "asset": candidate["coin"],

--- a/spider/README.md
+++ b/spider/README.md
@@ -65,7 +65,7 @@ export SENPI_AUTH_TOKEN=...
 export SPIDER_DECISION_MODEL=gemini-2.5-pro    # or any model the runtime supports
 ```
 
-### Step 4 — Stop v3.x cron, start v4.0.0 daemon
+### Step 4 — Stop v2.x cron (if present), start v4.0.x daemon
 
 ```bash
 openclaw cron list | grep spider

--- a/spider/SKILL.md
+++ b/spider/SKILL.md
@@ -13,11 +13,12 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "4.0.2"
+  version: "4.0.1"
   platform: senpi
   exchange: hyperliquid
   requires:
-    - senpi-trading-runtime
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
 ---
 
 # 🕷️ SPIDER v3.0 — Patient Anchor Sniper
@@ -139,8 +140,8 @@ See [README.md](README.md) for fresh-install + migration commands from v2.0.
 
 ## Fleet patches incorporated
 
-- ✓ **Held-asset dedup** (3-layer; Pangolin v2.1 pattern)
-- ✓ **Post-close cooldown** (7d, matches min-hold; Pangolin v2.1.2 pattern)
+- ✓ **Held-asset dedup** (3-layer: producer pre-filter, LLM gate, runtime per_asset_cooldown)
+- ✓ **Post-close cooldown** (7d, matches min-hold; producer-side runtime-cooldown backstop)
 - ✓ **Reentrancy lockfile** (fcntl)
 - ✓ **Wallet-from-config** (no hardcoding)
 - ✓ **drawdown_reset_on_day_rollover: false** (Roach lesson)
@@ -154,9 +155,9 @@ User-conversation Claude sessions MUST NOT call any of:
 `ratchet_stop_add`, `ratchet_stop_edit`, `ratchet_stop_delete`,
 `cancel_order`, `strategy_close`, `strategy_close_positions`.
 
-These tools are reserved for the **producer cron** (entry path) and
+These tools are reserved for the **producer daemon** (entry path) and
 the **DSL ratchet engine** (exit path). User-conversation sessions
-are **read-only**. The producer cron will handle real signals on its next tick.
+are **read-only**. The producer daemon will handle real signals on its next tick.
 
 ## License
 

--- a/spider/scripts/spider-producer.py
+++ b/spider/scripts/spider-producer.py
@@ -59,16 +59,16 @@ v3.0 redesign trade-off:
   DROP    — 7-day paper-trade warmup (gate-paused indefinitely).
   DROP    — pilot protocol (50/75/100% staged entry).
 
-What v3.0 ACTUALLY DOES every cron tick:
+What v3.0+ ACTUALLY DOES every producer tick:
   - Reads top-15 SM leaderboard markets via MCP
   - Scores each on 4-factor composite (arena, SM, funding, relstr)
   - Skips any held assets + post-close cooldowns + non-LONG candidates
   - Applies fleet-concentration leverage cap if applicable
-  - Emits TOP candidate scoring >= 7.0 via external-scanner ingest
+  - Emits TOP candidate scoring >= 7.0 via client.push_signal()
   - Runtime LLM gate evaluates regime (BTC drawdown, vol expansion,
     funding regime flipping) and either honors or rejects
 
-Cadence: hourly cron OK; agent's own logic skips when position open.
+Cadence: hourly tick OK; producer skips when position open.
 The 7-day min-hold is enforced producer-side (skip emission) AND
 DSL-side (Phase 1 max_loss is the only early exit).
 
@@ -189,7 +189,7 @@ W_FUNDING = 0.15      # funding favorability for longs (low/negative = good)
 W_RELSTR = 0.15       # 30d relative strength
 
 # Score component thresholds
-SM_MIN_PCT = 8.0      # less strict than Cheetah's 10% — Spider scores by quality
+SM_MIN_PCT = 8.0      # quality-scored rather than gated tightly — Spider tolerates lower SM consensus than tighter scoring agents
 SM_MIN_TRADERS = 30
 ARENA_MIN_ACTIVE_TRADERS = 150
 
@@ -216,7 +216,7 @@ def get_anchor_leverage_for_score(score):
 
 
 def get_safe_leverage(wallet, asset, requested_leverage):
-    """Clamp to Hyperliquid asset max — Cheetah's leverage safety pattern."""
+    """Clamp to Hyperliquid asset max via strategy_get_asset_trading_limits."""
     try:
         limits = cfg.mcporter_call(
             "strategy_get_asset_trading_limits",
@@ -586,7 +586,7 @@ def fetch_arena_long_exposure():
             # a list at `data.positions`, got a dict, silently skipped every
             # trader → arena_long_exposure empty → W_ARENA component (4pts)
             # never fired → Spider candidates capped below MIN_SCORE.
-            # Same bug pattern caught and fixed in Cheetah v7.1.1.
+            # (Same nested-dict bug pattern seen elsewhere in the fleet.)
             positions = []
             if isinstance(positions_data, dict):
                 d = positions_data.get("data", positions_data)


### PR DESCRIPTION
Both Jackal (v3.0.0) and Spider (v4.0.1) are already on helpers-native. Surface-text cleanup so github matches what's running.

**Jackal:**
- `version: "3.0.1"` → `"3.0.0"` (producer VERSION authoritative)
- `requires:` → `senpi-trading-runtime>=1.1.0` + `senpi_runtime_helpers`
- "producer runs on a cron" → "producer runs as a long-lived daemon"
- Stripped cross-agent refs (Rachin/PR #209/Daniel) from producer docstring + comments

**Spider:**
- `version: "4.0.2"` → `"4.0.1"` (producer VERSION authoritative)
- `requires:` → `senpi-trading-runtime>=1.1.0` + `senpi_runtime_helpers`
- "Pangolin v2.1 pattern" / "Pangolin v2.1.2 pattern" → generic functional descriptions
- "producer cron" → "producer daemon" (×2)
- "every cron tick" → "every producer tick"; "via external-scanner ingest" → "via client.push_signal()"
- Stripped "Cheetah v7.1.1" / "Cheetah's 10%" / "Cheetah's leverage safety pattern" cross-refs
- README Step 4 corrected: Spider v3.x was already helpers-native (PR #225), so cron-delete only applies to legacy v2.x installs

No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)