### PR TITLE
fix(onboarding): harden the 10 onboarding agents with HYPE 40→60 lessons

### DIFF
--- a/albatross/runtime.yaml
+++ b/albatross/runtime.yaml
@@ -88,7 +88,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false
+        ensure_execution_as_taker: true         # 2026-05-21 HYPE lesson: momentum entries must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING), so taker fallback ON
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -161,7 +161,7 @@ exit:
   order_type: FEE_OPTIMIZED_LIMIT
   fee_optimized_limit_options:
     ensure_execution_as_taker: true
-    execution_timeout_seconds: 60
+    execution_timeout_seconds: 30          # 2026-05-21: 60->30 — keep the maker attempt comfortably under the server connection window
   dsl_preset:
     hard_timeout:
       enabled: true

--- a/albatross/scripts/albatross-producer.py
+++ b/albatross/scripts/albatross-producer.py
@@ -286,18 +286,23 @@ def push_mirror_signal(leader, new_pos, margin_usd, leverage, held_assets):
     if cfg.was_recently_signaled(dedup_key):
         return False
 
+    # 2026-05-21 HYPE lesson (root cause B): optional NUMERIC fields must never
+    # be emitted as None — the runtime signal schema types these as `number` and
+    # rejects null, which drops the ENTIRE signal silently. weeks_traded may be
+    # absent from the candidate dict, and entryPx/leverage come from external
+    # position data that can be missing. Coalesce every numeric field to 0.
     data_block = {
         "leaderUsername": leader.get("username"),
         "leaderXHandle": leader.get("xHandle"),
-        "leaderConvictionScore": leader.get("conviction_score"),
-        "leaderWeeksTraded": leader.get("weeks_traded"),
-        "leaderWeeklyRoeMean": leader.get("weekly_mean_roe"),
-        "leaderMonthlyRoe": leader.get("monthly_roe"),
+        "leaderConvictionScore": leader.get("conviction_score") or 0.0,
+        "leaderWeeksTraded": leader.get("weeks_traded") or 0,
+        "leaderWeeklyRoeMean": leader.get("weekly_mean_roe") or 0.0,
+        "leaderMonthlyRoe": leader.get("monthly_roe") or 0.0,
         "leverage": leverage,
         "marginUsd": margin_usd,
         "direction": direction,
-        "leaderEntryPrice": new_pos.get("entryPx"),
-        "leaderLeverage": new_pos.get("leverage"),
+        "leaderEntryPrice": new_pos.get("entryPx") or 0.0,
+        "leaderLeverage": new_pos.get("leverage") or 0,
         "reason": f"ALBATROSS_MIRROR {coin} {direction} from {leader.get('username')} (conviction {leader.get('conviction_score')})",
         "heldAssets": held_assets,
     }

--- a/beaver/runtime.yaml
+++ b/beaver/runtime.yaml
@@ -91,7 +91,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false        # ALO patience on entry
+        ensure_execution_as_taker: true         # 2026-05-21 HYPE lesson: momentum entries must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING), so taker fallback ON
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -167,7 +167,7 @@ exit:
   order_type: FEE_OPTIMIZED_LIMIT
   fee_optimized_limit_options:
     ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
-    execution_timeout_seconds: 60
+    execution_timeout_seconds: 30          # 2026-05-21: 60->30 — keep the maker attempt comfortably under the server connection window
   dsl_preset:
     hard_timeout:
       enabled: false                                # DISABLED — single-asset trend pattern

--- a/bobcat/runtime.yaml
+++ b/bobcat/runtime.yaml
@@ -91,7 +91,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false        # ALO patience on entry
+        ensure_execution_as_taker: true         # 2026-05-21 HYPE lesson: momentum entries must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING), so taker fallback ON
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -167,7 +167,7 @@ exit:
   order_type: FEE_OPTIMIZED_LIMIT
   fee_optimized_limit_options:
     ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
-    execution_timeout_seconds: 60
+    execution_timeout_seconds: 30          # 2026-05-21: 60->30 — keep the maker attempt comfortably under the server connection window
   dsl_preset:
     hard_timeout:
       enabled: true                                 # 48h cap — equities have weekend pricing gaps

--- a/hawk/SKILL.md
+++ b/hawk/SKILL.md
@@ -4,9 +4,9 @@ description: >-
   HAWK v1.0.0 — 4h Breakout Buyer / Breakdown Seller. LONG when price
   breaks above the 7-day high AND Senpi Smart-Money is > 55% long.
   SHORT when price breaks below the 7-day low AND SM is > 55% short.
-  Universe: BTC, ETH, SOL. Tight DSL — Phase 1 max_loss 8% (failed
-  breakouts get cut fast); Phase 2 locks fast at +5% (real breakouts
-  ratchet-protect immediately). hard_timeout 24h.
+  Universe: BTC, ETH, SOL. Asymmetric DSL — Phase 1 max_loss 8% (failed
+  breakouts get cut fast) but Phase 2 wide "let winners run" ladder
+  (T0 +10% / lock 0); a real breakout can run far. hard_timeout 24h.
 license: MIT
 metadata:
   author: jason-goldberg
@@ -34,7 +34,7 @@ Hawk fixes all three:
 2. **Smart Money must be > 55% in the breakout direction** (gate, not score)
 3. **DSL Phase 1 max_loss 8%** — failed breakouts close before they hurt
 
-When a breakout DOES work, Phase 2 locks fast (+5% → 30% lock) so a winning breakout immediately starts ratchet-protecting profit.
+When a breakout DOES work, Phase 2 uses a wide "let winners run" ladder — no profit lock until +10%, then a trailing ratchet out to +100%. A real breakout can run far; the old +5% / lock-30 design chopped the position out on the first pullback. Phase 1's 8% max_loss still cuts a FAILED breakout fast.
 
 ## CRITICAL RULES
 
@@ -47,13 +47,13 @@ If either gate fails, producer outputs `WAITING — no breakout with SM agreemen
 ### RULE 2: Producer enters. DSL exits.
 No `close_position` call site in the producer. DSL Phase 1 + Phase 2 + hard_timeout 24h own all exits.
 
-### RULE 3: Tight DSL is intentional
+### RULE 3: Asymmetric DSL — tight Phase 1, wide Phase 2
 Hawk's DSL is designed for breakouts:
 - Phase 1 max_loss **8%** (vs Beaver's 20%) — failed breakouts must be cut fast
-- Phase 2 first tier **+5% / lock 30%** — real breakouts lock profit immediately
+- Phase 2 wide **"let winners run" ladder** (T0 +10% / lock 0 → T5 +100% / lock 85) — a real breakout can run far; the old tight T0 (+5% / lock 30) locked a floor after ~1-2% price and chopped winners out on the first pullback (HYPE 40→60 post-mortem, 2026-05-21)
 - hard_timeout **24h** — if a breakout hasn't worked in 24h, it failed
 
-Don't widen this DSL — it would defeat the strategy.
+Keep Phase 1 tight (cut failed breakouts), but never re-tighten Phase 2 — the rare breakout that runs is what pays for the strategy.
 
 ### RULE 4: Universe is BTC, ETH, SOL
 Operators can override via `universe` in config, but the default is the three most-liquid majors. Adding low-liquidity coins to the universe will cause noisy "breakouts" that don't follow through.
@@ -79,7 +79,7 @@ Operators can override via `universe` in config, but the default is the three mo
 
 **Floor:** `minScore: 5`. Typical entry needs breakout magnitude moderate + SM aligned + 4h trend = 7.
 
-## DSL preset (tight Hawk profile)
+## DSL preset (asymmetric Hawk profile — tight Phase 1, wide Phase 2)
 
 | Phase | Component | Setting |
 |---|---|---|
@@ -89,11 +89,12 @@ Operators can override via `universe` in config, but the default is the three mo
 | Time cuts | hard_timeout | **24h** (kills failed breakouts) |
 | Time cuts | weak_peak_cut | **60min @ 3.0% min** (kills stale chop) |
 | Time cuts | dead_weight_cut | DISABLED |
-| Phase 2 | T0 | +5% / lock 30% |
-| Phase 2 | T1 | +10% / lock 50% |
-| Phase 2 | T2 | +20% / lock 65% |
-| Phase 2 | T3 | +35% / lock 75% |
-| Phase 2 | T4 | +60% / lock 85% |
+| Phase 2 | T0 | **+10% / lock 0** (let it breathe) |
+| Phase 2 | T1 | +20% / lock 25% |
+| Phase 2 | T2 | +30% / lock 40% |
+| Phase 2 | T3 | +50% / lock 60% |
+| Phase 2 | T4 | +75% / lock 75% |
+| Phase 2 | T5 | +100% / lock 85% |
 
 ## Scanner pattern
 

--- a/hawk/runtime.yaml
+++ b/hawk/runtime.yaml
@@ -91,7 +91,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false        # ALO patience on entry
+        ensure_execution_as_taker: true         # 2026-05-21 HYPE lesson: momentum entries must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING), so taker fallback ON
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -167,7 +167,7 @@ exit:
   order_type: FEE_OPTIMIZED_LIMIT
   fee_optimized_limit_options:
     ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
-    execution_timeout_seconds: 60
+    execution_timeout_seconds: 30          # 2026-05-21: 60->30 — keep the maker attempt comfortably under the server connection window
   dsl_preset:
     hard_timeout:
       enabled: true                                 # 24h cap — failed breakouts get cut
@@ -187,11 +187,17 @@ exit:
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,   lock_hw_pct: 30 }
-        - { trigger_pct: 10,  lock_hw_pct: 50 }
-        - { trigger_pct: 20,  lock_hw_pct: 65 }
-        - { trigger_pct: 35,  lock_hw_pct: 75 }
-        - { trigger_pct: 60,  lock_hw_pct: 85 }
+        # 2026-05-21 HYPE lesson: a real breakout can run far. The old tight
+        # ladder (T0 +5% / lock 30) locked a floor after ~1-2% price and capped
+        # the very trend Hawk exists to catch. Widened to the "let winners run"
+        # ladder — T0 lock 0 lets the breakout breathe; Phase 1 (max_loss 8 /
+        # retrace 5) still cuts a FAILED breakout fast.
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"

--- a/hedgehog/runtime.yaml
+++ b/hedgehog/runtime.yaml
@@ -91,7 +91,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false        # ALO patience on entry
+        ensure_execution_as_taker: true         # 2026-05-21 HYPE lesson: momentum entries must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING), so taker fallback ON
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -167,7 +167,7 @@ exit:
   order_type: FEE_OPTIMIZED_LIMIT
   fee_optimized_limit_options:
     ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
-    execution_timeout_seconds: 60
+    execution_timeout_seconds: 30          # 2026-05-21: 60->30 — keep the maker attempt comfortably under the server connection window
   dsl_preset:
     hard_timeout:
       enabled: true                                 # 48h cap — equities have weekend pricing gaps

--- a/heron/runtime.yaml
+++ b/heron/runtime.yaml
@@ -91,7 +91,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false        # ALO patience on entry
+        ensure_execution_as_taker: true         # 2026-05-21 HYPE lesson: momentum entries must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING), so taker fallback ON
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -167,7 +167,7 @@ exit:
   order_type: FEE_OPTIMIZED_LIMIT
   fee_optimized_limit_options:
     ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
-    execution_timeout_seconds: 60
+    execution_timeout_seconds: 30          # 2026-05-21: 60->30 — keep the maker attempt comfortably under the server connection window
   dsl_preset:
     hard_timeout:
       enabled: false                                # DISABLED — single-asset trend pattern

--- a/hummingbird/runtime.yaml
+++ b/hummingbird/runtime.yaml
@@ -91,7 +91,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false        # ALO patience on entry
+        ensure_execution_as_taker: true         # 2026-05-21 HYPE lesson: momentum entries must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING), so taker fallback ON
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -167,7 +167,7 @@ exit:
   order_type: FEE_OPTIMIZED_LIMIT
   fee_optimized_limit_options:
     ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
-    execution_timeout_seconds: 60
+    execution_timeout_seconds: 30          # 2026-05-21: 60->30 — keep the maker attempt comfortably under the server connection window
   dsl_preset:
     hard_timeout:
       enabled: false                                # DISABLED — single-asset trend pattern

--- a/lemur/runtime.yaml
+++ b/lemur/runtime.yaml
@@ -91,7 +91,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false        # ALO patience on entry
+        ensure_execution_as_taker: true         # 2026-05-21 HYPE lesson: momentum entries must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING), so taker fallback ON
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -167,7 +167,7 @@ exit:
   order_type: FEE_OPTIMIZED_LIMIT
   fee_optimized_limit_options:
     ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
-    execution_timeout_seconds: 60
+    execution_timeout_seconds: 30          # 2026-05-21: 60->30 — keep the maker attempt comfortably under the server connection window
   dsl_preset:
     hard_timeout:
       enabled: false                                # DISABLED — single-asset trend pattern

--- a/raccoon/runtime.yaml
+++ b/raccoon/runtime.yaml
@@ -167,7 +167,7 @@ exit:
   order_type: FEE_OPTIMIZED_LIMIT
   fee_optimized_limit_options:
     ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
-    execution_timeout_seconds: 60
+    execution_timeout_seconds: 30          # 2026-05-21: 60->30 — keep the maker attempt comfortably under the server connection window
   dsl_preset:
     hard_timeout:
       enabled: true                                 # 48h — forces Monday-open exit so positions don't camp through the next week

--- a/salamander/SKILL.md
+++ b/salamander/SKILL.md
@@ -5,9 +5,9 @@ description: >-
   LONG when 4h trend is BULLISH AND 1h price pulled back 3-7% from
   recent high AND Smart Money is > 55% long. SHORT when 4h trend is
   BEARISH AND 1h price rallied 3-7% from recent low AND SM is > 55%
-  short. Universe: BTC, ETH, SOL. Asymmetric DSL — Phase 1 wider (10%
-  max_loss, pullbacks need room) but Phase 2 tighter (T0 +5% / lock
-  30%, when thesis works lock fast).
+  short. Universe: BTC, ETH, SOL. Wide DSL throughout — Phase 1 10%
+  max_loss (pullbacks need room to develop) AND Phase 2 "let winners
+  run" ladder (T0 +10% / lock 0); the resumed trend can run far.
 license: MIT
 metadata:
   author: jason-goldberg
@@ -47,11 +47,11 @@ The 4h trend must be NON-NEUTRAL. Salamander does not trade chop. If higher-lows
 ### RULE 2: Pullback band is hard
 The pullback must fall in `[pullbackMinPct, pullbackMaxPct]` (default 3-7%). Outside that band, no entry. Configurable per asset volatility (smaller bands for stable majors, wider for HYPE-tier).
 
-### RULE 3: Asymmetric DSL is intentional
+### RULE 3: Wide DSL throughout
 - **Phase 1 max_loss 10%** (wider than Hawk's 8%) — pullbacks within a trend need a few percent of room to develop
-- **Phase 2 T0 +5% / lock 30%** (same as Hawk) — when the pullback resolves and the trend resumes, lock fast
+- **Phase 2 wide "let winners run" ladder** (T0 +10% / lock 0 → T5 +100% / lock 85) — when the pullback resolves, the resumed trend can run far. The old tight T0 (+5% / lock 30) locked a floor after ~1-2% price and chopped the continuation out on the first wiggle (HYPE 40→60 post-mortem, 2026-05-21).
 
-If you tighten Phase 1 below 10%, you'll cut legitimate pullback continuations as noise.
+If you tighten Phase 1 below 10%, you'll cut legitimate pullback continuations as noise — and never re-tighten Phase 2, or you cap the very continuation Salamander exists to ride.
 
 ### RULE 4: Producer enters. DSL exits.
 No close_position call site. DSL Phase 1 + Phase 2 + hard_timeout 48h own all exits.
@@ -76,7 +76,7 @@ No close_position call site. DSL Phase 1 + Phase 2 + hard_timeout 48h own all ex
 
 **Floor:** `minScore: 5`. Typical entry clears 5-7.
 
-## DSL preset (asymmetric)
+## DSL preset (wide throughout — Phase 1 roomy, Phase 2 let-winners-run)
 
 | Phase | Component | Setting |
 |---|---|---|
@@ -86,11 +86,12 @@ No close_position call site. DSL Phase 1 + Phase 2 + hard_timeout 48h own all ex
 | Time cuts | hard_timeout | **48h** (pullback resolution can take time) |
 | Time cuts | weak_peak_cut | 90min / 3% min |
 | Time cuts | dead_weight_cut | DISABLED |
-| Phase 2 | T0 | **+5% / lock 30%** (tight — lock fast when thesis works) |
-| Phase 2 | T1 | +10% / lock 50% |
-| Phase 2 | T2 | +20% / lock 65% |
-| Phase 2 | T3 | +35% / lock 75% |
-| Phase 2 | T4 | +60% / lock 85% |
+| Phase 2 | T0 | **+10% / lock 0** (let the continuation breathe) |
+| Phase 2 | T1 | +20% / lock 25% |
+| Phase 2 | T2 | +30% / lock 40% |
+| Phase 2 | T3 | +50% / lock 60% |
+| Phase 2 | T4 | +75% / lock 75% |
+| Phase 2 | T5 | +100% / lock 85% |
 
 ## Scanner pattern
 

--- a/salamander/runtime.yaml
+++ b/salamander/runtime.yaml
@@ -91,7 +91,7 @@ actions:
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: false        # ALO patience on entry
+        ensure_execution_as_taker: true         # 2026-05-21 HYPE lesson: momentum entries must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING), so taker fallback ON
         execution_timeout_seconds: 30
     context:
       - type: signal
@@ -167,7 +167,7 @@ exit:
   order_type: FEE_OPTIMIZED_LIMIT
   fee_optimized_limit_options:
     ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
-    execution_timeout_seconds: 60
+    execution_timeout_seconds: 30          # 2026-05-21: 60->30 — keep the maker attempt comfortably under the server connection window
   dsl_preset:
     hard_timeout:
       enabled: true                                 # 24h cap — failed pullbacks get cut
@@ -187,11 +187,18 @@ exit:
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 5,   lock_hw_pct: 30 }
-        - { trigger_pct: 10,  lock_hw_pct: 50 }
-        - { trigger_pct: 20,  lock_hw_pct: 65 }
-        - { trigger_pct: 35,  lock_hw_pct: 75 }
-        - { trigger_pct: 60,  lock_hw_pct: 85 }
+        # 2026-05-21 HYPE lesson: a pullback that resolves resumes the trend,
+        # which can run far. The old tight ladder (T0 +5% / lock 30) locked a
+        # floor after ~1-2% price and capped the continuation Salamander exists
+        # to ride. Widened to the "let winners run" ladder — T0 lock 0 lets the
+        # resumed trend breathe; Phase 1 (max_loss 10 / retrace 6) still owns
+        # the downside if the pullback keeps going instead of resolving.
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
 
 notifications:
   telegram_chat_id: "${TELEGRAM_CHAT_ID}"


### PR DESCRIPTION
Applies the four live-fleet HYPE post-mortem fixes to the onboarding tier, **classified by strategy class** (the Dog lesson: don't blindly widen — faders stay tight).

| # | Fix | Applied to |
|---|---|---|
| 1 | Exit `execution_timeout` 60→30 (under ~45s server drop) | **all 10** |
| 2 | Entry `ensure_execution_as_taker` false→true (no naked CREATE_ORDER_RESTING) | 9 momentum/follower agents |
| 3 | Phase 2 → wide "let winners run" ladder (T0 +10%/0 → T5 +100%/85) | **Hawk, Salamander** (other 7 already wide) |
| 4 | Coalesce optional numeric fields None→0 (schema-reject) | **Albatross** |

### Strategy-class nuance (the key call)
**Raccoon kept maker-only entry + tight ladder.** Its weekend-reconciliation edge is a *bounded, non-urgent* Monday-open snap on thin XYZ liquidity — taker fees would erase the edge, and a tight ladder correctly banks the bounded move. Same class as the live faders (Owl / Pangolin / Bald-eagle), which we deliberately left maker-only in the live-fleet fix.

### Doc-sync
Hawk & Salamander SKILL.md DSL sections rewritten — both previously documented the tight ladder as "intentional / don't widen," which now contradicts the config.

### Notes
- Phase 1 floors unchanged (catastrophic-loss protection).
- READMEs already use `disown`-safe launch.
- Entry timeouts were already 30 (only exits were 60) — corrects the original audit assumption.
- All 10 YAMLs validated; Albatross producer compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)