### PR TITLE
cleanup: rewrite SKILL.md descriptions for public website + Otter README

### DIFF
--- a/bald-eagle/SKILL.md
+++ b/bald-eagle/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: bald-eagle-strategy
 description: >-
-  BALD EAGLE v5.0 — XYZ Contrarian Fader (senpi_runtime_helpers). Counter-
-  trades SM consensus on 6 high-liquidity XYZ macro assets (CL, BRENTOIL,
-  GOLD, SILVER, SP500, XYZ100) when SM concentration is high AND the 4h
-  move is exhausting. Plumbing-only migration from v4.1: producer pushes
-  signals via SenpiClient.push_signal, runtime owns execution + daily caps
-  + cooldowns + drawdown halt + DSL exits. Thesis preserved verbatim.
+  XYZ contrarian fader. Plays the XYZ DEX exclusively — counter-trades
+  SM consensus on 6 high-liquidity macro assets (CL, BRENTOIL, GOLD,
+  SILVER, SP500, XYZ100) when the move is exhausting. Wide DSL gives
+  macro reversals time to develop.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/bison/SKILL.md
+++ b/bison/SKILL.md
@@ -1,13 +1,10 @@
 ---
 name: bison-strategy
 description: >-
-  BISON v3.0.0 — Conviction Holder, senpi_runtime_helpers migration.
-  Plumbing-only flip from openclaw cron + mcporter subprocess to
-  in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST to
-  runtime /signals, long-lived producer_daemon). Thesis preserved
-  verbatim from v2.1: BTC/ETH/SOL asset whitelist, MIN_SCORE 11,
-  conviction-scaled margin (25%/31%/37%), wide DSL with time-cuts
-  DISABLED. Fewer trades, longer holds, bigger moves.
+  Conviction holder on a tight BTC/ETH/SOL whitelist. Fewer trades,
+  longer holds, bigger moves. Demands a high score from 5+ independent
+  components — won't fire on weak setups in small-caps where rotation
+  agents grind fees.
 license: Apache-2.0
 metadata:
   author: jason-goldberg

--- a/cheetah/SKILL.md
+++ b/cheetah/SKILL.md
@@ -1,16 +1,11 @@
 ---
 name: cheetah-strategy
 description: >-
-  CHEETAH v7.0.0 — Multi-signal confluence sniper, senpi_runtime_helpers
-  migration. Plumbing-only flip from openclaw-CLI subprocess + mcporter
-  subprocess to in-process SenpiClient (direct HTTPS for MCP, direct
-  HTTP POST to runtime /signals, long-lived producer_daemon). Thesis
-  preserved verbatim from v6.1: refuses to trade unless ALL major
-  signals align — SM consensus, velocity, acceleration, dual price
-  confirmation, volume spike, quality-trader alignment, rank climb.
-  Score 10/15 floor, score-scaled leverage (3x/5x/7x/8x),
-  FEE_OPTIMIZED_LIMIT entries AND exits, held-asset dedup, post-close
-  cooldown.
+  Multi-signal confluence sniper. Scores 7 independent signals — SM
+  consensus + velocity + acceleration + dual price confirmation +
+  volume spike + quality-trader alignment + rank climb — and only
+  fires when the confluence is strong (MIN_SCORE 10 / max 15). Patience
+  is the edge.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/condor/SKILL.md
+++ b/condor/SKILL.md
@@ -1,14 +1,10 @@
 ---
 name: condor-strategy
 description: >-
-  CONDOR v4.0.0 — One Amazing Trade per Day, senpi_runtime_helpers
-  migration. Plumbing-only flip from openclaw cron + mcporter
-  subprocess to in-process SenpiClient (direct HTTPS for MCP, direct
-  HTTP POST to runtime /signals, long-lived producer_daemon). Thesis
-  preserved verbatim from v3.4: top 50 HL assets, 3TF alignment hard
-  gate + MACRO_TREND_GATE + SM consensus >=70%, MIN_SCORE 12,
-  score-scaled sizing (50%/70%/80%), 10x leverage cap, 6-tier DSL
-  ladder from Kodiak SOL empirical wins.
+  One amazing trade per day. Hunts the highest-conviction trend
+  continuation across the top 50 HL assets — 3-timeframe alignment,
+  ≥70% SM concentration, clean macro tape, MIN_SCORE 12 floor. Most
+  days, Condor stays flat.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/dire/SKILL.md
+++ b/dire/SKILL.md
@@ -1,18 +1,10 @@
 ---
 name: dire-strategy
 description: >-
-  DIRE v2.0.0 — BRENTOIL XYZ specialist, helpers-native rewrite (2026-05-12).
-  Plumbing-only migration from v1.7.0: producer + v2 runtime
-  (Wolverine v5 / Grizzly v6 / Polar / Kodiak template). NO thesis change.
-  The scanner becomes a producer that emits signals via
-  SenpiClient.push_signal(); the v2 runtime owns execution, DSL exits, and
-  risk guard rails. v1.7.0 thesis preserved verbatim: 4TF alignment hard
-  gate, SM HARD BLOCK via mark/oracle premium proxy, OI velocity scoring,
-  volume spike scoring, price cleanliness check, MIN_SCORE 11, ALL FIVE
-  soft confirmations required (FP-003), FP-001 quiet hours (00-04 UTC
-  unless apex 12+), conviction-scaled sizing (3x / 5x / 7x / 10x by score),
-  DSL preset with v1.7 T0/T1 patch (T0 5%/35% lock, T1 8%/50%). First
-  Kodiak-family port to a non-crypto asset.
+  BRENTOIL XYZ specialist. The first non-crypto port of the Kodiak
+  family — adapts the six-gate alpha-hunter pattern to oil's
+  geopolitical-news-driven cadence. Tighter drawdown halt (15%) than
+  crypto siblings to account for oil's harsher tail risk.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/dog/SKILL.md
+++ b/dog/SKILL.md
@@ -1,14 +1,10 @@
 ---
 name: dog-strategy
 description: >-
-  DOG v3.0.0 — Contrarian Pup (SM Exhaustion Fader), senpi_runtime_helpers
-  migration. Plumbing-only flip from openclaw-CLI subprocess + mcporter
-  subprocess + Python state to in-process SenpiClient (direct HTTPS for
-  MCP, direct HTTP POST to runtime /signals, long-lived producer_daemon).
-  Thesis preserved verbatim from v2.5: multi-asset (BTC/ETH/SOL/HYPE)
-  contrarian fader, 3.0% exhaustion gate, regime hard-gate, 15m freshness
-  gate, MIN_SCORE 8, conservative leverage (7x base, 10x at score 12+),
-  wide DSL for reversal development.
+  Multi-asset SM-exhaustion fader. Scans BTC/ETH/SOL/HYPE every 3
+  minutes, identifies the dominant top-trader side, fires OPPOSITE
+  when the 4h move is stretched (≥3%) AND SM is still building.
+  Catches the window before the crowded trade pukes.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/grizzly/SKILL.md
+++ b/grizzly/SKILL.md
@@ -1,18 +1,10 @@
 ---
 name: grizzly-strategy
 description: >-
-  GRIZZLY v7.0.0 — BTC alpha hunter, senpi_runtime_helpers migration.
-  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
-  to in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST to
-  runtime /signals, long-lived producer_daemon). Thesis preserved
-  verbatim from v6.0.0: BTC single-asset trend hunter, six-gate entry
-  validation including v5.5 macro V-recovery gate (block fades within
-  1.25% of 24h extreme), RSI hard gates (70/30 — BTC-tuned),
-  multi-factor scoring (~17 max), conviction-scaled leverage (7x
-  default / 10x conviction / 10x apex), MIN_SCORE 12, FP-001 quiet
-  hours, FP-003 requireAllConfirmations gate. Trades WITH SM consensus
-  and trend, NOT contrarian. Family member alongside Kodiak (SOL),
-  Wolverine (HYPE), Polar (ETH).
+  Single-asset BTC alpha hunter. Trades WITH smart money consensus when
+  BTC's 4h/1h/15m/5m momentum is unified in one direction. Six-gate
+  entry validation including a macro V-recovery gate. Not a contrarian
+  — SM-opposes is a hard block.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/jackal/SKILL.md
+++ b/jackal/SKILL.md
@@ -1,16 +1,10 @@
 ---
 name: jackal-tracker
 description: >-
-  JACKAL v3.0.0 — The Smart Stalker (senpi_runtime_helpers migration).
-  Plumbing-only port from v2.0: producer rewritten on
-  `senpi_runtime_helpers` (in-process SenpiClient, no openclaw / mcporter
-  subprocesses). NO thesis change. Architecture is identical to v2: pure
-  producer + external_scanner + LLM-gated OPEN_POSITION action +
-  declarative risk guardrails + runtime-managed DSL. Producer observes
-  top-performing Senpi traders, detects new entries by pool members,
-  enriches with consensus + TA + funding context, and lets an LLM
-  (operator-selected via `$JACKAL_DECISION_MODEL`) evaluate each
-  candidate before the runtime executes with our own DSL.
+  Smart-money stalker. Watches the top 25 Senpi perp traders, detects
+  new entries within 10 minutes of fill, and gates each candidate
+  through an LLM second-opinion (consensus + TA + funding + freshness)
+  before committing. Not a passive copy-trader — the gate is the edge.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/jaguar/SKILL.md
+++ b/jaguar/SKILL.md
@@ -1,16 +1,11 @@
 ---
 name: jaguar-strategy
 description: >-
-  JAGUAR v4.0.0 — Striker (rank-jump detector), senpi_runtime_helpers
-  migration. Plumbing-only flip from openclaw-CLI subprocess +
-  mcporter subprocess + cron-driven self-executing scanner to
-  in-process SenpiClient + long-lived producer_daemon + helpers-native
-  push_signal. Thesis preserved verbatim from v3.7: violent
-  FIRST_JUMP signals, rank-jump ≥ 10, MIN_SCORE 9, conviction-scaled
-  leverage (10x apex / 7x conviction), 15m velocity hard gate, $3M
-  day-notional liquidity floor, XYZ ban, one-amazing-trade-per-day
-  discipline. Risk policy: max 3 entries/day when day is RED,
-  unlimited when GREEN (cap losers, ride winners).
+  Rank-jump explosion hunter. Fires when an asset rockets 10+ ranks
+  toward the top of the Smart Money leaderboard (from rank 20+ to
+  rank 11+) with active velocity build and 4h price agreement.
+  Asymmetric discipline by P&L state — capped at 3 entries on RED days,
+  unlimited on GREEN.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/kestrel/SKILL.md
+++ b/kestrel/SKILL.md
@@ -1,15 +1,10 @@
 ---
 name: kestrel-strategy
 description: >-
-  KESTREL v3.0.0 — XYZ Macro Breakout Rider (senpi_runtime_helpers
-  migration). Plumbing-only port from v2.0. NO thesis change. NO
-  scoring change. NO threshold change. Producer ports onto
-  `senpi_runtime_helpers` (in-process SenpiClient + direct HTTP POST
-  to runtime /signals + producer_daemon long-lived loop). Detects
-  >=1.5% hourly price breakouts on commodities, indices, and
-  high-volume equities 24/7 on Hyperliquid XYZ DEX. LLM regime gate +
-  FEE_OPTIMIZED_LIMIT entries/exits + held-asset dedup + post-close
-  cooldown + chain DB telemetry. Conservative 3-5x leverage.
+  XYZ macro breakout rider. Rides 1H breakouts (≥1.5% with volume
+  confirmation) on commodities, indices, and high-volume equities —
+  24/7 on Hyperliquid XYZ including weekends. Wide DSL for the 1-3
+  hour follow-through.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/kodiak/SKILL.md
+++ b/kodiak/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: kodiak-strategy
 description: >-
-  KODIAK v7.0.0 — SOL alpha hunter, senpi_runtime_helpers migration.
-  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
-  to in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST to
-  runtime /signals, long-lived producer_daemon). Thesis preserved
-  verbatim from v6.0.1: SOL alpha hunter, single-asset focus, v5.1
-  base-tech-score floor with multi-factor scoring (SM consensus,
-  trend structure, momentum, funding, OI, BTC correlation, RSI),
-  conviction-tiered leverage (5x default, 6x conviction at score 11+,
-  7x apex at score 13+), 240-min asset cooldown.
+  Single-asset SOL alpha hunter. Multi-factor scoring across SM
+  consensus, multi-timeframe trend structure, momentum, funding, OI,
+  BTC correlation, and RSI — only fires when confluence is unambiguous.
+  The founding template of the Kodiak family (Grizzly/Polar/Wolverine/
+  Dire are all tuned forks).
 license: MIT
 metadata:
   author: jason-goldberg

--- a/lemon/SKILL.md
+++ b/lemon/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: lemon-strategy
 description: >-
-  LEMON v2.0.0 — Degen Fader, senpi_runtime_helpers migration. Counter-
-  trades CHOPPY/DEGEN consensus on 12 crypto majors + 4 XYZ assets when
-  SM is exhausting. MACRO_TREND_GATE (crypto only, blocks fades when
-  |BTC 4h| > 3%). Plumbing-only flip from openclaw cron + mcporter to
-  in-process SenpiClient + long-lived producer_daemon. Thesis preserved
-  verbatim from v1.3.
+  Degen fader. Counter-trades CHOPPY/DEGEN consensus on 12 crypto
+  majors plus 4 XYZ macro assets when 15m velocity is exhausting.
+  MACRO_TREND_GATE blocks crypto fades during BTC trends; decorrelated
+  XYZ assets keep firing.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/mantis/SKILL.md
+++ b/mantis/SKILL.md
@@ -1,15 +1,10 @@
 ---
 name: mantis-strategy
 description: >-
-  MANTIS v6.0.0 — Slipstream (Cross-Asset Catchup Hunter),
-  senpi_runtime_helpers migration. Plumbing-only flip from
-  openclaw cron + mcporter subprocess + in-Python state to
-  in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST
-  to runtime /signals, long-lived producer_daemon). Thesis preserved
-  verbatim from v5.0: when BTC (or another leader) makes a significant
-  4h move and a correlated alt hasn't responded yet, Mantis strikes
-  the alt before the catchup completes. Confidence-tier sizing
-  preserved. Leader-reversal veto NOW WORKS (v5.0 was silent no-op).
+  Cross-asset lag detector. When BTC makes a significant 4h move and a
+  correlated alt hasn't responded yet, Mantis strikes the alt before
+  the catchup completes. Trades the statistical lag, not the momentum
+  itself. Hard veto if BTC reverses mid-position.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/orca/SKILL.md
+++ b/orca/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: orca-strategy
 description: >-
-  ORCA v4.0.0 — Gen-1 Vanilla Striker, senpi_runtime_helpers migration.
-  Plumbing-only flip from openclaw cron + mcporter subprocess to
-  in-process SenpiClient + long-lived producer_daemon. Thesis preserved
-  verbatim from v3.0: pure FIRST_JUMP detection + base Striker scoring
-  + volume confirmation. DSL exit managed by plugin runtime via
-  runtime.yaml.
+  The fleet's reference baseline. Pure FIRST_JUMP detection on the
+  Hyperliquid leaderboard — universe-wide, minimal MCP fan-out, no
+  scoring novelty, no per-asset specialization. If a more exotic
+  strategy can't beat Orca, the exotic isn't earning its complexity.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/otter/README.md
+++ b/otter/README.md
@@ -1,8 +1,14 @@
-# 🦦 OTTER v2.0.0 — Open Interest Velocity Hunter. senpi_runtime_helpers.
+# 🦦 OTTER — Open Interest Velocity Hunter
+
+Hunts fresh perp positions building — 1h Open Interest growth confirmed by directional price action. The only Senpi agent that tracks OI velocity over time, not just snapshots.
 
 Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-**Plumbing-only migration from v1.0. NO thesis change. NO scoring change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry.
+## Thesis
+
+Open Interest is the total notional of open perpetual contracts. Spot trading doesn't generate OI — only fresh perp positions do. So OI growth = real new leveraged capital deployed. When 1h OI delta is >= 5% AND price moves in the same direction by >= 0.5%, that's the **TOP-LEFT (LONGS entering)** or **TOP-RIGHT (SHORTS entering)** quadrant of the OI/price matrix — fresh institutional flow with directional conviction. Otter rides that flow for 1-3 hours then exits via DSL hard timeout.
+
+The fleet uses OI as a **snapshot filter** (size threshold). **Otter is the only agent to track OI delta over time** — a uniquely perp-native signal that no other Senpi agent computes.
 
 ## Install
 
@@ -84,14 +90,6 @@ tail -f /tmp/otter-producer.log | jq -c 'select(.event=="daemon_tick_finished")'
 Expected: `status=ok` every tick (300s interval — Otter's longer cadence reflects 5min OI sampling cadence).
 
 ---
-
-## Thesis
-
-Open Interest is the total notional of open perpetual contracts. Spot trading doesn't generate OI — only fresh perp positions do. So OI growth = real new leveraged capital deployed. When 1h OI delta is >= 5% AND price moves in the same direction by >= 0.5%, that's the **TOP-LEFT (LONGS entering)** or **TOP-RIGHT (SHORTS entering)** quadrant of the OI/price matrix — fresh institutional flow with directional conviction. Otter rides that flow for 1-3 hours then exits via DSL hard timeout.
-
-## What's novel
-
-The fleet uses OI as a **snapshot filter** (size threshold). **Otter is the only agent to track OI delta over time** — a uniquely perp-native signal that no other Senpi agent computes.
 
 ## v2 architecture
 

--- a/otter/SKILL.md
+++ b/otter/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: otter-strategy
 description: >-
-  OTTER v2.0.0 — Open Interest Velocity Hunter (senpi_runtime_helpers
-  migration). Plumbing-only port from v1.0. NO thesis change. NO scoring
-  change. Producer ports onto `senpi_runtime_helpers` (in-process
-  SenpiClient + direct HTTP POST to runtime /signals + producer_daemon
-  long-lived loop). Trades the rate of change of OI on Hyperliquid
-  perps — when 1h OI delta is >= 5% AND price moves in the same
-  direction by >= 0.5%, that's fresh leveraged positioning with
-  directional conviction (TOP-LEFT or TOP-RIGHT quadrant of the
-  OI/price matrix). Otter follows the flow for 1-3 hours then exits.
-  Conviction-scaled leverage (5/7/10 by score) per the fleet-winning
-  pattern.
+  Open Interest velocity hunter. The only Senpi agent that tracks OI
+  delta over time, not just OI snapshots. Fires when 1h OI grows ≥5%
+  AND price moves ≥0.5% in the same direction — fresh leveraged
+  capital deployed with directional conviction. Rides the flow 1-3
+  hours.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/owl/SKILL.md
+++ b/owl/SKILL.md
@@ -1,14 +1,10 @@
 ---
 name: owl-strategy
 description: >-
-  OWL v8.0 — Pure contrarian crowding-unwind hunter (senpi_runtime_helpers).
-  Wait for the crowd to overcommit. Wait for them to exhaust. Then eat their
-  liquidations. Producer pushes signals to the runtime via direct HTTP POST;
-  runtime LLM gates them (pass-through), executes via FEE_OPTIMIZED_LIMIT
-  (maker-first), and manages DSL exits autonomously. Conviction-scaled
-  leverage (7/8/10 by score) per the fleet Polar v2.4 / Bald Eagle v3.0
-  pattern. Entry direction is OPPOSITE of crowd direction — Owl is the
-  only Senpi agent that fades crowding.
+  Pure contrarian. Waits for crowding to persist 1+ hour AND exhaustion
+  signals (volume decline, price stall, RSI divergence) to fire — then
+  fades the crowd at the unwind. The only Senpi agent that times
+  mean-reversion off both crowding and exhaustion together.
 license: Apache-2.0
 metadata:
   author: jason-goldberg

--- a/pangolin/SKILL.md
+++ b/pangolin/SKILL.md
@@ -1,16 +1,10 @@
 ---
 name: pangolin-strategy
 description: >-
-  PANGOLIN v3.0.0 — Extreme Funding Rate Fader, senpi_runtime_helpers
-  migration. Plumbing-only flip from openclaw-CLI subprocess + mcporter
-  subprocess to in-process SenpiClient. Pangolin is the canonical
-  reference producer for the senpi_runtime_helpers SDK wrapper pattern.
-  Thesis preserved verbatim from v2.2.0:
-  funding-fade entries opposite to elevated funding rates (>0.015%/8h
-  ≈ 20% annualized), persistence ≥3h, regime confirms or neutral.
-  Conservative 3-5x leverage, wide DSL (12h hard_timeout). Collects
-  funding every 8h while crowded positions mean-revert (24-48h thesis).
-  Phase 2 v2.2 ratchet ladder T0 8/50, T1 16/65, T2 30/85, T3 50/92.
+  Funding-rate fader. Counter-positions when funding stays extreme
+  (>0.015%/8h ≈ 20% annualized) for 3+ hours — collects 8h funding
+  payments while waiting for crowded sides to capitulate. Wide DSL
+  for the 24-48h horizon.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/polar/SKILL.md
+++ b/polar/SKILL.md
@@ -1,15 +1,10 @@
 ---
 name: polar-strategy
 description: >-
-  POLAR v5.0.0 — ETH alpha hunter, senpi_runtime_helpers migration.
-  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
-  to in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST to
-  runtime /signals, long-lived producer_daemon). Thesis preserved
-  verbatim from v4.2.0: ETH single-asset hybrid, hyperfeed SM gates
-  (pct≥5%, traders≥30, cc_15m≥0.3), structural gates (4h trend,
-  1h-4h alignment, 15m momentum, RSI), multi-factor scoring (~17 max),
-  conviction-tiered leverage (5x standard / 7x conviction / 10x apex),
-  MIN_SCORE 12, FP-001 quiet hours (00-04 UTC unless apex score 17+).
+  Single-asset ETH alpha hunter. Combines Hyperfeed Smart Money
+  acceleration with multi-timeframe structural alignment — SM gates
+  fire candidates, structural gates veto them. The ETH variant of the
+  Kodiak family.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/python/SKILL.md
+++ b/python/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: python-strategy
 description: >-
-  PYTHON v2.0.0 — The Patience Hunter, senpi_runtime_helpers migration.
-  Multi-day hold agent (96h target). Scans top 50 HL assets every 10 min,
-  holds up to 2 concurrent positions for 2-4 days, low leverage (3-7x),
-  LONG-biased. Plumbing-only flip from openclaw cron + mcporter to
-  in-process SenpiClient + producer_daemon. Thesis preserved verbatim
-  from v1.2.
+  Patience hunter. Multi-day LONG-biased trend holds on the top 50 HL
+  assets — target 96-hour hold, 36% win rate paired to a 3.14:1
+  win/loss ratio. Wide DSL Phase 1 retrace breathes through
+  intra-trend pullbacks; weak-peak cut disabled so winners only close
+  on price action.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/raptor/SKILL.md
+++ b/raptor/SKILL.md
@@ -1,12 +1,11 @@
 ---
 name: raptor-strategy
 description: >-
-  RAPTOR v4.0.0 — Hot Streak Follower, senpi_runtime_helpers migration.
-  Finds ELITE/RELIABLE quality traders currently winning weekly, identifies
-  their strongest position, confirms SM alignment, applies whale
-  entry-price discipline (5% threshold — skip if asset has already run in
-  whale's favor post-entry). Plumbing-only migration from v3.4; thesis
-  preserved verbatim including v3.4 nested-positions parser fix.
+  Hot-streak follower. Finds ELITE/RELIABLE traders winning weekly,
+  picks their strongest open position, confirms SM alignment, and
+  applies whale entry-price discipline (skip if asset has already run
+  >5% in their favor). Rides hot streaks without bag-holding for
+  mid-exit whales.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/roach/SKILL.md
+++ b/roach/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: roach-strategy
 description: >-
-  ROACH v3.0.0 — Striker-only scanner, senpi_runtime_helpers migration.
-  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
-  to in-process SenpiClient. Thesis preserved verbatim from v2.1.0:
-  Stalker permanently disabled, only trades violent FIRST_JUMP /
-  IMMEDIATE_MOVER explosions backed by 1.5x volume, 1h price alignment,
-  4h trend agreement. Long stretches of silence are EXPECTED — the
+  Striker-only — Stalker disabled. Fires solely on violent FIRST_JUMP
+  / IMMEDIATE_MOVER explosions backed by 1.5x volume, 1h price
+  alignment, and 4h trend agreement. Days of silence are expected; the
   patience is the edge.
 license: MIT
 metadata:

--- a/scorpion/SKILL.md
+++ b/scorpion/SKILL.md
@@ -1,16 +1,10 @@
 ---
 name: scorpion-tracker
 description: >-
-  SCORPION v5.0.0 — Multi-Market Active Trader, senpi_runtime_helpers
-  migration. Plumbing-only flip from openclaw-CLI subprocess + mcporter
-  subprocess to in-process SenpiClient. Plus security fix: v4.x read
-  wallet from BANNED generic STRATEGY_ADDRESS env var; v5.0.0 uses
-  per-agent SCORPION_WALLET (with backward-compat fallback + deprecation
-  warning). Thesis preserved verbatim from v4.1.2: only Senpi predator
-  hunting across both crypto AND XYZ DEX commodities/indices, SM
-  concentration + 4H trend alignment scoring, asymmetric MIN_SCORE
-  (crypto 11 / XYZ 9), v4.1.1 held-asset dedup, v4.1.2 post-close
-  cooldown.
+  The only fleet predator that hunts across BOTH crypto and XYZ DEX.
+  Asymmetric MIN_SCORE thresholds (crypto 11 / XYZ 9) reflect that
+  XYZ flow is slower and crowd-heavy. Breadth via 15 crypto perps
+  plus 4 XYZ macro assets under one scorer.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/spider/SKILL.md
+++ b/spider/SKILL.md
@@ -1,15 +1,10 @@
 ---
 name: spider-strategy
 description: >-
-  SPIDER v4.0.0 — Single-leg patient anchor sniper
-  (senpi_runtime_helpers migration). Plumbing-only port from v3.0.2.
-  NO thesis change. NO scoring change. NO threshold change. Producer
-  ports onto `senpi_runtime_helpers` (in-process SenpiClient + direct
-  HTTP POST to runtime /signals + producer_daemon long-lived loop).
-  Holds one high-conviction long for 7+ days. Scored on arena leader
-  alignment + SM consensus + funding favorability + 30d relative
-  strength. LLM regime-aware gate vetoes during BTC catastrophe / vol
-  expansion / funding flipping.
+  Patient anchor. Holds ONE high-conviction long for 7+ days while the
+  rest of the fleet churns. Edge comes from arena-leader alignment,
+  positive carry, 30-day relative strength, and fee-aware execution.
+  Patience is the edge.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/turbine/SKILL.md
+++ b/turbine/SKILL.md
@@ -1,16 +1,11 @@
 ---
 name: turbine-strategy
 description: >-
-  TURBINE v3.2 — Volume rotation on TWO wallets, ONE producer daemon.
-  Both wallets receive the same volume-rotation alpha (same scoring,
-  same asset universe, same funding-fade direction selection). The
-  wallet boundary just selects DSL behavior: VOLUME wallet's runtime
-  has hard_timeout 10min and no Phase 2 (pure rotation cadence);
-  RUNNERS wallet's runtime has hard_timeout 240min and Phase 2 ratchet
-  enabled (let winners run). Most positions exit at small loss/win
-  on either wallet; ~5% land on a real directional move and ratchet
-  to apex on the runners wallet — that asymmetry is the alpha v3.0/v3.1
-  was leaving on the table by force-cutting at 10 min.
+  Volume engine plus runners. ONE producer feeds TWO strategy wallets
+  with the same volume-rotation alpha but different DSL exit profiles
+  — the volume wallet farms maker-only rotation cadence for builder-
+  fee recycling, the runners wallet rides the rare directional move
+  to apex.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/vulture/SKILL.md
+++ b/vulture/SKILL.md
@@ -1,16 +1,10 @@
 ---
 name: vulture-strategy
 description: >-
-  VULTURE v4.0.0 — Long-Tail Momentum Rider, senpi_runtime_helpers
-  migration. Plumbing-only flip from openclaw-CLI subprocess +
-  mcporter subprocess to in-process SenpiClient. Thesis preserved
-  verbatim from v3.1.1: 25+ small/mid-cap Hyperliquid perps (HEMI,
-  WLD, MON, XPL, AIXBT, ARB, ASTER, ZEC, LIT, TAO, POLYX, LDO, APT,
-  DYDX, ONDO, SUI, etc.) that no other Senpi predator covers,
-  LONG_TAIL_MOMENTUM scoring, v2.4 1h-alignment gate, FP-001 quiet
-  hours, conviction-scaled leverage (3x cautious / 5x conviction /
-  7x apex). Built from #1 Arena winner's 3-week playbook (38.6%
-  win rate, 6.15x profit factor).
+  Long-tail momentum rider. Hunts 25+ small/mid-cap Hyperliquid perps
+  no other Senpi agent covers — holds winners for days, cuts losers
+  fast. Score-scaled leverage (3/5/7x), 7-day hard timeout, apex
+  ratchet locks 85% of peak ROE.
 license: MIT
 metadata:
   author: jason-goldberg

--- a/wolverine/SKILL.md
+++ b/wolverine/SKILL.md
@@ -1,16 +1,9 @@
 ---
 name: wolverine-strategy
 description: >-
-  WOLVERINE v5.0.0 — HYPE alpha hunter, senpi_runtime_helpers migration.
-  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
-  to in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST to
-  runtime /signals, long-lived producer_daemon). Thesis preserved
-  verbatim from v4.2.0: HYPE single-asset hybrid, six-gate entry
-  validation (4h trend, 4h strength ≥0.65, 1h-4h alignment, 15m
-  momentum ≥0.15, base-tech floor, 4h magnitude ≥1.0%), SM hard-block
-  on opposing direction, RSI hard gates (74/26), multi-factor scoring
-  (~17 max), conviction-tiered leverage (3x standard / 5x apex),
-  MIN_SCORE 9, FP-001 quiet hours.
+  Single-asset HYPE alpha hunter. Trades multi-timeframe trend
+  alignment on Hyperliquid's native token — six-gate entry validation
+  tuned for HYPE's faster cadence and thinner overnight liquidity.
 license: MIT
 metadata:
   author: jason-goldberg


### PR DESCRIPTION
## Summary

Every strategy's \`SKILL.md\` frontmatter \`description:\` field was a developer-facing changelog dump like:

\`\`\`yaml
description: >-
  KODIAK v7.0.0 — SOL alpha hunter, senpi_runtime_helpers migration.
  Plumbing-only flip from openclaw-CLI subprocess + mcporter subprocess
  to in-process SenpiClient (direct HTTPS for MCP, direct HTTP POST to
  runtime /signals, long-lived producer_daemon). Thesis preserved
  verbatim from v6.0.1: ...
\`\`\`

The new Senpi website will scrape these onto public strategy cards. They need to read as thesis intros, not migration notes.

## Changes

- **26 SKILL.md description fields rewritten** as clean 2-3 sentence intros — no version numbers, no migration history, no implementation jargon. Each describes what the strategy actually does and why.
- **otter/README.md restructured** to lead with thesis like every other agent: H1 cleaned of version + implementation-detail suffix, changelog paragraph replaced with a tagline, Thesis section moved above Install, duplicate Thesis + "What's novel" sections removed.

## Accuracy verification

Code-level verification pass caught 4 factual inaccuracies in my first draft. All corrected before this PR:

| Strategy | Issue caught | Fix |
|---|---|---|
| Jaguar | Claimed "into the top 10" but producer skips assets already at rank ≤ 10 | "from rank 20+ to rank 11+" |
| Orca | Claimed "one MCP call per scan" but producer makes multiple per-candidate calls | "minimal MCP fan-out" |
| Mantis | Implied multiple leader assets supported but \`LEADER_UNIVERSE = ["BTC"]\` only | BTC-only |
| Cheetah | Claimed "every signal agrees" but scoring is additive — MIN_SCORE 10 / max 15 can be reached without all 7 firing | "scores 7 independent signals … only fires when confluence is strong" |

The other 22 descriptions were verified accurate against producer code, runtime.yaml, and config.json.

## Test plan

- [ ] Render any SKILL.md on GitHub and confirm the frontmatter description reads as a clean intro
- [ ] Confirm website mockup with these descriptions reads naturally
- [ ] Spot-check 3-4 descriptions against the strategy's actual producer code

🤖 Generated with [Claude Code](https://claude.com/claude-code)