### PR TITLE
[DO NOT MERGE - NOT TESTED] fix(turbine): restore mode field consistency (producer + both scanners)

### DIFF
--- a/turbine/runtime-runners.yaml
+++ b/turbine/runtime-runners.yaml
@@ -61,6 +61,12 @@ scanners:
       context: false
     config:
       fields:
+        # Mirror turbine_volume_signals. The producer (scripts/turbine-producer.py)
+        # emits the SAME data_block to both wallet scanners — including `mode` —
+        # so the runners scanner MUST declare it or senpi-trading-runtime rejects
+        # every runners signal with INVALID_REQUEST ("received undeclared data
+        # field 'mode'"). Observed on Turbine prod 2026-05-18 at ~15 rejects/hr.
+        mode: { type: string, required: true }                 # "VOLUME"
         thesis: { type: string, required: true }
         leverage: { type: number, required: true }
         marginUsd: { type: number, required: true }

--- a/turbine/scripts/turbine-producer.py
+++ b/turbine/scripts/turbine-producer.py
@@ -335,6 +335,12 @@ def emit_signal(wallet, scanner, signal_type, asset, direction, thesis,
         cfg.log(f"wallet not set; cannot emit signal to {scanner}")
         return False
     data_block = {
+        # Emitted to BOTH wallet scanners. Both turbine_volume_signals and
+        # turbine_runners_signals must declare `mode` in their config.fields,
+        # or the senpi-trading-runtime receiver rejects the signal with
+        # INVALID_REQUEST ("received undeclared data field 'mode'"). The volume
+        # gate's decision_prompt also branches on mode != "VOLUME".
+        "mode": "VOLUME",
         "thesis": thesis,
         "leverage": float(leverage),
         "marginUsd": float(margin_usd),


### PR DESCRIPTION
## Summary

Restores `mode`-field consistency for the Turbine skill so a clean deploy from `main` matches the working prod box. Three components must agree on the `mode` field; `main` currently does not.

## The inconsistency on `main`

The producer (`turbine/scripts/turbine-producer.py`) emits one `data_block` to **both** wallet scanners. The volume gate already depends on `mode`:
- `turbine/runtime-volume.yaml` declares `mode: { required: true }`
- its `decision_prompt` branches on `mode != "VOLUME"`

But on `main`:

| Component | `mode`? | Effect on a clean deploy |
|---|---|---|
| producer `data_block` | ❌ not emitted | — |
| volume scanner schema | ✅ required | rejects every volume signal (missing required `mode`) |
| runners scanner schema | ❌ not declared | — |

And on the **live prod box**, the producer *was* emitting `mode` while the runners scanner did **not** declare it → `INVALID_REQUEST: received undeclared data field 'mode'`, ~15 rejects/hour on Turbine on 2026-05-18 (runners wallet silently dropped every entry until the runtime was reinstalled with a corrected schema).

## Fix

Match the working box configuration — all three agree:
- **producer**: emit `mode: "VOLUME"` in `data_block` (first field).
- **runners scanner**: declare `mode: { type: string, required: true }` (mirrors volume).

After the change both scanners declare the identical 10-field set, exactly matching the producer's `data_block` keys.

## Test plan

- [x] `python3 -m py_compile turbine/scripts/turbine-producer.py` passes
- [x] Both runtime YAMLs parse; `turbine_volume_signals` and `turbine_runners_signals` field sets are identical and include `mode`
- [x] Field set matches producer `data_block` keys exactly (mode, thesis, leverage, marginUsd, fundingRegime, fundingAnnualizedPct, spreadBps, slotIndex, isXyz, cycleMin)
- [ ] **NOT validated by a fresh end-to-end install** — the equivalent fix is already live on the Turbine prod box (reinstalled runtime), where rejections stopped at 2026-05-18T23:55Z and a 12-min monitor on 2026-05-19 showed 0 new rejections. Hence DO-NOT-MERGE pending a clean-deploy check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape/schema of trading signals by adding a required `mode` field, which can affect runtime validation and signal acceptance if any component is misaligned. Scoped to Turbine’s external signal payload and runners runtime config.
> 
> **Overview**
> Restores `mode` field consistency across Turbine’s producer and runners runtime so signals aren’t rejected by the trading runtime schema validator.
> 
> The producer now includes `"mode": "VOLUME"` in the emitted `data_block`, and the `turbine_runners_signals` scanner schema declares `mode` as a required string to match the payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eaaa666bbff5dc583d4ad1efbcafe40a478933b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->