### PR TITLE
docs: recommend DSL on every strategy (default-on, user can opt out)

### DIFF
--- a/senpi-entrypoint/references/post-onboarding.md
+++ b/senpi-entrypoint/references/post-onboarding.md
@@ -172,7 +172,9 @@ Both paths build on the same runtime.
 
 **Step 4 — Shape the thesis** *within* that structure: use Senpi MCP tools (market data, discovery, leaderboard) to shape entry logic, then map it onto the producer (cloned or new). The thesis rides on top of the runtime — it doesn't replace it.
 
-The goal: the user ends with a deployable runtime strategy — whether from a template or their own scanner — not an un-runnable plan.
+**Always recommend DSL.** Whatever the user builds, recommend attaching the runtime's DSL (Dynamic Stop-Loss) exit by default — it's the two-phase trailing stop that protects a position from running unprotected if the producer goes quiet or a fill lands late. The user decides (they can tune or skip it), but the default recommendation is DSL on, every strategy. Config lives in `runtime.yaml`'s `dsl_preset` — see [`dsl-configuration.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/dsl-configuration.md).
+
+The goal: the user ends with a deployable, DSL-protected runtime strategy — whether from a template or their own scanner — not an un-runnable plan.
 
 ---
 

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -37,6 +37,14 @@ Whether you cloned a template or wrote your own scanner, the contract is identic
 
 A "custom strategy" means **custom signal logic inside a standard producer**, not a custom harness. If you find yourself calling `create_position` or writing exit logic in the producer, stop — that belongs to the runtime.
 
+### Recommended for every strategy: attach DSL
+
+**Recommend DSL (Dynamic Stop-Loss) on every strategy, by default — both paths, every time.** It's the runtime's two-phase trailing exit (Phase 1 caps the loss, Phase 2 ratchets profit as the position runs) and it's the layer that keeps a position from running **unprotected** if the producer goes quiet, the host restarts, or an entry fills late. A strategy with no DSL carries naked-position risk: when anything interrupts the producer or the fill, nothing is managing the exit.
+
+The user and their agent decide for themselves — DSL can be tuned or turned off — **but the recommended default is DSL on, for every strategy.** When proposing a strategy, default to attaching it and only drop it if the user explicitly opts out.
+
+Configure it in `runtime.yaml`'s `dsl_preset` (phases, tiers, time-cuts) — see **[`references/dsl-configuration.md`](references/dsl-configuration.md)** for the full field reference and tuning guidance, and **[`references/risk-gates.md`](references/risk-gates.md)** for the declarative risk guard-rails that pair with it.
+
 Full worked examples: **[`references/strategy-examples.md`](references/strategy-examples.md)**. The rest of this doc is the reference for each piece.
 
 ## Core Concepts


### PR DESCRIPTION
## Why

DSL is the layer that protects a position when something upstream fails — producer death, host restart, late fills. The recent naked-position incidents (Railway producer deaths, CREATE_ORDER_RESTING late fills) are exactly what DSL guards against. We should recommend it on every strategy.

## Fix (docs only, 2 files)

Both authoring surfaces — `senpi-trading-runtime/SKILL.md` and the `senpi-entrypoint` build flow — now explicitly **recommend attaching DSL to every strategy by default**, for both the template path and the bring-your-own-scanner path.

Framing per the ask: **recommend DSL-on as the default; the user/agent decides and can tune or disable it.** When proposing a strategy, default to attaching DSL and only drop it on explicit opt-out.

Both point to `dsl-configuration.md` (`dsl_preset`: phases, tiers, time-cuts) + `risk-gates.md` for how to configure it.

## Test plan
- [ ] Both surfaces recommend DSL-on by default, framed as user's choice
- [ ] Both link to dsl-configuration.md for the how-to
- [ ] No code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)