### PR TITLE
docs(otter): restructure README to lead with thesis

### DIFF
--- a/otter/README.md
+++ b/otter/README.md
@@ -1,8 +1,12 @@
-# 🦦 OTTER v2.0.0 — Open Interest Velocity Hunter. senpi_runtime_helpers.
+# 🦦 Otter — Open Interest Velocity Hunter
+
+Trades fresh leveraged positioning the moment it appears: detects 1h Open Interest velocity with price confirmation, and rides the new flow.
 
 Part of the [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
-**Plumbing-only migration from v1.0. NO thesis change. NO scoring change.** Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry.
+## Thesis
+
+When Open Interest on an asset accelerates sharply within an hour *and* price confirms the direction, fresh leveraged capital is entering — often ahead of a larger move. Otter scans for that OI-velocity signature, requires price confirmation to filter noise, and enters with the flow. The edge is reacting to new positioning before the crowd reprices.
 
 ## Install
 


### PR DESCRIPTION
Otter's README was the last in the fleet still leading with migration-changelog cruft (`OTTER v2.0.0 — ... senpi_runtime_helpers. Plumbing-only migration...`). This restructures it to lead with a clean `Otter — Open Interest Velocity Hunter` header + plain-English Thesis section, matching the rest of the fleet.

Closes the otter README follow-up flagged during the catalog rebuild (PR #294). Also the one salvageable item from orphan-history PR #278 — see note below.

## Re: the three May-13 cleanup PRs (#269, #277, #278)

All three are orphan-history (no merge base with main) and can't be safely merged/rebased — applying any of them reverts a week+ of changes. Their intents are mostly already on main (#294 did the onboarding-ref purge; the top-level README was already rebuilt). **Recommend closing all three.** This PR redoes #278's one still-relevant item (otter README) fresh against current main.

## Test plan
- [ ] otter/README.md leads with thesis, no version cruft in H1
- [ ] Install/verification sections intact