### PR TITLE
docs: route strategy-authoring to the runtime references first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,19 @@ This repo is almost entirely AI-generated. The rules below exist because they ha
 
 ---
 
+## ▶ Writing or editing a trading strategy? Start here
+
+Do **not** improvise a strategy from scratch. The canonical authoring path lives in `senpi-trading-runtime/`. Read in this order before writing code:
+
+1. **`senpi-trading-runtime/references/producer-patterns.md`** — the archetype catalog. Pick the closest pattern; it links to a working example agent. Copy that example.
+2. **`senpi-trading-runtime/references/python-producer-sdk.md`** — build the producer on the bundled `senpi_runtime_helpers` SDK. Never hand-roll MCP calls or the daemon loop.
+3. **`senpi-trading-runtime/references/yaml-schema.md`** + **`risk-gates.md`** + **`dsl-configuration.md`** — configure `runtime.yaml`, risk guard-rails, and the DSL exit.
+4. Verify with **`senpi-trading-runtime/references/senpi-helpers-cli.md`**.
+
+Fastest correct path: pick an archetype → clone the named example agent (`kodiak`, `cheetah`, `roach`) → swap in your signal logic → tune thresholds. Full read-order is at the top of `senpi-trading-runtime/SKILL.md`.
+
+---
+
 ## Skill Attribution (REQUIRED for strategy-representing skills only)
 
 **Scope:** This rule applies only to skills that *are* a trading strategy — i.e. adopting the skill results in a new strategy wallet being created and run under its thesis. This covers every animal-named / strategy-named skill in this repo (e.g. grizzly, kodiak, polar, cheetah, bald-eagle, owl, scorpion).

--- a/senpi-entrypoint/references/post-onboarding.md
+++ b/senpi-entrypoint/references/post-onboarding.md
@@ -151,18 +151,22 @@ Which sounds interesting? I can explain any in detail or deploy one right now.
 
 ### If user says "Build a new trading strategy" or "build a strategy" or "custom strategy" or "create a strategy"
 
-Help the user brainstorm custom strategies by combining Senpi tools and skills. Start the conversation with:
+Building a real, deployable strategy means building it on the **Senpi Trading Runtime** — the canonical runtime + DSL exit engine + Python Producer SDK. Do NOT treat this as a pure brainstorm or improvise a strategy from scratch: route the user through the runtime's authoring path so what they build actually deploys and is risk-protected.
 
-> Help me brainstorm some custom strategies we could build from combining senpi tools and/or senpi skills
+**Step 1 — Install the runtime skill:**
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
 
-The LLM should use its knowledge of the available Senpi MCP tools (market data, discovery, trading, portfolio) and installed skills to propose creative strategy ideas. Walk the user through:
+**Step 2 — Pick an archetype.** Read [`senpi-trading-runtime/references/producer-patterns.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/producer-patterns.md) — the catalog of producer/scanner archetypes (universe trend-follower, single-asset alpha hunter, trader-follower, funding fade, etc.). Each links to a working example agent. Help the user pick the one closest to their idea and **start from that example.**
 
-1. **Market scan** — Use available Senpi MCP tools to identify current market conditions and opportunities.
-2. **Strategy ideation** — Brainstorm approaches that combine multiple Senpi tools and skills in novel ways (e.g. combining discovery signals with specific entry/exit logic, layering multiple timeframes, blending copy-trading signals with technical filters).
-3. **Plan outline** — Draft a concrete plan: which tools to use, entry/exit criteria, risk parameters, position sizing, and how the pieces fit together.
-4. **Next steps** — Offer to help the user refine the strategy, backtest the logic manually with current data, or point them to existing strategies that are closest to their idea.
+**Step 3 — Build on the SDK + runtime,** following the read-order at the top of [`senpi-trading-runtime/SKILL.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/SKILL.md):
+- [`python-producer-sdk.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/python-producer-sdk.md) — build the producer on `senpi_runtime_helpers` (never hand-roll MCP calls or the daemon loop).
+- [`yaml-schema.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/yaml-schema.md) + [`risk-gates.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/risk-gates.md) — configure `runtime.yaml`, risk guard-rails, and the DSL exit.
 
-Do NOT require any specific skill installation for this flow — it is a brainstorming and planning session powered by the LLM and whatever MCP tools are already available.
+**Step 4 — Brainstorm the thesis** *within* that structure: use Senpi MCP tools (market data, discovery, leaderboard) to shape entry/exit logic, then map it onto the chosen archetype's producer. The brainstorm rides on top of the runtime — it doesn't replace it.
+
+The goal: the user ends with a deployable runtime strategy built from a proven pattern, not an un-runnable plan.
 
 ---
 

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -13,6 +13,18 @@ metadata:
 
 On-chain position tracker with automated DSL (Dynamic Stop-Loss) exit engine. Monitors a wallet's positions on Hyperliquid for lifecycle events (open, close, edit, flip) and applies two-phase trailing stop-loss protection to all positions.
 
+## ▶ Writing a new strategy? Read these first, in this order
+
+This skill is the canonical way to build a Senpi strategy. **Before writing any code, read in sequence:**
+
+1. **[`references/producer-patterns.md`](references/producer-patterns.md)** — pick your archetype (universe trend-follower, single-asset alpha hunter, trader-follower, funding fade, etc.). Each pattern links to a working example agent's `producer.py` + `runtime.yaml`. **Start here — copy the closest example.**
+2. **[`references/python-producer-sdk.md`](references/python-producer-sdk.md)** — build the producer on the bundled `senpi_runtime_helpers` SDK (`SenpiClient`, `producer_daemon`, `scanner_lock`, `tick_cache`). Don't hand-roll MCP calls or the daemon loop.
+3. **[`references/yaml-schema.md`](references/yaml-schema.md)** — configure `runtime.yaml` (scanners, actions, decision gate).
+4. **[`references/risk-gates.md`](references/risk-gates.md)** + **[`references/dsl-configuration.md`](references/dsl-configuration.md)** — declare risk guard-rails and tune the two-phase exit.
+5. **[`references/senpi-helpers-cli.md`](references/senpi-helpers-cli.md)** — verify the daemon is alive and ticking after deploy.
+
+Full worked examples: **[`references/strategy-examples.md`](references/strategy-examples.md)**. The rest of this doc is the reference for each piece.
+
 ## Core Concepts
 
 **Python Producer SDK ships with this skill** at `senpi_runtime_helpers/`. When wiring up an `external_scanner` (a Python producer that pushes signals into this runtime), build it on this SDK — it wraps the `/signals` endpoint, the `SignalItem` schema, the per-tick lock, and the long-running daemon scheduler in one stdlib-only Python package. Recipes and rules: see [Python Producer SDK](#python-producer-sdk) below.


### PR DESCRIPTION
## Problem

New agents aren't clear how to write strategies. Root cause: the three surfaces an agent hits when building a strategy all failed to point at the canonical runtime references (`producer-patterns.md`, the Producer SDK, the `senpi-trading-runtime` folder) up front.

The worst offender — the **"Build a new trading strategy" onboarding flow** in `senpi-entrypoint` — was a freeform LLM brainstorm that never mentioned the runtime and explicitly said *"do NOT require any specific skill installation."* The one path whose entire job is "help me build a strategy" routed agents *away* from the runtime.

## Fix (docs only, 3 files)

1. **`senpi-entrypoint/references/post-onboarding.md`** — rewrote the build-a-strategy flow: install `senpi-trading-runtime` → pick an archetype from `producer-patterns.md` (start from the linked example) → build on the SDK + `yaml-schema`/`risk-gates` → brainstorm the thesis *within* that structure (not instead of it).
2. **`CLAUDE.md`** — the first doc any AI editor reads — added a top "Writing or editing a strategy? Start here" section with the ordered read path.
3. **`senpi-trading-runtime/SKILL.md`** — added an upfront "Writing a new strategy? Read these first, in this order" block right after the intro (the `producer-patterns` "start here" pointer was buried at line 95 behind wire-format detail).

All three now send an agent to **`producer-patterns.md` first**, with the identical ordered path: producer-patterns → python-producer-sdk → yaml-schema → risk-gates/dsl-configuration → senpi-helpers-cli.

## Test plan
- [ ] An agent reading CLAUDE.md, the entrypoint build-flow, or the runtime SKILL.md lands on producer-patterns.md as step 1
- [ ] No code touched — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)