### PR TITLE
Claude should warn developers.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,9 @@ A new skill is not complete until both files above exist with the correct `skill
 
 This mistake recurs. If you see `@senpi/` (no `-ai`) in any doc, `runtime.yaml` comment, producer docstring, or error-message string on `main`, treat it as a bug and fix it. Grep every diff that touches `@senpi/` — if there's no `-ai` after `@senpi`, it's the wrong package for `main`.
 
-### Before you write `@senpi/runtime` (no `-ai`), ask the user
+### Before you write `@senpi/runtime` (no `-ai`), ask the user — on every branch
 
-If you (the AI) are about to commit `@senpi/runtime` anywhere — producer, doc, `runtime.yaml`, comment, anywhere — **stop and ask first**. Use plain language:
+If you (the AI) are about to commit `@senpi/runtime` anywhere on **any** branch — producer, doc, `runtime.yaml`, comment, anywhere — **stop and ask first**. The rule applies regardless of which branch you're on, because the AI can't reliably tell whether the current branch will land on `main` later. Use plain language:
 
 > "I'm about to write `@senpi/runtime` (no `-ai`). Two packages exist:
 >

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,11 +105,16 @@ This mistake recurs. If you see `@senpi/` (no `-ai`) in any doc, `runtime.yaml` 
 
 If you (the AI) are about to commit `@senpi/runtime` anywhere on **any** branch — producer, doc, `runtime.yaml`, comment, anywhere — **stop and ask first**. The rule applies regardless of which branch you're on, because the AI can't reliably tell whether the current branch will land on `main` later. Use plain language:
 
-> "I'm about to write `@senpi/runtime` (no `-ai`). Two packages exist:
+> "I'm about to write `@senpi/runtime` (no `-ai`). Before I do, please confirm which package you mean.
 >
-> - **`@senpi-ai/runtime`** — the package your end users install. Default for anything shipping to `main`. If users will read or run this file, this is the answer.
-> - **`@senpi/runtime`** — internal package, used to test runtime-plugin changes on Railway boxes ourselves. Only correct if this work is on a feature branch validating a runtime build, NOT for anything users install.
+> - **`@senpi-ai/runtime`** — the package your end users install on their Railway / OpenClaw hosts. Use this for anything that may land on `main`.
+>   - **If you pick this when you actually wanted the internal one**: nothing breaks. The file just won't reference your in-flight test build.
+>
+> - **`@senpi/runtime`** — internal package; we use it to test runtime-plugin changes on Railway boxes ourselves. Only correct on a feature branch validating a runtime build, never on anything users install.
+>   - **If you pick this when users will install this skill**: their `npm install @senpi/runtime@1.1.0` returns **404**. Their OpenClaw host won't boot. Their trading agent goes offline until someone tells them the right package name.
+>
+> Default if you're not sure: **`@senpi-ai/runtime`**.
 >
 > Which one do you want?"
 
-When unsure, default to **`@senpi-ai/runtime`**. A working user install beats a clever test reference.
+The consequences are asymmetric. The wrong `@senpi-ai/runtime` pick is recoverable on a single feature branch. The wrong `@senpi/runtime` pick on `main` blocks every user from installing the skill. When in doubt, default to **`@senpi-ai/runtime`**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,3 +100,16 @@ A new skill is not complete until both files above exist with the correct `skill
 `@senpi/runtime` (no `-ai`) is a **separately-published internal package for runtime-side dev testing on Railway boxes**. It only ships `-dev.*` pre-releases — there is no stable `1.x.x`. Feature branches doing runtime-plugin validation may legitimately pin it; **anything on `main` must not**. Operators running `npm install @senpi/runtime@1.1.0` from a skill on `main` hit a 404 — the user's box stays broken until someone tells them which package they actually wanted.
 
 This mistake recurs. If you see `@senpi/` (no `-ai`) in any doc, `runtime.yaml` comment, producer docstring, or error-message string on `main`, treat it as a bug and fix it. Grep every diff that touches `@senpi/` — if there's no `-ai` after `@senpi`, it's the wrong package for `main`.
+
+### Before you write `@senpi/runtime` (no `-ai`), ask the user
+
+If you (the AI) are about to commit `@senpi/runtime` anywhere — producer, doc, `runtime.yaml`, comment, anywhere — **stop and ask first**. Use plain language:
+
+> "I'm about to write `@senpi/runtime` (no `-ai`). Two packages exist:
+>
+> - **`@senpi-ai/runtime`** — the package your end users install. Default for anything shipping to `main`. If users will read or run this file, this is the answer.
+> - **`@senpi/runtime`** — internal package, used to test runtime-plugin changes on Railway boxes ourselves. Only correct if this work is on a feature branch validating a runtime build, NOT for anything users install.
+>
+> Which one do you want?"
+
+When unsure, default to **`@senpi-ai/runtime`**. A working user install beats a clever test reference.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adds guidance to prevent accidentally referencing the internal `@senpi/runtime` package; no runtime or business logic is modified.
> 
> **Overview**
> Adds a new rule in `CLAUDE.md` requiring the AI/editor to **stop and ask for confirmation** before writing `@senpi/runtime` (no `-ai`) anywhere, emphasizing that `@senpi-ai/runtime` is the safe default for anything that may land on `main` and documenting the install-breakage consequences of choosing the wrong package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1063e479b1d7e9c6050a66bf4f663f889237d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->