### PR TITLE
fix(dsl): widen Cheetah/Scorpion/Orca Phase 2 ladders — HYPE 40→60 post-mortem

### DIFF
--- a/cheetah/runtime.yaml
+++ b/cheetah/runtime.yaml
@@ -250,20 +250,24 @@ exit:
     phase2:
       enabled: true
       tiers:
-        # v6.1 (2026-05-05): T0 trigger 5→3, T0 lock 35→40, T1 10→7,
-        # T1 lock 50→55, T2 20→15, T2 lock 65→70, T3 35→30. First
-        # post-v6.0 trade (ZEC LONG, 2026-05-04 23:19 UTC) peaked at
-        # +3.05% margin ROE — never reached old T0 trigger of 5%.
-        # Closed via Phase 1 retrace at -4.09% / -$9.68. Same Pangolin
-        # v2.2 pattern: peak below T0, exit via retrace giving back
-        # entire peak. At 3x leverage (score 10 standard tier), normal
-        # favorable moves register as small ROE; T0 needs to fire on
-        # +3% peaks to capture the typical Cheetah winner.
-        - { trigger_pct: 3,  lock_hw_pct: 40 }
-        - { trigger_pct: 7,  lock_hw_pct: 55 }
-        - { trigger_pct: 15, lock_hw_pct: 70 }
-        - { trigger_pct: 30, lock_hw_pct: 80 }
-        - { trigger_pct: 50, lock_hw_pct: 90 }
+        # 2026-05-21 HYPE 40→60 (+47% price / ~+140% margin ROE at 3x)
+        # post-mortem: the v6.1 "capture the typical small winner" ladder
+        # (T0 +3% margin / lock 40) locked a profit floor after a ~1% price
+        # move, so the first pullback chopped Cheetah out. Across the 5-day
+        # HYPE run Cheetah churned 177 fills for a best single HYPE trade of
+        # +$9 and net -$23 — the tight ladder optimized the median trade and
+        # capped the right-tail move that pays for everything. Migrated to
+        # the Bison "let winners run" ladder (validated: Bison +93% SOL ROE,
+        # Condor +$190 held HYPE leg, Vulture +$99/+$86 held HYPE longs).
+        # T0 lock=0 lets a +10% mover retrace fully before any profit lock;
+        # the rare +50-100% move makes the book. Median gives back a bit;
+        # right tail is uncapped.
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 25 }
+        - { trigger_pct: 30, lock_hw_pct: 40 }
+        - { trigger_pct: 50, lock_hw_pct: 60 }
+        - { trigger_pct: 75, lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/orca/runtime.yaml
+++ b/orca/runtime.yaml
@@ -142,15 +142,25 @@ exit:
     phase1:
       enabled: true
       max_loss_pct: 20.0
-      retrace_threshold: 3
+      # 2026-05-21 HYPE post-mortem: retrace_threshold 3 fired on any 3%
+      # retrace from peak in Phase 1, exiting before T0 even armed. Raised
+      # to 8 to give trends room while max_loss_pct holds catastrophic risk.
+      retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,  lock_hw_pct: 30 }
-        - { trigger_pct: 10, lock_hw_pct: 50 }
-        - { trigger_pct: 15, lock_hw_pct: 70 }
-        - { trigger_pct: 20, lock_hw_pct: 85 }
+        # Migrated to Bison "let winners run" ladder (was T0 +5% / lock 30,
+        # 4 tiers ending at +20%). Orca traded 18 coins / 191 fills during
+        # the HYPE run and never held a winner; the tight 4-tier ladder
+        # capped every move. T0 lock=0 + a tier out to +100% margin ROE
+        # lets the rare trend trade run.
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/scorpion/runtime.yaml
+++ b/scorpion/runtime.yaml
@@ -333,12 +333,18 @@ exit:
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,   lock_hw_pct: 50 }   # v4.1: 30 → 50 — fix asymmetry math (5% peak now locks 2.5% breakeven floor instead of 1.5%)
-        - { trigger_pct: 10,  lock_hw_pct: 65 }   # v4.1: 50 → 65
-        - { trigger_pct: 15,  lock_hw_pct: 75 }   # v4.1: 70 → 75
-        - { trigger_pct: 25,  lock_hw_pct: 85 }
-        - { trigger_pct: 40,  lock_hw_pct: 90 }
-        - { trigger_pct: 80,  lock_hw_pct: 94 }
+        # 2026-05-21 HYPE 40→60 post-mortem: v4.1's T0 +5% / lock 50 (a
+        # 2.5% breakeven floor at 5x) chopped every Scorpion HYPE long
+        # inside 1.5-4h — caught the moves, never held one. Net -$15 on the
+        # run. Migrated to the Bison "let winners run" ladder: T0 lock=0
+        # gives the position room to develop before any profit lock,
+        # capturing the right-tail trend move instead of scalping +1% price.
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"


### PR DESCRIPTION
## Why

HYPE ran 40→60 (+47% price) over 5 days (5/16–5/21). Live-fill audit (Hyperliquid Info API) shows the three agents with the **tightest Phase 2 ladders in the fleet** caught HYPE moves but got chopped out within minutes-to-hours, never holding a winner:

| Agent | Old T0 | Locks after (price) | HYPE result |
|---|---|---|---|
| Cheetah | +3% margin / lock 40 | ~0.6% (5x) | 177 fills, best single +$9, net **−$23** |
| Scorpion | +5% / lock 50 | ~1.0% (5x) | every HYPE long chopped 1.5–4h, **−$15** |
| Orca | +5% / lock 30, retrace 3 | ~0.7% (7x) | 18 coins / 191 fills, never held, **−$48** |

The tight ladders optimize the **median** trade and cap the **right tail** — the rare trend move that pays for everything.

## Fix

All three migrated to the validated **Bison "let winners run" ladder**:
```
T0 +10% / lock 0   T1 +20% / 25   T2 +30% / 40
T3 +50% / 60       T4 +75% / 75   T5 +100% / 85
```
Orca `retrace_threshold` raised 3→8. Phase 1 `max_loss_pct` unchanged (catastrophic-loss protection intact).

## Evidence the wide ladder works (same HYPE run)
- **Bison** +93% SOL ROE history; **Condor** held a HYPE leg to **+$190**; **Vulture** held HYPE longs to **+$99 / +$86**. The agents that held won; the agents with tight T0 locks bled.

## Not changed
- Bison / Wolverine / Vulture already on the wide ladder.
- Condor (+$103 on the run) is winning — left alone.
- Raptor's miss is a **direction** problem (shorted the uptrend), not DSL — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)