### PR TITLE
fix: annualize HL funding ×8760 (hourly), recalibrate Pangolin floor

### DIFF
--- a/jackal/README.md
+++ b/jackal/README.md
@@ -136,6 +136,7 @@ Expected: `status=ok` every tick (60 s interval).
 
 ## Changelog
 
+- **v3.0.1** — Funding annualization fix. HL funding is hourly, so `funding_annualized_pct` (enrichment context fed to the LLM gate) must use `× 24 × 365 (×8760)`, not `× 3 × 365`. The prior value was 8x too low. Display/context-only — Jackal has no hard funding gate, so entry behavior is unchanged.
 - **v3.0.0** — Plumbing-only migration from v2.0 (NO thesis change). Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry. v2.0.9 contamination rule applied: `JACKAL_WALLET` replaces generic `STRATEGY_ADDRESS`.
 - **v2.0** — Original SECONDARY-SIGNAL architecture (top-trader pool diff + LLM gate).
 

--- a/jackal/SKILL.md
+++ b/jackal/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0.0"
+  version: "3.0.1"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -242,6 +242,9 @@ context is too strict.
 ---
 
 ## Changelog
+
+### v3.0.1 (2026-05-22) — funding annualization fix
+- `funding_annualized_pct` now uses `× 24 × 365 (×8760)` — HL funding is hourly, so the prior `× 3 × 365` was 8x too low. This value is enrichment context for the LLM gate only (no hard funding threshold), so entry behavior is unchanged.
 
 ### v3.0.0 (2026-05-08) — senpi_runtime_helpers migration (plumbing-only)
 - Producer rewritten on `senpi_runtime_helpers.SenpiClient` — direct HTTPS

--- a/jackal/scripts/jackal-producer.py
+++ b/jackal/scripts/jackal-producer.py
@@ -56,7 +56,7 @@ from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ign
 # scanner_lock with stale-PID auto-recovery.
 
 
-VERSION = "3.0.0"
+VERSION = "3.0.1"
 
 # Hardcoded — must match runtime.yaml external_scanner.name.
 SCANNER_NAME = "jackal_signals"
@@ -416,7 +416,7 @@ def enrich_with_ta(candidate, funding_regime):
                 if funding is not None:
                     try:
                         f = float(funding)
-                        out["funding_annualized_pct"] = round(f * 3 * 365 * 100, 2)
+                        out["funding_annualized_pct"] = round(f * 8760 * 100, 2)  # HL funding is HOURLY → ×24×365
                     except (TypeError, ValueError):
                         pass
     except Exception:

--- a/pangolin/README.md
+++ b/pangolin/README.md
@@ -123,6 +123,12 @@ Expected: `status=ok` every tick (300s interval — Pangolin's longer cadence re
 
 ## Changelog
 
+### v3.0.1 — funding annualization fix
+
+**Bug fix + threshold recalibration.** Hyperliquid funding is charged **hourly**, so annualized funding is `rate × 24 × 365 (×8760)`, not `× 3 × 365`. Two corrections:
+- **Display math:** the `annualized` figure shown in signal reasons + `data.annualizedPct` was 8x too low. Fixed to `×8760`.
+- **Entry threshold:** `MIN_FUNDING_RATE` was `0.00015`, set under an 8h-cadence assumption to mean "~20% annualized." Under HL's true hourly cadence that floor is actually **~131% annualized** — ~8x stricter than intended. Recalibrated to `0.0000228` (the real ~20% floor), restoring design intent. **This widens entry frequency ~8x — review accordingly.**
+
 ### v3.0.0 — senpi_runtime_helpers migration
 
 **Plumbing-only migration from v2.2.0. NO thesis change.** Pangolin is the canonical reference producer for the `senpi_runtime_helpers` SDK wrapper pattern.

--- a/pangolin/SKILL.md
+++ b/pangolin/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0.0"
+  version: "3.0.1"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/pangolin/references/skill-attribution.md
+++ b/pangolin/references/skill-attribution.md
@@ -4,7 +4,7 @@ When calling `strategy_create` or `strategy_create_custom_strategy`, always incl
 
 ```json
 "skill_name": "pangolin",
-"skill_version": "3.0.0"
+"skill_version": "3.0.1"
 ```
 
 This is required for attribution and tracking. Example:
@@ -16,7 +16,7 @@ This is required for attribution and tracking. Example:
     "initialBudget": 500,
     "positions": [],
     "skill_name": "pangolin",
-    "skill_version": "3.0.0"
+    "skill_version": "3.0.1"
   }
 }
 ```

--- a/pangolin/scripts/pangolin-producer.py
+++ b/pangolin/scripts/pangolin-producer.py
@@ -126,7 +126,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import pangolin_config as cfg
 
 
-VERSION = "3.0.0"  # single source of truth; matches SKILL.md frontmatter
+VERSION = "3.0.1"  # single source of truth; matches SKILL.md frontmatter
 
 # v2.0.0: Agent-specific wallet env var. NO fallback to STRATEGY_ADDRESS
 # (contamination risk per Turbine v2.0.9 fix — see feedback_mcp_auth_is_fleet_wide.md).
@@ -171,7 +171,7 @@ _PREV_HELD_FILE = _STATE_DIR / "previously-held.json"
 # HARDCODED CONSTANTS (fleet-tuned, not operator-set)
 # ═══════════════════════════════════════════════════════════════
 MIN_SCORE = 9                         # v1.4: raised from 7 (new persistence + regime points)
-MIN_FUNDING_RATE = 0.00015            # v1.1: 20% annualized threshold
+MIN_FUNDING_RATE = 0.0000228          # ~20% annualized floor (hourly funding × 8760 × 100). v3.0.1: was 0.00015, which under HL's HOURLY cadence is ~131% ann — ~8x stricter than the intended 20% (the old value assumed an 8h cadence). Recalibrated to design intent.
 MIN_OI_USD = 1_000_000                # v1.3 floor — ensures liquidity
 MIN_PERSISTENCE_HOURS = 3             # v1.4: hard gate against fresh spikes
 ASSET_COOLDOWN_MINUTES = 240          # v1 — 4h. Post-EMIT cooldown.
@@ -544,7 +544,7 @@ def scan_funding_extremes():
 
         # Funding extremity
         abs_funding = abs(funding)
-        annualized = abs_funding * 3 * 365 * 100
+        annualized = abs_funding * 8760 * 100   # HL funding is HOURLY → ×24×365
         if abs_funding >= 0.001:
             score += 4
             reasons.append(f"EXTREME_FUNDING {funding*100:.4f}% ({annualized:.0f}% ann)")


### PR DESCRIPTION
## What

Hyperliquid charges funding **hourly**, so annualized funding = `rate × 24 × 365` (**×8760**) — not `× 3 × 365` (an 8-hour / Binance-style cadence). Two of our producers had the 8h assumption baked in.

**Verified against live data (not assumed):**
- Senpi MCP `asset_context.funding` for BTC = `0.0000125` — **identical** to Hyperliquid's own Info API (`metaAndAssetCtxs`) raw `funding` field.
- `0.0000125/hr` is exactly HL's documented baseline (`0.01% per 8h ÷ 8`).
- `market_get_asset_data` `funding_history` rows are spaced **1 hour** apart.

So the field both producers read (`ctx["funding"]`) is unambiguously a **per-hour** rate.

## Fixes

| Producer | Change | Behavior impact |
|---|---|---|
| **Pangolin** | display `annualized` `×3×365 → ×8760` | Was mislabeling annualized 8x low (LLM reason strings + `data.annualizedPct`) |
| **Pangolin** | `MIN_FUNDING_RATE` `0.00015 → 0.0000228` | **⚠️ real behavior change — review** |
| **Jackal** | `funding_annualized_pct` `×3×365 → ×8760` | Enrichment context only; no hard funding gate → entry behavior unchanged |

✅ **Owl** and **Bald-eagle** already use `×8760` — untouched.

## ⚠️ The one consequential change — Pangolin's entry floor

`MIN_FUNDING_RATE` was `0.00015`, commented "20% annualized threshold." That label only holds under the *wrong* 8h cadence (`0.00015 × 1095 ≈ 16%`). Under HL's real **hourly** cadence, `0.00015/hr ≈ **131% annualized**` — meaning Pangolin has been entering only on funding ~8x more extreme than designed.

This PR recalibrates to `0.0000228` = the **intended ~20% annualized** floor (`20 ÷ 8760 ÷ 100`), restoring design intent. **This widens Pangolin's candidate set ~8x.** Scoring + persistence + regime + per-asset cooldown gates still apply downstream, so it won't trade everything — but reviewers should confirm they want the wider floor vs. keeping the stricter (accidental) 131%.

## Versioning
Both bumped 3.0.0 → 3.0.1 (SKILL.md frontmatter + producer `VERSION` + Pangolin `skill-attribution.md`); README/SKILL changelogs synced.

## Related
- Companion to #317, which documents the resolved convention (`×8760`, HL is hourly) in `strategy-creation.md`.
- Separate backend item being sent to Yoseph: `market_get_funding_history`'s tool description labels funding as "8h" and its `min_annualized_pct` filter likely uses the same 8h assumption — needs the same ×8760 correction server-side (couldn't verify live; endpoint was returning 401/unavailable during this work).

## Review asks
1. **Pangolin floor:** OK to widen to the intended ~20% (`0.0000228`), or keep the stricter ~131%?
2. Any other consumers of `data.annualizedPct` / `fundingAnnualizedPct` that assumed the old 8x-low value?