### PR TITLE
docs(dsl/risk): smart default — cut duds without capping winners + risk envelope

### DIFF
--- a/senpi-trading-runtime/references/dsl-configuration.md
+++ b/senpi-trading-runtime/references/dsl-configuration.md
@@ -8,7 +8,7 @@ The DSL (Dynamic Stop-Loss) manages exit logic for open perpetual positions. It 
 
 **The right DSL shape depends on the strategy class.** A single "one-size" stop is wrong for most strategies — a trend-follower needs room to let a winner run, while a fader needs to bank a bounded snapback fast. Start from the preset that matches your thesis, then hand-tune the fields.
 
-> ⭐ **Default = `balanced`.** If you're unsure, start here. It lets a position **breathe** — no profit lock until +10% ROE, lock ramps gradually, and a runner tier out to +100% — while a 15% max-loss floor and a 24h outer-bound timeout protect the downside. This replaces the older tight default whose +7%/lock-40 first tier and +20% cap chopped trend winners during the 2026-05 HYPE run.
+> ⭐ **Default = `balanced`.** If you're unsure, start here. It lets a position **breathe** — no profit lock until +10% ROE, lock ramps gradually, and a runner tier out to +100% — while three layers protect it: a **15% max-loss floor** (catastrophic stop), a **weak_peak_cut** that frees a dead-on-arrival position (never reached +3% ROE in 2h) *without touching a winner*, and a **72h hard_timeout** outer bound long enough not to cap a multi-day trend. This replaces the older tight default whose +7%/lock-40 first tier and +20% cap chopped trend winners during the 2026-05 HYPE run.
 
 | Preset | Use for | Character |
 |--------|---------|-----------|
@@ -60,7 +60,11 @@ dsl_preset:
 dsl_preset:
   hard_timeout:
     enabled: true
-    interval_in_minutes: 1440                   # 24h outer bound only
+    interval_in_minutes: 4320                   # 72h — outer bound only; won't cap a multi-day winner
+  weak_peak_cut:
+    enabled: true
+    interval_in_minutes: 120                    # frees a dead-on-arrival position (peak < 3% ROE in 2h) WITHOUT touching a winner
+    min_value: 3.0
   phase1:
     enabled: true
     max_loss_pct: 15.0
@@ -430,4 +434,4 @@ exit:
         - { trigger_pct: 100, lock_hw_pct: 85 }
 ```
 
-> The block above shows every time-cut key for reference. The `balanced` default enables only `hard_timeout` (24h outer bound); see [DSL Presets](#dsl-presets) for which time-cuts each class uses (`mean_reversion` adds `weak_peak_cut`; `scalp` adds `dead_weight_cut`; `let_winners_run` uses none).
+> The block above shows every time-cut key for reference. The `balanced` default enables `hard_timeout` (72h outer bound) + `weak_peak_cut` (frees dead-on-arrival positions); see [DSL Presets](#dsl-presets) for which time-cuts each class uses (`scalp` adds `dead_weight_cut`; `let_winners_run` uses none).

--- a/senpi-trading-runtime/references/dsl-presets.yaml
+++ b/senpi-trading-runtime/references/dsl-presets.yaml
@@ -40,12 +40,18 @@ presets:
     use_for: General-purpose / unsure (the default)
     character: >-
       Breathes early (no lock until +10%), locks gradually, runner tier to
-      +100%, 24h outer-bound timeout. Survives normal noise via a 15% margin
-      floor.
+      +100%, 15% margin floor. Smart auto-close: weak_peak_cut frees a
+      dead-on-arrival position (never reached +3% ROE in 2h) WITHOUT touching
+      a winner, and a 72h hard_timeout is a true outer bound that won't cap a
+      multi-day trend.
     dsl_preset:
       hard_timeout:
         enabled: true
-        interval_in_minutes: 1440
+        interval_in_minutes: 4320       # 72h — outer bound only; long enough not to cut a multi-day winner
+      weak_peak_cut:
+        enabled: true
+        interval_in_minutes: 120        # if it hasn't reached +3% ROE in 2h, free the capital (Phase 1 only; never cuts a position past T0)
+        min_value: 3.0
       phase1:
         enabled: true
         max_loss_pct: 15.0

--- a/senpi-trading-runtime/references/risk-gates.md
+++ b/senpi-trading-runtime/references/risk-gates.md
@@ -26,6 +26,28 @@ Every signal that reaches `open-position` triggers a real-time gate check via MC
 
 **Default booleans (when `guard_rails` exists):** `bypass_max_entries_per_day_on_profit` and `drawdown_reset_on_day_rollover` default to `false`.
 
+## Recommended default envelope
+
+⚠️ Because the `risk:` block is fully optional and omitting a field disables that gate, a strategy that ships without `risk.guard_rails` runs with **no daily-loss halt, no drawdown halt, no cooldowns, and no entry cap** — only the DSL's `max_loss_pct` protects each individual position. That's rarely what you want. **Pair the `balanced` DSL preset with this guard-rail envelope** unless you have a reason to deviate — it's the "smart default" that works for most strategies:
+
+```yaml
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15          # halt new entries after a -15% day
+    drawdown_halt_pct: 25             # circuit breaker on a -25% PnL drawdown from peak
+    drawdown_reset_on_day_rollover: false
+    max_consecutive_losses: 3         # + cooldown_minutes → pause after a losing streak
+    cooldown_minutes: 60
+    per_asset_cooldown_minutes: 240   # 4h between attempts on the same asset (anti-whipsaw)
+    max_entries_per_day: 5            # caps fee-bleed / runaway over-trading
+    bypass_max_entries_per_day_on_profit: false
+```
+
+Tune per strategy class: faders/scalpers want a **lower** `per_asset_cooldown_minutes` and **higher** `max_entries_per_day`; conviction holders want the opposite. The fail-safe below means an over-tight envelope only ever *suspends* trading — it never forces a bad entry.
+
+**Fail-safe:** any risk MCP call that errors (network/timeout/missing snapshot) returns `CLOSED` for halt-class gates and `COOLDOWN` for asset checks — trading is suspended whenever risk state is unknown. There is no permissive fallback.
+
 ## Gate 5 timestamp arithmetic
 
 `max_entries_per_day` is enforced by counting opens since UTC midnight. The MCP fields involved — `discovery_get_trader_history.openTime`/`closeTime` and `discovery_get_trader_state` position `startTime` — are **Unix epoch seconds**, and the runtime compares them against **UTC midnight expressed in seconds** (same unit end-to-end). Don't pass milliseconds anywhere in this path.


### PR DESCRIPTION
## Investigation answer (what you asked)
- **No "Phase 0."** The DSL has only **Phase 1** (entry → first tier) and **Phase 2** (first tier → exit). What feels like "phase 0" (the moment of entry) *is* Phase 1, governed by `max_loss_pct` (absolute floor) + `retrace_threshold` (trailing) + any time-cuts.
- **No auto-closes by default.** All three DSL time-cuts (`hard_timeout`/`weak_peak_cut`/`dead_weight_cut`) are optional and **off** unless configured. And the entire **`risk:` block is optional** — omit it and every gate (daily-loss, drawdown, cooldowns, entry cap) is a no-op. A bare config protects each position only by the DSL `max_loss`; nothing caps holding time, daily loss, drawdown, or over-trading.

## Making the default smart for most situations
**`balanced` DSL** — replaced the bare 24h `hard_timeout` (which would cap a multi-day winner) with a two-part smart auto-close:
- `weak_peak_cut` 120min / 3% — frees a **dead-on-arrival** position (never reached +3% ROE in 2h) **without touching a winner** (Phase-1-only by construction, since 3% < the +10% T0).
- `hard_timeout` 72h — a true outer bound, long enough not to clip a multi-day trend.

So the default now does all four: **lets winners run** (no early lock, +100% runner tier) · **cuts duds fast** (weak_peak) · **caps catastrophic loss** (15% max_loss) · **frees genuinely-stuck capital** (72h).

**Risk gates** — added a **Recommended default envelope** to `risk-gates.md` (daily-loss 15%, drawdown halt 25%, consecutive-loss + per-asset cooldowns, 5 entries/day) so a strategy that ships without `risk.guard_rails` isn't left fully unprotected. Documented the fail-safe (unknown risk state → `CLOSED`, never permissive).

## Follow-up for the runtime team
Today these are documented defaults you copy. The durable version: have the engine **apply this envelope when `risk:` is omitted** (so "no risk block" means "safe defaults," not "no protection"), and support `dsl_preset.template: <name>` resolution. Folding into the Rachin thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)