### PR TITLE
chore(runtime): bump SKILL.md version 2.1 -> 2.2

### DIFF
--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -4,7 +4,7 @@ description: "The Senpi Trading Runtime OpenClaw plugin runs automated trading s
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.1"
+  version: "2.2"
   platform: senpi
   exchange: hyperliquid
 ---


### PR DESCRIPTION
## Summary

Single-line bump of \`senpi-trading-runtime/SKILL.md\` frontmatter version from \`2.1\` to \`2.2\`.

## Why

PR #262 merged doc-only changes:
- 5 files updated from the wrong npm package name (\`@senpi/runtime\`) to the correct one (\`@senpi-ai/runtime\`).
- \`CLAUDE.md\` section added warning AI editors against the dev/prod package confusion + a stop-and-ask rule on any branch.

\`senpi-entrypoint/scripts/check-skill-updates.py\` only surfaces a skill update to existing hosts when **both** the folder hash AND \`metadata.version\` change. PR #262 changed the hash but left the version at \`2.1\` — so the doc fix would silently NOT reach hosts already on 2.1 (every Railway box installed since PR #244 merged ~2 days ago).

This bump makes the next \`senpi-skill-update-check\` cron tick surface the upgrade. Operators then re-run \`npx skills add --skill senpi-trading-runtime -g -y\` and pick up the corrected docs.

## Versioning convention

Kept the 2-segment format the skill has used so far: \`1.0\` → \`2.0\` → \`2.1\` → \`2.2\`. Doc-only fixes are arguably PATCH (would be \`2.1.1\` if we were on strict 3-segment semver), but switching format on a one-line bump felt riskier than just preserving the existing pattern. Happy to revisit when there's a reason to.

## Test plan

- [x] Frontmatter \`version: \"2.1\"\` → \`version: \"2.2\"\`.
- [x] No other changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc/metadata-only change; no runtime code or behavior is modified.
> 
> **Overview**
> Updates `senpi-trading-runtime/SKILL.md` frontmatter `metadata.version` from `2.1` to `2.2` so skill update checks surface the latest documentation changes to existing installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 704745f2ee8e6edd6a739f0c89765668a1535364. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->