### PR TITLE
docs: make both strategy-authoring paths first-class, one structure

### DIFF
--- a/senpi-entrypoint/references/post-onboarding.md
+++ b/senpi-entrypoint/references/post-onboarding.md
@@ -158,15 +158,21 @@ Building a real, deployable strategy means building it on the **Senpi Trading Ru
 npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
 ```
 
-**Step 2 — Pick an archetype.** Read [`senpi-trading-runtime/references/producer-patterns.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/producer-patterns.md) — the catalog of producer/scanner archetypes (universe trend-follower, single-asset alpha hunter, trader-follower, funding fade, etc.). Each links to a working example agent. Help the user pick the one closest to their idea and **start from that example.**
+**Step 2 — Pick the path.** Read [`senpi-trading-runtime/references/producer-patterns.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/producer-patterns.md) — the catalog of producer/scanner archetypes. Then, based on how close an existing strategy is to the user's idea:
+- **Path A — start from a template:** a listed strategy is close. Clone its linked example agent and swap in the user's asset / thresholds. Fastest.
+- **Path B — bring their own scanner:** the user's signal logic is novel. Pick the archetype *structurally* closest, then write a new producer on the SDK. Their logic is custom; the structure is standard.
+
+Both paths build on the same runtime.
 
 **Step 3 — Build on the SDK + runtime,** following the read-order at the top of [`senpi-trading-runtime/SKILL.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/SKILL.md):
-- [`python-producer-sdk.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/python-producer-sdk.md) — build the producer on `senpi_runtime_helpers` (never hand-roll MCP calls or the daemon loop).
+- [`python-producer-sdk.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/python-producer-sdk.md) — build (Path B) or tune (Path A) the producer on `senpi_runtime_helpers` (never hand-roll MCP calls or the daemon loop).
 - [`yaml-schema.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/yaml-schema.md) + [`risk-gates.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/risk-gates.md) — configure `runtime.yaml`, risk guard-rails, and the DSL exit.
 
-**Step 4 — Brainstorm the thesis** *within* that structure: use Senpi MCP tools (market data, discovery, leaderboard) to shape entry/exit logic, then map it onto the chosen archetype's producer. The brainstorm rides on top of the runtime — it doesn't replace it.
+**The invariant for both paths:** the producer ONLY emits signals (`push_signal`). It never calls `create_position`, never writes its own exit/stop logic, never hand-rolls the daemon. The runtime owns execution, DSL exits, and risk for every strategy — that's what keeps a custom scanner on the same rails as a cloned template. A "custom strategy" = custom signal logic in a standard producer, not a custom harness.
 
-The goal: the user ends with a deployable runtime strategy built from a proven pattern, not an un-runnable plan.
+**Step 4 — Shape the thesis** *within* that structure: use Senpi MCP tools (market data, discovery, leaderboard) to shape entry logic, then map it onto the producer (cloned or new). The thesis rides on top of the runtime — it doesn't replace it.
+
+The goal: the user ends with a deployable runtime strategy — whether from a template or their own scanner — not an un-runnable plan.
 
 ---
 

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -15,13 +15,27 @@ On-chain position tracker with automated DSL (Dynamic Stop-Loss) exit engine. Mo
 
 ## ▶ Writing a new strategy? Read these first, in this order
 
-This skill is the canonical way to build a Senpi strategy. **Before writing any code, read in sequence:**
+This skill is the canonical way to build a Senpi strategy. **Every strategy is built the same way** — on this runtime, with the Producer SDK, DSL exit engine, and risk guard-rails. There are **two on-ramps** to that one structure:
 
-1. **[`references/producer-patterns.md`](references/producer-patterns.md)** — pick your archetype (universe trend-follower, single-asset alpha hunter, trader-follower, funding fade, etc.). Each pattern links to a working example agent's `producer.py` + `runtime.yaml`. **Start here — copy the closest example.**
-2. **[`references/python-producer-sdk.md`](references/python-producer-sdk.md)** — build the producer on the bundled `senpi_runtime_helpers` SDK (`SenpiClient`, `producer_daemon`, `scanner_lock`, `tick_cache`). Don't hand-roll MCP calls or the daemon loop.
+- **Path A — Start from a template.** Something close to your idea already exists. Pick the closest archetype in `producer-patterns.md`, clone the linked example agent, and swap in your asset / thresholds. Fastest path when a near-match exists.
+- **Path B — Bring your own scanner/producer.** Your signal logic is novel and no template fits. Pick the archetype in `producer-patterns.md` that's *structurally* closest to your approach, then write a new producer on the SDK. **Your signal logic is yours; the surrounding structure is standard.**
+
+Both paths follow the same read-order:
+
+1. **[`references/producer-patterns.md`](references/producer-patterns.md)** — pick the archetype (universe trend-follower, single-asset alpha hunter, trader-follower, funding fade, etc.). Each links to a working example agent's `producer.py` + `runtime.yaml`. **Path A: clone the closest example. Path B: use it as your structural template.**
+2. **[`references/python-producer-sdk.md`](references/python-producer-sdk.md)** — build (Path B) or tune (Path A) the producer on the bundled `senpi_runtime_helpers` SDK (`SenpiClient`, `producer_daemon`, `scanner_lock`, `tick_cache`). Don't hand-roll MCP calls or the daemon loop.
 3. **[`references/yaml-schema.md`](references/yaml-schema.md)** — configure `runtime.yaml` (scanners, actions, decision gate).
 4. **[`references/risk-gates.md`](references/risk-gates.md)** + **[`references/dsl-configuration.md`](references/dsl-configuration.md)** — declare risk guard-rails and tune the two-phase exit.
 5. **[`references/senpi-helpers-cli.md`](references/senpi-helpers-cli.md)** — verify the daemon is alive and ticking after deploy.
+
+### The invariant (both paths)
+
+Whether you cloned a template or wrote your own scanner, the contract is identical:
+
+- **The producer ONLY emits signals** via `push_signal` / `POST /signals`. It does **not** call `create_position`, **does not** write its own stop-loss / exit logic, and **does not** hand-roll a daemon loop or risk checks.
+- **The runtime owns execution, DSL exits, and risk guard-rails** for every strategy — always. That's what keeps a bring-your-own scanner on the same rails as a proven template.
+
+A "custom strategy" means **custom signal logic inside a standard producer**, not a custom harness. If you find yourself calling `create_position` or writing exit logic in the producer, stop — that belongs to the runtime.
 
 Full worked examples: **[`references/strategy-examples.md`](references/strategy-examples.md)**. The rest of this doc is the reference for each piece.
 


### PR DESCRIPTION
## Why

#297 routed agents to the runtime references but leaned toward "clone a template." Bring-your-own-scanner was a footnote — which risks an agent interpreting "custom strategy" as "hand-roll the daemon + call create_position myself," breaking the runtime model.

## Fix (docs only, 2 files)

Both on-ramps are now first-class and explicitly converge on one structure:

- **Path A — start from a template:** clone the closest example agent, swap asset/thresholds.
- **Path B — bring your own scanner:** novel signal logic → pick the structurally closest archetype → write a new producer on the SDK.

Same read-order for both (producer-patterns → SDK → yaml → risk-gates/dsl → verify), plus an explicit **invariant** stated in both `senpi-trading-runtime/SKILL.md` and the `senpi-entrypoint` build flow:

> The producer ONLY emits signals (`push_signal`). It never calls `create_position`, never writes exit/stop logic, never hand-rolls the daemon. The runtime owns execution, DSL exits, and risk for every strategy. A "custom strategy" = custom signal logic in a standard producer, not a custom harness.

That invariant is what keeps a custom scanner on the same rails (runtime + DSL + yaml + risk) as a cloned template — solving both paths gracefully.

## Test plan
- [ ] Both SKILL.md and the entrypoint build-flow present Path A + Path B as equals converging on one structure
- [ ] The producer-only-emits-signals invariant is explicit in both
- [ ] No code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)