### PR TITLE
cleanup: top-level README — align with merged deletions + runtime 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,25 +36,18 @@ Skills are versioned and MIT-licensed. Anyone can fork a skill, modify it, or bu
 ┌──────────────────────────────────▼───────────────────────────────────────┐
 │                        CAPABILITIES (this repo)                           │
 │                                                                            │
-│   senpi-trading-runtime  ─── Plugin runtime + Python Producer SDK                 │
+│   senpi-trading-runtime  ─── Plugin runtime + Python Producer SDK +        │
+│                              DSL exit engine + maker-first execution      │
 │                              Consumes: Strategy state, Position,           │
-│                              Execution, Audit MCP categories               │
-│                                                                            │
-│   dsl-dynamic-stop-loss  ─── DSL exit engine                              │
-│                              Phase 1 (max-loss + retrace) +                │
-│                              Phase 2 (ratcheting trailing)                 │
-│                              Consumes: Strategy state, Position MCP        │
+│                              Execution, Audit, Ratchet Stop MCP            │
 │                                                                            │
 │                              (Python Producer SDK — senpi_runtime_helpers │
 │                              — ships inside this skill: SenpiClient,       │
 │                              producer_daemon, fcntl lock)                  │
 │                                                                            │
-│   fee-optimizer          ─── When to ALO vs MARKET                         │
-│   shared                 ─── Hyperfeed scoring primitives                  │
-│   opportunity-scanner    ─── 4-stage funnel: 500 perps → top               │
-│   emerging-movers        ─── SM market-rank acceleration                   │
-│   whale-index            ─── Top-trader notional aggregator                │
-│                              Consume: Discovery, Hyperfeed, Market data    │
+│                              Producer/scanner archetype catalog →          │
+│                              senpi-trading-runtime/references/             │
+│                              producer-patterns.md                          │
 │                                                                            │
 │   senpi-entrypoint, senpi-onboard, senpi-getting-started-guide             │
 │                              Onboarding + setup flows                      │
@@ -64,7 +57,7 @@ Skills are versioned and MIT-licensed. Anyone can fork a skill, modify it, or bu
 ┌──────────────────────────────────▼───────────────────────────────────────┐
 │                  TRADING STRATEGY SKILLS (this repo)                      │
 │                                                                            │
-│   ~40 self-contained skills, one per directory                             │
+│   26 self-contained skills, one per directory                              │
 │   Each: producer/scanner script + runtime.yaml + SKILL.md                  │
 │                                                                            │
 │   Bucketed below by trading thesis, not asset class.                       │
@@ -93,77 +86,40 @@ Every capability is a thin layer over a specific slice of the Senpi MCP surface.
 | Capability | MCP categories used | Key tools touched |
 |---|---|---|
 | `senpi-trading-runtime` | Strategy state · Position · Execution · Audit · Ratchet Stop | `strategy_get_clearinghouse_state`, `create_position`, `edit_position`, `close_position`, `cancel_order`, `execution_get_open_position_details`, `audit_query`, `ratchet_stop_*` |
-| `dsl-dynamic-stop-loss` | Strategy state · Position · Ratchet Stop | `strategy_get_clearinghouse_state`, `ratchet_stop_add`, `ratchet_stop_edit`, `ratchet_stop_events`, `close_position` |
-| `senpi_runtime_helpers` (ships with `senpi-trading-runtime`) | ALL — the in-process client wraps every MCP tool | `mcp_call(tool, **params)` — generic dispatch over the full 68-tool surface |
-| `fee-optimizer` | Market data · Position | `market_get_asset_data`, `create_position` (FEE_OPTIMIZED_LIMIT params) |
-| `shared` (`hyperfeed_scoring`) | Hyperfeed · Discovery | `leaderboard_get_top`, `leaderboard_get_trader`, `discovery_get_top_traders` |
-| `opportunity-scanner` | Hyperfeed · Discovery · Market data | `leaderboard_get_markets`, `discovery_get_top_traders`, `market_get_asset_data`, `market_get_funding_regime` |
-| `emerging-movers` | Hyperfeed | `leaderboard_get_markets`, `leaderboard_get_momentum_events` |
-| `whale-index` | Hyperfeed · Discovery | `leaderboard_get_top`, `leaderboard_get_trader_positions`, `discovery_get_trader_state` |
-| `autonomous-trading` | Strategy lifecycle · Position · Account | `strategy_create_custom_strategy`, `strategy_top_up`, `account_get_portfolio`, `create_position`, `close_position` |
+| `senpi_runtime_helpers` (ships inside `senpi-trading-runtime`) | ALL — the in-process client wraps every MCP tool | `mcp_call(tool, **params)` — generic dispatch over the full 68-tool surface |
 | `senpi-entrypoint`, `senpi-onboard`, `senpi-getting-started-guide` | User & rewards · Account · Strategy lifecycle · Documentation | `user_get_me`, `account_get_portfolio`, `strategy_create`, `list_senpi_guides`, `read_senpi_guide` |
 
 Detail on each capability follows. The full tool surface is enumerated in the **Senpi MCP — Tool Reference** section below.
 
-## `senpi-trading-runtime/` — Plugin Runtime
+## `senpi-trading-runtime/` — Plugin Runtime (`@senpi/runtime` 1.1.0)
 
-The OpenClaw plugin that owns the trading loop. Replaces the legacy Python cron + state file system.
+The canonical OpenClaw plugin that owns the trading loop. Every active strategy in this repo targets this runtime via its `runtime.yaml`.
 
-Two major versions exist; a skill targets one of them via its `runtime.yaml`:
+What the runtime provides out of the box:
 
-- **Runtime 1.0** — Python DSL cron, fcntl-locked producer scripts, openclaw subprocess for MCP calls. Most skills in this repo run on 1.0.
-- **senpi-trading-runtime** — In-process producer daemon, direct HTTPS to MCP, declarative `risk.guard_rails`, native FEE_OPTIMIZED_LIMIT entries + exits, trade-chain DB telemetry. New skills target 2.0 by default.
+- **In-process producer daemon** — long-lived scoring loop with built-in fcntl reentrancy guard, tick telemetry, graceful shutdown.
+- **Two-phase DSL exit engine** — Phase 1 (max-loss + consecutive-breach + retrace) cuts losing trades early; Phase 2 (ratcheting trailing stop with tiered locks, e.g. +10%/35%, +20%/55%, +35%/70% of high-water margin ROE) lets winners run while locking incremental gains.
+- **Native FEE_OPTIMIZED_LIMIT execution** — maker-first entries and exits via Hyperliquid ALO.
+- **Declarative risk gates** — `risk.guard_rails` covers daily loss caps, drawdown halts, consecutive-loss cooldowns, per-asset cooldowns.
+- **Position tracker** — runs every 10s, reconciles live HL state with internal DSL state.
+- **Trade-chain DB telemetry** — every action / inaction recorded with full reasoning for `audit_query` lookback.
 
-Runtime version is determined by which plugin is loaded on the operator's host, not by which features the YAML declares.
+**Producer/scanner archetype catalog:** [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md) — the 11 distinct producer archetypes deployed across the fleet (universe trend-follower, Kodiak-family single-asset, multi-asset whitelist, trader-follower, striker, funding-regime fade, contrarian unwind, cross-asset lag, XYZ contrarian fader, volume engine), each linked to a working example agent's `producer.py` + `_config.py` + `runtime.yaml`. Pick a pattern, fetch the three files, swap the scoring logic, deploy.
 
-## `dsl-dynamic-stop-loss/` — DSL Exit Engine
+## `senpi_runtime_helpers` — Python Producer SDK (ships inside `senpi-trading-runtime`)
 
-Two-phase exit logic with no Python state files:
+The Python SDK every fleet producer imports. Ships inside the `senpi-trading-runtime` skill (`senpi-trading-runtime/senpi_runtime_helpers/`) — installing the runtime skill installs the SDK.
 
-- **Phase 1** — max-loss + consecutive-breach + retrace. Cuts losing trades early.
-- **Phase 2** — ratcheting trailing stop with tiered locks (e.g. +10%/35%, +20%/55%, +35%/70% of high-water margin ROE). Lets winners run while locking incremental gains.
-- **Optional time cuts** — hard_timeout, weak_peak_cut, dead_weight_cut. Single-asset agents typically disable time cuts to avoid the v1 DSL Phase 2 hard-timeout misfire.
-
-Used by every active trading skill in the repo.
-
-## `senpi_runtime_helpers` — Python Producer SDK (ships with `senpi-trading-runtime`)
-
-The Python SDK every helpers-native producer imports. Ships inside the `senpi-trading-runtime` skill (`senpi-trading-runtime/senpi_runtime_helpers/`) — installing the runtime skill installs the SDK.
-
-- `SenpiClient` — direct HTTPS to MCP (no `mcporter` / `openclaw` subprocess shell-out) and direct POST to runtime `/signals`.
+- `SenpiClient` — direct HTTPS to MCP (no subprocess shell-out) and direct POST to runtime `/signals`.
 - `producer_daemon(fn, interval_seconds, name, tick_timeout)` — long-lived loop with built-in fcntl reentrancy guard, structured tick telemetry, signal-handled graceful shutdown.
 - `log_event` / `cache` / `parallel` — shared logging schema, simple TTL cache, parallel MCP fan-out.
 - `senpi-helpers` operator CLI — list / health / stats / stop / restart for producer daemons.
-
-## `fee-optimizer/` — Order-type Decision Skill
-
-When to use FEE_OPTIMIZED_LIMIT (ALO maker) vs MARKET orders on Hyperliquid. Standard params for entry / exit / take-profit. Loaded as a side skill at deploy time; most strategy skills already encode their choice in `runtime.yaml`.
-
-## `shared/` — Hyperfeed Scoring Primitives
-
-`hyperfeed_scoring.py` — reusable scoring components used by multiple strategy skills (rank-velocity, contribution-velocity, drawdown rejection). Pure stdlib.
-
-## `opportunity-scanner/` — Universe-narrowing Funnel
-
-Four-stage funnel that screens all 500+ Hyperliquid perps down to a top-N opportunity list. Scores 0–400 across Smart Money, market structure, technical setup, and fundamentals. Strategy skills can consume the output as one of multiple inputs.
-
-## `emerging-movers/` — SM Rank Acceleration
-
-Lightweight scanner that tracks Smart Money market-concentration rank changes across all Hyperliquid assets. Flags assets accelerating up the ranks before consensus solidifies.
-
-## `whale-index/` — Top-Trader Notional Aggregator
-
-Per-asset rollup of top-trader notional positioning. Useful as a confluence input for strategies that already have a primary signal.
 
 ## Onboarding & setup
 
 - `senpi-entrypoint/` — Onboard an AI agent end-to-end (account, API key, MCP config, first skill install).
 - `senpi-getting-started-guide/` — Guides a user through their first trade (mirror or custom strategy).
 - `senpi-onboard/` — Account + API-key + MCP-server setup only.
-
-## `autonomous-trading/` — Budget/Target/Deadline Orchestrator
-
-Gives an agent a budget, a target, and a deadline; orchestrates DSL + Opportunity Scanner + Emerging Movers into a full lifecycle. Higher-level than any individual strategy skill.
 
 ---
 
@@ -319,110 +275,90 @@ Each tool's full schema (params, types, response shape) is in the MCP server its
 
 Each strategy is a directory at the repo root. The bucketing below is by **how the strategy decides what to trade**, not by which asset it ends up on. A skill belongs to one bucket only.
 
-Each row links to the skill's own README and notes the runtime version it targets.
+Every active skill targets the canonical `@senpi/runtime` 1.1.0 plugin (the `senpi-trading-runtime` skill). Each row links to the skill's own README.
 
 ## Single-asset alpha hunters (Kodiak family)
 
 Patient, single-asset specialists. One ticker per skill, deep wall of confluence required before entry, DSL Phase 2 set to ride winners.
 
-| Skill | Asset | Runtime | One-liner |
-|---|---|---|---|
-| [kodiak](kodiak/) | SOL | 2.0 | SOL alpha hunter — base technical score + trend strength gates |
-| [grizzly](grizzly/) | BTC | 2.0 | BTC alpha hunter — Kodiak template, BTC-specific tuning |
-| [polar](polar/) | ETH | 2.0 | ETH alpha hunter — hybrid hyperfeed + structural veto |
-| [wolverine](wolverine/) | HYPE | 2.0 | HYPE alpha hunter — Kodiak template ported to native HYPE |
+| Skill | Asset | One-liner |
+|---|---|---|
+| [kodiak](kodiak/) | SOL | SOL alpha hunter — base technical score + trend strength gates |
+| [grizzly](grizzly/) | BTC | BTC alpha hunter — Kodiak template, BTC-specific tuning |
+| [polar](polar/) | ETH | ETH alpha hunter — hybrid hyperfeed + structural veto |
+| [wolverine](wolverine/) | HYPE | HYPE alpha hunter — Kodiak template ported to native HYPE |
 
 ## XYZ-market specialists
 
 Trade Hyperliquid's HIP-3 `xyz:*` perps — equities, commodities, indices, metals. 24/7 markets, different spread / funding profile than crypto.
 
-| Skill | Universe | Runtime | One-liner |
-|---|---|---|---|
-| [bald-eagle](bald-eagle/) | XYZ macro | 1.0 | Wide DSL timings tuned for macro-asset rhythm |
-| [kestrel](kestrel/) | XYZ macro | 2.0 | Macro breakout rider on commodities/indices/equities |
-| [dire](dire/) | xyz:BRENTOIL | 1.0 | BRENTOIL specialist — news-driven oil momentum |
+| Skill | Universe | One-liner |
+|---|---|---|
+| [bald-eagle](bald-eagle/) | XYZ macro | Wide DSL timings tuned for macro-asset rhythm |
+| [kestrel](kestrel/) | XYZ macro | Macro breakout rider on commodities/indices/equities |
+| [dire](dire/) | xyz:BRENTOIL | BRENTOIL specialist — news-driven oil momentum |
 
 ## Multi-signal confluence
 
 Combine multiple independent signals (SM concentration, trend, funding, structure) and only enter when several agree.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [cheetah](cheetah/) | 2.0 | Multi-signal confluence sniper — strict gate, lower frequency, higher quality |
-| [condor](condor/) | 1.0 | "One amazing trade per day" — high-conviction momentum |
-| [sentinel](sentinel/) | 1.0 | Quality-trader convergence scanner |
-| [hawk](hawk/) | 1.0 | Multi-asset momentum bot |
+| Skill | One-liner |
+|---|---|
+| [cheetah](cheetah/) | Multi-signal confluence sniper — strict gate, lower frequency, higher quality |
+| [condor](condor/) | "One amazing trade per day" — high-conviction momentum |
 
 ## Smart-Money signal followers
 
 Watch the top-trader cohort and either mirror or stalk their positions with our own DSL + risk overlay.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [jackal](jackal/) | 2.0 | Smart Stalker — LLM-gated mirror of top-trader entries |
-| [spider](spider/) | 2.0 | Patient anchor — single long-side position, 7+ day hold |
-| [vulture](vulture/) | 2.0 | Long-tail momentum rider — pre-arms Phase 2 tier-2 trailing |
+| Skill | One-liner |
+|---|---|
+| [jackal](jackal/) | Smart Stalker — LLM-gated mirror of top-trader entries |
+| [spider](spider/) | Patient anchor — single long-side position, 7+ day hold |
+| [vulture](vulture/) | Long-tail momentum rider — pre-arms Phase 2 tier-2 trailing |
 
 ## Contrarian / faders
 
 Bet against crowded positioning. Funding extremes, exhaustion, late-cycle SM crowding.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [pangolin](pangolin/) | 2.0 | Funding rate fader — strikes against extreme funding |
-| [owl](owl/) | 1.0 | Pure contrarian — crowding-unwind plays |
-| [Grizzly-Horribilis](Grizzly-Horribilis/) | 1.0 | BTC contrarian sniper |
-| [bison](bison/) | 1.0 | Conviction holder — wide bands, ratchet trailing |
-| [lemon](lemon/) | 1.0 | Degen fader — counter-trade CHOPPY traders at peaks |
-| [dog](dog/) | 1.0 | Multi-asset SM-exhaustion fader |
+| Skill | One-liner |
+|---|---|
+| [pangolin](pangolin/) | Funding rate fader — strikes against extreme funding |
+| [owl](owl/) | Pure contrarian — crowding-unwind plays |
+| [bison](bison/) | Conviction holder — wide bands, ratchet trailing |
+| [lemon](lemon/) | Degen fader — counter-trade CHOPPY traders at peaks |
+| [dog](dog/) | Multi-asset SM-exhaustion fader |
 
 ## Striker / rank-jump
 
 Enter on rank acceleration or trend ignition. High frequency, tight DSL, fast exits.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [roach](roach/) | 2.0 | Striker-only — Stalker disabled, position discipline |
-| roach-b (variant) | 2.0 | Striker-only variant B — A/B partner to Roach |
-| [jaguar](jaguar/) | 1.0 | Hot-streak striker — rank-jump scanner |
-| [raptor](raptor/) | 1.0 | Hot streak follower |
-| [orca](orca/) | 1.0 | Gen-2 striker with FIRST_JUMP detection |
-| [cobra](cobra/) | 1.0 | Arena sprint predator — single-asset, concentrated margin |
+| Skill | One-liner |
+|---|---|
+| [roach](roach/) | Striker-only — Stalker disabled, position discipline |
+| roach-b (variant) | Striker-only variant B — A/B partner to Roach |
+| [jaguar](jaguar/) | Hot-streak striker — rank-jump scanner |
+| [raptor](raptor/) | Hot streak follower |
+| [orca](orca/) | Gen-2 striker with FIRST_JUMP detection |
 
-## Macro / regime-aware
+## Cross-asset / regime detection
 
-Cross-asset, regime detection, range-bound liquidity capture. Don't require a single primary signal.
+Macro-aware setups that anchor on BTC moves and hunt for laggards.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [mantis](mantis/) | 1.0 | Cross-asset catchup hunter — BTC lead → correlated alts |
-| [mamba](mamba/) | 1.0 | Range-bound + regime protection |
-| [viper](viper/) | 1.0 | Range-bound liquidity sniper |
-| [komodo](komodo/) | 1.0 | Momentum event consensus |
-
-## Velocity / pattern detection
-
-Detect emerging acceleration before consensus solidifies.
-
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [phoenix](phoenix/) | 1.0 | Contribution velocity scanner — SM profit accel vs price |
-| [hydra](hydra/) | 1.0 | Squeeze detector |
-| [vixen](vixen/) | 1.0 | Multi-asset trend scanner |
-| [shark](shark/) | 1.0 | Position tracker + liquidation cascade scanner |
-| [rhino](rhino/) | 1.0 | Momentum pyramider |
-| [barracuda](barracuda/) | 1.0 | Funding decay collector |
+| Skill | One-liner |
+|---|---|
+| [mantis](mantis/) | Cross-asset catchup hunter — BTC lead → correlated alt laggards |
 
 ## Specialized missions
 
 Unique theses that don't fit the buckets above.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [turbine](turbine/) | 2.0 | Volume-rotation engine — builder-fee farming on maker-only rotation across two strategy wallets |
-| [otter](otter/) | 2.0 | Open Interest velocity hunter — 1h OI delta with price confirmation |
-| [python](python/) | 1.0 | Patient multi-asset scanner — multi-day hold |
-| [scorpion](scorpion/) | 2.0 | Multi-market active trader — both crypto AND XYZ commodities |
+| Skill | One-liner |
+|---|---|
+| [turbine](turbine/) | Volume-rotation engine — builder-fee farming on maker-only rotation across two strategy wallets |
+| [otter](otter/) | Open Interest velocity hunter — 1h OI delta with price confirmation |
+| [python](python/) | Patient multi-asset scanner — multi-day hold |
+| [scorpion](scorpion/) | Multi-market active trader — both crypto AND XYZ commodities |
 
 ---
 
@@ -432,36 +368,24 @@ Unique theses that don't fit the buckets above.
 senpi-skills/
 ├── README.md                       ← this file
 ├── CLAUDE.md                       ← repo conventions for Claude agents
-├── DSL-MIGRATION-PLAYBOOK.md       ← Runtime 1 → 2 migration notes
 ├── catalog.json                    ← skill registry
 │
 ├── senpi-trading-runtime/          ╮
-│   └── senpi_runtime_helpers/      │ ← Python Producer SDK bundled with runtime
-├── dsl-dynamic-stop-loss/          │
-├── fee-optimizer/                  │ Capabilities (see top of this README)
-├── shared/                         │
-├── opportunity-scanner/            │
-├── emerging-movers/                │
-├── whale-index/                    │
-├── autonomous-trading/             │
-├── senpi-entrypoint/               │
+│   ├── senpi_runtime_helpers/      │
+│   └── references/
+│       └── producer-patterns.md    │ ← 11-archetype producer/scanner catalog
+├── senpi-entrypoint/               │ Capabilities (see top of this README)
 ├── senpi-getting-started-guide/    │
 └── senpi-onboard/                  ╯
 │
 ├── kodiak/  grizzly/  polar/  wolverine/      ╮
-├── cheetah/ condor/   sentinel/ hawk/         │
+├── cheetah/ condor/                           │
 ├── jackal/  spider/   vulture/                │
-├── pangolin/ owl/  bison/  lemon/  dog/       │
-├── Grizzly-Horribilis/                        │
-├── roach/   jaguar/  raptor/  orca/  cobra/   │ Trading Strategy Skills
-├── mantis/  mamba/   viper/   komodo/         │
-├── phoenix/ hydra/   vixen/   shark/  rhino/  │
-├── barracuda/                                 │
+├── pangolin/ owl/    bison/  lemon/  dog/     │
+├── roach/   jaguar/  raptor/  orca/           │ Trading Strategy Skills
+├── mantis/                                    │
 ├── turbine/ otter/   python/   scorpion/      │
 ├── bald-eagle/  kestrel/  dire/               ╯
-│
-└── (legacy strategy proposals: feral-fox-v3-strategy.md, ghost-fox-*,
-    tiger-strategy/, wolf-strategy/, wolf-howl/ — kept for reference)
 ```
 
 Each strategy directory contains:
@@ -483,7 +407,7 @@ Each strategy directory contains:
 
 1. Deploy an [OpenClaw](https://openclaw.ai) agent and configure Senpi MCP access.
 2. Pick a strategy skill from the buckets above. Read its `README.md`.
-3. Install the senpi-trading-runtime plugin per the skill's requirement. Producer-based skills additionally need the `senpi-trading-runtime` skill installed (`npx skills add … --skill senpi-trading-runtime -g -y`) — it ships the Python Producer SDK (`senpi_runtime_helpers`) the producer imports.
+3. Install the `senpi-trading-runtime` skill (`npx skills add … --skill senpi-trading-runtime -g -y`) — it ships the canonical runtime plugin plus the Python Producer SDK (`senpi_runtime_helpers`) the strategy's producer imports.
 4. Pull the skill's scripts + `runtime.yaml` from main into your host workspace.
 5. Set the required env vars (`<SKILL>_WALLET`, `SENPI_AUTH_TOKEN`, and optionally a `<SKILL>_DECISION_MODEL` for LLM-gated actions).
 6. Start the producer daemon per the skill's README.
@@ -498,11 +422,12 @@ Each strategy directory contains:
 
 Each skill is self-contained. To build a new one:
 
-1. Start from a producer-based skill (`kodiak/`, `cheetah/`, or `roach/`) as a template.
-2. Replace the producer's signal-generation logic with your thesis.
-3. Tune `runtime.yaml` — universe, score thresholds, DSL config, risk guard-rails.
-4. Document in `SKILL.md` (frontmatter) and `README.md` (operator-facing).
-5. Submit a PR.
+1. Pick the archetype that matches your thesis from [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md). The catalog maps each archetype to a working example agent and links its `producer.py` + `_config.py` + `runtime.yaml`.
+2. Copy the structure from the example agent.
+3. Replace the producer's signal-generation logic with your thesis.
+4. Tune `runtime.yaml` — universe, score thresholds, DSL config, risk guard-rails.
+5. Document in `SKILL.md` (frontmatter) and `README.md` (operator-facing).
+6. Submit a PR.
 
 Bucketing in this README is by thesis, not asset. New skills should add themselves to whichever bucket fits, or open a new one if the thesis is genuinely novel.
 


### PR DESCRIPTION
## Summary

Reflects the state of main after PRs #266-#276 landed (capability/strategy cleanup PRs). Top-level README had ~15 stale references to deleted directories and obsolete Runtime 1.0 vs 2.0 framing.

- **Capabilities section** — drop sections, at-a-glance rows, and repo-layout entries for: \`dsl-dynamic-stop-loss\`, \`fee-optimizer\`, \`shared\`, \`opportunity-scanner\`, \`emerging-movers\`, \`whale-index\`, \`autonomous-trading\`, and \`DSL-MIGRATION-PLAYBOOK.md\`.
- **Strategy buckets** — drop deleted skills: sentinel, hawk, cobra, Grizzly-Horribilis, mamba, viper, komodo, phoenix, hydra, vixen, shark, rhino, barracuda. Remove the now-empty "Velocity / pattern detection" bucket. Rename "Macro / regime-aware" → "Cross-asset / regime detection" (mantis only).
- **Runtime version** — drop the Runtime 1.0 vs 2.0 fork framing. Every active skill targets canonical \`@senpi/runtime\` 1.1.0. Drop the Runtime column from every bucket table.
- **Producer-patterns catalog** — reference \`senpi-trading-runtime/references/producer-patterns.md\` in three places (architecture diagram, runtime capability section, Contributing block) as the canonical starting point for new strategies.
- **Skill count** — "~40 self-contained skills" → "26" to match what's actually in the repo.

## Test plan

- [ ] Render README on GitHub and confirm no broken links to deleted directories
- [ ] Confirm all 26 surviving skill directories appear in exactly one bucket
- [ ] Confirm producer-patterns.md link works once PR #270 merges
- [ ] Confirm architecture diagram capabilities box is accurate vs current repo contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)