### PR TITLE
docs(runtime): sync skill yaml-schema reference with runtime schema

### DIFF
--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -115,22 +115,9 @@ Scanners detect trading opportunities. For an external momentum strategy, you ne
 
 Rules for external scanners:
 - Do NOT set `interval` (it's push-driven, not polled)
-- Do NOT set `depends_on` (push-driven scanners do not consume upstream artifacts)
 - Must enable at least one of `outputs.signals` or `outputs.context`
 - Must define `config.fields` with at least one field
 - Each field needs a `type`: `string`, `number`, `boolean`, `object`, or `array`
-
-**Registered scanner types:** `position_tracker`, `external_scanner`, `momentum`, `emerging_movers`, `oi_tracker`, `prescreener`, `liquidation_watchdog`, `market_regime`, `sm_flip`, `opportunity`.
-
-**Other scanner fields (apply to all types):**
-
-| Field | What it does |
-|-------|-------------|
-| `depends_on` | Array of upstream scanner dependencies (`scanner`, `required`, `max_age`, `on_missing`, `on_stale`) |
-| `blocked_assets` | List of asset tickers to exclude from this scanner |
-| `retention` | `last_only` or `rolling_window` |
-| `retention_max_runs` | Integer; max retained runs when using `rolling_window` |
-| `advanced` | Passthrough record for advanced scanner options |
 
 ### Define How Trades Are Entered
 
@@ -281,7 +268,6 @@ These are hard requirements — if you violate them, the YAML will fail to load:
 | "when using actions that depend on scanners, you must also add a non-empty 'scanners:' block" | OPEN_POSITION action but no scanners | Add a `scanners:` block with at least one scanner |
 | "Duplicate scanner name(s)" | Two scanners have the same name | Rename one of them |
 | "external_scanner does not allow interval" | You set `interval` on an external scanner | Remove the `interval` field |
-| "external_scanner does not support depends_on" | You set `depends_on` on an external scanner | Remove `depends_on`; declare it on the consuming scanner instead |
 | "external_scanner must enable at least one of outputs.signals or outputs.context" | Both outputs are `false` (or `outputs` is missing) | Set at least one of `outputs.signals` / `outputs.context` to `true` |
 | "external_scanner requires a non-empty config.fields map" | Missing field definitions | Add `config: { fields: { ... } }` |
 | "DSL requires at least one position-tracker scanner" | Exit management without position tracking | Add a `position_tracker` scanner |

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -36,9 +36,10 @@ The `strategy` block tells the runtime which wallet to trade and how much capita
 | `wallet` | Your wallet address (use `${WALLET_ADDRESS}` to keep it in env) | **yes** |
 | `slots` | Max concurrent positions | no |
 | `margin_per_slot` | Fixed USD margin per position | no |
-| `margin_pct` | Margin as % of account (1-100) | no |
+| `margin_pct` | Margin as % of account (positive, max 100) | no |
 | `trading_risk` | Risk profile: `conservative`, `moderate`, or `aggressive` | no |
 | `default_leverage` | Leverage multiplier | no |
+| `leverage_multipliers` | Per-risk-level leverage overrides: `{ conservative?, moderate?, aggressive? }` | no |
 | `enabled` | Set to `false` to pause without uninstalling | no |
 
 ### Set Up Notifications

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -268,6 +268,7 @@ These are hard requirements — if you violate them, the YAML will fail to load:
 | "when using actions that depend on scanners, you must also add a non-empty 'scanners:' block" | OPEN_POSITION action but no scanners | Add a `scanners:` block with at least one scanner |
 | "Duplicate scanner name(s)" | Two scanners have the same name | Rename one of them |
 | "external_scanner does not allow interval" | You set `interval` on an external scanner | Remove the `interval` field |
+| "external_scanner does not support depends_on" | You set `depends_on` on an external scanner | Remove `depends_on`; declare it on the consuming scanner instead |
 | "external_scanner must enable at least one of outputs.signals or outputs.context" | Both outputs are `false` (or `outputs` is missing) | Set at least one of `outputs.signals` / `outputs.context` to `true` |
 | "external_scanner requires a non-empty config.fields map" | Missing field definitions | Add `config: { fields: { ... } }` |
 | "DSL requires at least one position-tracker scanner" | Exit management without position tracking | Add a `position_tracker` scanner |

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -170,6 +170,17 @@ Pass the **bare** model name to `decision_model`. The runtime forwards it to the
 
 The DSL exit engine monitors your open positions and closes them based on configurable rules.
 
+**Top-level `exit` fields:**
+
+| Field | What it does | Default |
+|-------|-------------|---------|
+| `engine` | Exit engine identifier; typically `dsl` | — |
+| `interval_seconds` | DSL polling interval (integer, 5–3600) | `30` |
+| `order_type` | Order type for DSL-initiated closes: `MARKET` or `FEE_OPTIMIZED_LIMIT` | `MARKET` |
+| `fee_optimized_limit_options.ensure_execution_as_taker` | Ensure fill as taker if limit times out | — |
+| `fee_optimized_limit_options.execution_timeout_seconds` | Limit-order timeout (integer, 1–300) | — |
+| `dsl_preset` | DSL exit profile (see below) | — |
+
 **Time-based cuts** close positions that aren't performing:
 - `hard_timeout`: Close after N minutes no matter what
 - `weak_peak_cut`: Close if peak ROE% never reaches `min_value` after N minutes

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -140,12 +140,23 @@ Actions decide what to do with signals. For LLM-driven entries:
 | Field | What it does |
 |-------|-------------|
 | `decision_mode` | `llm` (AI decides), `rule` (automatic), or `no_decision` (disabled) |
-| `decision_model` | Which LLM model to use (e.g. `claude-sonnet-4-20250514`) |
+| `decision_model` | Which LLM model to use. **Bare model name only — no provider prefix.** See [Model name format](#model-name-format). |
 | `scanners` | Which scanner(s) trigger this action |
 | `min_confidence` | Minimum LLM confidence (1-10) to execute the trade |
 | `params.order_type` | `MARKET` or `FEE_OPTIMIZED_LIMIT` |
 | `context` | What data to inject into the prompt |
 | `decision_prompt` | The prompt template with `{{placeholders}}` |
+
+#### Model name format
+
+Pass the **bare** model name to `decision_model`. The runtime forwards it to the OpenClaw `llm-task` gateway, which adds its own provider prefix when routing. Passing a prefixed name causes a double-prefix and the gateway responds with `500 Unknown model`.
+
+| | Example |
+|---|---|
+| Valid | `gemini-2.5-pro`, `claude-sonnet-4-20250514`, `gemini-3.1-pro-preview` |
+| Invalid | `google/gemini-2.5-pro`, `anthropic/claude-sonnet-4-20250514` |
+
+**Provider selection is not configured here.** The runtime auto-detects the backend at boot: if `ANTHROPIC_API_KEY` is set in the runtime's environment, it uses the Anthropic SDK directly; otherwise it routes through the OpenClaw gateway (which requires `OPENCLAW_GATEWAY_TOKEN`). The bare-name rule applies to the gateway path — the default in production.
 
 ### Configure Exit Management
 

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -57,10 +57,12 @@ notifications:
 | `dsl_lifecycle` | Notify on DSL position open/close | `true` |
 | `dsl_notify_sl_updates` | Notify on stop-loss level changes | `false` |
 | `action_lifecycle` | Notify on action execution (open/close) | `true` |
+| `gateway_url` | Override the OpenClaw gateway URL for delivery | `http://127.0.0.1:18789` |
+| `gateway_token` | Override the OpenClaw gateway auth token | `process.env.OPENCLAW_GATEWAY_TOKEN` |
 
 > **Field name caveat:** The `notifications` block currently accepts unknown keys without erroring, so a typo like `action_lifecycle_notifications` is silently ignored and the default takes effect. Use the exact key shown above.
 
-**Requirement:** The `OPENCLAW_GATEWAY_TOKEN` environment variable must be set for Telegram delivery.
+**Requirement:** Telegram delivery needs an OpenClaw gateway token — either `OPENCLAW_GATEWAY_TOKEN` in the runtime's environment, or `gateway_token` in this block.
 
 ### Configure Risk Protection
 

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -115,9 +115,22 @@ Scanners detect trading opportunities. For an external momentum strategy, you ne
 
 Rules for external scanners:
 - Do NOT set `interval` (it's push-driven, not polled)
+- Do NOT set `depends_on` (push-driven scanners do not consume upstream artifacts)
 - Must enable at least one of `outputs.signals` or `outputs.context`
 - Must define `config.fields` with at least one field
 - Each field needs a `type`: `string`, `number`, `boolean`, `object`, or `array`
+
+**Registered scanner types:** `position_tracker`, `external_scanner`, `momentum`, `emerging_movers`, `oi_tracker`, `prescreener`, `liquidation_watchdog`, `market_regime`, `sm_flip`, `opportunity`.
+
+**Other scanner fields (apply to all types):**
+
+| Field | What it does |
+|-------|-------------|
+| `depends_on` | Array of upstream scanner dependencies (`scanner`, `required`, `max_age`, `on_missing`, `on_stale`) |
+| `blocked_assets` | List of asset tickers to exclude from this scanner |
+| `retention` | `last_only` or `rolling_window` |
+| `retention_max_runs` | Integer; max retained runs when using `rolling_window` |
+| `advanced` | Passthrough record for advanced scanner options |
 
 ### Define How Trades Are Entered
 

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -281,6 +281,8 @@ These are hard requirements — if you violate them, the YAML will fail to load:
 | "when using actions that depend on scanners, you must also add a non-empty 'scanners:' block" | OPEN_POSITION action but no scanners | Add a `scanners:` block with at least one scanner |
 | "Duplicate scanner name(s)" | Two scanners have the same name | Rename one of them |
 | "external_scanner does not allow interval" | You set `interval` on an external scanner | Remove the `interval` field |
+| "external_scanner does not support depends_on" | You set `depends_on` on an external scanner | Remove `depends_on`; declare it on the consuming scanner instead |
+| "external_scanner must enable at least one of outputs.signals or outputs.context" | Both outputs are `false` (or `outputs` is missing) | Set at least one of `outputs.signals` / `outputs.context` to `true` |
 | "external_scanner requires a non-empty config.fields map" | Missing field definitions | Add `config: { fields: { ... } }` |
 | "DSL requires at least one position-tracker scanner" | Exit management without position tracking | Add a `position_tracker` scanner |
 | "DSL requires a POSITION_TRACKER action" | Exit management without tracker action | Add a `POSITION_TRACKER` action |

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -19,6 +19,9 @@ Install a YAML file with `openclaw senpi runtime create --path /path/to/your.yam
 | `exit` | no | DSL exit engine config. See [Configure Exit Management](#configure-exit-management). |
 | `risk` | no | Guard-rail gates. See [Configure Risk Protection](#configure-risk-protection). |
 | `notifications` | no | Telegram notifications. See [Set Up Notifications](#set-up-notifications). |
+| `health` | no | Health-check configuration (passthrough record). |
+| `hooks` | no | Lifecycle hooks (array; passthrough). |
+| `advanced` | no | Advanced runtime options (passthrough record). |
 
 ---
 

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -290,4 +290,3 @@ These are hard requirements — if you violate them, the YAML will fail to load:
 | "max_loss_pct is required" | Phase1 enabled without max_loss_pct | Add `max_loss_pct` to phase1 or preset root |
 | "exit / DSL preset validation failed" | Invalid DSL preset structure | Check tier sort order and required fields |
 | "Unsupported version" | Major version not in `SUPPORTED_RUNTIME_VERSIONS` | Use `version: 1` or omit the field |
-| "'strategies' (plural) is no longer supported" | Using the deprecated plural key | Change to `strategy:` (singular) with a single wallet |

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -145,6 +145,8 @@ Actions decide what to do with signals. For LLM-driven entries:
 
 | Field | What it does |
 |-------|-------------|
+| `name` | Action identifier (required) |
+| `action_type` | Registered action type (required): `OPEN_POSITION`, `CLOSE_POSITION`, or `POSITION_TRACKER` |
 | `decision_mode` | `llm` (AI decides), `rule` (automatic), or `no_decision` (disabled) |
 | `decision_model` | Which LLM model to use. **Bare model name only — no provider prefix.** See [Model name format](#model-name-format). |
 | `scanners` | Which scanner(s) trigger this action |

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -11,7 +11,7 @@ Install a YAML file with `openclaw senpi runtime create --path /path/to/your.yam
 | Key | Required | Purpose |
 |-----|----------|---------|
 | `name` | yes | Runtime name (human-readable identifier). |
-| `version` | no | Runtime version string. |
+| `version` | no | Runtime version (integer or string). The major version must be supported by the runtime (currently `[1]`). |
 | `description` | no | Free-form description. |
 | `strategy` | yes | Wallet, slots, risk profile, leverage — see [Define Your Strategy](#define-your-strategy). |
 | `scanners` | conditional | At least one scanner is required when any action depends on one. See [Connect Your Signal Source](#connect-your-signal-source). |
@@ -287,3 +287,5 @@ These are hard requirements — if you violate them, the YAML will fail to load:
 | "Action decision_prompt references names with no matching context entry or param" | `{{placeholder}}` doesn't match any context entry | Check that your context entries match your placeholders |
 | "max_loss_pct is required" | Phase1 enabled without max_loss_pct | Add `max_loss_pct` to phase1 or preset root |
 | "exit / DSL preset validation failed" | Invalid DSL preset structure | Check tier sort order and required fields |
+| "Unsupported version" | Major version not in `SUPPORTED_RUNTIME_VERSIONS` | Use `version: 1` or omit the field |
+| "'strategies' (plural) is no longer supported" | Using the deprecated plural key | Change to `strategy:` (singular) with a single wallet |

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -160,7 +160,7 @@ Actions decide what to do with signals. For LLM-driven entries:
 |-------|-------------|
 | `name` | Action identifier (required) |
 | `action_type` | Registered action type (required): `OPEN_POSITION`, `CLOSE_POSITION`, or `POSITION_TRACKER` |
-| `decision_mode` | `llm` (AI decides), `rule` (automatic), or `no_decision` (disabled) |
+| `decision_mode` | `llm` (AI decides), `rule` (automatic), or `none` (disabled) |
 | `decision_model` | Which LLM model to use. **Bare model name only — no provider prefix.** See [Model name format](#model-name-format). |
 | `scanners` | Which scanner(s) trigger this action |
 | `min_confidence` | Minimum LLM confidence (1-10) to execute the trade |


### PR DESCRIPTION
## Summary
Brings `senpi-trading-runtime/references/yaml-schema.md` back into sync with the runtime's actual Zod schema (`senpi-trading-runtime/src/runtime/runtime-schema.ts`) and the runtime's own authoritative spec (`docs/runtime-docs/strategy-yaml-spec.md`). Each drift fixed in a separate commit:

1. `decision_model` bare-name rule + provider auto-detect note (original PR scope)
2. Top-level sections: add `health`, `hooks`, `advanced`
3. Strategy block: add `leverage_multipliers`; correct `margin_pct` range from `1-100` to `positive, max 100`
4. Notifications block: add `gateway_url`, `gateway_token` (also acknowledged as alternatives to the env-var-only requirement note)
5. Actions block: add required `name` and `action_type` rows; enumerate registered action types (`OPEN_POSITION`, `CLOSE_POSITION`, `POSITION_TRACKER`)
6. Exit block: document top-level fields (`engine`, `interval_seconds`, `order_type`, `fee_optimized_limit_options`, `dsl_preset`)
7. Scanner block: list registered scanner types; add missing common fields (`depends_on`, `blocked_assets`, `retention`, `retention_max_runs`, `advanced`); note `depends_on` prohibition for external scanners
8. Version validation: clarify `version` accepts int or string and major must be in `SUPPORTED_RUNTIME_VERSIONS` (currently `[1]`); add "Unsupported version" to the validation-errors table
9. `decision_mode`: correct disabled value from `no_decision` to `none` — the actually registered strategy (`src/actions/decision-engine.ts:142`). The runtime's own spec is also wrong on this; out of scope here.
10. External-scanner validation errors: add "does not support depends_on" and "must enable at least one of outputs.signals or outputs.context"

Note: an earlier commit also added a row for the loader's `'strategies' (plural) is no longer supported` error and was reverted in the final commit. The plural schema only ever existed in unpublished tags v1.0.0-v1.0.72; the first npm release of `@senpi-ai/runtime` was v1.0.73 on 2026-03-30, after the singular rename. No user has a plural recipe to migrate from, so the doc has no reason to reference that defensive guard.

## Why
The skill claims to be a "schema reference for the runtime YAML file. Defines every top-level section, every field, wiring rules, template variables, and validation errors." Several fields, validation errors, and one wrong value had drifted from the runtime's actual schema and behavior. Agents reading only this skill would author YAMLs that fail validation in non-obvious ways (e.g. `no_decision`, `margin_pct: 0.5`, `google/...` model names).

## Test plan
- [ ] Skim each commit individually — they are scoped to single logical changes
- [ ] Confirm `yaml-schema.md` renders correctly and the new `#model-name-format` anchor resolves
- [ ] Spot-check a sample of cited file paths (e.g. `runtime-schema.ts:54-58`, `decision-engine.ts:142`) match what the schema/code actually says

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that update the YAML reference to match current runtime validation/behavior; low risk aside from potentially confusing users if any detail is still incorrect.
> 
> **Overview**
> Updates `references/yaml-schema.md` to match the runtime’s current YAML schema and validation rules.
> 
> Documents additional/clarified config surface: new top-level blocks (`health`, `hooks`, `advanced`), strategy leverage overrides (`leverage_multipliers`) and corrected `margin_pct` constraints, notification gateway overrides (`gateway_url`, `gateway_token`), required action fields (`name`, `action_type`) plus `decision_mode: none`, and explicit top-level `exit` fields.
> 
> Adds guidance and new validation-error entries around `decision_model` *bare model name* requirements, external-scanner restrictions (including `depends_on`/outputs), and unsupported `version` majors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b4e1ee9b4dd6b03749d3a16578a000ccfe16c41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->