### PR TITLE
docs: strategy-creation.md — Ignas dogfood round 2 (defer roster, inline presets, MCP envelopes, CLOSE/exit clarity)

### DIFF
--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -1,5 +1,7 @@
 # Producer Patterns — Scanner Archetypes Catalog
 
+> **When to read this:** [`strategy-creation.md`](strategy-creation.md) is the build doc — start there. Come here for one thing: to **pick your archetype and the example agent to clone** (this catalog + the decision tree below are the single source of truth for that). Jump to your archetype's section or the [decision tree](#decision-tree--help-a-user-pick-their-first-strategy); you don't need to read cover-to-cover.
+
 The active fleet of trading agents on Senpi implements roughly a dozen distinct producer/scanner archetypes. This doc catalogs them so you can pick a starting pattern when building your own strategy.
 
 Every active fleet agent's producer is built on the `senpi_runtime_helpers` SDK (`SenpiClient`, `producer_daemon`, `push_signal`). What differs between agents is **which MCP tools they call**, **how they score signals**, and **what scoring archetype they implement**. Pick the archetype that matches the kind of market regime you want to hunt, then copy the structure from the named example agent.

--- a/senpi-trading-runtime/references/signal-schema.md
+++ b/senpi-trading-runtime/references/signal-schema.md
@@ -1,5 +1,7 @@
 # Signal schema reference
 
+> **Read only if [`strategy-creation.md`](strategy-creation.md) doesn't cover your edge case.** That doc inlines the `push_signal(...)` contract you need to build. This is the exhaustive wire-format reference — reach for it for the `POST /signals` envelope, per-item error codes, or unusual `data` field types.
+
 Full description of the `SignalItem` shape consumed by
 `senpi-trading-runtime`'s `POST /signals` endpoint, as exposed by
 `SenpiClient.push_signal(...)` and `push_signals([...])`.

--- a/senpi-trading-runtime/references/strategy-creation.md
+++ b/senpi-trading-runtime/references/strategy-creation.md
@@ -60,9 +60,12 @@ mcp = tick_cache(client)                  # per-tick memoization; call MCP tools
 
 def run_one_tick():
     with scanner_lock(LOCK_NAME):
-        # 1. Pull whatever your thesis needs (cached per tick):
-        markets = mcp("leaderboard_get_markets", limit=100)
-        # ch = mcp("strategy_get_clearinghouse_state", strategy_wallet=WALLET)  # current positions
+        # 1. Pull whatever your thesis needs (cached per tick). EVERY MCP tool
+        #    returns the envelope {success, data, meta} — your payload is under
+        #    "data". Always unwrap with .get("data", resp) (see shapes below):
+        resp = mcp("market_list_instruments")
+        instruments = resp.get("data", resp).get("instruments", [])
+        # ch = mcp("strategy_get_clearinghouse_state", strategy_wallet=WALLET).get("data", {})
         # 2. Score / gate per your thesis. 3. Emit ONLY when a signal qualifies:
         if signal_ready:
             client.push_signal(
@@ -84,6 +87,35 @@ if __name__ == "__main__":
 ```
 
 The config/wrapper module (`scripts/<skill>_config.py`) just exposes the `SenpiClient`; copy it from the example agent — it's boilerplate.
+
+### MCP response envelopes (so you don't guess the shape)
+
+Every Senpi MCP tool returns the same outer envelope — `{ "success": bool, "data": {...}, "meta": {...} }`. **Always read your payload from `data`** (`resp.get("data", resp)` is the fleet idiom — the fallback is harmless if a future runtime ever unwraps for you). The two market-scan tools you'll reach for most:
+
+```jsonc
+// market_list_instruments()  — full tradeable universe (main DEX + XYZ)
+{ "success": true, "data": { "instruments": [
+    { "name": "BTC", "sz_decimals": 5, "max_leverage": 40, "is_delisted": false,
+      "context": { "coin": "BTC", "funding": "0.0000125", "openInterest": "29013.5",
+                   "prevDayPx": "77702.0", "dayNtlVlm": "1492870202.9", "premium": "-0.00026",
+                   "oraclePx": "76825.0", "markPx": "76803.0", "midPx": "76802.5", "dayBaseVlm": "19315.1" } }
+  ] }, "meta": {...} }
+
+// market_get_asset_data(asset="BTC")  — one asset, deep
+{ "success": true, "data": {
+    "asset": "BTC",
+    "candles": { "1h": [...] },                       // keyed by the intervals you requested
+    "funding_history": [ { "coin": "BTC", "fundingRate": "0.0000125", "premium": "-0.0003", "time": 1779120000018 } ],  // rows are HOURLY
+    "asset_context": { "coin": "BTC", "funding": "0.0000125", "openInterest": "...", "markPx": "...", "oraclePx": "..." },
+    "oi_velocity": { "current_oi": ..., "oi_trend": "BUILDING" }  // may be null
+  }, "meta": {...} }
+```
+
+So: `market_list_instruments` → `data["instruments"]` (a **list**); `market_get_asset_data` → `data["asset_context"]` / `data["funding_history"]` / `data["candles"]`. All numeric fields arrive as **strings** — cast with `float(...)`.
+
+### Exits are the runtime's job — you do NOT add a close leg
+
+The producer emits **entry** signals only; **DSL owns every exit** (Step 4). That's the invariant — a normal strategy has **no `CLOSE_POSITION` action** at all. Do not invent one to "close on signal," and note there is **no `signal_type_filter` field** — actions bind to scanners via the `scanners:` list, not by signal type. (Producer-driven signal-invalidation closes are an advanced, rarely-needed pattern: a separate `CLOSE_POSITION` action subscribed to its **own** scanner that the producer pushes exit signals to — see [`yaml-schema.md`](yaml-schema.md). Default and recommended: let DSL handle it.)
 
 ## Step 3 — `runtime.yaml` (complete minimal template)
 
@@ -130,8 +162,8 @@ exit:
   engine: dsl
   interval_seconds: 30
   dsl_preset:
-    # PASTE the chosen preset's dsl_preset block from references/dsl-presets.yaml.
-    # Default = balanced (shown). Swap per the Step-1 table.
+    # Default = balanced (shown). For let_winners_run / mean_reversion / scalp,
+    # paste the matching block from Step 4 below — all four are inlined there.
     phase1: { enabled: true, max_loss_pct: 15.0, retrace_threshold: 10, consecutive_breaches_required: 1 }
     phase2:
       enabled: true
@@ -156,16 +188,66 @@ risk:
 
 ## Step 4 — DSL presets (pick one; default `balanced`)
 
-`balanced` is inlined in Step 3. For the others, copy the `dsl_preset` block from [`dsl-presets.yaml`](dsl-presets.yaml):
+`balanced` is inlined in Step 3. All four are paste-ready below — drop the matching block straight under `exit: { engine: dsl, interval_seconds: 30, dsl_preset: ... }`. (`phase2.tiers` must be ascending by `trigger_pct`; ROE %, not price %.)
 
-| Preset | Character |
-|---|---|
-| `balanced` ⭐ | Breathes early, runner tier to +100%, 72h outer bound, smart time-cuts |
-| `let_winners_run` | Widest — no time-cuts; for trend / momentum / followers |
-| `mean_reversion` | Tight — banks the snapback fast (lock 30% @ +5%); for faders |
-| `scalp` | Tightest — fast locks + short timeouts; for high-frequency |
+**`let_winners_run`** — trend / momentum / single-asset / striker / trader-follower. Widest; no time-cuts.
+```yaml
+phase1: { enabled: true, max_loss_pct: 20.0, retrace_threshold: 8, consecutive_breaches_required: 1 }
+phase2:
+  enabled: true
+  tiers:
+    - { trigger_pct: 10,  lock_hw_pct: 0 }
+    - { trigger_pct: 20,  lock_hw_pct: 25 }
+    - { trigger_pct: 30,  lock_hw_pct: 40 }
+    - { trigger_pct: 50,  lock_hw_pct: 60 }
+    - { trigger_pct: 75,  lock_hw_pct: 75 }
+    - { trigger_pct: 100, lock_hw_pct: 85 }
+```
 
-**Always attach DSL** unless the user explicitly opts out — it's what protects a position if the producer goes quiet or a fill lands late.
+**`balanced`** ⭐ default — general-purpose / unsure. (Same block as Step 3.)
+```yaml
+hard_timeout: { enabled: true, interval_in_minutes: 4320 }        # 72h outer bound
+weak_peak_cut: { enabled: true, interval_in_minutes: 360, min_value: 3.0 }
+phase1: { enabled: true, max_loss_pct: 15.0, retrace_threshold: 10, consecutive_breaches_required: 1 }
+phase2:
+  enabled: true
+  tiers:
+    - { trigger_pct: 10,  lock_hw_pct: 0 }
+    - { trigger_pct: 20,  lock_hw_pct: 30 }
+    - { trigger_pct: 35,  lock_hw_pct: 50 }
+    - { trigger_pct: 60,  lock_hw_pct: 70 }
+    - { trigger_pct: 100, lock_hw_pct: 85 }
+```
+
+**`mean_reversion`** — faders / contrarian / range unwinds. Tight; banks the snapback fast; time-cuts on.
+```yaml
+hard_timeout: { enabled: true, interval_in_minutes: 2880 }        # 48h
+weak_peak_cut: { enabled: true, interval_in_minutes: 120, min_value: 2.0 }
+phase1: { enabled: true, max_loss_pct: 15.0, retrace_threshold: 6, consecutive_breaches_required: 1 }
+phase2:
+  enabled: true
+  tiers:
+    - { trigger_pct: 5,  lock_hw_pct: 30 }
+    - { trigger_pct: 10, lock_hw_pct: 50 }
+    - { trigger_pct: 15, lock_hw_pct: 65 }
+    - { trigger_pct: 25, lock_hw_pct: 80 }
+    - { trigger_pct: 40, lock_hw_pct: 90 }
+```
+
+**`scalp`** — high-frequency, fee-sensitive. Tightest; fast locks + short timeouts.
+```yaml
+hard_timeout: { enabled: true, interval_in_minutes: 90 }
+dead_weight_cut: { enabled: true, interval_in_minutes: 45 }
+phase1: { enabled: true, max_loss_pct: 8.0, retrace_threshold: 5, consecutive_breaches_required: 1 }
+phase2:
+  enabled: true
+  tiers:
+    - { trigger_pct: 5,  lock_hw_pct: 50 }
+    - { trigger_pct: 10, lock_hw_pct: 70 }
+    - { trigger_pct: 15, lock_hw_pct: 85 }
+```
+
+**Always attach DSL** unless the user explicitly opts out — it's what protects a position if the producer goes quiet or a fill lands late. Field-by-field tuning: [`dsl-configuration.md`](dsl-configuration.md).
 
 ## Step 5 — Verify
 
@@ -185,6 +267,7 @@ grep daemon_tick_finished /tmp/<skill>-producer.log | tail -3   # "status":"ok"
 - **Runtime package on main is `@senpi-ai/runtime`** (with the `-ai`), never `@senpi/runtime`.
 - **Hyperliquid funding is hourly — annualize with `×24×365` (`×8760`), never `×3×365`.** The `funding` field on the asset context (and each `funding_history` row, spaced 1h apart) is the **per-hour** rate — verified against Hyperliquid's Info API: both return `0.0000125` for BTC at baseline (HL's `0.01%/8h ÷ 8`). So annualized % = `abs(funding) × 8760 × 100`. Annualizing `×3×365` (an 8-hour / Binance-style assumption) understates funding by ~8x. Owl's producer is the correct reference; don't copy an 8h convention.
 - **One runtime per wallet.** Installing a second for the same wallet is rejected — delete the first.
+- **This doc is canonical — don't reverse-engineer conventions from live fleet producers.** Some shipped producers still carry legacy conventions (e.g. the old `×3×365` funding annualization) pending fleet reconciliation. Trust the patterns here; don't fetch another agent's source to "double-check" — you'll just copy a bug.
 
 ## Deep references (only if the template above isn't enough)
 

--- a/senpi-trading-runtime/references/strategy-creation.md
+++ b/senpi-trading-runtime/references/strategy-creation.md
@@ -10,32 +10,29 @@ A Senpi strategy is **a Python producer that emits signals + a `runtime.yaml` th
 
 ## The 5 steps
 
-1. **Pick your archetype + example + DSL preset** (table below). Clone the example agent's three files as your starting point.
+1. **Pick your archetype + example agent** from [`producer-patterns.md`](producer-patterns.md), then **map it to a DSL preset** (heuristic below). Clone the example agent's three files as your starting point.
 2. **Write the producer** (`scripts/<skill>-producer.py`) on the bundled SDK — skeleton below.
 3. **Write `runtime.yaml`** — complete minimal template below.
 4. **Write `config/<skill>-config.json`** — operator-tunable defaults (wallet, chatId, model via env).
 5. **Verify** the daemon is alive + ticking.
 
-If the user gave you full autonomy, **pick the archetype + preset yourself** from the table. Otherwise, **prompt the user** to pick.
+If the user gave you full autonomy, **pick the archetype + preset yourself**. Otherwise, **prompt the user** to pick.
 
-## Step 1 — Archetype → example agent → DSL preset
+## Step 1 — Pick the archetype (+ example agent), then map it to a DSL preset
 
-**Not sure which archetype fits the user's idea?** Walk the [decision tree in `producer-patterns.md`](producer-patterns.md#decision-tree--help-a-user-pick-their-first-strategy) — it takes a user from "I don't know" (or "just give me a good one") through what they believe about markets to a concrete archetype + example agent. Once you've landed on a row below, come back here and build.
+**The archetype catalog and the example agent to clone for each live in [`producer-patterns.md`](producer-patterns.md) — that's the single source of truth, so this doc never duplicates (and never drifts from) the agent roster.** Go there to choose:
 
-| Archetype | Clone this example | DSL preset |
-|---|---|---|
-| Universe trend-follower | `condor`, `cheetah` | `let_winners_run` |
-| Single-asset alpha hunter | `kodiak` (SOL), `grizzly` (BTC), `polar` (ETH), `wolverine` (HYPE) | `let_winners_run` |
-| XYZ specialist | `dire` (oil), `kestrel` (macro) | `balanced` |
-| Multi-asset whitelist | `bison`, `hedgehog` | `balanced` |
-| Trader-follower / hot-streak | `jackal`, `spider`, `raptor` | `let_winners_run` |
-| Striker / rank-jump | `roach`, `jaguar`, `orca` | `balanced` |
-| Funding-rate fade | `pangolin`, `vulture` | `mean_reversion` |
-| Contrarian / crowding-unwind | `owl`, `dog`, `lemon` | `mean_reversion` |
-| Volume engine / high-frequency | `turbine` | `scalp` |
+- **Know roughly what you want?** Skim the archetype catalog and clone the example agent under the closest one.
+- **Not sure?** Walk the [decision tree](producer-patterns.md#decision-tree--help-a-user-pick-their-first-strategy) — it takes a user from "I don't know" (or "just give me a good one") through what they believe about markets to a concrete archetype + example agent.
 
-Fetch the chosen example's producer for the full reference (one fetch, optional):
-`https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<example>/scripts/<example>-producer.py`
+**Then map the archetype to a DSL preset** (default `balanced` when unsure):
+
+| Archetype class | DSL preset |
+|---|---|
+| Trend-follower · single-asset alpha · striker / rank-jump · trader-follower | `let_winners_run` |
+| Funding-fade · contrarian / crowding-unwind | `mean_reversion` |
+| Volume-engine · high-frequency | `scalp` |
+| Anything else, or unsure | `balanced` ⭐ |
 
 ## Step 2 — The producer (copy this skeleton)
 


### PR DESCRIPTION
Ignas's fresh-agent dogfood went **6 min → 2 min** after #317. This PR closes the remaining gaps his run surfaced — every fix removes a specific reference-fetch or a wrong-guess failure mode.

## Changes to `strategy-creation.md`

1. **Defer the archetype/example roster to `producer-patterns.md`** (the original #319 change). That doc is the single source of truth for archetype↔agent; duplicating it here drifted (it had shipped a phantom `barracuda`). Step 1 now points there + keeps only the stable archetype→DSL-preset heuristic inline.

2. **Inline all 4 DSL presets, paste-ready.** Previously only `balanced` was inlined, so the agent had to open `dsl-presets.yaml` to get `mean_reversion` (the preset the funding-fade archetype recommends). All four (`let_winners_run` / `balanced` / `mean_reversion` / `scalp`) are now drop-in blocks in Step 4.

3. **Document MCP response envelopes.** Added verified-live shapes for `market_list_instruments` and `market_get_asset_data`, plus the `resp.get("data", resp)` unwrap idiom and the "all numerics are strings" note. Kills the defensive `{instruments:[]}` / `{data:[]}` / bare-list guessing.

4. **Clarify exits + kill a real bug.** The agent guessed `signal_type_filter` to wire a close leg — **that field doesn't exist**, so the close would have silently failed to bind. The doc now states exits are DSL's job (the invariant — no `CLOSE_POSITION` action in a normal strategy), and that actions route by `scanners:`, not signal type. The rare producer-driven-close pattern is noted as advanced (separate scanner) with a pointer to `yaml-schema.md`.

5. **Gotcha: don't reverse-engineer from live fleet producers.** Some shipped producers still carry legacy conventions (e.g. the old `×3×365` funding annualization, being fixed in #318). This drove an unnecessary WebFetch to cross-check Pangolin. Added a line: this doc is canonical; don't copy from another agent's source.

6. **Edge-case-only preambles** on `signal-schema.md` (deep wire-format reference) and `producer-patterns.md` (scoped: "come here to pick archetype/example; jump to your section or the decision tree — don't read cover-to-cover").

## Net
An agent should now build a complete, correct strategy from `strategy-creation.md` alone — no preset read, no envelope guessing, no invalid close-leg field, no fleet-source cross-checks.

Supersedes the original #319 scope (folded in).