### PR TITLE
docs: top-of-README banner → strategy-creation.md (catch agents at repo root)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Senpi Skills — Open-Source AI Trading Skills for Hyperliquid
 
+> ## 🛠 Building a strategy? Read one doc: [`senpi-trading-runtime/references/strategy-creation.md`](senpi-trading-runtime/references/strategy-creation.md)
+> It's self-contained — the full path, an inline producer skeleton, a complete `runtime.yaml`, DSL presets, an archetype→example map, and the gotchas, in a single fetch. **Start there; you should not need to browse the repo or fetch other files to build a working strategy.**
+
 Every file in this repo is a self-contained, plug-and-play **skill** for an autonomous AI trading agent that operates on [Hyperliquid](https://hyperliquid.xyz) via the [Senpi](https://senpi.ai) platform.
 
 The repo is two things stacked on top of each other:


### PR DESCRIPTION
**For team review.** The PR-able half of the entry-point fix from Ignas's dogfood.

## Why
Ignas's agent path: `read_senpi_guide(senpi-overview)` → repo **root README** → browse/grep to find an example. That browse-and-grep was a big chunk of the ~6-min authoring time.

The `senpi-overview` guide is backend-served (can't fix routing here), **but the agent's next step — the root README — IS in this repo.** This puts a loud banner at the very top (placed to survive WebFetch summarization) routing strategy-builders straight to the self-contained `strategy-creation.md` (#306), short-circuiting the browse-and-grep.

## Pairs with
- **#306** — the `strategy-creation.md` doc this points to.
- The remaining backend piece (`senpi-overview` routing + its stale per-8h funding text) is a separate ask to the MCP-guide owner — **de-risked** because `strategy-creation.md` already carries the correct "HL funding is per-hour" gotcha, so a builder who lands on it is right regardless.

## Test plan
- [ ] Banner renders at the top of the README and links correctly
- [ ] Re-run Ignas's dogfood; confirm the agent reaches strategy-creation.md without the grep fallback
- [ ] No code touched