### PR TITLE
fix: use prod npm package @senpi-ai/runtime (not @senpi/runtime)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,3 +90,18 @@ When creating a strategy, include `skill_name` and `skill_version` in the call. 
 ### Creating a new skill
 
 A new skill is not complete until both files above exist with the correct `skill_name` (matching the directory name) and `skill_version` (matching the SKILL.md frontmatter `version` field).
+
+---
+
+## Runtime npm package — `@senpi-ai/runtime` (NOT `@senpi/runtime`)
+
+**Always** reference the Senpi runtime plugin as **`@senpi-ai/runtime`** in any doc, script, config example, or error message. The name without `-ai` (`@senpi/runtime`) is a separate dev/internal package — its `latest` is a pre-release dev build and no stable `1.x.x` version is published. Operators copying `npm install @senpi/runtime@1.1.0` from your docs will hit a 404.
+
+| | name | what it is | `latest` |
+|---|---|---|---|
+| ✅ use this | `@senpi-ai/runtime` | production, 27 stable versions | `1.1.0` |
+| ❌ never | `@senpi/runtime` | dev / internal, all `-dev.*` | `1.1.0-dev.runtime-phase-2.*` |
+
+Source-of-truth: `senpi-trading-runtime/package.json` declares `name: "@senpi-ai/runtime"`. Check that field if in doubt.
+
+The wrong name is easy to type by reflex (every other Senpi npm scope is `@senpi-ai/...`, but muscle memory often shortens it). Grep every diff that touches `@senpi/` — if there's no `-ai`, it's wrong.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,13 +95,13 @@ A new skill is not complete until both files above exist with the correct `skill
 
 ## Runtime npm package — `@senpi-ai/runtime` (NOT `@senpi/runtime`)
 
-**Always** reference the Senpi runtime plugin as **`@senpi-ai/runtime`** in any doc, script, config example, or error message. The name without `-ai` (`@senpi/runtime`) is a separate dev/internal package — its `latest` is a pre-release dev build and no stable `1.x.x` version is published. Operators copying `npm install @senpi/runtime@1.1.0` from your docs will hit a 404.
+**Always** reference the Senpi runtime plugin as **`@senpi-ai/runtime`** in any doc, script, config example, or error message. A separately-published package exists at `@senpi/runtime` (no `-ai`) with the same description, but it only publishes `-dev.*` pre-releases — no stable `1.x.x` is available. Operators copying `npm install @senpi/runtime@1.1.0` from your docs will hit a 404.
 
-| | name | what it is | `latest` |
-|---|---|---|---|
-| ✅ use this | `@senpi-ai/runtime` | production, 27 stable versions | `1.1.0` |
-| ❌ never | `@senpi/runtime` | dev / internal, all `-dev.*` | `1.1.0-dev.runtime-phase-2.*` |
+| | name | what gets installed |
+|---|---|---|
+| ✅ use this | `@senpi-ai/runtime` | stable `1.x.x` releases (`latest = 1.1.0`) |
+| ❌ never | `@senpi/runtime` | only `-dev.*` pre-releases |
 
 Source-of-truth: `senpi-trading-runtime/package.json` declares `name: "@senpi-ai/runtime"`. Check that field if in doubt.
 
-The wrong name is easy to type by reflex (every other Senpi npm scope is `@senpi-ai/...`, but muscle memory often shortens it). Grep every diff that touches `@senpi/` — if there's no `-ai`, it's wrong.
+Grep every diff that touches `@senpi/` — if there's no `-ai` after `@senpi`, it's the wrong package.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,15 +93,10 @@ A new skill is not complete until both files above exist with the correct `skill
 
 ---
 
-## Runtime npm package — `@senpi-ai/runtime` (NOT `@senpi/runtime`)
+## Runtime npm package — `@senpi-ai/runtime` (NOT `@senpi/runtime`) on `main`
 
-**Always** reference the Senpi runtime plugin as **`@senpi-ai/runtime`** in any doc, script, config example, or error message. A separately-published package exists at `@senpi/runtime` (no `-ai`) with the same description, but it only publishes `-dev.*` pre-releases — no stable `1.x.x` is available. Operators copying `npm install @senpi/runtime@1.1.0` from your docs will hit a 404.
+**Any skill committed to `main` that references the runtime plugin MUST use `@senpi-ai/runtime`.** That's the production npm package — what end users install on their Railway / OpenClaw hosts. `latest = 1.1.0`. Source-of-truth: `senpi-trading-runtime/package.json` declares `name: "@senpi-ai/runtime"`.
 
-| | name | what gets installed |
-|---|---|---|
-| ✅ use this | `@senpi-ai/runtime` | stable `1.x.x` releases (`latest = 1.1.0`) |
-| ❌ never | `@senpi/runtime` | only `-dev.*` pre-releases |
+`@senpi/runtime` (no `-ai`) is a **separately-published internal package for runtime-side dev testing on Railway boxes**. It only ships `-dev.*` pre-releases — there is no stable `1.x.x`. Feature branches doing runtime-plugin validation may legitimately pin it; **anything on `main` must not**. Operators running `npm install @senpi/runtime@1.1.0` from a skill on `main` hit a 404 — the user's box stays broken until someone tells them which package they actually wanted.
 
-Source-of-truth: `senpi-trading-runtime/package.json` declares `name: "@senpi-ai/runtime"`. Check that field if in doubt.
-
-Grep every diff that touches `@senpi/` — if there's no `-ai` after `@senpi`, it's the wrong package.
+This mistake recurs. If you see `@senpi/` (no `-ai`) in any doc, `runtime.yaml` comment, producer docstring, or error-message string on `main`, treat it as a bug and fix it. Grep every diff that touches `@senpi/` — if there's no `-ai` after `@senpi`, it's the wrong package for `main`.

--- a/grizzly/SKILL.md
+++ b/grizzly/SKILL.md
@@ -260,7 +260,7 @@ get audited.
 
 ## Install
 
-**Prerequisite:** plugin must be the published `@senpi/runtime` >= 1.1.0. The
+**Prerequisite:** plugin must be the published `@senpi-ai/runtime` >= 1.1.0. The
 senpi-trading-runtime skill must also be installed on this host — it
 ships the Python Producer SDK (`senpi_runtime_helpers`) that this
 producer imports. See README install steps.

--- a/owl/SKILL.md
+++ b/owl/SKILL.md
@@ -31,7 +31,7 @@ Wait for the crowd to overcommit. Wait for them to exhaust. Then eat their liqui
 
 **Plumbing-only migration. NO thesis change.** v7.1's crowding/exhaustion scoring, persistence gates, MACRO_TREND_GATE, conviction leverage, DSL preset are all preserved verbatim.
 
-Six-layer plumbing flip on @senpi/runtime 1.1.0 (same pattern as Wolverine/Lemon/Cheetah v3.0+ migrations):
+Six-layer plumbing flip on @senpi-ai/runtime 1.1.0 (same pattern as Wolverine/Lemon/Cheetah v3.0+ migrations):
 
 | Layer | v7.1 | v8.0 |
 |---|---|---|

--- a/owl/runtime.yaml
+++ b/owl/runtime.yaml
@@ -8,7 +8,7 @@ name: owl-tracker
 version: 1.8.0
 description: >
   OWL v8.0.0 — Pure Contrarian Crowding-Unwind Hunter, helpers-native
-  (2026-05-12). Plumbing-only migration on @senpi/runtime 1.1.0. NO
+  (2026-05-12). Plumbing-only migration on @senpi-ai/runtime 1.1.0. NO
   thesis change from v7.1. Same six-layer flip the rest of the fleet
   is doing: mcporter subprocess → SenpiClient.mcp_call() direct HTTPS,
   external-scanner ingest CLI → SenpiClient.push_signal() direct POST,

--- a/owl/scripts/owl-producer.py
+++ b/owl/scripts/owl-producer.py
@@ -13,7 +13,7 @@ MARGIN_PCT 0.25, MIN_COMBINED_SCORE 12, XYZ banned, 6h post-loss
 asset cooldown, dynamic daily cap by PnL.
 
 Six-layer plumbing flip (same pattern as Wolverine/Lemon/Cheetah
-v3.0+ migrations on @senpi/runtime 1.1.0):
+v3.0+ migrations on @senpi-ai/runtime 1.1.0):
   1. MCP calls — cfg.mcporter_call() shim routes through
      SenpiClient.mcp_call() (direct HTTPS, no mcporter subprocess).
   2. Signal emit — subprocess.run(["openclaw","senpi",

--- a/senpi-trading-runtime/references/python-producer-sdk.md
+++ b/senpi-trading-runtime/references/python-producer-sdk.md
@@ -126,7 +126,7 @@ ch_ok, ch = results[0]
 |---|---|
 | `signal_post: … code=INVALID_REQUEST` | Most common: `asset`/`direction` inside `data`. Move to top-level kwargs; verify `data` keys against `runtime.yaml` `config.fields`. |
 | `signal_post: … code=NOT_FOUND` | Verify runtime install (`openclaw senpi runtime list`); confirm `scanner` matches `runtime.yaml`. |
-| `signal_post: unexpected envelope shape` | Runtime is on the legacy envelope; bump the runtime plugin (id: `runtime`, npm package: `@senpi/runtime`) to `>= 1.1.0`. |
+| `signal_post: unexpected envelope shape` | Runtime is on the legacy envelope; bump the runtime plugin (id: `runtime`, npm package: `@senpi-ai/runtime`) to `>= 1.1.0`. |
 | `signal_post: HTTP 400 … Exceeded api.maxItemsPerSignalsRequest=10` | Batch too large; split batch (default cap 10). |
 | `MCP error: …` from `mcp_call` | Check tool name + arguments against `senpi-hyperliquid-mcp` schema. |
 | `lock_recovered_after_crash` | Previous holder crashed; auto-recovered — no action needed. |


### PR DESCRIPTION
## Summary

Five docs in the repo say \`@senpi/runtime\` — but **that's the dev/internal npm package**. Production is \`@senpi-ai/runtime\` (with the \`-ai\`).

Verified live against the npm registry:

| Package | What it is | versions | latest dist-tag |
|---|---|---|---|
| \`@senpi/runtime\` | dev / internal | 60 (all \`-dev.*\` pre-releases) | \`1.1.0-dev.runtime-phase-2.20260512102629\` |
| \`@senpi-ai/runtime\` | **production** | 27 (all stable) | \`1.1.0\` ✓ |

Source-of-truth: \`senpi-trading-runtime/package.json\` declares \`name: \"@senpi-ai/runtime\"\`.

**Operator impact**: anyone following the affected docs and running \`npm install @senpi/runtime@1.1.0\` gets a 404 (no stable \`1.1.0\` exists in the dev package). Running \`npm install @senpi/runtime@latest\` works but installs a dev build that's missing prod RPC methods — this is one of the failure modes called out in Bug #3 of the \"Bugs while updating agents to runtime 1.1.0\" report.

## Files changed

- \`owl/runtime.yaml\` — migration-line YAML comment
- \`owl/SKILL.md\` — \"Six-layer plumbing flip on @senpi/runtime 1.1.0\" header
- \`owl/scripts/owl-producer.py\` — producer-header docstring
- \`senpi-trading-runtime/references/python-producer-sdk.md\` — error-table row I added on PR #247 (the row that prompted this whole investigation)
- \`grizzly/SKILL.md\` — Prerequisite line

All 5 changes are the same one-token substitution: \`@senpi/runtime\` → \`@senpi-ai/runtime\`.

## Test plan

- [x] \`grep -rnE '@senpi/runtime' --include=\"*.md\" --include=\"*.py\" --include=\"*.yaml\" --include=\"*.json\" .\` returns zero hits after the change
- [x] \`npm view @senpi-ai/runtime@1.1.0\` resolves
- [x] No code or behavior change — docs only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates correcting the npm package name used in install/migration guidance; no runtime behavior or code paths change.
> 
> **Overview**
> Corrects multiple docs/comments to point operators at the production runtime plugin package `@senpi-ai/runtime` (and warns against `@senpi/runtime`, which is dev-only and lacks stable releases).
> 
> Updates affected install prerequisites and migration/error guidance in `grizzly/SKILL.md`, `owl/SKILL.md`, `owl/runtime.yaml`, `owl/scripts/owl-producer.py`, and `senpi-trading-runtime/references/python-producer-sdk.md`, and adds a repo-level convention note in `CLAUDE.md` to prevent recurrence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d08b122a8a4a6a0fb3e6ebe42472104d80c1ddbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->