### PR TITLE
fix(helpers): drop keep-alive pool, add idempotency-gated retry

### DIFF
--- a/senpi-trading-runtime/senpi_runtime_helpers/__init__.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/__init__.py
@@ -46,4 +46,4 @@ __all__ = [
     "log_event",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/senpi-trading-runtime/senpi_runtime_helpers/client.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/client.py
@@ -4,11 +4,15 @@ Bypasses openclaw gateway and mcporter entirely. The 6-process spawn tree
 (gateway → sh → python → node mcporter → npm exec → sh → node mcp-remote)
 is replaced with a single Python HTTP request.
 
-Connection reuse: a thread-local pool of `http.client.HTTPSConnection`
-keeps one keep-alive connection per (scheme, host, port) per thread. The
-first MCP call in a tick pays the TLS handshake; subsequent calls reuse
-the connection and only pay the request round-trip. On errors the
-connection is closed and re-opened on next use.
+Connection model: a FRESH `http.client` connection per request, always
+closed in a `finally`. There is deliberately no keep-alive pool. Producers
+make ~1 call per tick on a 90s+ cadence, so connection reuse saves nothing
+to amortize — while a pooled keep-alive socket, left idle past the server's
+keep-alive timeout, gets closed server-side and the next reuse raises
+`BrokenPipe` / "remote end closed connection". That stale-socket failure
+silently dropped trade signals; fresh-per-call removes the failure class
+entirely. A single, idempotency-gated retry (see `_with_post_retry`) covers
+genuinely transient blips (e.g. the runtime plugin mid-restart).
 
 Returns the same unwrapped JSON shape that `mcporter call` returns — so
 it is a near drop-in for `mcporter_call(tool, **params)`.
@@ -25,7 +29,7 @@ import time
 import urllib.error
 import urllib.request
 from contextlib import contextmanager
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlsplit
 
 from . import _config as cfg
@@ -39,11 +43,22 @@ _HELPERS_NAME = "senpi_runtime_helpers"
 # MCP `clientInfo.version`, and the package `__version__` is what `pip show`
 # / log scrapers report. A drift between the two makes incident triage say
 # different things depending on where you look.
-_HELPERS_VERSION = "0.1.0"
+_HELPERS_VERSION = "0.1.1"
 
 
 class SenpiClientError(Exception):
     """Raised when MCP or signal call fails for non-network reasons (auth, schema)."""
+
+
+class _NeverDelivered(urllib.error.URLError):
+    """Transport failure on the connect/send leg — the request never reached
+    the server, so re-issuing it is always safe (even for a non-idempotent POST)."""
+
+
+class _MaybeDelivered(urllib.error.URLError):
+    """Transport failure on the read-response leg — the request bytes were
+    already on the wire, so the server MAY have processed it. Re-issuing a
+    non-idempotent POST here risks a duplicate (e.g. a second position)."""
 
 
 class _MCPSession:
@@ -60,77 +75,57 @@ class _MCPSession:
         return next(self._id_counter)
 
 
-class _ConnectionPool:
-    """Thread-local keep-alive connection pool keyed by (scheme, host, port).
+def _new_connection(scheme: str, host: str, port: int, timeout: float) -> "http.client.HTTPConnection":
+    """Open a fresh connection. The constructor `timeout` governs connect,
+    send, and recv on this connection — no live-socket pushdown needed since
+    every call gets its own connection and connects immediately."""
+    cls = http.client.HTTPSConnection if scheme == "https" else http.client.HTTPConnection
+    return cls(host, port, timeout=timeout)
 
-    Each worker thread keeps its own connection per host, so two threads
-    in `parallel(...)` don't serialise on one connection. http.client's
-    HTTPConnection is single-request-at-a-time per instance; the
-    thread-local layout is the simplest way to get keep-alive without
-    adding a dependency on a real pool library.
+
+def _with_post_retry(do_call: "Callable[[], Any]", *, idempotent: bool) -> Any:
+    """Run `do_call` with at most ONE extra attempt, gated on idempotency.
+
+    - `_NeverDelivered` (connect/send leg failed): always retry — the request
+      never left us, so re-issuing cannot duplicate anything.
+    - `_MaybeDelivered` (read leg failed after send): retry ONLY when the
+      operation is idempotent (GET). For a non-idempotent POST (`/signals`,
+      MCP `tools/call`) we must NOT retry — the server may already have
+      processed it, and a blind retry could open a duplicate position.
+
+    Deliberately does NOT catch `urllib.error.HTTPError` (a delivered server
+    response — no transport problem) or `SenpiClientError` (protocol/schema).
+    No backoff: a fresh connect IS the wait, and the per-tick budget is tight.
     """
-
-    def __init__(self) -> None:
-        self._local = threading.local()
-
-    def _conns(self) -> Dict[Tuple[str, str, int], "http.client.HTTPConnection"]:
-        if not hasattr(self._local, "conns"):
-            self._local.conns = {}
-        return self._local.conns
-
-    def get(self, scheme: str, host: str, port: int, timeout: float) -> "http.client.HTTPConnection":
-        key = (scheme, host, port)
-        conns = self._conns()
-        conn = conns.get(key)
-        if conn is None:
-            cls = http.client.HTTPSConnection if scheme == "https" else http.client.HTTPConnection
-            conn = cls(host, port, timeout=timeout)
-            conns[key] = conn
-        else:
-            # `conn.timeout` is only consulted by http.client during connect().
-            # On a reused connection the socket was created with the original
-            # timeout; mutating the attribute now is a silent no-op. To make
-            # per-call timeout overrides actually take effect, push the new
-            # timeout down to the live socket's deadline. `conn.sock` is None
-            # before connect — that path is fine because the next request()
-            # will trigger connect() and pick up the updated `conn.timeout`.
-            conn.timeout = timeout
-            if conn.sock is not None:
-                conn.sock.settimeout(timeout)
-        return conn
-
-    def reset(self, scheme: str, host: str, port: int) -> None:
-        key = (scheme, host, port)
-        conns = self._conns()
-        conn = conns.pop(key, None)
-        if conn is not None:
-            try:
-                conn.close()
-            except OSError:
-                pass
+    try:
+        return do_call()
+    except _NeverDelivered:
+        return do_call()
+    except _MaybeDelivered:
+        if idempotent:
+            return do_call()
+        raise
 
 
 @contextmanager
 def _post_json(
-    pool: "_ConnectionPool",
     url: str,
     body: Any,
     headers: Dict[str, str],
     timeout: float,
 ):
-    """Context manager: POST a JSON body and yield the open
-    `http.client.HTTPResponse`.
+    """Context manager: POST a JSON body on a FRESH connection and yield the
+    open `http.client.HTTPResponse`.
 
-    Reuses a per-thread keep-alive connection from `pool`. On any transport
-    error the connection is closed (so the next call gets a fresh one) and a
-    `urllib.error.URLError` / `HTTPError` is raised to keep the existing
-    exception-handling shape intact.
+    The connection is unconditionally closed in `finally`, so the caller MUST
+    read the response body INSIDE the `with` block — `resp` is invalid after
+    the block exits.
 
-    On every exit path — success, error, or exception inside the `with` block
-    — `Connection: close` from the server triggers `pool.reset()`. Otherwise
-    the pool would retain a connection whose remote end is already closed,
-    causing the next call through that thread's pool to fail with a transport
-    error before the pool self-heals.
+    Transport failures are tagged by which leg failed so the retry wrapper can
+    decide whether re-issuing is safe:
+    - `conn.request(...)` (connect/send) failure → `_NeverDelivered`
+    - `conn.getresponse()` (read) failure → `_MaybeDelivered`
+    A 4xx/5xx response is a delivered result and surfaces as `urllib.error.HTTPError`.
     """
     parts = urlsplit(url)
     scheme = parts.scheme
@@ -149,38 +144,32 @@ def _post_json(
     }
     request_headers.update(headers)
 
-    conn = pool.get(scheme, host, port, timeout)
+    conn = _new_connection(scheme, host, port, timeout)
     try:
-        conn.request("POST", path, body=data, headers=request_headers)
-        resp = conn.getresponse()
-    except (http.client.HTTPException, ConnectionError, OSError, TimeoutError) as e:
-        pool.reset(scheme, host, port)
-        raise urllib.error.URLError(str(e)) from e
+        # Keep these two legs in SEPARATE try-blocks. Merging them would tag a
+        # read-leg failure as never-delivered and make non-idempotent POSTs
+        # retry-eligible — risking duplicate positions.
+        try:
+            conn.request("POST", path, body=data, headers=request_headers)
+        except (http.client.HTTPException, ConnectionError, OSError, TimeoutError) as e:
+            raise _NeverDelivered(str(e)) from e
+        try:
+            resp = conn.getresponse()
+        except (http.client.HTTPException, ConnectionError, OSError, TimeoutError) as e:
+            raise _MaybeDelivered(str(e)) from e
 
-    if resp.status >= 400:
-        # Drain so the connection can be reused for the next request.
-        body_bytes = resp.read()
-        # If the server signalled connection-close, drop our reference.
-        if resp.getheader("Connection", "").lower() == "close":
-            pool.reset(scheme, host, port)
-        raise urllib.error.HTTPError(
-            url, resp.status, resp.reason, dict(resp.getheaders()), io.BytesIO(body_bytes)
-        )
+        if resp.status >= 400:
+            body_bytes = resp.read()
+            raise urllib.error.HTTPError(
+                url, resp.status, resp.reason, dict(resp.getheaders()), io.BytesIO(body_bytes)
+            )
 
-    try:
         yield resp
     finally:
-        # Mirror the error-path cleanup on the success path too. Without this,
-        # `Connection: close` on a 2xx leaves a server-closed socket in the
-        # pool and the next call through that thread fails before pool reset.
         try:
-            if resp.getheader("Connection", "").lower() == "close":
-                pool.reset(scheme, host, port)
-        finally:
-            try:
-                resp.close()
-            except Exception:
-                pass
+            conn.close()
+        except Exception:
+            pass
 
 
 def _read_response_body(resp) -> Dict[str, Any]:
@@ -261,9 +250,6 @@ class SenpiClient:
         # Serializes initialize / notifications/initialized handshake so
         # parallel callers don't issue duplicate init POSTs.
         self._init_lock = threading.Lock()
-        # Thread-local keep-alive HTTP connections. First call per thread
-        # pays a TLS handshake; subsequent calls reuse the connection.
-        self._pool = _ConnectionPool()
 
     # ──────────────── MCP ────────────────
 
@@ -296,9 +282,15 @@ class SenpiClient:
             started = time.time()
             sid: Optional[str] = None
             try:
-                with _post_json(self._pool, self.mcp_url, body, self._mcp_headers(), timeout) as resp:
-                    sid = resp.headers.get("Mcp-Session-Id")  # case-insensitive in CPython
-                    _ = _read_response_body(resp)
+                # initialize POST. Non-idempotent → retry only if it never
+                # left us (`_NeverDelivered`), via `_with_post_retry`.
+                def _do_initialize() -> Optional[str]:
+                    with _post_json(self.mcp_url, body, self._mcp_headers(), timeout) as resp:
+                        candidate = resp.headers.get("Mcp-Session-Id")  # case-insensitive in CPython
+                        _ = _read_response_body(resp)
+                    return candidate
+
+                sid = _with_post_retry(_do_initialize, idempotent=False)
                 # Streamable-HTTP requires `notifications/initialized` after init.
                 # Use the candidate sid in headers for THIS handshake so the
                 # server can correlate; only commit it to the session if the
@@ -311,8 +303,12 @@ class SenpiClient:
                     "method": "notifications/initialized",
                     "params": {},
                 }
-                with _post_json(self._pool, self.mcp_url, note, note_headers, timeout) as resp:
-                    _ = resp.read()
+
+                def _do_notify() -> None:
+                    with _post_json(self.mcp_url, note, note_headers, timeout) as resp:
+                        _ = resp.read()
+
+                _with_post_retry(_do_notify, idempotent=False)
             except urllib.error.HTTPError as e:
                 # Init failed cleanly — leave session_id unset so the next
                 # attempt starts from scratch. No partial commit.
@@ -359,8 +355,12 @@ class SenpiClient:
         }
         started = time.time()
         try:
-            with _post_json(self._pool, self.mcp_url, body, self._mcp_headers(), timeout) as resp:
-                rpc = _read_response_body(resp)
+            # tools/call is non-idempotent → retry only if it never left us.
+            def _do_call() -> Any:
+                with _post_json(self.mcp_url, body, self._mcp_headers(), timeout) as resp:
+                    return _read_response_body(resp)
+
+            rpc = _with_post_retry(_do_call, idempotent=False)
             duration_ms = int((time.time() - started) * 1000)
             log_event("mcp_call", tool=tool, duration_ms=duration_ms, status="ok")
             return _unwrap_tool_result(rpc)
@@ -442,33 +442,39 @@ class SenpiClient:
         port = parts.port or 80
         path = (parts.path or "/") + (f"?{parts.query}" if parts.query else "")
 
-        conn = self._pool.get(scheme, host, port, timeout)
+        # GET is idempotent, so a retry is safe on EITHER leg. Fresh connection
+        # per attempt; closed in `finally`.
+        def _attempt() -> Tuple[int, bytes]:
+            conn = _new_connection(scheme, host, port, timeout)
+            try:
+                try:
+                    conn.request("GET", path, headers={"Host": parts.netloc, "Accept": "application/json"})
+                except (http.client.HTTPException, ConnectionError, OSError, TimeoutError) as e:
+                    raise _NeverDelivered(str(e)) from e
+                try:
+                    resp = conn.getresponse()
+                except (http.client.HTTPException, ConnectionError, OSError, TimeoutError) as e:
+                    raise _MaybeDelivered(str(e)) from e
+                return resp.status, resp.read()
+            finally:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
         try:
-            conn.request("GET", path, headers={"Host": parts.netloc, "Accept": "application/json"})
-            resp = conn.getresponse()
-        except (http.client.HTTPException, ConnectionError, OSError, TimeoutError) as e:
-            self._pool.reset(scheme, host, port)
+            status, raw = _with_post_retry(_attempt, idempotent=True)
+        except urllib.error.URLError as e:
             raise SenpiClientError(f"state probe transport error: {e}") from e
 
-        # Use HTTPResponse as a context manager so its socket-bookkeeping
-        # `close()` runs on every exit path (success, non-200 raise, JSON decode
-        # raise). Without `with`, leaving via raise leaves the keep-alive socket
-        # to GC — under boot + every 5-minute alive_check, that adds up.
-        with resp:
-            try:
-                raw = resp.read()
-            finally:
-                if resp.getheader("Connection", "").lower() == "close":
-                    self._pool.reset(scheme, host, port)
-
-            if resp.status != 200:
-                raise SenpiClientError(
-                    f"state probe HTTP {resp.status}: {raw[:200]!r}"
-                )
-            try:
-                parsed = json.loads(raw.decode("utf-8"))
-            except (json.JSONDecodeError, UnicodeDecodeError) as e:
-                raise SenpiClientError(f"state probe response not valid JSON: {e}") from e
+        if status != 200:
+            raise SenpiClientError(
+                f"state probe HTTP {status}: {raw[:200]!r}"
+            )
+        try:
+            parsed = json.loads(raw.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            raise SenpiClientError(f"state probe response not valid JSON: {e}") from e
 
         # Senpi-stack envelope:
         #   { "success": true, "data": { "runtimes": [RuntimeSystemState, ...] } }
@@ -602,8 +608,14 @@ class SenpiClient:
         body = items  # bare array — runtime schema is Array<SignalItem>
         started = time.time()
         try:
-            with _post_json(self._pool, self._signals_url(), body, {}, timeout) as resp:
-                raw = resp.read()
+            # POST /signals is NON-idempotent — a blind retry after the request
+            # may have been delivered could open a duplicate position. So retry
+            # only when the request provably never left us (`_NeverDelivered`).
+            def _do_post() -> bytes:
+                with _post_json(self._signals_url(), body, {}, timeout) as resp:
+                    return resp.read()
+
+            raw = _with_post_retry(_do_post, idempotent=False)
             duration_ms = int((time.time() - started) * 1000)
             # --- Body parse: distinguish empty / malformed / non-object ---
             # Three failure modes that previous code collapsed into one

--- a/senpi-trading-runtime/senpi_runtime_helpers/tests/test_client.py
+++ b/senpi-trading-runtime/senpi_runtime_helpers/tests/test_client.py
@@ -381,10 +381,10 @@ class ClientTests(unittest.TestCase):
         from senpi_runtime_helpers import client as client_mod
         original = client_mod._post_json
 
-        def with_legacy_header(pool, url, body, headers, timeout):
+        def with_legacy_header(url, body, headers, timeout):
             headers = dict(headers)
             headers["X-Mock-Shape"] = "legacy"
-            return original(pool, url, body, headers, timeout)
+            return original(url, body, headers, timeout)
 
         client_mod._post_json = with_legacy_header
         try:
@@ -410,10 +410,10 @@ class ClientTests(unittest.TestCase):
         from senpi_runtime_helpers import client as client_mod
         original = client_mod._post_json
 
-        def with_empty_header(pool, url, body, headers, timeout):
+        def with_empty_header(url, body, headers, timeout):
             headers = dict(headers)
             headers["X-Mock-Body"] = "empty"
-            return original(pool, url, body, headers, timeout)
+            return original(url, body, headers, timeout)
 
         client_mod._post_json = with_empty_header
         try:
@@ -435,10 +435,10 @@ class ClientTests(unittest.TestCase):
         from senpi_runtime_helpers import client as client_mod
         original = client_mod._post_json
 
-        def with_bad_json_header(pool, url, body, headers, timeout):
+        def with_bad_json_header(url, body, headers, timeout):
             headers = dict(headers)
             headers["X-Mock-Body"] = "bad-json"
-            return original(pool, url, body, headers, timeout)
+            return original(url, body, headers, timeout)
 
         client_mod._post_json = with_bad_json_header
         try:
@@ -507,121 +507,184 @@ class ClientTests(unittest.TestCase):
         with self.assertRaises(SenpiClientError):
             c.is_scanner_registered("0xrt1ABCDEF", "")
 
-    def test_fetch_state_closes_response_on_success(self) -> None:
-        """`_fetch_state` must run the HTTPResponse through a context manager so
-        its socket bookkeeping (HTTPResponse.close()) fires on every exit path.
-        Without the `with resp:` wrapper, repeated state probes leaked
-        keep-alive sockets — boot probe + every 5-min alive_check on a
-        long-running daemon.
-        """
-        from unittest.mock import MagicMock
+    def test_fetch_state_closes_connection_on_success(self) -> None:
+        """Every `_fetch_state` call must close its fresh connection — no FD
+        leak across repeated probes (boot + every alive_check on a long-running
+        daemon). We spy at the `http.client.HTTPConnection` level: the conn the
+        GET path creates must have `close()` called."""
+        from senpi_runtime_helpers import client as client_mod
+
+        created = []
+        real_cls = client_mod.http.client.HTTPConnection
+
+        class _SpyConn(real_cls):  # type: ignore[misc,valid-type]
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+                self._close_count = 0
+                created.append(self)
+
+            def close(self):
+                self._close_count += 1
+                return super().close()
 
         c = self._client_for_state()
-        # Drive a successful probe through the real mock server, but spy on
-        # `resp.close()` by wrapping `getresponse` to capture the response and
-        # patch its close method.
-        original_get = c._pool.get
-        captured = {}
+        client_mod.http.client.HTTPConnection = _SpyConn
+        try:
+            c.is_runtime_registered("0xrt1ABCDEF")
+        finally:
+            client_mod.http.client.HTTPConnection = real_cls
 
-        def spy_pool_get(scheme, host, port, timeout):
-            conn = original_get(scheme, host, port, timeout)
-            real_getresponse = conn.getresponse
+        self.assertTrue(created, "GET path created no connection")
+        self.assertTrue(all(conn._close_count >= 1 for conn in created),
+                        "a connection was not closed")
 
-            def wrapped_getresponse(*a, **kw):
-                resp = real_getresponse(*a, **kw)
-                resp.close = MagicMock(side_effect=resp.close)  # spy
-                captured["resp"] = resp
-                return resp
-
-            conn.getresponse = wrapped_getresponse
-            return conn
-
-        c._pool.get = spy_pool_get
-        c.is_runtime_registered("0xrt1ABCDEF")
-        self.assertIn("resp", captured)
-        captured["resp"].close.assert_called()
-
-    def test_pool_propagates_timeout_to_live_socket(self) -> None:
-        """Per-call timeout overrides must reach the live socket on reused
-        connections. Setting `conn.timeout` alone is a no-op after connect
-        (http.client only consults `conn.timeout` during connect()) — the
-        pool must also call `conn.sock.settimeout()` so subsequent requests
-        on the same connection honor the new deadline. Bugbot caught this
-        as a silent no-op on PR #208.
-        """
-        from unittest.mock import MagicMock
-        from senpi_runtime_helpers.client import _ConnectionPool
-
-        pool = _ConnectionPool()
-
-        # First get: brand-new conn. No socket yet → pool only sets
-        # conn.timeout. The next connect() picks it up.
-        conn = pool.get("http", "127.0.0.1", 18787, 10.0)
-        self.assertIsNone(conn.sock)
-        self.assertEqual(conn.timeout, 10.0)
-
-        # Simulate a connected socket so the reused-connection branch runs.
-        # MagicMock lets us assert that .settimeout(NEW) was called.
-        conn.sock = MagicMock()
-
-        # Second get with a different timeout. The fix must propagate the
-        # new value to the live socket via settimeout() — without it, the
-        # socket keeps its original deadline and per-call overrides are
-        # silently ignored.
-        same_conn = pool.get("http", "127.0.0.1", 18787, 2.5)
-        self.assertIs(same_conn, conn)
-        self.assertEqual(conn.timeout, 2.5)
-        conn.sock.settimeout.assert_called_once_with(2.5)
-
-    def test_post_json_resets_pool_on_connection_close_after_success(self) -> None:
-        """A 2xx response with `Connection: close` must trigger pool.reset.
-
-        Before the fix, _post_json only handled `Connection: close` on the
-        error path (status >= 400). On a successful response the pool kept
-        the connection — but the remote end was already closed — so the next
-        call through that thread's pool would fail with a transport error
-        before the pool self-healed. This test asserts the success-path
-        cleanup runs."""
+    def test_connection_closed_no_fd_leak(self) -> None:
+        """N successful mcp_calls → created connection count == closed count.
+        Locks in the `finally: conn.close()` contract that replaced the pool."""
         from senpi_runtime_helpers import client as client_mod
+
+        created = []
+        real_cls = client_mod.http.client.HTTPConnection
+
+        class _SpyConn(real_cls):  # type: ignore[misc,valid-type]
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+                self.closed_n = 0
+                created.append(self)
+
+            def close(self):
+                self.closed_n += 1
+                return super().close()
 
         client = SenpiClient(
             mcp_url=f"http://127.0.0.1:{self.port}",
             auth_token="test-token",
         )
-
-        # Make mcp_call inject the X-Mock-Conn-Close trigger header so the
-        # server replies with `Connection: close` on the 200 tools/call.
-        original = client_mod._post_json
-
-        def with_conn_close_header(pool, url, body, headers, timeout):
-            headers = dict(headers)
-            headers["X-Mock-Conn-Close"] = "1"
-            return original(pool, url, body, headers, timeout)
-
-        client_mod._post_json = with_conn_close_header
-        # Count reset() calls without stubbing them out — let the real reset
-        # still run so the pool is genuinely cleaned.
-        reset_calls = []
-        real_reset = client._pool.reset
-
-        def counting_reset(scheme, host, port):
-            reset_calls.append((scheme, host, port))
-            return real_reset(scheme, host, port)
-
-        client._pool.reset = counting_reset
+        client_mod.http.client.HTTPConnection = _SpyConn
         try:
-            client.mcp_call("any_tool", k=1)
+            for _ in range(20):
+                client.mcp_call("leaderboard_get_markets", limit=1)
         finally:
-            client_mod._post_json = original
+            client_mod.http.client.HTTPConnection = real_cls
 
-        # initialize + notifications/initialized + tools/call each receive
-        # Connection: close from the mock, so reset fires three times.
-        self.assertGreaterEqual(len(reset_calls), 1)
-        # All resets target the mock server's host:port.
-        for scheme, host, port in reset_calls:
-            self.assertEqual(scheme, "http")
-            self.assertEqual(host, "127.0.0.1")
-            self.assertEqual(port, self.port)
+        self.assertGreaterEqual(len(created), 20)
+        self.assertTrue(all(c.closed_n >= 1 for c in created),
+                        "every created connection must be closed exactly once-or-more")
+
+    # ──────────────── Retry / idempotency gate ────────────────
+    #
+    # The retry gate is the safety-critical part of the fix. A fresh connection
+    # is monkeypatched in so we can fail a chosen leg deterministically and
+    # count attempts. The capital-safety invariant: a non-idempotent POST whose
+    # request MAY have been delivered (read-leg failure) must NOT be retried.
+
+    def _install_fake_conn(self, *, fail_leg, exc, fail_attempts):
+        """Patch client_mod.http.client.HTTPConnection / HTTPSConnection with a
+        fake that raises `exc` from `fail_leg` ('request' or 'getresponse') for
+        the first `fail_attempts` instances, then delegates to the real class.
+        Returns a dict with the shared `request_count` / `instances`."""
+        from senpi_runtime_helpers import client as client_mod
+        real_http = client_mod.http.client.HTTPConnection
+        real_https = client_mod.http.client.HTTPSConnection
+        state = {"request_count": 0, "instances": 0}
+        outer = self
+
+        class _FakeConn:
+            def __init__(self, host, port, timeout=None):
+                state["instances"] += 1
+                self._n = state["instances"]
+                self._real = real_http(host, port, timeout=timeout)
+
+            def request(self, *a, **kw):
+                state["request_count"] += 1
+                if self._n <= fail_attempts and fail_leg == "request":
+                    raise exc
+                return self._real.request(*a, **kw)
+
+            def getresponse(self, *a, **kw):
+                if self._n <= fail_attempts and fail_leg == "getresponse":
+                    raise exc
+                return self._real.getresponse(*a, **kw)
+
+            def close(self):
+                return self._real.close()
+
+        client_mod.http.client.HTTPConnection = _FakeConn
+
+        def restore():
+            client_mod.http.client.HTTPConnection = real_http
+            client_mod.http.client.HTTPSConnection = real_https
+        outer.addCleanup(restore)
+        return state
+
+    def test_post_signals_not_retried_on_maybe_delivered(self) -> None:
+        """Read-leg failure on a POST /signals → request may have been
+        delivered → MUST NOT retry (would risk a duplicate position)."""
+        import http.client as _hc
+        client = SenpiClient(runtime_host="127.0.0.1", runtime_port=self.port)
+        state = self._install_fake_conn(
+            fail_leg="getresponse",
+            exc=_hc.RemoteDisconnected("Remote end closed connection without response"),
+            fail_attempts=1,
+        )
+        with self.assertRaises(Exception):  # URLError (_MaybeDelivered) propagates
+            client.push_signals([{"address": "0xabc", "scanner": "s1", "data": {"k": 1}}])
+        self.assertEqual(state["request_count"], 1, "POST must not be retried after send")
+
+    def test_post_signals_retried_on_connect_refused(self) -> None:
+        """Connect/send-leg failure → request never delivered → retry once,
+        and the second attempt succeeds."""
+        client = SenpiClient(runtime_host="127.0.0.1", runtime_port=self.port)
+        state = self._install_fake_conn(
+            fail_leg="request",
+            exc=ConnectionRefusedError("connection refused"),
+            fail_attempts=1,
+        )
+        result = client.push_signals([{"address": "0xabc", "scanner": "s1", "data": {"k": 1}}])
+        self.assertTrue(result.get("success"))
+        self.assertEqual(state["instances"], 2, "expected exactly one retry")
+
+    def test_mcp_call_not_retried_on_maybe_delivered(self) -> None:
+        """tools/call is non-idempotent too — read-leg failure must not retry."""
+        import http.client as _hc
+        client = SenpiClient(mcp_url=f"http://127.0.0.1:{self.port}", auth_token="t")
+        # Initialize first so the failure lands on the tools/call POST, not init.
+        client.mcp_call("warmup")
+        state = self._install_fake_conn(
+            fail_leg="getresponse",
+            exc=_hc.RemoteDisconnected("closed"),
+            fail_attempts=1,
+        )
+        with self.assertRaises(Exception):
+            client.mcp_call("any_tool", k=1)
+        self.assertEqual(state["request_count"], 1)
+
+    def test_fetch_state_retried_once_then_succeeds(self) -> None:
+        """GET /state is idempotent → retry on EITHER leg. First attempt fails
+        the read leg, second succeeds."""
+        import http.client as _hc
+        c = self._client_for_state()
+        state = self._install_fake_conn(
+            fail_leg="getresponse",
+            exc=_hc.RemoteDisconnected("closed"),
+            fail_attempts=1,
+        )
+        self.assertTrue(c.is_runtime_registered("0xrt1ABCDEF"))
+        self.assertEqual(state["instances"], 2, "GET should retry once")
+
+    def test_fetch_state_retry_exhausted_raises(self) -> None:
+        """Both GET attempts fail → SenpiClientError('state probe transport
+        error'); exactly two attempts (one retry)."""
+        c = self._client_for_state()
+        state = self._install_fake_conn(
+            fail_leg="request",
+            exc=ConnectionRefusedError("refused"),
+            fail_attempts=99,  # always fail
+        )
+        with self.assertRaises(SenpiClientError) as cm:
+            c.is_runtime_registered("0xrt1ABCDEF")
+        self.assertIn("state probe transport error", str(cm.exception))
+        self.assertEqual(state["instances"], 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Context

Roach (and the fleet) silently dropped trade signals. Root cause: the producer SDK `senpi_runtime_helpers` kept a thread-local **keep-alive HTTP connection pool**. A quiet producer leaves that socket idle past the server's keep-alive timeout, the server closes it, and the **first reuse raises** `BrokenPipe` / "remote end closed connection". `_post_json` and `_fetch_state` reset-and-raised with **no retry**, so the signal POST was dropped (confirmed live: LIT/TST/XMR push failures; 114 alive-check errors post-restart on the Roach box).

## Decision (made on the evidence)

- **Remove the keep-alive pool.** Fresh `http.client` connection per request, closed in `finally`. Reuse earns ~nothing for this workload: ~1 MCP call per 90s tick, 0/36 producers fan out, `tick_cache` dedupes, and the runtime path is localhost HTTP (no TLS handshake to amortize). It only added the stale-socket failure class.
- **Add one safety-gated retry.** GET `/state` (idempotent) retries on any transport error. Non-idempotent POSTs (`/signals`, MCP `tools/call`, init) retry **only** when the request provably never left us (connect/send leg → `_NeverDelivered`), **never** on a read-leg failure after send (`_MaybeDelivered`) — a blind POST retry could open a duplicate position.

## Scope

`senpi_runtime_helpers/` only. Producer skills untouched (the dead `mcporter_call(retries=2)` param and producer-side drop-without-retry live in skills, out of scope).

## Test plan

- `python -m unittest senpi_runtime_helpers.tests.test_client` — 27/27 pass, incl. the new gate tests:
  - `test_post_signals_not_retried_on_maybe_delivered` (read-leg drop → 1 request, no duplicate)
  - `test_post_signals_retried_on_connect_refused` (connect-leg fail → retry once → success)
  - `test_mcp_call_not_retried_on_maybe_delivered`
  - `test_fetch_state_retried_once_then_succeeds` / `_retry_exhausted_raises`
  - `test_fetch_state_closes_connection_on_success` (no FD leak)
- Full package suite — 308 passed, 18 skipped (Linux `/proc` tests on macOS).
- Guard grep: no `_ConnectionPool`/`_pool` refs left in non-test code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the transport/retry behavior for MCP calls, state probes, and trade-signal POSTs; mistakes here could either still drop signals or (worse) duplicate non-idempotent operations. Added tests reduce risk but this touches a capital-sensitive path.
> 
> **Overview**
> Eliminates the thread-local HTTP keep-alive pool in `SenpiClient`, switching all MCP and runtime API requests to **fresh `http.client` connections closed in `finally`** to avoid stale-socket `BrokenPipe` drops.
> 
> Adds an **idempotency-gated one-time retry** by classifying transport failures as `_NeverDelivered` (safe to retry) vs `_MaybeDelivered` (retry only for idempotent GETs), and wires this into MCP `initialize`/`tools/call`, `/signals` POST, and `/state` GET.
> 
> Bumps helper version to `0.1.1` and updates tests to assert connection closure and the retry/duplication-safety invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c1eb609a9fdf7929e33a2c67b64f4ffd846f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->