### PR TITLE
Add 10 onboarding strategies — DSL-driven, SM-confirmed, long-or-short

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,59 @@ Each strategy is a directory at the repo root. The bucketing below is by **how t
 
 Each row links to the skill's own README and notes the runtime version it targets.
 
+## 🎯 New to Senpi? Start here.
+
+Ten **onboarding-tier** strategies built around the **Senpi Smart-Money direction gate** + **DSL Phase 1/Phase 2 ratchet exits**. Each opens LONG or SHORT (no long-only), uses simple 5-component scoring (max ~9), and lets the runtime own all exit logic. Pick by what you want to trade.
+
+### 🟢 Crypto Trend Followers — pick your coin
+
+Asset-specific 4h trend riders with Smart-Money confirmation. Long when SM and 4h trend both align bullish; short when both align bearish; idle otherwise. Wide Bison-pattern DSL (T0 lock 0 → T5 lock 85) so winners can ride multi-day moves.
+
+| Skill | Asset | Runtime | One-liner |
+|---|---|---|---|
+| [beaver](beaver/) | BTC | 1.0 | **Start here.** BTC trend + SM gate. Onboarding default. |
+| [heron](heron/) | ETH | 1.0 | ETH trend + SM gate. Same shape as Beaver. |
+| [hummingbird](hummingbird/) | HYPE | 1.0 | HYPE trend + SM gate. Same shape as Beaver. |
+
+### 🔵 Diversified Crypto Basket
+
+| Skill | Assets | Runtime | One-liner |
+|---|---|---|---|
+| [hedgehog](hedgehog/) | BTC + ETH + SOL | 1.0 | Equal-weight basket. Each asset directional independently — BTC long + ETH short is allowed. Up to 3 simultaneous positions. |
+
+### 🟣 Smart-Money Conviction Mirror (multi-week, not lucky-week)
+
+| Skill | Source | Runtime | One-liner |
+|---|---|---|---|
+| [albatross](albatross/) | Arena leaders | 1.0 | Multi-week ROE conviction composite. `0.3 × monthly + 0.7 × weekly_mean − 0.5 × weekly_stdev`. Mirror only persistent winners, not lucky-week leaders. REQUIRES user-scope auth token. |
+
+### 🟡 Technical Patterns
+
+| Skill | Signal | Runtime | One-liner |
+|---|---|---|---|
+| [hawk](hawk/) | 7d high/low breakout | 1.0 | Buy 4h breakouts above 7d high; short breakdowns below 7d low. **TIGHT DSL** (8% max_loss, lock at +5%) — failed breakouts get cut fast. |
+| [salamander](salamander/) | Pullback in trend | 1.0 | Buy 3-7% pullbacks in 4h uptrends; short rallies in downtrends. **Asymmetric DSL** — wider Phase 1, tight Phase 2. |
+
+### 🟠 XYZ Equities (Hyperliquid's HIP-3 sub-DEX, 23/5 trading)
+
+Senpi's distinctive moat — equity, commodity, and pre-IPO perps that retail can't trade anywhere else.
+
+| Skill | Universe | Runtime | One-liner |
+|---|---|---|---|
+| [lemur](lemur/) | Pre-IPO Perpetuals (IPOPs) | 1.0 | **Auto-discovers IPOPs** via the trade.xyz funding signature. Today: xyz:SPCX. Future-proof for ANTHROPIC / OPENAI / STRIPE when listed. 24/7 trading, moderate DSL. |
+| [bobcat](bobcat/) | Big tech | 1.0 | NVDA / TSLA / AAPL / META / MSFT / GOOGL / AMZN / AMD / MU / INTC / TSM / ORCL. 4h trend + SM. Standard DSL, 48h hard timeout for weekend gap. |
+| [raccoon](raccoon/) | All XYZ (excl. IPOPs) | 1.0 | **Weekend-only.** Fri 22:00 UTC → Mon 00:00 UTC. Captures the Mon-open reconciliation snap-back when trade.xyz external pricing resumes after the 50h internal-oracle gap. |
+
+**All 10 onboarding strategies share:**
+- Helpers-native producer (`senpi_runtime_helpers`)
+- `recent-signals.json` race-window dedup (240s TTL) — Bison v3.0.1 pattern
+- DSL Phase 1 max_loss floor + Phase 2 wide ratchet ladder
+- Runtime LLM-gated entries via FEE_OPTIMIZED_LIMIT (maker-first ALO)
+- `runtime.yaml risk.guard_rails` for daily-loss / drawdown / cooldown gates
+- Long OR short on Smart-Money direction (none are long-only)
+
+---
+
 ## Single-asset alpha hunters (Kodiak family)
 
 Patient, single-asset specialists. One ticker per skill, deep wall of confluence required before entry, DSL Phase 2 set to ride winners.
@@ -351,7 +404,6 @@ Combine multiple independent signals (SM concentration, trend, funding, structur
 | [cheetah](cheetah/) | 2.0 | Multi-signal confluence sniper — strict gate, lower frequency, higher quality |
 | [condor](condor/) | 1.0 | "One amazing trade per day" — high-conviction momentum |
 | [sentinel](sentinel/) | 1.0 | Quality-trader convergence scanner |
-| [hawk](hawk/) | 1.0 | Multi-asset momentum bot |
 
 ## Smart-Money signal followers
 

--- a/albatross/README.md
+++ b/albatross/README.md
@@ -1,0 +1,152 @@
+# 🐦‍⬛ Albatross — Multi-week Arena Conviction Mirror
+
+Mirror the **consistent winners** from the Senpi Arena, not the lucky-week winners. Albatross pulls 4 weekly leaderboards + the current monthly leaderboard, computes a composite conviction score, and mirrors trades from the top-N traders by that score.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/skills).
+
+## Thesis
+
+Mirroring last week's Arena winner is a survivor-bias trap — a trader can post +98% from one good week and three flat weeks and still top the board. Albatross corrects for this with a multi-week composite that rewards persistence and penalizes variance:
+
+```
+conviction = 0.3 × monthly_roe
+            + 0.7 × mean(weekly_roe across last 4 weeks)
+            − 0.5 × stdev(weekly_roe)
+```
+
+A trader posting +30%/+25%/+20%/+15% beats a trader with one +98% week and three flat weeks, because the first one has both higher expected return AND lower variance.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Leader pool size | 5 (top by conviction) |
+| Pool refresh | every 4h |
+| Min weeks traded | 3 of last 4 |
+| Min weekly notional | $50K (filters toy accounts) |
+| Excluded xHandles | `["betashop"]` (no Senpi-fleet self-mirror) |
+| Tick interval | 300s (5 min) |
+| Margin per trade | 15% of equity |
+| Leverage | 5x default, max 5x |
+| Max entries per day | 5 |
+| Per-asset cooldown | 120 min |
+| Daily loss limit | 15% |
+| Drawdown halt | 20% |
+| Hard timeout | 96h (4d cap) |
+| Recent-signals dedup | 240s TTL |
+
+## ⚠️ REQUIRES USER-SCOPE AUTH TOKEN
+
+Albatross calls `strategy_list({userIds: [leader_user_id]})` and `discovery_get_trader_state(other_user_wallet)`. Both endpoints gate on requester user identity. **Service tokens will not work** — you'll see `SERR031: User not authorized` and `INVALID_TOKEN: Token does not contain a valid user ID` errors.
+
+The operator must provide a **Privy-issued Senpi user token** as `SENPI_AUTH_TOKEN`. Typically you'd:
+1. Log into senpi.ai as the user account that owns this strategy wallet
+2. Grab the bearer token from devtools (Network tab, any GraphQL request)
+3. Set as `SENPI_AUTH_TOKEN` env var on the producer host
+
+## Scanner pattern
+
+This strategy uses the **Trader follower (Jackal family)** scanner pattern with multi-week selection — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `arena_leaderboard` (×5 for pool composition), `strategy_list` (per-leader wallet resolution), `discovery_get_trader_state` (per-leader position fetch).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/albatross-producer.py | Long-lived daemon |
+| scripts/albatross_config.py | SDK probe + SenpiClient wrapper + leader pool / position state |
+| config/albatross-config.json | Operator-tunable defaults (wallet, weights, pool size) |
+
+## Install
+
+### Step 0 — Register the runtime plugin (one-time per host)
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your USER-SCOPE SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway: `openclaw gateway restart`
+
+### Step 1 — Install senpi-trading-runtime (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Albatross
+
+```bash
+mkdir -p /data/workspace/skills/albatross-strategy/{config,scripts,state,state/leader-positions,references}
+for f in scripts/albatross-producer.py scripts/albatross_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/albatross-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/albatross/$f" \
+    -o "/data/workspace/skills/albatross-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `config/albatross-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Set required env vars
+
+```bash
+export ALBATROSS_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=<USER-SCOPE Privy token, NOT a service token>
+export ALBATROSS_DECISION_MODEL=<your-preferred-model>   # bare model name
+```
+
+### Step 5 — Create runtime + start daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/albatross-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/albatross-strategy/scripts/albatross-producer.py \
+  > /tmp/albatross-producer.log 2>&1 &
+disown
+```
+
+## Verification
+
+```bash
+sleep 320
+tail -3 /tmp/albatross-producer.log | jq '._albatross_producer_version, .leader_pool_size, .top_leaders[0:3]'
+# Expected: _albatross_producer_version = "1.0.0", leader_pool_size between 1-5
+```
+
+If you see `"note": "no qualifying leaders"` after multiple ticks, either:
+- No traders in the current Arena window have positive composite score with 3+ weeks of activity
+- Your auth token is service-scoped (check producer log for SERR031 errors)
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+Multi-week Arena conviction mirror. Composite weighting replaces naive last-week-winner mirroring. Default 5-leader pool, 4h refresh, 96h hard timeout on mirrored positions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/albatross/SKILL.md
+++ b/albatross/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: albatross-strategy
+description: >-
+  ALBATROSS v1.0.0 — Multi-week Arena conviction tracker. Mirrors trades
+  from Senpi Arena participants whose ROE has been consistently strong
+  across the last 4 weekly periods + the current monthly leaderboard.
+  Composite conviction score (0.3 × monthly + 0.7 × weekly_mean − 0.5 ×
+  weekly_stdev) selects the top-N pool; producer detects when a leader
+  opens a new position and mirrors it. Wide Bison-pattern DSL ladder
+  with a 96h hard timeout cap.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐦‍⬛ ALBATROSS v1.0.0 — Multi-week Arena Conviction Mirror
+
+**Mirror the consistent winners, not the lucky-week winners.** Albatross selects Arena leaders by a composite score that rewards multi-week persistence and penalizes one-shot lucky weeks.
+
+## Why this strategy exists
+
+The Senpi Arena resets every Thursday. A trader can post a +98% weekly ROE from one good week and three flat weeks — and they'll top the leaderboard, but mirroring them is a survivor-bias trap.
+
+Albatross corrects for this by pulling **4 weekly snapshots + 1 monthly snapshot** and ranking by a composite that respects both magnitude and consistency:
+
+```
+conviction = 0.3 × monthly_roe
+            + 0.7 × mean(weekly_roe across last 4 weeks)
+            − 0.5 × stdev(weekly_roe)
+```
+
+A trader posting +30%/+25%/+20%/+15% across 4 weeks (mean +22.5%, stdev ±5.6%) scores **conviction ≈ 14.0**.
+A trader posting +98%/0%/-5%/-3% (mean +22.5%, stdev ±42.5%) scores **conviction ≈ -5.8** despite the same mean. Albatross rejects the second; mirrors the first.
+
+## CRITICAL RULES
+
+### RULE 1: REQUIRES USER-SCOPE AUTH TOKEN
+Service tokens cannot resolve other users' strategy wallets or call `discovery_get_trader_state` for other addresses. Both gate on user identity. **The operator must provide a Privy-issued Senpi user token via `SENPI_AUTH_TOKEN`**, not an MCP service key.
+
+### RULE 2: Producer mirrors. DSL exits.
+The producer detects when a leader opens a NEW position (diff against last-tick snapshot in `state/leader-positions/`) and emits one signal per detection. The runtime opens via FEE_OPTIMIZED_LIMIT. The DSL Phase 1 max_loss + Phase 2 wide ratchet manages exits.
+
+### RULE 3: Leader pool refreshes every 4h, not every tick
+Pulling 4 weekly leaderboards + 1 monthly on every 300s tick would burn MCP quota. The pool is cached in `state/leader-pool.json` with a `leaderRefreshHours` TTL (default 4). Only the per-leader position snapshots refresh per tick.
+
+### RULE 4: Exclude betashop xHandle by default
+Senpi's own fleet agents (Bison12, Cheetah, Jaguar2, etc.) often top the Arena. Mirroring them creates a feedback loop — Albatross would just be a slower copy of those agents. Config `excludeXHandles: ["betashop"]` filters them out. Operators can add other handles to skip.
+
+### RULE 5: 96h hard timeout cap
+We don't have visibility into the leader's exit logic. Hard timeout 96h (4 days) frees the slot if the position drifts without resolution. Phase 1 max_loss 20% catches catastrophic adverse moves; Phase 2 wide ladder lets winners run within the 96h window.
+
+## How Albatross composes its leader pool
+
+1. Pull `arena_leaderboard(period_type=WEEK, qualified=true)` for the current week + last 3 weeks.
+2. Pull `arena_leaderboard(period_type=MONTH, qualified=true)` for the current month.
+3. For each unique senpiUserId across those 5 calls:
+   - Compute `mean(weekly_roe)` and `stdev(weekly_roe)` across the weeks the trader appeared.
+   - Look up monthly_roe (default 0 if absent).
+   - `conviction = 0.3 × monthly + 0.7 × weekly_mean − 0.5 × weekly_stdev`.
+4. Filter to traders with:
+   - `conviction > 0` (no negative-expectation leaders)
+   - `weeks_traded >= 3` (default, ensures persistence)
+   - Each week's `notionalVolume >= 50000` (default, no toy accounts)
+   - `xHandle != "betashop"` (no Senpi fleet self-mirror)
+5. Top N by conviction → pool (default 5).
+
+## How Albatross detects new positions
+
+Per tick (every 300s):
+1. For each leader in the pool, call `strategy_list({userIds: [senpiUserId], status: ["ACTIVE"]})` → list of strategy wallet addresses.
+2. Call `discovery_get_trader_state(trader_addresses=wallets, latest=true)` → current open positions.
+3. Compare to last-tick snapshot in `state/leader-positions/<senpiUserId>.json`. Detect coins/directions present now but not in last snapshot.
+4. For each NEW position: emit `ALBATROSS_ARENA_MIRROR` signal with `asset`, `direction`, our sized `marginUsd`, and our capped `leverage`.
+
+## Mirror logic — what we copy and what we adapt
+
+| Field | Adapt |
+|---|---|
+| Asset | **Copy exactly** (BTC, ETH, NVDA, BRENTOIL, whatever they opened) |
+| Direction | **Copy exactly** |
+| Leverage | **Cap at config.leverage (default 5x, max 5x)** — we don't follow into 25x leverage |
+| Sizing | Fixed `marginPct * accountValue` (default 15%) — we don't size proportional to their conviction |
+| Order type | FEE_OPTIMIZED_LIMIT, maker-first 30s ALO |
+| TP/SL | Skip theirs, use our DSL |
+
+## Risk guardrails (`runtime.yaml` `risk.guard_rails`)
+
+| Gate | Setting | Why |
+|---|---|---|
+| max_entries_per_day | 5 | Multiple leaders fire — give the producer room |
+| per_asset_cooldown_minutes | 120 | Don't re-mirror same asset within 2h |
+| daily_loss_limit_pct | 15 | Cap a bad day |
+| max_consecutive_losses | 4 | Halt if leader pool is wrong for current regime |
+| cooldown_minutes (post-loss) | 30 | Cool off briefly |
+| drawdown_halt_pct | 20 | Catastrophic floor |
+| drawdown_reset_on_day_rollover | false | No grace |
+
+## Scanner pattern
+
+This strategy uses the **Trader follower (Jackal family)** scanner pattern with multi-week selection — see `senpi-trading-runtime/references/producer-patterns.md` for the canonical reference. Primary MCP calls: `arena_leaderboard` (×5 for pool composition), `strategy_list` (per-leader wallet resolution), `discovery_get_trader_state` (per-leader position fetch).
+
+## Operator install
+
+See [README.md](README.md). **Pay close attention to RULE 1 — service tokens will not work.**
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+First multi-week Arena conviction mirror. Composite score weighting (0.3 monthly + 0.7 weekly_mean − 0.5 weekly_stdev) replaces the naive "mirror this week's #1" approach. Default pool size 5, refresh every 4h, max 5 entries/day.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.

--- a/albatross/config/albatross-config.json
+++ b/albatross/config/albatross-config.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "ALBATROSS v1.0.0 — Multi-week Arena conviction tracker. Mirrors trades from Senpi Arena participants whose ROE has been consistently strong across the last 4 weeks AND the current month. Composite score = 0.3 × monthly_roe + 0.7 × mean(weekly_roe) − 0.5 × stdev(weekly_roe). Pool refreshes every 4h. Edit wallet/strategyId/chatId.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "leaderPoolSize": 5,
+  "leaderRefreshHours": 4,
+  "minWeeksTraded": 3,
+  "minWeeklyVolumeUsd": 50000,
+  "convictionWeights": {
+    "monthlyRoe": 0.3,
+    "weeklyRoeMean": 0.7,
+    "weeklyRoeStdevPenalty": 0.5
+  },
+  "marginPct": 0.15,
+  "leverage": 5,
+  "excludeXHandles": ["betashop"]
+}

--- a/albatross/references/skill-attribution.md
+++ b/albatross/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "albatross",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "albatross",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/albatross/runtime.yaml
+++ b/albatross/runtime.yaml
@@ -1,0 +1,195 @@
+name: albatross-tracker
+version: 1.0.0
+description: >
+  ALBATROSS v1.0.0 — Multi-week Arena conviction tracker.
+
+  Mirrors trades from Senpi Arena participants whose performance has been
+  consistently strong across the last 4 weekly Arena periods + the current
+  monthly leaderboard. Composite conviction score rewards persistence
+  and penalizes one-week-luck:
+
+    conviction = 0.3 × monthly_roe
+               + 0.7 × mean(weekly_roe across last 4 weeks)
+               − 0.5 × stdev(weekly_roe)
+
+  A trader with steady +30% weekly across 4 weeks AND +25% monthly beats
+  a trader with one +98% week and three flat weeks. That's the whole
+  point — Arena week-by-week mirroring suffers from survivor bias;
+  multi-week selection corrects for it.
+
+  Architecture: pool refreshes every 4h (cached in state/leader-pool.json).
+  Each 300s tick: for each leader, resolve their strategy wallets via
+  strategy_list, pull current positions via discovery_get_trader_state,
+  diff against last-tick snapshot, emit MIRROR signal for each new
+  position. DSL Phase 1 max_loss 20% / Phase 2 wide ladder handles
+  all exits. Time-cuts disabled — winners ride.
+
+  REQUIRES USER-SCOPE AUTH TOKEN. Service tokens cannot call strategy_list
+  or discovery_get_trader_state for other users — both gate on user identity.
+  Operators must provide a Privy-issued Senpi user token via SENPI_AUTH_TOKEN.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 3
+  margin_per_slot: 150
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 5
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_minutes: 30
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 120
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: albatross_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        leaderUsername: { type: string, required: false }
+        leaderXHandle: { type: string, required: false }
+        leaderConvictionScore: { type: number, required: false }
+        leaderWeeksTraded: { type: number, required: false }
+        leaderWeeklyRoeMean: { type: number, required: false }
+        leaderMonthlyRoe: { type: number, required: false }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        leaderEntryPrice: { type: number, required: false }
+        leaderLeverage: { type: number, required: false }
+        reason: { type: string, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: albatross_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${ALBATROSS_DECISION_MODEL}"   # REQUIRED. Bare model name only.
+    scanners: [albatross_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: albatross_signals
+    decision_prompt: |
+      You are Albatross's pass-through gate. Albatross mirrors trades
+      from Arena leaders who have demonstrated multi-week consistency.
+      The producer has already (a) computed the conviction-weighted
+      leader pool, (b) confirmed the source leader's composite score is
+      positive across 3+ weeks AND positive monthly ROE, and (c) detected
+      this is a genuinely NEW position the leader just opened.
+
+      SIGNAL:
+      {{signal_albatross_signals}}
+
+      ## STRICT OUTPUT RULES
+
+      1. asset MUST be copied from signal.asset (the asset the leader just opened).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (capped at 5x by config).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - leverage <= 0 OR marginUsd <= 0 (malformed signal)
+      - heldAssets already contains the asset (duplicate)
+      - asset missing OR direction not in {LONG, SHORT}
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: leaderConvictionScore >= 30 AND leaderWeeksTraded == 4
+      - 7-8:  leaderConvictionScore 10-30
+      - 7:    leaderConvictionScore > 0 (producer floor cleared)
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing leader + composite score (e.g. 'mirror NVDA LONG from KhakiLoop, conviction 42.3, weekly mean +28% across 4 weeks, monthly +47%')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "ALBATROSS_MIRROR ASSET DIR — from leader USERNAME"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — wide ladder, hard_timeout 96h cap) ──────────────
+#
+# Mirrored trades inherit direction from the source leader. We don't
+# know when they'll close their position, so we use our own DSL.
+# Phase 1 max_loss 20% provides catastrophic floor. Phase 2 wide
+# ladder so winning mirrors can ride. hard_timeout 96h (4 days) caps
+# the position since we don't have visibility into the leader's exit
+# rules — 4 days is long enough for most directional theses to play
+# out but short enough to free up the slot.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760              # 96h (4d) cap
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 90
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/albatross/scripts/albatross-producer.py
+++ b/albatross/scripts/albatross-producer.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+# Senpi ALBATROSS Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""ALBATROSS v1.0.0 — Multi-week Arena conviction tracker.
+
+Mirrors trades from Senpi Arena participants whose performance has
+been consistently strong across the last 4 weekly periods + the
+current monthly leaderboard. Selection criterion is a composite
+score that rewards persistence and penalizes single-week luck:
+
+    conviction = 0.3 × monthly_roe
+                + 0.7 × mean(weekly_roe across last 4 weeks)
+                − 0.5 × stdev(weekly_roe)
+
+A trader with steady +30% weekly across 4 weeks AND +25% monthly
+beats a trader with one +98% week and three flat weeks.
+
+Architecture (helpers-native):
+  1. Refresh leader pool every leaderRefreshHours (default 4h).
+     Pull arena_leaderboard for current week + last 3 weeks + month.
+     Compute composite score per senpiUserId. Filter to top-N qualified.
+     Cache pool in state/leader-pool.json with TTL.
+  2. Each producer tick (300s):
+     - For each leader in pool, fetch their strategy wallets via
+       strategy_list({userIds: [...]}).
+     - For each wallet, fetch current positions via
+       discovery_get_trader_state(wallet, latest=true).
+     - Diff against last-tick snapshot in state/leader-positions/.
+     - For each NEW position detected: emit MIRROR signal.
+  3. Producer writes to state/recent-signals.json (race-window dedup
+     mirrors Bison v3.0.1 pattern). DSL handles all exits.
+
+REQUIRES USER-SCOPE AUTH TOKEN — service tokens cannot call
+strategy_list, discovery_get_trader_state, or discovery_get_trader_history
+which are the core data sources here.
+
+Producer NEVER closes positions. DSL is the only exit path.
+"""
+
+import hashlib
+import math
+import os
+import statistics
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import albatross_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+
+VERSION = "1.0.0"
+SCANNER_NAME = "albatross_signals"
+SIGNAL_TYPE = "ALBATROSS_ARENA_MIRROR"
+
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 5
+DEFAULT_POOL_SIZE = 5
+DEFAULT_REFRESH_HOURS = 4
+DEFAULT_MIN_WEEKS_TRADED = 3
+DEFAULT_MIN_WEEKLY_VOL_USD = 50000
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("ALBATROSS_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Leader pool refresh
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_arena_week(period_number=None):
+    """Pull qualified leaderboard for a specific week (or current if None)."""
+    params = {"period_type": "WEEK", "qualified": True, "limit": 50}
+    if period_number is not None:
+        params["period_number"] = period_number
+    raw = cfg.mcp_call("arena_leaderboard", **params)
+    if not raw or not raw.get("success", True):
+        return []
+    leaderboard = raw.get("data", {}).get("leaderboard", {})
+    return leaderboard.get("entries", [])
+
+
+def fetch_arena_month():
+    raw = cfg.mcp_call("arena_leaderboard", period_type="MONTH", qualified=True, limit=50)
+    if not raw or not raw.get("success", True):
+        return []
+    leaderboard = raw.get("data", {}).get("leaderboard", {})
+    return leaderboard.get("entries", [])
+
+
+def _get_current_week_number():
+    """Pull the current week number from a fresh arena_leaderboard call."""
+    raw = cfg.mcp_call("arena_leaderboard", period_type="WEEK", qualified=True, limit=1)
+    if not raw or not raw.get("success", True):
+        return None
+    leaderboard = raw.get("data", {}).get("leaderboard", {})
+    return leaderboard.get("periodNumber")
+
+
+def compute_conviction_pool(config):
+    """Pull 4 weekly + 1 monthly leaderboards, build composite scores."""
+    weights = config.get("convictionWeights", {})
+    w_monthly = float(weights.get("monthlyRoe", 0.3))
+    w_weekly_mean = float(weights.get("weeklyRoeMean", 0.7))
+    w_stdev_penalty = float(weights.get("weeklyRoeStdevPenalty", 0.5))
+    min_weeks_traded = int(config.get("minWeeksTraded", DEFAULT_MIN_WEEKS_TRADED))
+    min_weekly_vol = float(config.get("minWeeklyVolumeUsd", DEFAULT_MIN_WEEKLY_VOL_USD))
+    excluded_handles = {h.lower() for h in config.get("excludeXHandles", ["betashop"])}
+
+    current_week = _get_current_week_number()
+    if current_week is None:
+        cfg.log("could not resolve current week number — pool refresh aborted")
+        return []
+
+    # Pull current + last 3 weeks
+    week_entries = {}
+    for offset in range(4):
+        week_num = current_week - offset
+        if week_num <= 0:
+            continue
+        entries = fetch_arena_week(week_num)
+        for e in entries:
+            uid = e.get("senpiUserId")
+            if not uid:
+                continue
+            handle = (e.get("xHandle") or "").lower()
+            if handle in excluded_handles:
+                continue
+            vol = float(e.get("notionalVolume", 0))
+            if vol < min_weekly_vol:
+                continue
+            roe = float(e.get("roePct", 0))
+            week_entries.setdefault(uid, {
+                "senpiUserId": uid,
+                "username": e.get("senpiUserName"),
+                "xHandle": e.get("xHandle"),
+                "weekly_roe_by_week": {},
+                "totalPnl": float(e.get("totalPnl", 0)),
+                "currentBalance": float(e.get("currentBalance", 0)),
+            })
+            week_entries[uid]["weekly_roe_by_week"][str(week_num)] = roe
+
+    # Pull current month
+    monthly_entries = fetch_arena_month()
+    monthly_roe_by_uid = {
+        e.get("senpiUserId"): float(e.get("roePct", 0))
+        for e in monthly_entries
+        if e.get("senpiUserId")
+    }
+
+    # Compose
+    candidates = []
+    for uid, snap in week_entries.items():
+        weekly_roes = list(snap["weekly_roe_by_week"].values())
+        if len(weekly_roes) < min_weeks_traded:
+            continue
+        weekly_mean = statistics.mean(weekly_roes)
+        weekly_std = statistics.pstdev(weekly_roes) if len(weekly_roes) > 1 else 0
+        monthly_roe = monthly_roe_by_uid.get(uid, 0.0)
+        conviction = (
+            w_monthly * monthly_roe
+            + w_weekly_mean * weekly_mean
+            - w_stdev_penalty * weekly_std
+        )
+        if conviction <= 0:
+            continue
+        candidates.append({
+            **snap,
+            "weekly_roe": weekly_roes,
+            "weekly_mean_roe": round(weekly_mean, 3),
+            "weekly_stdev_roe": round(weekly_std, 3),
+            "monthly_roe": round(monthly_roe, 3),
+            "conviction_score": round(conviction, 3),
+            "weeks_traded": len(weekly_roes),
+        })
+
+    candidates.sort(key=lambda c: c["conviction_score"], reverse=True)
+    pool_size = int(config.get("leaderPoolSize", DEFAULT_POOL_SIZE))
+    return candidates[:pool_size]
+
+
+def get_leader_pool(config):
+    """Return cached pool if fresh, otherwise recompute."""
+    refresh_hours = float(config.get("leaderRefreshHours", DEFAULT_REFRESH_HOURS))
+    cached = cfg.load_leader_pool()
+    now = time.time()
+    if cached and (now - cached.get("refreshed_at", 0)) < refresh_hours * 3600:
+        return cached.get("leaders", [])
+    leaders = compute_conviction_pool(config)
+    cfg.save_leader_pool({"refreshed_at": now, "leaders": leaders})
+    return leaders
+
+
+# ═══════════════════════════════════════════════════════════════
+# Leader position diffing
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_leader_strategy_wallets(senpi_user_id):
+    """Resolve a senpiUserId → list of strategy wallet addresses."""
+    raw = cfg.mcp_call("strategy_list", userIds=[senpi_user_id], status=["ACTIVE"])
+    if not raw or not raw.get("success", True):
+        return []
+    data = raw.get("data", raw)
+    strategies = data.get("strategies", data) if isinstance(data, dict) else data
+    if not isinstance(strategies, list):
+        return []
+    return [
+        s.get("strategyWalletAddress")
+        for s in strategies
+        if s.get("strategyWalletAddress")
+    ]
+
+
+def fetch_leader_positions(wallets):
+    """Pull current positions across all of a leader's strategy wallets."""
+    if not wallets:
+        return []
+    raw = cfg.mcp_call(
+        "discovery_get_trader_state",
+        trader_addresses=wallets,
+        latest=True,
+    )
+    if not raw or not raw.get("success", True):
+        return []
+    data = raw.get("data", raw)
+    states = data.get("traders", data) if isinstance(data, dict) else data
+    if not isinstance(states, list):
+        return []
+    positions = []
+    for state in states:
+        for pos in state.get("openPositions", []) if isinstance(state, dict) else []:
+            coin = pos.get("coin") or pos.get("asset")
+            szi = float(pos.get("szi", 0))
+            if not coin or szi == 0:
+                continue
+            positions.append({
+                "wallet": state.get("traderAddress"),
+                "coin": coin,
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "size": abs(szi),
+                "entryPx": float(pos.get("entryPx", 0)),
+                "leverage": float(pos.get("leverage", {}).get("value", 1)) if isinstance(pos.get("leverage"), dict) else float(pos.get("leverage", 1)),
+            })
+    return positions
+
+
+def detect_new_positions(senpi_user_id, current_positions):
+    """Returns positions present in current but not in last snapshot."""
+    last_snapshot = cfg.load_leader_positions(senpi_user_id)
+    last_keys = {f"{p.get('coin')}:{p.get('direction')}" for p in last_snapshot}
+    new_positions = [
+        p for p in current_positions
+        if f"{p.get('coin')}:{p.get('direction')}" not in last_keys
+    ]
+    # Update snapshot regardless
+    cfg.save_leader_positions(senpi_user_id, current_positions)
+    return new_positions
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_mirror_signal(leader, new_pos, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = new_pos["coin"]
+    direction = new_pos["direction"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    dedup_key = f"{coin}:{direction}"
+    if cfg.was_recently_signaled(dedup_key):
+        return False
+
+    data_block = {
+        "leaderUsername": leader.get("username"),
+        "leaderXHandle": leader.get("xHandle"),
+        "leaderConvictionScore": leader.get("conviction_score"),
+        "leaderWeeksTraded": leader.get("weeks_traded"),
+        "leaderWeeklyRoeMean": leader.get("weekly_mean_roe"),
+        "leaderMonthlyRoe": leader.get("monthly_roe"),
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": direction,
+        "leaderEntryPrice": new_pos.get("entryPx"),
+        "leaderLeverage": new_pos.get("leverage"),
+        "reason": f"ALBATROSS_MIRROR {coin} {direction} from {leader.get('username')} (conviction {leader.get('conviction_score')})",
+        "heldAssets": held_assets,
+    }
+
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=direction,
+            score=min(float(leader.get("conviction_score", 0)) / 50.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        cfg.record_signal(dedup_key)
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_albatross_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_albatross_producer_version": VERSION})
+        return
+
+    # Refresh leader pool (cached for refresh_hours)
+    leaders = get_leader_pool(config)
+    if not leaders:
+        cfg.output({
+            "status": "ok",
+            "note": "no qualifying leaders (composite score positive, >=3 weeks traded)",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_albatross_producer_version": VERSION,
+        })
+        return
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed_signals = []
+    for leader in leaders:
+        senpi_user_id = leader.get("senpiUserId")
+        wallets = fetch_leader_strategy_wallets(senpi_user_id)
+        if not wallets:
+            continue
+        current_positions = fetch_leader_positions(wallets)
+        new_positions = detect_new_positions(senpi_user_id, current_positions)
+        for pos in new_positions:
+            if push_mirror_signal(leader, pos, margin_usd, leverage, held_assets):
+                pushed_signals.append({
+                    "from_leader": leader.get("username"),
+                    "coin": pos["coin"],
+                    "direction": pos["direction"],
+                    "conviction": leader.get("conviction_score"),
+                })
+
+    cfg.output({
+        "status": "ok",
+        "leader_pool_size": len(leaders),
+        "signals_pushed": len(pushed_signals),
+        "pushed": pushed_signals,
+        "top_leaders": [
+            {
+                "username": l.get("username"),
+                "xHandle": l.get("xHandle"),
+                "conviction_score": l.get("conviction_score"),
+                "weekly_mean_roe": l.get("weekly_mean_roe"),
+                "monthly_roe": l.get("monthly_roe"),
+                "weeks_traded": l.get("weeks_traded"),
+            }
+            for l in leaders
+        ],
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_albatross_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"albatross-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/albatross/scripts/albatross_config.py
+++ b/albatross/scripts/albatross_config.py
@@ -1,0 +1,235 @@
+"""ALBATROSS v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Multi-week Arena conviction tracker. Pulls the last 4 Arena weekly
+leaderboards + the current monthly leaderboard, computes a composite
+conviction score per trader, and mirrors trades from the top-N pool.
+
+Composite score = 0.3 × monthly_roe + 0.7 × mean(weekly_roe) − 0.5 × stdev(weekly_roe).
+
+Architecture: helpers-native producer + leader pool refreshed every
+4h (cached in state/leader-pool.json) + per-leader position snapshots
+diffed each tick to detect new trades. Race-window dedup mirrors the
+Bison v3.0.1 pattern.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "albatross-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "albatross-config.json"
+STATE_DIR = SKILL_DIR / "state"
+LEADER_POOL_PATH = STATE_DIR / "leader-pool.json"
+LEADER_POSITIONS_DIR = STATE_DIR / "leader-positions"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+LEADER_POSITIONS_DIR.mkdir(parents=True, exist_ok=True)
+
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Albatross requires a user-scoped "
+            "auth token (NOT a service token) — it calls strategy_list, "
+            "discovery_get_trader_state, and discovery_get_trader_history "
+            "which all gate on user identity. Set it on the runtime host "
+            "before starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("albatross_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def mcp_call(tool, **params):
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] albatross_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts]) for the operator's own wallet."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def record_signal(key):
+    """key is `<asset>:<direction>` so LONG and SHORT on same asset don't collide."""
+    if not key:
+        return
+    now = time.time()
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    signals = {k: v for k, v in _read_recent_signals().items() if v >= cutoff}
+    signals[key.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(key, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not key:
+        return False
+    last = _read_recent_signals().get(key.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def load_leader_pool():
+    if not LEADER_POOL_PATH.exists():
+        return None
+    try:
+        with open(LEADER_POOL_PATH) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def save_leader_pool(pool):
+    try:
+        atomic_write(LEADER_POOL_PATH, pool)
+    except OSError:
+        pass
+
+
+def load_leader_positions(senpi_user_id):
+    """Last-tick snapshot of a leader's positions, keyed by senpiUserId."""
+    path = LEADER_POSITIONS_DIR / f"{senpi_user_id}.json"
+    if not path.exists():
+        return []
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def save_leader_positions(senpi_user_id, positions):
+    path = LEADER_POSITIONS_DIR / f"{senpi_user_id}.json"
+    try:
+        atomic_write(path, positions)
+    except OSError:
+        pass
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[albatross-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/beaver/README.md
+++ b/beaver/README.md
@@ -1,0 +1,171 @@
+# 🦫 Beaver — BTC Trend Follower (SM-confirmed)
+
+Onboarding-tier strategy. Single asset (BTC). Long OR short based on the confluence of 4h trend structure + Senpi Smart-Money leaderboard direction. Wide DSL ladder so winning trends can ride.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+Beaver is the default first-trade strategy for new Senpi users. It answers one question — "is BTC trending?" — by looking at the 4h candle structure (higher-lows = bullish, lower-highs = bearish) and the Senpi Smart-Money leaderboard (do top traders agree?). If the 4h trend exists and Smart Money is positioned in the same direction with at least 60% concentration, Beaver opens a single conviction position and hands it to the DSL.
+
+There are NO funding-rate filters, NO multi-asset whitelist tuning, NO XYZ universe to manage. One asset, one direction gate, one exit mechanism. Designed to be operable by someone who just learned what a perp is.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Asset | BTC (single-asset) |
+| Tick interval | 300s (5 min) |
+| MIN_SCORE (producer) | 5 (out of ~9 max) |
+| LLM min_confidence | 7 |
+| Leverage | 5x default, max 5x |
+| Margin per trade | 25% of equity |
+| Max positions | 1 |
+| Max entries per day | 2 |
+| Per-asset cooldown | 240 min (4h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 20% |
+| SM tilt minimum | 60% |
+| SM strong-tilt threshold | 70% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: false) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+| Recent-signals dedup | 240s TTL |
+
+## DSL preset (wide, Bison-pattern)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 20% |
+| Phase 1 | retrace_threshold | 8 |
+| Phase 1 | consecutive_breaches | 1 |
+| Time cuts | hard_timeout | **DISABLED** |
+| Time cuts | weak_peak_cut | **DISABLED** |
+| Time cuts | dead_weight_cut | **DISABLED** |
+| Phase 2 | T0 | +10% / 0% lock |
+| Phase 2 | T1 | +20% / 25% lock |
+| Phase 2 | T2 | +30% / 40% lock |
+| Phase 2 | T3 | +50% / 60% lock |
+| Phase 2 | T4 | +75% / 75% lock |
+| Phase 2 | T5 | +100% / 85% lock (apex) |
+
+## Scanner pattern
+
+This strategy uses the **Single-asset trend follower (Kodiak family)** scanner pattern with a Smart-Money direction gate — see `senpi-trading-runtime/references/producer-patterns.md` for the canonical reference. Primary MCP calls: `market_get_asset_data` (BTC candles), `leaderboard_get_markets` (SM direction).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/beaver-producer.py | Long-lived daemon; emits BEAVER_BTC_TREND signals |
+| scripts/beaver_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/beaver-config.json | Operator-tunable defaults (wallet, asset, minScore, sizing) |
+
+## Install
+
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+The Python Producer SDK (`senpi_runtime_helpers`) ships inside the senpi-trading-runtime skill. Install it once per host:
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Beaver
+
+```bash
+mkdir -p /data/workspace/skills/beaver-strategy/{config,scripts,state,references}
+for f in scripts/beaver-producer.py scripts/beaver_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/beaver-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/beaver/$f" \
+    -o "/data/workspace/skills/beaver-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/beaver-strategy/config/beaver-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+This is the canonical source of truth — producer reads from here on every tick.
+
+### Step 4 — Required env vars
+
+```bash
+export BEAVER_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                              # required
+export BEAVER_DECISION_MODEL=<your-preferred-model>      # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/beaver-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/beaver-strategy/scripts/beaver-producer.py \
+  > /tmp/beaver-producer.log 2>&1 &
+disown
+```
+
+After first launch, manage the daemon via the `senpi-helpers` CLI: `senpi-helpers list`, `senpi-helpers health <name>`, `senpi-helpers restart <name>`.
+
+## Verification
+
+```bash
+sleep 320  # wait one full tick
+tail -3 /tmp/beaver-producer.log | jq '._beaver_producer_version, .note // null, .best.score // null'
+# Expected: _beaver_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no qualifying setup (4h trend + SM gate not aligned)"` — common; BTC isn't in a clean trend
+- `"signals_pushed": 1, "best": { "coin": "BTC", "direction": "LONG"|"SHORT", "score": 5-9 }` — entry signal fired
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+First skill in the onboarding-tier trio (Beaver = BTC, Heron = ETH, Hummingbird = HYPE). Single asset, simple 5-component scoring, Smart-Money direction gate, wide Bison-pattern Phase 2 ladder. Designed as the default "I'm new to Senpi, where do I start?" strategy.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/beaver/SKILL.md
+++ b/beaver/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: beaver-strategy
+description: >-
+  BEAVER v1.0.0 — Onboarding-tier BTC trend follower. Long OR short
+  based on the confluence of 4h trend structure + Senpi Smart-Money
+  leaderboard direction. Single asset (BTC), simple 5-component
+  scoring (max ~9), wide Bison-pattern DSL Phase 2 ladder so winning
+  trends can run multi-day. Designed for first-time Senpi users.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦫 BEAVER v1.0.0 — BTC Trend Follower (SM-confirmed)
+
+**Onboarding tier. BTC only. Long OR short.** When BTC is in a 4h trend AND Senpi's Smart-Money leaderboard agrees with that direction, Beaver opens a single conviction position and lets the DSL ratchet manage it.
+
+## Why this strategy exists
+
+Beaver is the **default first-trade strategy** for new Senpi users:
+
+- **One asset** — BTC. No multi-asset whitelist to tune, no XYZ universe to filter, no funding regime to interpret.
+- **One question** — "Is BTC trending?" Beaver answers by looking at the 4h candle structure (higher-lows = bullish, lower-highs = bearish).
+- **One direction gate** — "Does Smart Money agree?" Beaver pulls Senpi's leaderboard concentration and requires top-trader positioning to align with the trend before firing.
+- **One exit mechanism** — DSL. Phase 1 max_loss 20% floor + Phase 2 wide ratchet ladder. Time-cuts all disabled — winning trends ride.
+
+If both gates pass and the score clears the floor, Beaver emits ONE signal per qualifying setup. Max 2 entries per day. 4h cooldown per asset.
+
+## CRITICAL RULES
+
+### RULE 1: Producer enters. DSL exits. Producer NEVER closes.
+The producer has no `close_position` call site. All exits flow through the DSL Phase 1 max_loss / Phase 2 ratchet retrace. This is the same structural guarantee as Bison v3.0.1 and Wolverine v6.0.0.
+
+### RULE 2: SM direction gate is hard, not soft
+If `leaderboard_get_markets` returns NEUTRAL or returns a direction OPPOSITE to the 4h trend, the producer outputs `WAITING — no qualifying setup` and does nothing. There is no override.
+
+### RULE 3: Producer emits signals via push_signal(); runtime opens
+The runtime's LLM-gated `beaver_entry` action receives the signal, validates it against the schema, and opens via FEE_OPTIMIZED_LIMIT with `ensure_execution_as_taker: false` (ALO patience on entry). Exit orders use `ensure_execution_as_taker: true` so closes always happen.
+
+### RULE 4: Race-window dedup is mandatory
+The producer writes to `state/recent-signals.json` after every successful `push_signal()` and checks the cache BEFORE building a thesis. 240s TTL covers the gap between push_signal returning OK and the resulting position appearing in the next-tick `clearinghouseState`. This is the Bison v3.0.1 fix applied at construction-time.
+
+### RULE 5: Onboarding defaults — don't tune them aggressively
+The default config is:
+- `minScore: 5` (out of ~9 max)
+- `smTiltMinPct: 60`
+- `smStrongTiltPct: 70`
+- 25% margin / 5x leverage
+- 2 entries/day, 4h cooldown
+
+These are tuned for **new users learning the platform**, not for aggressive alpha extraction. Don't push minScore higher (it starves the strategy); don't push leverage higher than 5x (operator capital risk).
+
+## How Beaver scores a trade
+
+**Direction gate** (all required):
+1. 4h trend ≠ NEUTRAL (higher-lows ≥ 60% bullish OR lower-highs ≥ 60% bearish)
+2. SM direction agrees with 4h trend
+3. SM tilt ≥ smTiltMinPct (default 60%)
+
+**Score components** (max ~9):
+
+| Signal | Points |
+|---|---|
+| 4h trend aligned with direction | +3 |
+| 1h trend confirms 4h | +2 |
+| SM aligned (gate-confirmed) | +2 |
+| SM strongly tilted (≥ smStrongTiltPct) | +1 |
+| Volume rising (>10% lookback delta) | +1 |
+
+**Floor:** `minScore: 5`. Typical entry clears 5-7. Strong setups clear 7-8. Apex (rare) clears 9.
+
+## DSL preset (Bison-pattern wide)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 20% |
+| Phase 1 | retrace_threshold | 8% |
+| Phase 1 | consecutive_breaches | 1 |
+| Time cuts | hard_timeout | **DISABLED** |
+| Time cuts | weak_peak_cut | **DISABLED** |
+| Time cuts | dead_weight_cut | **DISABLED** |
+| Phase 2 | T0 | +10% / lock 0 |
+| Phase 2 | T1 | +20% / lock 25% |
+| Phase 2 | T2 | +30% / lock 40% |
+| Phase 2 | T3 | +50% / lock 60% |
+| Phase 2 | T4 | +75% / lock 75% |
+| Phase 2 | T5 | +100% / lock 85% (apex) |
+
+The T0 lock at 0% is the key shift — a +10% mover can retrace fully without locking, giving real trends room to develop. This is the same ladder that produced Bison's SOL SHORT +71.1% closed win.
+
+## Risk guardrails (`runtime.yaml` `risk.guard_rails`)
+
+| Gate | Setting | Why |
+|---|---|---|
+| max_entries_per_day | 2 | Onboarding: fewer-stronger |
+| per_asset_cooldown_minutes | 240 | 4h between BTC attempts |
+| daily_loss_limit_pct | 15 | Cap a bad day |
+| max_consecutive_losses | 3 | Halt on losing streak |
+| cooldown_minutes (post-loss) | 60 | Cool off after a stop |
+| drawdown_halt_pct | 25 | Catastrophic-floor circuit breaker |
+| drawdown_reset_on_day_rollover | false | No grace at midnight |
+
+## Hardcoded constants (not configurable)
+
+- `ASSET`: "BTC" (Heron/Hummingbird are separate skills with ETH/HYPE)
+- `MAX_LEVERAGE`: 5
+- `RECENT_SIGNAL_TTL_SEC`: 240
+
+## Hard rule for user-conversation Claude sessions
+
+User-conversation Claude sessions MUST NOT call:
+`create_position`, `close_position`, `edit_position`,
+`ratchet_stop_add`, `ratchet_stop_edit`, `ratchet_stop_delete`,
+`cancel_order`, `strategy_close`, `strategy_close_positions`.
+
+These tools are reserved for the **producer daemon** (entry path) and the **DSL ratchet engine** (exit path). User-conversation sessions are **read-only**.
+
+## Scanner pattern
+
+This strategy uses the **Single-asset trend follower (Kodiak family)** scanner pattern with an added Smart-Money direction gate — see `senpi-trading-runtime/references/producer-patterns.md` (Pattern 1) for the canonical reference. Primary MCP calls: `market_get_asset_data` (BTC candles), `leaderboard_get_markets` (SM direction).
+
+## Operator install
+
+See [README.md](README.md) for fresh-install + env-var setup.
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+First skill in the onboarding-tier trio (Beaver = BTC, Heron = ETH, Hummingbird = HYPE). Shares scaffold + DSL preset; differs only in the `asset` config field. Designed as the default "I'm new to Senpi, where do I start?" answer.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy from this skill, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.

--- a/beaver/config/beaver-config.json
+++ b/beaver/config/beaver-config.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "BEAVER v1.0.0 — BTC trend follower with Smart-Money direction gate. Onboarding-tier strategy: simple scoring (max ~9), single asset (BTC), SM-confirmed long OR short. Edit wallet/strategyId/chatId. Defaults are tuned for new users — fewer-stronger entries, wide DSL Phase 2 ladder so winners can ride trends.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "asset": "BTC",
+  "minScore": 5,
+  "smTiltMinPct": 60,
+  "smStrongTiltPct": 70
+}

--- a/beaver/references/skill-attribution.md
+++ b/beaver/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "beaver",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "beaver",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/beaver/runtime.yaml
+++ b/beaver/runtime.yaml
@@ -1,0 +1,201 @@
+name: beaver-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Beaver
+# v1.0.0" and lives in description + SKILL.md + _beaver_producer_version.
+version: 1.0.0
+description: >
+  BEAVER v1.0.0 — BTC trend follower with Smart-Money direction gate.
+
+  Onboarding-tier strategy. Single asset (BTC). Long OR short based on
+  the confluence of 4h trend structure + Senpi Smart-Money leaderboard
+  direction. Designed for first-time Senpi users who want a clean
+  "is BTC trending? hold a directional position" experience without
+  having to think about funding rates, SM concentration math, or
+  multi-asset whitelist tuning.
+
+  Architecture (helpers-native, mirrors Wolverine v6.0.0 / Bison v3.0.1):
+    - Producer (beaver-producer.py) ticks every 300s, scores a BTC
+      thesis with 5 components (max ~9), emits BEAVER_BTC_TREND signal
+      via SenpiClient.push_signal() when score >= 5.
+    - LLM gate is pass-through — producer applied every filter
+      (4h trend non-neutral, SM direction agreement, SM tilt >= 60%).
+    - risk.guard_rails ENFORCES max_entries_per_day=2,
+      per_asset_cooldown, daily_loss_limit, drawdown_halt.
+    - DSL exits via FEE_OPTIMIZED_LIMIT, Bison-pattern wide Phase 2
+      ladder (T0 lock 0 through T5 lock 85) so winning trends can
+      ride multi-day moves. Time-cuts all DISABLED.
+
+  Onboarding tuning:
+    - minScore 5 (easy-to-hit floor; conservative directional confluence)
+    - 2 entries/day cap (low frequency, beginner-friendly)
+    - 25% margin / 5x leverage default (modest sizing, room to grow)
+    - 4h per-asset cooldown
+    - 15% daily-loss limit, 20% drawdown-halt (catastrophic-floor protection)
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 2                # onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20                 # hard stop circuit breaker
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240       # 4h between BTC attempts
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: beaver_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        trend4hStrength: { type: number, required: false }
+        trend1h: { type: string, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: beaver_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${BEAVER_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix. Senpi runtime resolves provider routing.
+    scanners: [beaver_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # ALO patience on entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: beaver_signals
+    decision_prompt: |
+      You are Beaver's pass-through gate. Beaver is a simple BTC trend
+      follower with a Smart-Money direction gate. The producer already
+      applied every filter (4h trend non-neutral, SM direction agrees
+      with 4h trend, SM tilt >= 60%, minScore 5). Your job is to honor
+      the signal and convert it into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_beaver_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be "BTC" (Beaver is single-asset).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - heldAssets contains "BTC" (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND SM tilt >= 70% AND trend4hStrength >= 0.80
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 BTC LONG, 4h_bullish_83%, 1h_confirms, SM aligned 65% — trend confluence with SM agreement')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "BTC",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "BEAVER_BTC_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — Bison-pattern wide ladder) ────────────────────
+#
+# Time-cuts all DISABLED — let trends run on the 4h timescale.
+# Phase 1 max_loss 20% provides catastrophic floor.
+# Phase 2 ladder mirrors Bison v3.0.1 / Wolverine v6.0.0:
+#   T0 +10% / lock 0     — confirms working, no lock yet
+#   T1 +20% / lock 25%
+#   T2 +30% / lock 40%
+#   T3 +50% / lock 60%
+#   T4 +75% / lock 75%
+#   T5 +100% / lock 85%  — apex; multi-day winners ratchet here
+exit:
+  engine: dsl
+  interval_seconds: 60                              # 60s mirrors Bison v3.0.1 REDUCE_ONLY-spam mitigation
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false                                # DISABLED — single-asset trend pattern
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/beaver/scripts/beaver-producer.py
+++ b/beaver/scripts/beaver-producer.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+# Senpi BEAVER Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""BEAVER v1.0.0 — BTC trend follower with Smart-Money direction gate.
+
+Onboarding strategy. Single asset (BTC). Long OR short based on the
+confluence of 4h trend structure + Senpi Smart-Money leaderboard
+direction. Wide DSL Phase 2 ladder so winners can ride trends.
+
+Producer ticks every 300s (5 min). Each tick:
+  1. Pull BTC candles (1h + 4h) and SM market concentration.
+  2. Compute 4h trend (higher-lows / lower-highs structure).
+  3. Determine direction: 4h trend + SM agreement → LONG or SHORT.
+  4. Score 5 components, max ~9. minScore floor 5.
+  5. Push signal via senpi_runtime_helpers if score >= floor.
+
+The runtime's LLM-gated `beaver_entry` action opens the position via
+FEE_OPTIMIZED_LIMIT. DSL handles all exits (Phase 1 max_loss 20% /
+retrace 8, Phase 2 Bison-pattern wide ladder, time-cuts disabled).
+
+Producer NEVER closes positions. Producer NEVER reasons about exits.
+The DSL is the only exit path.
+"""
+
+import hashlib
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import beaver_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+
+VERSION = "1.0.0"
+SCANNER_NAME = "beaver_signals"
+SIGNAL_TYPE = "BEAVER_BTC_TREND"
+
+# Hardcoded — Beaver is BTC-only. Forks (Heron=ETH, Hummingbird=HYPE)
+# substitute the asset string and use the same scaffold.
+ASSET = "BTC"
+
+# Scoring constants — onboarding-tier simplicity. Max ~9 points.
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 5
+
+# Direction-confirmation thresholds (config-overridable)
+SM_TILT_MIN_PCT_DEFAULT = 60
+SM_STRONG_TILT_PCT_DEFAULT = 70
+
+# Onboarding floor — 5 points typically requires 4h trend + 1h
+# confirmation + SM aligned. Below that, no entry.
+MIN_SCORE_DEFAULT = 5
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("BEAVER_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical helpers
+# ═══════════════════════════════════════════════════════════════
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH.
+
+    Returns (label, strength_pct) where strength_pct is the fraction
+    of recent candles that confirmed the structure.
+    """
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [float(c.get("low", c.get("l", 0))) for c in candles[-lookback:]]
+    highs = [float(c.get("high", c.get("h", 0))) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def volume_trend(candles, lookback=6):
+    """% change in avg(recent 3) vs avg(prior 3) volume."""
+    if len(candles) < lookback:
+        return 0.0
+    vols = [float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles[-lookback:]]
+    half = lookback // 2
+    recent = sum(vols[-half:]) / half if half > 0 else 1
+    earlier = sum(vols[:half]) / half if half > 0 else 1
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_market_data(asset):
+    """Pull 1h + 4h candles for the asset."""
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    """Return (direction, tilt_pct) for SM concentration on this asset.
+
+    direction ∈ {"LONG", "SHORT", "NEUTRAL"}.
+    tilt_pct is the percent of top-trader long/short concentration,
+    e.g. 70 = "70% of top traders are positioned long here."
+    """
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct = 0.0
+    short_pct = 0.0
+    found = False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        direction = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if direction == "LONG":
+            long_pct = pct
+        elif direction == "SHORT":
+            short_pct = pct
+
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, entry_cfg):
+    """Score a BTC entry. Returns dict with direction + score, or None.
+
+    Direction logic:
+      1. 4h trend != NEUTRAL  (required)
+      2. SM direction agrees with 4h trend  (required)
+      3. SM tilt >= smTiltMinPct  (required, default 60)
+
+    Score components (max ~9):
+      4h trend aligned     +3
+      1h confirms 4h       +2
+      SM aligned           +2
+      SM strongly tilted   +1  (when smTilt >= smStrongTiltPct)
+      Volume rising        +1
+    """
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    candles_4h = data.get("data", {}).get("candles", {}).get("4h", [])
+    if len(candles_4h) < 6 or len(candles_1h) < 6:
+        return None
+
+    trend_4h, str_4h = trend_structure(candles_4h)
+    trend_1h, str_1h = trend_structure(candles_1h)
+    if trend_4h == "NEUTRAL":
+        return None
+
+    # SM gate
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_tilt_min = float(entry_cfg.get("smTiltMinPct", SM_TILT_MIN_PCT_DEFAULT))
+    sm_strong_pct = float(entry_cfg.get("smStrongTiltPct", SM_STRONG_TILT_PCT_DEFAULT))
+    if sm_dir not in ("LONG", "SHORT"):
+        return None
+    if sm_tilt < sm_tilt_min:
+        return None
+
+    # 4h trend direction and SM direction must agree
+    direction = "LONG" if trend_4h == "BULLISH" else "SHORT"
+    if sm_dir != direction:
+        return None
+
+    score = 0
+    reasons = []
+
+    # 4h trend aligned
+    score += 3
+    reasons.append(f"4h_{trend_4h.lower()}_{str_4h:.0%}")
+
+    # 1h confirms 4h
+    if (direction == "LONG" and trend_1h == "BULLISH") or (direction == "SHORT" and trend_1h == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirms_{trend_1h.lower()}")
+
+    # SM aligned
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+
+    # SM strongly tilted
+    if sm_tilt >= sm_strong_pct:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    # Volume rising
+    vol_pct = volume_trend(candles_1h)
+    if vol_pct > 10:
+        score += 1
+        reasons.append(f"vol_rising_{vol_pct:+.0f}%")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_4h": trend_4h,
+        "trend_4h_strength": str_4h,
+        "trend_1h": trend_1h,
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": sm_tilt,
+        "volume_trend_pct": vol_pct,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        print("ERROR: strategy wallet not resolved", file=sys.stderr)
+        return False
+
+    # On-chain held-asset dedup (defense in depth — runtime per_asset_cooldown is authoritative)
+    if thesis["coin"].upper() in {h.upper() for h in held_assets}:
+        return False
+
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "trend4h": thesis["trend_4h"],
+        "trend4hStrength": thesis["trend_4h_strength"],
+        "trend1h": thesis["trend_1h"],
+        "smDirection": thesis["sm_direction"],
+        "smTiltPct": thesis["sm_tilt_pct"],
+        "volumeTrendPct": thesis["volume_trend_pct"],
+        "heldAssets": held_assets,
+    }
+
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=thesis["coin"],
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),  # normalize 0..1 (max ~9)
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {thesis['coin']}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {thesis['coin']}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — single tick. Daemon owns the per-tick scanner_lock.
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    asset = config.get("asset", ASSET).upper()
+    entry_cfg = config
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({
+            "status": "error",
+            "reason": "no_wallet",
+            "_beaver_producer_version": VERSION,
+        })
+        return
+
+    # Account state + held positions
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    if account_value <= 0:
+        cfg.output({
+            "status": "ok",
+            "note": "no account value",
+            "_beaver_producer_version": VERSION,
+        })
+        return
+
+    # Already holding this asset → nothing to do; DSL manages exit.
+    if asset in {h.upper() for h in held_assets}:
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": f"RIDING {asset}. DSL manages exit.",
+            "held_assets": held_assets,
+            "elapsed_sec": round(elapsed, 2),
+            "_beaver_producer_version": VERSION,
+        })
+        return
+
+    # Race-window dedup BEFORE building the thesis (saves MCP cost)
+    if cfg.was_recently_signaled(asset):
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": f"DEDUP_SKIP {asset} pushed within {cfg.RECENT_SIGNAL_TTL_SEC}s",
+            "held_assets": held_assets,
+            "elapsed_sec": round(elapsed, 2),
+            "_beaver_producer_version": VERSION,
+        })
+        return
+
+    # Score the thesis
+    thesis = build_thesis(asset, entry_cfg)
+    if thesis is None:
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no qualifying setup (4h trend + SM gate not aligned)",
+            "elapsed_sec": round(elapsed, 2),
+            "_beaver_producer_version": VERSION,
+        })
+        return
+
+    min_score = int(entry_cfg.get("minScore", MIN_SCORE_DEFAULT))
+    if thesis["score"] < min_score:
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": f"score_low {thesis['score']}/{min_score}",
+            "direction": thesis["direction"],
+            "reasons": thesis["reasons"][:5],
+            "elapsed_sec": round(elapsed, 2),
+            "_beaver_producer_version": VERSION,
+        })
+        return
+
+    # Sizing — onboarding default: 25% of equity, 5x leverage.
+    margin_pct = float(config.get("marginPct", 0.25))
+    margin_usd = round(account_value * margin_pct, 2)
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+
+    pushed = push_signal(thesis, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(thesis["coin"])
+
+    elapsed = time.time() - run_start
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": thesis["coin"],
+            "direction": thesis["direction"],
+            "score": thesis["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": thesis["reasons"][:5],
+        },
+        "held_assets": held_assets,
+        "elapsed_sec": round(elapsed, 2),
+        "_beaver_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"beaver-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/beaver/scripts/beaver_config.py
+++ b/beaver/scripts/beaver_config.py
@@ -1,0 +1,220 @@
+"""BEAVER v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Onboarding-tier BTC trend follower with Smart-Money direction gate.
+Single asset (BTC), simple 5-component scoring, SM-confirmed long OR
+short. NOT a HYPE-style alpha hunter — designed for first-time Senpi
+users who want a clean "BTC trending? hold a directional position"
+experience.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder. Mirrors the Wolverine v6.0.0 / Bison
+v3.0.1 pattern (race-window dedup, atomic write, etc).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "beaver-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "beaver-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Beaver ticks every 300s; BTC ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Beaver's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("beaver_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] beaver_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[beaver-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/bobcat/README.md
+++ b/bobcat/README.md
@@ -1,0 +1,47 @@
+# 🐈 Bobcat — Big Tech Equity Perp Trend Follower
+
+NVDA / TSLA / AAPL / META / MSFT / GOOGL / AMZN / AMD / MU / INTC / TSM / ORCL as perpetuals on Hyperliquid XYZ. Same names retail knows from their brokerage account, except here with leverage and 23/5 hours.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Universe | NVDA, TSLA, AAPL, META, MSFT, GOOGL, AMZN, AMD, MU, INTC, TSM, ORCL (xyz:) |
+| Tick interval | 300s (5 min) |
+| MIN_SCORE | 5 (of ~9) |
+| Leverage | 5x default, max 5x |
+| Margin per trade | 20% of equity |
+| Slots | 3 |
+| Max entries per day | 4 |
+| Per-asset cooldown | 240 min (4h) |
+| DSL Phase 1 max_loss | 15% |
+| DSL Phase 2 | Bison-pattern wide ladder |
+| hard_timeout | 48h |
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/bobcat-strategy/{config,scripts,state,references}
+for f in scripts/bobcat-producer.py scripts/bobcat_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/bobcat-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/bobcat/$f" \
+    -o "/data/workspace/skills/bobcat-strategy/$f"
+done
+
+export BOBCAT_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export BOBCAT_DECISION_MODEL=<your-preferred-model>
+
+openclaw senpi runtime create --path /data/workspace/skills/bobcat-strategy/runtime.yaml
+
+nohup python3 -u /data/workspace/skills/bobcat-strategy/scripts/bobcat-producer.py \
+  > /tmp/bobcat-producer.log 2>&1 &
+disown
+```
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/bobcat/SKILL.md
+++ b/bobcat/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: bobcat-strategy
+description: >-
+  BOBCAT v1.0.0 — Big Tech equity perp trend follower on Hyperliquid
+  XYZ. Universe: NVDA, TSLA, AAPL, META, MSFT, GOOGL, AMZN, AMD, MU,
+  INTC, TSM, ORCL. LONG OR SHORT on 4h trend + Smart Money direction.
+  Standard DSL — Phase 1 15% max_loss, Phase 2 standard ladder,
+  hard_timeout 48h (equities have weekend pricing gaps).
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐈 BOBCAT v1.0.0 — Big Tech Trend Follower
+
+**Trade NVDA / TSLA / AAPL / META / MSFT / GOOGL / AMZN / AMD / MU / INTC / TSM / ORCL as perpetuals on Hyperliquid XYZ.** Same names retail already knows from brokerage accounts — except here they're perps with leverage and 23/5 trading hours.
+
+## Why this strategy exists
+
+Big tech is the most-traded equity sector. Hyperliquid XYZ surfaces these as perps with 23/5 trading hours (vs traditional cash-session-only). Bobcat captures directional moves with the same trend + Smart-Money confluence pattern as Beaver, but on the highest-liquidity XYZ equities instead of crypto majors.
+
+The XYZ pricing methodology means:
+- **Cash session** (9:30am - 4pm ET, M-F): oracle = spot index value
+- **Extended session** (Sun 6pm ET - Fri 5pm ET, with 5-6pm ET daily gaps): oracle = futures price discounted to implied spot via the 1-hour EMA discount rate
+- **Weekend gap** (Fri 5pm ET - Sun 6pm ET): no external pricing — internal oracle mechanism
+
+Bobcat's `hard_timeout: 48h` ensures positions don't camp through the full weekend gap — the post-Friday-close → pre-Sunday-reopen window is where internal-oracle drift can accumulate.
+
+## CRITICAL RULES
+
+### RULE 1: Producer enters. DSL exits.
+Phase 1 max_loss 15% + Phase 2 standard ladder + hard_timeout 48h own all exits.
+
+### RULE 2: hard_timeout 48h is intentional
+Equity perps have a weekly cycle (cash session opens Sunday 6pm ET). 48h cap ensures we don't hold through the full Fri-Sun gap where internal-oracle drift accumulates without external price discovery.
+
+### RULE 3: Universe is whitelisted, not auto-discovered
+Unlike Lemur (which auto-discovers IPOPs by funding signature), Bobcat uses a fixed 12-ticker whitelist. Operators add/remove via `universe` config. Default list is the 12 most-liquid US big-tech names on XYZ.
+
+## How Bobcat scores a trade
+
+**Gates** (all required):
+1. 4h trend non-neutral
+2. SM direction agrees with 4h trend
+3. SM tilt >= 55%
+
+**Score components** (max ~9):
+
+| Signal | Points |
+|---|---|
+| 4h trend aligned | +3 |
+| 1h trend confirms 4h | +2 |
+| SM aligned (gate-confirmed) | +2 |
+| SM strongly tilted (>= 70%) | +1 |
+
+## DSL preset (standard)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 15% |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | **48h** |
+| Time cuts | weak_peak_cut | DISABLED |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0-T5 | Bison-pattern wide ladder |
+
+## Risk guardrails
+
+| Gate | Setting |
+|---|---|
+| max_entries_per_day | 4 |
+| per_asset_cooldown_minutes | 240 (4h) |
+| Slots | 3 |
+
+## Operator install
+
+See [README.md](README.md).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+See `references/skill-attribution.md`.

--- a/bobcat/config/bobcat-config.json
+++ b/bobcat/config/bobcat-config.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "BOBCAT v1.0.0 — Big Tech equity perp trend follower on Hyperliquid XYZ. Universe: NVDA, TSLA, AAPL, META, MSFT, GOOGL, AMZN, AMD, MU, INTC, TSM, ORCL. LONG OR SHORT on 4h trend + Smart Money direction. Standard DSL — Phase 1 15% max_loss, Phase 2 standard ladder, hard_timeout 48h.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "universe": ["xyz:NVDA", "xyz:TSLA", "xyz:AAPL", "xyz:META", "xyz:MSFT", "xyz:GOOGL", "xyz:AMZN", "xyz:AMD", "xyz:MU", "xyz:INTC", "xyz:TSM", "xyz:ORCL"],
+  "minScore": 5,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "marginPct": 0.20,
+  "leverage": 5
+}

--- a/bobcat/references/skill-attribution.md
+++ b/bobcat/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "bobcat",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "bobcat",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/bobcat/runtime.yaml
+++ b/bobcat/runtime.yaml
@@ -1,0 +1,201 @@
+name: bobcat-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Bobcat
+# v1.0.0" and lives in description + SKILL.md + _bobcat_producer_version.
+version: 1.0.0
+description: >
+  BOBCAT v1.0.0 — Big Tech equity perp trend follower with Smart-Money direction gate.
+
+  Onboarding-tier strategy. Single asset (BTC). Long OR short based on
+  the confluence of 4h trend structure + Senpi Smart-Money leaderboard
+  direction. Designed for first-time Senpi users who want a clean
+  "is BTC trending? hold a directional position" experience without
+  having to think about funding rates, SM concentration math, or
+  multi-asset whitelist tuning.
+
+  Architecture (helpers-native, mirrors Wolverine v6.0.0 / Bison v3.0.1):
+    - Producer (bobcat-producer.py) ticks every 300s, scores a BTC
+      thesis with 5 components (max ~9), emits BOBCAT_BTC_TREND signal
+      via SenpiClient.push_signal() when score >= 5.
+    - LLM gate is pass-through — producer applied every filter
+      (4h trend non-neutral, SM direction agreement, SM tilt >= 60%).
+    - risk.guard_rails ENFORCES max_entries_per_day=2,
+      per_asset_cooldown, daily_loss_limit, drawdown_halt.
+    - DSL exits via FEE_OPTIMIZED_LIMIT, Bison-pattern wide Phase 2
+      ladder (T0 lock 0 through T5 lock 85) so winning trends can
+      ride multi-day moves. Time-cuts all DISABLED.
+
+  Onboarding tuning:
+    - minScore 5 (easy-to-hit floor; conservative directional confluence)
+    - 2 entries/day cap (low frequency, beginner-friendly)
+    - 25% margin / 5x leverage default (modest sizing, room to grow)
+    - 4h per-asset cooldown
+    - 15% daily-loss limit, 20% drawdown-halt (catastrophic-floor protection)
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 3
+  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 4                # onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20                 # hard stop circuit breaker
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240       # 4h between BTC attempts
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: bobcat_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        trend4hStrength: { type: number, required: false }
+        trend1h: { type: string, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: bobcat_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${BOBCAT_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix. Senpi runtime resolves provider routing.
+    scanners: [bobcat_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # ALO patience on entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: bobcat_signals
+    decision_prompt: |
+      You are Bobcat's pass-through gate. Bobcat is a simple BTC trend
+      follower with a Smart-Money direction gate. The producer already
+      applied every filter (4h trend non-neutral, SM direction agrees
+      with 4h trend, SM tilt >= 60%, minScore 5). Your job is to honor
+      the signal and convert it into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_bobcat_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be "BTC" (Bobcat is single-asset).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - heldAssets contains "BTC" (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND SM tilt >= 70% AND trend4hStrength >= 0.80
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 BTC LONG, 4h_bullish_83%, 1h_confirms, SM aligned 65% — trend confluence with SM agreement')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "BTC",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "BOBCAT_BTC_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — Bison-pattern wide ladder) ────────────────────
+#
+# Time-cuts all DISABLED — let trends run on the 4h timescale.
+# Phase 1 max_loss 20% provides catastrophic floor.
+# Phase 2 ladder mirrors Bison v3.0.1 / Wolverine v6.0.0:
+#   T0 +10% / lock 0     — confirms working, no lock yet
+#   T1 +20% / lock 25%
+#   T2 +30% / lock 40%
+#   T3 +50% / lock 60%
+#   T4 +75% / lock 75%
+#   T5 +100% / lock 85%  — apex; multi-day winners ratchet here
+exit:
+  engine: dsl
+  interval_seconds: 60                              # 60s mirrors Bison v3.0.1 REDUCE_ONLY-spam mitigation
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                                 # 48h cap — equities have weekend pricing gaps
+      interval_in_minutes: 2880
+    weak_peak_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/bobcat/scripts/bobcat-producer.py
+++ b/bobcat/scripts/bobcat-producer.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+# Senpi BOBCAT Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+"""BOBCAT v1.0.0 — Big Tech equity perp trend follower.
+
+Universe: NVDA, TSLA, AAPL, META, MSFT, GOOGL, AMZN, AMD, MU, INTC,
+TSM, ORCL on Hyperliquid XYZ. LONG OR SHORT on 4h trend + Smart Money
+direction. Standard DSL — Phase 1 15% max_loss, Phase 2 standard ladder.
+"""
+
+import hashlib
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import bobcat_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "bobcat_signals"
+SIGNAL_TYPE = "BOBCAT_BIGTECH"
+
+DEFAULT_UNIVERSE = [
+    "xyz:NVDA", "xyz:TSLA", "xyz:AAPL", "xyz:META", "xyz:MSFT",
+    "xyz:GOOGL", "xyz:AMZN", "xyz:AMD", "xyz:MU", "xyz:INTC",
+    "xyz:TSM", "xyz:ORCL",
+]
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 5
+DEFAULT_MIN_SCORE = 5
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("BOBCAT_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def trend_structure(candles, lookback=6):
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_f(c, "low", "l") for c in candles[-lookback:]]
+    highs = [_f(c, "high", "h") for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def build_thesis(asset, entry_cfg):
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    candles_4h = data.get("data", {}).get("candles", {}).get("4h", [])
+    if len(candles_4h) < 6 or len(candles_1h) < 6:
+        return None
+
+    t4, s4 = trend_structure(candles_4h)
+    t1, _ = trend_structure(candles_1h)
+    if t4 == "NEUTRAL":
+        return None
+
+    direction = "LONG" if t4 == "BULLISH" else "SHORT"
+
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(entry_cfg.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(entry_cfg.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    score = 3  # 4h trend (gate-confirmed)
+    reasons = [f"4h_{t4.lower()}_{s4:.0%}"]
+    if (direction == "LONG" and t1 == "BULLISH") or (direction == "SHORT" and t1 == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirms_{t1.lower()}")
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    return {
+        "coin": asset, "direction": direction, "score": score, "reasons": reasons,
+        "trend_4h": t4, "trend_4h_strength": s4, "trend_1h": t1,
+        "sm_direction": sm_dir, "sm_tilt_pct": sm_tilt,
+    }
+
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"], "leverage": leverage, "marginUsd": margin_usd,
+        "direction": thesis["direction"], "reasons": thesis["reasons"],
+        "trend4h": thesis["trend_4h"], "trend4hStrength": thesis["trend_4h_strength"],
+        "trend1h": thesis["trend_1h"],
+        "smDirection": thesis["sm_direction"], "smTiltPct": thesis["sm_tilt_pct"],
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS, scanner=SCANNER_NAME,
+            asset=coin, direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),
+            signal_type=SIGNAL_TYPE, data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    universe = config.get("universe", DEFAULT_UNIVERSE)
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_bobcat_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_bobcat_producer_version": VERSION})
+        return
+
+    candidates = []
+    for asset in universe:
+        if asset.upper() in held_set:
+            continue
+        if cfg.was_recently_signaled(asset):
+            continue
+        thesis = build_thesis(asset, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no big-tech setup with 4h trend + SM agreement",
+            "universe": universe,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_bobcat_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.20))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"], "direction": best["direction"],
+            "score": best["score"], "leverage": leverage, "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_bobcat_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"bobcat-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/bobcat/scripts/bobcat_config.py
+++ b/bobcat/scripts/bobcat_config.py
@@ -1,0 +1,220 @@
+"""BOBCAT v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Onboarding-tier BTC trend follower with Smart-Money direction gate.
+Single asset (BTC), simple 5-component scoring, SM-confirmed long OR
+short. NOT a HYPE-style alpha hunter — designed for first-time Senpi
+users who want a clean "BTC trending? hold a directional position"
+experience.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder. Mirrors the Wolverine v6.0.0 / Bison
+v3.0.1 pattern (race-window dedup, atomic write, etc).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "bobcat-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "bobcat-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Bobcat ticks every 300s; BTC ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Bobcat's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("bobcat_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] bobcat_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[bobcat-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/hawk/README.md
+++ b/hawk/README.md
@@ -1,0 +1,63 @@
+# 🦅 Hawk — 4h Breakout / Breakdown (SM-confirmed)
+
+LONG when price breaks above the 7-day high AND Smart Money is > 55% long. SHORT when price breaks below the 7-day low AND SM is > 55% short. Universe: BTC, ETH, SOL. **Tight DSL** — failed breakouts cut at 8% max_loss; winning ones lock fast at +5%.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Universe | BTC, ETH, SOL |
+| Tick interval | 300s (5 min) |
+| MIN_SCORE | 5 (out of ~9) |
+| Leverage | 5x default, max 5x |
+| Margin per trade | 20% of equity |
+| Max entries per day | 2 |
+| Per-asset cooldown | 240 min (4h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 20% |
+| SM tilt minimum | 55% |
+| Breakout lookback | 168h (7 days) |
+| DSL Phase 1 max_loss | **8%** (tight) |
+| DSL Phase 1 retrace | **5** (tight) |
+| DSL Phase 2 T0 | **+5% / lock 30%** (fast) |
+| hard_timeout | 24h |
+| weak_peak_cut | 60min / 3% min |
+
+## Install
+
+Same install pattern as Beaver — see [Beaver README](../beaver/README.md) for the runtime-plugin registration. Strategy-specific commands:
+
+```bash
+mkdir -p /data/workspace/skills/hawk-strategy/{config,scripts,state,references}
+for f in scripts/hawk-producer.py scripts/hawk_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/hawk-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/hawk/$f" \
+    -o "/data/workspace/skills/hawk-strategy/$f"
+done
+
+export HAWK_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export HAWK_DECISION_MODEL=<your-preferred-model>
+
+openclaw senpi runtime create --path /data/workspace/skills/hawk-strategy/runtime.yaml
+
+nohup python3 -u /data/workspace/skills/hawk-strategy/scripts/hawk-producer.py \
+  > /tmp/hawk-producer.log 2>&1 &
+disown
+```
+
+## Verification
+
+```bash
+sleep 320
+tail -3 /tmp/hawk-producer.log | jq '._hawk_producer_version, .note // null, .best // null'
+```
+
+Most ticks output `"WAITING — no breakout with SM agreement on universe"` — that's normal. Hawk is a low-frequency strategy by design.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/hawk/SKILL.md
+++ b/hawk/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: hawk-strategy
+description: >-
+  HAWK v1.0.0 — 4h Breakout Buyer / Breakdown Seller. LONG when price
+  breaks above the 7-day high AND Senpi Smart-Money is > 55% long.
+  SHORT when price breaks below the 7-day low AND SM is > 55% short.
+  Universe: BTC, ETH, SOL. Tight DSL — Phase 1 max_loss 8% (failed
+  breakouts get cut fast); Phase 2 locks fast at +5% (real breakouts
+  ratchet-protect immediately). hard_timeout 24h.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦅 HAWK v1.0.0 — 4h Breakout Buyer / Breakdown Seller
+
+**Breakouts on majors with Smart-Money confirmation.** When price breaks above the 7-day high AND top traders are net long, Hawk goes LONG. When price breaks below the 7-day low AND top traders are net short, Hawk goes SHORT. Failed breakouts get cut fast — tight Phase 1 max_loss 8%.
+
+## Why this strategy exists
+
+Most retail breakout strategies fail because they:
+1. Don't filter for trend agreement (catching a breakout in the wrong direction)
+2. Don't validate with Smart Money (catching a fake breakout into a stop-hunt)
+3. Don't cut failed breakouts fast (turning small chop losses into max-pain disasters)
+
+Hawk fixes all three:
+1. **4h trend must align** with breakout direction
+2. **Smart Money must be > 55% in the breakout direction** (gate, not score)
+3. **DSL Phase 1 max_loss 8%** — failed breakouts close before they hurt
+
+When a breakout DOES work, Phase 2 locks fast (+5% → 30% lock) so a winning breakout immediately starts ratchet-protecting profit.
+
+## CRITICAL RULES
+
+### RULE 1: Both gates required, no exceptions
+- Breakout magnitude > 0 (latest close above 7d high OR below 7d low)
+- SM tilt >= smTiltMinPct (default 55%) in the same direction as the breakout
+
+If either gate fails, producer outputs `WAITING — no breakout with SM agreement`. No partial passes.
+
+### RULE 2: Producer enters. DSL exits.
+No `close_position` call site in the producer. DSL Phase 1 + Phase 2 + hard_timeout 24h own all exits.
+
+### RULE 3: Tight DSL is intentional
+Hawk's DSL is designed for breakouts:
+- Phase 1 max_loss **8%** (vs Beaver's 20%) — failed breakouts must be cut fast
+- Phase 2 first tier **+5% / lock 30%** — real breakouts lock profit immediately
+- hard_timeout **24h** — if a breakout hasn't worked in 24h, it failed
+
+Don't widen this DSL — it would defeat the strategy.
+
+### RULE 4: Universe is BTC, ETH, SOL
+Operators can override via `universe` in config, but the default is the three most-liquid majors. Adding low-liquidity coins to the universe will cause noisy "breakouts" that don't follow through.
+
+## How Hawk scores a trade
+
+**Gates** (all required):
+1. Latest 1h close > max(7d closes) OR < min(7d closes)
+2. SM direction agrees with breakout direction
+3. SM tilt >= 55%
+
+**Score components** (max ~9):
+
+| Signal | Points |
+|---|---|
+| Breakout magnitude ≥ 1.0% | +3 |
+| Breakout magnitude 0.3-1.0% | +2 |
+| Breakout magnitude < 0.3% | +1 |
+| SM aligned (gate-confirmed) | +2 |
+| SM strongly tilted (>= 70%) | +1 |
+| 4h trend aligned with direction | +2 |
+| Volume ≥ 1.5× average | +1 |
+
+**Floor:** `minScore: 5`. Typical entry needs breakout magnitude moderate + SM aligned + 4h trend = 7.
+
+## DSL preset (tight Hawk profile)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | **8%** (tight) |
+| Phase 1 | retrace_threshold | **5** (tight) |
+| Phase 1 | consecutive_breaches | 1 |
+| Time cuts | hard_timeout | **24h** (kills failed breakouts) |
+| Time cuts | weak_peak_cut | **60min @ 3.0% min** (kills stale chop) |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 | +5% / lock 30% |
+| Phase 2 | T1 | +10% / lock 50% |
+| Phase 2 | T2 | +20% / lock 65% |
+| Phase 2 | T3 | +35% / lock 75% |
+| Phase 2 | T4 | +60% / lock 85% |
+
+## Scanner pattern
+
+This strategy uses the **Multi-asset whitelist scanner with breakout-detection scoring** — see `senpi-trading-runtime/references/producer-patterns.md` for the canonical reference. Primary MCP calls: `market_get_asset_data` (per-asset candles), `leaderboard_get_markets` (SM direction).
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+First in the technical-pattern pair (Hawk = breakouts, Salamander = pullbacks). Tight DSL distinguishes from the trend-follower trio (Beaver/Heron/Hummingbird) which use Bison-pattern wide ladders. Hawk's edge requires fast cutting of failed breakouts AND fast locking of winning ones.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.

--- a/hawk/config/hawk-config.json
+++ b/hawk/config/hawk-config.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "HAWK v1.0.0 — 4h breakout buyer/breakdown seller (BTC/ETH/SOL). LONG when price breaks above 7d high AND SM > 55% long. SHORT when price breaks below 7d low AND SM > 55% short. TIGHT DSL — failed breakouts get cut at 8% max_loss. Phase 2 locks fast (T0 +5% / lock 30%).",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "universe": ["BTC", "ETH", "SOL"],
+  "minScore": 5,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "breakoutLookbackHours": 168,
+  "marginPct": 0.20,
+  "leverage": 5
+}

--- a/hawk/references/skill-attribution.md
+++ b/hawk/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "hawk",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "hawk",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/hawk/runtime.yaml
+++ b/hawk/runtime.yaml
@@ -1,0 +1,200 @@
+name: hawk-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Hawk
+# v1.0.0" and lives in description + SKILL.md + _hawk_producer_version.
+version: 1.0.0
+description: >
+  HAWK v1.0.0 — 4h breakout buyer/breakdown seller with Smart-Money direction gate.
+
+  Onboarding-tier strategy. Single asset (BTC). Long OR short based on
+  the confluence of 4h trend structure + Senpi Smart-Money leaderboard
+  direction. Designed for first-time Senpi users who want a clean
+  "is BTC trending? hold a directional position" experience without
+  having to think about funding rates, SM concentration math, or
+  multi-asset whitelist tuning.
+
+  Architecture (helpers-native, mirrors Wolverine v6.0.0 / Bison v3.0.1):
+    - Producer (hawk-producer.py) ticks every 300s, scores a BTC
+      thesis with 5 components (max ~9), emits HAWK_BTC_TREND signal
+      via SenpiClient.push_signal() when score >= 5.
+    - LLM gate is pass-through — producer applied every filter
+      (4h trend non-neutral, SM direction agreement, SM tilt >= 60%).
+    - risk.guard_rails ENFORCES max_entries_per_day=2,
+      per_asset_cooldown, daily_loss_limit, drawdown_halt.
+    - DSL exits via FEE_OPTIMIZED_LIMIT, Bison-pattern wide Phase 2
+      ladder (T0 lock 0 through T5 lock 85) so winning trends can
+      ride multi-day moves. Time-cuts all DISABLED.
+
+  Onboarding tuning:
+    - minScore 5 (easy-to-hit floor; conservative directional confluence)
+    - 2 entries/day cap (low frequency, beginner-friendly)
+    - 25% margin / 5x leverage default (modest sizing, room to grow)
+    - 4h per-asset cooldown
+    - 15% daily-loss limit, 20% drawdown-halt (catastrophic-floor protection)
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 2                # onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20                 # hard stop circuit breaker
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240       # 4h between BTC attempts
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: hawk_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        trend4hStrength: { type: number, required: false }
+        trend1h: { type: string, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: hawk_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${HAWK_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix. Senpi runtime resolves provider routing.
+    scanners: [hawk_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # ALO patience on entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: hawk_signals
+    decision_prompt: |
+      You are Hawk's pass-through gate. Hawk is a simple BTC trend
+      follower with a Smart-Money direction gate. The producer already
+      applied every filter (4h trend non-neutral, SM direction agrees
+      with 4h trend, SM tilt >= 60%, minScore 5). Your job is to honor
+      the signal and convert it into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_hawk_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be "BTC" (Hawk is single-asset).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - heldAssets contains "BTC" (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND SM tilt >= 70% AND trend4hStrength >= 0.80
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 BTC LONG, 4h_bullish_83%, 1h_confirms, SM aligned 65% — trend confluence with SM agreement')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "BTC",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "HAWK_BTC_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — Bison-pattern wide ladder) ────────────────────
+#
+# Time-cuts all DISABLED — let trends run on the 4h timescale.
+# Phase 1 max_loss 20% provides catastrophic floor.
+# Phase 2 ladder mirrors Bison v3.0.1 / Wolverine v6.0.0:
+#   T0 +10% / lock 0     — confirms working, no lock yet
+#   T1 +20% / lock 25%
+#   T2 +30% / lock 40%
+#   T3 +50% / lock 60%
+#   T4 +75% / lock 75%
+#   T5 +100% / lock 85%  — apex; multi-day winners ratchet here
+exit:
+  engine: dsl
+  interval_seconds: 60                              # 60s mirrors Bison v3.0.1 REDUCE_ONLY-spam mitigation
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                                 # 24h cap — failed breakouts get cut
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: true                                 # 60min/3% — stale breakouts cut
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 8.0
+      retrace_threshold: 5
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,   lock_hw_pct: 30 }
+        - { trigger_pct: 10,  lock_hw_pct: 50 }
+        - { trigger_pct: 20,  lock_hw_pct: 65 }
+        - { trigger_pct: 35,  lock_hw_pct: 75 }
+        - { trigger_pct: 60,  lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/hawk/scripts/hawk-producer.py
+++ b/hawk/scripts/hawk-producer.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+# Senpi HAWK Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""HAWK v1.0.0 — 4h Breakout Buyer / Breakdown Seller.
+
+LONG when price breaks above the 7-day high AND Smart Money is
+> 55% long. SHORT when price breaks below the 7-day low AND Smart Money
+is > 55% short. Universe: BTC, ETH, SOL.
+
+Failed breakouts must be cut fast. DSL Phase 1 max_loss 8% with retrace
+threshold 5. Phase 2 locks fast at +5% (lock_hw_pct: 30%) so a real
+breakout that runs immediately starts banking ratchet-protected profit.
+
+Producer ticks every 300s. Scoring is 5 components, max ~9.
+"""
+
+import hashlib
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import hawk_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "hawk_signals"
+SIGNAL_TYPE = "HAWK_BREAKOUT"
+
+DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL"]
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 5
+DEFAULT_MIN_SCORE = 5
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+DEFAULT_BREAKOUT_LOOKBACK_HOURS = 168  # 7 days
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("HAWK_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Breakout detection
+# ═══════════════════════════════════════════════════════════════
+
+def _candle_field(c, primary, alt=None, default=0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def detect_breakout(candles_1h, lookback_hours):
+    """Returns (direction, magnitude_pct) when price breaks above lookback
+    high or below lookback low, else (None, 0).
+
+    Breakout direction:
+      "LONG" if latest close > max(prior closes within lookback)
+      "SHORT" if latest close < min(prior closes within lookback)
+      else None
+    """
+    if len(candles_1h) < lookback_hours + 1:
+        return None, 0.0
+    window = candles_1h[-lookback_hours:]
+    latest = candles_1h[-1]
+    latest_close = _candle_field(latest, "close", "c")
+    prior_closes = [_candle_field(c, "close", "c") for c in window[:-1]]
+    if not prior_closes or latest_close <= 0:
+        return None, 0.0
+    high = max(prior_closes)
+    low = min(prior_closes)
+    if latest_close > high:
+        return "LONG", ((latest_close - high) / high) * 100
+    if latest_close < low:
+        return "SHORT", ((low - latest_close) / low) * 100
+    return None, 0.0
+
+
+def trend_4h(candles_4h, lookback=6):
+    if len(candles_4h) < lookback:
+        return "NEUTRAL"
+    lows = [_candle_field(c, "low", "l") for c in candles_4h[-lookback:]]
+    highs = [_candle_field(c, "high", "h") for c in candles_4h[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH"
+    if lower_highs >= total * 0.6:
+        return "BEARISH"
+    return "NEUTRAL"
+
+
+def volume_ratio(candles_1h):
+    if len(candles_1h) < 10:
+        return 1.0
+    avg_prior = sum(_candle_field(c, "volume", "v") for c in candles_1h[-10:-1]) / 9
+    latest_vol = _candle_field(candles_1h[-1], "volume", "v")
+    if avg_prior <= 0:
+        return 1.0
+    return latest_vol / avg_prior
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct = 0.0
+    short_pct = 0.0
+    found = False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, entry_cfg):
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    candles_4h = data.get("data", {}).get("candles", {}).get("4h", [])
+    lookback = int(entry_cfg.get("breakoutLookbackHours", DEFAULT_BREAKOUT_LOOKBACK_HOURS))
+    if len(candles_1h) < lookback + 1 or len(candles_4h) < 6:
+        return None
+
+    direction, magnitude_pct = detect_breakout(candles_1h, lookback)
+    if direction is None:
+        return None
+
+    # SM gate must agree with breakout direction
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(entry_cfg.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(entry_cfg.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    # 4h trend must align with direction (no fighting trend on breakouts)
+    t4 = trend_4h(candles_4h)
+    trend_aligned = (
+        (direction == "LONG" and t4 == "BULLISH")
+        or (direction == "SHORT" and t4 == "BEARISH")
+    )
+
+    vol_x = volume_ratio(candles_1h)
+
+    score = 0
+    reasons = []
+
+    # Breakout magnitude (+3 / +2 / +1)
+    if magnitude_pct >= 1.0:
+        score += 3
+        reasons.append(f"breakout_strong_{magnitude_pct:+.2f}%")
+    elif magnitude_pct >= 0.3:
+        score += 2
+        reasons.append(f"breakout_{magnitude_pct:+.2f}%")
+    else:
+        score += 1
+        reasons.append(f"breakout_weak_{magnitude_pct:+.2f}%")
+
+    # SM aligned (gate-confirmed)
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+
+    # SM strongly tilted
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    # 4h trend aligned
+    if trend_aligned:
+        score += 2
+        reasons.append(f"4h_trend_aligned_{t4.lower()}")
+
+    # Volume confirmation (>=1.5x average)
+    if vol_x >= 1.5:
+        score += 1
+        reasons.append(f"vol_{vol_x:.1f}x")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "breakout_pct": round(magnitude_pct, 3),
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": sm_tilt,
+        "trend_4h": t4,
+        "volume_ratio": round(vol_x, 2),
+    }
+
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "breakoutPct": thesis["breakout_pct"],
+        "smDirection": thesis["sm_direction"],
+        "smTiltPct": thesis["sm_tilt_pct"],
+        "trend4h": thesis["trend_4h"],
+        "volumeRatio": thesis["volume_ratio"],
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    universe = [a.upper() for a in config.get("universe", DEFAULT_UNIVERSE)]
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_hawk_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_hawk_producer_version": VERSION})
+        return
+
+    candidates = []
+    for asset in universe:
+        if asset in held_set:
+            continue
+        if cfg.was_recently_signaled(asset):
+            continue
+        thesis = build_thesis(asset, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no breakout with SM agreement on universe",
+            "universe": universe,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_hawk_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.20))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_hawk_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"hawk-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/hawk/scripts/hawk_config.py
+++ b/hawk/scripts/hawk_config.py
@@ -1,0 +1,220 @@
+"""HAWK v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Onboarding-tier BTC trend follower with Smart-Money direction gate.
+Single asset (BTC), simple 5-component scoring, SM-confirmed long OR
+short. NOT a HYPE-style alpha hunter — designed for first-time Senpi
+users who want a clean "BTC trending? hold a directional position"
+experience.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder. Mirrors the Wolverine v6.0.0 / Bison
+v3.0.1 pattern (race-window dedup, atomic write, etc).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "hawk-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "hawk-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Hawk ticks every 300s; BTC ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Hawk's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("hawk_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] hawk_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[hawk-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/hedgehog/README.md
+++ b/hedgehog/README.md
@@ -1,0 +1,47 @@
+# 🦔 Hedgehog — Major Crypto Basket (BTC + ETH + SOL)
+
+Equal-weight crypto basket. Each asset independently evaluated — BTC long, ETH short, SOL idle if that's what the signals say. Per-position DSL so one going wrong doesn't drag the others.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Universe | BTC, ETH, SOL |
+| Tick interval | 300s |
+| MIN_SCORE | 5 |
+| Leverage | 5x |
+| Margin per leg | 10% of equity (up to 3 legs = 30% max committed) |
+| Slots | 3 |
+| Max entries per day | 4 |
+| Per-asset cooldown | 240 min |
+| DSL Phase 1 max_loss | 15% per position |
+| DSL Phase 2 | Bison-pattern wide ladder |
+| hard_timeout | 48h |
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/hedgehog-strategy/{config,scripts,state,references}
+for f in scripts/hedgehog-producer.py scripts/hedgehog_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/hedgehog-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/hedgehog/$f" \
+    -o "/data/workspace/skills/hedgehog-strategy/$f"
+done
+
+export HEDGEHOG_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export HEDGEHOG_DECISION_MODEL=<your-preferred-model>
+
+openclaw senpi runtime create --path /data/workspace/skills/hedgehog-strategy/runtime.yaml
+
+nohup python3 -u /data/workspace/skills/hedgehog-strategy/scripts/hedgehog-producer.py \
+  > /tmp/hedgehog-producer.log 2>&1 &
+disown
+```
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/hedgehog/SKILL.md
+++ b/hedgehog/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: hedgehog-strategy
+description: >-
+  HEDGEHOG v1.0.0 — Equal-weight major-crypto basket (BTC + ETH + SOL).
+  Each asset evaluated independently via SM-confirmed 4h trend (long OR
+  short). Up to 3 simultaneous positions, one per asset. Per-position
+  DSL — one position going wrong doesn't drag down the others. The
+  diversification answer for users who want "exposure to crypto majors"
+  without picking a single coin.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦔 HEDGEHOG v1.0.0 — Major Crypto Basket
+
+**BTC + ETH + SOL equal-weight, each independently directional.** When BTC is trending and SM agrees, long it. When ETH is trending the other way and SM agrees, short it. Three slots, three independent positions — no forced correlation.
+
+## Why this strategy exists
+
+Most basket strategies force the same direction across all assets ("long-only crypto basket"). Hedgehog doesn't. Each asset gets its own SM-confirmed 4h-trend signal. If BTC is bullish and ETH is bearish, Hedgehog holds BTC long AND ETH short simultaneously. The diversification benefit is real because the per-asset directions are independent.
+
+For new users, this answers: "I want exposure to crypto majors but don't want to pick one." Hedgehog handles the picking — you provide the capital.
+
+## How Hedgehog operates
+
+Same scoring as Beaver, applied per-asset:
+
+**Per-asset gates** (all required):
+1. 4h trend non-neutral
+2. SM direction agrees with 4h trend
+3. SM tilt >= 55%
+
+**Per-asset score** (max ~9):
+
+| Signal | Points |
+|---|---|
+| 4h trend aligned | +3 |
+| 1h trend confirms | +2 |
+| SM aligned | +2 |
+| SM strongly tilted (>= 70%) | +1 |
+
+Producer iterates universe each tick, takes the highest-scoring qualifying asset that isn't already held, emits ONE signal per tick (max). Over several ticks the basket fills up to 3 positions.
+
+## CRITICAL RULES
+
+### RULE 1: Producer enters. DSL exits. Per-position.
+Each position has its own DSL (managed by the runtime's position_tracker). One position hitting Phase 1 max_loss doesn't trigger exits on the others.
+
+### RULE 2: 10% margin per leg (not per total)
+With up to 3 simultaneous positions at 10% each, max committed margin = 30% of equity. The other 70% stays in reserve.
+
+### RULE 3: No forced rebalancing
+Hedgehog opens positions when the gates pass. It doesn't force-close to "rebalance" — DSL exits each position on its own merits.
+
+## DSL preset (standard)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 15% (per position) |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | 48h |
+| Phase 2 | Bison-pattern wide ladder | |
+
+## Risk guardrails
+
+| Gate | Setting |
+|---|---|
+| Slots | 3 |
+| max_entries_per_day | 4 |
+| per_asset_cooldown_minutes | 240 |
+| daily_loss_limit_pct | 15 |
+| drawdown_halt_pct | 20 |
+
+## Operator install
+
+See [README.md](README.md).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+See `references/skill-attribution.md`.

--- a/hedgehog/config/hedgehog-config.json
+++ b/hedgehog/config/hedgehog-config.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "HEDGEHOG v1.0.0 \u2014 Equal-weight major-crypto basket (BTC + ETH + SOL). Each asset evaluated independently via SM-confirmed 4h trend (long OR short). Up to 3 simultaneous positions. Per-position DSL managed by runtime.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "universe": [
+    "BTC",
+    "ETH",
+    "SOL"
+  ],
+  "minScore": 5,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "marginPct": 0.1,
+  "leverage": 5
+}

--- a/hedgehog/references/skill-attribution.md
+++ b/hedgehog/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "hedgehog",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "hedgehog",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/hedgehog/runtime.yaml
+++ b/hedgehog/runtime.yaml
@@ -1,0 +1,201 @@
+name: hedgehog-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Hedgehog
+# v1.0.0" and lives in description + SKILL.md + _hedgehog_producer_version.
+version: 1.0.0
+description: >
+  HEDGEHOG v1.0.0 — BTC + ETH + SOL equal-weight long-or-short basket with Smart-Money direction gate.
+
+  Onboarding-tier strategy. Single asset (BTC). Long OR short based on
+  the confluence of 4h trend structure + Senpi Smart-Money leaderboard
+  direction. Designed for first-time Senpi users who want a clean
+  "is BTC trending? hold a directional position" experience without
+  having to think about funding rates, SM concentration math, or
+  multi-asset whitelist tuning.
+
+  Architecture (helpers-native, mirrors Wolverine v6.0.0 / Bison v3.0.1):
+    - Producer (hedgehog-producer.py) ticks every 300s, scores a BTC
+      thesis with 5 components (max ~9), emits HEDGEHOG_BTC_TREND signal
+      via SenpiClient.push_signal() when score >= 5.
+    - LLM gate is pass-through — producer applied every filter
+      (4h trend non-neutral, SM direction agreement, SM tilt >= 60%).
+    - risk.guard_rails ENFORCES max_entries_per_day=2,
+      per_asset_cooldown, daily_loss_limit, drawdown_halt.
+    - DSL exits via FEE_OPTIMIZED_LIMIT, Bison-pattern wide Phase 2
+      ladder (T0 lock 0 through T5 lock 85) so winning trends can
+      ride multi-day moves. Time-cuts all DISABLED.
+
+  Onboarding tuning:
+    - minScore 5 (easy-to-hit floor; conservative directional confluence)
+    - 2 entries/day cap (low frequency, beginner-friendly)
+    - 25% margin / 5x leverage default (modest sizing, room to grow)
+    - 4h per-asset cooldown
+    - 15% daily-loss limit, 20% drawdown-halt (catastrophic-floor protection)
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 3
+  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 4                # onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20                 # hard stop circuit breaker
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240       # 4h between BTC attempts
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: hedgehog_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        trend4hStrength: { type: number, required: false }
+        trend1h: { type: string, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: hedgehog_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${HEDGEHOG_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix. Senpi runtime resolves provider routing.
+    scanners: [hedgehog_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # ALO patience on entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: hedgehog_signals
+    decision_prompt: |
+      You are Hedgehog's pass-through gate. Hedgehog is a simple BTC trend
+      follower with a Smart-Money direction gate. The producer already
+      applied every filter (4h trend non-neutral, SM direction agrees
+      with 4h trend, SM tilt >= 60%, minScore 5). Your job is to honor
+      the signal and convert it into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_hedgehog_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be "BTC" (Hedgehog is single-asset).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - heldAssets contains "BTC" (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND SM tilt >= 70% AND trend4hStrength >= 0.80
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 BTC LONG, 4h_bullish_83%, 1h_confirms, SM aligned 65% — trend confluence with SM agreement')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "BTC",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "HEDGEHOG_BTC_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — Bison-pattern wide ladder) ────────────────────
+#
+# Time-cuts all DISABLED — let trends run on the 4h timescale.
+# Phase 1 max_loss 20% provides catastrophic floor.
+# Phase 2 ladder mirrors Bison v3.0.1 / Wolverine v6.0.0:
+#   T0 +10% / lock 0     — confirms working, no lock yet
+#   T1 +20% / lock 25%
+#   T2 +30% / lock 40%
+#   T3 +50% / lock 60%
+#   T4 +75% / lock 75%
+#   T5 +100% / lock 85%  — apex; multi-day winners ratchet here
+exit:
+  engine: dsl
+  interval_seconds: 60                              # 60s mirrors Bison v3.0.1 REDUCE_ONLY-spam mitigation
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                                 # 48h cap — equities have weekend pricing gaps
+      interval_in_minutes: 2880
+    weak_peak_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/hedgehog/scripts/hedgehog-producer.py
+++ b/hedgehog/scripts/hedgehog-producer.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+# Senpi HEDGEHOG Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+"""HEDGEHOG v1.0.0 — BTC + ETH + SOL equal-weight long-or-short basket.
+
+Universe: NVDA, TSLA, AAPL, META, MSFT, GOOGL, AMZN, AMD, MU, INTC,
+TSM, ORCL on Hyperliquid XYZ. LONG OR SHORT on 4h trend + Smart Money
+direction. Standard DSL — Phase 1 15% max_loss, Phase 2 standard ladder.
+"""
+
+import hashlib
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import hedgehog_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "hedgehog_signals"
+SIGNAL_TYPE = "HEDGEHOG_BIGTECH"
+
+DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL"]
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 5
+DEFAULT_MIN_SCORE = 5
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("HEDGEHOG_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def trend_structure(candles, lookback=6):
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_f(c, "low", "l") for c in candles[-lookback:]]
+    highs = [_f(c, "high", "h") for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def build_thesis(asset, entry_cfg):
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    candles_4h = data.get("data", {}).get("candles", {}).get("4h", [])
+    if len(candles_4h) < 6 or len(candles_1h) < 6:
+        return None
+
+    t4, s4 = trend_structure(candles_4h)
+    t1, _ = trend_structure(candles_1h)
+    if t4 == "NEUTRAL":
+        return None
+
+    direction = "LONG" if t4 == "BULLISH" else "SHORT"
+
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(entry_cfg.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(entry_cfg.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    score = 3  # 4h trend (gate-confirmed)
+    reasons = [f"4h_{t4.lower()}_{s4:.0%}"]
+    if (direction == "LONG" and t1 == "BULLISH") or (direction == "SHORT" and t1 == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirms_{t1.lower()}")
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    return {
+        "coin": asset, "direction": direction, "score": score, "reasons": reasons,
+        "trend_4h": t4, "trend_4h_strength": s4, "trend_1h": t1,
+        "sm_direction": sm_dir, "sm_tilt_pct": sm_tilt,
+    }
+
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"], "leverage": leverage, "marginUsd": margin_usd,
+        "direction": thesis["direction"], "reasons": thesis["reasons"],
+        "trend4h": thesis["trend_4h"], "trend4hStrength": thesis["trend_4h_strength"],
+        "trend1h": thesis["trend_1h"],
+        "smDirection": thesis["sm_direction"], "smTiltPct": thesis["sm_tilt_pct"],
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS, scanner=SCANNER_NAME,
+            asset=coin, direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),
+            signal_type=SIGNAL_TYPE, data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    universe = config.get("universe", DEFAULT_UNIVERSE)
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_hedgehog_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_hedgehog_producer_version": VERSION})
+        return
+
+    candidates = []
+    for asset in universe:
+        if asset.upper() in held_set:
+            continue
+        if cfg.was_recently_signaled(asset):
+            continue
+        thesis = build_thesis(asset, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no big-tech setup with 4h trend + SM agreement",
+            "universe": universe,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_hedgehog_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.20))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"], "direction": best["direction"],
+            "score": best["score"], "leverage": leverage, "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_hedgehog_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"hedgehog-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/hedgehog/scripts/hedgehog_config.py
+++ b/hedgehog/scripts/hedgehog_config.py
@@ -1,0 +1,220 @@
+"""HEDGEHOG v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Onboarding-tier BTC trend follower with Smart-Money direction gate.
+Single asset (BTC), simple 5-component scoring, SM-confirmed long OR
+short. NOT a HYPE-style alpha hunter — designed for first-time Senpi
+users who want a clean "BTC trending? hold a directional position"
+experience.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder. Mirrors the Wolverine v6.0.0 / Bison
+v3.0.1 pattern (race-window dedup, atomic write, etc).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "hedgehog-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "hedgehog-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Hedgehog ticks every 300s; BTC ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Hedgehog's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("hedgehog_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] hedgehog_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[hedgehog-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/heron/README.md
+++ b/heron/README.md
@@ -1,0 +1,171 @@
+# 🐦 Heron — ETH Trend Follower (SM-confirmed)
+
+Onboarding-tier strategy. Single asset (ETH). Long OR short based on the confluence of 4h trend structure + Senpi Smart-Money leaderboard direction. Wide DSL ladder so winning trends can ride.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+Heron is the default first-trade strategy for new Senpi users. It answers one question — "is ETH trending?" — by looking at the 4h candle structure (higher-lows = bullish, lower-highs = bearish) and the Senpi Smart-Money leaderboard (do top traders agree?). If the 4h trend exists and Smart Money is positioned in the same direction with at least 60% concentration, Heron opens a single conviction position and hands it to the DSL.
+
+There are NO funding-rate filters, NO multi-asset whitelist tuning, NO XYZ universe to manage. One asset, one direction gate, one exit mechanism. Designed to be operable by someone who just learned what a perp is.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Asset | ETH (single-asset) |
+| Tick interval | 300s (5 min) |
+| MIN_SCORE (producer) | 5 (out of ~9 max) |
+| LLM min_confidence | 7 |
+| Leverage | 5x default, max 5x |
+| Margin per trade | 25% of equity |
+| Max positions | 1 |
+| Max entries per day | 2 |
+| Per-asset cooldown | 240 min (4h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 20% |
+| SM tilt minimum | 60% |
+| SM strong-tilt threshold | 70% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: false) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+| Recent-signals dedup | 240s TTL |
+
+## DSL preset (wide, Bison-pattern)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 20% |
+| Phase 1 | retrace_threshold | 8 |
+| Phase 1 | consecutive_breaches | 1 |
+| Time cuts | hard_timeout | **DISABLED** |
+| Time cuts | weak_peak_cut | **DISABLED** |
+| Time cuts | dead_weight_cut | **DISABLED** |
+| Phase 2 | T0 | +10% / 0% lock |
+| Phase 2 | T1 | +20% / 25% lock |
+| Phase 2 | T2 | +30% / 40% lock |
+| Phase 2 | T3 | +50% / 60% lock |
+| Phase 2 | T4 | +75% / 75% lock |
+| Phase 2 | T5 | +100% / 85% lock (apex) |
+
+## Scanner pattern
+
+This strategy uses the **Single-asset trend follower (Kodiak family)** scanner pattern with a Smart-Money direction gate — see `senpi-trading-runtime/references/producer-patterns.md` for the canonical reference. Primary MCP calls: `market_get_asset_data` (ETH candles), `leaderboard_get_markets` (SM direction).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/heron-producer.py | Long-lived daemon; emits HERON_ETH_TREND signals |
+| scripts/heron_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/heron-config.json | Operator-tunable defaults (wallet, asset, minScore, sizing) |
+
+## Install
+
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+The Python Producer SDK (`senpi_runtime_helpers`) ships inside the senpi-trading-runtime skill. Install it once per host:
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Heron
+
+```bash
+mkdir -p /data/workspace/skills/heron-strategy/{config,scripts,state,references}
+for f in scripts/heron-producer.py scripts/heron_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/heron-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/heron/$f" \
+    -o "/data/workspace/skills/heron-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/heron-strategy/config/heron-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+This is the canonical source of truth — producer reads from here on every tick.
+
+### Step 4 — Required env vars
+
+```bash
+export HERON_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                              # required
+export HERON_DECISION_MODEL=<your-preferred-model>      # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/heron-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/heron-strategy/scripts/heron-producer.py \
+  > /tmp/heron-producer.log 2>&1 &
+disown
+```
+
+After first launch, manage the daemon via the `senpi-helpers` CLI: `senpi-helpers list`, `senpi-helpers health <name>`, `senpi-helpers restart <name>`.
+
+## Verification
+
+```bash
+sleep 320  # wait one full tick
+tail -3 /tmp/heron-producer.log | jq '._heron_producer_version, .note // null, .best.score // null'
+# Expected: _heron_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no qualifying setup (4h trend + SM gate not aligned)"` — common; ETH isn't in a clean trend
+- `"signals_pushed": 1, "best": { "coin": "ETH", "direction": "LONG"|"SHORT", "score": 5-9 }` — entry signal fired
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+First skill in the onboarding-tier trio (Heron = ETH, Heron = ETH, Hummingbird = HYPE). Single asset, simple 5-component scoring, Smart-Money direction gate, wide Bison-pattern Phase 2 ladder. Designed as the default "I'm new to Senpi, where do I start?" strategy.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/heron/SKILL.md
+++ b/heron/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: heron-strategy
+description: >-
+  HERON v1.0.0 — Onboarding-tier ETH trend follower. Long OR short
+  based on the confluence of 4h trend structure + Senpi Smart-Money
+  leaderboard direction. Single asset (ETH), simple 5-component
+  scoring (max ~9), wide Bison-pattern DSL Phase 2 ladder so winning
+  trends can run multi-day. Designed for first-time Senpi users.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐦 HERON v1.0.0 — ETH Trend Follower (SM-confirmed)
+
+**Onboarding tier. ETH only. Long OR short.** When ETH is in a 4h trend AND Senpi's Smart-Money leaderboard agrees with that direction, Heron opens a single conviction position and lets the DSL ratchet manage it.
+
+## Why this strategy exists
+
+Heron is the **default first-trade strategy** for new Senpi users:
+
+- **One asset** — ETH. No multi-asset whitelist to tune, no XYZ universe to filter, no funding regime to interpret.
+- **One question** — "Is ETH trending?" Heron answers by looking at the 4h candle structure (higher-lows = bullish, lower-highs = bearish).
+- **One direction gate** — "Does Smart Money agree?" Heron pulls Senpi's leaderboard concentration and requires top-trader positioning to align with the trend before firing.
+- **One exit mechanism** — DSL. Phase 1 max_loss 20% floor + Phase 2 wide ratchet ladder. Time-cuts all disabled — winning trends ride.
+
+If both gates pass and the score clears the floor, Heron emits ONE signal per qualifying setup. Max 2 entries per day. 4h cooldown per asset.
+
+## CRITICAL RULES
+
+### RULE 1: Producer enters. DSL exits. Producer NEVER closes.
+The producer has no `close_position` call site. All exits flow through the DSL Phase 1 max_loss / Phase 2 ratchet retrace. This is the same structural guarantee as Bison v3.0.1 and Wolverine v6.0.0.
+
+### RULE 2: SM direction gate is hard, not soft
+If `leaderboard_get_markets` returns NEUTRAL or returns a direction OPPOSITE to the 4h trend, the producer outputs `WAITING — no qualifying setup` and does nothing. There is no override.
+
+### RULE 3: Producer emits signals via push_signal(); runtime opens
+The runtime's LLM-gated `heron_entry` action receives the signal, validates it against the schema, and opens via FEE_OPTIMIZED_LIMIT with `ensure_execution_as_taker: false` (ALO patience on entry). Exit orders use `ensure_execution_as_taker: true` so closes always happen.
+
+### RULE 4: Race-window dedup is mandatory
+The producer writes to `state/recent-signals.json` after every successful `push_signal()` and checks the cache BEFORE building a thesis. 240s TTL covers the gap between push_signal returning OK and the resulting position appearing in the next-tick `clearinghouseState`. This is the Bison v3.0.1 fix applied at construction-time.
+
+### RULE 5: Onboarding defaults — don't tune them aggressively
+The default config is:
+- `minScore: 5` (out of ~9 max)
+- `smTiltMinPct: 60`
+- `smStrongTiltPct: 70`
+- 25% margin / 5x leverage
+- 2 entries/day, 4h cooldown
+
+These are tuned for **new users learning the platform**, not for aggressive alpha extraction. Don't push minScore higher (it starves the strategy); don't push leverage higher than 5x (operator capital risk).
+
+## How Heron scores a trade
+
+**Direction gate** (all required):
+1. 4h trend ≠ NEUTRAL (higher-lows ≥ 60% bullish OR lower-highs ≥ 60% bearish)
+2. SM direction agrees with 4h trend
+3. SM tilt ≥ smTiltMinPct (default 60%)
+
+**Score components** (max ~9):
+
+| Signal | Points |
+|---|---|
+| 4h trend aligned with direction | +3 |
+| 1h trend confirms 4h | +2 |
+| SM aligned (gate-confirmed) | +2 |
+| SM strongly tilted (≥ smStrongTiltPct) | +1 |
+| Volume rising (>10% lookback delta) | +1 |
+
+**Floor:** `minScore: 5`. Typical entry clears 5-7. Strong setups clear 7-8. Apex (rare) clears 9.
+
+## DSL preset (Bison-pattern wide)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 20% |
+| Phase 1 | retrace_threshold | 8% |
+| Phase 1 | consecutive_breaches | 1 |
+| Time cuts | hard_timeout | **DISABLED** |
+| Time cuts | weak_peak_cut | **DISABLED** |
+| Time cuts | dead_weight_cut | **DISABLED** |
+| Phase 2 | T0 | +10% / lock 0 |
+| Phase 2 | T1 | +20% / lock 25% |
+| Phase 2 | T2 | +30% / lock 40% |
+| Phase 2 | T3 | +50% / lock 60% |
+| Phase 2 | T4 | +75% / lock 75% |
+| Phase 2 | T5 | +100% / lock 85% (apex) |
+
+The T0 lock at 0% is the key shift — a +10% mover can retrace fully without locking, giving real trends room to develop. This is the same ladder that produced Bison's SOL SHORT +71.1% closed win.
+
+## Risk guardrails (`runtime.yaml` `risk.guard_rails`)
+
+| Gate | Setting | Why |
+|---|---|---|
+| max_entries_per_day | 2 | Onboarding: fewer-stronger |
+| per_asset_cooldown_minutes | 240 | 4h between ETH attempts |
+| daily_loss_limit_pct | 15 | Cap a bad day |
+| max_consecutive_losses | 3 | Halt on losing streak |
+| cooldown_minutes (post-loss) | 60 | Cool off after a stop |
+| drawdown_halt_pct | 25 | Catastrophic-floor circuit breaker |
+| drawdown_reset_on_day_rollover | false | No grace at midnight |
+
+## Hardcoded constants (not configurable)
+
+- `ASSET`: "ETH" (Heron/Hummingbird are separate skills with ETH/HYPE)
+- `MAX_LEVERAGE`: 5
+- `RECENT_SIGNAL_TTL_SEC`: 240
+
+## Hard rule for user-conversation Claude sessions
+
+User-conversation Claude sessions MUST NOT call:
+`create_position`, `close_position`, `edit_position`,
+`ratchet_stop_add`, `ratchet_stop_edit`, `ratchet_stop_delete`,
+`cancel_order`, `strategy_close`, `strategy_close_positions`.
+
+These tools are reserved for the **producer daemon** (entry path) and the **DSL ratchet engine** (exit path). User-conversation sessions are **read-only**.
+
+## Scanner pattern
+
+This strategy uses the **Single-asset trend follower (Kodiak family)** scanner pattern with an added Smart-Money direction gate — see `senpi-trading-runtime/references/producer-patterns.md` (Pattern 1) for the canonical reference. Primary MCP calls: `market_get_asset_data` (ETH candles), `leaderboard_get_markets` (SM direction).
+
+## Operator install
+
+See [README.md](README.md) for fresh-install + env-var setup.
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+First skill in the onboarding-tier trio (Heron = ETH, Heron = ETH, Hummingbird = HYPE). Shares scaffold + DSL preset; differs only in the `asset` config field. Designed as the default "I'm new to Senpi, where do I start?" answer.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy from this skill, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.

--- a/heron/config/heron-config.json
+++ b/heron/config/heron-config.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "HERON v1.0.0 — ETH trend follower with Smart-Money direction gate. Onboarding-tier strategy: simple scoring (max ~9), single asset (ETH), SM-confirmed long OR short. Edit wallet/strategyId/chatId. Defaults are tuned for new users — fewer-stronger entries, wide DSL Phase 2 ladder so winners can ride trends.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "asset": "ETH",
+  "minScore": 5,
+  "smTiltMinPct": 60,
+  "smStrongTiltPct": 70
+}

--- a/heron/references/skill-attribution.md
+++ b/heron/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "heron",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "heron",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/heron/runtime.yaml
+++ b/heron/runtime.yaml
@@ -1,0 +1,201 @@
+name: heron-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Heron
+# v1.0.0" and lives in description + SKILL.md + _heron_producer_version.
+version: 1.0.0
+description: >
+  HERON v1.0.0 — ETH trend follower with Smart-Money direction gate.
+
+  Onboarding-tier strategy. Single asset (ETH). Long OR short based on
+  the confluence of 4h trend structure + Senpi Smart-Money leaderboard
+  direction. Designed for first-time Senpi users who want a clean
+  "is ETH trending? hold a directional position" experience without
+  having to think about funding rates, SM concentration math, or
+  multi-asset whitelist tuning.
+
+  Architecture (helpers-native, mirrors Wolverine v6.0.0 / Bison v3.0.1):
+    - Producer (heron-producer.py) ticks every 300s, scores a ETH
+      thesis with 5 components (max ~9), emits HERON_ETH_TREND signal
+      via SenpiClient.push_signal() when score >= 5.
+    - LLM gate is pass-through — producer applied every filter
+      (4h trend non-neutral, SM direction agreement, SM tilt >= 60%).
+    - risk.guard_rails ENFORCES max_entries_per_day=2,
+      per_asset_cooldown, daily_loss_limit, drawdown_halt.
+    - DSL exits via FEE_OPTIMIZED_LIMIT, Bison-pattern wide Phase 2
+      ladder (T0 lock 0 through T5 lock 85) so winning trends can
+      ride multi-day moves. Time-cuts all DISABLED.
+
+  Onboarding tuning:
+    - minScore 5 (easy-to-hit floor; conservative directional confluence)
+    - 2 entries/day cap (low frequency, beginner-friendly)
+    - 25% margin / 5x leverage default (modest sizing, room to grow)
+    - 4h per-asset cooldown
+    - 15% daily-loss limit, 20% drawdown-halt (catastrophic-floor protection)
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 2                # onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20                 # hard stop circuit breaker
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240       # 4h between ETH attempts
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: heron_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        trend4hStrength: { type: number, required: false }
+        trend1h: { type: string, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: heron_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${HERON_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix. Senpi runtime resolves provider routing.
+    scanners: [heron_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # ALO patience on entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: heron_signals
+    decision_prompt: |
+      You are Heron's pass-through gate. Heron is a simple ETH trend
+      follower with a Smart-Money direction gate. The producer already
+      applied every filter (4h trend non-neutral, SM direction agrees
+      with 4h trend, SM tilt >= 60%, minScore 5). Your job is to honor
+      the signal and convert it into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_heron_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be "ETH" (Heron is single-asset).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - heldAssets contains "ETH" (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND SM tilt >= 70% AND trend4hStrength >= 0.80
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 ETH LONG, 4h_bullish_83%, 1h_confirms, SM aligned 65% — trend confluence with SM agreement')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "ETH",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "HERON_ETH_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — Bison-pattern wide ladder) ────────────────────
+#
+# Time-cuts all DISABLED — let trends run on the 4h timescale.
+# Phase 1 max_loss 20% provides catastrophic floor.
+# Phase 2 ladder mirrors Bison v3.0.1 / Wolverine v6.0.0:
+#   T0 +10% / lock 0     — confirms working, no lock yet
+#   T1 +20% / lock 25%
+#   T2 +30% / lock 40%
+#   T3 +50% / lock 60%
+#   T4 +75% / lock 75%
+#   T5 +100% / lock 85%  — apex; multi-day winners ratchet here
+exit:
+  engine: dsl
+  interval_seconds: 60                              # 60s mirrors Bison v3.0.1 REDUCE_ONLY-spam mitigation
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false                                # DISABLED — single-asset trend pattern
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/heron/scripts/heron-producer.py
+++ b/heron/scripts/heron-producer.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+# Senpi HERON Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""HERON v1.0.0 — ETH trend follower with Smart-Money direction gate.
+
+Onboarding strategy. Single asset (ETH). Long OR short based on the
+confluence of 4h trend structure + Senpi Smart-Money leaderboard
+direction. Wide DSL Phase 2 ladder so winners can ride trends.
+
+Producer ticks every 300s (5 min). Each tick:
+  1. Pull ETH candles (1h + 4h) and SM market concentration.
+  2. Compute 4h trend (higher-lows / lower-highs structure).
+  3. Determine direction: 4h trend + SM agreement → LONG or SHORT.
+  4. Score 5 components, max ~9. minScore floor 5.
+  5. Push signal via senpi_runtime_helpers if score >= floor.
+
+The runtime's LLM-gated `heron_entry` action opens the position via
+FEE_OPTIMIZED_LIMIT. DSL handles all exits (Phase 1 max_loss 20% /
+retrace 8, Phase 2 Bison-pattern wide ladder, time-cuts disabled).
+
+Producer NEVER closes positions. Producer NEVER reasons about exits.
+The DSL is the only exit path.
+"""
+
+import hashlib
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import heron_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+
+VERSION = "1.0.0"
+SCANNER_NAME = "heron_signals"
+SIGNAL_TYPE = "HERON_ETH_TREND"
+
+# Hardcoded — Heron is ETH-only. Forks (Heron=ETH, Hummingbird=HYPE)
+# substitute the asset string and use the same scaffold.
+ASSET = "ETH"
+
+# Scoring constants — onboarding-tier simplicity. Max ~9 points.
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 5
+
+# Direction-confirmation thresholds (config-overridable)
+SM_TILT_MIN_PCT_DEFAULT = 60
+SM_STRONG_TILT_PCT_DEFAULT = 70
+
+# Onboarding floor — 5 points typically requires 4h trend + 1h
+# confirmation + SM aligned. Below that, no entry.
+MIN_SCORE_DEFAULT = 5
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("HERON_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical helpers
+# ═══════════════════════════════════════════════════════════════
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH.
+
+    Returns (label, strength_pct) where strength_pct is the fraction
+    of recent candles that confirmed the structure.
+    """
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [float(c.get("low", c.get("l", 0))) for c in candles[-lookback:]]
+    highs = [float(c.get("high", c.get("h", 0))) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def volume_trend(candles, lookback=6):
+    """% change in avg(recent 3) vs avg(prior 3) volume."""
+    if len(candles) < lookback:
+        return 0.0
+    vols = [float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles[-lookback:]]
+    half = lookback // 2
+    recent = sum(vols[-half:]) / half if half > 0 else 1
+    earlier = sum(vols[:half]) / half if half > 0 else 1
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_market_data(asset):
+    """Pull 1h + 4h candles for the asset."""
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    """Return (direction, tilt_pct) for SM concentration on this asset.
+
+    direction ∈ {"LONG", "SHORT", "NEUTRAL"}.
+    tilt_pct is the percent of top-trader long/short concentration,
+    e.g. 70 = "70% of top traders are positioned long here."
+    """
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct = 0.0
+    short_pct = 0.0
+    found = False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        direction = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if direction == "LONG":
+            long_pct = pct
+        elif direction == "SHORT":
+            short_pct = pct
+
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, entry_cfg):
+    """Score a ETH entry. Returns dict with direction + score, or None.
+
+    Direction logic:
+      1. 4h trend != NEUTRAL  (required)
+      2. SM direction agrees with 4h trend  (required)
+      3. SM tilt >= smTiltMinPct  (required, default 60)
+
+    Score components (max ~9):
+      4h trend aligned     +3
+      1h confirms 4h       +2
+      SM aligned           +2
+      SM strongly tilted   +1  (when smTilt >= smStrongTiltPct)
+      Volume rising        +1
+    """
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    candles_4h = data.get("data", {}).get("candles", {}).get("4h", [])
+    if len(candles_4h) < 6 or len(candles_1h) < 6:
+        return None
+
+    trend_4h, str_4h = trend_structure(candles_4h)
+    trend_1h, str_1h = trend_structure(candles_1h)
+    if trend_4h == "NEUTRAL":
+        return None
+
+    # SM gate
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_tilt_min = float(entry_cfg.get("smTiltMinPct", SM_TILT_MIN_PCT_DEFAULT))
+    sm_strong_pct = float(entry_cfg.get("smStrongTiltPct", SM_STRONG_TILT_PCT_DEFAULT))
+    if sm_dir not in ("LONG", "SHORT"):
+        return None
+    if sm_tilt < sm_tilt_min:
+        return None
+
+    # 4h trend direction and SM direction must agree
+    direction = "LONG" if trend_4h == "BULLISH" else "SHORT"
+    if sm_dir != direction:
+        return None
+
+    score = 0
+    reasons = []
+
+    # 4h trend aligned
+    score += 3
+    reasons.append(f"4h_{trend_4h.lower()}_{str_4h:.0%}")
+
+    # 1h confirms 4h
+    if (direction == "LONG" and trend_1h == "BULLISH") or (direction == "SHORT" and trend_1h == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirms_{trend_1h.lower()}")
+
+    # SM aligned
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+
+    # SM strongly tilted
+    if sm_tilt >= sm_strong_pct:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    # Volume rising
+    vol_pct = volume_trend(candles_1h)
+    if vol_pct > 10:
+        score += 1
+        reasons.append(f"vol_rising_{vol_pct:+.0f}%")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_4h": trend_4h,
+        "trend_4h_strength": str_4h,
+        "trend_1h": trend_1h,
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": sm_tilt,
+        "volume_trend_pct": vol_pct,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        print("ERROR: strategy wallet not resolved", file=sys.stderr)
+        return False
+
+    # On-chain held-asset dedup (defense in depth — runtime per_asset_cooldown is authoritative)
+    if thesis["coin"].upper() in {h.upper() for h in held_assets}:
+        return False
+
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "trend4h": thesis["trend_4h"],
+        "trend4hStrength": thesis["trend_4h_strength"],
+        "trend1h": thesis["trend_1h"],
+        "smDirection": thesis["sm_direction"],
+        "smTiltPct": thesis["sm_tilt_pct"],
+        "volumeTrendPct": thesis["volume_trend_pct"],
+        "heldAssets": held_assets,
+    }
+
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=thesis["coin"],
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),  # normalize 0..1 (max ~9)
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {thesis['coin']}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {thesis['coin']}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — single tick. Daemon owns the per-tick scanner_lock.
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    asset = config.get("asset", ASSET).upper()
+    entry_cfg = config
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({
+            "status": "error",
+            "reason": "no_wallet",
+            "_heron_producer_version": VERSION,
+        })
+        return
+
+    # Account state + held positions
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    if account_value <= 0:
+        cfg.output({
+            "status": "ok",
+            "note": "no account value",
+            "_heron_producer_version": VERSION,
+        })
+        return
+
+    # Already holding this asset → nothing to do; DSL manages exit.
+    if asset in {h.upper() for h in held_assets}:
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": f"RIDING {asset}. DSL manages exit.",
+            "held_assets": held_assets,
+            "elapsed_sec": round(elapsed, 2),
+            "_heron_producer_version": VERSION,
+        })
+        return
+
+    # Race-window dedup BEFORE building the thesis (saves MCP cost)
+    if cfg.was_recently_signaled(asset):
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": f"DEDUP_SKIP {asset} pushed within {cfg.RECENT_SIGNAL_TTL_SEC}s",
+            "held_assets": held_assets,
+            "elapsed_sec": round(elapsed, 2),
+            "_heron_producer_version": VERSION,
+        })
+        return
+
+    # Score the thesis
+    thesis = build_thesis(asset, entry_cfg)
+    if thesis is None:
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no qualifying setup (4h trend + SM gate not aligned)",
+            "elapsed_sec": round(elapsed, 2),
+            "_heron_producer_version": VERSION,
+        })
+        return
+
+    min_score = int(entry_cfg.get("minScore", MIN_SCORE_DEFAULT))
+    if thesis["score"] < min_score:
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": f"score_low {thesis['score']}/{min_score}",
+            "direction": thesis["direction"],
+            "reasons": thesis["reasons"][:5],
+            "elapsed_sec": round(elapsed, 2),
+            "_heron_producer_version": VERSION,
+        })
+        return
+
+    # Sizing — onboarding default: 25% of equity, 5x leverage.
+    margin_pct = float(config.get("marginPct", 0.25))
+    margin_usd = round(account_value * margin_pct, 2)
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+
+    pushed = push_signal(thesis, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(thesis["coin"])
+
+    elapsed = time.time() - run_start
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": thesis["coin"],
+            "direction": thesis["direction"],
+            "score": thesis["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": thesis["reasons"][:5],
+        },
+        "held_assets": held_assets,
+        "elapsed_sec": round(elapsed, 2),
+        "_heron_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"heron-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/heron/scripts/heron_config.py
+++ b/heron/scripts/heron_config.py
@@ -1,0 +1,220 @@
+"""HERON v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Onboarding-tier ETH trend follower with Smart-Money direction gate.
+Single asset (ETH), simple 5-component scoring, SM-confirmed long OR
+short. NOT a HYPE-style alpha hunter — designed for first-time Senpi
+users who want a clean "ETH trending? hold a directional position"
+experience.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder. Mirrors the Wolverine v6.0.0 / Bison
+v3.0.1 pattern (race-window dedup, atomic write, etc).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "heron-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "heron-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Heron ticks every 300s; ETH ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Heron's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("heron_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] heron_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[heron-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/hummingbird/README.md
+++ b/hummingbird/README.md
@@ -1,0 +1,171 @@
+# 🪶 Hummingbird — HYPE Trend Follower (SM-confirmed)
+
+Onboarding-tier strategy. Single asset (HYPE). Long OR short based on the confluence of 4h trend structure + Senpi Smart-Money leaderboard direction. Wide DSL ladder so winning trends can ride.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+Hummingbird is the default first-trade strategy for new Senpi users. It answers one question — "is HYPE trending?" — by looking at the 4h candle structure (higher-lows = bullish, lower-highs = bearish) and the Senpi Smart-Money leaderboard (do top traders agree?). If the 4h trend exists and Smart Money is positioned in the same direction with at least 60% concentration, Hummingbird opens a single conviction position and hands it to the DSL.
+
+There are NO funding-rate filters, NO multi-asset whitelist tuning, NO XYZ universe to manage. One asset, one direction gate, one exit mechanism. Designed to be operable by someone who just learned what a perp is.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Asset | HYPE (single-asset) |
+| Tick interval | 300s (5 min) |
+| MIN_SCORE (producer) | 5 (out of ~9 max) |
+| LLM min_confidence | 7 |
+| Leverage | 5x default, max 5x |
+| Margin per trade | 25% of equity |
+| Max positions | 1 |
+| Max entries per day | 2 |
+| Per-asset cooldown | 240 min (4h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 20% |
+| SM tilt minimum | 60% |
+| SM strong-tilt threshold | 70% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: false) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+| Recent-signals dedup | 240s TTL |
+
+## DSL preset (wide, Bison-pattern)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 20% |
+| Phase 1 | retrace_threshold | 8 |
+| Phase 1 | consecutive_breaches | 1 |
+| Time cuts | hard_timeout | **DISABLED** |
+| Time cuts | weak_peak_cut | **DISABLED** |
+| Time cuts | dead_weight_cut | **DISABLED** |
+| Phase 2 | T0 | +10% / 0% lock |
+| Phase 2 | T1 | +20% / 25% lock |
+| Phase 2 | T2 | +30% / 40% lock |
+| Phase 2 | T3 | +50% / 60% lock |
+| Phase 2 | T4 | +75% / 75% lock |
+| Phase 2 | T5 | +100% / 85% lock (apex) |
+
+## Scanner pattern
+
+This strategy uses the **Single-asset trend follower (Kodiak family)** scanner pattern with a Smart-Money direction gate — see `senpi-trading-runtime/references/producer-patterns.md` for the canonical reference. Primary MCP calls: `market_get_asset_data` (HYPE candles), `leaderboard_get_markets` (SM direction).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/hummingbird-producer.py | Long-lived daemon; emits HUMMINGBIRD_HYPE_TREND signals |
+| scripts/hummingbird_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/hummingbird-config.json | Operator-tunable defaults (wallet, asset, minScore, sizing) |
+
+## Install
+
+### Step 0 — Register the runtime plugin in `openclaw.json` (one-time per host)
+
+The senpi-trading-runtime plugin won't bind its API port (`127.0.0.1:8787`) unless `plugins.entries.runtime` is present in `/data/.openclaw/openclaw.json`. Without that block the plugin logs `No plugin config found — skipping registration` and the producer daemon's `signal_post` calls fail with `[Errno 111] Connection refused`. Confirm or add:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "runtime": {
+        "enabled": true,
+        "config": {
+          "stateDir": "/data/.openclaw/senpi-state",
+          "apiKey": "<your SENPI_AUTH_TOKEN>",
+          "autoUpdate": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```
+
+Restart the gateway after editing so the plugin re-registers:
+
+```bash
+openclaw gateway restart
+sleep 10
+curl -s -m 5 http://127.0.0.1:8787/state | head -c 200
+# Expected: a JSON response with "success":true,"data":{"runtimes":[...]}
+```
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+The Python Producer SDK (`senpi_runtime_helpers`) ships inside the senpi-trading-runtime skill. Install it once per host:
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Hummingbird
+
+```bash
+mkdir -p /data/workspace/skills/hummingbird-strategy/{config,scripts,state,references}
+for f in scripts/hummingbird-producer.py scripts/hummingbird_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/hummingbird-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/hummingbird/$f" \
+    -o "/data/workspace/skills/hummingbird-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/hummingbird-strategy/config/hummingbird-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+This is the canonical source of truth — producer reads from here on every tick.
+
+### Step 4 — Required env vars
+
+```bash
+export HUMMINGBIRD_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                              # required
+export HUMMINGBIRD_DECISION_MODEL=<your-preferred-model>      # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/hummingbird-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/hummingbird-strategy/scripts/hummingbird-producer.py \
+  > /tmp/hummingbird-producer.log 2>&1 &
+disown
+```
+
+After first launch, manage the daemon via the `senpi-helpers` CLI: `senpi-helpers list`, `senpi-helpers health <name>`, `senpi-helpers restart <name>`.
+
+## Verification
+
+```bash
+sleep 320  # wait one full tick
+tail -3 /tmp/hummingbird-producer.log | jq '._hummingbird_producer_version, .note // null, .best.score // null'
+# Expected: _hummingbird_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no qualifying setup (4h trend + SM gate not aligned)"` — common; HYPE isn't in a clean trend
+- `"signals_pushed": 1, "best": { "coin": "HYPE", "direction": "LONG"|"SHORT", "score": 5-9 }` — entry signal fired
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+First skill in the onboarding-tier trio (Hummingbird = HYPE, Heron = ETH, Hummingbird = HYPE). Single asset, simple 5-component scoring, Smart-Money direction gate, wide Bison-pattern Phase 2 ladder. Designed as the default "I'm new to Senpi, where do I start?" strategy.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/hummingbird/SKILL.md
+++ b/hummingbird/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: hummingbird-strategy
+description: >-
+  HUMMINGBIRD v1.0.0 — Onboarding-tier HYPE trend follower. Long OR short
+  based on the confluence of 4h trend structure + Senpi Smart-Money
+  leaderboard direction. Single asset (HYPE), simple 5-component
+  scoring (max ~9), wide Bison-pattern DSL Phase 2 ladder so winning
+  trends can run multi-day. Designed for first-time Senpi users.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🪶 HUMMINGBIRD v1.0.0 — HYPE Trend Follower (SM-confirmed)
+
+**Onboarding tier. HYPE only. Long OR short.** When HYPE is in a 4h trend AND Senpi's Smart-Money leaderboard agrees with that direction, Hummingbird opens a single conviction position and lets the DSL ratchet manage it.
+
+## Why this strategy exists
+
+Hummingbird is the **default first-trade strategy** for new Senpi users:
+
+- **One asset** — HYPE. No multi-asset whitelist to tune, no XYZ universe to filter, no funding regime to interpret.
+- **One question** — "Is HYPE trending?" Hummingbird answers by looking at the 4h candle structure (higher-lows = bullish, lower-highs = bearish).
+- **One direction gate** — "Does Smart Money agree?" Hummingbird pulls Senpi's leaderboard concentration and requires top-trader positioning to align with the trend before firing.
+- **One exit mechanism** — DSL. Phase 1 max_loss 20% floor + Phase 2 wide ratchet ladder. Time-cuts all disabled — winning trends ride.
+
+If both gates pass and the score clears the floor, Hummingbird emits ONE signal per qualifying setup. Max 2 entries per day. 4h cooldown per asset.
+
+## CRITICAL RULES
+
+### RULE 1: Producer enters. DSL exits. Producer NEVER closes.
+The producer has no `close_position` call site. All exits flow through the DSL Phase 1 max_loss / Phase 2 ratchet retrace. This is the same structural guarantee as Bison v3.0.1 and Wolverine v6.0.0.
+
+### RULE 2: SM direction gate is hard, not soft
+If `leaderboard_get_markets` returns NEUTRAL or returns a direction OPPOSITE to the 4h trend, the producer outputs `WAITING — no qualifying setup` and does nothing. There is no override.
+
+### RULE 3: Producer emits signals via push_signal(); runtime opens
+The runtime's LLM-gated `hummingbird_entry` action receives the signal, validates it against the schema, and opens via FEE_OPTIMIZED_LIMIT with `ensure_execution_as_taker: false` (ALO patience on entry). Exit orders use `ensure_execution_as_taker: true` so closes always happen.
+
+### RULE 4: Race-window dedup is mandatory
+The producer writes to `state/recent-signals.json` after every successful `push_signal()` and checks the cache BEFORE building a thesis. 240s TTL covers the gap between push_signal returning OK and the resulting position appearing in the next-tick `clearinghouseState`. This is the Bison v3.0.1 fix applied at construction-time.
+
+### RULE 5: Onboarding defaults — don't tune them aggressively
+The default config is:
+- `minScore: 5` (out of ~9 max)
+- `smTiltMinPct: 60`
+- `smStrongTiltPct: 70`
+- 25% margin / 5x leverage
+- 2 entries/day, 4h cooldown
+
+These are tuned for **new users learning the platform**, not for aggressive alpha extraction. Don't push minScore higher (it starves the strategy); don't push leverage higher than 5x (operator capital risk).
+
+## How Hummingbird scores a trade
+
+**Direction gate** (all required):
+1. 4h trend ≠ NEUTRAL (higher-lows ≥ 60% bullish OR lower-highs ≥ 60% bearish)
+2. SM direction agrees with 4h trend
+3. SM tilt ≥ smTiltMinPct (default 60%)
+
+**Score components** (max ~9):
+
+| Signal | Points |
+|---|---|
+| 4h trend aligned with direction | +3 |
+| 1h trend confirms 4h | +2 |
+| SM aligned (gate-confirmed) | +2 |
+| SM strongly tilted (≥ smStrongTiltPct) | +1 |
+| Volume rising (>10% lookback delta) | +1 |
+
+**Floor:** `minScore: 5`. Typical entry clears 5-7. Strong setups clear 7-8. Apex (rare) clears 9.
+
+## DSL preset (Bison-pattern wide)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 20% |
+| Phase 1 | retrace_threshold | 8% |
+| Phase 1 | consecutive_breaches | 1 |
+| Time cuts | hard_timeout | **DISABLED** |
+| Time cuts | weak_peak_cut | **DISABLED** |
+| Time cuts | dead_weight_cut | **DISABLED** |
+| Phase 2 | T0 | +10% / lock 0 |
+| Phase 2 | T1 | +20% / lock 25% |
+| Phase 2 | T2 | +30% / lock 40% |
+| Phase 2 | T3 | +50% / lock 60% |
+| Phase 2 | T4 | +75% / lock 75% |
+| Phase 2 | T5 | +100% / lock 85% (apex) |
+
+The T0 lock at 0% is the key shift — a +10% mover can retrace fully without locking, giving real trends room to develop. This is the same ladder that produced Bison's SOL SHORT +71.1% closed win.
+
+## Risk guardrails (`runtime.yaml` `risk.guard_rails`)
+
+| Gate | Setting | Why |
+|---|---|---|
+| max_entries_per_day | 2 | Onboarding: fewer-stronger |
+| per_asset_cooldown_minutes | 240 | 4h between HYPE attempts |
+| daily_loss_limit_pct | 15 | Cap a bad day |
+| max_consecutive_losses | 3 | Halt on losing streak |
+| cooldown_minutes (post-loss) | 60 | Cool off after a stop |
+| drawdown_halt_pct | 25 | Catastrophic-floor circuit breaker |
+| drawdown_reset_on_day_rollover | false | No grace at midnight |
+
+## Hardcoded constants (not configurable)
+
+- `ASSET`: "HYPE" (Heron/Hummingbird are separate skills with ETH/HYPE)
+- `MAX_LEVERAGE`: 5
+- `RECENT_SIGNAL_TTL_SEC`: 240
+
+## Hard rule for user-conversation Claude sessions
+
+User-conversation Claude sessions MUST NOT call:
+`create_position`, `close_position`, `edit_position`,
+`ratchet_stop_add`, `ratchet_stop_edit`, `ratchet_stop_delete`,
+`cancel_order`, `strategy_close`, `strategy_close_positions`.
+
+These tools are reserved for the **producer daemon** (entry path) and the **DSL ratchet engine** (exit path). User-conversation sessions are **read-only**.
+
+## Scanner pattern
+
+This strategy uses the **Single-asset trend follower (Kodiak family)** scanner pattern with an added Smart-Money direction gate — see `senpi-trading-runtime/references/producer-patterns.md` (Pattern 1) for the canonical reference. Primary MCP calls: `market_get_asset_data` (HYPE candles), `leaderboard_get_markets` (SM direction).
+
+## Operator install
+
+See [README.md](README.md) for fresh-install + env-var setup.
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+First skill in the onboarding-tier trio (Hummingbird = HYPE, Heron = ETH, Hummingbird = HYPE). Shares scaffold + DSL preset; differs only in the `asset` config field. Designed as the default "I'm new to Senpi, where do I start?" answer.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy from this skill, include `skill_name` and `skill_version` in the call. See `references/skill-attribution.md` for details.

--- a/hummingbird/config/hummingbird-config.json
+++ b/hummingbird/config/hummingbird-config.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "HUMMINGBIRD v1.0.0 — HYPE trend follower with Smart-Money direction gate. Onboarding-tier strategy: simple scoring (max ~9), single asset (HYPE), SM-confirmed long OR short. Edit wallet/strategyId/chatId. Defaults are tuned for new users — fewer-stronger entries, wide DSL Phase 2 ladder so winners can ride trends.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "asset": "HYPE",
+  "minScore": 5,
+  "smTiltMinPct": 60,
+  "smStrongTiltPct": 70
+}

--- a/hummingbird/references/skill-attribution.md
+++ b/hummingbird/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "hummingbird",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "hummingbird",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/hummingbird/runtime.yaml
+++ b/hummingbird/runtime.yaml
@@ -1,0 +1,201 @@
+name: hummingbird-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Hummingbird
+# v1.0.0" and lives in description + SKILL.md + _hummingbird_producer_version.
+version: 1.0.0
+description: >
+  HUMMINGBIRD v1.0.0 — HYPE trend follower with Smart-Money direction gate.
+
+  Onboarding-tier strategy. Single asset (HYPE). Long OR short based on
+  the confluence of 4h trend structure + Senpi Smart-Money leaderboard
+  direction. Designed for first-time Senpi users who want a clean
+  "is HYPE trending? hold a directional position" experience without
+  having to think about funding rates, SM concentration math, or
+  multi-asset whitelist tuning.
+
+  Architecture (helpers-native, mirrors Wolverine v6.0.0 / Bison v3.0.1):
+    - Producer (hummingbird-producer.py) ticks every 300s, scores a HYPE
+      thesis with 5 components (max ~9), emits HUMMINGBIRD_HYPE_TREND signal
+      via SenpiClient.push_signal() when score >= 5.
+    - LLM gate is pass-through — producer applied every filter
+      (4h trend non-neutral, SM direction agreement, SM tilt >= 60%).
+    - risk.guard_rails ENFORCES max_entries_per_day=2,
+      per_asset_cooldown, daily_loss_limit, drawdown_halt.
+    - DSL exits via FEE_OPTIMIZED_LIMIT, Bison-pattern wide Phase 2
+      ladder (T0 lock 0 through T5 lock 85) so winning trends can
+      ride multi-day moves. Time-cuts all DISABLED.
+
+  Onboarding tuning:
+    - minScore 5 (easy-to-hit floor; conservative directional confluence)
+    - 2 entries/day cap (low frequency, beginner-friendly)
+    - 25% margin / 5x leverage default (modest sizing, room to grow)
+    - 4h per-asset cooldown
+    - 15% daily-loss limit, 20% drawdown-halt (catastrophic-floor protection)
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 2                # onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20                 # hard stop circuit breaker
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240       # 4h between HYPE attempts
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: hummingbird_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        trend4hStrength: { type: number, required: false }
+        trend1h: { type: string, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: hummingbird_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${HUMMINGBIRD_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix. Senpi runtime resolves provider routing.
+    scanners: [hummingbird_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # ALO patience on entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: hummingbird_signals
+    decision_prompt: |
+      You are Hummingbird's pass-through gate. Hummingbird is a simple HYPE trend
+      follower with a Smart-Money direction gate. The producer already
+      applied every filter (4h trend non-neutral, SM direction agrees
+      with 4h trend, SM tilt >= 60%, minScore 5). Your job is to honor
+      the signal and convert it into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_hummingbird_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be "HYPE" (Hummingbird is single-asset).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - heldAssets contains "HYPE" (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND SM tilt >= 70% AND trend4hStrength >= 0.80
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 HYPE LONG, 4h_bullish_83%, 1h_confirms, SM aligned 65% — trend confluence with SM agreement')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "HYPE",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "HUMMINGBIRD_HYPE_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — Bison-pattern wide ladder) ────────────────────
+#
+# Time-cuts all DISABLED — let trends run on the 4h timescale.
+# Phase 1 max_loss 20% provides catastrophic floor.
+# Phase 2 ladder mirrors Bison v3.0.1 / Wolverine v6.0.0:
+#   T0 +10% / lock 0     — confirms working, no lock yet
+#   T1 +20% / lock 25%
+#   T2 +30% / lock 40%
+#   T3 +50% / lock 60%
+#   T4 +75% / lock 75%
+#   T5 +100% / lock 85%  — apex; multi-day winners ratchet here
+exit:
+  engine: dsl
+  interval_seconds: 60                              # 60s mirrors Bison v3.0.1 REDUCE_ONLY-spam mitigation
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false                                # DISABLED — single-asset trend pattern
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/hummingbird/scripts/hummingbird-producer.py
+++ b/hummingbird/scripts/hummingbird-producer.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+# Senpi HUMMINGBIRD Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""HUMMINGBIRD v1.0.0 — HYPE trend follower with Smart-Money direction gate.
+
+Onboarding strategy. Single asset (HYPE). Long OR short based on the
+confluence of 4h trend structure + Senpi Smart-Money leaderboard
+direction. Wide DSL Phase 2 ladder so winners can ride trends.
+
+Producer ticks every 300s (5 min). Each tick:
+  1. Pull HYPE candles (1h + 4h) and SM market concentration.
+  2. Compute 4h trend (higher-lows / lower-highs structure).
+  3. Determine direction: 4h trend + SM agreement → LONG or SHORT.
+  4. Score 5 components, max ~9. minScore floor 5.
+  5. Push signal via senpi_runtime_helpers if score >= floor.
+
+The runtime's LLM-gated `hummingbird_entry` action opens the position via
+FEE_OPTIMIZED_LIMIT. DSL handles all exits (Phase 1 max_loss 20% /
+retrace 8, Phase 2 Bison-pattern wide ladder, time-cuts disabled).
+
+Producer NEVER closes positions. Producer NEVER reasons about exits.
+The DSL is the only exit path.
+"""
+
+import hashlib
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import hummingbird_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+
+VERSION = "1.0.0"
+SCANNER_NAME = "hummingbird_signals"
+SIGNAL_TYPE = "HUMMINGBIRD_HYPE_TREND"
+
+# Hardcoded — Hummingbird is HYPE-only. Forks (Heron=ETH, Hummingbird=HYPE)
+# substitute the asset string and use the same scaffold.
+ASSET = "HYPE"
+
+# Scoring constants — onboarding-tier simplicity. Max ~9 points.
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 5
+
+# Direction-confirmation thresholds (config-overridable)
+SM_TILT_MIN_PCT_DEFAULT = 60
+SM_STRONG_TILT_PCT_DEFAULT = 70
+
+# Onboarding floor — 5 points typically requires 4h trend + 1h
+# confirmation + SM aligned. Below that, no entry.
+MIN_SCORE_DEFAULT = 5
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("HUMMINGBIRD_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical helpers
+# ═══════════════════════════════════════════════════════════════
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH.
+
+    Returns (label, strength_pct) where strength_pct is the fraction
+    of recent candles that confirmed the structure.
+    """
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [float(c.get("low", c.get("l", 0))) for c in candles[-lookback:]]
+    highs = [float(c.get("high", c.get("h", 0))) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def volume_trend(candles, lookback=6):
+    """% change in avg(recent 3) vs avg(prior 3) volume."""
+    if len(candles) < lookback:
+        return 0.0
+    vols = [float(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles[-lookback:]]
+    half = lookback // 2
+    recent = sum(vols[-half:]) / half if half > 0 else 1
+    earlier = sum(vols[:half]) / half if half > 0 else 1
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_market_data(asset):
+    """Pull 1h + 4h candles for the asset."""
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    """Return (direction, tilt_pct) for SM concentration on this asset.
+
+    direction ∈ {"LONG", "SHORT", "NEUTRAL"}.
+    tilt_pct is the percent of top-trader long/short concentration,
+    e.g. 70 = "70% of top traders are positioned long here."
+    """
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct = 0.0
+    short_pct = 0.0
+    found = False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        direction = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if direction == "LONG":
+            long_pct = pct
+        elif direction == "SHORT":
+            short_pct = pct
+
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, entry_cfg):
+    """Score a HYPE entry. Returns dict with direction + score, or None.
+
+    Direction logic:
+      1. 4h trend != NEUTRAL  (required)
+      2. SM direction agrees with 4h trend  (required)
+      3. SM tilt >= smTiltMinPct  (required, default 60)
+
+    Score components (max ~9):
+      4h trend aligned     +3
+      1h confirms 4h       +2
+      SM aligned           +2
+      SM strongly tilted   +1  (when smTilt >= smStrongTiltPct)
+      Volume rising        +1
+    """
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    candles_4h = data.get("data", {}).get("candles", {}).get("4h", [])
+    if len(candles_4h) < 6 or len(candles_1h) < 6:
+        return None
+
+    trend_4h, str_4h = trend_structure(candles_4h)
+    trend_1h, str_1h = trend_structure(candles_1h)
+    if trend_4h == "NEUTRAL":
+        return None
+
+    # SM gate
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_tilt_min = float(entry_cfg.get("smTiltMinPct", SM_TILT_MIN_PCT_DEFAULT))
+    sm_strong_pct = float(entry_cfg.get("smStrongTiltPct", SM_STRONG_TILT_PCT_DEFAULT))
+    if sm_dir not in ("LONG", "SHORT"):
+        return None
+    if sm_tilt < sm_tilt_min:
+        return None
+
+    # 4h trend direction and SM direction must agree
+    direction = "LONG" if trend_4h == "BULLISH" else "SHORT"
+    if sm_dir != direction:
+        return None
+
+    score = 0
+    reasons = []
+
+    # 4h trend aligned
+    score += 3
+    reasons.append(f"4h_{trend_4h.lower()}_{str_4h:.0%}")
+
+    # 1h confirms 4h
+    if (direction == "LONG" and trend_1h == "BULLISH") or (direction == "SHORT" and trend_1h == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirms_{trend_1h.lower()}")
+
+    # SM aligned
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+
+    # SM strongly tilted
+    if sm_tilt >= sm_strong_pct:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    # Volume rising
+    vol_pct = volume_trend(candles_1h)
+    if vol_pct > 10:
+        score += 1
+        reasons.append(f"vol_rising_{vol_pct:+.0f}%")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_4h": trend_4h,
+        "trend_4h_strength": str_4h,
+        "trend_1h": trend_1h,
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": sm_tilt,
+        "volume_trend_pct": vol_pct,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        print("ERROR: strategy wallet not resolved", file=sys.stderr)
+        return False
+
+    # On-chain held-asset dedup (defense in depth — runtime per_asset_cooldown is authoritative)
+    if thesis["coin"].upper() in {h.upper() for h in held_assets}:
+        return False
+
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "trend4h": thesis["trend_4h"],
+        "trend4hStrength": thesis["trend_4h_strength"],
+        "trend1h": thesis["trend_1h"],
+        "smDirection": thesis["sm_direction"],
+        "smTiltPct": thesis["sm_tilt_pct"],
+        "volumeTrendPct": thesis["volume_trend_pct"],
+        "heldAssets": held_assets,
+    }
+
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=thesis["coin"],
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),  # normalize 0..1 (max ~9)
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {thesis['coin']}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {thesis['coin']}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — single tick. Daemon owns the per-tick scanner_lock.
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    asset = config.get("asset", ASSET).upper()
+    entry_cfg = config
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({
+            "status": "error",
+            "reason": "no_wallet",
+            "_hummingbird_producer_version": VERSION,
+        })
+        return
+
+    # Account state + held positions
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    if account_value <= 0:
+        cfg.output({
+            "status": "ok",
+            "note": "no account value",
+            "_hummingbird_producer_version": VERSION,
+        })
+        return
+
+    # Already holding this asset → nothing to do; DSL manages exit.
+    if asset in {h.upper() for h in held_assets}:
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": f"RIDING {asset}. DSL manages exit.",
+            "held_assets": held_assets,
+            "elapsed_sec": round(elapsed, 2),
+            "_hummingbird_producer_version": VERSION,
+        })
+        return
+
+    # Race-window dedup BEFORE building the thesis (saves MCP cost)
+    if cfg.was_recently_signaled(asset):
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": f"DEDUP_SKIP {asset} pushed within {cfg.RECENT_SIGNAL_TTL_SEC}s",
+            "held_assets": held_assets,
+            "elapsed_sec": round(elapsed, 2),
+            "_hummingbird_producer_version": VERSION,
+        })
+        return
+
+    # Score the thesis
+    thesis = build_thesis(asset, entry_cfg)
+    if thesis is None:
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no qualifying setup (4h trend + SM gate not aligned)",
+            "elapsed_sec": round(elapsed, 2),
+            "_hummingbird_producer_version": VERSION,
+        })
+        return
+
+    min_score = int(entry_cfg.get("minScore", MIN_SCORE_DEFAULT))
+    if thesis["score"] < min_score:
+        elapsed = time.time() - run_start
+        cfg.output({
+            "status": "ok",
+            "note": f"score_low {thesis['score']}/{min_score}",
+            "direction": thesis["direction"],
+            "reasons": thesis["reasons"][:5],
+            "elapsed_sec": round(elapsed, 2),
+            "_hummingbird_producer_version": VERSION,
+        })
+        return
+
+    # Sizing — onboarding default: 25% of equity, 5x leverage.
+    margin_pct = float(config.get("marginPct", 0.25))
+    margin_usd = round(account_value * margin_pct, 2)
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+
+    pushed = push_signal(thesis, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(thesis["coin"])
+
+    elapsed = time.time() - run_start
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": thesis["coin"],
+            "direction": thesis["direction"],
+            "score": thesis["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": thesis["reasons"][:5],
+        },
+        "held_assets": held_assets,
+        "elapsed_sec": round(elapsed, 2),
+        "_hummingbird_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"hummingbird-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/hummingbird/scripts/hummingbird_config.py
+++ b/hummingbird/scripts/hummingbird_config.py
@@ -1,0 +1,220 @@
+"""HUMMINGBIRD v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Onboarding-tier HYPE trend follower with Smart-Money direction gate.
+Single asset (HYPE), simple 5-component scoring, SM-confirmed long OR
+short. NOT a HYPE-style alpha hunter — designed for first-time Senpi
+users who want a clean "HYPE trending? hold a directional position"
+experience.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder. Mirrors the Wolverine v6.0.0 / Bison
+v3.0.1 pattern (race-window dedup, atomic write, etc).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "hummingbird-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "hummingbird-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Hummingbird ticks every 300s; HYPE ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Hummingbird's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("hummingbird_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] hummingbird_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[hummingbird-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/lemur/README.md
+++ b/lemur/README.md
@@ -1,0 +1,48 @@
+# 🦤 Lemur — Pre-IPO Perpetual (IPOP) Trend Follower
+
+Trade pre-IPO companies as perpetuals on Hyperliquid XYZ. Auto-discovers IPOPs via the trade.xyz funding signature. Today: `xyz:SPCX`. Auto-expands when trade.xyz lists Anthropic, OpenAI, Stripe, etc.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Universe | Auto-discovered IPOPs (funding ≤ 1e-7, max_leverage ≤ 5, daily vol ≥ $100K) |
+| Today's universe | `[xyz:SPCX]` |
+| Tick interval | 900s (15 min — IPOPs move slow per Discovery Bounds) |
+| MIN_SCORE | 5 (of ~9) |
+| Leverage | 3x default, auto-capped to instrument's own max (typically 5x) |
+| Margin per trade | 15% of equity |
+| Slots | 2 |
+| Max entries per day | 3 |
+| Per-asset cooldown | 360 min (6h) |
+| DSL Phase 1 max_loss | 10% |
+| DSL Phase 2 | Bison-pattern wide ladder (T0 lock 0 → T5 lock 85) |
+| Time cuts | All DISABLED |
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/lemur-strategy/{config,scripts,state,references}
+for f in scripts/lemur-producer.py scripts/lemur_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/lemur-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lemur/$f" \
+    -o "/data/workspace/skills/lemur-strategy/$f"
+done
+
+export LEMUR_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export LEMUR_DECISION_MODEL=<your-preferred-model>
+
+openclaw senpi runtime create --path /data/workspace/skills/lemur-strategy/runtime.yaml
+
+nohup python3 -u /data/workspace/skills/lemur-strategy/scripts/lemur-producer.py \
+  > /tmp/lemur-producer.log 2>&1 &
+disown
+```
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/lemur/SKILL.md
+++ b/lemur/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: lemur-strategy
+description: >-
+  LEMUR v1.0.0 — Pre-IPO Perpetual (IPOP) trend follower on Hyperliquid
+  XYZ. Auto-discovers IPOPs via the trade.xyz funding signature (1%
+  funding multiplier = ~100x smaller funding rates) + leverage cap
+  (≤5x pre-listing). Today: xyz:SPCX. Auto-expands when trade.xyz lists
+  more IPOPs. Long OR short on 4h trend + Smart Money agreement.
+  Moderate DSL — Discovery Bounds throttle velocity so positions don't
+  snap as fast as normal perps.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦤 LEMUR v1.0.0 — Pre-IPO Perpetual Trend Follower
+
+**Trade pre-IPO companies as perpetuals on Hyperliquid XYZ.** Today that's only SpaceX (`xyz:SPCX`). When trade.xyz lists Anthropic, OpenAI, Stripe, Databricks, etc., Lemur picks them up automatically via the structural IPOP signature.
+
+## Why this strategy exists
+
+Hyperliquid XYZ is one of the only venues where retail can perp-trade private companies. IPOPs (Pre-IPO Perpetuals) are a unique product:
+- **24/7 trading** (vs 23/5 for equity perps)
+- **Internal oracle** until the company actually IPOs (30-min EWMA price discovery)
+- **Funding multiplier 0.005** (vs 0.5 for standard XYZ perps — 100x smaller funding cost)
+- **Discovery Bounds** throttle price velocity to prevent gap moves
+
+Lemur captures the directional alpha on these markets while the standard equity perp space lacks them.
+
+## Auto-discovery: how Lemur finds IPOPs
+
+Per the trade.xyz design docs, IPOPs have two structural signatures:
+
+```python
+def is_ipop(inst):
+    return (
+        inst["name"].startswith("xyz:")
+        and not inst["is_delisted"]
+        and abs(float(inst["context"]["funding"])) <= 1e-7   # 100x smaller funding
+        and int(inst["max_leverage"]) <= 5                    # pre-listing leverage cap
+        and float(inst["context"]["dayNtlVlm"]) >= 100_000   # liquidity floor
+    )
+```
+
+The funding-rate signature is robust because it directly reflects the IPOP product spec (0.005 multiplier vs 0.5). When an IPOP CONVERTS to a normal equity perp after the company actually IPOs, its funding rate jumps back to the standard formula — Lemur auto-drops it from the universe.
+
+Today this returns `[xyz:SPCX]`. No hardcoded ticker list, no config update needed when trade.xyz lists new IPOPs.
+
+## CRITICAL RULES
+
+### RULE 1: Producer enters. DSL exits.
+DSL Phase 1 max_loss 10% + Phase 2 Bison-pattern wide ladder own all exits. Time-cuts all disabled (IPOPs trade 24/7).
+
+### RULE 2: Leverage auto-capped per instrument
+The config has `leverage: 3` default, but each IPOP's own `max_leverage` (e.g., SPCX's 5x cap) is the hard ceiling. Producer takes the MIN of config-leverage and instrument-leverage.
+
+### RULE 3: SM data may be sparse for pre-IPO names
+Few traders, less concentration data. If `leaderboard_get_markets` returns no entry for the IPOP, the producer falls back to "4h trend only" and tags the signal `sm_data_sparse_assumed_aligned`. Once a company has been listed and accumulates trader history, SM data fills in.
+
+### RULE 4: 15-min tick cadence (vs 5-min for normal trend strategies)
+Discovery Bounds throttle IPOP price moves to limited velocity. Polling every 5 min is wasteful — the underlying isn't moving fast enough to justify the MCP cost.
+
+## How Lemur scores a trade
+
+**Gates** (all required):
+1. Asset matches IPOP signature (funding + leverage + liquidity)
+2. 4h trend non-neutral
+3. SM direction agrees with 4h trend (OR SM data unavailable → assume aligned)
+4. SM tilt >= 55% (if SM data available)
+
+**Score components** (max ~9):
+
+| Signal | Points |
+|---|---|
+| 4h trend aligned (with strength %) | +3 |
+| 1h trend confirms 4h | +2 |
+| SM aligned (gate-confirmed; "assumed_aligned" if SM data sparse) | +2 |
+| SM strongly tilted (>= 70%) | +1 |
+
+## DSL preset (moderate, IPOP-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | **10%** (moderate — Discovery Bounds limit downside velocity) |
+| Phase 1 | retrace_threshold | 8 |
+| Phase 1 | consecutive_breaches | 1 |
+| Time cuts | hard_timeout | **DISABLED** (24/7 trading, multi-day theses welcome) |
+| Time cuts | weak_peak_cut | DISABLED |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 | +10% / 0% lock |
+| Phase 2 | T1 | +20% / 25% lock |
+| Phase 2 | T2 | +30% / 40% lock |
+| Phase 2 | T3 | +50% / 60% lock |
+| Phase 2 | T4 | +75% / 75% lock |
+| Phase 2 | T5 | +100% / 85% lock (apex) |
+
+## Risk guardrails
+
+| Gate | Setting |
+|---|---|
+| max_entries_per_day | 3 |
+| per_asset_cooldown_minutes | 360 (6h, IPOPs move slow) |
+| daily_loss_limit_pct | 15 |
+| max_consecutive_losses | 3 |
+| drawdown_halt_pct | 20 |
+| Slots | 2 (small universe today) |
+
+## Scanner pattern
+
+This strategy uses the **XYZ universe filter scanner with funding-signature discovery** — see `senpi-trading-runtime/references/producer-patterns.md` (extends Pattern 4, Bison-style multi-asset, with XYZ-specific filters). Primary MCP calls: `market_list_instruments` (universe discovery), `market_get_asset_data`, `leaderboard_get_markets`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+First Senpi skill explicitly designed for trade.xyz IPOPs. Funding-rate signature heuristic future-proofs against universe expansion. Universe = `[xyz:SPCX]` today.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+See `references/skill-attribution.md`.

--- a/lemur/config/lemur-config.json
+++ b/lemur/config/lemur-config.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "LEMUR v1.0.0 — Pre-IPO Perpetuals (IPOP) basket on Hyperliquid XYZ. Auto-discovers IPOPs via funding + leverage signature (per trade.xyz docs: IPOP funding multiplier is 0.005 vs 0.5 for standard XYZ perps = funding rates ~100x smaller; AND max_leverage <= 5 for the pre-listing cap). Today's universe: xyz:SPCX. Auto-expands when trade.xyz lists more IPOPs (e.g. ANTHROPIC, OPENAI, STRIPE). LONG OR SHORT based on 4h trend + SM direction. Wide DSL — IPOP velocity is throttled by Discovery Bounds so positions don't snap as fast as normal perps.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "minScore": 5,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "ipopFundingMaxAbs": 1e-7,
+  "ipopMaxLeverageCap": 5,
+  "ipopMinDailyVolUsd": 100000,
+  "marginPct": 0.15,
+  "leverage": 3
+}

--- a/lemur/references/skill-attribution.md
+++ b/lemur/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "lemur",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "lemur",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/lemur/runtime.yaml
+++ b/lemur/runtime.yaml
@@ -1,0 +1,201 @@
+name: lemur-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Lemur
+# v1.0.0" and lives in description + SKILL.md + _lemur_producer_version.
+version: 1.0.0
+description: >
+  LEMUR v1.0.0 — Pre-IPO Perpetual (IPOP) trend follower with Smart-Money direction gate.
+
+  Onboarding-tier strategy. Single asset (BTC). Long OR short based on
+  the confluence of 4h trend structure + Senpi Smart-Money leaderboard
+  direction. Designed for first-time Senpi users who want a clean
+  "is BTC trending? hold a directional position" experience without
+  having to think about funding rates, SM concentration math, or
+  multi-asset whitelist tuning.
+
+  Architecture (helpers-native, mirrors Wolverine v6.0.0 / Bison v3.0.1):
+    - Producer (lemur-producer.py) ticks every 300s, scores a BTC
+      thesis with 5 components (max ~9), emits LEMUR_BTC_TREND signal
+      via SenpiClient.push_signal() when score >= 5.
+    - LLM gate is pass-through — producer applied every filter
+      (4h trend non-neutral, SM direction agreement, SM tilt >= 60%).
+    - risk.guard_rails ENFORCES max_entries_per_day=2,
+      per_asset_cooldown, daily_loss_limit, drawdown_halt.
+    - DSL exits via FEE_OPTIMIZED_LIMIT, Bison-pattern wide Phase 2
+      ladder (T0 lock 0 through T5 lock 85) so winning trends can
+      ride multi-day moves. Time-cuts all DISABLED.
+
+  Onboarding tuning:
+    - minScore 5 (easy-to-hit floor; conservative directional confluence)
+    - 2 entries/day cap (low frequency, beginner-friendly)
+    - 25% margin / 5x leverage default (modest sizing, room to grow)
+    - 4h per-asset cooldown
+    - 15% daily-loss limit, 20% drawdown-halt (catastrophic-floor protection)
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 2
+  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 3                # onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20                 # hard stop circuit breaker
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 360       # 4h between BTC attempts
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: lemur_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        trend4hStrength: { type: number, required: false }
+        trend1h: { type: string, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: lemur_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${LEMUR_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix. Senpi runtime resolves provider routing.
+    scanners: [lemur_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # ALO patience on entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: lemur_signals
+    decision_prompt: |
+      You are Lemur's pass-through gate. Lemur is a simple BTC trend
+      follower with a Smart-Money direction gate. The producer already
+      applied every filter (4h trend non-neutral, SM direction agrees
+      with 4h trend, SM tilt >= 60%, minScore 5). Your job is to honor
+      the signal and convert it into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_lemur_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be "BTC" (Lemur is single-asset).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - heldAssets contains "BTC" (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND SM tilt >= 70% AND trend4hStrength >= 0.80
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 BTC LONG, 4h_bullish_83%, 1h_confirms, SM aligned 65% — trend confluence with SM agreement')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "BTC",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "LEMUR_BTC_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — Bison-pattern wide ladder) ────────────────────
+#
+# Time-cuts all DISABLED — let trends run on the 4h timescale.
+# Phase 1 max_loss 20% provides catastrophic floor.
+# Phase 2 ladder mirrors Bison v3.0.1 / Wolverine v6.0.0:
+#   T0 +10% / lock 0     — confirms working, no lock yet
+#   T1 +20% / lock 25%
+#   T2 +30% / lock 40%
+#   T3 +50% / lock 60%
+#   T4 +75% / lock 75%
+#   T5 +100% / lock 85%  — apex; multi-day winners ratchet here
+exit:
+  engine: dsl
+  interval_seconds: 60                              # 60s mirrors Bison v3.0.1 REDUCE_ONLY-spam mitigation
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false                                # DISABLED — single-asset trend pattern
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 10.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/lemur/scripts/lemur-producer.py
+++ b/lemur/scripts/lemur-producer.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+# Senpi LEMUR Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""LEMUR v1.0.0 — Pre-IPO Perpetuals (IPOP) basket on Hyperliquid XYZ.
+
+Auto-discovers IPOPs from the live xyz: instrument list using the
+structural funding signature documented by trade.xyz:
+
+  is_ipop(inst) iff
+    name.startswith("xyz:") AND
+    not is_delisted AND
+    abs(funding_rate) <= 1e-7 (1% multiplier vs 0.5 standard = ~100x smaller)
+    AND max_leverage <= 5 (pre-listing leverage cap)
+    AND daily_notional_volume >= 100000 (liquidity floor)
+
+Today this returns [xyz:SPCX] (SpaceX). When trade.xyz lists more IPOPs
+(ANTHROPIC, OPENAI, STRIPE, DATABRICKS), Lemur auto-expands.
+
+When an IPOP CONVERTS to a normal equity perp after the company IPOs,
+its funding rate jumps from ~6.25e-8 to ~6.25e-6 (100x) — Lemur
+auto-drops it from the universe at that point. Standard equity perps
+are Bobcat's territory.
+
+Discovery Bounds throttle price velocity on IPOPs (trade.xyz design)
+so the DSL profile is moderate, not catastrophic — Phase 1 max_loss
+10%, Phase 2 wide ladder for multi-day directional discovery.
+
+REQUIRES USER-SCOPE AUTH for leaderboard_get_markets.
+"""
+
+import hashlib
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import lemur_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "lemur_signals"
+SIGNAL_TYPE = "LEMUR_IPOP"
+
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 3
+DEFAULT_MIN_SCORE = 5
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+DEFAULT_IPOP_FUNDING_MAX = 1e-7
+DEFAULT_IPOP_LEV_CAP = 5
+DEFAULT_IPOP_MIN_VOL = 100000
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("LEMUR_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# IPOP universe discovery
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_ipop_universe(config):
+    """Filter xyz: instruments to those matching the IPOP signature.
+
+    Returns list of dicts: [{name, max_leverage, funding, vol_usd}].
+    """
+    raw = cfg.mcp_call("market_list_instruments", dex="xyz")
+    if not raw or not raw.get("success", True):
+        return []
+    data = raw.get("data", raw)
+    instruments = data.get("instruments", data) if isinstance(data, dict) else data
+    if not isinstance(instruments, list):
+        return []
+
+    max_funding = float(config.get("ipopFundingMaxAbs", DEFAULT_IPOP_FUNDING_MAX))
+    max_lev = int(config.get("ipopMaxLeverageCap", DEFAULT_IPOP_LEV_CAP))
+    min_vol = float(config.get("ipopMinDailyVolUsd", DEFAULT_IPOP_MIN_VOL))
+
+    universe = []
+    for inst in instruments:
+        if not isinstance(inst, dict):
+            continue
+        name = inst.get("name", "")
+        if not name.startswith("xyz:"):
+            continue
+        if inst.get("is_delisted", False):
+            continue
+        if int(inst.get("max_leverage", 999)) > max_lev:
+            continue
+        ctx = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        funding_abs = abs(float(ctx.get("funding", 0)))
+        if funding_abs > max_funding:
+            continue
+        vol_usd = float(ctx.get("dayNtlVlm", 0))
+        if vol_usd < min_vol:
+            continue
+        universe.append({
+            "name": name,
+            "max_leverage": int(inst.get("max_leverage", 5)),
+            "funding": funding_abs,
+            "vol_usd": vol_usd,
+        })
+    return universe
+
+
+def trend_structure(candles, lookback=6):
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_f(c, "low", "l") for c in candles[-lookback:]]
+    highs = [_f(c, "high", "h") for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def build_thesis(asset_name, entry_cfg):
+    data = fetch_market_data(asset_name)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    candles_4h = data.get("data", {}).get("candles", {}).get("4h", [])
+    if len(candles_4h) < 6 or len(candles_1h) < 6:
+        return None
+
+    t4, s4 = trend_structure(candles_4h)
+    t1, _ = trend_structure(candles_1h)
+    if t4 == "NEUTRAL":
+        return None
+
+    direction = "LONG" if t4 == "BULLISH" else "SHORT"
+
+    sm_dir, sm_tilt = fetch_sm_direction(asset_name)
+    sm_min = float(entry_cfg.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(entry_cfg.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+    # Note: IPOP SM data may be sparse pre-listing — fallback to 4h-trend-only if SM not available
+    if sm_dir is None:
+        sm_dir = direction  # fallback: assume aligned (SM data not available)
+        sm_tilt = sm_min     # minimum tilt for scoring purposes
+    elif sm_dir == "NEUTRAL" or sm_dir != direction:
+        return None
+    elif sm_tilt < sm_min:
+        return None
+
+    score = 0
+    reasons = []
+    score += 3
+    reasons.append(f"4h_{t4.lower()}_{s4:.0%}")
+    if (direction == "LONG" and t1 == "BULLISH") or (direction == "SHORT" and t1 == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirms_{t1.lower()}")
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%" if sm_tilt > DEFAULT_SM_TILT_MIN else "sm_data_sparse_assumed_aligned")
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    return {
+        "coin": asset_name,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_4h": t4,
+        "trend_4h_strength": s4,
+        "trend_1h": t1,
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": sm_tilt,
+    }
+
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "trend4h": thesis["trend_4h"],
+        "trend4hStrength": thesis["trend_4h_strength"],
+        "trend1h": thesis["trend_1h"],
+        "smDirection": thesis["sm_direction"],
+        "smTiltPct": thesis["sm_tilt_pct"],
+        "heldAssets": held_assets,
+        "ipopFlag": True,  # marker so downstream knows this is a pre-IPO product
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_lemur_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_lemur_producer_version": VERSION})
+        return
+
+    universe = fetch_ipop_universe(config)
+    if not universe:
+        cfg.output({
+            "status": "ok",
+            "note": "no IPOPs in universe (no instruments match funding+leverage heuristic)",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_lemur_producer_version": VERSION,
+        })
+        return
+
+    candidates = []
+    for inst in universe:
+        coin = inst["name"]
+        if coin.upper() in held_set:
+            continue
+        if cfg.was_recently_signaled(coin):
+            continue
+        thesis = build_thesis(coin, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            thesis["max_leverage_cap"] = inst["max_leverage"]
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no IPOP setup with 4h trend + SM agreement",
+            "ipop_universe": [u["name"] for u in universe],
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_lemur_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    config_leverage = int(config.get("leverage", DEFAULT_LEVERAGE))
+    # Auto-cap to the IPOP's own max_leverage (typically 5 for SPCX)
+    leverage = min(config_leverage, best.get("max_leverage_cap", MAX_LEVERAGE), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "ipop_universe": [u["name"] for u in universe],
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_lemur_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=900,  # 15min — IPOPs move slower per Discovery Bounds
+        name=f"lemur-producer-{_wallet_lock_id}",
+        tick_timeout=240,
+    )

--- a/lemur/scripts/lemur_config.py
+++ b/lemur/scripts/lemur_config.py
@@ -1,0 +1,220 @@
+"""LEMUR v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Onboarding-tier BTC trend follower with Smart-Money direction gate.
+Single asset (BTC), simple 5-component scoring, SM-confirmed long OR
+short. NOT a HYPE-style alpha hunter — designed for first-time Senpi
+users who want a clean "BTC trending? hold a directional position"
+experience.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder. Mirrors the Wolverine v6.0.0 / Bison
+v3.0.1 pattern (race-window dedup, atomic write, etc).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "lemur-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "lemur-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Lemur ticks every 300s; BTC ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Lemur's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("lemur_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] lemur_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[lemur-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/raccoon/README.md
+++ b/raccoon/README.md
@@ -1,0 +1,51 @@
+# 🦝 Raccoon — Weekend XYZ Reconciliation
+
+ONLY trades during the trade.xyz no-external-price weekend window (Fri 22:00 UTC → Mon 00:00 UTC). Captures the Monday-open snap-back when external pricing resumes. Broad XYZ universe (excludes IPOPs).
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Universe | All xyz: (not delisted, max_leverage >= 10, daily vol >= $1M) |
+| Active window | Fri 22:00 UTC → Mon 00:00 UTC (UTC clock) |
+| Tick interval | 300s (5 min during weekend) |
+| MIN_SCORE | 5 (of ~9) |
+| Leverage | 3x default, max 5x |
+| Margin per trade | 15% of equity |
+| Slots | 3 |
+| Max entries per day | 4 |
+| Per-asset cooldown | 480 min (8h) |
+| Min directional move | 2% over 48h |
+| DSL Phase 1 max_loss | 12% |
+| DSL Phase 2 T0 | +5% / lock 30% (lock fast) |
+| hard_timeout | 48h (Monday-open exit) |
+
+## Install
+
+```bash
+mkdir -p /data/workspace/skills/raccoon-strategy/{config,scripts,state,references}
+for f in scripts/raccoon-producer.py scripts/raccoon_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/raccoon-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/raccoon/$f" \
+    -o "/data/workspace/skills/raccoon-strategy/$f"
+done
+
+export RACCOON_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export RACCOON_DECISION_MODEL=<your-preferred-model>
+
+openclaw senpi runtime create --path /data/workspace/skills/raccoon-strategy/runtime.yaml
+
+nohup python3 -u /data/workspace/skills/raccoon-strategy/scripts/raccoon-producer.py \
+  > /tmp/raccoon-producer.log 2>&1 &
+disown
+```
+
+Run continuously — the producer self-gates to the weekend window. Outside Fri 22:00 → Mon 00:00 UTC, ticks output `OUTSIDE_WEEKEND_WINDOW` and consume minimal resources.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/raccoon/SKILL.md
+++ b/raccoon/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: raccoon-strategy
+description: >-
+  RACCOON v1.0.0 — Weekend XYZ reconciliation trader. ONLY emits signals
+  during Fri 22:00 UTC → Mon 00:00 UTC, when trade.xyz has no external
+  pricing for equities/commodities and uses internal oracle only.
+  Captures the Mon-open snap-back when external pricing resumes. Broad
+  XYZ universe (excludes IPOPs, which Lemur owns). LONG OR SHORT on
+  >2% directional move + volume confirmation + SM direction. Tight DSL
+  — Phase 1 12% max_loss, Phase 2 locks fast at +5%, hard_timeout 48h.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦝 RACCOON v1.0.0 — Weekend XYZ Reconciliation
+
+**The XYZ weekend is dead — except for the reconciliation gap.** Fri 17:00 ET through Sun 18:00 ET, trade.xyz has no external pricing for equities or commodities. The market trades against an internal 30-min EWMA oracle that drifts based on impact-price activity. When external pricing RESUMES Sunday evening, the internal-implied price snaps to the real external value. **That snap is the edge.**
+
+## Why this strategy exists
+
+Most Senpi strategies activate 24/7. Raccoon is the opposite — it ONLY runs during the weekend window (Fri 22:00 UTC → Mon 00:00 UTC). Outside that window, the producer outputs `OUTSIDE_WEEKEND_WINDOW` and does nothing.
+
+This is the structural pricing gap documented by trade.xyz:
+- **23/5 external coverage**: Sun 6pm ET - Fri 5pm ET (with 5-6pm ET daily gaps)
+- **Weekend internal-only**: Fri 5pm ET → Sun 6pm ET
+- **Reconciliation point**: Sun 6pm ET when external pricing resumes
+
+When sentiment accumulates during the weekend (news, geopolitical events, related-market moves), it shows up as directional pressure on the internal oracle even without external anchoring. Raccoon positions in that direction, captures the snap-back when external pricing returns Monday open.
+
+## CRITICAL RULES
+
+### RULE 1: Weekend window is hard-coded
+Producer checks UTC time at the start of each tick. Outside Fri 22:00 UTC → Mon 00:00 UTC, no MCP calls, no signals. Saves cost and prevents false weekday signals.
+
+### RULE 2: IPOPs excluded
+IPOPs (auto-detected by Lemur via low funding signature) trade 24/7 with their own internal mechanism. Raccoon filters them out (`min_max_leverage >= 10` excludes the 5x-leverage IPOP cap). Don't double-cover Lemur's territory.
+
+### RULE 3: hard_timeout 48h is mandatory
+Raccoon positions MUST exit before the next weekend starts. 48h cap from entry guarantees the position closes by Monday end-of-day at latest.
+
+### RULE 4: Producer enters. DSL exits.
+Phase 1 max_loss 12% + Phase 2 tight ladder + hard_timeout 48h own all exits.
+
+## How Raccoon scores a trade
+
+**Gates** (all required):
+1. Current UTC time within Fri 22:00 → Mon 00:00
+2. Instrument is xyz: with max_leverage >= 10 (excludes IPOPs) and daily vol >= $1M
+3. 48h directional move >= 2%
+4. SM direction agrees
+5. SM tilt >= 55%
+
+**Score components** (max ~9):
+
+| Signal | Points |
+|---|---|
+| 48h move >= 4% (strong) | +3 |
+| 48h move 2.5-4% (medium) | +2 |
+| 48h move 2-2.5% (weak) | +1 |
+| SM aligned (gate-confirmed) | +2 |
+| SM strongly tilted (>= 70%) | +1 |
+| Volume ratio recent/prior >= 1.5x | +1 |
+
+## DSL preset (tight, weekend-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | **12%** |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | **48h** (forces Mon-open exit) |
+| Time cuts | weak_peak_cut | DISABLED |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 | **+5% / lock 30%** (lock fast on reconciliation snap) |
+| Phase 2 | T1 | +10% / lock 50% |
+| Phase 2 | T2 | +20% / lock 65% |
+| Phase 2 | T3 | +35% / lock 75% |
+| Phase 2 | T4 | +60% / lock 85% |
+
+## Risk guardrails
+
+| Gate | Setting |
+|---|---|
+| max_entries_per_day | 4 |
+| per_asset_cooldown_minutes | 480 (8h) |
+| Slots | 3 |
+| daily_loss_limit_pct | 15 |
+| drawdown_halt_pct | 20 |
+
+## Scanner pattern
+
+This strategy uses the **XYZ universe filter with weekend-gate activation** — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_list_instruments` (universe), `market_get_asset_data`, `leaderboard_get_markets`.
+
+## Operator install
+
+See [README.md](README.md). Run continuously — the producer self-gates to the weekend window.
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+First Senpi skill explicitly designed around trade.xyz's external-pricing gap. Weekend-only activation, IPOP exclusion (Lemur's territory), Mon-open hard timeout, tight DSL for the reconciliation snap.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+See `references/skill-attribution.md`.

--- a/raccoon/config/raccoon-config.json
+++ b/raccoon/config/raccoon-config.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "RACCOON v1.0.0 — Weekend XYZ reconciliation trader. ONLY emits signals during Fri 22:00 UTC → Mon 00:00 UTC (the trade.xyz no-external-price window when XYZ uses internal oracle only). Captures the snap-back that happens at Mon-open when external pricing resumes. Broad XYZ universe (all non-delisted, vol >= $1M, max_leverage >= 10 to exclude pre-IPO IPOPs which are Lemur's territory). Long OR short based on >2% move with volume + SM direction.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "minScore": 5,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "minMoveAbsPct": 2.0,
+  "minVolUsd": 1000000,
+  "minMaxLeverage": 10,
+  "weekendStartUtcHour": 22,
+  "weekendStartDayOfWeek": 4,
+  "weekendEndDayOfWeek": 0,
+  "weekendEndUtcHour": 0,
+  "marginPct": 0.15,
+  "leverage": 3
+}

--- a/raccoon/references/skill-attribution.md
+++ b/raccoon/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "raccoon",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "raccoon",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/raccoon/runtime.yaml
+++ b/raccoon/runtime.yaml
@@ -1,0 +1,200 @@
+name: raccoon-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Raccoon
+# v1.0.0" and lives in description + SKILL.md + _raccoon_producer_version.
+version: 1.0.0
+description: >
+  RACCOON v1.0.0 — Weekend XYZ reconciliation trader with Smart-Money direction gate.
+
+  Onboarding-tier strategy. Single asset (BTC). Long OR short based on
+  the confluence of 4h trend structure + Senpi Smart-Money leaderboard
+  direction. Designed for first-time Senpi users who want a clean
+  "is BTC trending? hold a directional position" experience without
+  having to think about funding rates, SM concentration math, or
+  multi-asset whitelist tuning.
+
+  Architecture (helpers-native, mirrors Wolverine v6.0.0 / Bison v3.0.1):
+    - Producer (raccoon-producer.py) ticks every 300s, scores a BTC
+      thesis with 5 components (max ~9), emits RACCOON_BTC_TREND signal
+      via SenpiClient.push_signal() when score >= 5.
+    - LLM gate is pass-through — producer applied every filter
+      (4h trend non-neutral, SM direction agreement, SM tilt >= 60%).
+    - risk.guard_rails ENFORCES max_entries_per_day=2,
+      per_asset_cooldown, daily_loss_limit, drawdown_halt.
+    - DSL exits via FEE_OPTIMIZED_LIMIT, Bison-pattern wide Phase 2
+      ladder (T0 lock 0 through T5 lock 85) so winning trends can
+      ride multi-day moves. Time-cuts all DISABLED.
+
+  Onboarding tuning:
+    - minScore 5 (easy-to-hit floor; conservative directional confluence)
+    - 2 entries/day cap (low frequency, beginner-friendly)
+    - 25% margin / 5x leverage default (modest sizing, room to grow)
+    - 4h per-asset cooldown
+    - 15% daily-loss limit, 20% drawdown-halt (catastrophic-floor protection)
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 3
+  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 4                # onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20                 # hard stop circuit breaker
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 480       # 4h between BTC attempts
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: raccoon_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        trend4hStrength: { type: number, required: false }
+        trend1h: { type: string, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: raccoon_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${RACCOON_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix. Senpi runtime resolves provider routing.
+    scanners: [raccoon_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # ALO patience on entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: raccoon_signals
+    decision_prompt: |
+      You are Raccoon's pass-through gate. Raccoon is a simple BTC trend
+      follower with a Smart-Money direction gate. The producer already
+      applied every filter (4h trend non-neutral, SM direction agrees
+      with 4h trend, SM tilt >= 60%, minScore 5). Your job is to honor
+      the signal and convert it into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_raccoon_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be "BTC" (Raccoon is single-asset).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - heldAssets contains "BTC" (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND SM tilt >= 70% AND trend4hStrength >= 0.80
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 BTC LONG, 4h_bullish_83%, 1h_confirms, SM aligned 65% — trend confluence with SM agreement')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "BTC",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "RACCOON_BTC_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — Bison-pattern wide ladder) ────────────────────
+#
+# Time-cuts all DISABLED — let trends run on the 4h timescale.
+# Phase 1 max_loss 20% provides catastrophic floor.
+# Phase 2 ladder mirrors Bison v3.0.1 / Wolverine v6.0.0:
+#   T0 +10% / lock 0     — confirms working, no lock yet
+#   T1 +20% / lock 25%
+#   T2 +30% / lock 40%
+#   T3 +50% / lock 60%
+#   T4 +75% / lock 75%
+#   T5 +100% / lock 85%  — apex; multi-day winners ratchet here
+exit:
+  engine: dsl
+  interval_seconds: 60                              # 60s mirrors Bison v3.0.1 REDUCE_ONLY-spam mitigation
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                                 # 48h — forces Monday-open exit so positions don't camp through the next week
+      interval_in_minutes: 2880
+    weak_peak_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,   lock_hw_pct: 30 }
+        - { trigger_pct: 10,  lock_hw_pct: 50 }
+        - { trigger_pct: 20,  lock_hw_pct: 65 }
+        - { trigger_pct: 35,  lock_hw_pct: 75 }
+        - { trigger_pct: 60,  lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/raccoon/scripts/raccoon-producer.py
+++ b/raccoon/scripts/raccoon-producer.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+# Senpi RACCOON Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+"""RACCOON v1.0.0 — Weekend XYZ reconciliation trader.
+
+ONLY emits signals during Fri 22:00 UTC → Mon 00:00 UTC (the trade.xyz
+no-external-price window when XYZ uses internal oracle only). Outside
+this window, the producer outputs WAITING and does nothing.
+
+The thesis: from Fri 17:00 ET through Sun 18:00 ET, trade.xyz has no
+external price feed for equities or commodities (the underlying spot
+markets are closed). XYZ uses an internal 30-min EWMA oracle that
+drifts based on impact-price activity. When external pricing RESUMES
+Sunday 18:00 ET / Monday 00:00 UTC, the internal-oracle-implied price
+snaps back to the real external value. That snap is the edge.
+
+Raccoon positions during the gap in the direction of accumulated
+sentiment (>2% move with volume confirmation + SM agreement). DSL
+hard_timeout 48h enforces Monday-open exit so positions don't camp
+through the next week.
+"""
+
+import hashlib
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import raccoon_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "raccoon_signals"
+SIGNAL_TYPE = "RACCOON_XYZ_WEEKEND"
+
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 3
+DEFAULT_MIN_SCORE = 5
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+DEFAULT_MIN_MOVE_PCT = 2.0
+DEFAULT_MIN_VOL_USD = 1_000_000
+DEFAULT_MIN_MAX_LEV = 10  # excludes IPOPs (max_lev 5) which are Lemur's territory
+# Weekend window: Fri 22:00 UTC → Mon 00:00 UTC
+WEEKEND_START_DOW = 4   # Friday (Python weekday)
+WEEKEND_START_HOUR = 22
+WEEKEND_END_DOW = 0     # Monday
+WEEKEND_END_HOUR = 0
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("RACCOON_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def in_weekend_window(now=None):
+    """True if current UTC time is within Fri 22:00 UTC → Mon 00:00 UTC."""
+    now = now or datetime.now(timezone.utc)
+    dow = now.weekday()  # 0=Mon, 4=Fri, 5=Sat, 6=Sun
+    hour = now.hour
+    # Window: Fri 22:00 UTC → Mon 00:00 UTC
+    if dow == WEEKEND_START_DOW and hour >= WEEKEND_START_HOUR:
+        return True
+    if dow == 5 or dow == 6:  # Saturday or Sunday — all day
+        return True
+    if dow == WEEKEND_END_DOW and hour < WEEKEND_END_HOUR:
+        return True  # Mon before 00:00 — but this is the same as Sun 24:00, which would be Sun 23 hour... covered above
+    return False
+
+
+def fetch_weekend_universe(config):
+    """Filter xyz: instruments to those that are tradeable on the weekend
+    (i.e., NOT IPOPs which Lemur owns)."""
+    raw = cfg.mcp_call("market_list_instruments", dex="xyz")
+    if not raw or not raw.get("success", True):
+        return []
+    data = raw.get("data", raw)
+    instruments = data.get("instruments", data) if isinstance(data, dict) else data
+    if not isinstance(instruments, list):
+        return []
+
+    min_vol = float(config.get("minVolUsd", DEFAULT_MIN_VOL_USD))
+    min_max_lev = int(config.get("minMaxLeverage", DEFAULT_MIN_MAX_LEV))
+
+    universe = []
+    for inst in instruments:
+        if not isinstance(inst, dict):
+            continue
+        name = inst.get("name", "")
+        if not name.startswith("xyz:"):
+            continue
+        if inst.get("is_delisted", False):
+            continue
+        # Exclude IPOPs (max_lev <= 5) which are Lemur's territory
+        if int(inst.get("max_leverage", 0)) < min_max_lev:
+            continue
+        ctx = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        vol_usd = float(ctx.get("dayNtlVlm", 0))
+        if vol_usd < min_vol:
+            continue
+        universe.append({"name": name, "vol_usd": vol_usd})
+    return universe
+
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def detect_directional_move(candles_1h, min_pct):
+    """Returns (direction, move_pct, vol_x). Looks at the move from
+    Friday close (oldest in 1h window roughly) to latest close,
+    with volume confirmation (>1.5x recent avg)."""
+    if len(candles_1h) < 24:
+        return None, 0.0, 1.0
+    # Compare latest close vs ~48h ago (approximates Fri close → now move)
+    earlier = _f(candles_1h[-48], "close", "c") if len(candles_1h) >= 48 else _f(candles_1h[0], "close", "c")
+    latest = _f(candles_1h[-1], "close", "c")
+    if earlier <= 0 or latest <= 0:
+        return None, 0.0, 1.0
+    move_pct = ((latest - earlier) / earlier) * 100
+    abs_move = abs(move_pct)
+    if abs_move < min_pct:
+        return None, 0.0, 1.0
+    # Volume ratio: recent 6h vs prior 18h
+    if len(candles_1h) >= 24:
+        recent_vol = sum(_f(c, "volume", "v") for c in candles_1h[-6:]) / 6
+        prior_vol = sum(_f(c, "volume", "v") for c in candles_1h[-24:-6]) / 18
+        vol_x = recent_vol / prior_vol if prior_vol > 0 else 1.0
+    else:
+        vol_x = 1.0
+    direction = "LONG" if move_pct > 0 else "SHORT"
+    return direction, abs_move, vol_x
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def build_thesis(asset, entry_cfg):
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    if len(candles_1h) < 24:
+        return None
+
+    min_pct = float(entry_cfg.get("minMoveAbsPct", DEFAULT_MIN_MOVE_PCT))
+    direction, move_pct, vol_x = detect_directional_move(candles_1h, min_pct)
+    if direction is None:
+        return None
+
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(entry_cfg.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(entry_cfg.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    score = 0
+    reasons = []
+    # Move magnitude
+    if move_pct >= 4.0:
+        score += 3
+        reasons.append(f"move_strong_{move_pct:+.2f}%")
+    elif move_pct >= 2.5:
+        score += 2
+        reasons.append(f"move_{move_pct:+.2f}%")
+    else:
+        score += 1
+        reasons.append(f"move_weak_{move_pct:+.2f}%")
+    # SM aligned
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+    # SM strongly tilted
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+    # Volume confirmation
+    if vol_x >= 1.5:
+        score += 1
+        reasons.append(f"vol_{vol_x:.1f}x")
+
+    return {
+        "coin": asset, "direction": direction, "score": score, "reasons": reasons,
+        "move_pct": round(move_pct, 3) if direction == "LONG" else -round(move_pct, 3),
+        "vol_ratio": round(vol_x, 2),
+        "sm_direction": sm_dir, "sm_tilt_pct": sm_tilt,
+    }
+
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"], "leverage": leverage, "marginUsd": margin_usd,
+        "direction": thesis["direction"], "reasons": thesis["reasons"],
+        "movePct": thesis["move_pct"], "volRatio": thesis["vol_ratio"],
+        "smDirection": thesis["sm_direction"], "smTiltPct": thesis["sm_tilt_pct"],
+        "weekendWindow": True,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS, scanner=SCANNER_NAME,
+            asset=coin, direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),
+            signal_type=SIGNAL_TYPE, data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+
+    # Weekend gate — only activate during Fri 22:00 UTC → Mon 00:00 UTC
+    if not in_weekend_window():
+        cfg.output({
+            "status": "ok",
+            "note": "OUTSIDE_WEEKEND_WINDOW — Raccoon only fires Fri 22:00 UTC → Mon 00:00 UTC",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_raccoon_producer_version": VERSION,
+        })
+        return
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_raccoon_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_raccoon_producer_version": VERSION})
+        return
+
+    universe = fetch_weekend_universe(config)
+    if not universe:
+        cfg.output({
+            "status": "ok",
+            "note": "no XYZ instruments match liquidity/leverage filter",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_raccoon_producer_version": VERSION,
+        })
+        return
+
+    candidates = []
+    for inst in universe:
+        coin = inst["name"]
+        if coin.upper() in held_set:
+            continue
+        if cfg.was_recently_signaled(coin):
+            continue
+        thesis = build_thesis(coin, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — in weekend window but no qualifying XYZ move + SM agreement",
+            "universe_size": len(universe),
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_raccoon_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"], "direction": best["direction"],
+            "score": best["score"], "leverage": leverage, "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "universe_size": len(universe),
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_raccoon_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"raccoon-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/raccoon/scripts/raccoon_config.py
+++ b/raccoon/scripts/raccoon_config.py
@@ -1,0 +1,220 @@
+"""RACCOON v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Onboarding-tier BTC trend follower with Smart-Money direction gate.
+Single asset (BTC), simple 5-component scoring, SM-confirmed long OR
+short. NOT a HYPE-style alpha hunter — designed for first-time Senpi
+users who want a clean "BTC trending? hold a directional position"
+experience.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder. Mirrors the Wolverine v6.0.0 / Bison
+v3.0.1 pattern (race-window dedup, atomic write, etc).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "raccoon-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "raccoon-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Raccoon ticks every 300s; BTC ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Raccoon's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("raccoon_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] raccoon_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[raccoon-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/salamander/README.md
+++ b/salamander/README.md
@@ -1,0 +1,54 @@
+# 🦎 Salamander — Pullback Catcher
+
+Buy dips in uptrends, short rallies in downtrends. Salamander only acts when the **4h trend is established**, **price has pulled back 3-7% on 1h**, AND **Smart Money agrees with the trend direction**. Universe: BTC, ETH, SOL. Asymmetric DSL — Phase 1 wider (10% max_loss) to give pullbacks room, Phase 2 tighter to lock fast when the trend resumes.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Universe | BTC, ETH, SOL |
+| Tick interval | 300s |
+| MIN_SCORE | 5 (of ~9) |
+| Leverage | 5x default, max 5x |
+| Margin per trade | 20% of equity |
+| Max entries per day | 2 |
+| Per-asset cooldown | 240 min |
+| Daily loss limit | 15% |
+| Drawdown halt | 20% |
+| SM tilt minimum | 55% |
+| Pullback band | 3-7% (configurable) |
+| Pullback lookback | 24h |
+| DSL Phase 1 max_loss | **10%** (wide for pullback room) |
+| DSL Phase 2 T0 | **+5% / lock 30%** (tight, lock fast) |
+| hard_timeout | 48h |
+| weak_peak_cut | 90min / 3% min |
+
+## Install
+
+Same pattern as Hawk — see [Hawk README](../hawk/README.md). Strategy-specific:
+
+```bash
+mkdir -p /data/workspace/skills/salamander-strategy/{config,scripts,state,references}
+for f in scripts/salamander-producer.py scripts/salamander_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/salamander-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/salamander/$f" \
+    -o "/data/workspace/skills/salamander-strategy/$f"
+done
+
+export SALAMANDER_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export SALAMANDER_DECISION_MODEL=<your-preferred-model>
+
+openclaw senpi runtime create --path /data/workspace/skills/salamander-strategy/runtime.yaml
+
+nohup python3 -u /data/workspace/skills/salamander-strategy/scripts/salamander-producer.py \
+  > /tmp/salamander-producer.log 2>&1 &
+disown
+```
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/salamander/SKILL.md
+++ b/salamander/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: salamander-strategy
+description: >-
+  SALAMANDER v1.0.0 — Pullback catcher in established 4h trends.
+  LONG when 4h trend is BULLISH AND 1h price pulled back 3-7% from
+  recent high AND Smart Money is > 55% long. SHORT when 4h trend is
+  BEARISH AND 1h price rallied 3-7% from recent low AND SM is > 55%
+  short. Universe: BTC, ETH, SOL. Asymmetric DSL — Phase 1 wider (10%
+  max_loss, pullbacks need room) but Phase 2 tighter (T0 +5% / lock
+  30%, when thesis works lock fast).
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦎 SALAMANDER v1.0.0 — Pullback Catcher
+
+**Buy dips in uptrends, short rallies in downtrends.** Salamander only acts when the 4h trend is already established AND there's been a 3-7% counter-move on 1h timeframe AND Smart Money agrees with the original trend direction.
+
+## Why this strategy exists
+
+Pullbacks in established trends are one of the highest-edge setups in trading — the trend has already proved itself, the counter-move provides a better entry, and Smart Money confirmation filters out trend-break risk.
+
+**The 3-7% band is the sweet spot:**
+- < 3% pullback: noise, not a real entry
+- 3-7% pullback: tradeable counter-move within trend
+- > 7% pullback: the trend may be breaking; don't catch a falling knife
+
+Salamander requires ALL three:
+1. 4h trend BULLISH (or BEARISH)
+2. 1h pullback in the 3-7% band
+3. Smart Money agreeing with the 4h trend direction (> 55% tilt)
+
+If any one fails, no entry.
+
+## CRITICAL RULES
+
+### RULE 1: 4h trend gate, not score
+The 4h trend must be NON-NEUTRAL. Salamander does not trade chop. If higher-lows-vs-lower-highs is too close to call, the producer outputs `WAITING`.
+
+### RULE 2: Pullback band is hard
+The pullback must fall in `[pullbackMinPct, pullbackMaxPct]` (default 3-7%). Outside that band, no entry. Configurable per asset volatility (smaller bands for stable majors, wider for HYPE-tier).
+
+### RULE 3: Asymmetric DSL is intentional
+- **Phase 1 max_loss 10%** (wider than Hawk's 8%) — pullbacks within a trend need a few percent of room to develop
+- **Phase 2 T0 +5% / lock 30%** (same as Hawk) — when the pullback resolves and the trend resumes, lock fast
+
+If you tighten Phase 1 below 10%, you'll cut legitimate pullback continuations as noise.
+
+### RULE 4: Producer enters. DSL exits.
+No close_position call site. DSL Phase 1 + Phase 2 + hard_timeout 48h own all exits.
+
+## How Salamander scores a trade
+
+**Gates** (all required):
+1. 4h trend non-neutral
+2. 1h pullback (vs prior 24h max for LONG, prior 24h min for SHORT) in [3%, 7%] band
+3. SM direction agrees with 4h trend
+4. SM tilt >= 55%
+
+**Score components** (max ~9):
+
+| Signal | Points |
+|---|---|
+| 4h trend aligned (gate-confirmed) | +3 |
+| Pullback in 3-7% band (gate-confirmed) | +2 |
+| Pullback in 4-6% midpoint sweet spot | +1 |
+| SM aligned (gate-confirmed) | +2 |
+| SM strongly tilted (>= 70%) | +1 |
+
+**Floor:** `minScore: 5`. Typical entry clears 5-7.
+
+## DSL preset (asymmetric)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | **10%** (wider — pullbacks need room) |
+| Phase 1 | retrace_threshold | 6 |
+| Phase 1 | consecutive_breaches | 1 |
+| Time cuts | hard_timeout | **48h** (pullback resolution can take time) |
+| Time cuts | weak_peak_cut | 90min / 3% min |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 | **+5% / lock 30%** (tight — lock fast when thesis works) |
+| Phase 2 | T1 | +10% / lock 50% |
+| Phase 2 | T2 | +20% / lock 65% |
+| Phase 2 | T3 | +35% / lock 75% |
+| Phase 2 | T4 | +60% / lock 85% |
+
+## Scanner pattern
+
+This strategy uses the **Multi-asset whitelist scanner with pullback-detection scoring** — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data`, `leaderboard_get_markets`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-20) — initial release
+
+Second in the technical-pattern pair (Hawk = breakouts, Salamander = pullbacks). Asymmetric DSL distinguishes from Hawk's tight breakout profile — pullback theses need wider Phase 1 floor.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/salamander/config/salamander-config.json
+++ b/salamander/config/salamander-config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "SALAMANDER v1.0.0 — Pullback catcher (BTC/ETH/SOL). LONG when 4h trend is BULLISH AND 1h price pulled back 3-7% from recent high AND SM > 55% long. SHORT when 4h trend is BEARISH AND 1h price rallied 3-7% from recent low AND SM > 55% short. Asymmetric DSL: Phase 1 wider (10% max_loss, pullbacks need room) but Phase 2 tighter (T0 +5% / lock 30%, when thesis works lock fast).",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "universe": ["BTC", "ETH", "SOL"],
+  "minScore": 5,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "pullbackMinPct": 3.0,
+  "pullbackMaxPct": 7.0,
+  "pullbackLookbackHours": 24,
+  "marginPct": 0.20,
+  "leverage": 5
+}

--- a/salamander/references/skill-attribution.md
+++ b/salamander/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "salamander",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "salamander",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/salamander/runtime.yaml
+++ b/salamander/runtime.yaml
@@ -1,0 +1,200 @@
+name: salamander-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Salamander
+# v1.0.0" and lives in description + SKILL.md + _salamander_producer_version.
+version: 1.0.0
+description: >
+  SALAMANDER v1.0.0 — Pullback catcher within established 4h trend with Smart-Money direction gate.
+
+  Onboarding-tier strategy. Single asset (BTC). Long OR short based on
+  the confluence of 4h trend structure + Senpi Smart-Money leaderboard
+  direction. Designed for first-time Senpi users who want a clean
+  "is BTC trending? hold a directional position" experience without
+  having to think about funding rates, SM concentration math, or
+  multi-asset whitelist tuning.
+
+  Architecture (helpers-native, mirrors Wolverine v6.0.0 / Bison v3.0.1):
+    - Producer (salamander-producer.py) ticks every 300s, scores a BTC
+      thesis with 5 components (max ~9), emits SALAMANDER_BTC_TREND signal
+      via SenpiClient.push_signal() when score >= 5.
+    - LLM gate is pass-through — producer applied every filter
+      (4h trend non-neutral, SM direction agreement, SM tilt >= 60%).
+    - risk.guard_rails ENFORCES max_entries_per_day=2,
+      per_asset_cooldown, daily_loss_limit, drawdown_halt.
+    - DSL exits via FEE_OPTIMIZED_LIMIT, Bison-pattern wide Phase 2
+      ladder (T0 lock 0 through T5 lock 85) so winning trends can
+      ride multi-day moves. Time-cuts all DISABLED.
+
+  Onboarding tuning:
+    - minScore 5 (easy-to-hit floor; conservative directional confluence)
+    - 2 entries/day cap (low frequency, beginner-friendly)
+    - 25% margin / 5x leverage default (modest sizing, room to grow)
+    - 4h per-asset cooldown
+    - 15% daily-loss limit, 20% drawdown-halt (catastrophic-floor protection)
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 2                # onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20                 # hard stop circuit breaker
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240       # 4h between BTC attempts
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: salamander_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        trend4hStrength: { type: number, required: false }
+        trend1h: { type: string, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: salamander_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${SALAMANDER_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix. Senpi runtime resolves provider routing.
+    scanners: [salamander_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # ALO patience on entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: salamander_signals
+    decision_prompt: |
+      You are Salamander's pass-through gate. Salamander is a simple BTC trend
+      follower with a Smart-Money direction gate. The producer already
+      applied every filter (4h trend non-neutral, SM direction agrees
+      with 4h trend, SM tilt >= 60%, minScore 5). Your job is to honor
+      the signal and convert it into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_salamander_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be "BTC" (Salamander is single-asset).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - heldAssets contains "BTC" (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND SM tilt >= 70% AND trend4hStrength >= 0.80
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 BTC LONG, 4h_bullish_83%, 1h_confirms, SM aligned 65% — trend confluence with SM agreement')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "BTC",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "SALAMANDER_BTC_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — Bison-pattern wide ladder) ────────────────────
+#
+# Time-cuts all DISABLED — let trends run on the 4h timescale.
+# Phase 1 max_loss 20% provides catastrophic floor.
+# Phase 2 ladder mirrors Bison v3.0.1 / Wolverine v6.0.0:
+#   T0 +10% / lock 0     — confirms working, no lock yet
+#   T1 +20% / lock 25%
+#   T2 +30% / lock 40%
+#   T3 +50% / lock 60%
+#   T4 +75% / lock 75%
+#   T5 +100% / lock 85%  — apex; multi-day winners ratchet here
+exit:
+  engine: dsl
+  interval_seconds: 60                              # 60s mirrors Bison v3.0.1 REDUCE_ONLY-spam mitigation
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                                 # 24h cap — failed pullbacks get cut
+      interval_in_minutes: 2880
+    weak_peak_cut:
+      enabled: true                                 # 60min/3% — stale pullbacks cut
+      interval_in_minutes: 90
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                                # DISABLED
+      interval_in_minutes: 90
+    phase1:
+      enabled: true
+      max_loss_pct: 10.0
+      retrace_threshold: 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,   lock_hw_pct: 30 }
+        - { trigger_pct: 10,  lock_hw_pct: 50 }
+        - { trigger_pct: 20,  lock_hw_pct: 65 }
+        - { trigger_pct: 35,  lock_hw_pct: 75 }
+        - { trigger_pct: 60,  lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/salamander/scripts/salamander-producer.py
+++ b/salamander/scripts/salamander-producer.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+# Senpi SALAMANDER Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""SALAMANDER v1.0.0 — Pullback catcher.
+
+LONG when: 4h trend is BULLISH AND 1h price pulled back 3-7% from
+the recent high AND Smart Money is > 55% long.
+SHORT when: 4h trend is BEARISH AND 1h price rallied 3-7% from the
+recent low AND SM is > 55% short.
+
+"Buying the dip" or "shorting the rally" within an established trend.
+Pullbacks shallower than 3% are noise; deeper than 7% suggest the
+trend is breaking. Sweet spot: 3-7%.
+
+Asymmetric DSL:
+  Phase 1 max_loss 10% (wider — pullbacks need room to develop)
+  Phase 2 first tier +5% / lock 30% (tight — when thesis works, lock fast)
+"""
+
+import hashlib
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import salamander_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "salamander_signals"
+SIGNAL_TYPE = "SALAMANDER_PULLBACK"
+
+DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL"]
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 5
+DEFAULT_MIN_SCORE = 5
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+DEFAULT_PULLBACK_MIN = 3.0
+DEFAULT_PULLBACK_MAX = 7.0
+DEFAULT_PULLBACK_LOOKBACK = 24
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("SALAMANDER_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def trend_4h(candles_4h, lookback=6):
+    if len(candles_4h) < lookback:
+        return "NEUTRAL"
+    lows = [_f(c, "low", "l") for c in candles_4h[-lookback:]]
+    highs = [_f(c, "high", "h") for c in candles_4h[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH"
+    if lower_highs >= total * 0.6:
+        return "BEARISH"
+    return "NEUTRAL"
+
+
+def detect_pullback(candles_1h, lookback_hours, min_pct, max_pct, trend):
+    """Returns (direction, pullback_pct) when a pullback within the trend
+    falls in the [min_pct, max_pct] band, else (None, 0).
+
+    For BULLISH trend: looks at how far the latest close is BELOW the
+    recent high within lookback. If 3-7%, it's a LONG pullback.
+    For BEARISH trend: looks at how far latest close is ABOVE the recent
+    low. If 3-7%, it's a SHORT rally.
+    """
+    if len(candles_1h) < lookback_hours + 1 or trend == "NEUTRAL":
+        return None, 0.0
+    window = candles_1h[-lookback_hours:]
+    closes = [_f(c, "close", "c") for c in window]
+    if not closes or closes[-1] <= 0:
+        return None, 0.0
+    if trend == "BULLISH":
+        recent_high = max(closes[:-1])
+        if recent_high <= 0:
+            return None, 0.0
+        pullback_pct = ((recent_high - closes[-1]) / recent_high) * 100
+        if min_pct <= pullback_pct <= max_pct:
+            return "LONG", pullback_pct
+    else:  # BEARISH
+        recent_low = min(closes[:-1])
+        if recent_low <= 0:
+            return None, 0.0
+        rally_pct = ((closes[-1] - recent_low) / recent_low) * 100
+        if min_pct <= rally_pct <= max_pct:
+            return "SHORT", rally_pct
+    return None, 0.0
+
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def build_thesis(asset, entry_cfg):
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    candles_4h = data.get("data", {}).get("candles", {}).get("4h", [])
+    lookback = int(entry_cfg.get("pullbackLookbackHours", DEFAULT_PULLBACK_LOOKBACK))
+    if len(candles_1h) < lookback + 1 or len(candles_4h) < 6:
+        return None
+
+    t4 = trend_4h(candles_4h)
+    if t4 == "NEUTRAL":
+        return None
+
+    direction, pullback_pct = detect_pullback(
+        candles_1h, lookback,
+        float(entry_cfg.get("pullbackMinPct", DEFAULT_PULLBACK_MIN)),
+        float(entry_cfg.get("pullbackMaxPct", DEFAULT_PULLBACK_MAX)),
+        t4,
+    )
+    if direction is None:
+        return None
+
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(entry_cfg.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(entry_cfg.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    score = 0
+    reasons = []
+
+    # 4h trend aligned (gate-confirmed, this is the foundation)
+    score += 3
+    reasons.append(f"4h_{t4.lower()}_trend")
+
+    # Pullback in sweet spot 3-7%
+    score += 2
+    reasons.append(f"pullback_{pullback_pct:+.2f}%")
+
+    # Sweet spot midpoint bonus (4-6% is ideal — too shallow = noise, too deep = trend break)
+    if 4.0 <= pullback_pct <= 6.0:
+        score += 1
+        reasons.append("pullback_in_midpoint")
+
+    # SM aligned
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+
+    # SM strongly tilted
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_4h": t4,
+        "pullback_pct": round(pullback_pct, 3),
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": sm_tilt,
+    }
+
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "trend4h": thesis["trend_4h"],
+        "pullbackPct": thesis["pullback_pct"],
+        "smDirection": thesis["sm_direction"],
+        "smTiltPct": thesis["sm_tilt_pct"],
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    universe = [a.upper() for a in config.get("universe", DEFAULT_UNIVERSE)]
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_salamander_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_salamander_producer_version": VERSION})
+        return
+
+    candidates = []
+    for asset in universe:
+        if asset in held_set:
+            continue
+        if cfg.was_recently_signaled(asset):
+            continue
+        thesis = build_thesis(asset, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no pullback in trend with SM agreement on universe",
+            "universe": universe,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_salamander_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.20))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_salamander_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"salamander-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/salamander/scripts/salamander_config.py
+++ b/salamander/scripts/salamander_config.py
@@ -1,0 +1,220 @@
+"""SALAMANDER v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Onboarding-tier BTC trend follower with Smart-Money direction gate.
+Single asset (BTC), simple 5-component scoring, SM-confirmed long OR
+short. NOT a HYPE-style alpha hunter — designed for first-time Senpi
+users who want a clean "BTC trending? hold a directional position"
+experience.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder. Mirrors the Wolverine v6.0.0 / Bison
+v3.0.1 pattern (race-window dedup, atomic write, etc).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "salamander-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "salamander-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Salamander ticks every 300s; BTC ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Salamander's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("salamander_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] salamander_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[salamander-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
## Summary

Ten new helpers-native, DSL-driven, Smart-Money-confirmed strategies designed for **new users onboarding to Senpi**. Each follows the Bison v3.0.1 / Wolverine v6.0.0 pattern and uses the Senpi `leaderboard_get_markets` SM direction gate to decide long vs short (no long-only strategies).

## What's in

### 🟢 Crypto trend trio (asset-specific)
- **beaver/** — BTC trend + SM gate
- **heron/** — ETH trend + SM gate
- **hummingbird/** — HYPE trend + SM gate

### 🔵 Diversified basket
- **hedgehog/** — BTC + ETH + SOL equal-weight, each asset independently directional. Up to 3 simultaneous positions, per-position DSL

### 🟣 Multi-week conviction mirror
- **albatross/** — Mirrors Arena leaders by composite score `0.3 × monthly_roe + 0.7 × mean(weekly_roe) − 0.5 × stdev(weekly_roe)`. Rewards persistence, penalizes lucky-week luck. **REQUIRES user-scope SENPI_AUTH_TOKEN** (calls strategy_list + discovery_get_trader_state for other users)

### 🟡 Technical patterns
- **hawk/** — 4h breakout above 7d high (LONG) or breakdown below 7d low (SHORT). **TIGHT DSL** — Phase 1 8% max_loss, T0 locks 30% at +5%. Failed breakouts get cut fast.
- **salamander/** — 3-7% pullback in 4h uptrend (LONG) or rally in downtrend (SHORT). **Asymmetric DSL** — Phase 1 wider (10%), Phase 2 tight (T0 +5% / lock 30%).

### 🟠 XYZ equities (Hyperliquid HIP-3 / trade.xyz)
- **lemur/** — Pre-IPO Perpetuals (IPOPs). Auto-discovers via the trade.xyz funding signature (`|funding| ≤ 1e-7 AND max_leverage ≤ 5`). Today: `xyz:SPCX`. Future-proof against new IPOP listings (ANTHROPIC, OPENAI, STRIPE, etc.)
- **bobcat/** — Big tech: NVDA, TSLA, AAPL, META, MSFT, GOOGL, AMZN, AMD, MU, INTC, TSM, ORCL. 48h hard_timeout for the weekend pricing gap.
- **raccoon/** — Weekend-only. Fri 22:00 UTC → Mon 00:00 UTC. Captures the Mon-open snap-back when trade.xyz external pricing resumes after the 50h internal-oracle window. Excludes IPOPs.

## Shared architecture (all 10)

- Helpers-native producer (`senpi_runtime_helpers` SDK)
- Bison v3.0.1 race-window dedup (`state/recent-signals.json`, 240s TTL)
- Smart-Money direction gate via `leaderboard_get_markets`
- DSL Phase 1 max_loss floor + Phase 2 wide ratchet ladder
- Runtime LLM-gated entries via `FEE_OPTIMIZED_LIMIT` (maker-first ALO)
- `runtime.yaml risk.guard_rails` for daily-loss / drawdown / cooldown gates

## Stats

- **71 files** (10 strategies × 7 files each: producer, config helper, runtime.yaml, SKILL.md, README.md, config JSON, skill-attribution; +1 README.md edit)
- **+10,493 LOC** added, 1 removed
- All 70 strategy files compile cleanly (py_compile, json.load, yaml.safe_load)
- README.md updated with new "🎯 New to Senpi? Start here" section
- Stale `[hawk]` reference removed from Multi-signal confluence bucket (legacy hawk was deleted in `ef80a08`; the new hawk in this PR is a different concept)

## Per-strategy DSL profiles

| Strategy | Phase 1 max_loss | Phase 1 retrace | Phase 2 T0 | hard_timeout |
|---|---|---|---|---|
| Beaver/Heron/Hummingbird | 20% | 8 | +10% / lock 0 | DISABLED |
| Hedgehog | 15% per leg | 8 | +10% / lock 0 | 48h |
| Albatross | 20% | 8 | +10% / lock 0 | 96h (4d) |
| Hawk | **8%** (tight) | 5 | **+5% / lock 30%** (lock fast) | 24h |
| Salamander | 10% | 6 | +5% / lock 30% (asymmetric) | 48h |
| Lemur (IPOP) | 10% | 8 | +10% / lock 0 | DISABLED (24/7) |
| Bobcat | 15% | 8 | +10% / lock 0 | 48h |
| Raccoon | 12% | 8 | +5% / lock 30% (fast snap-back) | 48h (Mon-open) |

## Caveats

1. **Albatross requires user-scope SENPI_AUTH_TOKEN.** Service tokens can't call `strategy_list({userIds: [other_user]})` or `discovery_get_trader_state(other_user_wallet)`. Documented in Albatross SKILL.md + README.md.
2. **Lemur today is effectively single-asset.** Only `xyz:SPCX` matches the IPOP signature on Hyperliquid right now. Strategy is future-proofed — when trade.xyz lists more IPOPs they'll auto-appear in the universe.
3. **Raccoon is dormant 5 days a week.** Producer self-gates to Fri 22:00 → Mon 00:00 UTC. Outside that window every tick outputs `OUTSIDE_WEEKEND_WINDOW`. Intentional.

## Test plan

- [ ] Per-strategy operator install — pull files, set env vars, start daemon, verify VERSION in tick output
- [ ] Beaver first-tick — expect `"note": "WAITING — no qualifying setup"` initially (BTC may not be trending) OR a real signal if 4h trend + SM aligned
- [ ] Albatross first-tick (with user-scope auth) — expect `leader_pool_size` 1-5 with composite scores; if 0, check auth scope
- [ ] Raccoon — start during weekday → expect `OUTSIDE_WEEKEND_WINDOW`; restart Fri 22:00 UTC → expect universe scan + scoring
- [ ] Hedgehog — over a 24h window, should see 1-3 positions opening as gates pass on different assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)