### PR TITLE
cleanup: edit onboarding skills to promote senpi-trading-runtime as canonical

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ design/*
 venv/
 .venv/
 __pycache__/
+.claude/

--- a/senpi-entrypoint/SKILL.md
+++ b/senpi-entrypoint/SKILL.md
@@ -169,20 +169,29 @@ If the guide skill is not yet available, suggest these first actions instead:
 
 ## Step 4: Expand (User-Driven)
 
-Install additional trading skills on demand based on user interest:
+Install additional skills on demand based on user interest. Two paths:
+
+### To DEPLOY an existing strategy
+
+Install the strategy skill directly:
 
 ```bash
-npx skills add https://github.com/Senpi-ai/senpi-skills --skill <skill-name> -g -y
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill <strategy-name> -g -y
 ```
 
-Example:
+Look up the available strategy names from the live `list_strategies` MCP call (see post-onboarding.md → "Show me the strategies") — do NOT hardcode names here.
+
+### To BUILD a new autonomous strategy from scratch
+
+Install the runtime + Producer SDK skill — that's the canonical building block for every autonomous trading strategy in the fleet:
 
 ```bash
-npx skills add https://github.com/Senpi-ai/senpi-skills --skill wolf-strategy -g -y
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
 ```
 
-Onboarding is complete. The agent is now equipped with Senpi's trading
-toolkit and can install more skills as needed.
+Then walk the user through the build flow documented in `senpi-trading-runtime/SKILL.md` (runtime.yaml + producer.py + LLM decision gate + DSL exit preset). See `senpi-trading-runtime/references/producer-patterns.md` for the catalog of scanner archetypes the user can choose from.
+
+Onboarding is complete. The agent is now equipped with Senpi's trading toolkit and can install more skills as needed.
 
 ---
 

--- a/senpi-entrypoint/references/about-senpi.md
+++ b/senpi-entrypoint/references/about-senpi.md
@@ -53,23 +53,24 @@ Behavior rules:
 
 ## Core Capabilities
 
-- Discover high-performing traders and market opportunities (Discovery + market tools)
-- Copy top traders or run autonomous/custom strategy workflows
-- Apply risk controls such as dynamic stop-loss and budget-aware orchestration
-- Trade broad markets through Senpi's Hyperliquid-based stack (crypto perps and more)
+- **Run autonomous AI trading strategies** with `senpi-trading-runtime` — the canonical runtime + DSL exit engine + Python Producer SDK. Every active fleet strategy is built on this.
+- **Discover high-performing traders and market opportunities** via Discovery + market tools.
+- **Mirror top traders or deploy proven autonomous strategies** from the active fleet (live leaderboard at `strategies.senpi.ai`).
+- **Apply built-in risk controls** — daily loss caps, drawdown halts, consecutive-loss cooldowns, per-asset cooldowns — all enforced by `senpi-trading-runtime` declaratively in YAML.
+- **Trade broad markets** through Senpi's Hyperliquid-based stack (crypto perps + equities/metals/indices via XYZ DEX).
 
 ## Full Skill Catalog
 
-- `senpi-entrypoint`: onboarding flow for Senpi setup, discovery, and first-trade guidance.
+**Runtime / infrastructure:**
+- `senpi-trading-runtime`: the canonical OpenClaw plugin runtime + DSL exit engine + Python Producer SDK. Every autonomous trading strategy in the fleet is built on this. See `senpi-trading-runtime/SKILL.md`.
+
+**Onboarding:**
+- `senpi-entrypoint`: this skill — onboarding flow for Senpi setup, discovery, and first-trade guidance.
 - `senpi-onboard`: account + API key + MCP setup workflow.
-- `senpi-getting-started-guide`: interactive first-trade walkthrough.
-- `dsl-dynamic-stop-loss`: two-phase trailing stop-loss with tiered locking.
-- `opportunity-scanner`: market-wide scoring and setup discovery.
-- `emerging-movers`: smart-money rotation detection.
-- `autonomous-trading`: orchestrates DSL + scanner + movers.
-- `wolf-strategy`: full autonomous trading stack.
-- `wolf-howl`: nightly review and self-improvement loop.
-- `whale-index`: mirrors top-performing traders.
+- `senpi-getting-started-guide`: interactive first-trade walkthrough (mirror-strategy path).
+
+**Trading strategies:**
+- Active fleet of autonomous trading strategies — each a directory in this repo, all running live on `strategies.senpi.ai`. Fetch the current list via the `list_strategies` MCP call rather than enumerating here (the fleet changes; this catalog would drift).
 
 ## Install Skills
 

--- a/senpi-entrypoint/references/post-onboarding.md
+++ b/senpi-entrypoint/references/post-onboarding.md
@@ -151,18 +151,40 @@ Which sounds interesting? I can explain any in detail or deploy one right now.
 
 ### If user says "Build a new trading strategy" or "build a strategy" or "custom strategy" or "create a strategy"
 
-Help the user brainstorm custom strategies by combining Senpi tools and skills. Start the conversation with:
+The canonical path is to install `senpi-trading-runtime` and use its Producer SDK to author the strategy. That's how every active fleet strategy is built.
 
-> Help me brainstorm some custom strategies we could build from combining senpi tools and/or senpi skills
+**Step 1 — Install the runtime + Producer SDK:**
 
-The LLM should use its knowledge of the available Senpi MCP tools (market data, discovery, trading, portfolio) and installed skills to propose creative strategy ideas. Walk the user through:
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
 
-1. **Market scan** — Use available Senpi MCP tools to identify current market conditions and opportunities.
-2. **Strategy ideation** — Brainstorm approaches that combine multiple Senpi tools and skills in novel ways (e.g. combining discovery signals with specific entry/exit logic, layering multiple timeframes, blending copy-trading signals with technical filters).
-3. **Plan outline** — Draft a concrete plan: which tools to use, entry/exit criteria, risk parameters, position sizing, and how the pieces fit together.
-4. **Next steps** — Offer to help the user refine the strategy, backtest the logic manually with current data, or point them to existing strategies that are closest to their idea.
+The skill ships with `SenpiClient` (HTTPS MCP wrapper), `producer_daemon` (long-lived scheduler), `senpi-helpers` (operator CLI), the DSL exit engine, and full reference docs.
 
-Do NOT require any specific skill installation for this flow — it is a brainstorming and planning session powered by the LLM and whatever MCP tools are already available.
+**Step 2 — Walk the user through the strategy design:**
+
+1. **Pick a scanner archetype** — see `senpi-trading-runtime/references/producer-patterns.md` for the catalog of scanner patterns the active fleet implements (universe trend-follower, single-asset alpha hunter, trader-follower, funding-regime fade, cross-asset lag detector, multi-asset whitelist, XYZ specialist, contrarian crowding-unwind, etc.). Each pattern names its primary MCP tools, typical tick interval, and a living example agent to copy from.
+2. **Draft the `runtime.yaml`** — defer to `senpi-trading-runtime/references/yaml-schema.md` for field definitions and `references/strategy-examples.md` for templates. The YAML declares: scanners (`position_tracker` + the producer's `external_scanner`), actions (LLM-gated entry + position_tracker_action), `risk.guard_rails`, and the DSL exit preset.
+3. **Write the Python producer** — defer to `senpi-trading-runtime/references/python-producer-sdk.md`. The producer is a long-lived daemon using `producer_daemon(...)` that pushes signals via `client.push_signal(...)`. Reference any active fleet agent's `<agent>-producer.py` as a working template.
+
+**Step 3 — Deploy:**
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/<strategy>-strategy/runtime.yaml
+nohup python3 -u /data/workspace/skills/<strategy>-strategy/scripts/<strategy>-producer.py \
+  > /tmp/<strategy>-producer.log 2>&1 &
+disown
+```
+
+**Step 4 — Verify:**
+
+```bash
+ps -ef | grep <strategy>-producer | grep -v grep
+senpi-helpers list
+grep daemon_tick_finished /tmp/<strategy>-producer.log | tail -3
+```
+
+Building a strategy is a longer flow than deploying an existing one — set expectations with the user. If they want something running today, the "Deploy a proven strategy" path (set me up / catalog) is faster.
 
 ---
 
@@ -179,7 +201,7 @@ npx skills add https://github.com/Senpi-ai/senpi-skills --skill "${SLUG}" -g -y 
 npx skills add https://github.com/Senpi-ai/senpi-skills --skill "${SLUG}-strategy" -g -y
 ```
 
-This covers all known cases: slugs that match directly (e.g. `fox`, `viper`, `cobra`) and slugs that need the `-strategy` suffix (e.g. `tiger` → `tiger-strategy`, `ghost-fox` → `ghost-fox-strategy`, `mamba` → `mamba-strategy`).
+This covers two cases: slugs that match the folder name directly (most agents), and slugs that need the `-strategy` suffix (some legacy directories). The fallback handles both transparently — don't enumerate specific examples here, since the fleet changes.
 
 ---
 
@@ -244,7 +266,7 @@ Always lead with the current #1 by ROE from the leaderboard as the primary recom
 
 **DO NOT run `npx skills add --list` in the welcome message.** This dumps every folder including infrastructure and confuses new users. Only use it if the user specifically asks for a raw listing.
 
-**DO NOT explain crons, mcporter, DSL internals, or implementation details** unless the user asks. They deployed a trading agent — show them trading strategies, not plumbing.
+**DO NOT explain runtime internals, scanner plumbing, DSL implementation, or producer-daemon mechanics** unless the user asks. They deployed a trading agent — show them trading strategies, not plumbing. (For users who DO want to look under the hood: point them at `senpi-trading-runtime/SKILL.md`, which is the canonical reference.)
 
 **DO lead with the current top 2 strategies by ROE** from `get_leaderboard` as the default recommendation. Present both so the user makes an active choice. Always fetch fresh leaderboard data rather than assuming a fixed strategy is on top.
 

--- a/senpi-entrypoint/references/skill-recommendations.md
+++ b/senpi-entrypoint/references/skill-recommendations.md
@@ -1,51 +1,42 @@
 # Skill Recommendations
 
-When the user asks "what skills should I install?" or "what should I use for [goal]?",
-fetch the current catalog:
+When the user asks "what skills should I install?" or "what should I use for [goal]?", fetch the live strategy catalog from the senpi-agent-tracker MCP (see `references/post-onboarding.md` → "Show me the strategies" for the canonical call) and match their goal to the table below.
 
-```bash
-CATALOG=$(curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/catalog.json)
-```
-
-Then match their goal to the table below.
+Do NOT hardcode strategy names in this file. The active fleet changes; the table below is goal-to-pattern mapping, not goal-to-specific-strategy.
 
 ## Goal → Skill Mapping
 
-| User goal | Recommended skill | Min budget |
+| User goal | What to install | Notes |
 |---|---|---|
-| Best default — proven, works with any balance | FOX (`fox-strategy`) | $500 |
-| Trade range-bound markets / support & resistance | Viper (`viper`) | $500 |
-| Copy whale wallets automatically | Scorpion (`scorpion-strategy`) | $500 |
-| Leaderboard momentum — follow smart money early | Wolf (`wolf-strategy`) | $500 |
-| Funding rate arbitrage | Croc (`croc-strategy`) | $500 |
-| Triple-signal convergence (price + volume + new money) | Cobra (`cobra-strategy`) | $500 |
-| BTC only, maximum conviction, high leverage | Grizzly (`grizzly-strategy`) | $2,000 |
-| HYPE only, fastest asset | Cheetah (`cheetah-strategy`) | $1,000 |
-| 5 parallel scanners across 230 assets | Tiger (`tiger-strategy`) | $2,000 |
-| Contrarian — fade crowded trades at exhaustion | Owl (`owl-strategy`) | $1,000 |
-| Smart money consensus + liquidation front-running | Shark (`shark`) | $1,000 |
-| Multi-market scanner, single strongest signal | Hawk (`hawk-strategy`) | $1,000 |
-| FOX with higher conviction filters | Feral Fox (`feral-fox`) | $500 |
-| Feral Fox + infinite trailing stop | Ghost Fox (`ghost-fox`) | $500 |
-| Wolf in sniper mode, maker fees | Dire Wolf (`dire-wolf`) | $1,000 |
-| Viper + infinite trailing | Mamba (`mamba`) | $500 |
+| Build a new autonomous strategy from scratch | `senpi-trading-runtime` | The canonical runtime + DSL + Producer SDK. Use this when the user wants to author their own thesis rather than deploy an existing one. See `senpi-trading-runtime/SKILL.md` for the full build flow. |
+| Deploy a proven autonomous trading strategy | Top strategy from live leaderboard (sorted by ROE) | Fetch with `get_leaderboard` MCP call and recommend the top result whose `min_budget` ≤ the user's balance. |
+| Mirror a specific top trader (copy-trading) | `senpi-getting-started-guide` | Walks the user through `discovery_get_top_traders` + `strategy_create` to mirror one trader. The simplest first-trade path. |
+| Run multiple strategies in parallel | Top N strategies from live leaderboard | One strategy per wallet, isolated capital. Slot count by budget; see Budget Guidance below. |
 
 ## Budget Guidance
 
-| Balance | Recommended |
+Always fetch the live leaderboard via `get_leaderboard` and filter by each strategy's `min_budget` field. Recommend based on the user's balance:
+
+| Balance | Recommendation |
 |---|---|
-| < $500 | No catalog skill has min_budget below $500. Recommend funding to at least $500, then FOX or Viper. |
-| $500–$2,000 | FOX, Viper, Cobra, Scorpion, Wolf, Croc, Owl, Cheetah, Hawk, Shark, Dire Wolf |
-| $2,000–$5,000 | Any skill in the catalog |
-| > $5,000 | Grizzly, Bison, Tiger, or multi-skill deployment |
+| < $500 | Recommend funding to at least $500 before deploying any catalog strategy. Most active strategies have `min_budget` ≥ $500. |
+| $500 – $2,000 | Any active strategy with `min_budget` ≤ balance. Lead with the current #1 by ROE. |
+| $2,000 – $5,000 | Full catalog available. Lead with the current #1 by ROE. Multiple strategies in parallel become viable at this range. |
+| > $5,000 | Full catalog + multi-strategy deployment. Consider 2–3 strategies with different theses for diversification. |
 
 ## Presenting a Recommendation
 
-For each recommended skill, include:
-- Skill name + one-sentence description
-- Minimum budget
+For each recommended strategy, include:
+- Strategy name + one-line description (from `list_strategies` MCP)
+- Minimum budget (from leaderboard `min_budget` field)
+- Current ROE (from leaderboard `roe` field)
 - Install command: `npx skills add https://github.com/Senpi-ai/senpi-skills --skill <name> -g -y`
+
+For the "Build a new strategy" path:
+- Point them at `senpi-trading-runtime`'s SKILL.md as the build playbook
+- Mention `senpi-trading-runtime/references/producer-patterns.md` as the catalog of scanner archetypes they can choose from
+- Note: building a strategy requires Python familiarity and an LLM-decision-gate concept; not a 5-min path
 
 ## When Goal Is Unclear
 
-Ask one question: **"Are you looking to follow smart money, trade a specific asset, or have the agent scan everything autonomously?"** — then map their answer to the table above.
+Ask one question: **"Are you looking to deploy an existing strategy that's already running, mirror a specific trader you've identified, or build your own from scratch?"** — then map their answer to the table above.

--- a/senpi-getting-started-guide/references/next-steps.md
+++ b/senpi-getting-started-guide/references/next-steps.md
@@ -18,7 +18,9 @@ Use this for **celebration** (after first strategy is created), **after close** 
 >
 > **What you learned:** Discovery, mirroring a top trader, and creating a strategy.
 >
-> **Next:** Try "show my portfolio", "find opportunities", or install more skills — e.g. **Whale Index** to auto-mirror top traders, or **DSL** for protection.
+> **Next:** Try "show my portfolio", "find opportunities", or take one of these deeper paths:
+> - **Deploy a fully autonomous strategy** — Senpi runs a fleet of AI trading strategies live at strategies.senpi.ai. Say "show me the strategies" to pick one.
+> - **Build your own autonomous strategy** — Author a new strategy from scratch using `senpi-trading-runtime`, the canonical runtime + Producer SDK. Say "build a new strategy" and I'll walk you through.
 >
 > 🏆 **Feeling competitive?** Ask me about the **Agents Arena** — Senpi's weekly AI trading competition.
 
@@ -36,7 +38,7 @@ When the user closes their first strategy, show the result and suggest next step
 >
 > Result: +$X.XX (+X.XX%)
 >
-> **Next:** Explore more skills (DSL, Scanner, WOLF, Whale Index) or say "find opportunities" to discover more strategies.
+> **Next:** Say "show me the strategies" to deploy one of Senpi's live autonomous strategies, or "build a new strategy" to author your own using `senpi-trading-runtime`.
 
 **If loss:**
 
@@ -44,7 +46,7 @@ When the user closes their first strategy, show the result and suggest next step
 >
 > Result: -$X.XX (-X.X%). You kept size small and closed when you wanted.
 >
-> **Pro tip:** Install **DSL** for automatic protection. Say "find opportunities" to discover more.
+> **Pro tip:** Senpi's autonomous strategies (`senpi-trading-runtime`-based) come with built-in DSL trailing stop protection. Say "show me the strategies" to deploy one, or "find opportunities" to discover more.
 
 Update state: set `firstTrade.step: "STRATEGY_CLOSE"`, add `tradeDetails.closedAt`, `tradeDetails.pnl`, `tradeDetails.pnlPercent`, `tradeDetails.duration`. State remains `READY` with `firstTrade.completed: true` (already set when they created the strategy).
 

--- a/senpi-onboard/SKILL.md
+++ b/senpi-onboard/SKILL.md
@@ -369,7 +369,7 @@ Display a confirmation message that includes ALL of the following:
 3. **Referral link** -- `https://senpi.ai/skill.md?ref=<USER_REFERRAL_CODE>`
 4. **Credentials backup location** -- `~/.config/senpi/credentials.json`
 5. **Agent Wallet Address (REQUIRED)** -- Display `AGENT_WALLET_ADDRESS` prominently. Instruct user to fund it with USDC on a supported chain (Hyperliquid, Base, Arbitrum, Optimism, Polygon, or Ethereum). Without funds, the agent cannot trade.
-6. **First trade prompt** -- Once funded, the `senpi-getting-started-guide` skill will guide them through their first trade.
+6. **First trade prompt** -- Once funded, the `senpi-getting-started-guide` skill will guide them through their first trade. For users who want to author their own autonomous strategy (rather than walk through the first-trade mirror tutorial), point them at the `senpi-trading-runtime` skill — Senpi's canonical runtime + DSL + Producer SDK.
 7. **Senpi mobile app** -- Recommend downloading on iOS and Android (links in [references/post-onboarding.md](references/post-onboarding.md)).
 8. **Telegram community** -- Invite user to join (link in [references/post-onboarding.md](references/post-onboarding.md)).
 9. **Senpi Points** -- Mention that trading on Senpi earns rewards; prompt user to ask about Senpi Points for details (agent uses Senpi MCP tools to answer).


### PR DESCRIPTION
## Summary

Reorients the three onboarding skills (`senpi-entrypoint`, `senpi-getting-started-guide`, `senpi-onboard`) around `senpi-trading-runtime` as the canonical build-your-own-strategy path. Removes hardcoded references to deprecated capability skills and dormant strategy names.

(Replaces closed PR #268 — the prior branch accidentally committed local `.claude/worktrees/` artifacts. This PR is clean.)

## Why

Today's onboarding flow points users at skills that are about to be deleted in subsequent cleanup PRs (`dsl-dynamic-stop-loss`, `opportunity-scanner`, `emerging-movers`, `autonomous-trading`, `wolf-strategy`, `wolf-howl`, `whale-index`) and at dormant strategy skills that aren't in the active fleet. A new user following the onboarding flow today gets pointed at things that don't work or don't exist as canonical paths anymore.

This PR repaves the onboarding flow to:
1. **Lead with `senpi-trading-runtime`** as the canonical runtime + DSL + Producer SDK
2. **Stop hardcoding specific strategy names** in places that would drift (skill-recommendations.md goal table, post-onboarding.md slug-resolution examples)
3. **Defer to live MCP calls** (`list_strategies`, `get_leaderboard`) for any "what's in the fleet right now" question
4. **Add an explicit build-your-own-strategy path** that walks the user through `senpi-trading-runtime`'s YAML + Producer SDK + DSL flow

## Files changed (6 + .gitignore)

**`senpi-entrypoint/`** (4 files):
- `SKILL.md` — Step 4 "Expand" section now distinguishes Deploy vs Build paths
- `references/about-senpi.md` — Core Capabilities + Full Skill Catalog rewritten
- `references/skill-recommendations.md` — Goal->Skill table rewritten; Budget Guidance defers to live leaderboard
- `references/post-onboarding.md` — "Build a new strategy" flow now has explicit `senpi-trading-runtime` steps 1-4; slug-resolution + Catalog Rules cleaned

**`senpi-getting-started-guide/`** (1 file):
- `references/next-steps.md` — Celebrate + After Close sections no longer name dormant skills; point users at active fleet or `senpi-trading-runtime` build path

**`senpi-onboard/`** (1 file):
- `SKILL.md` — Step 7 confirmation message gains a one-liner for users who want to author their own strategy

**`.gitignore`** — added `.claude/` so local agent worktrees don't leak into future commits

## Forward dependency

`senpi-entrypoint/references/post-onboarding.md` now references `senpi-trading-runtime/references/producer-patterns.md` (the scanner-archetype catalog). That doc lands in PR #4 — until then the reference is forward-looking and will resolve once #4 merges.

## Test plan
- [x] Onboarding flow now has explicit Build-your-own-strategy path with concrete `senpi-trading-runtime` install + YAML + producer steps
- [x] No remaining hardcoded references to dormant strategy skills in any onboarding `.md`
- [x] All deferred-to-MCP-call paths (`list_strategies`, `get_leaderboard`) preserve the existing dynamic-fetch flow

## Part of broader cleanup

PR #3 of 10 in the senpi-skills cleanup series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)