### PR TITLE
fleet: HYPE +12.8% day post-mortem — three distinct fixes (Cheetah/Scorpion/Condor/Lemon/Wolverine)

### DIFF
--- a/cheetah/runtime.yaml
+++ b/cheetah/runtime.yaml
@@ -240,7 +240,12 @@ exit:
     phase1:
       enabled: true
       max_loss_pct: 15.0
-      retrace_threshold: 6
+      # 2026-05-14 HYPE +12.8% post-mortem: retrace_threshold 6 was firing
+      # on normal 2-3% pullbacks within strong trends, exiting at break-even
+      # before T0 ratchet engaged. Raised to 10 to allow more breathing room
+      # on volatile assets while preserving the catastrophic-loss protection
+      # of max_loss_pct.
+      retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true

--- a/condor/runtime.yaml
+++ b/condor/runtime.yaml
@@ -220,7 +220,11 @@ exit:
     phase1:
       enabled: true
       max_loss_pct: 20.0
-      retrace_threshold: 8
+      # 2026-05-14 HYPE +12.8% post-mortem: retrace_threshold 8 still tight
+      # enough to fire on normal pullbacks within strong trends. Raised to
+      # 12 (proportional to Cheetah/Scorpion's 6→10 bump) so Condor's
+      # "one amazing trade per day" doesn't get prematurely exited.
+      retrace_threshold: 12
       consecutive_breaches_required: 1
     phase2:
       enabled: true

--- a/lemon/scripts/lemon-producer.py
+++ b/lemon/scripts/lemon-producer.py
@@ -48,6 +48,10 @@ MARGIN_PCT = 0.30
 MIN_SCORE = 9
 XYZ_BANNED = False
 MACRO_GATE_BTC_4H_PCT = 3.0
+# 2026-05-14 HYPE +12.8% post-mortem: block fades when the asset itself is
+# in a strong directional run (4h ≥ 5%) AND the crowd is correctly riding
+# that direction. That's real trend, not exhaustion — fading loses.
+PER_ASSET_GATE_4H_PCT = 5.0
 
 LEVERAGE_TIERS = [
     {"min_score": 13, "leverage": 10},
@@ -154,6 +158,17 @@ def evaluate_fade(asset, sm, btc_4h):
     if not sm.get("is_xyz", False):
         if abs(btc_4h) > MACRO_GATE_BTC_4H_PCT:
             return None  # don't fade during BTC trending regime
+
+    # PER_ASSET_TREND_GATE (applies to crypto + XYZ)
+    # 2026-05-14 HYPE +12.8% post-mortem: Lemon shorted HYPE twice during
+    # the rally because MACRO_TREND_GATE only checks BTC. When a single
+    # asset itself is in a strong directional move ≥ 5% over 4h AND the
+    # SM crowd is correctly riding that move, the fade thesis fails —
+    # that's real trend, not exhaustion. Block these explicitly.
+    if sm_direction == "LONG" and p4h > PER_ASSET_GATE_4H_PCT:
+        return None  # asset rallying hard, crowd correctly long, don't fade
+    if sm_direction == "SHORT" and p4h < -PER_ASSET_GATE_4H_PCT:
+        return None  # asset dumping hard, crowd correctly short, don't fade
 
     score = 0
     reasons = []

--- a/scorpion/runtime.yaml
+++ b/scorpion/runtime.yaml
@@ -324,7 +324,11 @@ exit:
     phase1:
       enabled: true
       max_loss_pct: 15.0
-      retrace_threshold: 6
+      # 2026-05-14 HYPE +12.8% post-mortem: retrace_threshold 6 was firing
+      # on normal 2-3% pullbacks within strong trends. Raised to 10 to allow
+      # more breathing room on volatile crypto + XYZ moves while preserving
+      # max_loss_pct as the catastrophic-loss protection.
+      retrace_threshold: 10
       consecutive_breaches_required: 1
     phase2:
       enabled: true

--- a/wolverine/scripts/wolverine-producer.py
+++ b/wolverine/scripts/wolverine-producer.py
@@ -406,10 +406,20 @@ def build_hype_thesis():
 
     direction = "LONG" if trend_4h == "BULLISH" else "SHORT"
 
-    # GATE 3: 1h matches 4h
+    # GATE 3: 1h aligns with 4h (relaxed 2026-05-14)
+    # Original gate required strict equality: trend_1h == trend_4h. That
+    # blocks the common "pullback within trend" pattern where 4h is bullish
+    # but 1h has dipped briefly bearish/neutral inside an established uptrend.
+    # On HYPE specifically, 4h cadence is slower than 1h volatility, so
+    # strict alignment misses clean breakout entries. 2026-05-14 HYPE
+    # +12.8% post-mortem: gate blocked Wolverine all day on this exact
+    # mismatch. Relaxed to: 1h must NOT actively oppose 4h. NEUTRAL 1h
+    # passes (pullback-within-trend is allowed); only an actively
+    # OPPOSITE 1h blocks (genuine timeframe disagreement).
     trend_1h, _ = trend_structure(candles_1h)
-    if trend_1h != trend_4h:
-        return {"blocked": True, "reason": f"1h_{trend_1h}_vs_4h_{trend_4h}"}
+    opposite = {"BULLISH": "BEARISH", "BEARISH": "BULLISH"}
+    if trend_1h == opposite.get(trend_4h):
+        return {"blocked": True, "reason": f"1h_{trend_1h}_vs_4h_{trend_4h}_OPPOSITE"}
 
     # GATE 4: 15m momentum confirms
     mom_5m = price_momentum(candles_5m, 1)


### PR DESCRIPTION
## Context

2026-05-14: HYPE rallied **+12.8% over 18 hours**. Five fleet agents tried to participate — none captured the meat of the move. Root cause was **three distinct failure modes**, not one. This PR ships targeted fixes for each.

## Issue 1 — Phase 1 retrace fires before T0 ratchet engages (Cheetah / Scorpion / Condor)

Cheetah's case is the cleanest example: entered HYPE LONG at \$40 score 13, exited at +\$3.49 realized (~\$40.18 exit). Move continued to \$44.32 = +10.8%. **Captured 0.5% of an 11% move.**

Mechanism: Phase 1 \`retrace_threshold\` fires on % retrace from peak ROE. When a position briefly hits T0 trigger (+5% margin ROE) then immediately gives back below 5%, T0 lock never gets placed AND Phase 1 retrace also fires — exiting at break-even.

Fix: raise \`retrace_threshold\` on the multi-asset rotators.

| Agent | Old | New | Why |
|---|---|---|---|
| Cheetah | 6 | **10** | Most affected by today's HYPE pattern |
| Scorpion | 6 | **10** | Same scoring family + asset universe |
| Condor | 8 | **12** | Already slightly looser; proportional bump |

\`max_loss_pct\` preserved on all three as the catastrophic-loss protection.

## Issue 2 — Lemon fades into single-asset breakouts (MACRO_TREND_GATE only checks BTC)

Lemon shorted HYPE twice today (13:06 + 14:27 UTC) as \`LEMON_FADE\`. Existing MACRO_TREND_GATE only blocks crypto fades when \`|BTC 4h| > 3%\` — doesn't catch the case where the specific asset being faded is itself in a strong directional run.

Fix: new \`PER_ASSET_TREND_GATE\` in \`lemon-producer.py\`. Block fade when the asset's own 4h move ≥ 5% AND the SM crowd is correctly riding that direction. Applies to both crypto and XYZ.

This would have blocked both HYPE shorts today.

## Issue 3 — Wolverine strict 1h/4h alignment misses pullback-within-trend entries

Wolverine's Gate 3 (1h trend must STRICTLY match 4h trend) blocked all day. The 4h was weakly bullish while 1h had dipped neutral inside the established uptrend — the canonical "pullback within trend" pattern. Strict equality misses these on assets where 1h whips faster than 4h.

Fix: relax Gate 3 to **"1h must NOT actively oppose 4h."** NEUTRAL 1h passes (pullback-within-trend allowed); only an actively OPPOSITE 1h blocks.

## Files

| File | Change |
|---|---|
| \`cheetah/runtime.yaml\` | Phase 1 retrace_threshold 6→10 + inline post-mortem comment |
| \`scorpion/runtime.yaml\` | Phase 1 retrace_threshold 6→10 + comment |
| \`condor/runtime.yaml\` | Phase 1 retrace_threshold 8→12 + comment |
| \`lemon/scripts/lemon-producer.py\` | New PER_ASSET_TREND_GATE (~10 lines) + \`PER_ASSET_GATE_4H_PCT\` constant |
| \`wolverine/scripts/wolverine-producer.py\` | Gate 3: strict equality → not-opposite |

**NO change to producer scoring on Cheetah/Scorpion/Condor (only DSL exit behavior).** NO change to thesis on any agent. All five changes are tuning fixes to demonstrably underperforming behavior.

## Test plan

- [ ] Merge to main
- [ ] Ferry each affected operator with hot-reload / restart instructions
- [ ] Watch next 7 days for: Cheetah/Scorpion/Condor capturing more of trending moves, Lemon NOT firing during single-asset rallies, Wolverine firing on pullback-within-trend setups
- [ ] If any change overshoots (e.g. Cheetah holds too long and gives back gains beyond previous baseline), tune back

🤖 Generated with [Claude Code](https://claude.com/claude-code)