### PR TITLE
senpi-helpers: fix restart for daemons launched via "python3 script.py"

### DIFF
--- a/senpi-trading-runtime/references/senpi-helpers-cli.md
+++ b/senpi-trading-runtime/references/senpi-helpers-cli.md
@@ -334,35 +334,19 @@ environment.
 
 ### boot.json schema migration
 
-`boot.json` has two schemas in the wild:
+Two schemas in the wild: schema-1 (pre-2026-05) captured only `sys.argv`
+which was missing the interpreter — `Popen(argv)` then needed the script
+to be `+x`. Schema 2 captures `[sys.executable, "-u", *sys.argv]` and
+also records `log_path` so `restart` works after a clean stop.
 
-| schema | `argv` shape                                | how to launch |
-|--------|---------------------------------------------|---------------|
-| 1 (legacy) | `["/path/script.py"]`                   | `nohup python3 -u /path/script.py &` |
-| 2 (current) | `[sys.executable, "-u", "/path/script.py"]` | Written by every daemon since this fix |
+Migration is one-shot per daemon and transparent — `restart` auto-
+prepends the interpreter when reading a schema-1 file; the newly-spawned
+daemon writes schema 2 on its own. `--json` output exposes
+`"argv_normalized": true|false` for automation.
 
-Why schema 2 exists: schema-1 captured only `sys.argv`, which is the
-script + script args — interpreter and `-u` flag are consumed before
-Python's `sys.argv` is populated and cannot be recovered from inside the
-script. When the operator launched as `nohup python3 -u script.py &`, the
-script never needed to be `+x`. But `senpi-helpers restart` (which
-`Popen`s `argv` directly) then tried to `execve` the `.py` file, which
-fails with `EACCES` when the file isn't executable. Result: stop half
-succeeded, start half silently died with `PermissionError`, producer
-ended up dead.
-
-Migration is transparent and one-shot per daemon:
-- On `restart`, if `argv[0]` looks like a `.py` script (and not a python
-  interpreter), the helper prepends `[sys.executable, "-u"]` and prints
-  a one-line note.
-- The newly-spawned daemon calls `write_boot()` on startup and writes a
-  fresh schema-2 `boot.json`. The next `restart` goes through the modern
-  path, no migration needed.
-- Operators don't have to do anything. Schema-1 boot files keep working
-  forever; they just get rewritten on first restart.
-
-`--json` output includes `"argv_normalized": true|false` so automation
-can detect the migration.
+For the full history (why each schema bump happened, what the recycle
+guard does, how to author the next bump) see
+[`senpi-helpers-schema-history.md`](./senpi-helpers-schema-history.md).
 
 Exit codes:
 

--- a/senpi-trading-runtime/references/senpi-helpers-cli.md
+++ b/senpi-trading-runtime/references/senpi-helpers-cli.md
@@ -262,7 +262,8 @@ What `restart` does, in order:
    next time. Exit 1.
 3. If the daemon is currently running, run the `stop` flow first.
 4. Re-exec the daemon as a detached process:
-   - argv from boot.json
+   - argv from boot.json (auto-migrated from legacy schema 1 if needed —
+     see "boot.json schema migration" below)
    - cwd from boot.json
    - env from the CLI's **current** environment (NOT the captured
      env_snapshot — so wallet / auth / decision-model changes since the
@@ -276,6 +277,38 @@ What `restart` does, in order:
 
 The new daemon's env_snapshot in boot.json will be rewritten with the new
 environment.
+
+### boot.json schema migration
+
+`boot.json` has two schemas in the wild:
+
+| schema | `argv` shape                                | how to launch |
+|--------|---------------------------------------------|---------------|
+| 1 (legacy) | `["/path/script.py"]`                   | `nohup python3 -u /path/script.py &` |
+| 2 (current) | `[sys.executable, "-u", "/path/script.py"]` | Written by every daemon since this fix |
+
+Why schema 2 exists: schema-1 captured only `sys.argv`, which is the
+script + script args — interpreter and `-u` flag are consumed before
+Python's `sys.argv` is populated and cannot be recovered from inside the
+script. When the operator launched as `nohup python3 -u script.py &`, the
+script never needed to be `+x`. But `senpi-helpers restart` (which
+`Popen`s `argv` directly) then tried to `execve` the `.py` file, which
+fails with `EACCES` when the file isn't executable. Result: stop half
+succeeded, start half silently died with `PermissionError`, producer
+ended up dead.
+
+Migration is transparent and one-shot per daemon:
+- On `restart`, if `argv[0]` looks like a `.py` script (and not a python
+  interpreter), the helper prepends `[sys.executable, "-u"]` and prints
+  a one-line note.
+- The newly-spawned daemon calls `write_boot()` on startup and writes a
+  fresh schema-2 `boot.json`. The next `restart` goes through the modern
+  path, no migration needed.
+- Operators don't have to do anything. Schema-1 boot files keep working
+  forever; they just get rewritten on first restart.
+
+`--json` output includes `"argv_normalized": true|false` so automation
+can detect the migration.
 
 Exit codes:
 

--- a/senpi-trading-runtime/references/senpi-helpers-cli.md
+++ b/senpi-trading-runtime/references/senpi-helpers-cli.md
@@ -192,6 +192,60 @@ Exit codes:
 
 ---
 
+## `senpi-helpers start <name>`
+
+Launch a daemon as a detached process using argv + cwd recorded in
+`boot.json`. Idempotent — if a daemon with that name is already running
+(verified via the pid-recycle guard), reports it and exits 0 without
+spawning a duplicate.
+
+```bash
+senpi-helpers start [<name>] [--json]
+```
+
+| option   | default | notes                                       |
+|----------|---------|---------------------------------------------|
+| `--json` | off     | Emit a JSON result envelope.                |
+
+Outcomes:
+
+| outcome           | meaning                                                |
+|-------------------|--------------------------------------------------------|
+| `started`         | New daemon spawned; pid.json confirmed (or pending).   |
+| `already_running` | Daemon's recorded pid is alive AND fingerprints match. |
+
+Exit codes:
+
+| code | meaning                                                |
+|------|--------------------------------------------------------|
+| 0    | started or already_running                             |
+| 1    | start failed (script path missing, spawn failure)      |
+| 2    | no `boot.json` for the daemon — never launched         |
+
+**First-time launches** still require the manual playbook (the daemon has
+no `boot.json` until it writes one on its own startup). After that, every
+subsequent start / restart goes through this command.
+
+`start` shares the relaunch path with `restart`; the difference is that
+`start` doesn't run `stop` first. If the daemon is alive, `start` is a
+no-op. If it isn't, `start` is what `restart` would have done minus the
+stop half.
+
+### Pid-recycle guard
+
+`start` (and `stop`, `restart`, `health`, `list`) all use a recycle-safe
+liveness check: a daemon is considered alive only if the recorded pid
+exists AND `/proc/<pid>/cmdline` + `/proc/<pid>/stat` field 22 match the
+fingerprints `write_pid` captured at daemon launch. If the pid was
+recycled to an unrelated process, the helpers refuse to signal it.
+
+The fingerprints are pid.json schema 2 fields (`cmdline_fingerprint`,
+`start_time_jiffies`). Schema-1 pid.json files degrade to plain
+`os.kill(pid, 0)` liveness — same as before. Migration is one-shot per
+daemon on its next launch.
+
+---
+
 ## `senpi-helpers stop <name>`
 
 Stop a running daemon. SIGTERM first, poll for exit, escalate to SIGKILL on

--- a/senpi-trading-runtime/references/senpi-helpers-schema-history.md
+++ b/senpi-trading-runtime/references/senpi-helpers-schema-history.md
@@ -1,0 +1,159 @@
+# senpi-helpers state-file schema history
+
+Companion to `senpi-helpers-cli.md`. Keeps the deep "why this schema
+exists" context out of the operator-facing doc so the main reference
+stays focused on usage and short enough to fit comfortably in an agent's
+context window.
+
+Operators rarely need this file. Read it when:
+- A daemon's state file has an unfamiliar `schema` value.
+- You're auditing migrations in a debugging session.
+- You're authoring a new schema and want the protocol.
+
+## Versioning protocol
+
+Each state file (`pid.json`, `boot.json`, `heartbeat.json`) has its own
+`schema` integer field. Schemas evolve independently — bumping one
+doesn't require touching the others. Readers tolerate older AND newer
+schemas (forward-compat); when `state._read_json` sees an unsupported
+schema it logs a `state_unknown_schema` event and returns the data
+anyway, so callers using `.get(...)` degrade gracefully.
+
+Current supported schemas:
+
+| file              | schemas  |
+|-------------------|----------|
+| `pid.json`        | {1, 2}   |
+| `boot.json`       | {1, 2}   |
+| `heartbeat.json`  | {1}      |
+
+## boot.json — schema 1 → 2
+
+### Schema 1 (legacy, pre-2026-05-14)
+
+```json
+{
+  "argv": ["/path/script.py"],
+  "script_path": "/path/script.py",
+  "cwd": "/some/cwd",
+  "env_snapshot": { ... }
+}
+```
+
+`argv` captured only `sys.argv`, which is the script + script args.
+Python's interpreter and flags (`-u`, `-O`, etc.) are consumed before
+`sys.argv` is populated and aren't recoverable from inside the script.
+
+### Schema 2 (current)
+
+```json
+{
+  "argv": ["/usr/bin/python3", "-u", "/path/script.py"],
+  "script_path": "/path/script.py",
+  "cwd": "/some/cwd",
+  "env_snapshot": { ... },
+  "log_path": "/tmp/<name>.log"
+}
+```
+
+Two additions:
+- `argv[0]` is `sys.executable`; `argv[1]` is `-u`.
+- `log_path` persists here in addition to `pid.json`.
+
+### Why the schema 2 bump was needed
+
+The operator playbook launches daemons as
+`nohup python3 -u script.py &`. The script never needs to be `+x` because
+the interpreter is explicit on the command line. But `senpi-helpers
+restart` does `Popen(argv, ...)` which `execve`'s `argv[0]` directly —
+needing the script to be executable with a working shebang. On a real
+production box (vulture, 2026-05-13) this fails:
+
+```
+Popen raised: PermissionError [Errno 13] Permission denied:
+'/data/workspace/skills/vulture-strategy/scripts/vulture-producer.py'
+```
+
+The stop half of `restart` succeeded; the start half died silently
+because the agent's `exec` session terminated before `senpi-helpers`
+flushed its stderr. Operator's-eye view: daemon went away and didn't
+come back.
+
+`log_path` persisted to boot.json for the same reason: pid.json is
+removed on graceful exit; if the operator cleanly stopped the daemon,
+the next `restart` lost the log target.
+
+### Migration
+
+One-shot per daemon, transparent on read:
+- `manage._normalize_argv` prepends `[sys.executable, "-u"]` when
+  `argv[0]` is a `.py` script (heuristic: doesn't look like a python
+  interpreter binary, ends with `.py`).
+- The newly-spawned daemon's own `write_boot()` rewrites the file as
+  schema 2.
+- `--json` includes `argv_normalized: true|false` so automation can
+  detect the migration.
+
+Operators do nothing — schema-1 boot files keep working, get rewritten
+on first restart.
+
+## pid.json — schema 1 → 2
+
+### Schema 1
+
+```json
+{
+  "pid": 1234,
+  "start_time_iso": "...",
+  "wallet": "0x...",
+  "scanner": "...",
+  "log_path": "/tmp/<name>.log"
+}
+```
+
+### Schema 2 (current)
+
+Adds two fields for the pid-recycle guard:
+
+```json
+{
+  "pid": 1234,
+  ...
+  "cmdline_fingerprint": "<sha256 of /proc/<pid>/cmdline>",
+  "start_time_jiffies": 1234567890
+}
+```
+
+### Why the schema 2 bump was needed
+
+`os.kill(pid, 0)` reports any pid that exists in the kernel's process
+table as "alive" — including a recycled pid pointing at an unrelated
+process. In Docker/Railway containers where `pid_max` defaults to 32k,
+recycling on a long-running box is plausible. A `senpi-helpers stop`
+that signals the recycled pid would SIGTERM a stranger.
+
+The two fingerprints catch this: at signal-time `state.pid_alive_and_matches`
+cross-checks `/proc/<pid>/cmdline`'s sha256 + `/proc/<pid>/stat` field 22
+against the values `write_pid` captured at daemon launch. Mismatch ⇒
+treated as already-dead (the daemon is gone; this pid belongs to
+something else). The CLI never signals.
+
+Schema-1 pid.json (no fingerprints) degrades to plain `pid_alive` — no
+recycle protection until the next launch writes schema 2. Migration is
+one-shot per daemon, same as boot.json.
+
+## heartbeat.json
+
+Schema 1, unchanged. Rewritten after every daemon tick; ephemeral —
+recoverable from the next tick.
+
+## Authoring a new schema bump
+
+1. Add the new schema number to `_SUPPORTED_SCHEMAS` in `state.py`.
+2. Update the writer (e.g. `write_pid`) to emit the new shape. Keep the
+   payload superset of the prior schema so old readers ignore new
+   fields gracefully.
+3. If reading the new shape needs new field access in the CLI, use
+   `.get(...)` so old-schema files don't KeyError.
+4. Document the bump in this file: schema, why it exists, migration
+   approach, what older readers see.

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -452,17 +452,79 @@ LOGS_NO_LOG = 1
 LOGS_NOT_FOUND = 2
 
 
-def _print_last_n_lines(log_path: str, *, n: int) -> None:
-    """Read the tail of `log_path`. Tolerant of short files."""
-    # Don't pull the whole file into memory for large logs — use a deque.
-    from collections import deque
+# Read this many bytes per backward seek when tailing. 8 KiB is a typical
+# block size on most filesystems and comfortably fits hundreds of typical
+# log lines (~80–200 chars each). Tunable for tests.
+_TAIL_CHUNK_BYTES = 8192
+
+
+def _read_last_n_lines(log_path: str, *, n: int,
+                      chunk_bytes: int = _TAIL_CHUNK_BYTES) -> List[str]:
+    """Return the last `n` lines of `log_path` without reading the whole file.
+
+    Algorithm: seek to EOF, then read backwards in `chunk_bytes`-sized blocks
+    until we've accumulated at least n+1 newline characters (n+1 because n
+    lines have at most n+1 line breaks — the +1 catches the partial line
+    we'd otherwise truncate at the leading edge of our window). Decode the
+    accumulated bytes and return the last n lines.
+
+    Why not `collections.deque(fh, maxlen=n)`?
+        deque keeps memory bounded but its constructor IS Python's file
+        iterator — which reads the file line-by-line from the start. On
+        a multi-GB log, that's gigabytes of disk I/O and UTF-8 decoding
+        for "I want the last 50 lines." This implementation reads at
+        most O(n × avg_line_length) bytes from disk.
+
+    Returns lines as text (UTF-8, errors='replace') with their trailing
+    newlines preserved when present. Returns an empty list for n=0,
+    empty file, or unreadable file (caller writes the error).
+    """
+    if n <= 0:
+        return []
+    # Open binary so we can seek by byte offset. Text mode in Python 3
+    # forbids relative seeks on non-seek-from-zero positions.
+    fh = open(log_path, "rb")
     try:
-        with open(log_path, "r", errors="replace") as fh:
-            buf = deque(fh, maxlen=n)
+        fh.seek(0, os.SEEK_END)
+        end_pos = fh.tell()
+        if end_pos == 0:
+            return []
+        data = b""
+        pos = end_pos
+        # We want n+1 newlines so the chunk we keep starts AFTER a complete
+        # line break — otherwise the first "line" in our slice would be
+        # the tail of an earlier line that got cut by the chunk boundary.
+        target_newlines = n + 1
+        while pos > 0:
+            read_size = min(chunk_bytes, pos)
+            pos -= read_size
+            fh.seek(pos)
+            data = fh.read(read_size) + data
+            if data.count(b"\n") >= target_newlines:
+                break
+    finally:
+        fh.close()
+
+    text = data.decode("utf-8", errors="replace")
+    # splitlines(keepends=True) preserves trailing newlines on each line
+    # and handles a missing-final-newline case correctly (the last entry
+    # is a line without a newline, returned as-is).
+    lines = text.splitlines(keepends=True)
+    return lines[-n:]
+
+
+def _print_last_n_lines(log_path: str, *, n: int) -> None:
+    """Print the last `n` lines of `log_path` to stdout.
+
+    Uses the seek-from-end implementation so the I/O cost is O(n × line
+    length), not O(file size). Errors during read are written to stderr
+    and the function returns silently — same contract as before."""
+    try:
+        lines = _read_last_n_lines(log_path, n=n)
     except OSError as e:
         sys.stderr.write(f"senpi-helpers: cannot read {log_path}: {e}\n")
         return
-    for line in buf:
+    for line in lines:
         sys.stdout.write(line)
 
 

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -641,6 +641,7 @@ def cmd_restart(args: argparse.Namespace) -> int:
         return RESTART_FAILED
 
     new_pid = relaunch_result["pid"]
+    argv_normalized = bool(relaunch_result.get("argv_normalized"))
 
     # Confirm the new daemon actually wrote its pid.json. If not, the script
     # may have crashed before writing — but the Popen succeeded, so it's
@@ -659,6 +660,7 @@ def cmd_restart(args: argparse.Namespace) -> int:
         "old_pid": pid if pid_data else None,
         "stop_result": stop_result,
         "relaunch_result": relaunch_result,
+        "argv_normalized": argv_normalized,
         "pid_json_confirmed": confirmed is not None,
         "log_path": log_path,
     }
@@ -673,6 +675,15 @@ def cmd_restart(args: argparse.Namespace) -> int:
         print(f"  new pid:        {new_pid}")
         print(f"  log path:       {log_path}")
         print(f"  script:         {script_path}")
+        if argv_normalized:
+            # Legacy schema-1 boot.json was migrated on read. The new daemon
+            # will write a fresh schema-2 boot.json on startup; this message
+            # only appears for the first restart per daemon after the
+            # upgrade lands.
+            print(
+                "  boot.json:      schema 1 detected; interpreter "
+                "auto-prepended (one-time migration)"
+            )
         if confirmed is not None:
             print("  pid.json:       confirmed (new daemon is ticking)")
         else:

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -549,6 +549,266 @@ def cmd_logs(args: argparse.Namespace) -> int:
     return LOGS_OK
 
 
+# ─── Subcommand: diagnose ───────────────────────────────────────────────────
+#
+# Composite reader over pid.json + boot.json + heartbeat.json + the log
+# file. Runs a checklist (each check pure-fn over local state, no network,
+# no Railway) and reports pass/warn/fail + a suggestion per check.
+#
+# Used by the agent (and humans) when a daemon misbehaves to skip the
+# "ssh in + cat pid.json + cat boot.json + ls log + pgrep + parse output"
+# routine.
+
+DIAGNOSE_OK = 0
+DIAGNOSE_UNHEALTHY = 1
+DIAGNOSE_NOT_FOUND = 2
+
+# Stable string keys so JSON consumers (alerting, dashboards) can branch.
+_DIAG_PASS = "pass"
+_DIAG_WARN = "warn"
+_DIAG_FAIL = "fail"
+
+
+def _diag_check(key: str, status: str, message: str, suggestion: Optional[str] = None) -> Dict[str, Any]:
+    return {"key": key, "status": status, "message": message,
+            "suggestion": suggestion}
+
+
+def _run_diagnostic_checks(
+    name: str, *, state_dir: Optional[str],
+) -> List[Dict[str, Any]]:
+    """Run every diagnostic in order. Each returns a result dict.
+
+    The order is roughly "outer state → inner runtime" so the operator
+    sees structural problems (missing files) before runtime ones (stale
+    ticks). All checks are pure functions over the on-disk state — no
+    side effects, no Railway, no network.
+    """
+    pid_data = _state.read_pid(name, state_dir=state_dir)
+    boot_data = _state.read_boot(name, state_dir=state_dir)
+    hb_data = _state.read_heartbeat(name, state_dir=state_dir)
+
+    out: List[Dict[str, Any]] = []
+
+    # boot.json — without it, the daemon has never run under the helper.
+    if boot_data is None:
+        out.append(_diag_check(
+            "boot_json_present", _DIAG_FAIL,
+            "boot.json is missing",
+            suggestion=(
+                "The daemon has never started under the helper. Use your "
+                "skill's launch recipe once (nohup python3 -u <producer>.py "
+                "...); the daemon writes boot.json on its own startup."
+            ),
+        ))
+    else:
+        out.append(_diag_check(
+            "boot_json_present", _DIAG_PASS,
+            f"boot.json schema {boot_data.get('schema')}",
+        ))
+
+    # script_path — does the file the daemon was launched from still exist?
+    script_path = (boot_data or {}).get("script_path")
+    if not script_path:
+        out.append(_diag_check(
+            "script_path_recorded", _DIAG_WARN,
+            "script_path is not recorded in boot.json",
+            suggestion="Restart the daemon manually so boot.json captures it.",
+        ))
+    elif not os.path.exists(script_path):
+        out.append(_diag_check(
+            "script_path_exists", _DIAG_FAIL,
+            f"script_path '{script_path}' does not exist on disk",
+            suggestion=(
+                "The skill may have been moved or deleted. Re-clone or "
+                "re-install the skill at that path, or start manually so "
+                "boot.json picks up the new location."
+            ),
+        ))
+    else:
+        out.append(_diag_check(
+            "script_path_exists", _DIAG_PASS,
+            f"script_path {script_path} exists",
+        ))
+
+    # pid.json — present + pid still alive AND fingerprints match.
+    pid = (pid_data or {}).get("pid") if pid_data else None
+    if pid_data is None:
+        out.append(_diag_check(
+            "pid_json_present", _DIAG_WARN,
+            "pid.json is missing — daemon is not running",
+            suggestion=(
+                f"Run `senpi-helpers start {name}` to bring it back."
+            ),
+        ))
+    elif not isinstance(pid, int) or pid <= 0:
+        out.append(_diag_check(
+            "pid_json_valid", _DIAG_FAIL,
+            f"pid.json has invalid pid: {pid!r}",
+            suggestion=(
+                "Clear stale pid.json (rm) and start fresh, or upgrade the "
+                "helpers package — old schema may be in play."
+            ),
+        ))
+    else:
+        # Liveness with recycle guard.
+        alive_loose = _state.pid_alive(pid)
+        alive_strict = _pid_alive_for_daemon(pid_data)
+        if not alive_loose:
+            out.append(_diag_check(
+                "pid_alive", _DIAG_FAIL,
+                f"recorded pid {pid} is not running",
+                suggestion=f"Run `senpi-helpers start {name}` to relaunch.",
+            ))
+        elif alive_loose and not alive_strict:
+            out.append(_diag_check(
+                "pid_alive_and_matches", _DIAG_FAIL,
+                f"pid {pid} is alive but cmdline / start_time fingerprint "
+                f"doesn't match — kernel recycled it to a stranger",
+                suggestion=(
+                    "Run `senpi-helpers stop <name>` — the recycle guard "
+                    "will clear the stale pid.json without signaling the "
+                    "unrelated process."
+                ),
+            ))
+        else:
+            out.append(_diag_check(
+                "pid_alive_and_matches", _DIAG_PASS,
+                f"pid {pid} alive, fingerprints match",
+            ))
+
+    # log_path — resolve from pid → boot → default. Then check the file.
+    if boot_data is not None or pid_data is not None:
+        log_path = (pid_data or {}).get("log_path") or (boot_data or {}).get("log_path")
+        if not log_path:
+            env_snapshot = (boot_data or {}).get("env_snapshot") or {}
+            log_path = env_snapshot.get("SENPI_HELPERS_LOG_PATH")
+        if not log_path:
+            log_path = f"/tmp/{name}.log"
+            log_path_note = " (default — boot.json/pid.json didn't record one)"
+        else:
+            log_path_note = ""
+        if os.path.exists(log_path):
+            out.append(_diag_check(
+                "log_file_exists", _DIAG_PASS,
+                f"log file at {log_path}{log_path_note}",
+            ))
+        else:
+            out.append(_diag_check(
+                "log_file_exists", _DIAG_WARN,
+                f"log file not found at {log_path}{log_path_note}",
+                suggestion=(
+                    "The daemon may not have written yet, or the path is "
+                    "stale. After `senpi-helpers start`, the new daemon "
+                    "will write to this path."
+                ),
+            ))
+
+    # heartbeat freshness.
+    if hb_data is None:
+        out.append(_diag_check(
+            "heartbeat_present", _DIAG_WARN,
+            "heartbeat.json is missing — no tick has completed yet",
+        ))
+    else:
+        interval = (pid_data or {}).get("interval_seconds")
+        last_tick_iso = hb_data.get("last_tick_iso")
+        last_tick_age = _age_seconds(last_tick_iso)
+        last_tick_status = hb_data.get("last_tick_status")
+        if (
+            isinstance(interval, (int, float))
+            and interval > 0
+            and last_tick_age is not None
+            and last_tick_age > 2 * interval
+        ):
+            out.append(_diag_check(
+                "heartbeat_fresh", _DIAG_FAIL,
+                f"last tick was {last_tick_age}s ago, more than 2× interval "
+                f"({interval}s) — daemon is stalled",
+                suggestion=(
+                    f"Check `senpi-helpers logs {name}` for the last few "
+                    f"events. May need a restart."
+                ),
+            ))
+        elif last_tick_age is not None:
+            out.append(_diag_check(
+                "heartbeat_fresh", _DIAG_PASS,
+                f"last tick {last_tick_age}s ago",
+            ))
+        # Last tick outcome.
+        if last_tick_status is None:
+            out.append(_diag_check(
+                "last_tick_status", _DIAG_WARN,
+                "last_tick_status missing from heartbeat.json",
+            ))
+        elif last_tick_status not in ("ok", "skipped_locked"):
+            err_preview = (hb_data.get("last_tick_error") or "")
+            err_preview = err_preview[:120] + ("…" if len(err_preview) > 120 else "")
+            out.append(_diag_check(
+                "last_tick_status", _DIAG_FAIL,
+                f"last tick status was '{last_tick_status}'"
+                + (f": {err_preview}" if err_preview else ""),
+                suggestion=f"`senpi-helpers logs {name}` for full context.",
+            ))
+        else:
+            out.append(_diag_check(
+                "last_tick_status", _DIAG_PASS,
+                f"last tick status: {last_tick_status}",
+            ))
+
+    return out
+
+
+def _print_diagnose_summary(name: str, checks: List[Dict[str, Any]]) -> None:
+    """Human-readable diagnose report. One line per check + suggestion."""
+    by_status = {_DIAG_PASS: 0, _DIAG_WARN: 0, _DIAG_FAIL: 0}
+    for c in checks:
+        by_status[c["status"]] = by_status.get(c["status"], 0) + 1
+
+    print(f"name:           {name}")
+    print(f"summary:        "
+          f"{by_status[_DIAG_PASS]} pass, "
+          f"{by_status[_DIAG_WARN]} warn, "
+          f"{by_status[_DIAG_FAIL]} fail")
+    print()
+    glyph = {_DIAG_PASS: "✓", _DIAG_WARN: "!", _DIAG_FAIL: "✗"}
+    for c in checks:
+        g = glyph.get(c["status"], "?")
+        print(f"  [{g}] {c['key']:<28}  {c['message']}")
+        if c.get("suggestion"):
+            print(f"          → {c['suggestion']}")
+
+
+def cmd_diagnose(args: argparse.Namespace) -> int:
+    name = _resolve_name_readonly(args)
+    if name is None:
+        return DIAGNOSE_NOT_FOUND
+    # Confirm at least SOMETHING for this daemon exists; otherwise the
+    # diagnose output would be entirely "missing" rows with no signal.
+    if (
+        _state.read_pid(name, state_dir=args.state_dir) is None
+        and _state.read_boot(name, state_dir=args.state_dir) is None
+        and _state.read_heartbeat(name, state_dir=args.state_dir) is None
+    ):
+        sys.stderr.write(
+            f"senpi-helpers: no state files for '{name}'. "
+            f"Use `senpi-helpers list` to see registered daemons.\n"
+        )
+        return DIAGNOSE_NOT_FOUND
+
+    checks = _run_diagnostic_checks(name, state_dir=args.state_dir)
+
+    if args.json:
+        print(json.dumps(
+            {"name": name, "checks": checks}, indent=2, default=str,
+        ))
+    else:
+        _print_diagnose_summary(name, checks)
+
+    has_fail = any(c["status"] == _DIAG_FAIL for c in checks)
+    return DIAGNOSE_UNHEALTHY if has_fail else DIAGNOSE_OK
+
+
 # ─── Subcommand: stats ──────────────────────────────────────────────────────
 
 STATS_OK = 0
@@ -1255,6 +1515,24 @@ def _make_parser() -> argparse.ArgumentParser:
         help="Stream new lines as they're written (Ctrl-C to stop).",
     )
     logs_p.set_defaults(func=cmd_logs)
+
+    # diagnose
+    diag_p = sub.add_parser(
+        "diagnose",
+        help="Run a pre-flight checklist over pid/boot/heartbeat/log; pass/warn/fail per check.",
+        description=(
+            "Composite reader: pid.json + boot.json + heartbeat.json + log "
+            "file. Reports each check with pass / warn / fail and a "
+            "suggestion to act on failures. Use BEFORE filing a bug report "
+            "or stopping a misbehaving daemon."
+        ),
+    )
+    diag_p.add_argument(
+        "name", nargs="?", default=None,
+        help="Daemon name. Optional on single-daemon hosts.",
+    )
+    diag_p.add_argument("--json", action="store_true", help="Emit JSON instead of a summary.")
+    diag_p.set_defaults(func=cmd_diagnose)
 
     # stats
     stats_p = sub.add_parser(

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -440,6 +440,115 @@ def cmd_boot(args: argparse.Namespace) -> int:
     return BOOT_OK
 
 
+# ─── Subcommand: logs ───────────────────────────────────────────────────────
+#
+# Tail / follow the daemon's stderr log. Uses the same fallback chain as
+# `restart` / `stats` to find log_path: pid.json first, boot.json second
+# (schema 2+), boot.json env_snapshot's SENPI_HELPERS_LOG_PATH third,
+# /tmp/<name>.log default last.
+
+LOGS_OK = 0
+LOGS_NO_LOG = 1
+LOGS_NOT_FOUND = 2
+
+
+def _print_last_n_lines(log_path: str, *, n: int) -> None:
+    """Read the tail of `log_path`. Tolerant of short files."""
+    # Don't pull the whole file into memory for large logs — use a deque.
+    from collections import deque
+    try:
+        with open(log_path, "r", errors="replace") as fh:
+            buf = deque(fh, maxlen=n)
+    except OSError as e:
+        sys.stderr.write(f"senpi-helpers: cannot read {log_path}: {e}\n")
+        return
+    for line in buf:
+        sys.stdout.write(line)
+
+
+def _stream_log(log_path: str) -> None:
+    """`tail -F` semantics: keep reading even if file rotates or truncates.
+
+    Polls every 250 ms. Reopens on inode change (rotation). Truncation
+    (file shrunk) → seek back to current size.
+    """
+    poll = 0.25
+    inode = None
+    fh = None
+    pos = 0
+    try:
+        while True:
+            try:
+                st = os.stat(log_path)
+            except FileNotFoundError:
+                if fh is not None:
+                    fh.close()
+                    fh = None
+                time.sleep(poll)
+                continue
+            # Rotation detection: new inode → reopen at start.
+            if inode != st.st_ino:
+                if fh is not None:
+                    fh.close()
+                fh = open(log_path, "r", errors="replace")
+                inode = st.st_ino
+                # On first open, seek to end so we don't replay history.
+                fh.seek(0, os.SEEK_END)
+                pos = fh.tell()
+            # Truncation detection: file size < our position.
+            if st.st_size < pos:
+                fh.seek(0)
+                pos = 0
+            chunk = fh.read()
+            if chunk:
+                sys.stdout.write(chunk)
+                sys.stdout.flush()
+                pos = fh.tell()
+            else:
+                time.sleep(poll)
+    except KeyboardInterrupt:
+        # Operator hit Ctrl-C — exit cleanly.
+        pass
+    finally:
+        if fh is not None:
+            fh.close()
+
+
+def cmd_logs(args: argparse.Namespace) -> int:
+    name = _resolve_name_readonly(args)
+    if name is None:
+        return LOGS_NOT_FOUND
+
+    # Reuse the same fallback chain that restart/stats use. Suppress the
+    # default-warning to stderr — for `logs`, the operator just wants the
+    # log; if we end up at /tmp/<name>.log by default and it doesn't exist,
+    # the existence check below surfaces a clear "no log" message.
+    pid_data = _state.read_pid(name, state_dir=args.state_dir)
+    boot_data = _state.read_boot(name, state_dir=args.state_dir) or {}
+    log_path = _resolve_log_path_for_relaunch(
+        name, pid_data=pid_data, boot_data=boot_data,
+        warn_when_defaulting=False,
+    )
+
+    if not os.path.exists(log_path):
+        sys.stderr.write(
+            f"senpi-helpers: log file not found at {log_path}.\n"
+            f"  Resolved from: "
+            f"{'pid.json' if (pid_data or {}).get('log_path') else ('boot.json' if boot_data.get('log_path') else 'default')}\n"
+            f"  The daemon may not have written yet, or the path is stale.\n"
+        )
+        return LOGS_NO_LOG
+
+    if args.follow:
+        # Print a one-line breadcrumb to stderr so operators know which
+        # file they're tailing; stdout stays the log stream.
+        sys.stderr.write(f"senpi-helpers: tailing {log_path} (Ctrl-C to stop)\n")
+        _stream_log(log_path)
+    else:
+        _print_last_n_lines(log_path, n=args.lines)
+    return LOGS_OK
+
+
 # ─── Subcommand: stats ──────────────────────────────────────────────────────
 
 STATS_OK = 0
@@ -1121,6 +1230,31 @@ def _make_parser() -> argparse.ArgumentParser:
     )
     boot_p.add_argument("--json", action="store_true", help="Emit JSON instead of a summary.")
     boot_p.set_defaults(func=cmd_boot)
+
+    # logs
+    logs_p = sub.add_parser(
+        "logs",
+        help="Tail the daemon's stderr log (resolved from pid.json / boot.json).",
+        description=(
+            "Print the last N lines of the daemon's log file, optionally "
+            "following new output. The log_path is resolved through the same "
+            "fallback chain `restart` and `stats` use, so this works even "
+            "after a clean stop (when pid.json is gone)."
+        ),
+    )
+    logs_p.add_argument(
+        "name", nargs="?", default=None,
+        help="Daemon name. Optional on single-daemon hosts.",
+    )
+    logs_p.add_argument(
+        "-n", "--lines", type=int, default=50,
+        help="How many trailing lines to print (default: 50). Ignored with --follow.",
+    )
+    logs_p.add_argument(
+        "-f", "--follow", action="store_true",
+        help="Stream new lines as they're written (Ctrl-C to stop).",
+    )
+    logs_p.set_defaults(func=cmd_logs)
 
     # stats
     stats_p = sub.add_parser(

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -484,6 +484,12 @@ def _stream_log(log_path: str) -> None:
                 if fh is not None:
                     fh.close()
                     fh = None
+                # Reset inode too: if the file reappears later with the
+                # same inode (rare but possible on inode-recycling FS), we
+                # want a clean reopen. Without this, `inode != st.st_ino`
+                # below would be False and we'd skip past the reopen
+                # branch, then hit `fh.seek(0)` / `fh.read()` on None.
+                inode = None
                 time.sleep(poll)
                 continue
             # Rotation detection: new inode → reopen at start.

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -1434,6 +1434,11 @@ def cmd_start(args: argparse.Namespace) -> int:
         cwd=cwd,
         log_path=log_path,
         env=env_for_spawn,
+        # Defense in depth: for schema-2 argv [python3, -u, script],
+        # the argv[0] check inside relaunch_daemon only verifies the
+        # interpreter. Pass script_path explicitly so it gets validated
+        # too — gives RELAUNCH_SCRIPT_MISSING instead of spawn-then-die.
+        script_path=script_path,
     )
 
     if relaunch_result["outcome"] != _manage.RELAUNCH_OK:
@@ -1558,6 +1563,10 @@ def cmd_restart(args: argparse.Namespace) -> int:
         argv=argv,
         cwd=cwd,
         log_path=log_path,
+        # Defense in depth: see comment in cmd_start. cmd_restart already
+        # validates script_path above (RESTART_FAILED on missing), but a
+        # race between that check and the spawn is theoretically possible.
+        script_path=script_path,
     )
 
     if relaunch_result["outcome"] != _manage.RELAUNCH_OK:

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -1161,7 +1161,7 @@ def _resolve_inherit_env_source(spec: str) -> Tuple[Optional[int], Optional[str]
     """Map an `--inherit-env-from` value to (pid, error).
 
     Accepted spec values:
-      - `"openclaw"`  → pgrep -f '^openclaw$', head -1.
+      - `"openclaw"`  → multi-strategy resolution; see below.
       - Any decimal integer string → that pid.
       - Anything else → error.
 
@@ -1169,22 +1169,46 @@ def _resolve_inherit_env_source(spec: str) -> Tuple[Optional[int], Optional[str]
     Linux is the only supported target — `/proc` lookup happens via
     `state.read_proc_environ`. The check for non-Linux happens at the
     use-site so this helper stays pure.
+
+    Resolution strategy for `openclaw` (tries in order, first match wins):
+      1. `pgrep -x openclaw`  — exact match on the process's kernel-level
+         comm (argv[0] basename, truncated to TASK_COMM_LEN). Matches the
+         common production case where the binary is /usr/local/bin/openclaw
+         or just openclaw on PATH.
+      2. `pgrep -f '(^|/)openclaw($| )'` — word-boundary match against the
+         full cmdline. Catches `node /path/to/openclaw` style launches
+         where comm is `node` but `openclaw` appears as a path component.
+
+    The original `pgrep -f '^openclaw$'` matched only the rare case where
+    the FULL cmdline is literally `openclaw` with no args / path. Caught
+    by garg-prashant on PR #279.
     """
     if spec == "openclaw":
         import subprocess
-        try:
-            res = subprocess.run(
-                ["pgrep", "-f", r"^openclaw$"],
-                capture_output=True, text=True, check=False, timeout=5,
-            )
-        except (subprocess.SubprocessError, FileNotFoundError) as e:
-            return None, f"could not invoke pgrep: {e}"
-        if res.returncode != 0:
-            return None, "no process matching '^openclaw$' is running"
-        pids = [ln for ln in res.stdout.split() if ln.strip().isdigit()]
-        if not pids:
-            return None, "pgrep returned no pids for '^openclaw$'"
-        return int(pids[0]), None
+        attempts = [
+            (["pgrep", "-x", "openclaw"], "exact comm match"),
+            (["pgrep", "-f", r"(^|/)openclaw($| )"], "cmdline word match"),
+        ]
+        last_err: Optional[str] = None
+        for cmd, label in attempts:
+            try:
+                res = subprocess.run(
+                    cmd, capture_output=True, text=True,
+                    check=False, timeout=5,
+                )
+            except (subprocess.SubprocessError, FileNotFoundError) as e:
+                last_err = f"could not invoke pgrep ({label}): {e}"
+                continue
+            if res.returncode == 0 and res.stdout.strip():
+                pids = [ln for ln in res.stdout.split() if ln.strip().isdigit()]
+                if pids:
+                    return int(pids[0]), None
+            # rc=1 from pgrep = no match; not an error, try the next strategy.
+        return None, (
+            last_err
+            or "no openclaw process found (tried exact comm match + "
+               "cmdline word boundary)"
+        )
     # Plain integer pid.
     try:
         pid = int(spec)

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -91,15 +91,20 @@ def _shorten_wallet(wallet: Optional[str]) -> str:
     return f"{wallet[:6]}…{wallet[-4:]}" if len(wallet) > 14 else wallet
 
 
-def _resolve_name(args: argparse.Namespace) -> Optional[str]:
-    """Resolve `<name>` for subcommands that take one daemon.
+def _resolve_name_readonly(args: argparse.Namespace) -> Optional[str]:
+    """Resolve `<name>` for READ-ONLY subcommands (list, health, stats,
+    boot, logs).
 
     Rules:
       - Explicit `<name>` arg always wins.
       - If no daemons registered → return None (caller surfaces "not found").
-      - If exactly one daemon registered → use it (single-daemon hosts
-        shouldn't pay the cost of always typing the name).
+      - If exactly one daemon registered → use it. Single-daemon hosts
+        shouldn't pay the cost of always typing the name for inspection.
       - If multiple daemons registered → return None and print a list.
+
+    For DESTRUCTIVE subcommands (stop, restart, start), use
+    `_resolve_name_explicit` instead — auto-resolve is a footgun when the
+    operator could be on the wrong box.
     """
     if getattr(args, "name", None):
         return args.name
@@ -118,6 +123,50 @@ def _resolve_name(args: argparse.Namespace) -> Optional[str]:
         f"  Available: {', '.join(names)}\n"
     )
     return None
+
+
+def _resolve_name_explicit(
+    args: argparse.Namespace, *, action: str,
+) -> Optional[str]:
+    """Resolve `<name>` for DESTRUCTIVE subcommands (stop, restart, start).
+
+    Unlike `_resolve_name_readonly`, this NEVER auto-resolves to the only
+    daemon on the host. The operator (or agent) MUST type the name. This
+    closes a footgun: `senpi-helpers stop` typed on the wrong SSH session
+    used to silently kill whatever daemon happened to be on that box.
+
+    Read-only commands keep the auto-resolve convenience because they can
+    only mis-inform — not destroy state.
+
+    Why no interactive `[y/N]` prompt:
+        The primary tool consumer is the openclaw agent (via its `exec`
+        tool, which has no interactive stdin). An interactive prompt would
+        hang every agent-driven stop/restart. Requiring an explicit name
+        is equally safe and works for both human + agent uniformly.
+    """
+    if getattr(args, "name", None):
+        return args.name
+    names = _state.list_daemons(state_dir=args.state_dir)
+    if not names:
+        sys.stderr.write(
+            "senpi-helpers: no daemons found in state dir "
+            f"({_state.get_state_dir(args.state_dir)}).\n"
+        )
+        return None
+    sys.stderr.write(
+        f"senpi-helpers: '{action}' requires an explicit <name>. "
+        f"Auto-resolution is disabled for destructive commands.\n"
+        f"  Available: {', '.join(names)}\n"
+        f"  See: `senpi-helpers list` for details before choosing.\n"
+    )
+    return None
+
+
+# Backward-compat alias for any code that imported `_resolve_name`. The
+# new code should pick the correct variant. We keep this pointing at the
+# READ-ONLY variant to preserve old call-site behavior for non-destructive
+# subcommands; destructive commands are switched explicitly below.
+_resolve_name = _resolve_name_readonly
 
 
 def _collect_daemon_row(name: str, state_dir: Optional[str]) -> Dict[str, Any]:
@@ -494,7 +543,9 @@ def _print_stop_summary(name: str, pid: int, result: Dict[str, Any]) -> None:
 
 
 def cmd_stop(args: argparse.Namespace) -> int:
-    name = _resolve_name(args)
+    # Destructive: require an explicit <name>. See `_resolve_name_explicit`
+    # for why we don't auto-resolve on single-daemon hosts.
+    name = _resolve_name_explicit(args, action="stop")
     if name is None:
         return STOP_NOT_FOUND
 
@@ -664,7 +715,8 @@ START_NOT_FOUND = 2
 
 
 def cmd_start(args: argparse.Namespace) -> int:
-    name = _resolve_name(args)
+    # Destructive (spawns a process): require an explicit <name>.
+    name = _resolve_name_explicit(args, action="start")
     if name is None:
         return START_NOT_FOUND
 
@@ -771,7 +823,8 @@ def cmd_start(args: argparse.Namespace) -> int:
 
 
 def cmd_restart(args: argparse.Namespace) -> int:
-    name = _resolve_name(args)
+    # Destructive (kills the old daemon): require an explicit <name>.
+    name = _resolve_name_explicit(args, action="restart")
     if name is None:
         return RESTART_NOT_FOUND
 

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -466,65 +466,100 @@ def _print_last_n_lines(log_path: str, *, n: int) -> None:
         sys.stdout.write(line)
 
 
-def _stream_log(log_path: str) -> None:
-    """`tail -F` semantics: keep reading even if file rotates or truncates.
+class _LogTailer:
+    """`tail -F` state machine, factored out so the iteration logic is
+    directly unit-testable.
 
-    Polls every 250 ms. Reopens on inode change (rotation). Truncation
-    (file shrunk) → seek back to current size.
+    Each call to `step()` runs one observation cycle:
+      - Statting the file (handling FileNotFoundError).
+      - Reopening on inode change.
+      - Seeking-to-zero on truncation.
+      - Reading any new bytes.
+
+    Returns one of: ('output', chunk_str), ('wait', None). The caller
+    decides how to render output and how long to wait between steps.
     """
-    poll = 0.25
-    inode = None
-    fh = None
-    pos = 0
+
+    def __init__(self, log_path: str, *, poll_seconds: float = 0.25) -> None:
+        self.log_path = log_path
+        self.poll_seconds = poll_seconds
+        self.inode: Optional[int] = None
+        self.fh = None  # type: ignore[var-annotated]
+        self.pos: int = 0
+        # `started` is true once the FIRST successful open has happened.
+        # Independent of `inode` (which gets reset to None when the file
+        # disappears). This is what makes "seek to END" fire only on the
+        # initial open, not on rotation, recreation, or reappearance.
+        self.started: bool = False
+
+    def step(self) -> Tuple[str, Optional[str]]:
+        """Run one observation cycle. Returns the next action for the caller.
+
+        Pure-ish: only side effects are file I/O on `self.log_path`. No
+        sleeps; no writes to stdout. The caller composes those.
+        """
+        try:
+            st = os.stat(self.log_path)
+        except FileNotFoundError:
+            # File deleted (or never existed yet). Drop our handle so the
+            # next successful stat reopens cleanly; reset inode so the
+            # reopen branch fires even if the recreated file happens to
+            # land on the same inode the kernel just freed.
+            if self.fh is not None:
+                self.fh.close()
+                self.fh = None
+            self.inode = None
+            return ("wait", None)
+
+        # Reopen branch fires for: very first open, rotation (inode
+        # change), and reappearance after FileNotFoundError (inode is None).
+        if self.inode != st.st_ino:
+            if self.fh is not None:
+                self.fh.close()
+            self.fh = open(self.log_path, "r", errors="replace")
+            if not self.started:
+                # Very first open of this tailer instance — skip history
+                # so `logs --follow` doesn't replay the entire log file.
+                # Every subsequent reopen reads from byte 0, since the
+                # new/rotated/recreated file's content IS what we want.
+                self.fh.seek(0, os.SEEK_END)
+                self.started = True
+            self.inode = st.st_ino
+            self.pos = self.fh.tell()
+
+        # Truncation detection: file size shrank below our last position.
+        if st.st_size < self.pos:
+            self.fh.seek(0)
+            self.pos = 0
+
+        chunk = self.fh.read()
+        if chunk:
+            self.pos = self.fh.tell()
+            return ("output", chunk)
+        return ("wait", None)
+
+    def close(self) -> None:
+        if self.fh is not None:
+            self.fh.close()
+            self.fh = None
+
+
+def _stream_log(log_path: str) -> None:
+    """`tail -F` semantics: keep reading even if file rotates, truncates,
+    or temporarily disappears. Polls every 250 ms. Ctrl-C exits cleanly."""
+    tailer = _LogTailer(log_path)
     try:
         while True:
-            try:
-                st = os.stat(log_path)
-            except FileNotFoundError:
-                if fh is not None:
-                    fh.close()
-                    fh = None
-                # Reset inode too: if the file reappears later with the
-                # same inode (rare but possible on inode-recycling FS), we
-                # want a clean reopen. Without this, `inode != st.st_ino`
-                # below would be False and we'd skip past the reopen
-                # branch, then hit `fh.seek(0)` / `fh.read()` on None.
-                inode = None
-                time.sleep(poll)
-                continue
-            # Rotation detection: new inode → reopen.
-            if inode != st.st_ino:
-                # Capture whether this is the very first open BEFORE we
-                # reassign inode. First open skips history (we don't want
-                # to dump the entire historical log on `logs --follow`).
-                # Subsequent reopens (rotation OR reappearance) start from
-                # position 0 — otherwise we'd discard content already
-                # written to the rotated/new file by the time we noticed.
-                is_first_open = inode is None
-                if fh is not None:
-                    fh.close()
-                fh = open(log_path, "r", errors="replace")
-                if is_first_open:
-                    fh.seek(0, os.SEEK_END)
-                inode = st.st_ino
-                pos = fh.tell()
-            # Truncation detection: file size < our position.
-            if st.st_size < pos:
-                fh.seek(0)
-                pos = 0
-            chunk = fh.read()
-            if chunk:
-                sys.stdout.write(chunk)
+            action, payload = tailer.step()
+            if action == "output" and payload is not None:
+                sys.stdout.write(payload)
                 sys.stdout.flush()
-                pos = fh.tell()
             else:
-                time.sleep(poll)
+                time.sleep(tailer.poll_seconds)
     except KeyboardInterrupt:
-        # Operator hit Ctrl-C — exit cleanly.
         pass
     finally:
-        if fh is not None:
-            fh.close()
+        tailer.close()
 
 
 def cmd_logs(args: argparse.Namespace) -> int:

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -721,7 +721,11 @@ def _diag_check(key: str, status: str, message: str, suggestion: Optional[str] =
 
 
 def _run_diagnostic_checks(
-    name: str, *, state_dir: Optional[str],
+    name: str,
+    *,
+    pid_data: Optional[Dict[str, Any]],
+    boot_data: Optional[Dict[str, Any]],
+    hb_data: Optional[Dict[str, Any]],
 ) -> List[Dict[str, Any]]:
     """Run every diagnostic in order. Each returns a result dict.
 
@@ -729,11 +733,12 @@ def _run_diagnostic_checks(
     sees structural problems (missing files) before runtime ones (stale
     ticks). All checks are pure functions over the on-disk state — no
     side effects, no Railway, no network.
-    """
-    pid_data = _state.read_pid(name, state_dir=state_dir)
-    boot_data = _state.read_boot(name, state_dir=state_dir)
-    hb_data = _state.read_heartbeat(name, state_dir=state_dir)
 
+    State data is passed in (read once by the caller) so the CLI does
+    not double-read pid/boot/heartbeat — which previously also opened a
+    TOCTOU window between the existence pre-check and the per-check
+    pass. Bugbot Low-sev (commit 4b12ef3).
+    """
     out: List[Dict[str, Any]] = []
 
     # boot.json — without it, the daemon has never run under the helper.
@@ -929,20 +934,24 @@ def cmd_diagnose(args: argparse.Namespace) -> int:
     name = _resolve_name_readonly(args)
     if name is None:
         return DIAGNOSE_NOT_FOUND
-    # Confirm at least SOMETHING for this daemon exists; otherwise the
-    # diagnose output would be entirely "missing" rows with no signal.
-    if (
-        _state.read_pid(name, state_dir=args.state_dir) is None
-        and _state.read_boot(name, state_dir=args.state_dir) is None
-        and _state.read_heartbeat(name, state_dir=args.state_dir) is None
-    ):
+    # Read each state file ONCE and thread the values through. Doing the
+    # existence pre-check from the same dicts the per-check pass uses
+    # avoids a TOCTOU window where the pre-check sees state but the per-
+    # check pass sees None (a daemon that exited between the two reads),
+    # and trims wasted disk I/O. Bugbot Low-sev (commit 4b12ef3).
+    pid_data = _state.read_pid(name, state_dir=args.state_dir)
+    boot_data = _state.read_boot(name, state_dir=args.state_dir)
+    hb_data = _state.read_heartbeat(name, state_dir=args.state_dir)
+    if pid_data is None and boot_data is None and hb_data is None:
         sys.stderr.write(
             f"senpi-helpers: no state files for '{name}'. "
             f"Use `senpi-helpers list` to see registered daemons.\n"
         )
         return DIAGNOSE_NOT_FOUND
 
-    checks = _run_diagnostic_checks(name, state_dir=args.state_dir)
+    checks = _run_diagnostic_checks(
+        name, pid_data=pid_data, boot_data=boot_data, hb_data=hb_data,
+    )
 
     if args.json:
         print(json.dumps(

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -31,11 +31,13 @@ from . import stats as _stats
 
 
 # ─── Helpers shared across subcommands ──────────────────────────────────────
-
-
-# Canonical PID-liveness check lives in `state.py` — re-aliased locally so
-# existing call sites keep their idiomatic name without an extra import alias.
-_is_pid_alive = _state.pid_alive
+#
+# Schema awareness: this module reads pid.json / boot.json / heartbeat.json
+# via `state.read_*`. Each file is independently versioned — see the
+# top-of-file comment in `state.py` for the protocol. The CLI uses `.get(...)`
+# for any field that was added in a later schema (e.g. `cmdline_fingerprint`,
+# `log_path` in boot.json), so reading a legacy-schema file degrades cleanly
+# instead of KeyError'ing.
 
 
 def _parse_iso(s: Optional[str]) -> Optional[datetime]:
@@ -123,10 +125,13 @@ def _collect_daemon_row(name: str, state_dir: Optional[str]) -> Dict[str, Any]:
     pid_data = _state.read_pid(name, state_dir=state_dir) or {}
     hb_data = _state.read_heartbeat(name, state_dir=state_dir) or {}
     pid = pid_data.get("pid")
+    # `running` consults the pid-recycle guard: True only if the pid exists
+    # AND its cmdline/start-time fingerprints match what write_pid recorded.
+    # On schema-1 pid.json or non-Linux hosts, degrades to plain pid_alive.
     return {
         "name": name,
         "pid": pid if isinstance(pid, int) else None,
-        "running": _is_pid_alive(pid) if isinstance(pid, int) else False,
+        "running": _pid_alive_for_daemon(pid_data) if pid_data else False,
         "wallet": pid_data.get("wallet"),
         "scanner": pid_data.get("scanner"),
         "interval_seconds": pid_data.get("interval_seconds"),
@@ -251,7 +256,8 @@ def _build_health_payload(
     pid_data = pid_data or {}
     hb_data = hb_data or {}
     pid = pid_data.get("pid") if isinstance(pid_data.get("pid"), int) else None
-    running = _is_pid_alive(pid) if pid is not None else False
+    # Use pid-recycle guard so health doesn't false-positive on a recycled pid.
+    running = _pid_alive_for_daemon(pid_data) if pid is not None else False
     interval = pid_data.get("interval_seconds")
     uptime = _age_seconds(pid_data.get("start_time_iso"))
     last_tick_iso = hb_data.get("last_tick_iso")
@@ -406,17 +412,25 @@ def cmd_stats(args: argparse.Namespace) -> int:
     if name is None:
         return STATS_NOT_FOUND
 
+    # Stats can run on a cleanly-stopped daemon: pid.json may be gone, but
+    # boot.json (which persists) records log_path under schema 2+. Try both.
     pid_data = _state.read_pid(name, state_dir=args.state_dir)
-    if pid_data is None:
-        sys.stderr.write(
-            f"senpi-helpers: no pid.json for '{name}' — the daemon "
-            f"may have exited cleanly. Stats reads the log path recorded "
-            f"there. Try `senpi-helpers list` to see registered daemons.\n"
-        )
-        return STATS_NOT_FOUND
+    boot_data = _state.read_boot(name, state_dir=args.state_dir)
 
-    log_path = pid_data.get("log_path")
+    log_path = (pid_data or {}).get("log_path")
     if not log_path:
+        log_path = (boot_data or {}).get("log_path")
+    if not log_path and boot_data:
+        env_snapshot = boot_data.get("env_snapshot") or {}
+        log_path = env_snapshot.get("SENPI_HELPERS_LOG_PATH")
+
+    if not log_path:
+        if pid_data is None and boot_data is None:
+            sys.stderr.write(
+                f"senpi-helpers: no state files for '{name}'. "
+                f"Try `senpi-helpers list` to see registered daemons.\n"
+            )
+            return STATS_NOT_FOUND
         sys.stderr.write(
             f"senpi-helpers: daemon '{name}' did not record a log path. "
             f"Stats parses from the daemon's stderr log file; without a "
@@ -499,6 +513,30 @@ def cmd_stop(args: argparse.Namespace) -> int:
         )
         return STOP_NOT_FOUND
 
+    # Pid-recycle guard: if pid_data has fingerprints (schema 2) but
+    # /proc/<pid>'s cmdline or start_time doesn't match, the kernel has
+    # given our daemon's old pid to an unrelated process. Refuse to signal
+    # — treat as already-dead — and clear the stale pid.json.
+    if _state.pid_alive(pid) and not _pid_alive_for_daemon(pid_data):
+        sys.stderr.write(
+            f"senpi-helpers: pid {pid} is alive but its cmdline / start_time "
+            f"doesn't match what '{name}' recorded — likely a pid recycle. "
+            f"Refusing to SIGTERM an unrelated process. Clearing stale pid.json.\n"
+        )
+        _state.clear_pid(name, state_dir=args.state_dir)
+        result = {
+            "outcome": _manage.STOP_ALREADY_DEAD,
+            "elapsed_seconds": 0.0,
+            "sigterm_sent": False, "sigkill_sent": False,
+            "error": "pid recycled to unrelated process",
+        }
+        if args.json:
+            payload = {"name": name, "pid": pid, **result}
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"{name}: pid {pid} recycled — daemon already gone.")
+        return STOP_OK
+
     result = _manage.stop_pid(pid, timeout_seconds=args.timeout)
 
     # SIGKILL'd daemons can't run their own clear_pid, so the CLI cleans up.
@@ -552,6 +590,186 @@ def _wait_for_new_pid_json(
     return None
 
 
+def _pid_alive_for_daemon(pid_data: Optional[Dict[str, Any]]) -> bool:
+    """Liveness check that consults pid_data's fingerprints when available.
+
+    Use this everywhere the CLI asks "is my daemon's pid alive?" — `stop`,
+    `restart`, `start`, `health`, `list`. It defends against pid recycling
+    by cross-checking /proc/<pid>/cmdline and /proc/<pid>/stat against the
+    fingerprints `write_pid` recorded.
+    """
+    if not pid_data:
+        return False
+    pid = pid_data.get("pid")
+    if not isinstance(pid, int):
+        return False
+    return _state.pid_alive_and_matches(
+        pid,
+        expected_fingerprint=pid_data.get("cmdline_fingerprint"),
+        expected_jiffies=pid_data.get("start_time_jiffies"),
+    )
+
+
+def _resolve_log_path_for_relaunch(
+    name: str,
+    *,
+    pid_data: Optional[Dict[str, Any]],
+    boot_data: Dict[str, Any],
+    warn_when_defaulting: bool = True,
+) -> str:
+    """Pick the log path to point the relaunched daemon's stderr at.
+
+    Tried in order:
+      1. pid.json's log_path — most recent observed value.
+      2. boot.json's log_path (schema 2+) — survives clean stops.
+      3. boot.json env_snapshot's SENPI_HELPERS_LOG_PATH — operator override.
+      4. Deterministic default /tmp/<name>.log — with a stderr warning.
+
+    Extracted so `cmd_restart` and `cmd_start` share identical resolution
+    semantics. Each daemon's first successful relaunch under schema-2
+    boot.json will persist its log_path, so the default is one-shot.
+    """
+    log_path = (pid_data or {}).get("log_path")
+    if log_path:
+        return log_path
+    log_path = boot_data.get("log_path")
+    if log_path:
+        return log_path
+    env_snapshot = boot_data.get("env_snapshot") or {}
+    log_path = env_snapshot.get("SENPI_HELPERS_LOG_PATH")
+    if log_path:
+        return log_path
+    default_path = f"/tmp/{name}.log"
+    if warn_when_defaulting:
+        sys.stderr.write(
+            f"senpi-helpers: no log_path recorded in boot.json or pid.json; "
+            f"defaulting to {default_path}. (Set SENPI_HELPERS_LOG_PATH before "
+            f"launch, or rely on the new daemon's write_boot to persist the "
+            f"resolved path so future restarts use it.)\n"
+        )
+    return default_path
+
+
+# ─── Subcommand: start ──────────────────────────────────────────────────────
+#
+# `start` is the missing peer of `stop`/`restart`. Without it, operators had
+# to hand-type the `nohup python3 -u … > /tmp/<name>.log 2>&1 &` playbook
+# every time — which is what introduced the schema-1 boot.json gap we fixed
+# earlier in this branch. With `start`, the daemon's argv + log path come
+# from boot.json (auto-migrated if schema 1), the operator types one command.
+
+START_OK = 0
+START_FAILED = 1
+START_NOT_FOUND = 2
+
+
+def cmd_start(args: argparse.Namespace) -> int:
+    name = _resolve_name(args)
+    if name is None:
+        return START_NOT_FOUND
+
+    boot_data = _state.read_boot(name, state_dir=args.state_dir)
+    if boot_data is None:
+        sys.stderr.write(
+            f"senpi-helpers: cannot start '{name}': boot.json is missing.\n"
+            f"The daemon has never started under the helper, so there's no "
+            f"record of how to launch it. Use your skill's launch recipe one "
+            f"time (`nohup python3 -u <producer>.py > /tmp/{name}.log 2>&1 &` "
+            f"plus the skill's env vars); `start` will work from the next "
+            f"launch onward.\n"
+        )
+        return START_NOT_FOUND
+
+    script_path = boot_data.get("script_path")
+    argv = boot_data.get("argv") or []
+    cwd = boot_data.get("cwd")
+
+    if not script_path or not os.path.exists(script_path):
+        sys.stderr.write(
+            f"senpi-helpers: cannot start '{name}': script_path "
+            f"'{script_path}' no longer exists on disk.\n"
+        )
+        return START_FAILED
+
+    # Idempotent: if the daemon is already alive (and the pid hasn't been
+    # recycled to an unrelated process), do nothing. `_pid_alive_for_daemon`
+    # cross-checks cmdline + start_time fingerprints from pid.json.
+    pid_data = _state.read_pid(name, state_dir=args.state_dir)
+    pid = pid_data.get("pid") if pid_data else None
+    if isinstance(pid, int) and _pid_alive_for_daemon(pid_data):
+        if args.json:
+            print(json.dumps({
+                "name": name, "outcome": "already_running", "pid": pid,
+            }, indent=2, default=str))
+        else:
+            print(f"{name}: already running (pid {pid}). No action taken.")
+        return START_OK
+
+    log_path = _resolve_log_path_for_relaunch(
+        name, pid_data=pid_data, boot_data=boot_data,
+    )
+
+    relaunch_result = _manage.relaunch_daemon(
+        argv=argv,
+        cwd=cwd,
+        log_path=log_path,
+    )
+
+    if relaunch_result["outcome"] != _manage.RELAUNCH_OK:
+        sys.stderr.write(
+            f"senpi-helpers: start failed: {relaunch_result['outcome']} "
+            f"({relaunch_result.get('error')})\n"
+        )
+        if args.json:
+            print(json.dumps({
+                "name": name, "outcome": relaunch_result["outcome"],
+                "relaunch_result": relaunch_result,
+            }, indent=2, default=str))
+        return START_FAILED
+
+    new_pid = relaunch_result["pid"]
+    argv_normalized = bool(relaunch_result.get("argv_normalized"))
+    confirmed = _wait_for_new_pid_json(
+        name,
+        state_dir=args.state_dir,
+        expected_pid=new_pid,
+        timeout=_RELAUNCH_CONFIRM_TIMEOUT,
+    )
+
+    payload = {
+        "name": name,
+        "outcome": "started",
+        "new_pid": new_pid,
+        "relaunch_result": relaunch_result,
+        "argv_normalized": argv_normalized,
+        "pid_json_confirmed": confirmed is not None,
+        "log_path": log_path,
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2, default=str))
+    else:
+        print(f"{name}: started.")
+        print(f"  new pid:        {new_pid}")
+        print(f"  log path:       {log_path}")
+        print(f"  script:         {script_path}")
+        if argv_normalized:
+            print(
+                "  boot.json:      schema 1 detected; interpreter "
+                "auto-prepended (one-time migration)"
+            )
+        if confirmed is not None:
+            print("  pid.json:       confirmed (new daemon is ticking)")
+        else:
+            print(f"  pid.json:       not seen within {_RELAUNCH_CONFIRM_TIMEOUT}s")
+            print(
+                f"  → verify with `senpi-helpers health {name}` "
+                f"and check the log."
+            )
+
+    return START_OK
+
+
 def cmd_restart(args: argparse.Namespace) -> int:
     name = _resolve_name(args)
     if name is None:
@@ -584,11 +802,14 @@ def cmd_restart(args: argparse.Namespace) -> int:
         )
         return RESTART_FAILED
 
-    # If the daemon is running, stop it first (clean SIGTERM + escalation).
+    # If the daemon is running (and the pid hasn't been recycled to a
+    # stranger process), stop it first via SIGTERM + escalation.
+    # `_pid_alive_for_daemon` guards against recycling using cmdline +
+    # start_time fingerprints from pid.json.
     pid_data = _state.read_pid(name, state_dir=args.state_dir)
     pid = pid_data.get("pid") if pid_data else None
     stop_result: Optional[Dict[str, Any]] = None
-    if isinstance(pid, int) and _manage.is_pid_alive(pid):
+    if isinstance(pid, int) and _pid_alive_for_daemon(pid_data):
         stop_result = _manage.stop_pid(pid, timeout_seconds=args.timeout)
         if not _manage.stop_outcome_was_success(stop_result["outcome"]):
             sys.stderr.write(
@@ -605,22 +826,11 @@ def cmd_restart(args: argparse.Namespace) -> int:
         if stop_result["outcome"] == _manage.STOP_KILL_OK:
             _state.clear_pid(name, state_dir=args.state_dir)
 
-    # Restart needs a log path so the new daemon's stderr is captured
-    # somewhere the operator can find it. Pull from old pid.json
-    # (preferred) or boot.json env_snapshot's SENPI_HELPERS_LOG_PATH
-    # (operator-set explicit). If neither is available, fail loudly.
-    log_path = (pid_data or {}).get("log_path")
-    if not log_path:
-        env_snapshot = boot_data.get("env_snapshot") or {}
-        log_path = env_snapshot.get("SENPI_HELPERS_LOG_PATH")
-    if not log_path:
-        sys.stderr.write(
-            f"senpi-helpers: cannot restart '{name}': no log path recorded.\n"
-            f"`restart` needs to know where to send the new daemon's stderr. "
-            f"Start manually with `nohup python3 -u {script_path} > "
-            f"/tmp/{name}.log 2>&1 &` so the next pid.json captures the path.\n"
-        )
-        return RESTART_FAILED
+    # Shared resolution logic — see _resolve_log_path_for_relaunch's docstring
+    # for the fallback order. cmd_start uses the same helper.
+    log_path = _resolve_log_path_for_relaunch(
+        name, pid_data=pid_data, boot_data=boot_data,
+    )
 
     relaunch_result = _manage.relaunch_daemon(
         argv=argv,
@@ -744,7 +954,9 @@ def _make_parser() -> argparse.ArgumentParser:
         ),
     )
     sub = parser.add_subparsers(dest="command", metavar="<subcommand>")
-    sub.required = True  # py3.10 compat — required=True on add_subparsers isn't honored everywhere
+    # Some argparse releases don't honor `required=True` directly on
+    # `add_subparsers()` — set it explicitly for portability.
+    sub.required = True
 
     # list
     list_p = sub.add_parser(
@@ -804,6 +1016,27 @@ def _make_parser() -> argparse.ArgumentParser:
     )
     stats_p.add_argument("--json", action="store_true", help="Emit JSON instead of a summary.")
     stats_p.set_defaults(func=cmd_stats)
+
+    # start
+    start_p = sub.add_parser(
+        "start",
+        help="Start a daemon from its recorded boot.json (idempotent).",
+        description=(
+            "Launch the daemon as a detached process using argv + cwd from "
+            "boot.json. Idempotent — if a daemon with that name is already "
+            "running, `start` reports it and exits 0. If boot.json is missing "
+            "(the daemon has never been started under the helper), `start` "
+            "errors with the manual launch recipe."
+        ),
+    )
+    start_p.add_argument(
+        "name",
+        nargs="?",
+        default=None,
+        help="Daemon name. Optional on single-daemon hosts.",
+    )
+    start_p.add_argument("--json", action="store_true", help="Emit JSON instead of a summary.")
+    start_p.set_defaults(func=cmd_start)
 
     # stop
     stop_p = sub.add_parser(

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -492,14 +492,21 @@ def _stream_log(log_path: str) -> None:
                 inode = None
                 time.sleep(poll)
                 continue
-            # Rotation detection: new inode → reopen at start.
+            # Rotation detection: new inode → reopen.
             if inode != st.st_ino:
+                # Capture whether this is the very first open BEFORE we
+                # reassign inode. First open skips history (we don't want
+                # to dump the entire historical log on `logs --follow`).
+                # Subsequent reopens (rotation OR reappearance) start from
+                # position 0 — otherwise we'd discard content already
+                # written to the rotated/new file by the time we noticed.
+                is_first_open = inode is None
                 if fh is not None:
                     fh.close()
                 fh = open(log_path, "r", errors="replace")
+                if is_first_open:
+                    fh.seek(0, os.SEEK_END)
                 inode = st.st_ino
-                # On first open, seek to end so we don't replay history.
-                fh.seek(0, os.SEEK_END)
                 pos = fh.tell()
             # Truncation detection: file size < our position.
             if st.st_size < pos:

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -949,33 +949,26 @@ def cmd_stats(args: argparse.Namespace) -> int:
         return STATS_NOT_FOUND
 
     # Stats can run on a cleanly-stopped daemon: pid.json may be gone, but
-    # boot.json (which persists) records log_path under schema 2+. Try both.
+    # boot.json (which persists) records log_path under schema 2+.
     pid_data = _state.read_pid(name, state_dir=args.state_dir)
     boot_data = _state.read_boot(name, state_dir=args.state_dir)
 
-    log_path = (pid_data or {}).get("log_path")
-    if not log_path:
-        log_path = (boot_data or {}).get("log_path")
-    if not log_path and boot_data:
-        env_snapshot = boot_data.get("env_snapshot") or {}
-        log_path = env_snapshot.get("SENPI_HELPERS_LOG_PATH")
-
-    if not log_path:
-        if pid_data is None and boot_data is None:
-            sys.stderr.write(
-                f"senpi-helpers: no state files for '{name}'. "
-                f"Try `senpi-helpers list` to see registered daemons.\n"
-            )
-            return STATS_NOT_FOUND
+    if pid_data is None and boot_data is None:
         sys.stderr.write(
-            f"senpi-helpers: daemon '{name}' did not record a log path. "
-            f"Stats parses from the daemon's stderr log file; without a "
-            f"redirect, no log exists to parse.\n"
-            f"Fix by starting the daemon with stderr redirected — e.g. "
-            f"`nohup python3 -u <producer>.py > /tmp/{name}.log 2>&1 &` — "
-            f"or set SENPI_HELPERS_LOG_PATH=/path/to/log before launch.\n"
+            f"senpi-helpers: no state files for '{name}'. "
+            f"Try `senpi-helpers list` to see registered daemons.\n"
         )
-        return STATS_NO_LOG
+        return STATS_NOT_FOUND
+
+    # Use the SAME 4-level fallback chain that cmd_logs / cmd_restart use:
+    #   pid.json → boot.json → env_snapshot → /tmp/<name>.log default.
+    # Bugbot caught the prior inline 3-level chain (no default) — that
+    # made `stats` fail on a daemon where `logs` succeeded. Sharing the
+    # helper guarantees they stay aligned.
+    log_path = _resolve_log_path_for_relaunch(
+        name, pid_data=pid_data, boot_data=boot_data or {},
+        warn_when_defaulting=False,
+    )
 
     try:
         payload = _stats.aggregate_log_file(log_path, window_hours=args.hours)

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -489,19 +489,32 @@ def _read_last_n_lines(log_path: str, *, n: int,
         end_pos = fh.tell()
         if end_pos == 0:
             return []
-        data = b""
+        # Accumulate chunks in a list and join ONCE at the end. Prior
+        # version did `data = fh.read(read_size) + data` per iteration,
+        # which is O(N²) on bytes (each iteration allocates a new bytes
+        # object the size of cumulative data and copies everything).
+        # Track newline count incrementally too — `data.count(b'\n')`
+        # on growing data was the same O(N²) trap. External code-review
+        # nitpick #2.
+        chunks: List[bytes] = []
         pos = end_pos
         # We want n+1 newlines so the chunk we keep starts AFTER a complete
         # line break — otherwise the first "line" in our slice would be
         # the tail of an earlier line that got cut by the chunk boundary.
         target_newlines = n + 1
+        newlines_seen = 0
         while pos > 0:
             read_size = min(chunk_bytes, pos)
             pos -= read_size
             fh.seek(pos)
-            data = fh.read(read_size) + data
-            if data.count(b"\n") >= target_newlines:
+            chunk = fh.read(read_size)
+            chunks.append(chunk)
+            newlines_seen += chunk.count(b"\n")
+            if newlines_seen >= target_newlines:
                 break
+        # Chunks were appended back-to-front (newest-first). Reverse +
+        # join once to assemble the final byte string in O(N).
+        data = b"".join(reversed(chunks))
     finally:
         fh.close()
 

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -516,7 +516,21 @@ class _LogTailer:
         if self.inode != st.st_ino:
             if self.fh is not None:
                 self.fh.close()
-            self.fh = open(self.log_path, "r", errors="replace")
+                self.fh = None
+            # Race window: file passed our os.stat above, but could be
+            # deleted OR have its permissions changed before open() runs.
+            # If open raises, we MUST clear both self.fh and self.inode —
+            # otherwise self.fh stays as the now-closed old handle (that
+            # was already close()'d above). Next step would see "inode
+            # matches" (since we never updated self.inode), skip the
+            # reopen branch, then crash on self.fh.read() with
+            # "ValueError: I/O operation on closed file". Same recovery
+            # path as the FileNotFoundError-from-stat branch.
+            try:
+                self.fh = open(self.log_path, "r", errors="replace")
+            except OSError:
+                self.inode = None
+                return ("wait", None)
             if not self.started:
                 # Very first open of this tailer instance — skip history
                 # so `logs --follow` doesn't replay the entire log file.

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -379,6 +379,67 @@ def _print_health_summary(payload: Dict[str, Any]) -> None:
         print(f"last error:     {err[:200]}{'…' if len(err) > 200 else ''}")
 
 
+# ─── Subcommand: boot ───────────────────────────────────────────────────────
+#
+# Pure reader over boot.json. Operators / agents previously had to `cat`
+# the file directly on the box; surfaces argv, script_path, cwd, env
+# snapshot, and (schema 2+) log_path.
+
+BOOT_OK = 0
+BOOT_NOT_FOUND = 2
+
+
+def _print_boot_summary(boot_data: Dict[str, Any]) -> None:
+    """Human-readable single-block summary of boot.json."""
+    name = boot_data.get("name") or "-"
+    schema = boot_data.get("schema")
+    captured_at = boot_data.get("captured_at_iso") or "-"
+    script_path = boot_data.get("script_path") or "-"
+    cwd = boot_data.get("cwd") or "-"
+    log_path = boot_data.get("log_path") or "-"
+    argv = boot_data.get("argv") or []
+
+    print(f"name:           {name}")
+    print(f"schema:         {schema}")
+    print(f"captured at:    {captured_at}")
+    print(f"script path:    {script_path}")
+    print(f"cwd:            {cwd}")
+    print(f"log path:       {log_path}")
+    print(f"argv:           {' '.join(str(a) for a in argv)}")
+    env_snapshot = boot_data.get("env_snapshot") or {}
+    if env_snapshot:
+        print(f"env_snapshot ({len(env_snapshot)} keys):")
+        for k in sorted(env_snapshot):
+            v = str(env_snapshot[k])
+            # Truncate long values (e.g. wallet addresses are fine; URLs / paths
+            # get long). 60 chars + ellipsis keeps the column readable.
+            if len(v) > 60:
+                v = v[:60] + "…"
+            print(f"  {k:<28}  {v}")
+    else:
+        print("env_snapshot:   (empty)")
+
+
+def cmd_boot(args: argparse.Namespace) -> int:
+    name = _resolve_name_readonly(args)
+    if name is None:
+        return BOOT_NOT_FOUND
+    boot_data = _state.read_boot(name, state_dir=args.state_dir)
+    if boot_data is None:
+        sys.stderr.write(
+            f"senpi-helpers: no boot.json for '{name}' in "
+            f"{_state.get_state_dir(args.state_dir)}.\n"
+            f"The daemon has never started under the helper. "
+            f"Use `senpi-helpers list` to see what IS registered.\n"
+        )
+        return BOOT_NOT_FOUND
+    if args.json:
+        print(json.dumps(boot_data, indent=2, default=str))
+    else:
+        _print_boot_summary(boot_data)
+    return BOOT_OK
+
+
 # ─── Subcommand: stats ──────────────────────────────────────────────────────
 
 STATS_OK = 0
@@ -1043,6 +1104,23 @@ def _make_parser() -> argparse.ArgumentParser:
     )
     health_p.add_argument("--json", action="store_true", help="Emit JSON instead of a summary.")
     health_p.set_defaults(func=cmd_health)
+
+    # boot
+    boot_p = sub.add_parser(
+        "boot",
+        help="Show the daemon's recorded boot.json (argv, script, env_snapshot, log_path).",
+        description=(
+            "Pretty-print boot.json for the named daemon. Useful for verifying "
+            "the relaunch payload `restart`/`start` will use, including the "
+            "captured wallet / decision-model env vars and the script path."
+        ),
+    )
+    boot_p.add_argument(
+        "name", nargs="?", default=None,
+        help="Daemon name. Optional on single-daemon hosts.",
+    )
+    boot_p.add_argument("--json", action="store_true", help="Emit JSON instead of a summary.")
+    boot_p.set_defaults(func=cmd_boot)
 
     # stats
     stats_p = sub.add_parser(

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -23,7 +23,7 @@ import os
 import sys
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from . import manage as _manage
 from . import state as _state
@@ -1144,6 +1144,81 @@ START_FAILED = 1
 START_NOT_FOUND = 2
 
 
+def _resolve_inherit_env_source(spec: str) -> Tuple[Optional[int], Optional[str]]:
+    """Map an `--inherit-env-from` value to (pid, error).
+
+    Accepted spec values:
+      - `"openclaw"`  → pgrep -f '^openclaw$', head -1.
+      - Any decimal integer string → that pid.
+      - Anything else → error.
+
+    Returns `(pid, None)` on success or `(None, error_message)` on failure.
+    Linux is the only supported target — `/proc` lookup happens via
+    `state.read_proc_environ`. The check for non-Linux happens at the
+    use-site so this helper stays pure.
+    """
+    if spec == "openclaw":
+        import subprocess
+        try:
+            res = subprocess.run(
+                ["pgrep", "-f", r"^openclaw$"],
+                capture_output=True, text=True, check=False, timeout=5,
+            )
+        except (subprocess.SubprocessError, FileNotFoundError) as e:
+            return None, f"could not invoke pgrep: {e}"
+        if res.returncode != 0:
+            return None, "no process matching '^openclaw$' is running"
+        pids = [ln for ln in res.stdout.split() if ln.strip().isdigit()]
+        if not pids:
+            return None, "pgrep returned no pids for '^openclaw$'"
+        return int(pids[0]), None
+    # Plain integer pid.
+    try:
+        pid = int(spec)
+    except (TypeError, ValueError):
+        return None, (
+            f"invalid value {spec!r}: pass either an integer pid or "
+            f"the literal string 'openclaw'"
+        )
+    if pid <= 0:
+        return None, f"pid must be > 0 (got {pid})"
+    return pid, None
+
+
+def _build_inherited_env(spec: str) -> Tuple[Optional[Dict[str, str]], Optional[str]]:
+    """Resolve --inherit-env-from spec → merged env dict.
+
+    Returns `(env_dict, None)` on success: a copy of the inherited /proc
+    environ OVERLAID with the CLI's current `os.environ` (operator-set
+    values win). Returns `(None, error_msg)` on any failure.
+
+    Linux-only: returns an error on non-Linux hosts because /proc isn't
+    available. Production runs on Linux containers.
+
+    Spec validation runs BEFORE the platform check so an obviously-bad
+    value (typo, etc.) surfaces a useful error on dev machines too —
+    only the actual /proc read is gated on Linux.
+    """
+    pid, err = _resolve_inherit_env_source(spec)
+    if err is not None:
+        return None, err
+    if not sys.platform.startswith("linux"):
+        return None, (
+            "--inherit-env-from is only supported on Linux (requires /proc). "
+            "Production senpi-helpers runs on Linux; this dev host is not."
+        )
+    inherited = _state.read_proc_environ(pid)
+    if inherited is None:
+        return None, (
+            f"could not read /proc/{pid}/environ (missing pid, "
+            f"permission denied, or non-Linux)"
+        )
+    # Operator's explicit env wins over inherited. Inherited fills the
+    # gaps — auth tokens / api keys / runtime endpoints.
+    merged = {**inherited, **os.environ.copy()}
+    return merged, None
+
+
 def cmd_start(args: argparse.Namespace) -> int:
     # Destructive (spawns a process): require an explicit <name>.
     name = _resolve_name_explicit(args, action="start")
@@ -1191,10 +1266,24 @@ def cmd_start(args: argparse.Namespace) -> int:
         name, pid_data=pid_data, boot_data=boot_data,
     )
 
+    # Resolve --inherit-env-from if given. Falls back to passing env=None
+    # so relaunch_daemon inherits the CLI's current env (original behavior).
+    env_for_spawn = None
+    inherit_spec = getattr(args, "inherit_env_from", None)
+    if inherit_spec:
+        env_for_spawn, err = _build_inherited_env(inherit_spec)
+        if err is not None:
+            sys.stderr.write(
+                f"senpi-helpers: --inherit-env-from {inherit_spec!r} failed: "
+                f"{err}\n"
+            )
+            return START_FAILED
+
     relaunch_result = _manage.relaunch_daemon(
         argv=argv,
         cwd=cwd,
         log_path=log_path,
+        env=env_for_spawn,
     )
 
     if relaunch_result["outcome"] != _manage.RELAUNCH_OK:
@@ -1579,6 +1668,20 @@ def _make_parser() -> argparse.ArgumentParser:
         help="Daemon name. Optional on single-daemon hosts.",
     )
     start_p.add_argument("--json", action="store_true", help="Emit JSON instead of a summary.")
+    start_p.add_argument(
+        "--inherit-env-from",
+        metavar="PROCESS",
+        default=None,
+        dest="inherit_env_from",
+        help=(
+            "Inherit env from a running process (Linux-only). Pass either "
+            "a pid integer or the literal 'openclaw' (auto-resolved via "
+            "pgrep). Useful when launching from a fresh shell that lacks "
+            "auth tokens — pulls them from the running openclaw process "
+            "without manual /proc gymnastics. Operator-set env in the "
+            "current shell still wins over inherited values."
+        ),
+    )
     start_p.set_defaults(func=cmd_start)
 
     # stop

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -567,6 +567,15 @@ def cmd_logs(args: argparse.Namespace) -> int:
     if name is None:
         return LOGS_NOT_FOUND
 
+    # Validate --lines BEFORE doing any work: argparse accepts negative
+    # integers as type=int, and `deque(maxlen=-1)` raises ValueError →
+    # uncaught traceback to the operator. Clamp / reject explicitly.
+    if not args.follow and args.lines < 0:
+        sys.stderr.write(
+            f"senpi-helpers: --lines must be >= 0 (got {args.lines}).\n"
+        )
+        return LOGS_NO_LOG
+
     # Reuse the same fallback chain that restart/stats use. Suppress the
     # default-warning to stderr — for `logs`, the operator just wants the
     # log; if we end up at /tmp/<name>.log by default and it doesn't exist,

--- a/senpi-trading-runtime/senpi_runtime_helpers/cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/cli.py
@@ -575,11 +575,19 @@ class _LogTailer:
         """
         try:
             st = os.stat(self.log_path)
-        except FileNotFoundError:
-            # File deleted (or never existed yet). Drop our handle so the
-            # next successful stat reopens cleanly; reset inode so the
-            # reopen branch fires even if the recreated file happens to
-            # land on the same inode the kernel just freed.
+        except OSError:
+            # `OSError` (not just `FileNotFoundError`) so a transient
+            # `PermissionError` (parent dir chmod 000), `NotADirectoryError`,
+            # or generic disk error (EIO / EBUSY) doesn't crash
+            # `senpi-helpers logs --follow` — same recovery path we already
+            # use for the file-deleted case. The reopen branch downstream
+            # uses `except OSError` for the same reason; keeping the two
+            # symmetric closes the asymmetry Bugbot caught (Medium-sev,
+            # commit ed8732f, comment r3244947267).
+            #
+            # Drop our handle so the next successful stat reopens cleanly;
+            # reset inode so the reopen branch fires even if the recreated
+            # file happens to land on the same inode the kernel just freed.
             if self.fh is not None:
                 self.fh.close()
                 self.fh = None

--- a/senpi-trading-runtime/senpi_runtime_helpers/daemon.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/daemon.py
@@ -237,6 +237,15 @@ def producer_daemon(
         argv=list(sys.argv),
     )
 
+    # Ensure stderr/stdout point at a regular file BEFORE any state writes.
+    # When the daemon is launched by openclaw's `exec` tool (the production
+    # agent path), fd 2 is a pipe back to the agent — `detect_log_path`
+    # would return None and pid.json would never record where logs land.
+    # This fallback redirects to /tmp/<name>.log so the rest of the helpers
+    # toolchain (restart, stats) keeps working. No-op when the operator
+    # playbook already redirected (`nohup python3 -u script > log 2>&1`).
+    resolved_log_path = _state.ensure_daemon_stderr_redirected(name)
+
     # Self-describing state files for the senpi-helpers CLI. Written ONCE on
     # boot — heartbeat.json is rewritten after every tick below; pid.json is
     # cleared in the outer finally on clean exit. Lazy import of __version__
@@ -248,7 +257,7 @@ def producer_daemon(
         scanner=scanner,
         interval_seconds=interval_seconds,
         tick_timeout=tick_timeout,
-        log_path=_state.detect_log_path(),
+        log_path=resolved_log_path,
         version=_helpers_version,
         state_dir=state_dir,
     )

--- a/senpi-trading-runtime/senpi_runtime_helpers/daemon.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/daemon.py
@@ -16,6 +16,7 @@ graceful drain (current tick finishes, then loop exits).
 # Licensed under MIT
 
 import signal
+import sys
 import threading
 import time
 from contextlib import suppress
@@ -230,6 +231,10 @@ def producer_daemon(
         max_ticks=max_ticks,
         alive_check_enabled=alive_check is not None,
         alive_check_every_n_ticks=alive_check_every_n if alive_check is not None else None,
+        # sys.argv is the script + its CLI args (interpreter and flags are
+        # consumed before sys.argv is populated). Logged here so post-mortem
+        # audit shows what script the daemon was actually running.
+        argv=list(sys.argv),
     )
 
     # Self-describing state files for the senpi-helpers CLI. Written ONCE on

--- a/senpi-trading-runtime/senpi_runtime_helpers/manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/manage.py
@@ -22,6 +22,7 @@ Design:
 # Source: https://github.com/Senpi-ai/senpi-skills
 
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -266,28 +267,43 @@ def relaunch_daemon(
                 "error": "argv is empty",
                 "argv_normalized": False, "argv_used": []}
 
-    # Existence check: argv[0] may be the script (schema 1) or the
-    # interpreter (schema 2). Resolve it against the daemon's recorded
-    # `cwd` BEFORE checking — Popen will run with that cwd, so a relative
-    # path like `./producer.py` is valid relative to it even though it
-    # wouldn't exist relative to the CLI's current cwd. Falling back to
-    # os.getcwd() preserves the old behavior when cwd is None.
+    # Existence check: argv[0] may be the script (schema 1), the
+    # interpreter (schema 2 with absolute path like /usr/bin/python3),
+    # or a bare executable name relying on $PATH (schema 2 written by a
+    # virtualenv host where sys.executable is just "python", or an
+    # operator-authored boot.json with argv=["python3", ...]).
     #
-    # We require argv[0] to resolve to a REGULAR FILE, not just any
-    # existing path: an empty argv[0] would join with cwd to point at
-    # the cwd directory itself (which exists), and `argv[0]=/tmp` would
-    # likewise pass an `os.path.exists` check. Popen would fail on those
-    # at exec time, but with a less helpful error than ours.
+    # Resolution rules:
+    #   - empty argv[0]              → SCRIPT_MISSING (Popen can't exec "")
+    #   - absolute path              → check os.path.isfile directly
+    #   - relative with a separator  → join against `cwd` (Popen's cwd), check
+    #   - bare name (no separator)   → shutil.which against $PATH
+    #
+    # We require argv[0] to resolve to a REGULAR FILE, not just any path
+    # that exists: empty argv[0] would join to `cwd` (a directory),
+    # `/tmp` would also pass `os.path.exists`. Popen fails on those at
+    # exec, but with a less helpful error than ours.
     argv0 = argv[0]
     if not argv0:
         return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
                 "error": "argv[0] is empty",
                 "argv_normalized": False, "argv_used": list(argv)}
-    if not os.path.isabs(argv0):
-        argv0 = os.path.normpath(os.path.join(cwd or os.getcwd(), argv0))
-    if not os.path.isfile(argv0):
+    if os.path.isabs(argv0):
+        argv0_resolved = argv0
+    elif os.sep in argv0 or (os.altsep and os.altsep in argv0):
+        # Has a path separator → operator meant a relative path. Join with cwd.
+        argv0_resolved = os.path.normpath(os.path.join(cwd or os.getcwd(), argv0))
+    else:
+        # No path separator → bare name. Honor $PATH the way Popen does.
+        which_result = shutil.which(argv0)
+        if which_result is None:
+            return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
+                    "error": f"argv[0] {argv0!r} not found on $PATH",
+                    "argv_normalized": False, "argv_used": list(argv)}
+        argv0_resolved = which_result
+    if not os.path.isfile(argv0_resolved):
         return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
-                "error": f"argv[0] is not a regular file on disk: {argv0}",
+                "error": f"argv[0] is not a regular file on disk: {argv0_resolved}",
                 "argv_normalized": False, "argv_used": list(argv)}
 
     normalized_argv, was_normalized = _normalize_argv(argv)

--- a/senpi-trading-runtime/senpi_runtime_helpers/manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/manage.py
@@ -272,12 +272,22 @@ def relaunch_daemon(
     # path like `./producer.py` is valid relative to it even though it
     # wouldn't exist relative to the CLI's current cwd. Falling back to
     # os.getcwd() preserves the old behavior when cwd is None.
+    #
+    # We require argv[0] to resolve to a REGULAR FILE, not just any
+    # existing path: an empty argv[0] would join with cwd to point at
+    # the cwd directory itself (which exists), and `argv[0]=/tmp` would
+    # likewise pass an `os.path.exists` check. Popen would fail on those
+    # at exec time, but with a less helpful error than ours.
     argv0 = argv[0]
+    if not argv0:
+        return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
+                "error": "argv[0] is empty",
+                "argv_normalized": False, "argv_used": list(argv)}
     if not os.path.isabs(argv0):
         argv0 = os.path.normpath(os.path.join(cwd or os.getcwd(), argv0))
-    if not os.path.exists(argv0):
+    if not os.path.isfile(argv0):
         return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
-                "error": f"argv[0] not found on disk: {argv0}",
+                "error": f"argv[0] is not a regular file on disk: {argv0}",
                 "argv_normalized": False, "argv_used": list(argv)}
 
     normalized_argv, was_normalized = _normalize_argv(argv)

--- a/senpi-trading-runtime/senpi_runtime_helpers/manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/manage.py
@@ -24,10 +24,14 @@ Design:
 import os
 import signal
 import subprocess
+import sys
 import time
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from .state import pid_alive as is_pid_alive  # canonical PID-liveness check
+from .state import (
+    pid_alive as is_pid_alive,  # canonical PID-liveness check
+    looks_like_python_interpreter,  # heuristic for legacy argv normalization
+)
 
 
 # How long to wait after SIGKILL before declaring the process is unkillable.
@@ -163,6 +167,12 @@ def stop_outcome_was_success(outcome: str) -> bool:
 
 
 # ─── Relaunch (the back half of `restart`) ──────────────────────────────────
+#
+# `stop_pid` (above) is called with the OLD daemon's pid (read from pid.json).
+# It targets a SPECIFIC pid and CANNOT signal the helper process itself —
+# the helper's pid is never recorded in pid.json. So `restart` cannot
+# accidentally kill itself by PID. End-to-end coverage of this invariant is
+# in tests/test_restart_integration.py::test_restart_does_not_target_self_pid.
 
 
 # Relaunch outcome codes. Stable strings for JSON consumers.
@@ -172,19 +182,58 @@ RELAUNCH_LOG_OPEN_FAILED = "log_open_failed"
 RELAUNCH_SPAWN_FAILED = "spawn_failed"
 
 
+def _normalize_argv(argv: List[str]) -> Tuple[List[str], bool]:
+    """Migrate legacy boot.json argv (script-only) to interpreter-first form.
+
+    Schema 1 (legacy):  ["/path/script.py"]
+    Schema 2 (modern):  [sys.executable, "-u", "/path/script.py"]
+
+    Returns `(normalized_argv, was_normalized)`.
+
+    Migration rule: if argv[0] doesn't look like a python interpreter AND
+    it ends with `.py`, prepend `[sys.executable, "-u"]`. Idempotent — a
+    modern argv passes through unchanged. Non-.py argv[0] also passes
+    through (we don't try to "fix" launches we don't recognize).
+
+    Why this is needed: the operator playbook launches daemons as
+    `nohup python3 -u script.py &`. sys.argv inside that python is just
+    ["/path/script.py"] — interpreter and "-u" aren't observable from
+    inside the script. Schema-1 boot.json captured only sys.argv, inheriting
+    that gap. Popen([".py"]) requires the script to be `+x`, which the
+    operator's launch never required (interpreter was explicit on the
+    command line). We can't go back and fix existing boot.json on the
+    production fleet — so we migrate on read.
+
+    The new daemon, once it starts, calls `write_boot` and writes a fresh
+    schema-2 boot.json; migration is one-shot per daemon.
+    """
+    if not argv:
+        return argv, False
+    first = argv[0]
+    if looks_like_python_interpreter(first):
+        return argv, False
+    if first.endswith(".py"):
+        return [sys.executable, "-u", *argv], True
+    # Non-.py, non-python argv[0]: pass through. Could be a compiled binary
+    # or a wrapper script that DOES have +x. Not our place to second-guess.
+    return argv, False
+
+
 def relaunch_daemon(
     *,
     argv: List[str],
     cwd: Optional[str],
     log_path: str,
     env: Optional[Dict[str, str]] = None,
-    popen_factory: Callable[..., Any] = subprocess.Popen,
+    popen_factory: Optional[Callable[..., Any]] = None,
 ) -> Dict[str, Any]:
     """Re-exec a daemon as a detached process. Used by `restart`.
 
     Args:
-        argv: the daemon's argv (recorded in boot.json). argv[0] is the
-            script path; the script must still exist on disk.
+        argv: the daemon's argv (recorded in boot.json). For schema-2 boot
+            files this is `[interpreter, "-u", script, ...args]`; for
+            schema-1 (legacy) it's `[script, ...args]`. Legacy argv is
+            migrated transparently via `_normalize_argv`.
         cwd: working directory for the new process (recorded in boot.json).
             None falls back to the current process's CWD.
         log_path: path to the daemon's stderr log file. Opened in append
@@ -202,14 +251,28 @@ def relaunch_daemon(
     process survives the CLI's exit. `stdin=DEVNULL` to prevent the
     daemon from blocking on a closed parent stdin.
 
-    Returns a result dict with outcome, pid, error.
+    Returns a result dict with outcome, pid, error, argv_normalized,
+    argv_used. `argv_used` is what Popen was actually called with — a
+    schema-1→2 migration is observable to callers via `argv_normalized`.
     """
+    # Resolve popen_factory at call time so test monkeypatches of
+    # subprocess.Popen take effect. The historical default-arg form bound
+    # subprocess.Popen at import time and silently bypassed test mocks.
+    if popen_factory is None:
+        popen_factory = subprocess.Popen
+
     if not argv:
         return {"outcome": RELAUNCH_SPAWN_FAILED, "pid": None,
-                "error": "argv is empty"}
+                "error": "argv is empty",
+                "argv_normalized": False, "argv_used": []}
     if not os.path.exists(argv[0]):
+        # argv[0] may be the script (schema 1) or the interpreter (schema 2).
+        # Either should exist; the message names what we tried to find.
         return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
-                "error": f"script not found: {argv[0]}"}
+                "error": f"argv[0] not found on disk: {argv[0]}",
+                "argv_normalized": False, "argv_used": list(argv)}
+
+    normalized_argv, was_normalized = _normalize_argv(argv)
 
     try:
         # Open log file BEFORE spawning so an unwritable log path surfaces
@@ -217,13 +280,15 @@ def relaunch_daemon(
         log_fd = open(log_path, "a")
     except OSError as e:
         return {"outcome": RELAUNCH_LOG_OPEN_FAILED, "pid": None,
-                "error": f"cannot open {log_path}: {e}"}
+                "error": f"cannot open {log_path}: {e}",
+                "argv_normalized": was_normalized,
+                "argv_used": list(normalized_argv)}
 
     proc = None
     spawn_error: Optional[str] = None
     try:
         proc = popen_factory(
-            argv,
+            normalized_argv,
             cwd=cwd or None,
             env=env if env is not None else os.environ.copy(),
             stdout=log_fd,
@@ -249,5 +314,10 @@ def relaunch_daemon(
             pass
 
     if spawn_error is not None:
-        return {"outcome": RELAUNCH_SPAWN_FAILED, "pid": None, "error": spawn_error}
-    return {"outcome": RELAUNCH_OK, "pid": proc.pid, "error": None}
+        return {"outcome": RELAUNCH_SPAWN_FAILED, "pid": None,
+                "error": spawn_error,
+                "argv_normalized": was_normalized,
+                "argv_used": list(normalized_argv)}
+    return {"outcome": RELAUNCH_OK, "pid": proc.pid, "error": None,
+            "argv_normalized": was_normalized,
+            "argv_used": list(normalized_argv)}

--- a/senpi-trading-runtime/senpi_runtime_helpers/manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/manage.py
@@ -227,6 +227,7 @@ def relaunch_daemon(
     log_path: str,
     env: Optional[Dict[str, str]] = None,
     popen_factory: Optional[Callable[..., Any]] = None,
+    script_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Re-exec a daemon as a detached process. Used by `restart`.
 
@@ -247,6 +248,15 @@ def relaunch_daemon(
             decision-model changes since the daemon was started take
             effect). Tests pass an explicit dict.
         popen_factory: dependency-injected Popen for testability.
+        script_path: optional path to the python script the daemon
+            actually executes. For schema-2 argv `[python3, -u, X]`
+            the argv[0] check verifies the interpreter, not X — so a
+            deleted script would pass and crash at exec time. Callers
+            that know the script path (cmd_restart, cmd_start) pass it
+            here and we validate it BEFORE Popen, giving a clean
+            RELAUNCH_SCRIPT_MISSING instead of a spawn-then-die. None
+            (default) preserves prior behavior for callers that don't
+            know the script identity.
 
     Detached via `start_new_session=True` (POSIX setsid) so the new
     process survives the CLI's exit. `stdin=DEVNULL` to prevent the
@@ -305,6 +315,23 @@ def relaunch_daemon(
         return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
                 "error": f"argv[0] is not a regular file on disk: {argv0_resolved}",
                 "argv_normalized": False, "argv_used": list(argv)}
+
+    # Defense in depth: when the caller knows which file in argv IS the
+    # script (i.e. cmd_restart / cmd_start, which read script_path from
+    # boot.json), validate it explicitly. For schema-2 argv where argv[0]
+    # is the interpreter, the check above doesn't catch a missing script —
+    # Popen would spawn python3 and instantly die with "can't open file".
+    # This produces a clean SCRIPT_MISSING instead.
+    if script_path is not None:
+        sp_resolved = script_path
+        if not os.path.isabs(sp_resolved):
+            sp_resolved = os.path.normpath(
+                os.path.join(cwd or os.getcwd(), sp_resolved)
+            )
+        if not os.path.isfile(sp_resolved):
+            return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
+                    "error": f"script_path is not a regular file on disk: {sp_resolved}",
+                    "argv_normalized": False, "argv_used": list(argv)}
 
     normalized_argv, was_normalized = _normalize_argv(argv)
 

--- a/senpi-trading-runtime/senpi_runtime_helpers/manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/manage.py
@@ -277,14 +277,27 @@ def relaunch_daemon(
                 "error": "argv is empty",
                 "argv_normalized": False, "argv_used": []}
 
-    # Existence check: argv[0] may be the script (schema 1), the
-    # interpreter (schema 2 with absolute path like /usr/bin/python3),
-    # or a bare executable name relying on $PATH (schema 2 written by a
-    # virtualenv host where sys.executable is just "python", or an
-    # operator-authored boot.json with argv=["python3", ...]).
+    if not argv[0]:
+        return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
+                "error": "argv[0] is empty",
+                "argv_normalized": False, "argv_used": list(argv)}
+
+    # Normalize FIRST so the existence check operates on the same argv
+    # Popen will actually receive. Schema-1 boots with argv=["script.py"]
+    # become [interpreter, "-u", "script.py"] — argv[0] is now the
+    # interpreter (absolute path or bare name on $PATH). The script
+    # itself is validated separately via `script_path` (defense in depth).
     #
-    # Resolution rules:
-    #   - empty argv[0]              → SCRIPT_MISSING (Popen can't exec "")
+    # Pre-normalize order was buggy for bare-name `.py` argv[0]: the
+    # `shutil.which` branch searched $PATH for "script.py", returned None,
+    # and we falsely rejected the relaunch — even though `Popen([python3,
+    # -u, "script.py"], cwd=boot_cwd)` would succeed because the
+    # interpreter resolves the script relative to its cwd. Caught by
+    # Bugbot on commit 4e42860.
+    normalized_argv, was_normalized = _normalize_argv(argv)
+
+    # Existence check: argv[0] (post-normalization) is either an
+    # absolute path or a bare executable name. Resolution rules:
     #   - absolute path              → check os.path.isfile directly
     #   - relative with a separator  → join against `cwd` (Popen's cwd), check
     #   - bare name (no separator)   → shutil.which against $PATH
@@ -293,28 +306,24 @@ def relaunch_daemon(
     # that exists: empty argv[0] would join to `cwd` (a directory),
     # `/tmp` would also pass `os.path.exists`. Popen fails on those at
     # exec, but with a less helpful error than ours.
-    argv0 = argv[0]
-    if not argv0:
-        return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
-                "error": "argv[0] is empty",
-                "argv_normalized": False, "argv_used": list(argv)}
+    argv0 = normalized_argv[0]
     if os.path.isabs(argv0):
         argv0_resolved = argv0
     elif os.sep in argv0 or (os.altsep and os.altsep in argv0):
-        # Has a path separator → operator meant a relative path. Join with cwd.
         argv0_resolved = os.path.normpath(os.path.join(cwd or os.getcwd(), argv0))
     else:
-        # No path separator → bare name. Honor $PATH the way Popen does.
         which_result = shutil.which(argv0)
         if which_result is None:
             return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
                     "error": f"argv[0] {argv0!r} not found on $PATH",
-                    "argv_normalized": False, "argv_used": list(argv)}
+                    "argv_normalized": was_normalized,
+                    "argv_used": list(normalized_argv)}
         argv0_resolved = which_result
     if not os.path.isfile(argv0_resolved):
         return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
                 "error": f"argv[0] is not a regular file on disk: {argv0_resolved}",
-                "argv_normalized": False, "argv_used": list(argv)}
+                "argv_normalized": was_normalized,
+                "argv_used": list(normalized_argv)}
 
     # Defense in depth: when the caller knows which file in argv IS the
     # script (i.e. cmd_restart / cmd_start, which read script_path from
@@ -331,9 +340,11 @@ def relaunch_daemon(
         if not os.path.isfile(sp_resolved):
             return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
                     "error": f"script_path is not a regular file on disk: {sp_resolved}",
-                    "argv_normalized": False, "argv_used": list(argv)}
+                    "argv_normalized": was_normalized,
+                    "argv_used": list(normalized_argv)}
 
-    normalized_argv, was_normalized = _normalize_argv(argv)
+    # normalized_argv was computed at the top, before the existence check,
+    # so the check operated on the same argv Popen will receive.
 
     try:
         # Open log file BEFORE spawning so an unwritable log path surfaces

--- a/senpi-trading-runtime/senpi_runtime_helpers/manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/manage.py
@@ -265,11 +265,19 @@ def relaunch_daemon(
         return {"outcome": RELAUNCH_SPAWN_FAILED, "pid": None,
                 "error": "argv is empty",
                 "argv_normalized": False, "argv_used": []}
-    if not os.path.exists(argv[0]):
-        # argv[0] may be the script (schema 1) or the interpreter (schema 2).
-        # Either should exist; the message names what we tried to find.
+
+    # Existence check: argv[0] may be the script (schema 1) or the
+    # interpreter (schema 2). Resolve it against the daemon's recorded
+    # `cwd` BEFORE checking — Popen will run with that cwd, so a relative
+    # path like `./producer.py` is valid relative to it even though it
+    # wouldn't exist relative to the CLI's current cwd. Falling back to
+    # os.getcwd() preserves the old behavior when cwd is None.
+    argv0 = argv[0]
+    if not os.path.isabs(argv0):
+        argv0 = os.path.normpath(os.path.join(cwd or os.getcwd(), argv0))
+    if not os.path.exists(argv0):
         return {"outcome": RELAUNCH_SCRIPT_MISSING, "pid": None,
-                "error": f"argv[0] not found on disk: {argv[0]}",
+                "error": f"argv[0] not found on disk: {argv0}",
                 "argv_normalized": False, "argv_used": list(argv)}
 
     normalized_argv, was_normalized = _normalize_argv(argv)

--- a/senpi-trading-runtime/senpi_runtime_helpers/state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/state.py
@@ -52,7 +52,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, FrozenSet, List, Optional, Tuple
 
 from ._logging import log_event
 
@@ -493,7 +493,7 @@ def _atomic_write(path: Path, payload: Dict[str, Any]) -> bool:
 
 # What schemas each file may legitimately have. Extend this set when bumping;
 # readers warn loudly on values outside it so future migrations are visible.
-_SUPPORTED_SCHEMAS: Dict[str, frozenset[int]] = {
+_SUPPORTED_SCHEMAS: Dict[str, FrozenSet[int]] = {
     "pid.json": frozenset({1, 2}),
     "boot.json": frozenset({1, 2}),
     "heartbeat.json": frozenset({1}),

--- a/senpi-trading-runtime/senpi_runtime_helpers/state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/state.py
@@ -26,6 +26,7 @@ Override with `SENPI_HELPERS_STATE_DIR` on hosts without a `/data` volume.
 
 import json
 import os
+import re
 import sys
 import tempfile
 import time
@@ -36,6 +37,58 @@ from ._logging import log_event
 
 
 _DEFAULT_STATE_DIR = "/data/.openclaw/senpi-helpers"
+
+
+# ─── boot.json schema versioning ────────────────────────────────────────────
+#
+# Schema 2 (current):
+#   argv = [sys.executable, "-u", *sys.argv]
+#   - sys.executable is the absolute path to the running interpreter.
+#   - "-u" forces unbuffered stdout/stderr on relaunch. The operator
+#     playbook launches daemons as `nohup python3 -u script.py &`; we
+#     can't capture the original "-u" because interpreter flags are
+#     consumed before the script's sys.argv is populated. Hard-coding
+#     "-u" on capture is harmless and matches the operator expectation
+#     (real-time log lines).
+#
+# Schema 1 (legacy, pre-2026-05):
+#   argv = list(sys.argv)
+#   - Missing the interpreter. `manage.relaunch_daemon` then tried to
+#     `execve` the .py file directly, which failed with EACCES whenever
+#     the script wasn't `+x`. The operator playbook never demanded `+x`
+#     because the interpreter was explicit on the original command line.
+#   - `manage._normalize_argv` migrates legacy argv on read, prepending
+#     `[sys.executable, "-u"]`. The next `write_boot` from the relaunched
+#     daemon rewrites the file as schema 2 — migration is one-shot.
+#
+# Why we don't capture interpreter flags beyond "-u":
+#   sys.argv inside Python excludes interpreter flags (`-u`, `-O`,
+#   `-X dev`, `-W ...`). They've already been consumed by the interpreter
+#   before user code runs and cannot be recovered from inside the script.
+#   For producers, only "-u" matters in practice (log readability).
+#   Setting PYTHONUNBUFFERED=1 in env has the same effect; operators who
+#   need it can put it in their launch env and it will land in
+#   env_snapshot below.
+
+_PYTHON_INTERPRETER_RE = re.compile(
+    r"^(python|pypy)(\d+(\.\d+)?)?(\.exe)?$"
+)
+
+
+def looks_like_python_interpreter(path: str) -> bool:
+    """True if `path`'s basename matches a python/pypy interpreter pattern.
+
+    Matches: python, python3, python3.11, python.exe, python3.exe,
+             pypy, pypy3.
+    Does NOT match: python3.11-config, python-pip, myscript.py, cat,
+                    empty string, anything ending in .py.
+
+    Used by `manage._normalize_argv` to detect legacy boot.json argv
+    (where argv[0] is the script, not the interpreter).
+    """
+    if not path:
+        return False
+    return bool(_PYTHON_INTERPRETER_RE.match(os.path.basename(path).lower()))
 
 # Env-var prefixes / suffixes that the boot snapshot should capture. Skill
 # names (PANGOLIN, KODIAK, ...) follow the per-skill convention each skill
@@ -268,17 +321,30 @@ def write_pid(
 
 
 def write_boot(name: str, *, state_dir: Optional[str] = None) -> bool:
-    """Write `boot.json` for `name`. Captures argv + sanitized env snapshot.
+    """Write `boot.json` for `name`. Captures full launch shape (schema 2).
 
-    Called once at daemon start. `senpi-helpers restart` reads this file
-    to re-exec the producer; if it's missing or `script_path` no longer
-    exists on disk, restart fails with a clear message.
+    Called once at daemon start, before the producer's user code runs, so
+    sys.argv reflects the original launch and can't have been mutated.
+    `senpi-helpers restart` reads this file to re-exec the producer.
+
+    Schema 2 captures argv as `[sys.executable, "-u", *sys.argv]` so the
+    relaunch can `Popen(argv)` without needing the script to be `+x`.
+    See the schema-versioning comment near the top of this file for the
+    full rationale (in particular: why "-u" is hard-coded and why we
+    don't capture other interpreter flags).
     """
     script_path = os.path.realpath(sys.argv[0]) if sys.argv and sys.argv[0] else None
+    # Prepend interpreter + "-u" so the relaunch path doesn't require the
+    # script to be executable. If sys.argv is empty (extremely unusual —
+    # we still want a sensible boot.json), record just the interpreter.
+    if sys.argv:
+        argv = [sys.executable, "-u", *sys.argv]
+    else:
+        argv = [sys.executable, "-u"]
     payload = {
-        "schema": 1,
+        "schema": 2,
         "name": name,
-        "argv": list(sys.argv),
+        "argv": argv,
         "script_path": script_path,
         "cwd": os.getcwd(),
         "env_snapshot": _sanitized_env_snapshot(),

--- a/senpi-trading-runtime/senpi_runtime_helpers/state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/state.py
@@ -230,9 +230,23 @@ def start_time_jiffies_for_pid(pid: int) -> Optional[int]:
 
 
 def pid_alive(pid: Optional[int]) -> bool:
-    """Cheap liveness check via signal(0). Canonical implementation shared by
+    """Cheap liveness check. Canonical implementation shared by
     `lock.py`, `cli.py`, and `manage.py` — they all need to ask the same
     question ("is this pid alive?") and previously each kept a private copy.
+
+    The basic check is `os.kill(pid, 0)`. On Linux, we ALSO filter out
+    zombies (`State: Z`) and dead-pending-reap (`State: X`): `signal(0)`
+    succeeds on those because the kernel still has the pid slot, but the
+    process has already exited. Without this filter, `stop_pid` would
+    poll until its SIGTERM timeout, escalate to SIGKILL (a no-op on the
+    already-dead zombie), and falsely return `STOP_KILL_FAILED` after
+    the kernel-grace window — even though the daemon DID stop cleanly.
+
+    Production trigger: daemon launched via `nohup … &`, parent shell
+    exits, daemon reparented to PID 1. On Railway boxes PID 1 is the
+    `node src/server.js` Express wrapper, which doesn't reap orphan
+    zombies. Zombies accumulate; the senpi-helpers CLI was previously
+    blind to them.
 
     Treats EPERM as "alive" (process exists, but we lack permission to
     signal it — that case is non-zero on shared-host setups where the
@@ -244,13 +258,25 @@ def pid_alive(pid: Optional[int]) -> bool:
         return False
     try:
         os.kill(pid, 0)
-        return True
     except ProcessLookupError:
         return False
     except PermissionError:
         return True
     except OSError:
         return False
+    # signal(0) succeeded — process exists in the kernel's table. On Linux,
+    # consult /proc/<pid>/status to filter zombies. Non-Linux: trust signal(0).
+    try:
+        with open(f"/proc/{pid}/status") as f:
+            for line in f:
+                if line.startswith("State:"):
+                    # Example: "State:\tZ (zombie)" — split gives ["State:", "Z", ...].
+                    state_char = line.split()[1] if len(line.split()) >= 2 else ""
+                    return state_char not in ("Z", "X")
+    except (FileNotFoundError, PermissionError, OSError):
+        # /proc not available (non-Linux) or pid raced exit + reap. Trust signal(0).
+        pass
+    return True
 
 
 def pid_alive_and_matches(
@@ -400,7 +426,15 @@ def ensure_daemon_stderr_redirected(name: str) -> Optional[str]:
         os.dup2(fd, 1)  # stdout
         os.dup2(fd, 2)  # stderr
     finally:
-        os.close(fd)
+        # If stdin/stdout/stderr were closed by the caller (e.g. launched
+        # via `python3 script.py >&- 2>&-`), os.open could return fd 0, 1,
+        # or 2 as the lowest free descriptor. After our dup2 onto 1 and 2,
+        # those descriptors point at the log file we just opened.
+        # Unconditionally closing `fd` in that case would close the log
+        # file out from under our redirected streams. Guard: only close
+        # our temporary fd if it's NOT one of the standard streams.
+        if fd > 2:
+            os.close(fd)
     log_event(
         "log_path_fallback_applied",
         name=name,

--- a/senpi-trading-runtime/senpi_runtime_helpers/state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/state.py
@@ -167,6 +167,35 @@ def _read_proc_field(pid: int, field_name: str) -> Optional[str]:
         return None
 
 
+def read_proc_environ(pid: int) -> Optional[Dict[str, str]]:
+    """Parse `/proc/<pid>/environ` into a dict.
+
+    `/proc/<pid>/environ` is NUL-separated `KEY=value` entries (the
+    process's startup env, captured by the kernel at exec time). Returns
+    a dict; None if /proc isn't readable (non-Linux, missing pid, permission
+    denied). Skips malformed entries (no '=' or invalid key chars) silently
+    so a corrupt environ doesn't crash the helper.
+
+    Used by `senpi-helpers start --inherit-env-from <pid|openclaw>` so the
+    operator doesn't have to manually `cat /proc/<pid>/environ | tr ...`
+    to bootstrap the daemon's env with auth tokens.
+    """
+    raw = _read_proc_field(pid, "environ")
+    if raw is None:
+        return None
+    out: Dict[str, str] = {}
+    for entry in raw.split("\0"):
+        if "=" not in entry:
+            continue
+        key, _, value = entry.partition("=")
+        # Defensive: skip keys that aren't valid identifier-like names. A
+        # corrupt entry shouldn't poison the final env dict.
+        if not key or not all(c.isalnum() or c == "_" for c in key):
+            continue
+        out[key] = value
+    return out
+
+
 def cmdline_fingerprint_for_pid(pid: int) -> Optional[str]:
     """Hex sha256 of /proc/<pid>/cmdline, or None on Linux-less hosts."""
     raw = _read_proc_field(pid, "cmdline")

--- a/senpi-trading-runtime/senpi_runtime_helpers/state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/state.py
@@ -427,13 +427,25 @@ def ensure_daemon_stderr_redirected(name: str) -> Optional[str]:
         os.dup2(fd, 2)  # stderr
     finally:
         # If stdin/stdout/stderr were closed by the caller (e.g. launched
-        # via `python3 script.py >&- 2>&-`), os.open could return fd 0, 1,
-        # or 2 as the lowest free descriptor. After our dup2 onto 1 and 2,
-        # those descriptors point at the log file we just opened.
-        # Unconditionally closing `fd` in that case would close the log
-        # file out from under our redirected streams. Guard: only close
-        # our temporary fd if it's NOT one of the standard streams.
-        if fd > 2:
+        # via `python3 script.py < /dev/null >&- 2>&-`), os.open could
+        # return fd 0, 1, or 2 as the lowest free descriptor.
+        # - fd == 1 or 2: dup2 onto that fd is a no-op (target == source).
+        #   The descriptor IS the log file we just opened — closing our
+        #   handle would close the redirected stream itself.
+        # - fd == 0: stdin was closed; our log fd landed there. We don't
+        #   dup2 onto 0 (we only redirect 1 and 2), so fd 0 ends up
+        #   pointing at the log file as a write-only handle. Closing
+        #   would just leak the descriptor; NOT closing leaves stdin
+        #   in a weird "write-only to log" state that any sys.stdin.read
+        #   would crash on. Both are bad — but leaving it open is the
+        #   smaller leak; and the alternative ("close fd 0") is the same
+        #   resource-state problem in production: the daemon launched
+        #   without stdin to start with.
+        #
+        # Both edge cases are fine to close in our finally — the
+        # condition just protects 1 and 2, which dup2 made point at the
+        # SAME open-file-description as fd. Closing one closes both.
+        if fd not in (1, 2):
             os.close(fd)
     log_event(
         "log_path_fallback_applied",

--- a/senpi-trading-runtime/senpi_runtime_helpers/state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/state.py
@@ -197,11 +197,23 @@ def read_proc_environ(pid: int) -> Optional[Dict[str, str]]:
 
 
 def cmdline_fingerprint_for_pid(pid: int) -> Optional[str]:
-    """Hex sha256 of /proc/<pid>/cmdline, or None on Linux-less hosts."""
-    raw = _read_proc_field(pid, "cmdline")
-    if raw is None:
+    """Hex sha256 of /proc/<pid>/cmdline, or None on Linux-less hosts.
+
+    Reads raw bytes and hashes them directly. Prior implementation went
+    through `_read_proc_field` which decoded with `errors='replace'` and
+    then re-encoded for hashing — a lossy round-trip. For valid UTF-8
+    cmdlines (the common case) the result was identical, but if a
+    cmdline contained invalid byte sequences (rare; possible for binary
+    argv content), `\\x80\\x81` would decode to U+FFFD U+FFFD then
+    re-encode to 6 bytes (`\\xef\\xbf\\xbd\\xef\\xbf\\xbd`) — fingerprint
+    of the same on-disk bytes would differ from a direct hash. External
+    code-review nitpick #3.
+    """
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except (OSError, FileNotFoundError):
         return None
-    return hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()
 
 
 def start_time_jiffies_for_pid(pid: int) -> Optional[int]:

--- a/senpi-trading-runtime/senpi_runtime_helpers/state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/state.py
@@ -4,10 +4,13 @@
 Three files per daemon, all under `${SENPI_HELPERS_STATE_DIR}/<name>/`:
 
 - `pid.json`        — pid, start_time_iso, log_path, wallet, scanner,
-                       interval_seconds, tick_timeout, version. Removed on
-                       clean exit; reader checks PID liveness when present.
-- `boot.json`       — argv, script_path, cwd, env_snapshot. Everything
-                       needed for `senpi-helpers restart` to re-exec.
+                       interval_seconds, tick_timeout, version,
+                       cmdline_fingerprint, start_time_jiffies. Removed on
+                       clean exit; reader checks PID liveness (and recycle
+                       guard) when present.
+- `boot.json`       — argv, script_path, cwd, env_snapshot, log_path.
+                       Everything needed for `senpi-helpers restart` to
+                       re-exec. Persists across stop/restart cycles.
 - `heartbeat.json`  — last_tick_iso, last_tick_status, last_tick_code,
                        tick_count, error_count. Rewritten after every tick.
 
@@ -19,11 +22,29 @@ producer, not the other way around.
 The default state dir is `/data/.openclaw/senpi-helpers/` so the files
 survive a container restart on Railway (matching where openclaw state lives).
 Override with `SENPI_HELPERS_STATE_DIR` on hosts without a `/data` volume.
+
+Schema versioning protocol
+--------------------------
+Each file has its own `"schema"` integer field. Schemas evolve INDEPENDENTLY
+— bumping boot.json's schema does not require touching pid.json. Readers
+must tolerate older AND newer schemas (forward-compat), failing soft on
+fields they don't recognize.
+
+Current supported schemas:
+    pid.json:       {1, 2}    # 2 adds cmdline_fingerprint + start_time_jiffies
+    boot.json:      {1, 2}    # 2 adds log_path + interpreter-first argv
+    heartbeat.json: {1}
+
+When `_read_json` encounters a schema number outside the supported set, it
+logs a one-line warning and returns the data anyway — callers should access
+fields defensively (`.get(...)`) rather than assume a particular shape. We
+never delete a file just because its schema is unrecognised.
 """
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under MIT
 # Source: https://github.com/Senpi-ai/senpi-skills
 
+import hashlib
 import json
 import os
 import re
@@ -31,7 +52,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from ._logging import log_event
 
@@ -113,6 +134,72 @@ _SENSITIVE_KEYS = frozenset({
 })
 
 
+# ─── PID-recycle guard ──────────────────────────────────────────────────────
+#
+# `os.kill(pid, 0)` reports any pid that exists in the kernel's process table
+# as "alive" — including a recycled pid pointing at an unrelated process. In
+# Docker/Railway containers where pid_max defaults to 32k, recycling on a
+# long-running box is plausible. A `senpi-helpers stop` that signals the
+# recycled pid would SIGTERM a stranger.
+#
+# Defence in depth: record two cheap fingerprints in pid.json:
+#   - `cmdline_fingerprint`: sha256 of /proc/<pid>/cmdline (the daemon's full
+#     argv with NUL separators). Stable across the daemon's lifetime; almost
+#     certainly different from any unrelated process that lands on the same
+#     pid.
+#   - `start_time_jiffies`: field 22 of /proc/<pid>/stat. Monotonically
+#     increasing per-process. Two processes with the same pid cannot share
+#     this value unless one was killed and another spawned in the same jiffy
+#     (essentially impossible).
+#
+# `pid_alive_and_matches(pid, fingerprint, jiffies)` verifies both before
+# returning True. Callers that don't have the fingerprints (older pid.json,
+# non-Linux dev hosts) fall back to plain `pid_alive`.
+
+
+def _read_proc_field(pid: int, field_name: str) -> Optional[str]:
+    """Read /proc/<pid>/<field_name>. Returns None on any read failure
+    (file missing, permissions, non-Linux)."""
+    try:
+        with open(f"/proc/{pid}/{field_name}", "rb") as fh:
+            return fh.read().decode("utf-8", errors="replace")
+    except (OSError, FileNotFoundError):
+        return None
+
+
+def cmdline_fingerprint_for_pid(pid: int) -> Optional[str]:
+    """Hex sha256 of /proc/<pid>/cmdline, or None on Linux-less hosts."""
+    raw = _read_proc_field(pid, "cmdline")
+    if raw is None:
+        return None
+    return hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()
+
+
+def start_time_jiffies_for_pid(pid: int) -> Optional[int]:
+    """Field 22 of /proc/<pid>/stat — the process's start time in jiffies
+    since boot. Returns None on Linux-less hosts or unreadable stat file.
+
+    `/proc/<pid>/stat` line format: `pid (comm) state ppid pgrp session ...`.
+    The comm field can contain spaces and parens; field 22 is the 21st
+    AFTER the closing paren of (comm).
+    """
+    raw = _read_proc_field(pid, "stat")
+    if raw is None:
+        return None
+    # Find the last `)` so we skip past `comm` reliably.
+    rparen = raw.rfind(")")
+    if rparen < 0:
+        return None
+    tail = raw[rparen + 1:].strip().split()
+    # After ")": state(1) ppid(2) ... starttime(22). starttime is index 19
+    # in the post-paren split (1-indexed → 0-indexed -1 -1 since state was
+    # field 3 of the whole line).
+    try:
+        return int(tail[19])
+    except (IndexError, ValueError):
+        return None
+
+
 def pid_alive(pid: Optional[int]) -> bool:
     """Cheap liveness check via signal(0). Canonical implementation shared by
     `lock.py`, `cli.py`, and `manage.py` — they all need to ask the same
@@ -135,6 +222,39 @@ def pid_alive(pid: Optional[int]) -> bool:
         return True
     except OSError:
         return False
+
+
+def pid_alive_and_matches(
+    pid: Optional[int],
+    *,
+    expected_fingerprint: Optional[str] = None,
+    expected_jiffies: Optional[int] = None,
+) -> bool:
+    """Strict liveness check that guards against pid recycling.
+
+    Returns True iff:
+      - `pid_alive(pid)` (pid exists in kernel's process table), AND
+      - if `expected_fingerprint` was given, /proc/<pid>/cmdline hashes to
+        the same value, AND
+      - if `expected_jiffies` was given, /proc/<pid>/stat field 22 is the
+        same.
+
+    When `expected_*` are None (older pid.json before this fingerprinting
+    landed, or a non-Linux dev host) the function degrades to `pid_alive`.
+    Behavior preserved across the schema bump — callers can opt in gradually.
+    """
+    if not pid_alive(pid):
+        return False
+    assert isinstance(pid, int)
+    if expected_fingerprint is not None:
+        actual = cmdline_fingerprint_for_pid(pid)
+        if actual is not None and actual != expected_fingerprint:
+            return False  # different process; pid recycled
+    if expected_jiffies is not None:
+        actual = start_time_jiffies_for_pid(pid)
+        if actual is not None and actual != expected_jiffies:
+            return False
+    return True
 
 
 def _now_iso() -> str:
@@ -173,9 +293,9 @@ def detect_log_path() -> Optional[str]:
          (the canonical redirect-to-file launch form).
 
     Returns None when stderr is not redirected to a regular file (e.g.
-    interactive terminal, pipe, socket, deleted-file fd). The
-    `senpi-helpers stats` command surfaces this as a clear "log path
-    unknown" error rather than silently aggregating nothing.
+    interactive terminal, pipe, socket, deleted-file fd). Callers (the
+    daemon's startup, `senpi-helpers stats`) should fall back to
+    `/tmp/<name>.log` and warn rather than silently degrade.
     """
     env_override = os.environ.get("SENPI_HELPERS_LOG_PATH", "").strip()
     if env_override:
@@ -193,6 +313,72 @@ def detect_log_path() -> Optional[str]:
     if target.endswith(" (deleted)"):
         return None
     return target
+
+
+def ensure_daemon_stderr_redirected(name: str) -> Optional[str]:
+    """Ensure the daemon's stderr/stdout point at a regular file.
+
+    Called once at daemon startup, BEFORE write_pid / write_boot. If the
+    daemon was launched without explicit redirection (e.g. by openclaw's
+    `exec` tool, whose fd 2 is a pipe back to the agent), the helpers
+    state files would record `log_path = None`, breaking `senpi-helpers
+    stats` and `restart` for the rest of the daemon's life.
+
+    Behavior:
+      - If stderr already points at a real file, leave it alone and return
+        that path. This is the operator playbook case
+        (`nohup python3 -u … > /tmp/foo.log 2>&1 &`).
+      - Otherwise, on Linux open `/tmp/<name>.log` in append mode and dup2
+        it onto fd 1 and fd 2 so the existing file handle is preserved by
+        the kernel after we close ours. Return that path.
+      - On non-Linux (dev/macOS), return None without rewriting fds. The
+        path that motivates this function — openclaw on Linux containers
+        with stderr-is-a-pipe — only exists in production, and dup2'ing
+        in a unit-test or interactive shell would silently capture the
+        test runner's own stdout. Production behavior is preserved; dev
+        UX is the deliberate trade-off.
+      - If even the fallback can't be opened (read-only /tmp, permissions),
+        return None and let the caller log a state_write_failed-style event.
+
+    The fallback path is deterministic so operators can find it without
+    consulting state files. The /tmp/<name>.log pattern is also what the
+    error message in `cmd_restart` already documents.
+    """
+    existing = detect_log_path()
+    if existing:
+        return existing
+
+    # Linux-only: dup2'ing stdout/stderr in a non-daemon process (e.g. a
+    # unit-test runner) would hijack the parent's output. detect_log_path
+    # also relies on /proc/self/fd/2, which only exists on Linux — so on
+    # dev machines we return None and let callers handle it explicitly.
+    if not sys.platform.startswith("linux"):
+        return None
+
+    fallback = f"/tmp/{name}.log"
+    try:
+        # Open append so multiple daemon starts under the same name don't
+        # truncate each other's history.
+        fd = os.open(fallback, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    except OSError as e:
+        log_event(
+            "ensure_log_path_failed",
+            path=fallback,
+            error=f"{type(e).__name__}: {e}"[:200],
+        )
+        return None
+    try:
+        os.dup2(fd, 1)  # stdout
+        os.dup2(fd, 2)  # stderr
+    finally:
+        os.close(fd)
+    log_event(
+        "log_path_fallback_applied",
+        name=name,
+        log_path=fallback,
+        reason="stderr was not a regular file at daemon startup",
+    )
+    return fallback
 
 
 # ─── Env snapshot ───────────────────────────────────────────────────────────
@@ -276,13 +462,37 @@ def _atomic_write(path: Path, payload: Dict[str, Any]) -> bool:
         return False
 
 
+# What schemas each file may legitimately have. Extend this set when bumping;
+# readers warn loudly on values outside it so future migrations are visible.
+_SUPPORTED_SCHEMAS: Dict[str, frozenset[int]] = {
+    "pid.json": frozenset({1, 2}),
+    "boot.json": frozenset({1, 2}),
+    "heartbeat.json": frozenset({1}),
+}
+
+
 def _read_json(path: Path) -> Optional[Dict[str, Any]]:
     try:
         with path.open("r") as f:
             data = json.load(f)
-        return data if isinstance(data, dict) else None
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return None
+    if not isinstance(data, dict):
+        return None
+    # Soft schema check: warn but still return. Callers use .get(...) and
+    # tolerate missing fields, so a future-schema-2-on-old-CLI scenario
+    # degrades gracefully instead of crashing.
+    expected = _SUPPORTED_SCHEMAS.get(path.name)
+    if expected is not None:
+        actual = data.get("schema")
+        if actual is not None and actual not in expected:
+            log_event(
+                "state_unknown_schema",
+                path=str(path),
+                got_schema=actual,
+                supported=sorted(expected),
+            )
+    return data
 
 
 # ─── Public API: write ──────────────────────────────────────────────────────
@@ -304,11 +514,16 @@ def write_pid(
     Called once at daemon start, after argument validation. The file is
     deleted on clean exit via `clear_pid` so a missing `pid.json` is the
     canonical "not running" signal for the CLI.
+
+    Schema 2 (current) adds `cmdline_fingerprint` + `start_time_jiffies`
+    so the CLI can detect pid recycling — see `pid_alive_and_matches`.
+    Schema 1 (legacy) lacked these; readers degrade to plain pid_alive.
     """
+    pid = os.getpid()
     payload = {
-        "schema": 1,
+        "schema": 2,
         "name": name,
-        "pid": os.getpid(),
+        "pid": pid,
         "start_time_iso": _now_iso(),
         "wallet": wallet,
         "scanner": scanner,
@@ -316,6 +531,9 @@ def write_pid(
         "tick_timeout": tick_timeout,
         "log_path": log_path,
         "version": version,
+        # Fingerprints — both None on non-Linux dev hosts; callers tolerate.
+        "cmdline_fingerprint": cmdline_fingerprint_for_pid(pid),
+        "start_time_jiffies": start_time_jiffies_for_pid(pid),
     }
     return _atomic_write(daemon_dir(name, state_dir) / "pid.json", payload)
 
@@ -325,13 +543,19 @@ def write_boot(name: str, *, state_dir: Optional[str] = None) -> bool:
 
     Called once at daemon start, before the producer's user code runs, so
     sys.argv reflects the original launch and can't have been mutated.
-    `senpi-helpers restart` reads this file to re-exec the producer.
+    `senpi-helpers restart` (and `start`) reads this file to re-exec the
+    producer.
 
     Schema 2 captures argv as `[sys.executable, "-u", *sys.argv]` so the
     relaunch can `Popen(argv)` without needing the script to be `+x`.
     See the schema-versioning comment near the top of this file for the
     full rationale (in particular: why "-u" is hard-coded and why we
     don't capture other interpreter flags).
+
+    Schema 2 also records `log_path` here (in addition to pid.json). The
+    daemon's `pid.json` is removed on graceful exit, so restart/stats
+    have nowhere to find log_path otherwise. boot.json persists, so the
+    relaunch path always has a log target.
     """
     script_path = os.path.realpath(sys.argv[0]) if sys.argv and sys.argv[0] else None
     # Prepend interpreter + "-u" so the relaunch path doesn't require the
@@ -348,6 +572,7 @@ def write_boot(name: str, *, state_dir: Optional[str] = None) -> bool:
         "script_path": script_path,
         "cwd": os.getcwd(),
         "env_snapshot": _sanitized_env_snapshot(),
+        "log_path": detect_log_path(),
         "captured_at_iso": _now_iso(),
     }
     return _atomic_write(daemon_dir(name, state_dir) / "boot.json", payload)

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -1533,11 +1533,10 @@ class StartInheritEnvFromTests(CliFixtures):
         self.assertEqual(len(self._relaunch_calls), 0)
 
     def test_inherit_env_openclaw_alias_invokes_pgrep(self) -> None:
-        """The 'openclaw' literal resolves via pgrep. We mock pgrep so we
-        don't depend on a real openclaw process existing on the test host."""
+        """The 'openclaw' literal resolves via pgrep. Tries `pgrep -x openclaw`
+        first, falls back to a cmdline word match. We mock subprocess.run
+        so we don't depend on a real openclaw process on the test host."""
         self._seed_minimal_boot("oc-alias")
-        # Monkeypatch subprocess.run in cli to return a synthetic pgrep
-        # result pointing at our own pid.
         import subprocess as sp
         orig_run = sp.run
 
@@ -1545,7 +1544,12 @@ class StartInheritEnvFromTests(CliFixtures):
             class R:
                 returncode = 0
                 stdout = f"{os.getpid()}\n"
-            if cmd == ["pgrep", "-f", r"^openclaw$"]:
+            # Either resolution strategy returns our pid — we don't pin
+            # which one fires first so the test is resilient to ordering
+            # changes inside _resolve_inherit_env_source.
+            if cmd[:2] == ["pgrep", "-x"] and "openclaw" in cmd:
+                return R()
+            if cmd[:2] == ["pgrep", "-f"] and any("openclaw" in c for c in cmd):
                 return R()
             return orig_run(cmd, **kwargs)
         sp.run = fake_run
@@ -1568,6 +1572,44 @@ class StartInheritEnvFromTests(CliFixtures):
             ])
             self.assertEqual(rc, 0)
             self.assertEqual(len(self._relaunch_calls), 1)
+        finally:
+            sp.run = orig_run
+
+    def test_inherit_env_openclaw_alias_falls_back_when_exact_match_fails(self) -> None:
+        """Real installs put openclaw at /usr/local/bin/openclaw (so `pgrep -x
+        openclaw` matches comm) or run `node .../openclaw` (so comm is
+        `node` and only the cmdline match catches it). Verify the fallback
+        path fires when the exact-comm match misses."""
+        self._seed_minimal_boot("oc-fallback")
+        import subprocess as sp
+        orig_run = sp.run
+        invocations = []
+
+        def fake_run(cmd, **kwargs):
+            invocations.append(cmd)
+            class R:
+                returncode = 0
+                stdout = ""
+            if cmd[:2] == ["pgrep", "-x"]:
+                # Simulate "no exact comm match" — exit code 1, no stdout.
+                R.returncode = 1
+                return R()
+            if cmd[:2] == ["pgrep", "-f"]:
+                R.stdout = f"{os.getpid()}\n"
+                return R()
+            return orig_run(cmd, **kwargs)
+        sp.run = fake_run
+        try:
+            if not sys.platform.startswith("linux"):
+                self.skipTest("/proc lookup is Linux-only after pgrep resolves")
+            rc = cli.main([
+                "start", "oc-fallback", "--inherit-env-from", "openclaw", "--json",
+            ])
+            self.assertEqual(rc, 0)
+            # Both strategies should have been attempted in order.
+            self.assertEqual(len(invocations), 2)
+            self.assertEqual(invocations[0][:2], ["pgrep", "-x"])
+            self.assertEqual(invocations[1][:2], ["pgrep", "-f"])
         finally:
             sp.run = orig_run
 

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -1633,5 +1633,139 @@ class StartInheritEnvFromTests(CliFixtures):
         self.assertEqual(len(self._relaunch_calls), 0)
 
 
+# ─── _LogTailer state machine (adversarial input coverage) ──────────────────
+
+
+class LogTailerStepTests(unittest.TestCase):
+    """Unit-tests for the `tail -F` state machine extracted from
+    `_stream_log`. Tests the input domain explicitly rather than the
+    one happy path the original `_stream_log` exercised manually.
+
+    Each test drives `step()` directly with controlled file-system state."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="senpi-helpers-tailer-")
+        self.path = os.path.join(self.tmp, "log.txt")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, content: str, *, append: bool = False) -> None:
+        mode = "a" if append else "w"
+        with open(self.path, mode) as f:
+            f.write(content)
+
+    def test_first_open_skips_history(self) -> None:
+        """The very first step() must seek-to-end so `logs --follow`
+        doesn't replay the whole historical log."""
+        self._write("historical line 1\nhistorical line 2\n")
+        tailer = cli._LogTailer(self.path)
+        action, payload = tailer.step()
+        self.assertEqual(action, "wait")
+        self.assertIsNone(payload)
+        # If subsequent appends happen, those DO show up.
+        self._write("new line\n", append=True)
+        action, payload = tailer.step()
+        self.assertEqual(action, "output")
+        self.assertEqual(payload, "new line\n")
+        tailer.close()
+
+    def test_subsequent_appends_yield_output(self) -> None:
+        self._write("a\n")
+        tailer = cli._LogTailer(self.path)
+        tailer.step()  # first open; skips history
+        self._write("b\nc\n", append=True)
+        action, payload = tailer.step()
+        self.assertEqual(action, "output")
+        self.assertEqual(payload, "b\nc\n")
+        tailer.close()
+
+    def test_rotation_reads_new_file_from_start(self) -> None:
+        """When the inode changes (rotation), the new file's full content
+        must be returned — NOT skipped via seek-to-end. This was the
+        Bugbot finding on commit 1a84707."""
+        self._write("old content\n")
+        tailer = cli._LogTailer(self.path)
+        tailer.step()  # first open, skip history
+        # Rotate: replace the file with a fresh one (different inode).
+        os.unlink(self.path)
+        self._write("rotated content line 1\nrotated content line 2\n")
+        action, payload = tailer.step()
+        self.assertEqual(action, "output")
+        self.assertEqual(
+            payload, "rotated content line 1\nrotated content line 2\n",
+            "rotation reopen must read from byte 0 of the new file",
+        )
+        tailer.close()
+
+    def test_disappear_then_reappear_reads_new_content(self) -> None:
+        """The bug I introduced in commit 7a03c7c: after FileNotFoundError,
+        inode resets to None, then `is_first_open = (inode is None)` was
+        True on the next reopen → seek-to-end → content lost. The
+        `started`-flag refactor fixes this."""
+        self._write("initial\n")
+        tailer = cli._LogTailer(self.path)
+        tailer.step()  # first open, skips history; started=True now
+        # File disappears.
+        os.unlink(self.path)
+        action, _ = tailer.step()
+        self.assertEqual(action, "wait")
+        self.assertIsNone(tailer.fh, "fh should be closed after FileNotFoundError")
+        self.assertIsNone(tailer.inode, "inode reset so reopen fires on reappearance")
+        # File reappears with new content.
+        self._write("reappeared line 1\nreappeared line 2\n")
+        action, payload = tailer.step()
+        self.assertEqual(action, "output")
+        self.assertEqual(
+            payload, "reappeared line 1\nreappeared line 2\n",
+            "post-disappear reopen must read from byte 0, not seek-to-end",
+        )
+        tailer.close()
+
+    def test_truncation_resets_position_and_reads_from_zero(self) -> None:
+        """File shrunk below our last position → seek to 0, read whatever's
+        there (may be smaller than what we'd already emitted)."""
+        self._write("aaaaaaaaaaaaaaaaaaaa\n")  # 21 bytes
+        tailer = cli._LogTailer(self.path)
+        tailer.step()  # skip history
+        self._write("bb\n")  # truncated to 3 bytes
+        action, payload = tailer.step()
+        self.assertEqual(action, "output")
+        self.assertEqual(payload, "bb\n")
+        tailer.close()
+
+    def test_missing_file_returns_wait_without_crashing(self) -> None:
+        """File never exists. Tailer should return 'wait' indefinitely
+        without raising."""
+        # Path points at a nonexistent file from the start.
+        tailer = cli._LogTailer(os.path.join(self.tmp, "never-created.log"))
+        for _ in range(5):
+            action, payload = tailer.step()
+            self.assertEqual(action, "wait")
+        tailer.close()
+
+    def test_started_flag_survives_multiple_disappearances(self) -> None:
+        """A flapping log file (created → deleted → recreated → deleted →
+        recreated …) must always read from byte 0 after the first open.
+        Only the very first open seeks to end."""
+        self._write("history\n")
+        tailer = cli._LogTailer(self.path)
+        tailer.step()  # first open
+        # Disappear / reappear cycle 1.
+        os.unlink(self.path)
+        tailer.step()  # wait
+        self._write("cycle1 content\n")
+        action, payload = tailer.step()
+        self.assertEqual(payload, "cycle1 content\n")
+        # Disappear / reappear cycle 2.
+        os.unlink(self.path)
+        tailer.step()  # wait
+        self._write("cycle2 content\n")
+        action, payload = tailer.step()
+        self.assertEqual(payload, "cycle2 content\n",
+                         "second reappearance must also read from byte 0")
+        tailer.close()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -664,7 +664,12 @@ class RestartSubcommandTests(CliFixtures):
         self.assertIn("no longer exists", err)
         self.assertEqual(len(self._relaunch_calls), 0)
 
-    def test_restart_no_log_path_fails(self) -> None:
+    def test_restart_no_log_path_uses_default_with_warning(self) -> None:
+        """When no log_path is recorded anywhere (legacy schema-1 boot.json,
+        no pid.json after clean stop, no SENPI_HELPERS_LOG_PATH), restart
+        now falls back to /tmp/<name>.log with a stderr warning instead of
+        bailing. Previously failed RC=1; today it succeeds so the new
+        daemon's write_boot can persist a canonical path for next time."""
         self._seed_full("no-log", include_log=False)
         old_stderr = sys.stderr
         sys.stderr = io.StringIO()
@@ -673,9 +678,11 @@ class RestartSubcommandTests(CliFixtures):
             err = sys.stderr.getvalue()
         finally:
             sys.stderr = old_stderr
-        self.assertEqual(rc, 1)
-        self.assertIn("log path", err.lower())
-        self.assertEqual(len(self._relaunch_calls), 0)
+        self.assertEqual(rc, 0)
+        self.assertIn("/tmp/no-log.log", err)
+        # One relaunch_daemon call (the restart succeeded by using the default).
+        self.assertEqual(len(self._relaunch_calls), 1)
+        self.assertEqual(self._relaunch_calls[0]["log_path"], "/tmp/no-log.log")
 
     def test_restart_relaunch_failure_surfaces(self) -> None:
         self._seed_full("svc")
@@ -705,6 +712,126 @@ class RestartSubcommandTests(CliFixtures):
         finally:
             sys.stderr = old_stderr
         self.assertEqual(rc, 2)
+
+
+# ─── cmd_start (new in this PR) ─────────────────────────────────────────────
+
+
+class StartSubcommandTests(RestartSubcommandTests):
+    """`start` shares the relaunch path with `restart`; the difference is
+    that start doesn't run stop_pid. Inheriting from RestartSubcommandTests
+    reuses the fake-relaunch fixture without duplicating it."""
+
+    def test_start_no_existing_pid_relaunches_cold(self) -> None:
+        """Cleanly-stopped daemon (no pid.json) — start launches it fresh."""
+        d = os.path.join(self.tmp, "cold")
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "boot.json"), "w") as f:
+            json.dump({
+                "schema": 2, "name": "cold",
+                "argv": [sys.executable, "-u", self.script],
+                "script_path": self.script,
+                "cwd": "/tmp",
+                "env_snapshot": {},
+                "log_path": "/tmp/cold.log",
+                "captured_at_iso": "2026-05-12T08:00:00.000Z",
+            }, f)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["start", "cold", "--json"])
+        self.assertEqual(rc, 0)
+        doc = json.loads(buf.getvalue())
+        self.assertEqual(doc["outcome"], "started")
+        self.assertEqual(doc["new_pid"], 4242)
+        self.assertEqual(len(self._relaunch_calls), 1)
+        self.assertEqual(self._relaunch_calls[0]["log_path"], "/tmp/cold.log")
+
+    def test_start_idempotent_when_already_running(self) -> None:
+        """If pid is alive AND fingerprints match → skip the relaunch."""
+        # Use our own pid + matching fingerprints so _pid_alive_for_daemon
+        # returns True. On non-Linux fingerprints are None, which also passes.
+        d = os.path.join(self.tmp, "already-up")
+        os.makedirs(d, exist_ok=True)
+        own_pid = os.getpid()
+        from senpi_runtime_helpers import state as st_mod
+        with open(os.path.join(d, "pid.json"), "w") as f:
+            json.dump({
+                "schema": 2, "name": "already-up", "pid": own_pid,
+                "start_time_iso": "2026-05-12T08:00:00.000Z",
+                "wallet": None, "scanner": None,
+                "interval_seconds": 60.0, "tick_timeout": 60.0,
+                "log_path": "/tmp/already-up.log", "version": "0.0.0",
+                "cmdline_fingerprint": st_mod.cmdline_fingerprint_for_pid(own_pid),
+                "start_time_jiffies": st_mod.start_time_jiffies_for_pid(own_pid),
+            }, f)
+        with open(os.path.join(d, "boot.json"), "w") as f:
+            json.dump({
+                "schema": 2, "name": "already-up",
+                "argv": [sys.executable, "-u", self.script],
+                "script_path": self.script, "cwd": "/tmp",
+                "env_snapshot": {}, "log_path": "/tmp/already-up.log",
+                "captured_at_iso": "2026-05-12T08:00:00.000Z",
+            }, f)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["start", "already-up", "--json"])
+        self.assertEqual(rc, 0)
+        doc = json.loads(buf.getvalue())
+        self.assertEqual(doc["outcome"], "already_running")
+        # Crucially, NO relaunch call fired.
+        self.assertEqual(len(self._relaunch_calls), 0)
+
+    def test_start_missing_boot_fails(self) -> None:
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main(["start", "ghost"])
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 2)
+        self.assertEqual(len(self._relaunch_calls), 0)
+
+
+# ─── pid-recycle guard at the CLI layer ─────────────────────────────────────
+
+
+class StopRecycleGuardTests(RestartSubcommandTests):
+    """When pid.json's fingerprints don't match /proc/<pid>'s, cmd_stop must
+    refuse to SIGTERM and clear the stale pid.json."""
+
+    def test_stop_refuses_when_fingerprint_mismatch(self) -> None:
+        """pid is alive (we use os.getpid()) but the recorded fingerprint
+        won't match — recycle guard kicks in, no signal sent."""
+        if not sys.platform.startswith("linux"):
+            self.skipTest("requires /proc to compute live fingerprints")
+        d = os.path.join(self.tmp, "stale")
+        os.makedirs(d, exist_ok=True)
+        own_pid = os.getpid()
+        # Write pid.json with the WRONG fingerprint.
+        with open(os.path.join(d, "pid.json"), "w") as f:
+            json.dump({
+                "schema": 2, "name": "stale", "pid": own_pid,
+                "start_time_iso": "2026-05-12T08:00:00.000Z",
+                "wallet": None, "scanner": None,
+                "interval_seconds": 60.0, "tick_timeout": 60.0,
+                "log_path": "/tmp/stale.log", "version": "0.0.0",
+                "cmdline_fingerprint": "0" * 64,  # impossible hash
+                "start_time_jiffies": None,
+            }, f)
+        # Capture stdout + stderr so the recycle-guard message is testable.
+        out = io.StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            with redirect_stdout(out):
+                rc = cli.main(["stop", "stale"])
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 0)  # treated as success (already dead)
+        self.assertIn("recycle", err.lower())
+        # pid.json should have been cleared by the recycle-guard branch.
+        self.assertFalse(os.path.exists(os.path.join(d, "pid.json")))
 
 
 class HealthComputationTests(unittest.TestCase):

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -585,10 +585,26 @@ class StopSubcommandTests(CliFixtures):
         self.assertEqual(rc, 0)
 
 
-class RestartSubcommandTests(CliFixtures):
-    """Restart requires boot.json + an existing script_path. The actual
-    subprocess.Popen is mocked via cli._manage monkeypatching so the test
-    doesn't spawn real daemons."""
+class _RelaunchFixtures(CliFixtures):
+    """Shared fixture (NO test methods) for command tests that need:
+
+      - a real on-disk script file (`self.script`) so cmd_restart /
+        cmd_start's `os.path.exists(script_path)` check passes;
+      - a monkeypatched `cli._manage.relaunch_daemon` that records each
+        invocation in `self._relaunch_calls` and returns a canned success
+        result, so the test doesn't actually spawn a daemon.
+
+    This class deliberately has no `test_*` methods. unittest discovery
+    picks it up as a TestCase (it inherits from CliFixtures → TestCase)
+    but produces an empty test suite from it.
+
+    Bugbot Low-sev (commit 214a0eb): three sibling test classes used to
+    inherit from `RestartSubcommandTests` directly to share these
+    fixtures, which had the side effect of running every restart-specific
+    test 4× (once in the parent, once in each of the three children) for
+    18 redundant runs. Sharing the fixture via a no-test mixin removes
+    the inflation without losing the convenience.
+    """
 
     def setUp(self) -> None:
         super().setUp()
@@ -644,6 +660,12 @@ class RestartSubcommandTests(CliFixtures):
                 "env_snapshot": {},
                 "captured_at_iso": "2026-05-12T08:00:00.000Z",
             }, f)
+
+
+class RestartSubcommandTests(_RelaunchFixtures):
+    """Restart requires boot.json + an existing script_path. The actual
+    subprocess.Popen is mocked via cli._manage monkeypatching so the test
+    doesn't spawn real daemons."""
 
     def test_restart_success_with_dead_daemon_skips_stop(self) -> None:
         self._seed_full("svc")  # dead pid in pid.json
@@ -767,10 +789,11 @@ class RestartSubcommandTests(CliFixtures):
 # ─── cmd_start (new in this PR) ─────────────────────────────────────────────
 
 
-class StartSubcommandTests(RestartSubcommandTests):
+class StartSubcommandTests(_RelaunchFixtures):
     """`start` shares the relaunch path with `restart`; the difference is
-    that start doesn't run stop_pid. Inheriting from RestartSubcommandTests
-    reuses the fake-relaunch fixture without duplicating it."""
+    that start doesn't run stop_pid. Inheriting from `_RelaunchFixtures`
+    reuses the fake-relaunch setup without picking up `RestartSubcommandTests`'
+    test methods (Bugbot Low-sev on commit 214a0eb)."""
 
     def test_start_no_existing_pid_relaunches_cold(self) -> None:
         """Cleanly-stopped daemon (no pid.json) — start launches it fresh."""
@@ -845,11 +868,16 @@ class StartSubcommandTests(RestartSubcommandTests):
 # ─── pid-recycle guard at the CLI layer ─────────────────────────────────────
 
 
-class AutoResolveDisabledForDestructiveCommandsTests(RestartSubcommandTests):
+class AutoResolveDisabledForDestructiveCommandsTests(_RelaunchFixtures):
     """Single-daemon-host footgun fix. Stop / restart / start now require
     an explicit <name>; auto-resolve is reserved for read-only commands
     (list, health, stats, boot, logs). Verifies the new contract — and
-    that read-only commands keep auto-resolving."""
+    that read-only commands keep auto-resolving.
+
+    Inherits from `_RelaunchFixtures` (not `RestartSubcommandTests`) so
+    parent restart tests don't run again under this class — Bugbot
+    Low-sev on commit 214a0eb. The destructive-without-name tests still
+    need the fake-relaunch mock to assert it was *not* called."""
 
     def _seed_minimal_daemon(self, name: str) -> None:
         """Just enough state so `list_daemons` returns this name."""
@@ -929,9 +957,16 @@ class AutoResolveDisabledForDestructiveCommandsTests(RestartSubcommandTests):
         self.assertEqual(doc["outcome"], "already_dead")
 
 
-class StopRecycleGuardTests(RestartSubcommandTests):
+class StopRecycleGuardTests(CliFixtures):
     """When pid.json's fingerprints don't match /proc/<pid>'s, cmd_stop must
-    refuse to SIGTERM and clear the stale pid.json."""
+    refuse to SIGTERM and clear the stale pid.json.
+
+    Inherits from `CliFixtures` directly — cmd_stop never reaches
+    relaunch_daemon, so the fake-relaunch fixture isn't needed here.
+    Was inheriting from `RestartSubcommandTests` (Bugbot Low-sev on
+    commit 214a0eb) which both ran restart tests redundantly AND made
+    each stop-recycle test pay the script-creation + monkeypatch cost
+    for nothing."""
 
     def test_stop_refuses_when_fingerprint_mismatch(self) -> None:
         """pid is alive (we use os.getpid()) but the recorded fingerprint
@@ -1863,6 +1898,48 @@ class StartInheritEnvFromTests(CliFixtures):
         self.assertEqual(rc, 1)
         self.assertIn("Linux", err)
         self.assertEqual(len(self._relaunch_calls), 0)
+
+
+# ─── Test-suite shape (Bugbot Low-sev: subclass-redundancy) ────────────────
+
+
+class TestSuiteShapeTests(unittest.TestCase):
+    """Bugbot Low-sev (commit 214a0eb): three test classes inherited from
+    `RestartSubcommandTests` to share the fake-relaunch fixture, which had
+    the side effect of re-running every `test_restart_*` method per
+    subclass — 18 redundant runs across CI.
+
+    Pin the contract: subclasses share the fixture via a no-test mixin
+    (`_RelaunchFixtures`), not via subclassing a concrete TestCase that
+    has its own test methods. New subclasses must not introduce the same
+    inflation.
+    """
+
+    def test_no_subclass_inherits_test_methods_from_restart_class(self) -> None:
+        loader = unittest.TestLoader()
+        parent_test_names = set(loader.getTestCaseNames(RestartSubcommandTests))
+        # Sanity: parent really does have the restart tests we expect.
+        self.assertTrue(
+            any(n.startswith("test_restart_") for n in parent_test_names),
+            "RestartSubcommandTests is expected to own the test_restart_* methods",
+        )
+        for child_cls in (
+            StartSubcommandTests,
+            AutoResolveDisabledForDestructiveCommandsTests,
+            StopRecycleGuardTests,
+        ):
+            child_test_names = set(loader.getTestCaseNames(child_cls))
+            overlap = parent_test_names & child_test_names
+            self.assertEqual(
+                overlap, set(),
+                msg=(
+                    f"{child_cls.__name__} inherits {len(overlap)} test "
+                    f"method(s) from RestartSubcommandTests; each runs "
+                    f"redundantly. Inherit fixture only (e.g. via "
+                    f"_RelaunchFixtures), not test methods. "
+                    f"Overlap: {sorted(overlap)}"
+                ),
+            )
 
 
 # ─── _LogTailer state machine (adversarial input coverage) ──────────────────

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -1061,5 +1061,85 @@ class FormattingTests(unittest.TestCase):
         self.assertEqual(age, 0)
 
 
+# ─── cmd_boot ───────────────────────────────────────────────────────────────
+
+
+class BootSubcommandTests(CliFixtures):
+    """`senpi-helpers boot <name>` is a pure reader over boot.json.
+    Verifies the JSON pass-through path, the human renderer, and the
+    not-found error case."""
+
+    def _write_boot(self, name: str, payload: dict) -> None:
+        d = os.path.join(self.tmp, name)
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "boot.json"), "w") as f:
+            json.dump(payload, f)
+
+    def test_boot_emits_json_passthrough(self) -> None:
+        payload = {
+            "schema": 2, "name": "svc",
+            "argv": ["/usr/bin/python3", "-u", "/data/scripts/svc.py"],
+            "script_path": "/data/scripts/svc.py", "cwd": "/data",
+            "env_snapshot": {"WALLET_ADDRESS": "0xabc"},
+            "log_path": "/tmp/svc.log",
+            "captured_at_iso": "2026-05-12T08:00:00.000Z",
+        }
+        self._write_boot("svc", payload)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["boot", "svc", "--json"])
+        self.assertEqual(rc, 0)
+        doc = json.loads(buf.getvalue())
+        self.assertEqual(doc, payload)
+
+    def test_boot_human_output_includes_key_fields(self) -> None:
+        self._write_boot("svc", {
+            "schema": 2, "name": "svc",
+            "argv": ["/usr/bin/python3", "/data/scripts/svc.py"],
+            "script_path": "/data/scripts/svc.py", "cwd": "/data",
+            "env_snapshot": {"WALLET_ADDRESS": "0xabc"},
+            "log_path": "/tmp/svc.log",
+            "captured_at_iso": "2026-05-12T08:00:00.000Z",
+        })
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["boot", "svc"])
+        out = buf.getvalue()
+        self.assertEqual(rc, 0)
+        self.assertIn("svc", out)
+        self.assertIn("/data/scripts/svc.py", out)
+        self.assertIn("/tmp/svc.log", out)
+        self.assertIn("WALLET_ADDRESS", out)
+        self.assertIn("0xabc", out)
+
+    def test_boot_truncates_long_env_values_in_human_output(self) -> None:
+        long_token = "x" * 200
+        self._write_boot("svc", {
+            "schema": 2, "name": "svc",
+            "argv": [], "script_path": "/x.py", "cwd": "/",
+            "env_snapshot": {"BIG_VAR": long_token},
+            "log_path": None, "captured_at_iso": "2026-05-12T08:00:00.000Z",
+        })
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            cli.main(["boot", "svc"])
+        out = buf.getvalue()
+        # First 60 chars of long_token should appear; the full 200-char value
+        # should NOT (truncated with ellipsis).
+        self.assertIn("x" * 60, out)
+        self.assertNotIn("x" * 200, out)
+
+    def test_boot_missing_returns_not_found(self) -> None:
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main(["boot", "ghost"])
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 2)
+        self.assertIn("no boot.json", err)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -1549,6 +1549,49 @@ class DiagnoseSubcommandTests(CliFixtures):
         r = self._run_json("stale")
         self.assertEqual(self._check_status(r["doc"], "heartbeat_fresh"), "fail")
 
+    def test_diagnose_reads_each_state_file_only_once(self) -> None:
+        """Bugbot Low-sev (commit 4b12ef3): cmd_diagnose previously read
+        pid/boot/heartbeat in a pre-check guard, then `_run_diagnostic_checks`
+        re-read the same three files. Two read passes burn extra disk I/O
+        AND open a TOCTOU window where the pre-check sees state and the
+        check pass sees None (or vice versa) on a daemon that just exited.
+
+        This test pins the contract: each state file is read at most once
+        per `cmd_diagnose` invocation.
+        """
+        # Stage minimal state so the pre-check passes (any non-None survives).
+        self._write_files("once", boot_data={
+            "schema": 2, "name": "once",
+            "argv": [], "script_path": self.tmp,
+            "cwd": "/", "env_snapshot": {}, "log_path": None,
+            "captured_at_iso": "2026-05-12T08:00:00.000Z",
+        })
+        # Wrap each state reader with a counter; keep the original behavior.
+        from senpi_runtime_helpers import state as st_mod
+        counts = {"read_pid": 0, "read_boot": 0, "read_heartbeat": 0}
+        originals = {k: getattr(st_mod, k) for k in counts}
+
+        def make_counter(name: str):
+            def wrapper(*args, **kwargs):
+                counts[name] += 1
+                return originals[name](*args, **kwargs)
+            return wrapper
+
+        # Patch on the cli module — that's where cmd_diagnose looks them up.
+        from senpi_runtime_helpers import cli as cli_mod
+        for k in counts:
+            setattr(cli_mod._state, k, make_counter(k))
+        try:
+            self._run_json("once")
+        finally:
+            for k, v in originals.items():
+                setattr(cli_mod._state, k, v)
+
+        self.assertEqual(
+            counts, {"read_pid": 1, "read_boot": 1, "read_heartbeat": 1},
+            msg=f"each state file should be read exactly once; got {counts}",
+        )
+
     def test_diagnose_all_passing_returns_ok(self) -> None:
         # Build a fully-clean state: script_path = an existing file in tmp,
         # pid = own pid (alive), no fingerprints (degrades cleanly),

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -1831,6 +1831,94 @@ class LogTailerStepTests(unittest.TestCase):
             self.assertEqual(action, "wait")
         tailer.close()
 
+    def test_open_failure_after_stat_succeeds_returns_wait(self) -> None:
+        """Adversarial race: between os.stat (succeeds) and open() (raises),
+        the file is deleted or permissions yanked. step() must catch the
+        OSError, reset state, and return wait — NOT propagate."""
+        self._write("content\n")
+        tailer = cli._LogTailer(self.path)
+        tailer.step()  # first open establishes baseline; skips history
+
+        import builtins
+        real_open = builtins.open
+        real_stat = os.stat
+        try:
+            os.stat = lambda path: type("S", (), {
+                "st_ino": (tailer.inode or 0) + 1,  # forces inode-change branch
+                "st_size": 100,
+            })()
+
+            def raising_open(*args, **kwargs):
+                if args and args[0] == self.path:
+                    raise PermissionError("simulated race: file unreadable")
+                return real_open(*args, **kwargs)
+            builtins.open = raising_open
+
+            action, payload = tailer.step()
+        finally:
+            builtins.open = real_open
+            os.stat = real_stat
+
+        self.assertEqual(action, "wait")
+        self.assertIsNone(payload)
+        self.assertIsNone(tailer.fh, "fh must be None after open failure")
+        self.assertIsNone(tailer.inode, "inode must be reset for clean retry")
+        tailer.close()
+
+    def test_open_failure_then_next_step_does_not_crash_on_closed_fh(self) -> None:
+        """The exact bug Cursor Bugbot caught on commit 57fad61.
+
+        If reopen's open() raises after self.fh.close() succeeded, the
+        OLD self.fh attribute pointed at the now-closed handle. On the
+        next step() call — if the inode happened to match the old one —
+        the reopen branch was skipped, then self.fh.read() raised
+        ValueError ('I/O operation on closed file').
+
+        Verify the fix: after an open failure, the next normal step()
+        recovers cleanly without touching the closed handle.
+        """
+        self._write("initial\n")
+        tailer = cli._LogTailer(self.path)
+        tailer.step()  # first open
+        old_inode = tailer.inode
+
+        # Force an open failure by closing the file beneath us AND making
+        # open raise. We use the same monkeypatch trick as above to drive
+        # the reopen branch and force the failure deterministically.
+        import builtins
+        real_open = builtins.open
+        real_stat = os.stat
+        try:
+            # Inode reported by stat differs → forces reopen.
+            os.stat = lambda path: type("S", (), {
+                "st_ino": (old_inode or 0) + 1,
+                "st_size": 100,
+            })()
+
+            def raising_open(*args, **kwargs):
+                if args and args[0] == self.path:
+                    raise PermissionError("simulated")
+                return real_open(*args, **kwargs)
+            builtins.open = raising_open
+            tailer.step()  # open fails — fh and inode must reset
+        finally:
+            builtins.open = real_open
+            os.stat = real_stat
+
+        # Now the file is back; the next step must NOT touch a closed
+        # handle. Critical: even if inode happens to match, fh is None
+        # (the fix), so the reopen branch fires fresh.
+        self._write("recovered\n", append=True)
+        action, payload = tailer.step()  # must not raise
+        self.assertEqual(action, "output")
+        # The reopen reads from byte 0 (per the started-flag rule:
+        # only the very first open seeks to end). So we get the full
+        # file content. The CRITICAL assertion is "no exception thrown
+        # on closed-handle"; the exact payload is incidental but locked
+        # for regression visibility.
+        self.assertEqual(payload, "initial\nrecovered\n")
+        tailer.close()
+
     def test_started_flag_survives_multiple_disappearances(self) -> None:
         """A flapping log file (created → deleted → recreated → deleted →
         recreated …) must always read from byte 0 after the first open.

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -395,7 +395,14 @@ class StatsSubcommandTests(CliFixtures):
         self.assertEqual(doc["name"], "svc")
         self.assertEqual(doc["window_hours"], 24)
 
-    def test_stats_missing_log_path_returns_no_log_exit(self) -> None:
+    def test_stats_missing_log_path_falls_back_to_default(self) -> None:
+        """Bugbot caught the divergence between cmd_stats and cmd_logs.
+        cmd_stats now uses the SAME 4-level fallback chain (pid → boot →
+        env → /tmp/<name>.log). When the default path doesn't exist, we
+        still return STATS_NO_LOG, but the error mentions exactly where
+        we looked — more actionable than the old 'did not record a log
+        path' message.
+        """
         # Seed pid.json WITHOUT log_path.
         d = os.path.join(self.tmp, "no-log-path")
         os.makedirs(d, exist_ok=True)
@@ -407,6 +414,11 @@ class StatsSubcommandTests(CliFixtures):
                 "interval_seconds": 300.0, "tick_timeout": 60.0,
                 "log_path": None, "version": "0.1.0",
             }, f)
+        # Make sure /tmp/no-log-path.log doesn't exist (the fallback target).
+        try:
+            os.unlink("/tmp/no-log-path.log")
+        except FileNotFoundError:
+            pass
         old_stderr = sys.stderr
         sys.stderr = io.StringIO()
         try:
@@ -415,8 +427,46 @@ class StatsSubcommandTests(CliFixtures):
         finally:
             sys.stderr = old_stderr
         self.assertEqual(rc, 1)  # STATS_NO_LOG
-        self.assertIn("log path", err.lower())
-        self.assertIn("SENPI_HELPERS_LOG_PATH", err)
+        # Error references the resolved default path so the operator knows
+        # exactly which file we tried to read.
+        self.assertIn("/tmp/no-log-path.log", err)
+
+    def test_stats_uses_default_path_same_as_logs_command(self) -> None:
+        """Regression guard against Bugbot's finding: cmd_stats and
+        cmd_logs should both succeed when /tmp/<name>.log exists, even if
+        no daemon recorded log_path explicitly. Pre-fix, cmd_stats failed
+        STATS_NO_LOG while cmd_logs found the default."""
+        # Seed pid.json with log_path=None (the realistic case for an
+        # older daemon launched before schema 2 always populated log_path).
+        d = os.path.join(self.tmp, "default-log")
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "pid.json"), "w") as f:
+            json.dump({
+                "schema": 1, "name": "default-log", "pid": os.getpid(),
+                "start_time_iso": "2026-05-12T08:00:00.000Z",
+                "wallet": "0x" + "a" * 40, "scanner": "s",
+                "interval_seconds": 300.0, "tick_timeout": 60.0,
+                "log_path": None, "version": "0.1.0",
+            }, f)
+        log_path = "/tmp/default-log.log"
+        try:
+            os.unlink(log_path)
+        except FileNotFoundError:
+            pass
+        try:
+            with open(log_path, "w") as f:
+                f.write("")
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli.main(["stats", "default-log", "--json"])
+            self.assertEqual(rc, 0)
+            doc = json.loads(buf.getvalue())
+            self.assertEqual(doc["log_path"], log_path)
+        finally:
+            try:
+                os.unlink(log_path)
+            except FileNotFoundError:
+                pass
 
     def test_stats_missing_log_file_returns_no_log_exit(self) -> None:
         self._seed_with_log("svc", "/no/such/file.log")

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -1194,6 +1194,108 @@ class BootSubcommandTests(CliFixtures):
 # ─── cmd_logs ───────────────────────────────────────────────────────────────
 
 
+# ─── Adversarial coverage of the seek-from-end tail (input domain) ──────────
+#
+# Walked the parameter space explicitly per the
+# memory/feedback_tdd_adversarial.md discipline:
+#   n: 0, 1, < lines, == lines, > lines
+#   file size: empty, < chunk, > chunk (forces multiple backward reads)
+#   last line: with trailing newline, without
+#   single line longer than chunk (forces backward read until first \n)
+#   non-UTF-8 bytes (errors=replace)
+
+
+class ReadLastNLinesTests(unittest.TestCase):
+    """_read_last_n_lines is the seek-from-end implementation. Tests
+    correctness across input classes; the I/O cost (O(n × line length),
+    not O(file size)) is implicit in the algorithm — verified by the
+    'large file with small chunk' tests that exercise the backward loop."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="tail-test-")
+        self.path = os.path.join(self.tmp, "log.txt")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_bytes(self, b: bytes) -> None:
+        with open(self.path, "wb") as f:
+            f.write(b)
+
+    def test_n_zero_returns_empty(self) -> None:
+        self._write_bytes(b"a\nb\nc\n")
+        self.assertEqual(cli._read_last_n_lines(self.path, n=0), [])
+
+    def test_empty_file_returns_empty(self) -> None:
+        self._write_bytes(b"")
+        self.assertEqual(cli._read_last_n_lines(self.path, n=10), [])
+
+    def test_n_equals_file_lines_returns_all(self) -> None:
+        self._write_bytes(b"a\nb\nc\n")
+        self.assertEqual(
+            cli._read_last_n_lines(self.path, n=3), ["a\n", "b\n", "c\n"],
+        )
+
+    def test_n_more_than_file_lines_returns_all(self) -> None:
+        self._write_bytes(b"a\nb\n")
+        self.assertEqual(
+            cli._read_last_n_lines(self.path, n=10), ["a\n", "b\n"],
+        )
+
+    def test_n_one_returns_only_last_line(self) -> None:
+        self._write_bytes(b"a\nb\nc\n")
+        self.assertEqual(cli._read_last_n_lines(self.path, n=1), ["c\n"])
+
+    def test_last_line_without_trailing_newline_preserved(self) -> None:
+        self._write_bytes(b"a\nb\nfinal-no-newline")
+        result = cli._read_last_n_lines(self.path, n=2)
+        self.assertEqual(result, ["b\n", "final-no-newline"])
+
+    def test_single_line_no_newline(self) -> None:
+        self._write_bytes(b"only-line-no-newline")
+        self.assertEqual(
+            cli._read_last_n_lines(self.path, n=10), ["only-line-no-newline"],
+        )
+
+    def test_file_larger_than_chunk_forces_backward_loop(self) -> None:
+        """File >> chunk_bytes. Backward-read loop must keep reading
+        chunks until enough newlines accumulated. This is the case that
+        the deque-based implementation handled correctly but slowly —
+        and that the seek-from-end implementation handles fast."""
+        # 200 lines × ~30 bytes each = ~6 KB. Use chunk_bytes=64 to force
+        # ~100 backward iterations — the loop's correctness under load.
+        for i in range(200):
+            with open(self.path, "ab") as f:
+                f.write(f"line-{i:04d}-some-content\n".encode())
+        result = cli._read_last_n_lines(self.path, n=5, chunk_bytes=64)
+        self.assertEqual(len(result), 5)
+        self.assertEqual(result[0], "line-0195-some-content\n")
+        self.assertEqual(result[-1], "line-0199-some-content\n")
+
+    def test_single_line_larger_than_chunk(self) -> None:
+        """A single line longer than chunk_bytes. Backward loop reads
+        until pos==0 because no newline boundary is found. Returns the
+        whole giant line."""
+        giant = b"x" * 50_000 + b"\n"  # one 50KB line with newline
+        self._write_bytes(giant)
+        result = cli._read_last_n_lines(self.path, n=1, chunk_bytes=4096)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result[0]), 50_001)  # 50K x's + \n
+        self.assertTrue(result[0].endswith("\n"))
+
+    def test_non_utf8_bytes_decoded_with_replace(self) -> None:
+        """Log files can contain stray binary bytes (e.g. control chars
+        from a misbehaving subprocess). The bytes-mode read + decode with
+        errors='replace' should never raise."""
+        self._write_bytes(b"valid line\n\x80\x81invalid\nlast\n")
+        result = cli._read_last_n_lines(self.path, n=3)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0], "valid line\n")
+        # Replacement char might be U+FFFD or the literal — either is fine
+        # so long as no exception was raised.
+        self.assertEqual(result[2], "last\n")
+
+
 class LogsSubcommandTests(CliFixtures):
     """`senpi-helpers logs <name>` prints the tail of the daemon's log file.
     Tests the non-follow path (the follow path is real-time streaming —

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -2053,6 +2053,62 @@ class LogTailerStepTests(unittest.TestCase):
             self.assertEqual(action, "wait")
         tailer.close()
 
+    def test_stat_permission_error_returns_wait_and_resets_state(self) -> None:
+        """Adversarial input enumeration for `os.stat`: parent directory's
+        permissions get changed mid-tail (`chmod 000 /var/log`), so stat
+        raises `PermissionError` instead of `FileNotFoundError`. The
+        previous handler caught only `FileNotFoundError`, so this case
+        propagated through `_stream_log` → `cmd_logs` and crashed
+        `senpi-helpers logs --follow` with a raw traceback.
+
+        Bugbot Medium-sev (commit ed8732f, comment r3244947267).
+        """
+        self._write("initial\n")
+        tailer = cli._LogTailer(self.path)
+        tailer.step()  # first open establishes baseline; started=True now
+
+        real_stat = os.stat
+        try:
+            os.stat = lambda path: (_ for _ in ()).throw(
+                PermissionError("simulated parent-dir chmod 000")
+            )
+            action, payload = tailer.step()
+        finally:
+            os.stat = real_stat
+
+        self.assertEqual(action, "wait")
+        self.assertIsNone(payload)
+        # State must be reset the same way FileNotFoundError already does,
+        # so a subsequent successful stat reopens cleanly.
+        self.assertIsNone(tailer.fh, "fh must be closed after stat failure")
+        self.assertIsNone(tailer.inode, "inode must be reset for clean retry")
+        tailer.close()
+
+    def test_stat_generic_oserror_returns_wait_and_resets_state(self) -> None:
+        """Adversarial input enumeration: `os.stat` can also raise plain
+        `OSError` (e.g. EIO from a failing disk, EBUSY from a transient
+        mount race). Same recovery contract as `FileNotFoundError` and
+        `PermissionError` — return wait, reset state, do not propagate.
+        """
+        self._write("initial\n")
+        tailer = cli._LogTailer(self.path)
+        tailer.step()
+
+        real_stat = os.stat
+        try:
+            os.stat = lambda path: (_ for _ in ()).throw(
+                OSError(5, "Input/output error")  # errno.EIO
+            )
+            action, payload = tailer.step()
+        finally:
+            os.stat = real_stat
+
+        self.assertEqual(action, "wait")
+        self.assertIsNone(payload)
+        self.assertIsNone(tailer.fh)
+        self.assertIsNone(tailer.inode)
+        tailer.close()
+
     def test_open_failure_after_stat_succeeds_returns_wait(self) -> None:
         """Adversarial race: between os.stat (succeeds) and open() (raises),
         the file is deleted or permissions yanked. step() must catch the

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -1221,5 +1221,187 @@ class LogsSubcommandTests(CliFixtures):
         self.assertIn("log file not found", err)
 
 
+# ─── cmd_diagnose ───────────────────────────────────────────────────────────
+
+
+class DiagnoseSubcommandTests(CliFixtures):
+    """`senpi-helpers diagnose <name>` runs the pre-flight checklist over
+    pid/boot/heartbeat/log. Each test stages a specific failure mode and
+    asserts the right check key flips to fail."""
+
+    def _write_files(
+        self, name: str, *,
+        pid_data: dict = None,
+        boot_data: dict = None,
+        hb_data: dict = None,
+    ) -> None:
+        d = os.path.join(self.tmp, name)
+        os.makedirs(d, exist_ok=True)
+        if pid_data is not None:
+            with open(os.path.join(d, "pid.json"), "w") as f:
+                json.dump(pid_data, f)
+        if boot_data is not None:
+            with open(os.path.join(d, "boot.json"), "w") as f:
+                json.dump(boot_data, f)
+        if hb_data is not None:
+            with open(os.path.join(d, "heartbeat.json"), "w") as f:
+                json.dump(hb_data, f)
+
+    def _run_json(self, name: str) -> dict:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["diagnose", name, "--json"])
+        return {"rc": rc, "doc": json.loads(buf.getvalue())}
+
+    def _check_status(self, doc: dict, key: str) -> str:
+        for c in doc["checks"]:
+            if c["key"] == key:
+                return c["status"]
+        return "missing"
+
+    def test_diagnose_no_state_returns_not_found(self) -> None:
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main(["diagnose", "ghost"])
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 2)
+
+    def test_diagnose_missing_boot_json_fails_that_check(self) -> None:
+        # Only heartbeat present.
+        self._write_files("hb-only", hb_data={
+            "schema": 1, "name": "hb-only",
+            "last_tick_iso": "2026-05-12T08:00:00.000Z",
+            "last_tick_status": "ok", "tick_count": 1, "error_count": 0,
+        })
+        r = self._run_json("hb-only")
+        self.assertEqual(self._check_status(r["doc"], "boot_json_present"), "fail")
+        self.assertEqual(r["rc"], 1)  # any fail → DIAGNOSE_UNHEALTHY
+
+    def test_diagnose_script_path_missing_on_disk_fails(self) -> None:
+        self._write_files("ghost-script", boot_data={
+            "schema": 2, "name": "ghost-script",
+            "argv": [], "script_path": "/nonexistent/path.py",
+            "cwd": "/", "env_snapshot": {}, "log_path": None,
+            "captured_at_iso": "2026-05-12T08:00:00.000Z",
+        })
+        r = self._run_json("ghost-script")
+        self.assertEqual(self._check_status(r["doc"], "script_path_exists"), "fail")
+
+    def test_diagnose_pid_dead_fails_pid_alive_check(self) -> None:
+        self._write_files("dead-pid",
+            boot_data={
+                "schema": 2, "name": "dead-pid",
+                "argv": [], "script_path": self.tmp,  # exists (dir)
+                "cwd": "/", "env_snapshot": {}, "log_path": None,
+                "captured_at_iso": "2026-05-12T08:00:00.000Z",
+            },
+            pid_data={
+                "schema": 2, "name": "dead-pid", "pid": 2147483646,
+                "start_time_iso": "2026-05-12T08:00:00.000Z",
+                "wallet": None, "scanner": None,
+                "interval_seconds": 60.0, "tick_timeout": 60.0,
+                "log_path": None, "version": "0.0.0",
+                "cmdline_fingerprint": None, "start_time_jiffies": None,
+            },
+        )
+        r = self._run_json("dead-pid")
+        self.assertEqual(self._check_status(r["doc"], "pid_alive"), "fail")
+
+    def test_diagnose_alive_with_recycled_pid_fails_fingerprint_check(self) -> None:
+        if not sys.platform.startswith("linux"):
+            self.skipTest("recycle guard requires /proc")
+        own_pid = os.getpid()
+        self._write_files("recycled",
+            boot_data={
+                "schema": 2, "name": "recycled",
+                "argv": [], "script_path": self.tmp,
+                "cwd": "/", "env_snapshot": {}, "log_path": None,
+                "captured_at_iso": "2026-05-12T08:00:00.000Z",
+            },
+            pid_data={
+                "schema": 2, "name": "recycled", "pid": own_pid,
+                "start_time_iso": "2026-05-12T08:00:00.000Z",
+                "wallet": None, "scanner": None,
+                "interval_seconds": 60.0, "tick_timeout": 60.0,
+                "log_path": None, "version": "0.0.0",
+                "cmdline_fingerprint": "0" * 64,   # bogus
+                "start_time_jiffies": None,
+            },
+        )
+        r = self._run_json("recycled")
+        self.assertEqual(self._check_status(r["doc"], "pid_alive_and_matches"), "fail")
+
+    def test_diagnose_stale_heartbeat_fails(self) -> None:
+        # last_tick was hours ago; interval is 60s → way past 2× threshold.
+        self._write_files("stale",
+            boot_data={
+                "schema": 2, "name": "stale",
+                "argv": [], "script_path": self.tmp,
+                "cwd": "/", "env_snapshot": {}, "log_path": None,
+                "captured_at_iso": "2026-05-12T08:00:00.000Z",
+            },
+            pid_data={
+                "schema": 2, "name": "stale", "pid": os.getpid(),
+                "start_time_iso": "2026-05-12T08:00:00.000Z",
+                "wallet": None, "scanner": None,
+                "interval_seconds": 60.0, "tick_timeout": 60.0,
+                "log_path": None, "version": "0.0.0",
+                "cmdline_fingerprint": None, "start_time_jiffies": None,
+            },
+            hb_data={
+                "schema": 1, "name": "stale",
+                "last_tick_iso": "2020-01-01T00:00:00.000Z",  # ancient
+                "last_tick_status": "ok",
+                "tick_count": 1, "error_count": 0,
+            },
+        )
+        r = self._run_json("stale")
+        self.assertEqual(self._check_status(r["doc"], "heartbeat_fresh"), "fail")
+
+    def test_diagnose_all_passing_returns_ok(self) -> None:
+        # Build a fully-clean state: script_path = an existing file in tmp,
+        # pid = own pid (alive), no fingerprints (degrades cleanly),
+        # heartbeat = recent (within 2× interval).
+        from datetime import datetime, timezone, timedelta
+        recent_iso = (
+            datetime.now(timezone.utc) - timedelta(seconds=5)
+        ).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        script_path = os.path.join(self.tmp, "fake-script.py")
+        with open(script_path, "w") as f:
+            f.write("# stub\n")
+        log_path = os.path.join(self.tmp, "fake.log")
+        with open(log_path, "w") as f:
+            f.write("starting...\n")
+        self._write_files("clean",
+            boot_data={
+                "schema": 2, "name": "clean",
+                "argv": [], "script_path": script_path,
+                "cwd": "/", "env_snapshot": {}, "log_path": log_path,
+                "captured_at_iso": "2026-05-12T08:00:00.000Z",
+            },
+            pid_data={
+                "schema": 2, "name": "clean", "pid": os.getpid(),
+                "start_time_iso": recent_iso,
+                "wallet": None, "scanner": None,
+                "interval_seconds": 60.0, "tick_timeout": 60.0,
+                "log_path": log_path, "version": "0.0.0",
+                "cmdline_fingerprint": None, "start_time_jiffies": None,
+            },
+            hb_data={
+                "schema": 1, "name": "clean",
+                "last_tick_iso": recent_iso,
+                "last_tick_status": "ok",
+                "tick_count": 1, "error_count": 0,
+            },
+        )
+        r = self._run_json("clean")
+        self.assertEqual(r["rc"], 0)
+        # No checks should be fail.
+        fails = [c for c in r["doc"]["checks"] if c["status"] == "fail"]
+        self.assertEqual(fails, [], msg=f"unexpected failures: {fails}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -795,6 +795,90 @@ class StartSubcommandTests(RestartSubcommandTests):
 # ─── pid-recycle guard at the CLI layer ─────────────────────────────────────
 
 
+class AutoResolveDisabledForDestructiveCommandsTests(RestartSubcommandTests):
+    """Single-daemon-host footgun fix. Stop / restart / start now require
+    an explicit <name>; auto-resolve is reserved for read-only commands
+    (list, health, stats, boot, logs). Verifies the new contract — and
+    that read-only commands keep auto-resolving."""
+
+    def _seed_minimal_daemon(self, name: str) -> None:
+        """Just enough state so `list_daemons` returns this name."""
+        d = os.path.join(self.tmp, name)
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "pid.json"), "w") as f:
+            json.dump({
+                "schema": 2, "name": name, "pid": 2147483646,
+                "start_time_iso": "2026-05-12T08:00:00.000Z",
+                "wallet": None, "scanner": None,
+                "interval_seconds": 60.0, "tick_timeout": 60.0,
+                "log_path": None, "version": "0.0.0",
+                "cmdline_fingerprint": None, "start_time_jiffies": None,
+            }, f)
+
+    def test_stop_without_name_on_single_daemon_host_errors(self) -> None:
+        self._seed_minimal_daemon("solo")
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main(["stop"])
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        # 2 = NOT_FOUND (semantic: "couldn't determine which daemon").
+        self.assertEqual(rc, 2)
+        self.assertIn("explicit <name>", err)
+        self.assertIn("solo", err)
+
+    def test_restart_without_name_on_single_daemon_host_errors(self) -> None:
+        self._seed_minimal_daemon("solo")
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main(["restart"])
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 2)
+        self.assertIn("explicit <name>", err)
+        # No relaunch_daemon should have fired.
+        self.assertEqual(len(self._relaunch_calls), 0)
+
+    def test_start_without_name_on_single_daemon_host_errors(self) -> None:
+        self._seed_minimal_daemon("solo")
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main(["start"])
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 2)
+        self.assertIn("explicit <name>", err)
+        self.assertEqual(len(self._relaunch_calls), 0)
+
+    def test_list_without_name_still_works_on_single_daemon_host(self) -> None:
+        """Read-only commands keep auto-resolve. Otherwise we'd break every
+        operator's `senpi-helpers list` muscle memory."""
+        self._seed_minimal_daemon("solo")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["list", "--json"])
+        self.assertEqual(rc, 0)
+        doc = json.loads(buf.getvalue())
+        self.assertEqual(len(doc["daemons"]), 1)
+        self.assertEqual(doc["daemons"][0]["name"], "solo")
+
+    def test_stop_with_explicit_name_still_works(self) -> None:
+        """Confirm the existing happy-path didn't regress."""
+        self._seed_minimal_daemon("explicit")  # writes pid.json with dead pid
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["stop", "explicit", "--json"])
+        self.assertEqual(rc, 0)
+        doc = json.loads(buf.getvalue())
+        self.assertEqual(doc["outcome"], "already_dead")
+
+
 class StopRecycleGuardTests(RestartSubcommandTests):
     """When pid.json's fingerprints don't match /proc/<pid>'s, cmd_stop must
     refuse to SIGTERM and clear the stale pid.json."""

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -1207,6 +1207,43 @@ class LogsSubcommandTests(CliFixtures):
         self.assertEqual(rc, 0)
         self.assertEqual(out, "only-line")
 
+    def test_logs_negative_lines_rejected_cleanly(self) -> None:
+        """argparse accepts negative integers as type=int. `deque(maxlen=-1)`
+        would raise ValueError → uncaught traceback to the operator.
+        cmd_logs must validate the value and emit a clean error."""
+        log_path = os.path.join(self.tmp, "neg.log")
+        with open(log_path, "w") as f:
+            f.write("line\n")
+        self._seed_boot_with_log("neg-lines", log_path)
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main(["logs", "neg-lines", "-n", "-5"])
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        # Either non-zero exit (graceful error) or zero (clamped to 0 with
+        # a warning). Critical: NO unhandled exception, NO crash.
+        self.assertNotEqual(rc, None)
+        # Error should mention the bad value explicitly.
+        self.assertTrue(
+            "lines" in err.lower() or "negative" in err.lower(),
+            f"expected error about lines value; got: {err!r}",
+        )
+
+    def test_logs_zero_lines_prints_nothing(self) -> None:
+        """`--lines 0` is a degenerate but valid request: print no lines.
+        Should not crash."""
+        log_path = os.path.join(self.tmp, "zero.log")
+        with open(log_path, "w") as f:
+            f.write("hello\n" * 5)
+        self._seed_boot_with_log("zero-lines", log_path)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["logs", "zero-lines", "-n", "0"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(buf.getvalue(), "")
+
     def test_logs_missing_file_returns_no_log(self) -> None:
         # boot.json points at a path that doesn't exist on disk.
         self._seed_boot_with_log("missing", "/tmp/does-not-exist-XYZ.log")

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -1403,5 +1403,193 @@ class DiagnoseSubcommandTests(CliFixtures):
         self.assertEqual(fails, [], msg=f"unexpected failures: {fails}")
 
 
+# ─── cmd_start --inherit-env-from ───────────────────────────────────────────
+
+
+class StartInheritEnvFromTests(CliFixtures):
+    """`senpi-helpers start --inherit-env-from <pid|openclaw>` reads /proc
+    environ and merges with the caller's env. Operator-set env wins."""
+
+    def _seed_minimal_boot(self, name: str) -> str:
+        """Returns the script_path that boot.json points at."""
+        d = os.path.join(self.tmp, name)
+        os.makedirs(d, exist_ok=True)
+        # Make a real script file so cmd_start's existence check passes.
+        script = os.path.join(self.tmp, f"{name}-script.py")
+        with open(script, "w") as f:
+            f.write("# stub\n")
+        with open(os.path.join(d, "boot.json"), "w") as f:
+            json.dump({
+                "schema": 2, "name": name,
+                "argv": [sys.executable, "-u", script],
+                "script_path": script, "cwd": "/",
+                "env_snapshot": {}, "log_path": f"/tmp/{name}.log",
+                "captured_at_iso": "2026-05-12T08:00:00.000Z",
+            }, f)
+        return script
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Stub relaunch_daemon so the test never spawns a real process.
+        self._cli = cli
+        self._orig_relaunch = self._cli._manage.relaunch_daemon
+        self._relaunch_calls = []
+
+        def fake_relaunch(**kwargs):
+            self._relaunch_calls.append(kwargs)
+            return {
+                "outcome": self._cli._manage.RELAUNCH_OK,
+                "pid": 4242, "error": None,
+                "argv_normalized": False, "argv_used": kwargs.get("argv", []),
+            }
+        self._cli._manage.relaunch_daemon = fake_relaunch
+
+    def tearDown(self) -> None:
+        self._cli._manage.relaunch_daemon = self._orig_relaunch
+        super().tearDown()
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"),
+        "/proc-based env inheritance is Linux-only",
+    )
+    def test_inherit_env_from_own_pid_merges_into_relaunch(self) -> None:
+        self._seed_minimal_boot("env-test")
+        # Set a unique env var so we can verify it's inherited.
+        os.environ["SENPI_HELPERS_INHERIT_TEST"] = "from-our-environ"
+        try:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli.main([
+                    "start", "env-test", "--inherit-env-from", str(os.getpid()),
+                    "--json",
+                ])
+        finally:
+            os.environ.pop("SENPI_HELPERS_INHERIT_TEST", None)
+        self.assertEqual(rc, 0)
+        # relaunch_daemon was called with an env dict (not None).
+        self.assertEqual(len(self._relaunch_calls), 1)
+        env_passed = self._relaunch_calls[0]["env"]
+        self.assertIsInstance(env_passed, dict)
+        # Either HOME or PATH should be there (inherited from this process).
+        self.assertTrue("HOME" in env_passed or "PATH" in env_passed)
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"),
+        "/proc-based env inheritance is Linux-only",
+    )
+    def test_inherit_env_explicit_env_wins_over_inherited(self) -> None:
+        """Operator-set env in the current shell takes priority — fills in
+        the auth tokens from the inherited env, but the operator can
+        override anything they explicitly set."""
+        self._seed_minimal_boot("priority-test")
+        # Inherited (from our /proc/self/environ) will have HOME.
+        # Override it in our os.environ to a unique value.
+        os.environ["HOME"] = "/explicitly-overridden"
+        try:
+            cli.main([
+                "start", "priority-test", "--inherit-env-from", str(os.getpid()),
+                "--json",
+            ])
+        finally:
+            # Restore parent's HOME — important for the rest of the test
+            # suite, which may rely on it.
+            del os.environ["HOME"]
+        env_passed = self._relaunch_calls[0]["env"]
+        self.assertEqual(env_passed["HOME"], "/explicitly-overridden")
+
+    def test_inherit_env_invalid_value_errors_cleanly(self) -> None:
+        self._seed_minimal_boot("invalid-test")
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main([
+                "start", "invalid-test", "--inherit-env-from", "not-a-pid-or-openclaw",
+            ])
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 1)  # START_FAILED
+        self.assertIn("invalid value", err)
+        # Crucially, NO relaunch call fired.
+        self.assertEqual(len(self._relaunch_calls), 0)
+
+    @unittest.skipUnless(
+        sys.platform.startswith("linux"),
+        "Tests the /proc-read failure path; on macOS the Linux gate fires first",
+    )
+    def test_inherit_env_nonexistent_pid_errors_cleanly(self) -> None:
+        self._seed_minimal_boot("ghost-pid")
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main([
+                "start", "ghost-pid", "--inherit-env-from", "2147483646",
+            ])
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 1)
+        self.assertIn("could not read", err)
+        self.assertEqual(len(self._relaunch_calls), 0)
+
+    def test_inherit_env_openclaw_alias_invokes_pgrep(self) -> None:
+        """The 'openclaw' literal resolves via pgrep. We mock pgrep so we
+        don't depend on a real openclaw process existing on the test host."""
+        self._seed_minimal_boot("oc-alias")
+        # Monkeypatch subprocess.run in cli to return a synthetic pgrep
+        # result pointing at our own pid.
+        import subprocess as sp
+        orig_run = sp.run
+
+        def fake_run(cmd, **kwargs):
+            class R:
+                returncode = 0
+                stdout = f"{os.getpid()}\n"
+            if cmd == ["pgrep", "-f", r"^openclaw$"]:
+                return R()
+            return orig_run(cmd, **kwargs)
+        sp.run = fake_run
+        try:
+            if not sys.platform.startswith("linux"):
+                # On macOS we expect the linux-gate to fail; only run the
+                # check we care about: pgrep was attempted.
+                old_stderr = sys.stderr
+                sys.stderr = io.StringIO()
+                try:
+                    rc = cli.main([
+                        "start", "oc-alias", "--inherit-env-from", "openclaw",
+                    ])
+                finally:
+                    sys.stderr = old_stderr
+                self.assertEqual(rc, 1)
+                return
+            rc = cli.main([
+                "start", "oc-alias", "--inherit-env-from", "openclaw", "--json",
+            ])
+            self.assertEqual(rc, 0)
+            self.assertEqual(len(self._relaunch_calls), 1)
+        finally:
+            sp.run = orig_run
+
+    @unittest.skipIf(
+        sys.platform.startswith("linux"),
+        "macOS-only: verifies the Linux gate fires off Linux",
+    )
+    def test_inherit_env_on_non_linux_returns_error(self) -> None:
+        self._seed_minimal_boot("dev-host")
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main([
+                "start", "dev-host", "--inherit-env-from", str(os.getpid()),
+            ])
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 1)
+        self.assertIn("Linux", err)
+        self.assertEqual(len(self._relaunch_calls), 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_cli.py
@@ -1141,5 +1141,85 @@ class BootSubcommandTests(CliFixtures):
         self.assertIn("no boot.json", err)
 
 
+# ─── cmd_logs ───────────────────────────────────────────────────────────────
+
+
+class LogsSubcommandTests(CliFixtures):
+    """`senpi-helpers logs <name>` prints the tail of the daemon's log file.
+    Tests the non-follow path (the follow path is real-time streaming —
+    too fragile to unit-test deterministically, exercised manually)."""
+
+    def _seed_boot_with_log(self, name: str, log_path: str) -> None:
+        d = os.path.join(self.tmp, name)
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "boot.json"), "w") as f:
+            json.dump({
+                "schema": 2, "name": name,
+                "argv": [], "script_path": "/x.py", "cwd": "/",
+                "env_snapshot": {}, "log_path": log_path,
+                "captured_at_iso": "2026-05-12T08:00:00.000Z",
+            }, f)
+
+    def test_logs_prints_last_n_lines(self) -> None:
+        log_path = os.path.join(self.tmp, "svc.log")
+        with open(log_path, "w") as f:
+            for i in range(200):
+                f.write(f"line-{i}\n")
+        self._seed_boot_with_log("svc", log_path)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["logs", "svc", "--lines", "10"])
+        out = buf.getvalue().splitlines()
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(out), 10)
+        # Tail = last 10 lines: line-190 .. line-199.
+        self.assertEqual(out[0], "line-190")
+        self.assertEqual(out[-1], "line-199")
+
+    def test_logs_default_lines_is_50(self) -> None:
+        log_path = os.path.join(self.tmp, "svc2.log")
+        with open(log_path, "w") as f:
+            for i in range(120):
+                f.write(f"row-{i}\n")
+        self._seed_boot_with_log("svc2", log_path)
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["logs", "svc2"])
+        out = buf.getvalue().splitlines()
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(out), 50)
+        # Tail = last 50: row-70 .. row-119.
+        self.assertEqual(out[0], "row-70")
+        self.assertEqual(out[-1], "row-119")
+
+    def test_logs_resolves_path_from_boot_json_when_pid_json_absent(self) -> None:
+        """After a clean stop, pid.json is gone but boot.json still has
+        log_path. `logs` should use the boot.json value."""
+        log_path = os.path.join(self.tmp, "post-stop.log")
+        with open(log_path, "w") as f:
+            f.write("only-line\n")
+        self._seed_boot_with_log("cleanly-stopped", log_path)
+        # No pid.json on disk for this daemon.
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli.main(["logs", "cleanly-stopped"])
+        out = buf.getvalue().strip()
+        self.assertEqual(rc, 0)
+        self.assertEqual(out, "only-line")
+
+    def test_logs_missing_file_returns_no_log(self) -> None:
+        # boot.json points at a path that doesn't exist on disk.
+        self._seed_boot_with_log("missing", "/tmp/does-not-exist-XYZ.log")
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            rc = cli.main(["logs", "missing"])
+            err = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(rc, 1)  # LOGS_NO_LOG
+        self.assertIn("log file not found", err)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
@@ -507,6 +507,42 @@ class RelaunchNormalizationTests(unittest.TestCase):
         self.assertEqual(captured["argv"], modern_argv)
         self.assertEqual(result["argv_used"], modern_argv)
 
+    def test_relaunch_with_relative_argv0_resolves_against_cwd(self) -> None:
+        """Schema-1 boot.json can record argv = ['./producer.py'] when the
+        operator launched from the script's directory. Popen will use the
+        daemon's cwd (`cwd=` parameter), so the existence check must too —
+        otherwise we'd return RELAUNCH_SCRIPT_MISSING for a launch that
+        would actually work.
+
+        Caught by garg-prashant on PR #279.
+        """
+        # Put a fake script in a subdir so we can pass a relative argv[0]
+        # against an explicit cwd.
+        import tempfile
+        sub = tempfile.mkdtemp(prefix="relaunch-relcwd-")
+        script_name = "producer.py"
+        with open(os.path.join(sub, script_name), "w") as f:
+            f.write("# fake\n")
+        factory, captured = self._make_fake_popen()
+        try:
+            result = manage.relaunch_daemon(
+                argv=[f"./{script_name}"],
+                cwd=sub,
+                log_path=self.log,
+                popen_factory=factory,
+            )
+            self.assertEqual(
+                result["outcome"], manage.RELAUNCH_OK,
+                f"expected OK, got: {result}",
+            )
+            # Popen receives the normalized argv (which still includes the
+            # relative path — we don't rewrite it; only the existence check
+            # was resolved against cwd).
+            self.assertEqual(captured["kwargs"].get("cwd"), sub)
+        finally:
+            import shutil
+            shutil.rmtree(sub, ignore_errors=True)
+
     def test_empty_argv_result_includes_normalization_fields(self) -> None:
         """Failure paths still populate argv_normalized / argv_used keys so
         callers can branch on them without KeyError."""

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
@@ -222,7 +222,14 @@ class RelaunchDaemonTests(unittest.TestCase):
         )
         self.assertEqual(result["outcome"], manage.RELAUNCH_OK)
         self.assertEqual(result["pid"], 4242)
-        self.assertEqual(captured["argv"], [self.script, "--flag"])
+        # Legacy schema-1 argv (script-only); _normalize_argv prepends the
+        # interpreter so Popen doesn't need the script to be executable.
+        self.assertEqual(
+            captured["argv"],
+            [sys.executable, "-u", self.script, "--flag"],
+        )
+        self.assertTrue(result["argv_normalized"])
+        self.assertEqual(result["argv_used"], captured["argv"])
         # Detach must be on.
         self.assertTrue(captured["kwargs"].get("start_new_session"))
         # stdin must be muted.
@@ -371,6 +378,144 @@ class StopOutcomeSuccessTests(unittest.TestCase):
 
     def test_invalid_pid_is_failure(self) -> None:
         self.assertFalse(manage.stop_outcome_was_success(manage.STOP_INVALID_PID))
+
+
+# ─── Tests for _normalize_argv (R7-R12) ─────────────────────────────────────
+
+
+class NormalizeArgvTests(unittest.TestCase):
+    """_normalize_argv migrates schema-1 boot.json argv (script-only) to
+    schema-2 (interpreter-first). Idempotent — modern argv passes through.
+    """
+
+    def test_passthrough_for_modern_shape(self) -> None:
+        """R7: [interpreter, script] is left unchanged."""
+        argv = ["/usr/bin/python3", "/path/script.py"]
+        out, was_norm = manage._normalize_argv(argv)
+        self.assertEqual(out, argv)
+        self.assertFalse(was_norm)
+
+    def test_passthrough_for_versioned_python(self) -> None:
+        """R8: /usr/bin/python3.11 is recognized as an interpreter."""
+        argv = ["/usr/bin/python3.11", "/path/script.py"]
+        out, was_norm = manage._normalize_argv(argv)
+        self.assertEqual(out, argv)
+        self.assertFalse(was_norm)
+
+    def test_prepends_for_legacy_script_only(self) -> None:
+        """R9: ['script.py'] → [sys.executable, '-u', 'script.py'], was_norm=True."""
+        argv = ["/path/script.py"]
+        out, was_norm = manage._normalize_argv(argv)
+        self.assertEqual(out, [sys.executable, "-u", "/path/script.py"])
+        self.assertTrue(was_norm)
+
+    def test_prepends_preserving_script_args(self) -> None:
+        """R10: script's own arguments are preserved after normalization."""
+        argv = ["/path/script.py", "--flag", "x"]
+        out, was_norm = manage._normalize_argv(argv)
+        self.assertEqual(
+            out, [sys.executable, "-u", "/path/script.py", "--flag", "x"],
+        )
+        self.assertTrue(was_norm)
+
+    def test_passthrough_for_unknown_non_py_binary(self) -> None:
+        """R11: non-.py argv[0] is NOT 'fixed' — we don't second-guess."""
+        argv = ["/usr/bin/cat", "/path/file"]
+        out, was_norm = manage._normalize_argv(argv)
+        self.assertEqual(out, argv)
+        self.assertFalse(was_norm)
+
+    def test_empty_argv(self) -> None:
+        """R12: empty argv passes through; relaunch_daemon handles emptiness."""
+        out, was_norm = manage._normalize_argv([])
+        self.assertEqual(out, [])
+        self.assertFalse(was_norm)
+
+    def test_idempotent_when_applied_twice(self) -> None:
+        """Defensive: normalizing an already-modern argv must not stack."""
+        argv = ["/path/script.py"]
+        once, _ = manage._normalize_argv(argv)
+        twice, was_norm_again = manage._normalize_argv(once)
+        self.assertEqual(twice, once)
+        self.assertFalse(was_norm_again)
+
+
+# ─── relaunch_daemon's normalization contract (R13-R14) ─────────────────────
+
+
+class RelaunchNormalizationTests(unittest.TestCase):
+    """relaunch_daemon must call Popen with the normalized argv, and surface
+    `argv_normalized` + `argv_used` in its result dict so callers (CLI,
+    automation) can see what was actually launched.
+    """
+
+    def setUp(self) -> None:
+        import tempfile
+        # Use a non-+x .py file — the original bug's smoking gun.
+        fd, self.script = tempfile.mkstemp(suffix=".py", prefix="legacy-")
+        os.write(fd, b"# fake daemon, intentionally not +x\n")
+        os.close(fd)
+        os.chmod(self.script, 0o644)
+        fd2, self.log = tempfile.mkstemp(suffix=".log", prefix="legacy-log-")
+        os.close(fd2)
+
+    def tearDown(self) -> None:
+        for path in (self.script, self.log):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+    def _make_fake_popen(self, fake_pid: int = 999):
+        captured = {}
+        class FakeProc:
+            pid = fake_pid
+        def factory(argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+            return FakeProc()
+        return factory, captured
+
+    def test_relaunch_uses_normalized_argv_for_legacy_boot(self) -> None:
+        """R13: legacy [script] → Popen called with [executable, "-u", script]."""
+        factory, captured = self._make_fake_popen()
+        result = manage.relaunch_daemon(
+            argv=[self.script],
+            cwd=None,
+            log_path=self.log,
+            popen_factory=factory,
+        )
+        self.assertEqual(result["outcome"], manage.RELAUNCH_OK)
+        self.assertTrue(result["argv_normalized"])
+        self.assertEqual(
+            captured["argv"], [sys.executable, "-u", self.script],
+        )
+        self.assertEqual(result["argv_used"], captured["argv"])
+
+    def test_relaunch_records_argv_used_when_no_normalization(self) -> None:
+        """R14: modern [executable, script] passes through, was_norm=False."""
+        factory, captured = self._make_fake_popen()
+        modern_argv = [sys.executable, self.script]
+        result = manage.relaunch_daemon(
+            argv=modern_argv,
+            cwd=None,
+            log_path=self.log,
+            popen_factory=factory,
+        )
+        self.assertEqual(result["outcome"], manage.RELAUNCH_OK)
+        self.assertFalse(result["argv_normalized"])
+        self.assertEqual(captured["argv"], modern_argv)
+        self.assertEqual(result["argv_used"], modern_argv)
+
+    def test_empty_argv_result_includes_normalization_fields(self) -> None:
+        """Failure paths still populate argv_normalized / argv_used keys so
+        callers can branch on them without KeyError."""
+        result = manage.relaunch_daemon(
+            argv=[], cwd=None, log_path=self.log,
+        )
+        self.assertEqual(result["outcome"], manage.RELAUNCH_SPAWN_FAILED)
+        self.assertIn("argv_normalized", result)
+        self.assertIn("argv_used", result)
 
 
 if __name__ == "__main__":

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
@@ -251,7 +251,10 @@ class RelaunchDaemonTests(unittest.TestCase):
             popen_factory=factory,
         )
         self.assertEqual(result["outcome"], manage.RELAUNCH_SCRIPT_MISSING)
-        self.assertIn("not found", result["error"])
+        # Error mentions both that we tried + what we tried — exact wording
+        # may evolve (today: "argv[0] is not a regular file on disk: …"),
+        # so match the path rather than a brittle substring.
+        self.assertIn("/no/such/script.py", result["error"])
 
     def test_relaunch_empty_argv_fails(self) -> None:
         factory, _ = self._make_fake_popen()
@@ -506,6 +509,51 @@ class RelaunchNormalizationTests(unittest.TestCase):
         self.assertFalse(result["argv_normalized"])
         self.assertEqual(captured["argv"], modern_argv)
         self.assertEqual(result["argv_used"], modern_argv)
+
+    def test_relaunch_empty_argv0_returns_script_missing(self) -> None:
+        """Adversarial: argv = [""] (empty string).
+
+        Before garg-prashant's cwd-resolution fix, `os.path.exists("")`
+        returned False ⇒ RELAUNCH_SCRIPT_MISSING. My fix joined "" against
+        cwd, which yields the cwd itself (a directory that exists). The
+        existence check passed despite argv[0] being garbage. Now we
+        require argv[0] to resolve to a FILE, not just a path that exists.
+
+        Caught while doing the adversarial review of commit e0fd059."""
+        factory, _ = self._make_fake_popen()
+        result = manage.relaunch_daemon(
+            argv=[""],
+            cwd=self.tmp_cwd_for_tests if hasattr(self, "tmp_cwd_for_tests") else None,
+            log_path=self.log,
+            popen_factory=factory,
+        )
+        self.assertEqual(
+            result["outcome"], manage.RELAUNCH_SCRIPT_MISSING,
+            "empty argv[0] must fail the existence check, not pass via cwd",
+        )
+
+    def test_relaunch_argv0_pointing_at_a_directory_fails(self) -> None:
+        """Adversarial: argv[0] = a directory path (a real path that
+        exists, but isn't an executable file).
+
+        `os.path.exists()` returns True for directories. Popen would fail
+        on exec, but the helper's pre-check should refuse before Popen so
+        the operator gets a clearer error."""
+        import tempfile
+        dir_path = tempfile.mkdtemp(prefix="argv0-is-dir-")
+        try:
+            factory, _ = self._make_fake_popen()
+            result = manage.relaunch_daemon(
+                argv=[dir_path], cwd=None, log_path=self.log,
+                popen_factory=factory,
+            )
+            self.assertEqual(
+                result["outcome"], manage.RELAUNCH_SCRIPT_MISSING,
+                "argv[0] pointing at a directory must not pass the file check",
+            )
+        finally:
+            import shutil
+            shutil.rmtree(dir_path, ignore_errors=True)
 
     def test_relaunch_with_relative_argv0_resolves_against_cwd(self) -> None:
         """Schema-1 boot.json can record argv = ['./producer.py'] when the

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
@@ -510,6 +510,52 @@ class RelaunchNormalizationTests(unittest.TestCase):
         self.assertEqual(captured["argv"], modern_argv)
         self.assertEqual(result["argv_used"], modern_argv)
 
+    def test_relaunch_bare_name_argv0_resolved_via_path(self) -> None:
+        """Adversarial: argv[0] is a bare executable name (no path
+        separator) that exists on $PATH. Popen would resolve it via $PATH;
+        the existence check must do the same instead of joining it with
+        cwd and failing.
+
+        Pre-fix: os.path.join(cwd, 'python3') → '/data/python3' →
+        os.path.isfile false → RELAUNCH_SCRIPT_MISSING (FALSE NEGATIVE).
+        Caught by external reviewer on PR #279.
+        """
+        # Use 'python3' — guaranteed on every CI host and on production.
+        # If shutil.which can't find it, the test environment is broken in
+        # a way no fix here addresses; skip gracefully.
+        import shutil
+        if shutil.which("python3") is None:
+            self.skipTest("python3 not on $PATH in this test environment")
+
+        factory, captured = self._make_fake_popen()
+        result = manage.relaunch_daemon(
+            argv=["python3", "-u", self.script],
+            cwd=None,  # cwd doesn't matter; resolution is via $PATH
+            log_path=self.log,
+            popen_factory=factory,
+        )
+        self.assertEqual(
+            result["outcome"], manage.RELAUNCH_OK,
+            f"bare-name argv[0] on $PATH must NOT fail existence check; "
+            f"got: {result}",
+        )
+        # Popen was called with the original argv unchanged — we don't
+        # rewrite to the resolved path because Popen handles that itself.
+        self.assertEqual(captured["argv"][0], "python3")
+
+    def test_relaunch_bare_name_argv0_not_on_path_fails(self) -> None:
+        """Adversarial: argv[0] is a bare name that's NOT on $PATH.
+        Should fail with a clear $PATH error message — distinct from the
+        'not a regular file' message for path-shaped argv[0]."""
+        factory, _ = self._make_fake_popen()
+        result = manage.relaunch_daemon(
+            argv=["definitely-not-on-path-XYZQ"],
+            cwd=None, log_path=self.log,
+            popen_factory=factory,
+        )
+        self.assertEqual(result["outcome"], manage.RELAUNCH_SCRIPT_MISSING)
+        self.assertIn("$PATH", result["error"])
+
     def test_relaunch_empty_argv0_returns_script_missing(self) -> None:
         """Adversarial: argv = [""] (empty string).
 

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
@@ -245,15 +245,20 @@ class RelaunchDaemonTests(unittest.TestCase):
         self.assertEqual(captured["kwargs"]["stdout"], captured["kwargs"]["stderr"])
 
     def test_relaunch_missing_script_fails_loudly(self) -> None:
+        """After the normalize-first reorder, argv[0]=script.py is
+        normalized to [interpreter, -u, script.py] before the existence
+        check — so argv[0] (the interpreter) always exists. The script
+        itself is validated via the explicit script_path parameter that
+        cmd_restart / cmd_start pass through. Without script_path, the
+        helper trusts argv (Popen would discover the missing script at
+        exec time). With script_path, we catch it cleanly here."""
         factory, _ = self._make_fake_popen()
         result = manage.relaunch_daemon(
             argv=["/no/such/script.py"], cwd=None, log_path=self.log,
             popen_factory=factory,
+            script_path="/no/such/script.py",
         )
         self.assertEqual(result["outcome"], manage.RELAUNCH_SCRIPT_MISSING)
-        # Error mentions both that we tried + what we tried — exact wording
-        # may evolve (today: "argv[0] is not a regular file on disk: …"),
-        # so match the path rather than a brittle substring.
         self.assertIn("/no/such/script.py", result["error"])
 
     def test_relaunch_empty_argv_fails(self) -> None:
@@ -547,6 +552,42 @@ class RelaunchNormalizationTests(unittest.TestCase):
                 script_path="./producer.py",  # relative; cwd resolves it
             )
             self.assertEqual(result["outcome"], manage.RELAUNCH_OK)
+        finally:
+            shutil.rmtree(sub, ignore_errors=True)
+
+    def test_relaunch_bare_name_dot_py_argv0_resolves_via_cwd(self) -> None:
+        """Bugbot caught: schema-1 boot.json from operator playbook
+        (`nohup python3 -u script.py`) records argv = ["script.py"] —
+        bare name, no path separator, .py extension. Pre-fix, this hit
+        the shutil.which branch and falsely returned SCRIPT_MISSING
+        because PATH doesn't contain scripts. Popen would actually
+        succeed because _normalize_argv prepends the interpreter and the
+        interpreter resolves the script relative to cwd.
+
+        Fix: normalize argv FIRST (so argv[0] becomes interpreter, not
+        script), THEN do the existence check on the normalized argv[0].
+        """
+        import tempfile, shutil
+        sub = tempfile.mkdtemp(prefix="bare-py-cwd-")
+        try:
+            with open(os.path.join(sub, "producer.py"), "w") as f:
+                f.write("# stub\n")
+            factory, captured = self._make_fake_popen()
+            result = manage.relaunch_daemon(
+                argv=["producer.py"],  # legacy schema-1 shape
+                cwd=sub,
+                log_path=self.log,
+                popen_factory=factory,
+            )
+            self.assertEqual(
+                result["outcome"], manage.RELAUNCH_OK,
+                f"bare-name .py argv[0] should not be rejected; got: {result}",
+            )
+            # Popen should be called with the normalized argv (interpreter
+            # prepended), NOT shutil.which-resolved.
+            self.assertEqual(captured["argv"][0], sys.executable)
+            self.assertIn("producer.py", captured["argv"])
+            self.assertTrue(result["argv_normalized"])
         finally:
             shutil.rmtree(sub, ignore_errors=True)
 

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_manage.py
@@ -510,6 +510,46 @@ class RelaunchNormalizationTests(unittest.TestCase):
         self.assertEqual(captured["argv"], modern_argv)
         self.assertEqual(result["argv_used"], modern_argv)
 
+    def test_relaunch_script_path_param_catches_missing_script_for_schema2(self) -> None:
+        """Adversarial: schema-2 argv = [python3, -u, script]. argv[0] is
+        the interpreter (always exists). If `script` is deleted between
+        cmd_restart's check and the spawn, Popen would spawn python3 and
+        instantly die. Pass script_path explicitly so the helper catches
+        it BEFORE spawn.
+
+        Caught by external reviewer on PR #279 (issue #1)."""
+        factory, _ = self._make_fake_popen()
+        # Use sys.executable as argv[0] — that's always a real interpreter
+        # on the test host (passes the argv[0] check). The script_path
+        # points at a path that doesn't exist.
+        result = manage.relaunch_daemon(
+            argv=[sys.executable, "-u", "/no/such/script.py"],
+            cwd=None, log_path=self.log,
+            popen_factory=factory,
+            script_path="/no/such/script.py",  # caller-known script path
+        )
+        self.assertEqual(result["outcome"], manage.RELAUNCH_SCRIPT_MISSING)
+        self.assertIn("/no/such/script.py", result["error"])
+
+    def test_relaunch_script_path_param_resolves_relative_against_cwd(self) -> None:
+        """script_path can be relative (matches operator launches from the
+        script's directory). Resolve against cwd same as argv[0]."""
+        import tempfile, shutil
+        sub = tempfile.mkdtemp(prefix="relaunch-script-rel-")
+        try:
+            with open(os.path.join(sub, "producer.py"), "w") as f:
+                f.write("# stub\n")
+            factory, _ = self._make_fake_popen()
+            result = manage.relaunch_daemon(
+                argv=[sys.executable, "-u", "./producer.py"],
+                cwd=sub, log_path=self.log,
+                popen_factory=factory,
+                script_path="./producer.py",  # relative; cwd resolves it
+            )
+            self.assertEqual(result["outcome"], manage.RELAUNCH_OK)
+        finally:
+            shutil.rmtree(sub, ignore_errors=True)
+
     def test_relaunch_bare_name_argv0_resolved_via_path(self) -> None:
         """Adversarial: argv[0] is a bare executable name (no path
         separator) that exists on $PATH. Popen would resolve it via $PATH;

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_restart_integration.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_restart_integration.py
@@ -247,13 +247,14 @@ class StopPidTargetingTests(unittest.TestCase):
             pid = 1
 
         orig_stop_pid = manage.stop_pid
-        orig_is_pid_alive = manage.is_pid_alive
+        orig_pid_alive_and_matches = st.pid_alive_and_matches
         orig_popen = subprocess.Popen
         orig_wait = cli._wait_for_new_pid_json
         try:
             manage.stop_pid = fake_stop
-            # Pretend the daemon pid is alive so cmd_restart calls stop.
-            manage.is_pid_alive = lambda p: p == daemon_pid
+            # cli now uses _pid_alive_for_daemon → state.pid_alive_and_matches.
+            # Force it to report alive for the daemon_pid (which is synthetic).
+            st.pid_alive_and_matches = lambda pid, **_kw: pid == daemon_pid
             subprocess.Popen = lambda *_a, **_kw: FakeProc()
             cli._wait_for_new_pid_json = lambda *_a, **_kw: None
 
@@ -261,7 +262,7 @@ class StopPidTargetingTests(unittest.TestCase):
             cli.cmd_restart(ns)
         finally:
             manage.stop_pid = orig_stop_pid
-            manage.is_pid_alive = orig_is_pid_alive
+            st.pid_alive_and_matches = orig_pid_alive_and_matches
             subprocess.Popen = orig_popen
             cli._wait_for_new_pid_json = orig_wait
 

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_restart_integration.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_restart_integration.py
@@ -1,0 +1,407 @@
+"""Integration tests for `senpi-helpers restart` — end-to-end argv-normalization.
+
+Tests focus on the boundary between cli.cmd_restart and manage.relaunch_daemon
+for legacy schema-1 boot.json files (the production bug).
+
+Two test classes:
+
+- `CmdRestartLegacyMigrationTests` (fast): mocks subprocess.Popen and the
+  pid-confirmation wait. Runs in ~10 ms. Always enabled.
+
+- `CmdRestartRealSubprocessTests` (slow, gated): spawns real subprocesses
+  on a non-+x script to prove the bug's fix end-to-end. Skipped unless
+  RUN_SLOW_INTEGRATION=1 is set in env so CI / normal test runs stay fast.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+_HELPERS_PARENT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _HELPERS_PARENT not in sys.path:
+    sys.path.insert(0, _HELPERS_PARENT)
+
+from senpi_runtime_helpers import cli, manage, state as st  # noqa: E402
+
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_argparse_ns(name, state_dir, *, json_out=False,
+                     timeout=5.0):
+    """Minimal argparse.Namespace matching what `cmd_restart` consumes."""
+    return argparse.Namespace(
+        name=name,
+        state_dir=state_dir,
+        json=json_out,
+        timeout=timeout,
+        # `_resolve_name` may consult these; defaults are fine.
+        list_known=False,
+    )
+
+
+def _write_legacy_boot(state_dir: str, name: str, script_path: str) -> None:
+    """Drop a schema-1 boot.json (script-only argv) like a production daemon
+    started via `nohup python3 -u <script> &` would have written."""
+    daemon_dir = os.path.join(state_dir, name)
+    os.makedirs(daemon_dir, exist_ok=True)
+    payload = {
+        "schema": 1,
+        "name": name,
+        "argv": [script_path],
+        "script_path": script_path,
+        "cwd": "/tmp",
+        "env_snapshot": {},
+        "captured_at_iso": "2026-05-12T22:11:16.470Z",
+    }
+    with open(os.path.join(daemon_dir, "boot.json"), "w") as f:
+        json.dump(payload, f)
+
+
+def _write_pid_json(state_dir: str, name: str, pid: int, log_path: str) -> None:
+    daemon_dir = os.path.join(state_dir, name)
+    os.makedirs(daemon_dir, exist_ok=True)
+    payload = {
+        "schema": 1, "name": name, "pid": pid,
+        "start_time_iso": "2026-05-12T22:11:16.470Z",
+        "wallet": "0xtest", "scanner": "test",
+        "interval_seconds": 60.0, "tick_timeout": 60.0,
+        "log_path": log_path, "version": "0.0.0-test",
+    }
+    with open(os.path.join(daemon_dir, "pid.json"), "w") as f:
+        json.dump(payload, f)
+
+
+# ─── R15: fast mocked path ──────────────────────────────────────────────────
+
+
+class CmdRestartLegacyMigrationTests(unittest.TestCase):
+    """End-to-end through `cmd_restart` with a legacy boot.json and a
+    non-executable script. Verifies that Popen is invoked with the
+    interpreter prepended, which is the entire point of this fix.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="senpi-helpers-restart-int-")
+        self.addCleanup(self._cleanup)
+        # Real non-+x .py file — argv[0] existence check needs it on disk.
+        fd, self.script = tempfile.mkstemp(suffix=".py", prefix="legacy-fake-",
+                                           dir=self.tmp)
+        os.write(fd, b"# fake daemon, not executable\n")
+        os.close(fd)
+        os.chmod(self.script, 0o644)
+        self.log = os.path.join(self.tmp, "fake.log")
+        with open(self.log, "w") as fh:
+            fh.write("")
+
+    def _cleanup(self) -> None:
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_legacy_boot_json_triggers_normalization(self) -> None:
+        """R15: schema-1 boot.json + non-+x script → cmd_restart calls
+        Popen with [sys.executable, "-u", script]."""
+        _write_legacy_boot(self.tmp, "legacy-daemon", self.script)
+        # Use this process's pid as the "old daemon" but neutralize stop_pid
+        # so we don't actually kill ourselves.
+        _write_pid_json(self.tmp, "legacy-daemon", os.getpid(), self.log)
+
+        captured = {}
+
+        class FakeProc:
+            pid = 999_999
+
+        def fake_popen(argv, **kwargs):
+            captured["argv"] = argv
+            captured["kwargs"] = kwargs
+            return FakeProc()
+
+        # Intercept all the side-effecting boundaries: don't really kill the
+        # current process, don't actually spawn anything, don't wait for pid.json.
+        orig_stop_pid = manage.stop_pid
+        orig_is_pid_alive = manage.is_pid_alive
+        orig_popen = subprocess.Popen
+        orig_wait = cli._wait_for_new_pid_json
+        try:
+            manage.stop_pid = lambda *_a, **_kw: {
+                "outcome": manage.STOP_TERM_OK,
+                "elapsed_seconds": 0.0,
+                "sigterm_sent": True, "sigkill_sent": False, "error": None,
+            }
+            manage.is_pid_alive = lambda _pid: True  # so cmd_restart calls stop
+            subprocess.Popen = fake_popen
+            cli._wait_for_new_pid_json = lambda *_a, **_kw: None
+
+            ns = _make_argparse_ns("legacy-daemon", self.tmp)
+            rc = cli.cmd_restart(ns)
+        finally:
+            manage.stop_pid = orig_stop_pid
+            manage.is_pid_alive = orig_is_pid_alive
+            subprocess.Popen = orig_popen
+            cli._wait_for_new_pid_json = orig_wait
+
+        self.assertEqual(rc, cli.RESTART_OK)
+        self.assertEqual(
+            captured["argv"],
+            [sys.executable, "-u", self.script],
+            "cmd_restart must invoke Popen with the interpreter prepended "
+            "for a legacy schema-1 boot.json",
+        )
+
+    def test_modern_boot_json_no_normalization(self) -> None:
+        """Schema-2 boot.json (interpreter already in argv) → Popen called
+        with argv unchanged; argv_normalized=False."""
+        daemon_dir = os.path.join(self.tmp, "modern-daemon")
+        os.makedirs(daemon_dir, exist_ok=True)
+        modern_argv = [sys.executable, "-u", self.script]
+        with open(os.path.join(daemon_dir, "boot.json"), "w") as f:
+            json.dump({
+                "schema": 2, "name": "modern-daemon",
+                "argv": modern_argv, "script_path": self.script,
+                "cwd": "/tmp", "env_snapshot": {},
+                "captured_at_iso": "2026-05-14T00:00:00.000Z",
+            }, f)
+        _write_pid_json(self.tmp, "modern-daemon", os.getpid(), self.log)
+
+        captured = {}
+
+        class FakeProc:
+            pid = 12345
+
+        def fake_popen(argv, **kwargs):
+            captured["argv"] = argv
+            return FakeProc()
+
+        orig_stop_pid = manage.stop_pid
+        orig_is_pid_alive = manage.is_pid_alive
+        orig_popen = subprocess.Popen
+        orig_wait = cli._wait_for_new_pid_json
+        try:
+            manage.stop_pid = lambda *_a, **_kw: {
+                "outcome": manage.STOP_TERM_OK, "elapsed_seconds": 0.0,
+                "sigterm_sent": True, "sigkill_sent": False, "error": None,
+            }
+            manage.is_pid_alive = lambda _pid: True
+            subprocess.Popen = fake_popen
+            cli._wait_for_new_pid_json = lambda *_a, **_kw: None
+
+            ns = _make_argparse_ns("modern-daemon", self.tmp)
+            rc = cli.cmd_restart(ns)
+        finally:
+            manage.stop_pid = orig_stop_pid
+            manage.is_pid_alive = orig_is_pid_alive
+            subprocess.Popen = orig_popen
+            cli._wait_for_new_pid_json = orig_wait
+
+        self.assertEqual(rc, cli.RESTART_OK)
+        self.assertEqual(captured["argv"], modern_argv)
+
+
+# ─── R17: stop_pid never targets the helper's own pid ───────────────────────
+
+
+class StopPidTargetingTests(unittest.TestCase):
+    """`cmd_restart` must call `stop_pid` with the daemon's pid from
+    pid.json, NEVER with the helper's own pid. This is the "could the
+    restart kill itself?" check. The implementation reads pid_data["pid"];
+    we verify that path by instrumenting stop_pid."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="senpi-helpers-targeting-")
+        self.addCleanup(self._cleanup)
+        fd, self.script = tempfile.mkstemp(suffix=".py", prefix="legacy-",
+                                           dir=self.tmp)
+        os.close(fd)
+        self.log = os.path.join(self.tmp, "fake.log")
+        with open(self.log, "w") as fh:
+            fh.write("")
+        _write_legacy_boot(self.tmp, "target-test", self.script)
+
+    def _cleanup(self) -> None:
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_stop_pid_called_with_daemon_pid_not_helper_pid(self) -> None:
+        helper_pid = os.getpid()
+        daemon_pid = helper_pid + 999_000  # synthetic; must differ from helper
+        if daemon_pid == helper_pid:
+            self.skipTest("could not pick a synthetic daemon pid distinct from os.getpid()")
+        _write_pid_json(self.tmp, "target-test", daemon_pid, self.log)
+
+        called_with = {}
+
+        def fake_stop(pid, **_kw):
+            called_with["pid"] = pid
+            return {
+                "outcome": manage.STOP_TERM_OK, "elapsed_seconds": 0.0,
+                "sigterm_sent": True, "sigkill_sent": False, "error": None,
+            }
+
+        class FakeProc:
+            pid = 1
+
+        orig_stop_pid = manage.stop_pid
+        orig_is_pid_alive = manage.is_pid_alive
+        orig_popen = subprocess.Popen
+        orig_wait = cli._wait_for_new_pid_json
+        try:
+            manage.stop_pid = fake_stop
+            # Pretend the daemon pid is alive so cmd_restart calls stop.
+            manage.is_pid_alive = lambda p: p == daemon_pid
+            subprocess.Popen = lambda *_a, **_kw: FakeProc()
+            cli._wait_for_new_pid_json = lambda *_a, **_kw: None
+
+            ns = _make_argparse_ns("target-test", self.tmp)
+            cli.cmd_restart(ns)
+        finally:
+            manage.stop_pid = orig_stop_pid
+            manage.is_pid_alive = orig_is_pid_alive
+            subprocess.Popen = orig_popen
+            cli._wait_for_new_pid_json = orig_wait
+
+        self.assertEqual(called_with.get("pid"), daemon_pid,
+                         "stop_pid must target the daemon's pid from pid.json")
+        self.assertNotEqual(called_with.get("pid"), helper_pid,
+                            "stop_pid must NEVER be called with the helper's own pid")
+
+
+# ─── R16: real-subprocess gated test ────────────────────────────────────────
+
+
+@unittest.skipUnless(
+    os.environ.get("RUN_SLOW_INTEGRATION") == "1",
+    "set RUN_SLOW_INTEGRATION=1 to run the real-subprocess integration test",
+)
+class CmdRestartRealSubprocessTests(unittest.TestCase):
+    """Reproduces the production bug with real subprocesses. Slow (~3 s)
+    and uses real signals — gated behind RUN_SLOW_INTEGRATION=1."""
+
+    DAEMON_SCRIPT = """\
+import os, sys, time
+PID_PATH = os.environ["INT_PID_PATH"]
+MARK_PATH = os.environ["INT_MARK_PATH"]
+with open(PID_PATH, "w") as f:
+    f.write(str(os.getpid()))
+with open(MARK_PATH, "w") as f:
+    f.write("STARTED\\n")
+# Hold long enough that stop_pid sees us alive when the test calls
+# cmd_restart. The test explicitly kills us in teardown.
+time.sleep(60.0)
+"""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="senpi-helpers-real-int-")
+        self.addCleanup(self._cleanup)
+        # Real non-+x .py daemon script.
+        self.script = os.path.join(self.tmp, "fake-producer.py")
+        with open(self.script, "w") as fh:
+            fh.write("#!/usr/bin/env python3\n")
+            fh.write(self.DAEMON_SCRIPT)
+        os.chmod(self.script, 0o644)
+        self.log = os.path.join(self.tmp, "daemon.log")
+        with open(self.log, "w") as fh:
+            fh.write("")
+        self.int_pid_file = os.path.join(self.tmp, "daemon.pid")
+        self.mark_file = os.path.join(self.tmp, "started.mark")
+        self._old_env = dict(os.environ)
+        os.environ["INT_PID_PATH"] = self.int_pid_file
+        os.environ["INT_MARK_PATH"] = self.mark_file
+        self.children = []
+
+    def _cleanup(self) -> None:
+        import shutil
+        # Reap any leftover children to keep CI quiet.
+        for proc in self.children:
+            try:
+                proc.kill()
+                proc.wait(timeout=2)
+            except Exception:
+                pass
+        os.environ.clear()
+        os.environ.update(self._old_env)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_full_restart_cycle_on_non_executable_script(self) -> None:
+        # 1) Launch the "old daemon" the way operators do: explicit interpreter.
+        old = subprocess.Popen(
+            [sys.executable, "-u", self.script],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        self.children.append(old)
+        # Drain the child in a background thread so when stop_pid kills it,
+        # the kernel reaps the zombie immediately. Without this, is_pid_alive
+        # would keep returning True on the zombie pid until tearDown ran.
+        # Same pattern as test_manage.py::_drain_in_background.
+        threading.Thread(
+            target=lambda: old.wait(),
+            daemon=True,
+        ).start()
+        # Wait for it to write its pid + mark file.
+        for _ in range(50):
+            if os.path.exists(self.int_pid_file) and os.path.exists(self.mark_file):
+                break
+            time.sleep(0.05)
+        self.assertTrue(os.path.exists(self.int_pid_file),
+                        "old daemon did not write its pid file in 2.5s")
+        with open(self.int_pid_file) as fh:
+            old_pid = int(fh.read().strip())
+        self.assertTrue(manage.is_pid_alive(old_pid),
+                        "old daemon pid not alive after launch")
+
+        # 2) Write legacy schema-1 boot.json and a pid.json pointing at the
+        #    real running daemon.
+        _write_legacy_boot(self.tmp, "real-daemon", self.script)
+        _write_pid_json(self.tmp, "real-daemon", old_pid, self.log)
+
+        # 3) Restart via the CLI's real cmd_restart entry point.
+        # Reset mark + pid files so we can detect the NEW daemon.
+        for path in (self.int_pid_file, self.mark_file):
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+
+        ns = _make_argparse_ns("real-daemon", self.tmp, json_out=True,
+                               timeout=5.0)
+        rc = cli.cmd_restart(ns)
+        self.assertEqual(rc, cli.RESTART_OK)
+
+        # 4) Old daemon should be dead within a short window.
+        for _ in range(50):
+            if not manage.is_pid_alive(old_pid):
+                break
+            time.sleep(0.05)
+        self.assertFalse(manage.is_pid_alive(old_pid),
+                         "stop_pid failed to kill the old daemon")
+
+        # 5) New daemon must have started (mark file appears) within timeout.
+        new_pid = None
+        for _ in range(100):
+            if os.path.exists(self.int_pid_file):
+                with open(self.int_pid_file) as fh:
+                    new_pid = int(fh.read().strip())
+                if new_pid and new_pid != old_pid:
+                    break
+            time.sleep(0.05)
+        self.assertIsNotNone(new_pid,
+                             "new daemon did not write its pid file — restart failed")
+        self.assertNotEqual(new_pid, old_pid)
+        self.assertTrue(manage.is_pid_alive(new_pid),
+                        "new daemon pid is not alive post-restart")
+
+        # 6) Teardown via the helper to be a good citizen.
+        try:
+            os.kill(new_pid, 15)
+        except ProcessLookupError:
+            pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_restart_integration.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_restart_integration.py
@@ -122,10 +122,13 @@ class CmdRestartLegacyMigrationTests(unittest.TestCase):
             captured["kwargs"] = kwargs
             return FakeProc()
 
-        # Intercept all the side-effecting boundaries: don't really kill the
-        # current process, don't actually spawn anything, don't wait for pid.json.
+        # Intercept the side-effecting boundaries we DO care about:
+        # don't actually kill os.getpid(), don't spawn a real Popen, don't
+        # wait for pid.json. The liveness check that cmd_restart runs
+        # (`_pid_alive_for_daemon` → `state.pid_alive_and_matches`) sees
+        # `os.getpid()` as alive on its own — we don't need to monkeypatch
+        # liveness, just neutralize the consequences.
         orig_stop_pid = manage.stop_pid
-        orig_is_pid_alive = manage.is_pid_alive
         orig_popen = subprocess.Popen
         orig_wait = cli._wait_for_new_pid_json
         try:
@@ -134,7 +137,6 @@ class CmdRestartLegacyMigrationTests(unittest.TestCase):
                 "elapsed_seconds": 0.0,
                 "sigterm_sent": True, "sigkill_sent": False, "error": None,
             }
-            manage.is_pid_alive = lambda _pid: True  # so cmd_restart calls stop
             subprocess.Popen = fake_popen
             cli._wait_for_new_pid_json = lambda *_a, **_kw: None
 
@@ -142,7 +144,6 @@ class CmdRestartLegacyMigrationTests(unittest.TestCase):
             rc = cli.cmd_restart(ns)
         finally:
             manage.stop_pid = orig_stop_pid
-            manage.is_pid_alive = orig_is_pid_alive
             subprocess.Popen = orig_popen
             cli._wait_for_new_pid_json = orig_wait
 
@@ -178,8 +179,10 @@ class CmdRestartLegacyMigrationTests(unittest.TestCase):
             captured["argv"] = argv
             return FakeProc()
 
+        # Same as test_legacy_boot_json_triggers_normalization: we don't
+        # monkeypatch liveness because os.getpid() is genuinely alive and
+        # cmd_restart's `_pid_alive_for_daemon` resolves correctly on its own.
         orig_stop_pid = manage.stop_pid
-        orig_is_pid_alive = manage.is_pid_alive
         orig_popen = subprocess.Popen
         orig_wait = cli._wait_for_new_pid_json
         try:
@@ -187,7 +190,6 @@ class CmdRestartLegacyMigrationTests(unittest.TestCase):
                 "outcome": manage.STOP_TERM_OK, "elapsed_seconds": 0.0,
                 "sigterm_sent": True, "sigkill_sent": False, "error": None,
             }
-            manage.is_pid_alive = lambda _pid: True
             subprocess.Popen = fake_popen
             cli._wait_for_new_pid_json = lambda *_a, **_kw: None
 
@@ -195,7 +197,6 @@ class CmdRestartLegacyMigrationTests(unittest.TestCase):
             rc = cli.cmd_restart(ns)
         finally:
             manage.stop_pid = orig_stop_pid
-            manage.is_pid_alive = orig_is_pid_alive
             subprocess.Popen = orig_popen
             cli._wait_for_new_pid_json = orig_wait
 

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
@@ -298,9 +298,22 @@ class PidAliveTests(unittest.TestCase):
         from senpi_runtime_helpers import manage
         self.assertIs(manage.is_pid_alive, st.pid_alive)
 
-    def test_cli_module_imports_canonical_implementation(self) -> None:
+    def test_cli_module_uses_canonical_pid_alive_via_recycle_guard(self) -> None:
+        """The CLI now consults pid_alive through the pid-recycle guard
+        helper (`_pid_alive_for_daemon` → `state.pid_alive_and_matches`),
+        not via a bare `_is_pid_alive` alias. This test pins the new
+        invariant — `state.pid_alive` is still the leaf-level liveness
+        check, just one indirection deeper."""
         from senpi_runtime_helpers import cli
-        self.assertIs(cli._is_pid_alive, st.pid_alive)
+        # The recycle-aware helper exists at the cli layer.
+        self.assertTrue(callable(cli._pid_alive_for_daemon))
+        # And `state.pid_alive_and_matches` (the dispatcher) chains into
+        # `state.pid_alive` for the basic existence check. Verified by
+        # passing a definitely-dead pid: pid_alive returns False ⇒
+        # pid_alive_and_matches returns False without consulting
+        # fingerprints.
+        self.assertFalse(st.pid_alive_and_matches(2147483646))
+        self.assertFalse(st.pid_alive(2147483646))
 
 
 class LogPathDetectionTests(unittest.TestCase):
@@ -353,10 +366,12 @@ class JsonShapeTests(unittest.TestCase):
             "shape", tick=1, status="ok", code=None, duration_ms=10,
             error=None, tick_count=1, error_count=0, state_dir=self.tmp,
         )
-        # boot.json bumped to schema 2 (interpreter-first argv); pid + heartbeat
-        # are still schema 1. See state.py top-of-file comment for boot's
-        # versioning history.
-        expected_schemas = {"pid": 1, "boot": 2, "heartbeat": 1}
+        # Schema versions per file (see state.py top-of-file protocol):
+        #   pid.json schema 2 — adds cmdline_fingerprint + start_time_jiffies
+        #     for the pid-recycle guard.
+        #   boot.json schema 2 — adds interpreter-first argv + log_path.
+        #   heartbeat.json schema 1 — unchanged.
+        expected_schemas = {"pid": 2, "boot": 2, "heartbeat": 1}
         for kind in ("pid", "boot", "heartbeat"):
             with open(os.path.join(self.tmp, "shape", f"{kind}.json")) as f:
                 doc = json.load(f)
@@ -441,6 +456,29 @@ class WriteBootSchema2Tests(unittest.TestCase):
         self.assertEqual(data["argv"], ["/usr/bin/python3", "-u"])
         self.assertIsNone(data["script_path"])
 
+    def test_log_path_recorded_in_boot_json(self) -> None:
+        """R-log: boot.json captures log_path so restart/stats survive a
+        clean stop (which removes pid.json)."""
+        os.environ["SENPI_HELPERS_LOG_PATH"] = "/tmp/explicit.log"
+        try:
+            ok = st.write_boot("R-log-test", state_dir=self.tmp)
+            self.assertTrue(ok)
+            data = st.read_boot("R-log-test", state_dir=self.tmp)
+            self.assertEqual(data["log_path"], "/tmp/explicit.log")
+        finally:
+            os.environ.pop("SENPI_HELPERS_LOG_PATH", None)
+
+    def test_log_path_can_be_none_when_undetectable(self) -> None:
+        """If detect_log_path can't determine a path (stderr is a pipe, no
+        explicit env override), log_path is None — readers must tolerate it."""
+        os.environ.pop("SENPI_HELPERS_LOG_PATH", None)
+        ok = st.write_boot("R-log-none", state_dir=self.tmp)
+        self.assertTrue(ok)
+        data = st.read_boot("R-log-none", state_dir=self.tmp)
+        # In CI / dev environments stderr might be redirected to a real file
+        # or a pipe. Either way the field must exist (not KeyError).
+        self.assertIn("log_path", data)
+
 
 # ─── Tests for looks_like_python_interpreter (R5-R6) ────────────────────────
 
@@ -486,6 +524,188 @@ class LooksLikePythonInterpreterTests(unittest.TestCase):
                     st.looks_like_python_interpreter(path),
                     f"{path!r} should NOT be detected as a python interpreter",
                 )
+
+
+# ─── Tests for ensure_daemon_stderr_redirected ──────────────────────────────
+
+
+@unittest.skipUnless(
+    sys.platform.startswith("linux"),
+    "ensure_daemon_stderr_redirected relies on /proc/self/fd/2 (Linux-only). "
+    "Production runs on Linux containers; the fallback is exercised there.",
+)
+class EnsureDaemonStderrRedirectedTests(unittest.TestCase):
+    """Daemon-side log-path fallback. Run from a subprocess so we don't
+    permanently dup2 onto this test process's own fd 1/2."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="senpi-helpers-ensure-log-")
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+        # Best-effort cleanup of any /tmp/<name>.log files we created.
+        for name in ("ensure-test-already-redirected", "ensure-test-pipe-fallback"):
+            try:
+                os.unlink(f"/tmp/{name}.log")
+            except FileNotFoundError:
+                pass
+
+    def _run_in_subprocess(self, script: str) -> str:
+        """Run a python snippet in a clean subprocess and return its stdout
+        (the resolved log_path, one line). Lets us control fd 2 redirection
+        per-test without dirtying this test process."""
+        import subprocess
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True, text=True, timeout=10,
+        )
+        if proc.returncode != 0:
+            self.fail(f"subprocess failed rc={proc.returncode}: {proc.stderr}")
+        return proc.stdout.strip()
+
+    def test_no_op_when_stderr_already_points_at_a_file(self) -> None:
+        """If the daemon was launched as `python ... > log 2>&1`, the
+        fallback must NOT clobber the existing redirection."""
+        log_file = os.path.join(self.tmp, "explicit.log")
+        # Subprocess sets stderr to a real file, then calls ensure().
+        out = self._run_in_subprocess(
+            "import os, sys\n"
+            f"sys.path.insert(0, {repr(_HELPERS_PARENT)})\n"
+            "from senpi_runtime_helpers import state\n"
+            f"fd = os.open({repr(log_file)}, os.O_WRONLY|os.O_CREAT, 0o644)\n"
+            "os.dup2(fd, 2); os.close(fd)\n"
+            "print(state.ensure_daemon_stderr_redirected('test-already'))\n"
+        )
+        self.assertEqual(out, log_file)
+
+    def test_fallback_to_tmp_name_log_when_stderr_is_pipe(self) -> None:
+        """The motivating bug: openclaw exec gives the daemon a pipe on fd 2.
+        ensure() must redirect to /tmp/<name>.log so the helpers state files
+        record a usable path."""
+        fallback_path = "/tmp/ensure-test-pipe-fallback.log"
+        try:
+            os.unlink(fallback_path)
+        except FileNotFoundError:
+            pass
+        # Subprocess: pipe stderr, then call ensure().
+        # stdout (where we print the result) goes back to us via capture_output.
+        import subprocess
+        proc = subprocess.run(
+            [sys.executable, "-c",
+             "import os, sys\n"
+             f"sys.path.insert(0, {repr(_HELPERS_PARENT)})\n"
+             "from senpi_runtime_helpers import state\n"
+             "# Replace fd 2 with a pipe so detect_log_path returns None.\n"
+             "r, w = os.pipe()\n"
+             "os.dup2(w, 2); os.close(w); os.close(r)\n"
+             "result = state.ensure_daemon_stderr_redirected('ensure-test-pipe-fallback')\n"
+             "# Write result to fd 3 so we don't compete with the dup2'd stderr.\n"
+             "import sys as _s; _s.stdout.write(str(result)); _s.stdout.flush()\n"
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        self.assertEqual(proc.returncode, 0,
+                         f"subprocess failed: {proc.stderr}")
+        self.assertEqual(proc.stdout.strip(), fallback_path)
+        self.assertTrue(os.path.exists(fallback_path),
+                        f"fallback log not created at {fallback_path}")
+
+
+# ─── Tests for pid-recycle guard ────────────────────────────────────────────
+
+
+class PidAliveAndMatchesTests(unittest.TestCase):
+    """pid_alive_and_matches degrades to plain pid_alive on hosts without
+    fingerprints (non-Linux or schema-1 pid.json), and strictly rejects on
+    fingerprint mismatch."""
+
+    def test_degrades_to_pid_alive_when_no_fingerprints(self) -> None:
+        # Our own pid is alive. With None fingerprints, no extra check fires.
+        self.assertTrue(
+            st.pid_alive_and_matches(os.getpid(),
+                                     expected_fingerprint=None,
+                                     expected_jiffies=None)
+        )
+
+    def test_returns_false_when_pid_not_alive(self) -> None:
+        self.assertFalse(
+            st.pid_alive_and_matches(2147483646,
+                                     expected_fingerprint="anything",
+                                     expected_jiffies=12345)
+        )
+
+    def test_rejects_on_fingerprint_mismatch(self) -> None:
+        """If /proc/<pid>/cmdline returns a real fingerprint and it doesn't
+        match the expected one, the pid was recycled to a stranger — return
+        False. Linux-only assertion; on macOS the fingerprint helper returns
+        None and the check degrades to pid_alive (which is True)."""
+        if not sys.platform.startswith("linux"):
+            self.skipTest("requires /proc for cmdline fingerprint check")
+        self.assertFalse(
+            st.pid_alive_and_matches(
+                os.getpid(),
+                expected_fingerprint="0" * 64,  # impossible hash
+                expected_jiffies=None,
+            )
+        )
+
+    def test_rejects_on_jiffies_mismatch(self) -> None:
+        if not sys.platform.startswith("linux"):
+            self.skipTest("requires /proc for stat field 22 check")
+        self.assertFalse(
+            st.pid_alive_and_matches(
+                os.getpid(),
+                expected_fingerprint=None,
+                expected_jiffies=1,  # impossibly early
+            )
+        )
+
+    def test_write_pid_records_fingerprints(self) -> None:
+        tmp = tempfile.mkdtemp(prefix="senpi-helpers-fp-")
+        try:
+            ok = st.write_pid(
+                "fp-test", wallet="0xabc", scanner=None,
+                interval_seconds=60.0, tick_timeout=60.0, log_path=None,
+                version="0.0.0", state_dir=tmp,
+            )
+            self.assertTrue(ok)
+            data = st.read_pid("fp-test", state_dir=tmp)
+            self.assertEqual(data["schema"], 2)
+            # On Linux both fields are populated; on macOS both are None
+            # (no /proc). Either way the keys must exist.
+            self.assertIn("cmdline_fingerprint", data)
+            self.assertIn("start_time_jiffies", data)
+        finally:
+            import shutil
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+# ─── Tests for unknown-schema warning ───────────────────────────────────────
+
+
+class UnknownSchemaWarningTests(unittest.TestCase):
+    """_read_json logs (but does not crash) on an unsupported schema number.
+
+    Verified by writing a pid.json with schema=999 and checking that
+    read_pid returns the data without raising."""
+
+    def test_read_json_returns_data_for_unknown_schema(self) -> None:
+        tmp = tempfile.mkdtemp(prefix="senpi-helpers-schema-warn-")
+        try:
+            daemon_dir = os.path.join(tmp, "future-daemon")
+            os.makedirs(daemon_dir)
+            future_pid = {"schema": 999, "name": "future-daemon", "pid": 1234}
+            with open(os.path.join(daemon_dir, "pid.json"), "w") as f:
+                json.dump(future_pid, f)
+            data = st.read_pid("future-daemon", state_dir=tmp)
+            # Reader returns the dict despite unknown schema.
+            self.assertIsNotNone(data)
+            self.assertEqual(data["schema"], 999)
+        finally:
+            import shutil
+            shutil.rmtree(tmp, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
@@ -744,34 +744,55 @@ class EnsureDaemonStderrRedirectedTests(unittest.TestCase):
     def test_fallback_to_tmp_name_log_when_stderr_is_pipe(self) -> None:
         """The motivating bug: openclaw exec gives the daemon a pipe on fd 2.
         ensure() must redirect to /tmp/<name>.log so the helpers state files
-        record a usable path."""
+        record a usable path.
+
+        Test mechanics: ensure() does `dup2(fd, 1)` AND `dup2(fd, 2)` —
+        BOTH fds get redirected to the fallback log file. So the subprocess
+        cannot write its assertion back via `sys.stdout` (which is fd 1).
+        Have the subprocess write its result to a separate result file we
+        read after it exits — this side-steps the fd-redirection issue.
+        """
         fallback_path = "/tmp/ensure-test-pipe-fallback.log"
+        for p in (fallback_path,):
+            try:
+                os.unlink(p)
+            except FileNotFoundError:
+                pass
+        result_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".result", delete=False)
+        result_file.close()
         try:
-            os.unlink(fallback_path)
-        except FileNotFoundError:
-            pass
-        # Subprocess: pipe stderr, then call ensure().
-        # stdout (where we print the result) goes back to us via capture_output.
-        import subprocess
-        proc = subprocess.run(
-            [sys.executable, "-c",
-             "import os, sys\n"
-             f"sys.path.insert(0, {repr(_HELPERS_PARENT)})\n"
-             "from senpi_runtime_helpers import state\n"
-             "# Replace fd 2 with a pipe so detect_log_path returns None.\n"
-             "r, w = os.pipe()\n"
-             "os.dup2(w, 2); os.close(w); os.close(r)\n"
-             "result = state.ensure_daemon_stderr_redirected('ensure-test-pipe-fallback')\n"
-             "# Write result to fd 3 so we don't compete with the dup2'd stderr.\n"
-             "import sys as _s; _s.stdout.write(str(result)); _s.stdout.flush()\n"
-            ],
-            capture_output=True, text=True, timeout=10,
-        )
-        self.assertEqual(proc.returncode, 0,
-                         f"subprocess failed: {proc.stderr}")
-        self.assertEqual(proc.stdout.strip(), fallback_path)
-        self.assertTrue(os.path.exists(fallback_path),
-                        f"fallback log not created at {fallback_path}")
+            import subprocess
+            proc = subprocess.run(
+                [sys.executable, "-c",
+                 "import os, sys\n"
+                 f"sys.path.insert(0, {repr(_HELPERS_PARENT)})\n"
+                 "from senpi_runtime_helpers import state\n"
+                 "# Replace fd 2 with a pipe so detect_log_path returns None.\n"
+                 "r, w = os.pipe()\n"
+                 "os.dup2(w, 2); os.close(w); os.close(r)\n"
+                 "result = state.ensure_daemon_stderr_redirected('ensure-test-pipe-fallback')\n"
+                 "# Cannot use sys.stdout — ensure() dup2'd fd 1 onto the\n"
+                 "# fallback log file. Write to a separate result path the\n"
+                 "# parent reads after we exit.\n"
+                 f"with open({repr(result_file.name)}, 'w') as _f:\n"
+                 "    _f.write(str(result))\n"
+                ],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                timeout=10,
+            )
+            self.assertEqual(proc.returncode, 0,
+                             "subprocess crashed; ensure() raised or fd math went wrong")
+            with open(result_file.name) as fh:
+                result_str = fh.read().strip()
+            self.assertEqual(result_str, fallback_path)
+            self.assertTrue(os.path.exists(fallback_path),
+                            f"fallback log not created at {fallback_path}")
+        finally:
+            try:
+                os.unlink(result_file.name)
+            except OSError:
+                pass
 
 
 # ─── Tests for pid-recycle guard ────────────────────────────────────────────

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
@@ -316,6 +316,86 @@ class PidAliveTests(unittest.TestCase):
         self.assertFalse(st.pid_alive(2147483646))
 
 
+class PidAliveZombieFilterTests(unittest.TestCase):
+    """Zombies sit in the kernel's process table until their parent reap()s
+    them. `os.kill(pid, 0)` succeeds on a zombie — but the process is dead.
+    `pid_alive` must filter zombies so `stop_pid`/`restart` don't report
+    `STOP_KILL_FAILED` after a daemon has actually exited cleanly.
+
+    Linux-only: /proc is the source of truth for process state. On non-Linux
+    dev hosts the function degrades to the plain signal(0) result.
+
+    Repro path the fix addresses: daemon launched via `nohup … &`, parent
+    bash exits, daemon reparented to PID 1, daemon dies, PID 1 doesn't
+    actively reap → zombie. Production: Railway's `node src/server.js` as
+    PID 1 doesn't reap.
+    """
+
+    def _spawn_and_kill(self):
+        """Spawn a short-lived subprocess WITHOUT waiting on it, so it
+        becomes a zombie under this test process (the parent). Returns the
+        pid. The test process is the parent — we leave it un-reaped so the
+        zombie sits in the process table.
+        """
+        import subprocess
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import sys; sys.exit(0)"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        # Wait for the child to actually exit. `signal(0)` will still
+        # report it alive — the kernel keeps the slot until we wait().
+        # poll() observes exit without reaping (only wait() reaps).
+        for _ in range(200):
+            if proc.poll() is not None:
+                break
+            import time as _time
+            _time.sleep(0.01)
+        return proc
+
+    @unittest.skipUnless(sys.platform.startswith("linux"), "Linux /proc only")
+    def test_zombie_is_not_alive(self):
+        """signal(0) succeeds on a zombie but the daemon has DIED — `stop_pid`
+        polling pid_alive would otherwise spin until SIGKILL grace ends, then
+        wrongly report STOP_KILL_FAILED. Filter zombies via /proc/<pid>/status."""
+        proc = self._spawn_and_kill()
+        try:
+            self.assertEqual(proc.poll(), 0,
+                             "zombie test requires the child to have exited")
+            # Confirm it's a zombie at the kernel level.
+            with open(f"/proc/{proc.pid}/status") as f:
+                state_line = next(l for l in f if l.startswith("State:"))
+            self.assertIn("Z", state_line,
+                          f"expected zombie state, got: {state_line.strip()}")
+            # The bug: signal(0) returns success for zombies.
+            self.assertFalse(
+                st.pid_alive(proc.pid),
+                "pid_alive must return False for zombies; otherwise stop_pid "
+                "spins to SIGKILL escalation on already-dead daemons.",
+            )
+        finally:
+            # Reap before the test process exits to keep CI clean.
+            proc.wait()
+
+    @unittest.skipUnless(sys.platform.startswith("linux"), "Linux /proc only")
+    def test_live_process_still_reported_alive(self):
+        """Regression guard: the zombie filter must not break the common
+        path. The current Python process is alive; pid_alive must return True.
+        """
+        self.assertTrue(st.pid_alive(os.getpid()))
+
+    @unittest.skipUnless(sys.platform.startswith("linux"), "Linux /proc only")
+    def test_proc_status_missing_falls_back_to_signal_zero(self):
+        """If `/proc/<pid>/status` cannot be read (race: pid just exited and
+        was reaped between signal(0) and our /proc read), the function must
+        not crash. The contract is: when /proc is unreadable, trust signal(0).
+        """
+        # Use init's pid (1) — always alive on any container, /proc/1/status
+        # always readable. Sanity-check the normal path. The race itself is
+        # hard to engineer deterministically; this test guards the
+        # "/proc read failure" recovery branch indirectly via code review.
+        self.assertTrue(st.pid_alive(1))
+
+
 class LogPathDetectionTests(unittest.TestCase):
     def setUp(self) -> None:
         self._prev = os.environ.get("SENPI_HELPERS_LOG_PATH")
@@ -579,6 +659,69 @@ class EnsureDaemonStderrRedirectedTests(unittest.TestCase):
             "print(state.ensure_daemon_stderr_redirected('test-already'))\n"
         )
         self.assertEqual(out, log_file)
+
+    def test_does_not_close_redirected_streams_when_fd_is_1_or_2(self) -> None:
+        """Adversarial: if stdin/stdout/stderr are closed (rare but possible
+        on `python script.py >&- 2>&-` launches), os.open returns the
+        lowest free fd — which could be 1 or 2. After dup2(fd, 1/2),
+        unconditionally `os.close(fd)` would close the very stream we just
+        redirected. Verify the post-fallback log handle is still usable.
+
+        Caught by reviewer on PR #279.
+        """
+        fallback_path = "/tmp/ensure-test-fd-guard.log"
+        try:
+            os.unlink(fallback_path)
+        except FileNotFoundError:
+            pass
+        try:
+            import subprocess
+            # Subprocess closes fd 1 and 2 BEFORE calling ensure(). After
+            # the call, write a known marker via os.write() to fd 2 — if
+            # ensure() closed fd 2 by mistake, that write raises EBADF.
+            # Marker has to land in the LOG FILE (since ensure redirects
+            # fd 2 to the fallback), which we can then check from the
+            # parent process.
+            script = (
+                "import os, sys\n"
+                f"sys.path.insert(0, {repr(_HELPERS_PARENT)})\n"
+                "from senpi_runtime_helpers import state\n"
+                "# Close fd 1 and fd 2 entirely. fd 0 is left alone so\n"
+                "# subprocess capture_output (which gives stdin=DEVNULL\n"
+                "# from the parent) doesn't fight us.\n"
+                "os.close(1)\n"
+                "os.close(2)\n"
+                "result = state.ensure_daemon_stderr_redirected('ensure-test-fd-guard')\n"
+                "# Write a sentinel to fd 2. If ensure() left fd 2 closed,\n"
+                "# this raises OSError EBADF and the subprocess fails with\n"
+                "# a non-zero exit, which the assertion below catches.\n"
+                "os.write(2, b'POST_ENSURE_WROTE_OK\\n')\n"
+            )
+            proc = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True, text=True, timeout=10,
+            )
+            # Subprocess must NOT have crashed. A crash here means stdout
+            # OR stderr got closed by the close-fd-after-dup2 bug.
+            self.assertEqual(
+                proc.returncode, 0,
+                f"subprocess failed (likely closed-fd regression): "
+                f"rc={proc.returncode} stderr={proc.stderr!r}",
+            )
+            # Sentinel reached the fallback log file (where fd 2 was
+            # redirected to). Confirms post-ensure fd 2 is still writable.
+            self.assertTrue(os.path.exists(fallback_path),
+                            f"fallback log not created at {fallback_path}")
+            with open(fallback_path) as f:
+                content = f.read()
+            self.assertIn("POST_ENSURE_WROTE_OK", content,
+                          "expected sentinel in log; fd 2 must remain "
+                          "writable after ensure_daemon_stderr_redirected")
+        finally:
+            try:
+                os.unlink(fallback_path)
+            except FileNotFoundError:
+                pass
 
     def test_fallback_to_tmp_name_log_when_stderr_is_pipe(self) -> None:
         """The motivating bug: openclaw exec gives the daemon a pipe on fd 2.

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
@@ -331,50 +331,68 @@ class PidAliveZombieFilterTests(unittest.TestCase):
     PID 1 doesn't reap.
     """
 
-    def _spawn_and_kill(self):
-        """Spawn a short-lived subprocess WITHOUT waiting on it, so it
-        becomes a zombie under this test process (the parent). Returns the
-        pid. The test process is the parent — we leave it un-reaped so the
-        zombie sits in the process table.
+    def _spawn_zombie(self):
+        """Spawn a subprocess and wait for it to exit WITHOUT calling
+        waitpid() or Popen.poll()/.wait() — both of those reap the zombie.
+
+        Returns the pid. The caller is responsible for reaping (call
+        `os.waitpid(pid, 0)` in finally). Until then, the pid stays in
+        the kernel's process table as `State: Z (zombie)`.
+
+        We can't use Popen.poll()/.wait() to detect exit because both
+        synchronously reap (the kernel removes the pid from the process
+        table). We have to poll /proc/<pid>/status directly until we see
+        `State: Z`.
         """
-        import subprocess
+        import subprocess, time as _time
         proc = subprocess.Popen(
             [sys.executable, "-c", "import sys; sys.exit(0)"],
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
-        # Wait for the child to actually exit. `signal(0)` will still
-        # report it alive — the kernel keeps the slot until we wait().
-        # poll() observes exit without reaping (only wait() reaps).
+        pid = proc.pid
+        # Wait up to 2s for the child to enter zombie state.
+        # Read /proc/<pid>/status directly — does NOT reap.
         for _ in range(200):
-            if proc.poll() is not None:
-                break
-            import time as _time
+            try:
+                with open(f"/proc/{pid}/status") as f:
+                    state_line = next(l for l in f if l.startswith("State:"))
+                if "Z" in state_line.split()[1]:
+                    return pid, proc
+            except (FileNotFoundError, StopIteration, IndexError):
+                pass
             _time.sleep(0.01)
-        return proc
+        # Best-effort cleanup if we couldn't get a zombie.
+        try:
+            proc.wait(timeout=1.0)
+        except Exception:
+            pass
+        return None, proc
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "Linux /proc only")
     def test_zombie_is_not_alive(self):
         """signal(0) succeeds on a zombie but the daemon has DIED — `stop_pid`
         polling pid_alive would otherwise spin until SIGKILL grace ends, then
         wrongly report STOP_KILL_FAILED. Filter zombies via /proc/<pid>/status."""
-        proc = self._spawn_and_kill()
+        pid, proc = self._spawn_zombie()
         try:
-            self.assertEqual(proc.poll(), 0,
-                             "zombie test requires the child to have exited")
-            # Confirm it's a zombie at the kernel level.
-            with open(f"/proc/{proc.pid}/status") as f:
+            self.assertIsNotNone(pid, "couldn't capture zombie state in 2s window")
+            # Re-confirm it's still a zombie immediately before the assertion.
+            with open(f"/proc/{pid}/status") as f:
                 state_line = next(l for l in f if l.startswith("State:"))
-            self.assertIn("Z", state_line,
+            self.assertIn("Z", state_line.split()[1],
                           f"expected zombie state, got: {state_line.strip()}")
             # The bug: signal(0) returns success for zombies.
             self.assertFalse(
-                st.pid_alive(proc.pid),
+                st.pid_alive(pid),
                 "pid_alive must return False for zombies; otherwise stop_pid "
                 "spins to SIGKILL escalation on already-dead daemons.",
             )
         finally:
             # Reap before the test process exits to keep CI clean.
-            proc.wait()
+            try:
+                proc.wait(timeout=1.0)
+            except Exception:
+                pass
 
     @unittest.skipUnless(sys.platform.startswith("linux"), "Linux /proc only")
     def test_live_process_still_reported_alive(self):

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
@@ -75,7 +75,10 @@ class WriteReadRoundTripTests(unittest.TestCase):
         data = st.read_boot("round-trip-boot", state_dir=self.tmp)
         self.assertIsNotNone(data)
         self.assertEqual(data["name"], "round-trip-boot")
-        self.assertEqual(data["argv"], list(sys.argv))
+        # Schema 2: argv is [sys.executable, "-u", *sys.argv]. See the
+        # schema-versioning comment near the top of state.py.
+        self.assertEqual(data["schema"], 2)
+        self.assertEqual(data["argv"], [sys.executable, "-u", *sys.argv])
         self.assertEqual(data["cwd"], os.getcwd())
         self.assertIn("env_snapshot", data)
         self.assertIsInstance(data["env_snapshot"], dict)
@@ -350,11 +353,139 @@ class JsonShapeTests(unittest.TestCase):
             "shape", tick=1, status="ok", code=None, duration_ms=10,
             error=None, tick_count=1, error_count=0, state_dir=self.tmp,
         )
+        # boot.json bumped to schema 2 (interpreter-first argv); pid + heartbeat
+        # are still schema 1. See state.py top-of-file comment for boot's
+        # versioning history.
+        expected_schemas = {"pid": 1, "boot": 2, "heartbeat": 1}
         for kind in ("pid", "boot", "heartbeat"):
             with open(os.path.join(self.tmp, "shape", f"{kind}.json")) as f:
                 doc = json.load(f)
-            self.assertEqual(doc.get("schema"), 1, f"{kind}.json missing schema")
+            self.assertEqual(
+                doc.get("schema"), expected_schemas[kind],
+                f"{kind}.json wrong schema: got {doc.get('schema')}",
+            )
             self.assertEqual(doc.get("name"), "shape", f"{kind}.json missing name")
+
+
+# ─── Tests for schema-2 write_boot (R1-R4) ──────────────────────────────────
+
+
+class WriteBootSchema2Tests(unittest.TestCase):
+    """write_boot's schema-2 output: [sys.executable, "-u", *sys.argv].
+
+    Each test stubs sys.argv (and where needed, sys.executable) and asserts
+    the boot.json payload reflects the schema-2 contract. See the
+    schema-versioning comment near the top of state.py for the rationale.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp(prefix="senpi-helpers-write-boot-")
+        self.addCleanup(self._cleanup)
+        # Save sys.argv / sys.executable so each test can mutate them.
+        self._orig_argv = list(sys.argv)
+        self._orig_executable = sys.executable
+        self.addCleanup(self._restore_sys)
+
+    def _cleanup(self) -> None:
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _restore_sys(self) -> None:
+        sys.argv[:] = self._orig_argv
+        sys.executable = self._orig_executable
+
+    def test_argv_includes_sys_executable_and_dash_u(self) -> None:
+        """R1: argv = [interpreter, "-u", script, ...args]."""
+        sys.argv[:] = ["/scripts/foo-producer.py", "--mode", "live"]
+        sys.executable = "/usr/bin/python3"
+        ok = st.write_boot("R1-test", state_dir=self.tmp)
+        self.assertTrue(ok)
+        data = st.read_boot("R1-test", state_dir=self.tmp)
+        self.assertEqual(
+            data["argv"],
+            ["/usr/bin/python3", "-u", "/scripts/foo-producer.py", "--mode", "live"],
+        )
+
+    def test_schema_field_is_2(self) -> None:
+        """R2: payload['schema'] is 2 on every fresh write_boot."""
+        ok = st.write_boot("R2-test", state_dir=self.tmp)
+        self.assertTrue(ok)
+        data = st.read_boot("R2-test", state_dir=self.tmp)
+        self.assertEqual(data["schema"], 2)
+
+    def test_script_path_resolved_to_realpath(self) -> None:
+        """R3: script_path follows symlinks (realpath), distinct from argv[0]."""
+        real_dir = os.path.join(self.tmp, "scripts")
+        os.makedirs(real_dir, exist_ok=True)
+        real_script = os.path.join(real_dir, "foo.py")
+        with open(real_script, "w") as fh:
+            fh.write("# fake\n")
+        link_path = os.path.join(self.tmp, "link.py")
+        os.symlink(real_script, link_path)
+
+        sys.argv[:] = [link_path]
+        ok = st.write_boot("R3-test", state_dir=self.tmp)
+        self.assertTrue(ok)
+        data = st.read_boot("R3-test", state_dir=self.tmp)
+        self.assertEqual(data["script_path"], os.path.realpath(link_path))
+        # argv preserves the link path (we don't realpath inside argv).
+        self.assertEqual(data["argv"][2], link_path)
+
+    def test_handles_empty_sys_argv(self) -> None:
+        """R4: empty sys.argv records [interpreter, "-u"] and script_path=None."""
+        sys.argv[:] = []
+        sys.executable = "/usr/bin/python3"
+        ok = st.write_boot("R4-test", state_dir=self.tmp)
+        self.assertTrue(ok)
+        data = st.read_boot("R4-test", state_dir=self.tmp)
+        self.assertEqual(data["argv"], ["/usr/bin/python3", "-u"])
+        self.assertIsNone(data["script_path"])
+
+
+# ─── Tests for looks_like_python_interpreter (R5-R6) ────────────────────────
+
+
+class LooksLikePythonInterpreterTests(unittest.TestCase):
+    """Heuristic used by manage._normalize_argv to detect modern boot.json
+    argv (where argv[0] is the interpreter) vs legacy (script-only)."""
+
+    POSITIVE_CASES = [
+        "python", "python3", "python3.11", "python.exe", "python3.exe",
+        "python3.11.exe", "pypy", "pypy3", "pypy3.10",
+        "/usr/bin/python3", "/usr/bin/python3.11",
+        # case insensitive
+        "PYTHON3", "/usr/bin/PYTHON3.11",
+        # Note: Windows-style paths ("C:\\Python311\\python.exe") aren't
+        # supported on Linux/macOS because os.path.basename uses the host's
+        # path separator. Production runs on Linux only; we don't carry the
+        # complexity of cross-platform basename here.
+    ]
+
+    NEGATIVE_CASES = [
+        "", "myscript.py", "/path/to/script.py",
+        "python3.11-config", "python-pip", "python-something",
+        "cat", "/usr/bin/cat", "/path/to/script.sh",
+        "pythonfoo",   # bare-letter suffix, not version digits
+        "/path/python3.11.dev",  # has trailing non-version garbage
+    ]
+
+    def test_positive_cases(self) -> None:
+        """R5: every recognized python/pypy invocation is detected."""
+        for path in self.POSITIVE_CASES:
+            with self.subTest(path=path):
+                self.assertTrue(
+                    st.looks_like_python_interpreter(path),
+                    f"{path!r} should be recognized as a python interpreter",
+                )
+
+    def test_negative_cases(self) -> None:
+        """R6: non-interpreter paths must not match."""
+        for path in self.NEGATIVE_CASES:
+            with self.subTest(path=path):
+                self.assertFalse(
+                    st.looks_like_python_interpreter(path),
+                    f"{path!r} should NOT be detected as a python interpreter",
+                )
 
 
 if __name__ == "__main__":

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_state.py
@@ -682,6 +682,57 @@ class PidAliveAndMatchesTests(unittest.TestCase):
             shutil.rmtree(tmp, ignore_errors=True)
 
 
+# ─── Tests for read_proc_environ (used by --inherit-env-from) ───────────────
+
+
+@unittest.skipUnless(
+    sys.platform.startswith("linux"),
+    "read_proc_environ requires /proc (Linux-only)",
+)
+class ReadProcEnvironTests(unittest.TestCase):
+    """Reads /proc/<pid>/environ for the --inherit-env-from flag.
+    Production-only path; gated on Linux."""
+
+    def test_reads_own_environ(self) -> None:
+        """Use os.getpid() as the test pid — we know our own environ."""
+        os.environ["SENPI_HELPERS_READ_ENVIRON_TEST"] = "marker-value"
+        try:
+            env = st.read_proc_environ(os.getpid())
+        finally:
+            os.environ.pop("SENPI_HELPERS_READ_ENVIRON_TEST", None)
+        self.assertIsNotNone(env)
+        # Linux note: /proc/self/environ snapshots the env at exec time, so
+        # post-fork modifications via os.environ may not appear. The marker
+        # MIGHT not be there. We assert the function returns a dict with
+        # SOMETHING reasonable (it should at least have PATH or HOME).
+        self.assertIsInstance(env, dict)
+        self.assertTrue(env, "expected non-empty environ dict")
+        # Most CI/dev shells set HOME or PATH.
+        self.assertTrue(
+            "HOME" in env or "PATH" in env or "PWD" in env,
+            f"environ unexpectedly missing common keys: {sorted(env)[:10]}",
+        )
+
+    def test_returns_none_for_missing_pid(self) -> None:
+        self.assertIsNone(st.read_proc_environ(2147483646))
+
+    def test_skips_malformed_entries(self) -> None:
+        """Bad env entries (no '=' or weird key chars) don't poison the dict."""
+        # Can't easily inject bad data into our own /proc; rely on the
+        # robust parser tested indirectly via test_reads_own_environ.
+        # Direct unit test: invoke the parsing logic via a writable file.
+        # Path A: shadow _read_proc_field via monkeypatching.
+        orig = st._read_proc_field
+        try:
+            st._read_proc_field = lambda pid, field: (
+                "GOOD=ok\0NO_EQUALS_SIGN\0BAD-KEY=value\0OTHER=valid\0"
+            )
+            env = st.read_proc_environ(123)  # pid value ignored under stub
+        finally:
+            st._read_proc_field = orig
+        self.assertEqual(env, {"GOOD": "ok", "OTHER": "valid"})
+
+
 # ─── Tests for unknown-schema warning ───────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Five batches of fixes shipped on this branch, derived from production failures observed today on **vulture** and **scorpion** and from in-depth code review of the senpi-helpers CLI.

| Batch | Commit | Theme |
|---|---|---|
| 1 | `5cd3a4f` | argv normalization — restart for `python3 -u script.py` daemons |
| 2 | `743ceb9` | log_path persists in boot.json + `start` command + pid-recycle guard + schema docs |
| 3 | `e2b11a9` | drop auto-resolve for destructive commands |
| 4 | `5cc63eb` + `400f2b2` | `boot` + `logs` inspection commands |
| 5 | `5793a46` | `diagnose` — composite pre-flight checklist |
| 6 | `7d4ab99` | `start --inherit-env-from <pid\|openclaw>` |

## What's in each batch

### Batch 1 — argv normalization (`5cd3a4f`)

`senpi-helpers restart` was failing silently on daemons launched the operator-documented way (`nohup python3 -u script.py &`). Two compounding bugs:

1. `state.write_boot` captured only `sys.argv`, missing the interpreter.
2. `manage.relaunch_daemon` did `Popen(argv)` which `execve`'s the .py file directly — fails with `PermissionError [Errno 13]` when the script isn't `+x`.

**Fix**: bump boot.json to schema 2 with `argv = [sys.executable, "-u", *sys.argv]`. Migrate schema-1 boot.json on read via `manage._normalize_argv` — legacy files keep working.

### Batch 2 — log_path + start + recycle guard (`743ceb9`)

Found while restarting vulture+scorpion live today: `senpi-helpers restart` was failing EARLIER than the argv bug — with `"no log path recorded"` (pid.json gone after clean exit, log_path was only there). Plus four more fixes:

- **boot.json schema 2 also persists `log_path`** so restart works after clean stop.
- **New `senpi-helpers start <name>`** command (idempotent peer of stop/restart).
- **Pid-recycle guard**: pid.json schema 2 records `cmdline_fingerprint` + `start_time_jiffies`. Every command consults `_pid_alive_for_daemon` which cross-checks both before signaling.
- **`ensure_daemon_stderr_redirected`**: dups stdout/stderr to `/tmp/<name>.log` when the daemon's stderr is a pipe (openclaw exec path). Linux-gated.
- **Schema versioning protocol** documented; `_read_json` warns on unknown schemas.

### Batch 3 — explicit name for destructive commands (`e2b11a9`)

`senpi-helpers stop` (no args) on a single-daemon host was auto-resolving and silently killing whatever daemon was there. Footgun for: wrong-box SSH, multi-window terminal confusion, muscle memory.

**Fix**: split `_resolve_name_readonly` (auto-resolves, used by list/health/stats/boot/logs/diagnose) and `_resolve_name_explicit` (NEVER auto-resolves, used by stop/restart/start).

No `[y/N]` prompt — openclaw's `exec` tool has no usable stdin and would hang. Same UX for human + agent: type the name.

### Batch 4 — `boot` + `logs` inspection (`5cc63eb` + `400f2b2`)

Two new read-only commands:

- **`senpi-helpers boot <name>`** — pretty-prints boot.json (argv, script_path, cwd, log_path, env_snapshot with long values truncated). `--json` for machine consumers.
- **`senpi-helpers logs <name> [-n N] [-f]`** — tail/follow the daemon log; resolves log_path via the same chain as restart/stats (pid → boot → env → /tmp default). `--follow` uses `tail -F` semantics (reopen on rotation, seek-to-0 on truncation, Ctrl-C clean exit).

### Batch 5 — `diagnose <name>` (`5793a46`)

Composite reader over pid.json + boot.json + heartbeat.json + log file. Replaces the manual ssh+cat+pgrep ritual when triaging a misbehaving daemon. Runs ~10 pure-function checks (pass/warn/fail + suggestion per check):

```
[✓] boot_json_present         boot.json schema 2
[✓] script_path_exists        /data/scripts/x.py exists
[✗] pid_alive_and_matches     pid 1234 is alive but cmdline / start_time fingerprint
                              doesn't match — kernel recycled it to a stranger
       → Run `senpi-helpers stop <name>` — the recycle guard will clear …
[!] log_file_exists           log file not found at /tmp/x.log
[✓] heartbeat_fresh           last tick 12s ago
[✓] last_tick_status          last tick status: ok
```

RC=0 when all checks pass; RC=1 when any fails (machine-friendly for cron/alerts).

### Batch 6 — `start --inherit-env-from <pid|openclaw>` (`7d4ab99`)

When starting vulture/scorpion manually today I had to:
1. `pgrep -f '^openclaw$'`
2. `cat /proc/<pid>/environ | tr '\0' '\n'` then `export` each line
3. THEN `nohup python3 -u <script>`

Now: `senpi-helpers start <name> --inherit-env-from openclaw`. Reads /proc/<openclaw>/environ, merges with the CLI's current env (operator-set values still win), passes to Popen. Linux-only; spec validation runs before the platform gate so dev-host typos still get useful errors.

## Live validation today (pre-merge)

Vulture + scorpion producers were both dead on the fleet. Reproduced two failures live on the boxes — the log_path issue (batch 2) hit FIRST, before the argv bug (batch 1) would have. Manual nohup launches restored both. They're ticking now with new pids:

- vulture pid 66914, daemon_started 2026-05-14T16:27:07Z
- scorpion pid 65709, daemon_started 2026-05-14T16:28:24Z

## Test plan

- [x] **283 tests green** (was 202 before this branch). +81 new, +3 updated assertions, 12 skipped on macOS for Linux-only paths.
- [x] `RUN_SLOW_INTEGRATION=1` full suite passes — real-subprocess reproducer for the original argv bug end-to-end.
- [x] Coverage: argv normalization, log_path fallback chain, recycle guard (positive + negative + Linux/macOS asymmetry), boot.json reader (+truncation), logs tail (+default lines), diagnose (each failure mode + all-passing), `--inherit-env-from` (pid + openclaw alias + invalid spec + Linux gate), auto-resolve disabled for destructive cmds.

## Backward compatibility

- Schema-1 `boot.json`: restart's `_normalize_argv` prepends interpreter on read. New daemon writes schema-2 on startup; migration is one-shot per daemon.
- Schema-1 `pid.json`: `pid_alive_and_matches` degrades to plain `pid_alive` when fingerprints are None.
- Existing consumers that pass `<name>` explicitly: unaffected. Auto-resolve removal only affects single-daemon-host TUI calls without a name.

## Verification (post-merge operator action)

```bash
# On vulture:
senpi-helpers diagnose vulture-producer-5ad1a1e05a2d
# Expect: all checks pass (it's running via my manual launch).

senpi-helpers stop vulture-producer-5ad1a1e05a2d
senpi-helpers start vulture-producer-5ad1a1e05a2d --inherit-env-from openclaw
# Expect: schema-1 boot.json migration banner + daemon_started in log.

senpi-helpers logs vulture-producer-5ad1a1e05a2d -n 20
# Expect: last 20 log lines from /tmp/vulture-producer.log.

senpi-helpers boot vulture-producer-5ad1a1e05a2d
# Expect: pretty-printed boot.json showing schema 2 + the new log_path field.
```

If green: scorpion + every other fleet box gets the same one-shot fix.

## What's deliberately out of scope (follow-up PRs)

From the code-review plan (`plans/03-...md` + `plans/04-...md`):
- Extract `_perform_relaunch` shared helper (internal refactor)
- `--strict-pid` flag (opt-in stricter recycle check)
- CLI-side lock for `cmd_start` (defensive only; no observed race)
- CI-on-Linux check (operator/infra)
- Tail-log-on-confirmation-timeout (workflow polish)

## Planning artifacts (in this PR's investigation tree)

- `debugging-tasks/engine_failuer_issue/plans/01-senpi-helpers-restart-fix.md` — batch 1 plan
- `debugging-tasks/engine_failuer_issue/plans/02-senpi-helpers-systemic-fixes.md` — batch 2 plan
- `debugging-tasks/engine_failuer_issue/plans/03-senpi-helpers-cli-deep-review.md` — code review
- `debugging-tasks/engine_failuer_issue/plans/04-senpi-helpers-cli-followups.md` — batches 3-6 plan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core daemon lifecycle management (start/stop/restart), state-file schemas, and PID/log handling; mistakes could prevent daemons from restarting or could interfere with signaling. Changes are well-covered by expanded unit tests but still affect production ops paths.
> 
> **Overview**
> Fixes daemon relaunch reliability by bumping `boot.json`/`pid.json` to schema 2, adding legacy argv normalization (script-only → interpreter-first) and persisting `log_path` so `restart`/`stats` work after clean stops.
> 
> Hardens safety and operability: adds a pid-recycle guard (fingerprinted liveness via `/proc`), redirects daemon stderr to `/tmp/<name>.log` when launched with piped stderr, and disables implicit name auto-resolution for destructive commands (`start`/`stop`/`restart`).
> 
> Expands the CLI with new inspection and triage commands (`start`, `boot`, `logs`, `diagnose`) including `start --inherit-env-from <pid|openclaw>` for `/proc`-based env inheritance, plus shared log-path resolution and extensive new tests for tailing, diagnostics, and relaunch edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8ea1efda66461f29e760b24c7315e5808920b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->