### PR TITLE
docs(readme): runtime 1.1.0 + 26-skill live fleet

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ Skills are versioned and MIT-licensed. Anyone can fork a skill, modify it, or bu
 ┌──────────────────────────────────▼───────────────────────────────────────┐
 │                  TRADING STRATEGY SKILLS (this repo)                      │
 │                                                                            │
-│   ~40 self-contained skills, one per directory                             │
-│   Each: producer/scanner script + runtime.yaml + SKILL.md                  │
+│   26 live trading strategy skills, one per directory                       │
+│   Each: producer script + runtime.yaml + SKILL.md + config.json            │
 │                                                                            │
-│   Bucketed below by trading thesis, not asset class.                       │
+│   Bucketed below into 11 producer archetypes (see                          │
+│   senpi-trading-runtime/references/producer-patterns.md).                  │
 │   Skills consume MCP via the runtime + helpers; never call MCP directly.   │
 └──────────────────────────────────┬───────────────────────────────────────┘
                                    │
@@ -109,10 +110,19 @@ Detail on each capability follows. The full tool surface is enumerated in the **
 
 The OpenClaw plugin that owns the trading loop. Replaces the legacy Python cron + state file system.
 
-Two major versions exist; a skill targets one of them via its `runtime.yaml`:
+Current release: **`@senpi/runtime` 1.1.0** (live on prod since 2026-05-12). Every live skill in this repo runs on 1.1.0. Features:
 
-- **Runtime 1.0** — Python DSL cron, fcntl-locked producer scripts, openclaw subprocess for MCP calls. Most skills in this repo run on 1.0.
-- **senpi-trading-runtime** — In-process producer daemon, direct HTTPS to MCP, declarative `risk.guard_rails`, native FEE_OPTIMIZED_LIMIT entries + exits, trade-chain DB telemetry. New skills target 2.0 by default.
+- In-process producer daemon (long-lived Python loop, no per-tick subprocess spawn)
+- Direct HTTPS to MCP and direct POST to runtime `/signals` (no `mcporter` / `openclaw` subprocess shell-out)
+- Declarative `risk.guard_rails` — daily caps, drawdown halt, consecutive-loss halt, per-asset cooldowns
+- Native FEE_OPTIMIZED_LIMIT on entries AND exits (~0.02–0.03% maker-fill savings per close vs MARKET)
+- Trade-chain DB telemetry — LIFECYCLE / DECISION_EXECUTED / ACTION_RESULT / DSL_CREATED / DSL_CLOSED per trade
+- `GET /state` daemon liveness probe + `{success, data, error}` envelope on `/signals` + `/audit`
+
+Two producer patterns are supported, both running on runtime 1.1.0:
+
+- **Helpers-native** — producer imports `senpi_runtime_helpers` (SDK bundled with the runtime skill). Default for new skills.
+- **Direct-MCP** — producer calls MCP directly via the wrapper client. Used by a handful of older or specialized skills (e.g. Turbine).
 
 Runtime version is determined by which plugin is loaded on the operator's host, not by which features the YAML declares.
 
@@ -317,112 +327,116 @@ Each tool's full schema (params, types, response shape) is in the MCP server its
 
 # Trading Strategy Skills
 
-Each strategy is a directory at the repo root. The bucketing below is by **how the strategy decides what to trade**, not by which asset it ends up on. A skill belongs to one bucket only.
+The live fleet — **26 skills across 11 producer archetypes**. Every skill targets runtime **1.1.0**. Bucketing matches [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md), the canonical archetype catalog.
 
-Each row links to the skill's own README and notes the runtime version it targets.
+Each row links to the skill's directory.
 
-## Single-asset alpha hunters (Kodiak family)
+## 1. Universe trend-follower
 
-Patient, single-asset specialists. One ticker per skill, deep wall of confluence required before entry, DSL Phase 2 set to ride winners.
+Top-N universe scan, multi-TF + SM consensus, conviction-tiered leverage. Catches coordinated risk-on / risk-off moves across crypto majors.
 
-| Skill | Asset | Runtime | One-liner |
+| Skill | Version | Asset / Universe | Description |
 |---|---|---|---|
-| [kodiak](kodiak/) | SOL | 2.0 | SOL alpha hunter — base technical score + trend strength gates |
-| [grizzly](grizzly/) | BTC | 2.0 | BTC alpha hunter — Kodiak template, BTC-specific tuning |
-| [polar](polar/) | ETH | 2.0 | ETH alpha hunter — hybrid hyperfeed + structural veto |
-| [wolverine](wolverine/) | HYPE | 2.0 | HYPE alpha hunter — Kodiak template ported to native HYPE |
+| [condor](condor/) | v3.0 | Top-50 HL liquid | Scans top-50 liquid assets every 180s. SM consensus + multi-TF alignment → conviction tiers. |
+| [cheetah](cheetah/) | v5.2 | Top-100 SM | Multi-signal confluence (SM + velocity + dual-price + volume + quality-trader). 15-point integer score. |
+| [python](python/) | v1.0 | Multi-tier universe | Mixed-signature scan with multi-day-hold thesis. Funding, volume, RSI extremes, move-exhaustion penalty. |
+| [scorpion](scorpion/) | v3.0 | Universe + funding | Universe scan with funding-regime backstop and post-close per-asset cooldown. |
 
-## XYZ-market specialists
+## 2. Single-asset alpha hunter (Kodiak family)
 
-Trade Hyperliquid's HIP-3 `xyz:*` perps — equities, commodities, indices, metals. 24/7 markets, different spread / funding profile than crypto.
+One asset, six-gate entry validation, tight scoring, conviction-tiered leverage.
 
-| Skill | Universe | Runtime | One-liner |
+| Skill | Version | Asset | Description |
 |---|---|---|---|
-| [bald-eagle](bald-eagle/) | XYZ macro | 1.0 | Wide DSL timings tuned for macro-asset rhythm |
-| [kestrel](kestrel/) | XYZ macro | 2.0 | Macro breakout rider on commodities/indices/equities |
-| [dire](dire/) | xyz:BRENTOIL | 1.0 | BRENTOIL specialist — news-driven oil momentum |
+| [kodiak](kodiak/) | v5.1 | SOL | The original template. Six-gate framework, SOL-tuned thresholds. |
+| [grizzly](grizzly/) | v5.3 | BTC | BTC-tuned thresholds — calmer regime, tighter sizing. |
+| [polar](polar/) | v3.0 | ETH | ETH-tuned thresholds, deep confluence required. |
+| [wolverine](wolverine/) | v3.0 | HYPE | HYPE-tuned thresholds for its high-vol native profile. |
 
-## Multi-signal confluence
+## 3. Single-asset XYZ specialist
 
-Combine multiple independent signals (SM concentration, trend, funding, structure) and only enter when several agree.
+Kodiak architecture applied to a single non-crypto XYZ asset.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [cheetah](cheetah/) | 2.0 | Multi-signal confluence sniper — strict gate, lower frequency, higher quality |
-| [condor](condor/) | 1.0 | "One amazing trade per day" — high-conviction momentum |
-| [sentinel](sentinel/) | 1.0 | Quality-trader convergence scanner |
-| [hawk](hawk/) | 1.0 | Multi-asset momentum bot |
+| Skill | Version | Asset | Description |
+|---|---|---|---|
+| [dire](dire/) | v1.0 | xyz:BRENTOIL | BRENTOIL specialist. Wider phase-1 loss tolerances, commodity-specific drawdown guardrails. |
 
-## Smart-Money signal followers
+## 4. Multi-asset whitelist
 
-Watch the top-trader cohort and either mirror or stalk their positions with our own DSL + risk overlay.
+Strict whitelist of 3–6 majors, best-of-N selection per tick.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [jackal](jackal/) | 2.0 | Smart Stalker — LLM-gated mirror of top-trader entries |
-| [spider](spider/) | 2.0 | Patient anchor — single long-side position, 7+ day hold |
-| [vulture](vulture/) | 2.0 | Long-tail momentum rider — pre-arms Phase 2 tier-2 trailing |
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [bison](bison/) | v1.0 | BTC · ETH · SOL | Iterates BTC / ETH / SOL per tick, fires the best-scoring above MIN_SCORE. Tick 300s. |
 
-## Contrarian / faders
+## 5. Trader-follower / hot-streak
 
-Bet against crowded positioning. Funding extremes, exhaustion, late-cycle SM crowding.
+Top-trader pool + conviction-gated coat-tail entries.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [pangolin](pangolin/) | 2.0 | Funding rate fader — strikes against extreme funding |
-| [owl](owl/) | 1.0 | Pure contrarian — crowding-unwind plays |
-| [Grizzly-Horribilis](Grizzly-Horribilis/) | 1.0 | BTC contrarian sniper |
-| [bison](bison/) | 1.0 | Conviction holder — wide bands, ratchet trailing |
-| [lemon](lemon/) | 1.0 | Degen fader — counter-trade CHOPPY traders at peaks |
-| [dog](dog/) | 1.0 | Multi-asset SM-exhaustion fader |
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [raptor](raptor/) | v3.0 | Multi (top traders) | 24h-cached trader pool. Gates on reputation, position size, SM alignment, per-trader entry discipline. |
+| [jackal](jackal/) | v1.0 | Multi (top traders) | Active trader pool + new-entry detector. Enriches with TA + funding regime. |
+| [spider](spider/) | v2.0 | Multi (arena-anchored) | Patient anchor sniper — arena-leader overlap + SM universe + funding + relative strength. 7-day minimum hold. |
 
-## Striker / rank-jump
+## 6. Striker / rank-jump
 
-Enter on rank acceleration or trend ignition. High frequency, tight DSL, fast exits.
+Detect rank acceleration on the SM leaderboard. First-jump events, high-conviction-per-trade.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [roach](roach/) | 2.0 | Striker-only — Stalker disabled, position discipline |
-| roach-b (variant) | 2.0 | Striker-only variant B — A/B partner to Roach |
-| [jaguar](jaguar/) | 1.0 | Hot-streak striker — rank-jump scanner |
-| [raptor](raptor/) | 1.0 | Hot streak follower |
-| [orca](orca/) | 1.0 | Gen-2 striker with FIRST_JUMP detection |
-| [cobra](cobra/) | 1.0 | Arena sprint predator — single-asset, concentrated margin |
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [jaguar](jaguar/) | v3.2 | Multi (rank-jumpers) | Detects 10+ rank jumps in one tick from mid-ranks (#25+). $3M+ notional, 50+ trader-count gates. |
+| [roach](roach/) | v1.0 | Multi (Strikers) | Striker-only emitter. FIRST_JUMP / IMMEDIATE_MOVER with volume floor. |
+| [roach](roach/) (roach-b instance) | v1.0 | Multi (Strikers) | Second wallet instance of the Roach producer. |
+| [orca](orca/) | v1.0 | Multi (Strikers) | Gen-1 vanilla Striker — FIRST_JUMP + volume + base scoring. |
 
-## Macro / regime-aware
+## 7. Funding-regime fade
 
-Cross-asset, regime detection, range-bound liquidity capture. Don't require a single primary signal.
+Persistent funding extremity → fade the crowd at exhaustion.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [mantis](mantis/) | 1.0 | Cross-asset catchup hunter — BTC lead → correlated alts |
-| [mamba](mamba/) | 1.0 | Range-bound + regime protection |
-| [viper](viper/) | 1.0 | Range-bound liquidity sniper |
-| [komodo](komodo/) | 1.0 | Momentum event consensus |
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [pangolin](pangolin/) | v1.4 | Multi (OI > $3M) | Funding extremity + persistence + SM positioning + cooldowns. Quiet-hours gating (00–04 UTC). |
+| [dog](dog/) | v2.0 | 4-coin whitelist | Funding fade on 4-coin watchlist with regime hard-gate. |
+| [vulture](vulture/) | v2.3 | HYPE | HYPE funding-regime contrarian. Funding-history + held-position enrichment. |
 
-## Velocity / pattern detection
+## 8. Contrarian crowding-unwind hunter
 
-Detect emerging acceleration before consensus solidifies.
+Wait for crowd to overcommit AND exhaustion signals; enter opposite.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [phoenix](phoenix/) | 1.0 | Contribution velocity scanner — SM profit accel vs price |
-| [hydra](hydra/) | 1.0 | Squeeze detector |
-| [vixen](vixen/) | 1.0 | Multi-asset trend scanner |
-| [shark](shark/) | 1.0 | Position tracker + liquidation cascade scanner |
-| [rhino](rhino/) | 1.0 | Momentum pyramider |
-| [barracuda](barracuda/) | 1.0 | Funding decay collector |
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [owl](owl/) | v6.1 | Multi (OI > $3M) | Crowding persistence (1+ hour) + multi-signal exhaustion. Tick 900s. 6h per-asset cooldown. |
+| [lemon](lemon/) | v1.1 | Crypto majors + XYZ | Degen Fader — counter-trades CHOPPY/DEGEN consensus. MACRO_TREND_GATE blocks fades during strong BTC trends. |
 
-## Specialized missions
+## 9. Cross-asset lag detector
 
-Unique theses that don't fit the buckets above.
+BTC leads alts on macro moves; capture the catch-up.
 
-| Skill | Runtime | One-liner |
-|---|---|---|
-| [turbine](turbine/) | 2.0 | Volume-rotation engine — builder-fee farming on maker-only rotation across two strategy wallets |
-| [otter](otter/) | 2.0 | Open Interest velocity hunter — 1h OI delta with price confirmation |
-| [python](python/) | 1.0 | Patient multi-asset scanner — multi-day hold |
-| [scorpion](scorpion/) | 2.0 | Multi-market active trader — both crypto AND XYZ commodities |
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [mantis](mantis/) | v5.0 | Multi (BTC-led laggards) | BTC moves >2% in 4h → identifies laggard alts with follow-rate ≥0.8. Tick 60s. Often silent on quiet BTC days. |
+
+## 10. Multi-asset XYZ contrarian fader
+
+Multiple XYZ macro assets, contrarian direction flip on SM over-concentration.
+
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [bald-eagle](bald-eagle/) | v1.0 | 6 XYZ macro | CL, BRENTOIL, GOLD, SILVER, SP500, XYZ100. Spread filter + 10-min stale-cancel auto-purge. |
+| [kestrel](kestrel/) | v1.1 | 13 XYZ macro | 13-asset XYZ macro universe with funding alignment. Broader variant of the XYZ contrarian thesis. |
+
+## 11. Volume engine / market-making (specialized)
+
+Not directional. Two-wallet pair recycling builder fees against a volume target.
+
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [turbine](turbine/) | v3.2 | Two-wallet pair | High-frequency cancel + create cycle. Volume wallet + runner wallet. Daily top-ups; net bleed = mission cost rate. |
+
+For full archetype theses, distinguishing MCP signatures, and code snippets, see [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md).
+
+> **Live fleet trackers:** [strategies.senpi.ai](https://strategies.senpi.ai) (all-time PnL) · [senpi.ai/arena](https://senpi.ai/arena) (weekly ROE). One agent — Sentinel — runs an in-house producer not published to this repo; it appears on the live trackers but has no source link here.
 
 ---
 
@@ -432,7 +446,6 @@ Unique theses that don't fit the buckets above.
 senpi-skills/
 ├── README.md                       ← this file
 ├── CLAUDE.md                       ← repo conventions for Claude agents
-├── DSL-MIGRATION-PLAYBOOK.md       ← Runtime 1 → 2 migration notes
 ├── catalog.json                    ← skill registry
 │
 ├── senpi-trading-runtime/          ╮
@@ -449,20 +462,17 @@ senpi-skills/
 └── senpi-onboard/                  ╯
 │
 ├── kodiak/  grizzly/  polar/  wolverine/      ╮
-├── cheetah/ condor/   sentinel/ hawk/         │
-├── jackal/  spider/   vulture/                │
-├── pangolin/ owl/  bison/  lemon/  dog/       │
-├── Grizzly-Horribilis/                        │
-├── roach/   jaguar/  raptor/  orca/  cobra/   │ Trading Strategy Skills
-├── mantis/  mamba/   viper/   komodo/         │
-├── phoenix/ hydra/   vixen/   shark/  rhino/  │
-├── barracuda/                                 │
-├── turbine/ otter/   python/   scorpion/      │
-├── bald-eagle/  kestrel/  dire/               ╯
-│
-└── (legacy strategy proposals: feral-fox-v3-strategy.md, ghost-fox-*,
-    tiger-strategy/, wolf-strategy/, wolf-howl/ — kept for reference)
+├── condor/  cheetah/  python/  scorpion/      │
+├── jackal/  spider/   raptor/                 │
+├── pangolin/ dog/  vulture/                   │ 26 Trading Strategy Skills
+├── owl/  lemon/                               │ (live fleet)
+├── roach/   jaguar/  orca/                    │
+├── mantis/                                    │
+├── bison/   dire/  bald-eagle/  kestrel/      │
+└── turbine/                                   ╯
 ```
+
+Roach-B is a second wallet instance of the `roach/` producer (no separate directory). Otter (`otter/`) is in the repo but currently paused; see git history for prior versions.
 
 Each strategy directory contains:
 


### PR DESCRIPTION
## Summary

Bring the root README in line with the current platform state — runtime 1.1.0 and the 26-skill live fleet.

## Runtime section
- Replace the "Runtime 1.0 / Runtime 2.0" framing with the single current release: **\`@senpi/runtime\` 1.1.0** (live on prod since 2026-05-12).
- Document the two producer patterns (helpers-native + direct-MCP), both running on 1.1.0.
- List 1.1.0 features: in-process producer daemon, direct HTTPS MCP, declarative \`risk.guard_rails\`, FEE_OPTIMIZED_LIMIT entries + exits, trade-chain DB telemetry, \`/state\` liveness probe.

## Trading Strategy Skills
- Replace the old 8-bucket thesis taxonomy with the 11 producer archetypes from [\`producer-patterns.md\`](senpi-trading-runtime/references/producer-patterns.md) so README + producer-patterns + senpi.ai website share one bucketing.
- List the **26 live skills** with version, asset/universe, and one-line description. Every skill now targets runtime 1.1.0.
- Remove dead references to skills that no longer exist in the repo: hawk, sentinel, cobra, mamba, viper, komodo, phoenix, hydra, vixen, shark, rhino, barracuda, Grizzly-Horribilis. Sentinel is noted as in-house (on Predators tracker but no public producer).
- Remove broken DSL-MIGRATION-PLAYBOOK.md link.
- Update repo-layout block and architecture diagram skill count.

## Test plan
- [ ] Render README on GitHub, verify all 26 skill links resolve.
- [ ] Verify the strategy bucketing matches \`producer-patterns.md\`.
- [ ] Confirm Sentinel callout reads accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)