### PR TITLE
docs: strategy-authoring onboarding — route to runtime refs, two paths, recommend DSL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,19 @@ This repo is almost entirely AI-generated. The rules below exist because they ha
 
 ---
 
+## ▶ Writing or editing a trading strategy? Start here
+
+Do **not** improvise a strategy from scratch. The canonical authoring path lives in `senpi-trading-runtime/`. Read in this order before writing code:
+
+1. **`senpi-trading-runtime/references/producer-patterns.md`** — the archetype catalog. Pick the closest pattern; it links to a working example agent. Copy that example.
+2. **`senpi-trading-runtime/references/python-producer-sdk.md`** — build the producer on the bundled `senpi_runtime_helpers` SDK. Never hand-roll MCP calls or the daemon loop.
+3. **`senpi-trading-runtime/references/yaml-schema.md`** + **`risk-gates.md`** + **`dsl-configuration.md`** — configure `runtime.yaml`, risk guard-rails, and the DSL exit.
+4. Verify with **`senpi-trading-runtime/references/senpi-helpers-cli.md`**.
+
+Fastest correct path: pick an archetype → clone the named example agent (`kodiak`, `cheetah`, `roach`) → swap in your signal logic → tune thresholds. Full read-order is at the top of `senpi-trading-runtime/SKILL.md`.
+
+---
+
 ## Skill Attribution (REQUIRED for strategy-representing skills only)
 
 **Scope:** This rule applies only to skills that *are* a trading strategy — i.e. adopting the skill results in a new strategy wallet being created and run under its thesis. This covers every animal-named / strategy-named skill in this repo (e.g. grizzly, kodiak, polar, cheetah, bald-eagle, owl, scorpion).

--- a/senpi-entrypoint/references/post-onboarding.md
+++ b/senpi-entrypoint/references/post-onboarding.md
@@ -151,18 +151,30 @@ Which sounds interesting? I can explain any in detail or deploy one right now.
 
 ### If user says "Build a new trading strategy" or "build a strategy" or "custom strategy" or "create a strategy"
 
-Help the user brainstorm custom strategies by combining Senpi tools and skills. Start the conversation with:
+Building a real, deployable strategy means building it on the **Senpi Trading Runtime** — the canonical runtime + DSL exit engine + Python Producer SDK. Do NOT treat this as a pure brainstorm or improvise a strategy from scratch: route the user through the runtime's authoring path so what they build actually deploys and is risk-protected.
 
-> Help me brainstorm some custom strategies we could build from combining senpi tools and/or senpi skills
+**Step 1 — Install the runtime skill:**
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
 
-The LLM should use its knowledge of the available Senpi MCP tools (market data, discovery, trading, portfolio) and installed skills to propose creative strategy ideas. Walk the user through:
+**Step 2 — Pick the path.** Read [`senpi-trading-runtime/references/producer-patterns.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/producer-patterns.md) — the catalog of producer/scanner archetypes. Then, based on how close an existing strategy is to the user's idea:
+- **Path A — start from a template:** a listed strategy is close. Clone its linked example agent and swap in the user's asset / thresholds. Fastest.
+- **Path B — bring their own scanner:** the user's signal logic is novel. Pick the archetype *structurally* closest, then write a new producer on the SDK. Their logic is custom; the structure is standard.
 
-1. **Market scan** — Use available Senpi MCP tools to identify current market conditions and opportunities.
-2. **Strategy ideation** — Brainstorm approaches that combine multiple Senpi tools and skills in novel ways (e.g. combining discovery signals with specific entry/exit logic, layering multiple timeframes, blending copy-trading signals with technical filters).
-3. **Plan outline** — Draft a concrete plan: which tools to use, entry/exit criteria, risk parameters, position sizing, and how the pieces fit together.
-4. **Next steps** — Offer to help the user refine the strategy, backtest the logic manually with current data, or point them to existing strategies that are closest to their idea.
+Both paths build on the same runtime.
 
-Do NOT require any specific skill installation for this flow — it is a brainstorming and planning session powered by the LLM and whatever MCP tools are already available.
+**Step 3 — Build on the SDK + runtime,** following the read-order at the top of [`senpi-trading-runtime/SKILL.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/SKILL.md):
+- [`python-producer-sdk.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/python-producer-sdk.md) — build (Path B) or tune (Path A) the producer on `senpi_runtime_helpers` (never hand-roll MCP calls or the daemon loop).
+- [`yaml-schema.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/yaml-schema.md) + [`risk-gates.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/risk-gates.md) — configure `runtime.yaml`, risk guard-rails, and the DSL exit.
+
+**The invariant for both paths:** the producer ONLY emits signals (`push_signal`). It never calls `create_position`, never writes its own exit/stop logic, never hand-rolls the daemon. The runtime owns execution, DSL exits, and risk for every strategy — that's what keeps a custom scanner on the same rails as a cloned template. A "custom strategy" = custom signal logic in a standard producer, not a custom harness.
+
+**Step 4 — Shape the thesis** *within* that structure: use Senpi MCP tools (market data, discovery, leaderboard) to shape entry logic, then map it onto the producer (cloned or new). The thesis rides on top of the runtime — it doesn't replace it.
+
+**Always recommend DSL.** Whatever the user builds, recommend attaching the runtime's DSL (Dynamic Stop-Loss) exit by default — it's the two-phase trailing stop that protects a position from running unprotected if the producer goes quiet or a fill lands late. The user decides (they can tune or skip it), but the default recommendation is DSL on, every strategy. Config lives in `runtime.yaml`'s `dsl_preset` — see [`dsl-configuration.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/dsl-configuration.md).
+
+The goal: the user ends with a deployable, DSL-protected runtime strategy — whether from a template or their own scanner — not an un-runnable plan.
 
 ---
 

--- a/senpi-onboard/references/post-onboarding.md
+++ b/senpi-onboard/references/post-onboarding.md
@@ -150,18 +150,30 @@ Which sounds interesting? I can explain any in detail or deploy one right now.
 
 ### If user says "Build a new trading strategy" or "build a strategy" or "custom strategy" or "create a strategy"
 
-Help the user brainstorm custom strategies by combining Senpi tools and skills. Start the conversation with:
+Building a real, deployable strategy means building it on the **Senpi Trading Runtime** — the canonical runtime + DSL exit engine + Python Producer SDK. Do NOT treat this as a pure brainstorm or improvise a strategy from scratch: route the user through the runtime's authoring path so what they build actually deploys and is risk-protected.
 
-> Help me brainstorm some custom strategies we could build from combining senpi tools and/or senpi skills
+**Step 1 — Install the runtime skill:**
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
 
-The LLM should use its knowledge of the available Senpi MCP tools (market data, discovery, trading, portfolio) and installed skills to propose creative strategy ideas. Walk the user through:
+**Step 2 — Pick the path.** Read [`senpi-trading-runtime/references/producer-patterns.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/producer-patterns.md) — the catalog of producer/scanner archetypes. Then, based on how close an existing strategy is to the user's idea:
+- **Path A — start from a template:** a listed strategy is close. Clone its linked example agent and swap in the user's asset / thresholds. Fastest.
+- **Path B — bring their own scanner:** the user's signal logic is novel. Pick the archetype *structurally* closest, then write a new producer on the SDK. Their logic is custom; the structure is standard.
 
-1. **Market scan** — Use available Senpi MCP tools to identify current market conditions and opportunities.
-2. **Strategy ideation** — Brainstorm approaches that combine multiple Senpi tools and skills in novel ways (e.g. combining discovery signals with specific entry/exit logic, layering multiple timeframes, blending copy-trading signals with technical filters).
-3. **Plan outline** — Draft a concrete plan: which tools to use, entry/exit criteria, risk parameters, position sizing, and how the pieces fit together.
-4. **Next steps** — Offer to help the user refine the strategy, backtest the logic manually with current data, or point them to existing strategies that are closest to their idea.
+Both paths build on the same runtime.
 
-Do NOT require any specific skill installation for this flow — it is a brainstorming and planning session powered by the LLM and whatever MCP tools are already available.
+**Step 3 — Build on the SDK + runtime,** following the read-order at the top of [`senpi-trading-runtime/SKILL.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/SKILL.md):
+- [`python-producer-sdk.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/python-producer-sdk.md) — build (Path B) or tune (Path A) the producer on `senpi_runtime_helpers` (never hand-roll MCP calls or the daemon loop).
+- [`yaml-schema.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/yaml-schema.md) + [`risk-gates.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/risk-gates.md) — configure `runtime.yaml`, risk guard-rails, and the DSL exit.
+
+**The invariant for both paths:** the producer ONLY emits signals (`push_signal`). It never calls `create_position`, never writes its own exit/stop logic, never hand-rolls the daemon. The runtime owns execution, DSL exits, and risk for every strategy — that's what keeps a custom scanner on the same rails as a cloned template. A "custom strategy" = custom signal logic in a standard producer, not a custom harness.
+
+**Always recommend DSL.** Whatever the user builds, recommend attaching the runtime's DSL (Dynamic Stop-Loss) exit by default — it's the two-phase trailing stop that protects a position from running unprotected if the producer goes quiet or a fill lands late. The user decides (they can tune or skip it), but the default recommendation is DSL on, every strategy. Config lives in `runtime.yaml`'s `dsl_preset` — see [`dsl-configuration.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/dsl-configuration.md).
+
+**Step 4 — Shape the thesis** *within* that structure: use Senpi MCP tools (market data, discovery, leaderboard) to shape entry logic, then map it onto the producer (cloned or new). The thesis rides on top of the runtime — it doesn't replace it.
+
+The goal: the user ends with a deployable, DSL-protected runtime strategy — whether from a template or their own scanner — not an un-runnable plan.
 
 ---
 

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -13,6 +13,40 @@ metadata:
 
 On-chain position tracker with automated DSL (Dynamic Stop-Loss) exit engine. Monitors a wallet's positions on Hyperliquid for lifecycle events (open, close, edit, flip) and applies two-phase trailing stop-loss protection to all positions.
 
+## ▶ Writing a new strategy? Read these first, in this order
+
+This skill is the canonical way to build a Senpi strategy. **Every strategy is built the same way** — on this runtime, with the Producer SDK, DSL exit engine, and risk guard-rails. There are **two on-ramps** to that one structure:
+
+- **Path A — Start from a template.** Something close to your idea already exists. Pick the closest archetype in `producer-patterns.md`, clone the linked example agent, and swap in your asset / thresholds. Fastest path when a near-match exists.
+- **Path B — Bring your own scanner/producer.** Your signal logic is novel and no template fits. Pick the archetype in `producer-patterns.md` that's *structurally* closest to your approach, then write a new producer on the SDK. **Your signal logic is yours; the surrounding structure is standard.**
+
+Both paths follow the same read-order:
+
+1. **[`references/producer-patterns.md`](references/producer-patterns.md)** — pick the archetype (universe trend-follower, single-asset alpha hunter, trader-follower, funding fade, etc.). Each links to a working example agent's `producer.py` + `runtime.yaml`. **Path A: clone the closest example. Path B: use it as your structural template.**
+2. **[`references/python-producer-sdk.md`](references/python-producer-sdk.md)** — build (Path B) or tune (Path A) the producer on the bundled `senpi_runtime_helpers` SDK (`SenpiClient`, `producer_daemon`, `scanner_lock`, `tick_cache`). Don't hand-roll MCP calls or the daemon loop.
+3. **[`references/yaml-schema.md`](references/yaml-schema.md)** — configure `runtime.yaml` (scanners, actions, decision gate).
+4. **[`references/risk-gates.md`](references/risk-gates.md)** + **[`references/dsl-configuration.md`](references/dsl-configuration.md)** — declare risk guard-rails and tune the two-phase exit.
+5. **[`references/senpi-helpers-cli.md`](references/senpi-helpers-cli.md)** — verify the daemon is alive and ticking after deploy.
+
+### The invariant (both paths)
+
+Whether you cloned a template or wrote your own scanner, the contract is identical:
+
+- **The producer ONLY emits signals** via `push_signal` / `POST /signals`. It does **not** call `create_position`, **does not** write its own stop-loss / exit logic, and **does not** hand-roll a daemon loop or risk checks.
+- **The runtime owns execution, DSL exits, and risk guard-rails** for every strategy — always. That's what keeps a bring-your-own scanner on the same rails as a proven template.
+
+A "custom strategy" means **custom signal logic inside a standard producer**, not a custom harness. If you find yourself calling `create_position` or writing exit logic in the producer, stop — that belongs to the runtime.
+
+### Recommended for every strategy: attach DSL
+
+**Recommend DSL (Dynamic Stop-Loss) on every strategy, by default — both paths, every time.** It's the runtime's two-phase trailing exit (Phase 1 caps the loss, Phase 2 ratchets profit as the position runs) and it's the layer that keeps a position from running **unprotected** if the producer goes quiet, the host restarts, or an entry fills late. A strategy with no DSL carries naked-position risk: when anything interrupts the producer or the fill, nothing is managing the exit.
+
+The user and their agent decide for themselves — DSL can be tuned or turned off — **but the recommended default is DSL on, for every strategy.** When proposing a strategy, default to attaching it and only drop it if the user explicitly opts out.
+
+Configure it in `runtime.yaml`'s `dsl_preset` (phases, tiers, time-cuts) — see **[`references/dsl-configuration.md`](references/dsl-configuration.md)** for the full field reference and tuning guidance, and **[`references/risk-gates.md`](references/risk-gates.md)** for the declarative risk guard-rails that pair with it.
+
+Full worked examples: **[`references/strategy-examples.md`](references/strategy-examples.md)**. The rest of this doc is the reference for each piece.
+
 ## Core Concepts
 
 **Python Producer SDK ships with this skill** at `senpi_runtime_helpers/`. When wiring up an `external_scanner` (a Python producer that pushes signals into this runtime), build it on this SDK — it wraps the `/signals` endpoint, the `SignalItem` schema, the per-tick lock, and the long-running daemon scheduler in one stdlib-only Python package. Recipes and rules: see [Python Producer SDK](#python-producer-sdk) below.


### PR DESCRIPTION
**For team review — not to be merged by me.** This is the consolidated re-open of #297/#298/#299 (admin-merged in error; backed out of main in 43999f1). Docs only, no code.

## Problem

New agents — ours and users' — aren't clear how to write strategies. Every surface an agent hits when building one (`CLAUDE.md`, the runtime `SKILL.md`, the senpi-entrypoint "build a strategy" flow) failed to route them to the canonical references. The build-a-strategy onboarding flow was a freeform brainstorm that never mentioned the runtime, producer-patterns, or the SDK — and said "do NOT require any skill install." Result: agents improvising off-pattern strategies, hand-rolling daemons, and shipping positions with no exit protection.

## Solution (three changes, one PR)

1. **Route to `producer-patterns.md` first** — one ordered read-path (producer-patterns → SDK → yaml → risk-gates/dsl → verify), repeated in all three surfaces.
2. **Two on-ramps, one structure** — Path A (clone a template) and Path B (bring your own scanner) are equals converging on the same runtime + DSL + yaml + risk.
3. **Recommend DSL on every strategy** by default (user can tune/opt out), with a config pointer.

## Important notes

- **Docs only** — no code touched.
- Two load-bearing principles now stated explicitly everywhere: **(1)** the producer ONLY emits signals — never `create_position`, never its own exit logic, never a hand-rolled daemon; the runtime owns execution/DSL/risk. **(2)** DSL on by default — the protection that would've prevented the naked positions from last week's producer-death + late-fill incidents.
- Touches **senpi-entrypoint**, which the team owns — please review the build-flow framing especially.
- Consolidated into one PR because the three changes are layered edits to the same 3 files (couldn't be separate non-conflicting PRs).

## Test plan
- [ ] CLAUDE.md / runtime SKILL.md / entrypoint build-flow all route to producer-patterns.md first
- [ ] Both authoring paths present + the producer-only-emits-signals invariant explicit
- [ ] DSL recommended by default with config pointer
- [ ] No code touched