### PR TITLE
fix(dsl): lengthen balanced weak_peak_cut 2h→6h to avoid churn

### DIFF
--- a/senpi-trading-runtime/references/dsl-configuration.md
+++ b/senpi-trading-runtime/references/dsl-configuration.md
@@ -8,7 +8,7 @@ The DSL (Dynamic Stop-Loss) manages exit logic for open perpetual positions. It 
 
 **The right DSL shape depends on the strategy class.** A single "one-size" stop is wrong for most strategies — a trend-follower needs room to let a winner run, while a fader needs to bank a bounded snapback fast. Start from the preset that matches your thesis, then hand-tune the fields.
 
-> ⭐ **Default = `balanced`.** If you're unsure, start here. It lets a position **breathe** — no profit lock until +10% ROE, lock ramps gradually, and a runner tier out to +100% — while three layers protect it: a **15% max-loss floor** (catastrophic stop), a **weak_peak_cut** that frees a dead-on-arrival position (never reached +3% ROE in 2h) *without touching a winner*, and a **72h hard_timeout** outer bound long enough not to cap a multi-day trend. This replaces the older tight default whose +7%/lock-40 first tier and +20% cap chopped trend winners during the 2026-05 HYPE run.
+> ⭐ **Default = `balanced`.** If you're unsure, start here. It lets a position **breathe** — no profit lock until +10% ROE, lock ramps gradually, and a runner tier out to +100% — while three layers protect it: a **15% max-loss floor** (catastrophic stop), a **weak_peak_cut** that frees a position only if it's BOTH flat (never reached +3% ROE in 6h) AND fading — *never a winner or a position still near its high* — and a **72h hard_timeout** outer bound long enough not to cap a multi-day trend. This replaces the older tight default whose +7%/lock-40 first tier and +20% cap chopped trend winners during the 2026-05 HYPE run.
 
 | Preset | Use for | Character |
 |--------|---------|-----------|
@@ -63,7 +63,7 @@ dsl_preset:
     interval_in_minutes: 4320                   # 72h — outer bound only; won't cap a multi-day winner
   weak_peak_cut:
     enabled: true
-    interval_in_minutes: 120                    # frees a dead-on-arrival position (peak < 3% ROE in 2h) WITHOUT touching a winner
+    interval_in_minutes: 360                    # 6h — only frees a position that is BOTH flat (peak < 3% ROE) AND fading; gives slow developers room, never touches a winner
     min_value: 3.0
   phase1:
     enabled: true

--- a/senpi-trading-runtime/references/dsl-presets.yaml
+++ b/senpi-trading-runtime/references/dsl-presets.yaml
@@ -41,16 +41,16 @@ presets:
     character: >-
       Breathes early (no lock until +10%), locks gradually, runner tier to
       +100%, 15% margin floor. Smart auto-close: weak_peak_cut frees a
-      dead-on-arrival position (never reached +3% ROE in 2h) WITHOUT touching
-      a winner, and a 72h hard_timeout is a true outer bound that won't cap a
-      multi-day trend.
+      position that is BOTH flat (never reached +3% ROE in 6h) AND fading — it
+      never touches a winner or a position still near its high — and a 72h
+      hard_timeout is a true outer bound that won't cap a multi-day trend.
     dsl_preset:
       hard_timeout:
         enabled: true
         interval_in_minutes: 4320       # 72h — outer bound only; long enough not to cut a multi-day winner
       weak_peak_cut:
         enabled: true
-        interval_in_minutes: 120        # if it hasn't reached +3% ROE in 2h, free the capital (Phase 1 only; never cuts a position past T0)
+        interval_in_minutes: 360        # 6h — gives a slow developer real room; only fires if peak ROE never cleared +3% AND price is declining (Phase 1 only; never cuts a position past T0)
         min_value: 3.0
       phase1:
         enabled: true


### PR DESCRIPTION
The balanced default's dud-cut was 2h, too aggressive for a 'breathe' default — a legitimate directional trade can take longer than 2h to develop. Lengthened to **6h**. Mechanics unchanged: still fires only when a position is BOTH flat (peak never cleared +3% ROE) AND declining, so it never touches a winner or a position near its high; it just frees genuinely-dead capital after a quarter-day instead of 2h. 72h hard_timeout remains the outer bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)