### PR TITLE
fix(entry): force taker fallback on momentum agents (Condor/Bison/Dire/Jaguar)

### DIFF
--- a/bison/runtime.yaml
+++ b/bison/runtime.yaml
@@ -105,7 +105,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false      # v2.1 hard rule: ALO patience, taker fallback OFF
+        ensure_execution_as_taker: true       # 2026-05-21: was false. Maker-only entries rest and silently fail to open during fast moves (CREATE_ORDER_RESTING). Bison is a conviction momentum holder — missing the entry costs the whole trade. Taker fallback guarantees fill + DSL attach.
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -206,9 +206,11 @@ actions:
 #
 # v3.0 update: order_type → FEE_OPTIMIZED_LIMIT (was MARKET). Saves
 # ~0.020-0.030% per maker-filled close. Taker fallback enabled
-# (ensure_execution_as_taker: true) on the exit path so closes always
-# happen — entry path keeps ensure_execution_as_taker: false (v2.1
-# patience rule).
+# (ensure_execution_as_taker: true) on BOTH paths. 2026-05-21: the entry
+# path was flipped from the v2.1 maker-only "patience" rule to taker
+# fallback ON after maker-only entries were shown to rest on the book and
+# silently fail to open during fast moves (CREATE_ORDER_RESTING). A
+# conviction momentum holder cannot afford to miss the entry.
 #
 # v3.0.1 (2026-05-18): interval_seconds 30 → 60. Audit on Bison12
 # (M192943) 2026-05-15 and 2026-05-17 showed clusters of

--- a/condor/runtime.yaml
+++ b/condor/runtime.yaml
@@ -100,7 +100,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false      # v3.x ALO patience (entry side); taker fallback OFF
+        ensure_execution_as_taker: true       # 2026-05-21: was false. Maker-only entries rest on the book and silently fail to open during fast trend moves (CREATE_ORDER_RESTING). Condor is trend-continuation — missing the entry costs the whole trade. Taker fallback guarantees fill + DSL attach.
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -196,9 +196,11 @@ actions:
 # 2h @ 3% was pre-empting. Phase 1 + Phase 2 own exits.
 #
 # v4.0 update: order_type → FEE_OPTIMIZED_LIMIT (was MARKET). Saves
-# ~0.020-0.030% per maker-filled close. Taker fallback enabled on
-# exits so closes always happen. Entry path keeps
-# ensure_execution_as_taker: false (v3.x patience rule).
+# ~0.020-0.030% per maker-filled close. Taker fallback enabled on BOTH
+# paths. 2026-05-21: the entry path was flipped from the v3.x maker-only
+# "patience" rule to taker fallback ON after maker-only entries were shown
+# to rest on the book and silently fail to open during fast trend moves
+# (CREATE_ORDER_RESTING). Trend-continuation cannot afford to miss the entry.
 #
 # v4.0.1 (2026-05-18): interval_seconds 30 → 60. Same lesson as
 # Bison v3.0.1 — when runtime position-state pull lags HL after a

--- a/dire/runtime.yaml
+++ b/dire/runtime.yaml
@@ -120,7 +120,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false       # entries: maker-first (xyz spreads narrower than crypto perps)
+        ensure_execution_as_taker: true        # 2026-05-21: was false. Trend agent must catch the entry; maker-only can rest and fail to open (CREATE_ORDER_RESTING). xyz spreads are narrow so taker cost is minimal — taker fallback is nearly free here.
         execution_timeout_seconds: 30
     context:
       - type: signal

--- a/jaguar/runtime.yaml
+++ b/jaguar/runtime.yaml
@@ -115,7 +115,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false   # entries: prefer maker fill on ALO; fall through to taker on timeout
+        ensure_execution_as_taker: true    # 2026-05-21: comment said "fall through to taker on timeout" but false does NOT do that — it leaves the order resting (CREATE_ORDER_RESTING) and the position never opens. Striker NEEDS the violent-jump entry; true delivers the intended taker fallback.
         execution_timeout_seconds: 30
     context:
       - type: signal


### PR DESCRIPTION
## Why
HYPE 40→60 post-mortem proved maker-only entries (`ensure_execution_as_taker: false`) **rest on the book and silently fail to open** during fast moves — `create_position` returns `ENGINE_FAILURE / CREATE_ORDER_RESTING`. That's exactly when a trend agent most needs to be filled (Python lost its HYPE entry this way).

## Flipped false→true (momentum/trend — must catch the entry)
| Agent | Thesis |
|---|---|
| Condor | trend-continuation, apex confluence |
| Bison | conviction momentum holder |
| Dire | 4TF trend (xyz spreads narrow → taker cost minimal) |
| Jaguar | violent rank-jump striker (comment already *intended* taker fallback; `false` never delivered it) |

## Left `false` by design (mean-reversion / fee-arb faders)
Bald-eagle (Contrarian Fader), Owl (crowding-unwind), Pangolin (funding fader). Their edge is the maker rebate and entries are non-urgent. For these the naked-resting risk is a **runtime** fix (auto-cancel the resting order on timeout), not a config flip — tracked with the runtime team.

Exit paths and timeouts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)