### PR TITLE
feat: Badger + Egret strategies (first 2 of the new-strategy set)

### DIFF
--- a/badger/README.md
+++ b/badger/README.md
@@ -1,6 +1,6 @@
 # 🦡 Badger — OI-Divergence Breakout Anticipator
 
-Advanced-tier strategy. Multi-asset (BTC/ETH/SOL/HYPE). Takes a price breakout **only when rising open interest confirms it** — new money committing, not a fakeout — with Smart-Money agreement. Wide DSL ladder so a confirmed breakout can run.
+Multi-signal whitelist strategy. Multi-asset (BTC/ETH/SOL/HYPE). Takes a price breakout **only when rising open interest confirms it** — new money committing, not a fakeout — with Smart-Money agreement. Wide DSL ladder so a confirmed breakout can run.
 
 Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 

--- a/badger/README.md
+++ b/badger/README.md
@@ -1,0 +1,136 @@
+# 🦡 Badger — OI-Divergence Breakout Anticipator
+
+Advanced-tier strategy. Multi-asset (BTC/ETH/SOL/HYPE). Takes a price breakout **only when rising open interest confirms it** — new money committing, not a fakeout — with Smart-Money agreement. Wide DSL ladder so a confirmed breakout can run.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+Most range breakouts fail. The single best filter for follow-through is **open interest**: a breakout on rising OI means new positions are being opened in the breakout direction (real conviction); a breakout on flat/declining OI is shorts covering or stops triggering (a fakeout). Badger fires only when price breaks the prior 24h range **and** OI is rising **and** Smart Money agrees — then hands the position to a wide DSL ladder. It's the OI-confirmed version of a breakout buyer.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Universe | BTC, ETH, SOL, HYPE |
+| Tick interval | 300s (5 min) |
+| MIN_SCORE (producer) | 5 (out of ~10 max) |
+| LLM min_confidence | 7 |
+| Leverage | 5x default, max 5x |
+| Margin per trade | 20% of equity |
+| Breakout lookback | 24h |
+| OI-rising floor | 2% (1h) |
+| OI strong-build bonus | 5% |
+| SM tilt minimum | 55% |
+| Max entries per day | 3 |
+| Per-asset cooldown | 240 min (4h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 20% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (wide, Bison-pattern — let winners run)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 20% |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout / weak_peak_cut / dead_weight_cut | **all DISABLED** |
+| Phase 2 | T0 | +10% / 0% lock |
+| Phase 2 | T1 | +20% / 25% lock |
+| Phase 2 | T2 | +30% / 40% lock |
+| Phase 2 | T3 | +50% / 60% lock |
+| Phase 2 | T4 | +75% / 75% lock |
+| Phase 2 | T5 | +100% / 85% lock (apex) |
+
+## Scanner pattern
+
+**Multi-asset whitelist scanner with OI-confirmed breakout scoring** — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data` (candles + `asset_context.openInterest` + `oi_velocity`), `leaderboard_get_markets` (SM direction). When `oi_velocity` is null, the producer self-computes OI velocity from a persisted last-OI cache (`state/oi-state.json`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/badger-producer.py | Long-lived daemon; emits BADGER_OI_BREAKOUT signals |
+| scripts/badger_config.py | SDK probe + SenpiClient wrapper + recent-signals + OI-state cache |
+| config/badger-config.json | Operator-tunable defaults (wallet, universe, OI/SM thresholds, sizing) |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+The Python Producer SDK (`senpi_runtime_helpers`) ships inside the senpi-trading-runtime skill:
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Badger
+
+```bash
+mkdir -p /data/workspace/skills/badger-strategy/{config,scripts,state,references}
+for f in scripts/badger-producer.py scripts/badger_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/badger-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/badger/$f" \
+    -o "/data/workspace/skills/badger-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/badger-strategy/config/badger-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export BADGER_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                          # required
+export BADGER_DECISION_MODEL=<your-preferred-model>  # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/badger-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/badger-strategy/scripts/badger-producer.py \
+  > /tmp/badger-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon from the shell job table so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 320  # wait one full tick
+tail -3 /tmp/badger-producer.log | jq '._badger_producer_version, .note // null, .best.score // null'
+# Expected: _badger_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no OI-confirmed breakout with SM agreement on universe"` — common
+- `"signals_pushed": 1, "best": { "coin": ..., "direction": "LONG"|"SHORT", "score": 5-10 }` — entry fired
+
+Note: the OI-velocity cache warms up after one tick per asset, so the first tick may show `WAITING` even on a clean breakout until a prior OI reading exists.
+
+## Changelog
+
+### v1.0.0 (2026-05-21) — initial release
+
+First fleet agent to gate breakouts on open-interest velocity. Built with the 2026-05-21 HYPE post-mortem guidelines baked in: wide "let winners run" Phase 2 ladder, taker-fallback entries, exit timeout 30s, no null numeric signal fields, disown-safe launch.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/badger/SKILL.md
+++ b/badger/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: badger-strategy
+description: >-
+  BADGER v1.0.0 — OI-Divergence Breakout Anticipator. Open interest is
+  the fuel of a breakout: a price push beyond the prior 24h range that is
+  confirmed by RISING open interest = new money committing = real
+  follow-through; a breakout on flat/declining OI is a fakeout. LONG on an
+  up-breakout + rising OI + SM net long; SHORT on the mirror. Universe:
+  BTC, ETH, SOL, HYPE. Wide "let winners run" DSL — Phase 1 max_loss 20%,
+  Phase 2 T0 +10% / lock 0 → T5 +100% / lock 85, time-cuts disabled.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦡 BADGER v1.0.0 — OI-Divergence Breakout Anticipator
+
+**Only take the breakout the order flow confirms.** Badger waits for price to break its prior 24h range AND for open interest to be *rising* into that break — proof that new money is committing, not just stops getting run. A breakout on flat or declining OI is a fakeout; Badger skips it.
+
+## Why this strategy exists
+
+Pure price-breakout strategies (like Hawk) fire on every range break — and most range breaks fail. The single best filter for "will this breakout follow through?" is **open interest**:
+
+- **Price breaks out + OI rising** → new positions are being opened in the breakout direction. Real conviction, real follow-through.
+- **Price breaks out + OI flat/falling** → no new money; the move is shorts covering or stops triggering. Fakeout. Skip.
+
+Badger is the OI-confirmed version of a breakout buyer. The rising-OI gate is what separates it from Hawk.
+
+## CRITICAL RULES
+
+### RULE 1: OI-rising is a hard gate
+Open interest must be rising at least `oiRisingMinPct` (default 2%) over the 1h window. Below that, no entry — regardless of how clean the price breakout looks. This is the whole edge.
+
+### RULE 2: OI velocity has a fallback
+The runtime's `market_get_asset_data` exposes an `oi_velocity` object, but it can be `null`. When it is, Badger falls back to a **self-computed OI delta** from a persisted last-OI cache (`state/oi-state.json`). The cache warms up after one tick per asset, so a freshly-started Badger may output `WAITING` for the first tick on each asset until it has a prior OI reading to compare against.
+
+### RULE 3: Producer enters. DSL exits.
+No `close_position` call site. DSL Phase 1 max_loss + Phase 2 wide ladder + (disabled) time-cuts own all exits. A confirmed breakout can run far — the wide ladder lets it.
+
+### RULE 4: Universe is BTC, ETH, SOL, HYPE
+Operators can override via `universe` in config. Low-liquidity coins produce noisy OI readings; keep the universe liquid.
+
+## How Badger scores a trade
+
+**Gates** (all required):
+1. Price breaks the prior 24h high (LONG) or low (SHORT)
+2. OI rising >= `oiRisingMinPct` (default 2%)
+3. SM direction agrees with the breakout direction
+4. SM tilt >= `smTiltMinPct` (default 55%)
+
+**Score components** (max ~10):
+
+| Signal | Points |
+|---|---|
+| Breakout magnitude ≥ 1.0% | +3 |
+| Breakout magnitude 0.3–1.0% | +2 |
+| Breakout magnitude < 0.3% | +1 |
+| OI rising (gate-confirmed) | +2 |
+| OI strongly building (≥ `oiStrongPct`, default 5%) | +1 |
+| SM aligned (gate-confirmed) | +2 |
+| SM strongly tilted (≥ 70%) | +1 |
+| 4h structure confirms breakout direction | +1 |
+| Volume rising (> 10%) | +1 |
+
+**Floor:** `minScore: 5`. Typical entry clears 6–8.
+
+## DSL preset (wide — let winners run)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | **20%** (cuts a failed breakout) |
+| Phase 1 | retrace_threshold | 8 |
+| Phase 1 | consecutive_breaches | 1 |
+| Time cuts | hard_timeout | **DISABLED** |
+| Time cuts | weak_peak_cut | **DISABLED** |
+| Time cuts | dead_weight_cut | **DISABLED** |
+| Phase 2 | T0 | **+10% / lock 0** (let it breathe) |
+| Phase 2 | T1 | +20% / lock 25% |
+| Phase 2 | T2 | +30% / lock 40% |
+| Phase 2 | T3 | +50% / lock 60% |
+| Phase 2 | T4 | +75% / lock 75% |
+| Phase 2 | T5 | +100% / lock 85% |
+
+## Scanner pattern
+
+This strategy uses the **Multi-asset whitelist scanner with OI-confirmed breakout scoring** — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data` (candles + `asset_context.openInterest` + `oi_velocity`), `leaderboard_get_markets` (SM direction).
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-21) — initial release
+
+Advanced-tier gap-filler. First fleet agent to gate breakouts on open-interest velocity. Built with the 2026-05-21 HYPE post-mortem guidelines baked in: wide "let winners run" Phase 2 ladder (a confirmed breakout can run far), taker-fallback entries (a breakout entry must fill — maker-only risks CREATE_ORDER_RESTING), exit timeout 30s, and no null numeric signal fields.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/badger/SKILL.md
+++ b/badger/SKILL.md
@@ -99,7 +99,7 @@ See [README.md](README.md).
 
 ### v1.0.0 (2026-05-21) — initial release
 
-Advanced-tier gap-filler. First fleet agent to gate breakouts on open-interest velocity. Built with the 2026-05-21 HYPE post-mortem guidelines baked in: wide "let winners run" Phase 2 ladder (a confirmed breakout can run far), taker-fallback entries (a breakout entry must fill — maker-only risks CREATE_ORDER_RESTING), exit timeout 30s, and no null numeric signal fields.
+Gap-filler in the multi-signal whitelist family. First fleet agent to gate breakouts on open-interest velocity. Built with the 2026-05-21 HYPE post-mortem guidelines baked in: wide "let winners run" Phase 2 ladder (a confirmed breakout can run far), taker-fallback entries (a breakout entry must fill — maker-only risks CREATE_ORDER_RESTING), exit timeout 30s, and no null numeric signal fields.
 
 ## License
 

--- a/badger/config/badger-config.json
+++ b/badger/config/badger-config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "BADGER v1.0.0 — OI-Divergence Breakout Anticipator (BTC/ETH/SOL/HYPE). LONG when price breaks the prior 24h high AND open interest is rising (>= oiRisingMinPct) AND Smart Money is net long; SHORT on the mirror. The rising-OI gate is the edge — it filters fakeout breakouts that have no new money behind them. Wide DSL Phase 2 ladder (T0 +10% / lock 0) so a confirmed breakout can run. Edit wallet/strategyId/chatId.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "universe": ["BTC", "ETH", "SOL", "HYPE"],
+  "minScore": 5,
+  "breakoutLookbackHours": 24,
+  "oiRisingMinPct": 2.0,
+  "oiStrongPct": 5.0,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "marginPct": 0.20,
+  "leverage": 5
+}

--- a/badger/references/skill-attribution.md
+++ b/badger/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "badger",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "badger",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/badger/runtime.yaml
+++ b/badger/runtime.yaml
@@ -1,0 +1,197 @@
+name: badger-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Badger
+# v1.0.0" and lives in description + SKILL.md + _badger_producer_version.
+version: 1.0.0
+description: >
+  BADGER v1.0.0 — OI-Divergence Breakout Anticipator.
+
+  Open interest is the fuel of a breakout. A price push beyond its recent
+  range confirmed by RISING open interest = new money committing = real
+  follow-through; a breakout on flat/declining OI is a fakeout. Badger
+  takes the OI-confirmed breakout (long or short) with Smart-Money
+  agreement, across BTC/ETH/SOL/HYPE, and hands it to a wide DSL ladder.
+
+  Architecture (helpers-native, mirrors Wolverine v6.0.0 / Bison v3.0.1):
+    - Producer (badger-producer.py) ticks every 300s, scans the universe,
+      scores an OI-confirmed-breakout thesis (max ~10), emits
+      BADGER_OI_BREAKOUT via SenpiClient.push_signal() when score >= 5.
+    - LLM gate is pass-through — producer applied every filter
+      (price breakout, OI rising >= 2%, SM direction agreement, SM tilt).
+    - risk.guard_rails ENFORCES max_entries_per_day, per_asset_cooldown,
+      daily_loss_limit, drawdown_halt.
+    - DSL exits via FEE_OPTIMIZED_LIMIT, Bison-pattern wide Phase 2 ladder
+      (T0 lock 0 through T5 lock 85) so a confirmed breakout can run.
+      Time-cuts all DISABLED.
+
+  Tuning:
+    - minScore 5, breakout lookback 24h, OI-rising floor 2%, SM tilt 55%
+    - 20% margin / 5x leverage default
+    - per-asset 4h cooldown, 15% daily-loss limit, 20% drawdown-halt
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 250
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: badger_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        breakoutDir: { type: string, required: false }
+        breakoutMagPct: { type: number, required: false }
+        oiChangePct: { type: number, required: false }
+        oiSource: { type: string, required: false }
+        trend4h: { type: string, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: badger_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${BADGER_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix. Senpi runtime resolves provider routing.
+    scanners: [badger_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # momentum entries must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING); a confirmed breakout won't wait
+        execution_timeout_seconds: 30           # keep the maker attempt comfortably under the server connection window
+    context:
+      - type: signal
+        scanner: badger_signals
+    decision_prompt: |
+      You are Badger's pass-through gate. Badger only fires on a price
+      breakout that is CONFIRMED by rising open interest (new money) and
+      Smart-Money agreement. The producer already applied every filter
+      (price broke the prior 24h range edge, OI rising >= 2%, SM direction
+      agrees, SM tilt >= 55%, minScore 5). Honor the signal and convert it
+      into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_badger_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (preserve case).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND oiChangePct >= 5 AND smTiltPct >= 70
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 8 SOL LONG, breakout_up +0.9%, oi_rising +6.2%, SM aligned 68% — OI-confirmed breakout')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "BADGER_OI_BREAKOUT ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — Bison-pattern wide ladder) ────────────────────
+#
+# A confirmed breakout can run far, so let it. Time-cuts DISABLED.
+# Phase 1 max_loss 20% provides the catastrophic floor (cuts a failed
+# breakout). Phase 2 mirrors Bison v3.0.1 / Wolverine v6.0.0:
+#   T0 +10% / lock 0     — confirms working, no lock yet
+#   T1 +20% / lock 25%   ... T5 +100% / lock 85%
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/badger/scripts/badger-producer.py
+++ b/badger/scripts/badger-producer.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+# Senpi BADGER Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""BADGER v1.0.0 — OI-Divergence Breakout Anticipator.
+
+Open interest is the fuel of a breakout. A price push beyond its recent
+range that is confirmed by RISING open interest means new money is
+committing — the breakout has conviction and follow-through. A breakout
+on flat/declining OI is usually a fakeout (no new money, just stops).
+
+LONG when: price breaks the prior 24h high AND OI is rising AND Smart
+Money is net long. SHORT when: price breaks the prior 24h low AND OI is
+rising AND Smart Money is net short. Universe: BTC/ETH/SOL/HYPE.
+
+The OI-rising gate is what distinguishes Badger from a pure price-breakout
+agent (Hawk): Badger only takes the breakout the order flow confirms.
+
+DSL: wide "let winners run" Phase 2 ladder (T0 +10% / lock 0 → T5 +100% /
+lock 85). A confirmed breakout can run far; Phase 1 max_loss 20% cuts a
+failed one. Time-cuts disabled. Producer NEVER closes — DSL owns exits.
+
+OI velocity: uses market_get_asset_data's oi_velocity object when present;
+when it is null, Badger falls back to a self-computed delta from a
+persisted last-OI cache (warms up after one tick per asset).
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import badger_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "badger_signals"
+SIGNAL_TYPE = "BADGER_OI_BREAKOUT"
+
+DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL", "HYPE"]
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 5
+DEFAULT_MIN_SCORE = 5
+
+DEFAULT_BREAKOUT_LOOKBACK = 24       # 1h bars (prior 24h) for the range edge
+DEFAULT_OI_RISING_MIN_PCT = 2.0     # OI must rise at least this % to confirm
+DEFAULT_OI_STRONG_PCT = 5.0         # strongly-building bonus
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("BADGER_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical helpers
+# ═══════════════════════════════════════════════════════════════
+
+def trend_structure(candles, lookback=6):
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_f(c, "low", "l") for c in candles[-lookback:]]
+    highs = [_f(c, "high", "h") for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def breakout_signal(candles_1h, lookback):
+    """Returns (direction, magnitude_pct) where direction is 'UP' (close
+    above prior `lookback`-bar high), 'DOWN' (below prior low), or None."""
+    if len(candles_1h) < lookback + 1:
+        return None, 0.0
+    closes = [_f(c, "close", "c") for c in candles_1h[-(lookback + 1):]]
+    latest = closes[-1]
+    prior = closes[:-1]
+    if not prior or latest <= 0:
+        return None, 0.0
+    hi, lo = max(prior), min(prior)
+    if hi > 0 and latest > hi:
+        return "UP", ((latest - hi) / hi) * 100
+    if lo > 0 and latest < lo:
+        return "DOWN", ((lo - latest) / lo) * 100
+    return None, 0.0
+
+
+def oi_velocity_1h(asset_data, coin):
+    """Return (oi_change_pct_1h, source). Prefers the runtime oi_velocity
+    object; falls back to a self-computed delta from the persisted last-OI
+    cache. Returns (None, 'unavailable') when neither is usable yet."""
+    data = asset_data.get("data", {})
+    ctx = data.get("asset_context", {}) or {}
+    cur_oi = _f(ctx, "openInterest")
+    oiv = data.get("oi_velocity")
+    if isinstance(oiv, dict):
+        ch = oiv.get("oi_change_pct")
+        if isinstance(ch, dict) and ch.get("1h") is not None:
+            try:
+                return float(ch["1h"]), "oi_velocity"
+            except (TypeError, ValueError):
+                pass
+    if cur_oi > 0:
+        prev = cfg.read_oi_state().get(coin.upper())
+        if prev and float(prev.get("oi", 0)) > 0:
+            pct = ((cur_oi - float(prev["oi"])) / float(prev["oi"])) * 100
+            return pct, "computed"
+    return None, "unavailable"
+
+
+def volume_trend(candles, lookback=6):
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, entry_cfg):
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    candles_4h = data.get("data", {}).get("candles", {}).get("4h", [])
+    lookback = int(entry_cfg.get("breakoutLookbackHours", DEFAULT_BREAKOUT_LOOKBACK))
+    if len(candles_1h) < lookback + 1 or len(candles_4h) < 6:
+        # still refresh the OI cache so next tick has a baseline
+        oi_now = _f(data.get("data", {}).get("asset_context", {}) or {}, "openInterest")
+        if oi_now > 0:
+            cfg.record_oi(asset, oi_now)
+        return None
+
+    # Always refresh the OI baseline for this asset (warms the fallback cache).
+    oi_now = _f(data.get("data", {}).get("asset_context", {}) or {}, "openInterest")
+
+    # GATE 1 — price breakout
+    bo_dir, bo_mag = breakout_signal(candles_1h, lookback)
+    if bo_dir is None:
+        if oi_now > 0:
+            cfg.record_oi(asset, oi_now)
+        return None
+    direction = "LONG" if bo_dir == "UP" else "SHORT"
+
+    # GATE 2 — OI rising (the conviction gate, Badger's core edge)
+    oi_pct, oi_src = oi_velocity_1h(data, asset)
+    if oi_now > 0:
+        cfg.record_oi(asset, oi_now)
+    oi_min = float(entry_cfg.get("oiRisingMinPct", DEFAULT_OI_RISING_MIN_PCT))
+    if oi_pct is None:
+        return None  # OI unknown (cache warming) — no conviction read, skip
+    if oi_pct < oi_min:
+        return None  # breakout without rising OI = likely fakeout
+
+    # GATE 3 — Smart-Money agreement
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(entry_cfg.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(entry_cfg.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    trend_4h, str_4h = trend_structure(candles_4h)
+    oi_strong = float(entry_cfg.get("oiStrongPct", DEFAULT_OI_STRONG_PCT))
+
+    score = 0
+    reasons = []
+
+    # Breakout magnitude
+    if bo_mag >= 1.0:
+        score += 3
+    elif bo_mag >= 0.3:
+        score += 2
+    else:
+        score += 1
+    reasons.append(f"breakout_{bo_dir.lower()}_{bo_mag:+.2f}%")
+
+    # OI rising (gate-confirmed) + strongly-building bonus
+    score += 2
+    reasons.append(f"oi_rising_{oi_pct:+.1f}%_{oi_src}")
+    if oi_pct >= oi_strong:
+        score += 1
+        reasons.append("oi_strongly_building")
+
+    # SM aligned (gate-confirmed) + strong bonus
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    # 4h structure confirms breakout direction
+    if (direction == "LONG" and trend_4h == "BULLISH") or (direction == "SHORT" and trend_4h == "BEARISH"):
+        score += 1
+        reasons.append(f"4h_confirms_{trend_4h.lower()}")
+
+    # Volume rising bonus
+    vol_pct = volume_trend(candles_1h)
+    if vol_pct > 10:
+        score += 1
+        reasons.append(f"vol_rising_{vol_pct:+.0f}%")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "breakout_dir": bo_dir,
+        "breakout_mag_pct": round(bo_mag, 3),
+        "oi_change_pct": round(oi_pct, 3),
+        "oi_source": oi_src,
+        "trend_4h": trend_4h,
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": sm_tilt,
+        "volume_trend_pct": round(vol_pct, 2),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    # Coalesce numeric fields — runtime schema rejects null for `number`.
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "breakoutDir": thesis["breakout_dir"],
+        "breakoutMagPct": thesis.get("breakout_mag_pct") or 0.0,
+        "oiChangePct": thesis.get("oi_change_pct") or 0.0,
+        "oiSource": thesis.get("oi_source") or "unavailable",
+        "trend4h": thesis["trend_4h"],
+        "smDirection": thesis["sm_direction"],
+        "smTiltPct": thesis.get("sm_tilt_pct") or 0.0,
+        "volumeTrendPct": thesis.get("volume_trend_pct") or 0.0,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 10.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — multi-asset whitelist scan. Daemon owns the per-tick lock.
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    universe = [a.upper() for a in config.get("universe", DEFAULT_UNIVERSE)]
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_badger_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_badger_producer_version": VERSION})
+        return
+
+    candidates = []
+    for asset in universe:
+        if asset in held_set:
+            continue
+        if cfg.was_recently_signaled(asset):
+            continue
+        thesis = build_thesis(asset, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no OI-confirmed breakout with SM agreement on universe",
+            "universe": universe,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_badger_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.20))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_badger_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"badger-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/badger/scripts/badger_config.py
+++ b/badger/scripts/badger_config.py
@@ -1,6 +1,6 @@
 """BADGER v1.0.0 — Shared config + MCP shim + helpers wrapper.
 
-Advanced-tier OI-Divergence Breakout Anticipator. Multi-asset whitelist
+OI-Divergence Breakout Anticipator. Multi-asset whitelist
 (BTC/ETH/SOL/HYPE). Open interest is the fuel of a breakout: a price
 push confirmed by RISING open interest = new money committing = real
 follow-through. A breakout on flat/declining OI is a fakeout. Badger

--- a/badger/scripts/badger_config.py
+++ b/badger/scripts/badger_config.py
@@ -1,0 +1,251 @@
+"""BADGER v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Advanced-tier OI-Divergence Breakout Anticipator. Multi-asset whitelist
+(BTC/ETH/SOL/HYPE). Open interest is the fuel of a breakout: a price
+push confirmed by RISING open interest = new money committing = real
+follow-through. A breakout on flat/declining OI is a fakeout. Badger
+takes the OI-confirmed breakout, long or short, with Smart-Money
+agreement, and hands it to a wide DSL ladder so a real breakout can run.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder. Mirrors the Wolverine v6.0.0 / Bison v3.0.1
+pattern (race-window dedup, atomic write, simplified producer_daemon).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "badger-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "badger-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+OI_STATE_PATH = STATE_DIR / "oi-state.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Badger ticks every 300s; ALO fills typically
+# settle within 30-60s. 240s covers the full fill window plus next-tick
+# clearinghouseState refresh, so the on-chain held-asset check picks up
+# where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Badger's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("badger_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] badger_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+# ─── OI state cache (for self-computed OI velocity) ──────────
+#
+# market_get_asset_data exposes oi_velocity, but it can be null. When
+# it is, Badger falls back to a self-computed OI delta: it persists the
+# last-seen openInterest per asset and compares on the next tick. Stores
+# {coin: {"oi": float, "ts": epoch}}.
+
+def read_oi_state():
+    if not OI_STATE_PATH.exists():
+        return {}
+    try:
+        with open(OI_STATE_PATH) as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def record_oi(coin, oi):
+    if not coin or oi is None:
+        return
+    state = read_oi_state()
+    state[coin.upper()] = {"oi": float(oi), "ts": time.time()}
+    try:
+        atomic_write(OI_STATE_PATH, state)
+    except OSError:
+        pass
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[badger-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/egret/README.md
+++ b/egret/README.md
@@ -1,0 +1,133 @@
+# 🐦 Egret — Smart-Money Divergence Fader
+
+Multi-asset (BTC/ETH/SOL/HYPE). When the Smart-Money crowd is extremely concentrated one way but price won't confirm it, the crowded side is exhausted — Egret fades the unwind. Tight DSL, maker-only entry (the mean-reversion profile, opposite the fleet's momentum agents).
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+SM concentration is usually a *with-the-trend* confirmation. At an extreme (70–85% of top traders on one side) it flips contrarian — **if price refuses to follow.** A maximally-long crowd while price stalls has no one left to buy; the unwind is the edge. Egret fades extreme crowding that price is diverging from, with RSI exhaustion as confirmation, and banks the bounded snapback with a tight DSL.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Universe | BTC, ETH, SOL, HYPE |
+| Tick interval | 300s (5 min) |
+| MIN_SCORE (producer) | 5 (out of ~9 max) |
+| LLM min_confidence | 7 |
+| Leverage | 4x default, max 5x |
+| Margin per trade | 15% of equity |
+| SM crowding floor | 70% |
+| SM ultra-crowded | 80% |
+| Divergence lookback | 4h |
+| Max entries per day | 3 |
+| Per-asset cooldown | 360 min (6h) |
+| Daily loss limit | 12% |
+| Drawdown halt | 18% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **false** — fader, maker-only) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (tight — bank the snapback)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 15% |
+| Phase 1 | retrace_threshold | 6 |
+| Time cuts | hard_timeout | **48h (enabled)** |
+| Time cuts | weak_peak_cut | **120min / 2% (enabled)** |
+| Phase 2 | T0 | +5% / 30% lock |
+| Phase 2 | T1 | +10% / 50% lock |
+| Phase 2 | T2 | +15% / 65% lock |
+| Phase 2 | T3 | +25% / 80% lock |
+| Phase 2 | T4 | +40% / 90% lock |
+
+This is the **inverse** of the momentum agents' wide ladder — a fade is a bounded unwind, not a trend, so it banks fast.
+
+## Scanner pattern
+
+**Contrarian fader** archetype (same family as Owl / Bald-eagle / Pangolin) with an SM-vs-price divergence trigger — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `leaderboard_get_markets` (SM concentration), `market_get_asset_data` (price momentum + RSI).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, tight DSL preset, `risk.guard_rails`) |
+| scripts/egret-producer.py | Long-lived daemon; emits EGRET_SM_FADE signals |
+| scripts/egret_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/egret-config.json | Operator-tunable defaults (wallet, universe, crowding/RSI thresholds, sizing) |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Egret
+
+```bash
+mkdir -p /data/workspace/skills/egret-strategy/{config,scripts,state,references}
+for f in scripts/egret-producer.py scripts/egret_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/egret-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/egret/$f" \
+    -o "/data/workspace/skills/egret-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/egret-strategy/config/egret-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export EGRET_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                         # required
+export EGRET_DECISION_MODEL=<your-preferred-model>  # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/egret-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/egret-strategy/scripts/egret-producer.py \
+  > /tmp/egret-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 320  # wait one full tick
+tail -3 /tmp/egret-producer.log | jq '._egret_producer_version, .note // null, .best.score // null'
+# Expected: _egret_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no exhausted-crowd divergence on universe"` — common (extreme crowding + divergence is rare by design)
+- `"signals_pushed": 1, "best": { "coin": ..., "direction": "LONG"|"SHORT", "score": 5-9 }` — fade fired
+
+## Changelog
+
+### v1.0.0 (2026-05-21) — initial release
+
+Adds an SM-divergence trigger to the contrarian-fader archetype. Tight ladder + maker-only entry + enabled time-cuts (the fader profile), the deliberate inverse of the momentum agents' wide ladder + taker-fallback.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/egret/SKILL.md
+++ b/egret/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: egret-strategy
+description: >-
+  EGRET v1.0.0 — Smart-Money Divergence Fader. When the Smart-Money crowd
+  is extremely concentrated one way (>= 70%) but price is NOT confirming
+  (stalled or rolled over against the crowd), the crowded side is
+  exhausted — Egret fades it. FADE SHORT into crowded longs price won't
+  carry; FADE LONG into crowded shorts. RSI exhaustion confirms. Universe:
+  BTC, ETH, SOL, HYPE. Mean-reversion class — TIGHT DSL (T0 +5% / lock 30,
+  bank the snapback), MAKER-ONLY entry, time-cuts ENABLED.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐦 EGRET v1.0.0 — Smart-Money Divergence Fader
+
+**When the crowd is all-in and price won't follow, fade the crowd.** Egret looks for extreme Smart-Money concentration that price is *not* confirming — the setup that precedes a crowded-side unwind — and takes the other side.
+
+## Why this strategy exists
+
+Smart-Money concentration is usually a *confirmation* signal (the fleet's momentum agents trade *with* it). But at an **extreme** — when 70–85% of top traders are piled onto one side — it flips into a *contrarian* signal, **if price refuses to follow.** A crowd that's maximally long while price stalls or rolls over has no one left to buy; the unwind is the edge.
+
+Egret is the mirror image of the fleet's momentum agents:
+- They trade **with** SM when price confirms.
+- Egret trades **against** SM when price **diverges** from an extreme crowd.
+
+## CRITICAL RULES
+
+### RULE 1: Crowding extreme AND price divergence — both required
+SM concentration must be >= `crowdingMinPct` (default 70%) **and** price must be failing to confirm the crowd over the lookback window (crowded long but price not rising, or crowded short but price not falling). Extreme crowding *with* a confirming price is a working trend — Egret does NOT fade that.
+
+### RULE 2: This is a fader — tuned opposite the momentum agents
+Egret is mean-reversion, so its risk profile is the inverse of Badger/Hawk/Bison (the 2026-05-21 per-strategy-class rule):
+- **TIGHT Phase 2 ladder** (T0 +5% / lock 30) — a fade is a *bounded* snapback; bank it fast. Holding a fade for a +50% trend would violate the thesis.
+- **MAKER-ONLY entry** (`ensure_execution_as_taker: false`) — a fade is non-urgent and fee-sensitive; if the maker can't fill, the trade wasn't ripe.
+- **Time-cuts ENABLED** — a fade resolves quickly or the thesis failed.
+
+### RULE 3: Producer enters. DSL exits.
+No `close_position` call site. DSL Phase 1 + tight Phase 2 + hard_timeout 48h + weak_peak_cut own all exits.
+
+## How Egret scores a trade
+
+**Gates** (all required):
+1. SM concentration >= `crowdingMinPct` (default 70%)
+2. Price diverging from the crowd over the lookback (not confirming)
+
+**Score components** (max ~9):
+
+| Signal | Points |
+|---|---|
+| SM crowded (gate-confirmed) | +2 |
+| SM ultra-crowded (≥ `crowdingExtremePct`, default 80%) | +1 |
+| Price clearly diverging (≥ 0.5% against the crowd) | +3 |
+| Price merely stalled | +2 |
+| RSI exhausted (≥ 68 for fade-short / ≤ 32 for fade-long) | +2 |
+| RSI stretched (≥ 60 / ≤ 40) | +1 |
+
+**Floor:** `minScore: 5`.
+
+## DSL preset (tight — bank the snapback)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 15% |
+| Phase 1 | retrace_threshold | 6 |
+| Time cuts | hard_timeout | **48h (ENABLED)** |
+| Time cuts | weak_peak_cut | **120min / 2% (ENABLED)** |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 | +5% / lock 30% |
+| Phase 2 | T1 | +10% / lock 50% |
+| Phase 2 | T2 | +15% / lock 65% |
+| Phase 2 | T3 | +25% / lock 80% |
+| Phase 2 | T4 | +40% / lock 90% |
+
+## Scanner pattern
+
+This strategy uses the **Contrarian fader** archetype (same family as Owl / Bald-eagle / Pangolin) with an SM-vs-price divergence trigger — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `leaderboard_get_markets` (SM concentration), `market_get_asset_data` (price momentum + RSI).
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-21) — initial release
+
+Adds an SM-divergence trigger to the contrarian-fader archetype. Built with the per-strategy-class DSL rule: tight ladder + maker-only entry + enabled time-cuts (the fader profile), the deliberate inverse of the momentum agents' wide ladder + taker-fallback.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/egret/config/egret-config.json
+++ b/egret/config/egret-config.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "EGRET v1.0.0 — Smart-Money Divergence Fader (BTC/ETH/SOL/HYPE). When SM concentration is extreme (>= crowdingMinPct) on one side but price is NOT confirming over the recent window (divergence), fade the exhausted crowd: crowded LONG + price stalled → SHORT; crowded SHORT + price stalled → LONG. RSI exhaustion adds conviction. TIGHT DSL (bank the bounded snapback) + MAKER-ONLY entry (fades are non-urgent, fee-sensitive). Edit wallet/strategyId/chatId.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "universe": ["BTC", "ETH", "SOL", "HYPE"],
+  "minScore": 5,
+  "crowdingMinPct": 70,
+  "crowdingExtremePct": 80,
+  "confirmMaxPct": 0.5,
+  "divergenceLookbackHours": 4,
+  "marginPct": 0.15,
+  "leverage": 4
+}

--- a/egret/references/skill-attribution.md
+++ b/egret/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "egret",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "egret",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/egret/runtime.yaml
+++ b/egret/runtime.yaml
@@ -1,0 +1,188 @@
+name: egret-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Egret v1.0.0"
+# and lives in description + SKILL.md + _egret_producer_version.
+version: 1.0.0
+description: >
+  EGRET v1.0.0 — Smart-Money Divergence Fader.
+
+  When the Smart-Money crowd is extremely concentrated one way but price
+  is NOT confirming (it has stalled or rolled over against the crowd),
+  the crowded side is exhausted and the unwind is the edge. Egret fades
+  it across BTC/ETH/SOL/HYPE — FADE SHORT into crowded longs that price
+  won't carry, FADE LONG into crowded shorts.
+
+  This is a mean-reversion / unwind play, so it is tuned OPPOSITE to the
+  fleet's momentum agents (the 2026-05-21 per-strategy-class rule):
+    - DSL is TIGHT (T0 +5% / lock 30) — bank the bounded snapback fast.
+      A fader holding for a +50% trend would violate its own thesis.
+    - Entry is MAKER-ONLY (ensure_execution_as_taker: false) — a fade is
+      non-urgent and fee-sensitive; if the maker can't fill, it wasn't
+      ripe. Same class as the live faders Owl / Pangolin / Bald-eagle.
+    - Time-cuts ENABLED — a fade resolves quickly or the thesis failed.
+
+  Architecture (helpers-native): producer ticks every 300s, scores an
+  exhausted-crowd thesis (max ~9), emits EGRET_SM_FADE via
+  SenpiClient.push_signal() when score >= 5. LLM gate is pass-through.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 200
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 90
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 360       # 6h between fade attempts on the same asset
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: egret_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        smCrowdDirection: { type: string, required: false }
+        smCrowdPct: { type: number, required: false }
+        priceMomentumPct: { type: number, required: false }
+        rsi: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: egret_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${EGRET_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [egret_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # FADER: maker-only is correct here. A fade is non-urgent and fee-sensitive — if the maker can't fill, the trade wasn't ripe. (The taker-fallback rule is for MOMENTUM agents that must catch a move; a fader is the opposite.)
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: egret_signals
+    decision_prompt: |
+      You are Egret's pass-through gate. Egret FADES an exhausted crowd:
+      the producer found extreme Smart-Money concentration (>= 70%) on one
+      side that price is NOT confirming, plus RSI exhaustion. The emitted
+      direction is the FADE (opposite the crowd). The producer applied
+      every filter (crowding, divergence, RSI, minScore 5). Honor the
+      signal and convert it into an OPEN_POSITION.
+
+      SIGNAL:
+      {{signal_egret_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (preserve case).
+      2. direction MUST be copied from signal.direction (the FADE direction —
+         it is intentionally OPPOSITE signal.data.smCrowdDirection).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND smCrowdPct >= 80 AND RSI clearly exhausted
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 8 ETH SHORT (fade), SM crowded LONG 82%, price diverging -0.8%, RSI 71 — exhausted crowd unwind')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY (the fade)",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "EGRET_SM_FADE ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — TIGHT fader profile) ──────────────────────────
+#
+# A fade is a BOUNDED unwind — bank the snapback fast, don't hold for a
+# trend. Tight Phase 2 ladder + ENABLED time-cuts (a fade resolves
+# quickly or the thesis failed). This is intentionally the OPPOSITE of
+# the momentum agents' wide "let winners run" ladder.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true                 # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true                                 # ENABLED — a fade resolves quickly or the thesis failed
+      interval_in_minutes: 2880                      # 48h outer bound
+    weak_peak_cut:
+      enabled: true                                 # ENABLED — cut a stale fade
+      interval_in_minutes: 120
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 90
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,   lock_hw_pct: 30 }     # bank the snapback fast
+        - { trigger_pct: 10,  lock_hw_pct: 50 }
+        - { trigger_pct: 15,  lock_hw_pct: 65 }
+        - { trigger_pct: 25,  lock_hw_pct: 80 }
+        - { trigger_pct: 40,  lock_hw_pct: 90 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/egret/scripts/egret-producer.py
+++ b/egret/scripts/egret-producer.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+# Senpi EGRET Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""EGRET v1.0.0 — Smart-Money Divergence Fader.
+
+When the Smart-Money crowd is extremely concentrated one direction but
+price is NOT confirming — it has stalled or rolled over against the
+crowd — the crowded side is exhausted and the unwind is the edge. Egret
+fades it.
+
+FADE SHORT when: SM is >= crowdingMinPct LONG (crowded longs) AND price
+has stalled/fallen over the recent window (divergence) AND RSI is
+stretched (overbought). FADE LONG on the mirror. Universe: BTC/ETH/SOL/HYPE.
+
+This is a mean-reversion / unwind play — the move is BOUNDED (the crowd
+covers, price snaps back, done). So:
+  - DSL is TIGHT (T0 +5% / lock 30 — bank the snapback fast; a fader
+    holding for a +50% trend would be violating its own thesis).
+  - Entry is MAKER-ONLY (ensure_execution_as_taker: false) — a fade is
+    non-urgent and fee-sensitive; if the maker doesn't fill, the trade
+    wasn't ripe. Same class as the live faders Owl / Pangolin / Bald-eagle.
+
+Producer NEVER closes — DSL owns exits.
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import egret_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "egret_signals"
+SIGNAL_TYPE = "EGRET_SM_FADE"
+
+DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL", "HYPE"]
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 5
+
+DEFAULT_CROWDING_MIN_PCT = 70.0     # SM concentration must be at least this to be "crowded"
+DEFAULT_CROWDING_EXTREME_PCT = 80.0
+DEFAULT_CONFIRM_MAX_PCT = 0.5       # if price moved less than this WITH the crowd over the window, it's diverging
+DEFAULT_DIVERGENCE_LOOKBACK = 4     # 1h bars for the price-confirmation window
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("EGRET_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical helpers
+# ═══════════════════════════════════════════════════════════════
+
+def price_momentum(candles, n_bars):
+    if len(candles) < n_bars + 1:
+        return 0.0
+    old = _f(candles[-(n_bars + 1)], "close", "c")
+    new = _f(candles[-1], "close", "c")
+    if old <= 0:
+        return 0.0
+    return ((new - old) / old) * 100
+
+
+def calc_rsi(closes, period=14):
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0.0, d))
+        losses.append(max(0.0, -d))
+    avg_g = sum(gains[-period:]) / period
+    avg_l = sum(losses[-period:]) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    """Return (direction, concentration_pct). direction = the crowded side;
+    concentration_pct = how concentrated (e.g. 78 = 78% of top traders are
+    on that side)."""
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — fade the exhausted crowd
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, entry_cfg):
+    # GATE 1 — extreme SM crowding
+    sm_dir, sm_pct = fetch_sm_direction(asset)
+    if sm_dir not in ("LONG", "SHORT"):
+        return None
+    crowd_min = float(entry_cfg.get("crowdingMinPct", DEFAULT_CROWDING_MIN_PCT))
+    crowd_extreme = float(entry_cfg.get("crowdingExtremePct", DEFAULT_CROWDING_EXTREME_PCT))
+    if sm_pct < crowd_min:
+        return None
+
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_1h = data.get("data", {}).get("candles", {}).get("1h", [])
+    if len(candles_1h) < 16:
+        return None
+    closes = [_f(c, "close", "c") for c in candles_1h]
+
+    lookback = int(entry_cfg.get("divergenceLookbackHours", DEFAULT_DIVERGENCE_LOOKBACK))
+    confirm_max = float(entry_cfg.get("confirmMaxPct", DEFAULT_CONFIRM_MAX_PCT))
+    mom = price_momentum(candles_1h, lookback)
+    rsi = calc_rsi(closes)
+
+    # GATE 2 — price NOT confirming the crowd (divergence)
+    # Crowded LONG but price hasn't risen (mom <= confirm_max) → exhaustion → FADE SHORT.
+    # Crowded SHORT but price hasn't fallen (mom >= -confirm_max) → FADE LONG.
+    if sm_dir == "LONG":
+        if mom > confirm_max:
+            return None  # crowd long AND price rising — no divergence, don't fade a working trend
+        fade_direction = "SHORT"
+    else:  # SHORT
+        if mom < -confirm_max:
+            return None
+        fade_direction = "LONG"
+
+    score = 0
+    reasons = []
+
+    # SM crowding (gate-confirmed) + ultra-crowded bonus
+    score += 2
+    reasons.append(f"sm_crowded_{sm_dir.lower()}_{sm_pct:.0f}%")
+    if sm_pct >= crowd_extreme:
+        score += 1
+        reasons.append("sm_ultra_crowded")
+
+    # Divergence magnitude — the further price is from confirming, the stronger
+    if (sm_dir == "LONG" and mom <= -0.5) or (sm_dir == "SHORT" and mom >= 0.5):
+        score += 3
+        reasons.append(f"price_diverging_{mom:+.2f}%")
+    else:
+        score += 2
+        reasons.append(f"price_stalled_{mom:+.2f}%")
+
+    # RSI exhaustion confirms the fade
+    if fade_direction == "SHORT" and rsi >= 68:
+        score += 2
+        reasons.append(f"rsi_overbought_{rsi:.0f}")
+    elif fade_direction == "LONG" and rsi <= 32:
+        score += 2
+        reasons.append(f"rsi_oversold_{rsi:.0f}")
+    elif (fade_direction == "SHORT" and rsi >= 60) or (fade_direction == "LONG" and rsi <= 40):
+        score += 1
+        reasons.append(f"rsi_stretched_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": fade_direction,
+        "score": score,
+        "reasons": reasons,
+        "sm_crowd_direction": sm_dir,
+        "sm_crowd_pct": sm_pct,
+        "price_momentum_pct": round(mom, 3),
+        "rsi": round(rsi, 1),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "smCrowdDirection": thesis["sm_crowd_direction"],
+        "smCrowdPct": thesis.get("sm_crowd_pct") or 0.0,
+        "priceMomentumPct": thesis.get("price_momentum_pct") or 0.0,
+        "rsi": thesis.get("rsi") or 0.0,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — multi-asset whitelist scan
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    universe = [a.upper() for a in config.get("universe", DEFAULT_UNIVERSE)]
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_egret_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_egret_producer_version": VERSION})
+        return
+
+    candidates = []
+    for asset in universe:
+        if asset in held_set:
+            continue
+        if cfg.was_recently_signaled(asset):
+            continue
+        thesis = build_thesis(asset, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no exhausted-crowd divergence on universe",
+            "universe": universe,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_egret_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_egret_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"egret-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/egret/scripts/egret_config.py
+++ b/egret/scripts/egret_config.py
@@ -1,0 +1,222 @@
+"""EGRET v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Smart-Money Divergence Fader. Multi-asset (BTC/ETH/SOL/HYPE). When the
+Smart-Money crowd is extremely concentrated one way but price is NOT
+confirming (it has stalled or rolled over against the crowd), the
+crowded side is exhausted — Egret fades it. A mean-reversion / unwind
+strategy, so the DSL is TIGHT (bank the bounded snapback) and the entry
+is maker-only (a fade is non-urgent and fee-sensitive — same class as
+the live faders Owl / Pangolin / Bald-eagle).
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ tight DSL ladder. Mirrors the race-window dedup / atomic-write /
+simplified producer_daemon pattern shared across the fleet.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "egret-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "egret-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Egret ticks every 300s; HYPE ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Egret's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("egret_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] egret_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[egret-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
First two of the new-strategy set, validated and slotted into existing archetypes (no "advanced" label).

- **Badger** — OI-Divergence Breakout Anticipator. Multi-signal whitelist (Hawk family + an open-interest gate): takes a breakout only when rising OI confirms it. Momentum → wide "let winners run" DSL.
- **Egret** — Smart-Money Divergence Fader. Fades extreme SM crowding (≥70%) that price won't confirm. Contrarian-fader family → tight DSL + maker-only entry + time-cuts on.

Both built with all HYPE-postmortem guidelines baked in (per-class DSL, taker-by-class, exit timeout 30, coalesced numeric fields, simplified daemon signature, disown launch). Validated: YAML/JSON parse, producers compile, data_block↔scanner field parity.

**Note:** these are 2 of a planned 10. The remaining 8 (Piranha, Marlin, Chameleon, Cuckoo, Falcon, Osprey, Remora, Meerkat) are still to be built. Producer-patterns roster + the onboarding decision tree are being updated in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)