### PR TITLE
fix(python): force taker fallback on entries — naked-order bug killed HYPE entry

### DIFF
--- a/python/runtime.yaml
+++ b/python/runtime.yaml
@@ -68,7 +68,16 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false
+        # 2026-05-21: was false (maker-only ALO patience). During the HYPE
+        # 40→60 run the maker entry rested and never filled — create_position
+        # returned ENGINE_FAILURE / CREATE_ORDER_RESTING on "PYTHON_PATIENCE
+        # HYPE LONG" (5/19 00:15) and 11 other entries (TAO/LIT/TON/SUI/NEAR/
+        # VVV/ONDO) over 5/18-5/21. Maker-only entries silently die exactly
+        # during fast moves — the trends we most want to catch. The engine
+        # error itself prescribes ensureExecutionAsTaker: true. Flip to true so
+        # the order crosses as taker at the timeout and the position opens with
+        # DSL attached, instead of resting on the book with no position.
+        ensure_execution_as_taker: true
         execution_timeout_seconds: 30
     context:
       - type: signal


### PR DESCRIPTION
## Why

Audit (`audit_query`, M194286) shows Python logged **12 `create_position` ENGINE_FAILURE / CREATE_ORDER_RESTING** failures over 5/18–5/21 — including **`PYTHON_PATIENCE HYPE LONG` at 2026-05-19 00:15**. Python tried to long HYPE at ~$47 *before* the explosive leg, but its maker entry rested on the book and never opened a position. Same failure on TAO / LIT / TON / SUI / NEAR / VVV / ONDO.

Entry config was `ensure_execution_as_taker: false` (maker-only ALO patience). Maker-only entries **silently die exactly during fast moves** — the trends we most want to catch. The engine error message itself prescribes the fix:
> *"Retry with feeOptimizedLimitOptions.ensureExecutionAsTaker: true to force execution as taker if the maker order does not fill."*

## Fix
`ensure_execution_as_taker: false → true` on `python_entry` (timeout unchanged, 30s). The order now crosses as taker at the timeout and opens with DSL attached, instead of resting with no position. Fee cost is marginal vs a missed/naked entry.

## Note
Condor and Bison also run `ensure_execution_as_taker: false` on entries (same latent risk). They're currently green so left untouched here — recommend the same flip but flagged separately for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)