### PR TITLE
feat(marlin): Order-Book Imbalance Momentum (microstructure)

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -376,6 +376,21 @@
       "version": "6.0.0"
     },
     {
+      "id": "marlin",
+      "tracker_slug": "marlin",
+      "name": "Marlin \u2014 Order-Book Imbalance Momentum",
+      "emoji": "\ud83d\udc1f",
+      "tagline": "Reads the L2 order book \u2014 enters in the direction of resting-depth imbalance when momentum and Smart Money agree, then holds the move. Not a scalper.",
+      "group": "microstructure-order-flow",
+      "sort_order": 2,
+      "min_budget": 500,
+      "risk_level": "moderate",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/marlin",
+      "version": "1.0.0"
+    },
+    {
       "id": "orca",
       "tracker_slug": "orca",
       "name": "Orca \u2014 Rank-Jump Striker",

--- a/marlin/README.md
+++ b/marlin/README.md
@@ -1,0 +1,130 @@
+# 🐟 Marlin — Order-Book Imbalance Momentum
+
+Multi-asset (BTC/ETH/SOL/HYPE). Reads the L2 order book — when resting depth is lopsided (bids ≫ asks or the reverse), that's directional pressure. Marlin enters in that direction **only when 15m momentum and Smart Money agree**, then holds the move with a wide DSL. It times the entry on the book; it does **not** scalp.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+Order-book imbalance is a real microstructure edge, but trading it as a per-tick scalp just bleeds fees. Marlin uses it as **entry timing** on a momentum thesis: the book says which side has pressure now; momentum + SM confirm the move; then it holds with a wide stop ladder and lets it work. Bid-heavy + 15m up + SM long → LONG; ask-heavy + 15m down + SM short → SHORT.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Universe | BTC, ETH, SOL, HYPE |
+| Tick interval | 180s (3 min) |
+| MIN_SCORE (producer) | 5 (out of ~9 max) |
+| LLM min_confidence | 7 |
+| Leverage | 4x default, max 5x |
+| Margin per trade | 15% of equity |
+| Book levels summed | top 10 per side |
+| Imbalance floor | 1.5× (bid/ask depth) |
+| Strong-imbalance bonus | 2.5× |
+| 15m momentum floor | 0.1% |
+| SM tilt minimum | 55% |
+| Max entries per day | 4 |
+| Per-asset cooldown | 180 min (3h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 22% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (wide + 24h outer bound)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 18% |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | **24h (enabled)** |
+| Time cuts | weak_peak_cut / dead_weight_cut | disabled |
+| Phase 2 | T0 → T5 | +10/0 · +20/25 · +30/40 · +50/60 · +75/75 · +100/85 |
+
+## Scanner pattern
+
+**Microstructure / order-flow** archetype (with Piranha) — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data` (L2 `order_book` + candles), `leaderboard_get_markets` (SM). Pure signal functions are unit-tested in `tests/test_signal.py` (`python3 marlin/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/marlin-producer.py | Long-lived daemon; emits MARLIN_BOOK_IMBALANCE signals |
+| scripts/marlin_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/marlin-config.json | Operator-tunable defaults (wallet, universe, imbalance/SM thresholds, sizing) |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Marlin
+
+```bash
+mkdir -p /data/workspace/skills/marlin-strategy/{config,scripts,state,references}
+for f in scripts/marlin-producer.py scripts/marlin_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/marlin-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/marlin/$f" \
+    -o "/data/workspace/skills/marlin-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/marlin-strategy/config/marlin-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export MARLIN_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                            # required
+export MARLIN_DECISION_MODEL=<your-preferred-model>    # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/marlin-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/marlin-strategy/scripts/marlin-producer.py \
+  > /tmp/marlin-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 200  # wait one full tick
+tail -3 /tmp/marlin-producer.log | jq '._marlin_producer_version, .note // null, .best.score // null'
+# Expected: _marlin_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no book-imbalance + momentum + SM alignment on universe"` — common
+- `"signals_pushed": 1, "best": { "coin": ..., "direction": "LONG"|"SHORT", "score": 5-9 }` — entry fired
+
+## Changelog
+
+### v1.0.0 (2026-05-22) — initial release
+
+Second agent in the microstructure/order-flow family (with Piranha). Order-book imbalance as entry-timing on a momentum thesis — deliberately not a scalper. Wide "let winners run" ladder + 24h hard_timeout, taker-fallback entry, exit timeout 30s, no null numeric signal fields, disown-safe launch, unit-tested signal functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/marlin/SKILL.md
+++ b/marlin/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: marlin-strategy
+description: >-
+  MARLIN v1.0.0 — Order-Book Imbalance Momentum. A persistent resting-depth
+  imbalance in the L2 book is a near-term pressure tell: bids ≫ asks = buy
+  pressure, asks ≫ bids = sell pressure. Marlin enters in the imbalance
+  direction WHEN 15m momentum and Smart Money agree — it times the entry on
+  the book, then holds the move (it is NOT a scalper). Universe: BTC, ETH,
+  SOL, HYPE. Wide "let winners run" DSL + 24h hard_timeout.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐟 MARLIN v1.0.0 — Order-Book Imbalance Momentum
+
+**Time the entry on the book; hold the move.** Marlin reads the L2 order book — when resting depth is lopsided (bids ≫ asks, or the reverse), that's directional pressure. It enters in that direction *only when* short-term momentum and Smart Money agree, then hands the position to a wide DSL. It does not scalp.
+
+## Why this strategy exists
+
+Order-book imbalance is a genuine microstructure edge — but trading it as a per-tick scalp just bleeds fees (the fastest way to lose on perps). Marlin uses the imbalance differently: as the **entry-timing signal** on a momentum thesis. The book tells you *which side has pressure right now*; momentum and SM confirm the move is real; then you hold it with a wide stop ladder and let it work, instead of flipping in and out.
+
+- **Bids ≫ asks** (ratio ≥ `imbalanceMin`) + 15m up + SM long → **LONG**
+- **Asks ≫ bids** (ratio ≤ 1/`imbalanceMin`) + 15m down + SM short → **SHORT**
+
+## CRITICAL RULES
+
+### RULE 1: Imbalance picks the side, momentum + SM confirm it
+The order-book ratio (bid depth / ask depth over the top `levelsN` levels) selects the candidate direction. The trade only fires if 15m momentum is moving that way **and** Smart Money agrees. A lopsided book with no momentum/SM confirmation is noise — skip it.
+
+### RULE 2: Not a scalper — hold the move
+The imbalance is entry-*timing*, not an exit signal. Marlin holds with a wide "let winners run" Phase 2 ladder; a 24h `hard_timeout` is the only time-based exit (the microstructure thesis is short-horizon, but the move itself is given room). Turning this into a per-tick scalp would erase the edge in fees.
+
+### RULE 3: Producer enters. DSL exits.
+No `close_position` call site. Phase 1 max_loss 18% + Phase 2 wide ladder + 24h hard_timeout own all exits.
+
+### RULE 4: Universe is BTC, ETH, SOL, HYPE
+Liquid majors only — thin books give unreliable imbalance readings.
+
+## How Marlin scores a trade
+
+**Gates** (all required):
+1. Book imbalance on one side (ratio ≥ `imbalanceMin` for LONG, ≤ 1/`imbalanceMin` for SHORT)
+2. 15m momentum confirms that side (≥ `momMinPct`)
+3. SM direction agrees, tilt ≥ `smTiltMinPct` (default 55%)
+
+**Score components** (max ~9):
+
+| Signal | Points |
+|---|---|
+| Book imbalance (gate-confirmed) | +2 |
+| Strongly imbalanced (≥ `imbalanceStrong`, default 2.5×) | +1 |
+| 15m momentum confirms (gate-confirmed) | +2 |
+| 5m momentum aligned | +1 |
+| SM aligned (gate-confirmed) | +2 |
+| SM strongly tilted (≥ 70%) | +1 |
+| Volume rising (> 10%) | +1 |
+
+**Floor:** `minScore: 5`.
+
+## DSL preset (wide + short-horizon outer bound)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 18% |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | **24h (ENABLED)** |
+| Time cuts | weak_peak_cut / dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T5 | +10/0 · +20/25 · +30/40 · +50/60 · +75/75 · +100/85 |
+
+## Scanner pattern
+
+**Microstructure / order-flow** archetype (alongside Piranha) — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data` (L2 `order_book` + candles), `leaderboard_get_markets` (SM). The pure signal functions (`book_imbalance`, `imbalance_direction`, `price_move_pct`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-22) — initial release
+
+Second agent in the microstructure/order-flow family (with Piranha). Trades L2 order-book imbalance as entry-timing on a momentum thesis — deliberately NOT a scalper (fee discipline). Built with the per-class DSL rule: wide "let winners run" ladder + short-horizon 24h hard_timeout, taker-fallback entry, exit timeout 30s, no null numeric signal fields, and unit-tested pure signal functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/marlin/config/marlin-config.json
+++ b/marlin/config/marlin-config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "MARLIN v1.0.0 — Order-Book Imbalance Momentum (BTC/ETH/SOL/HYPE). Enters in the direction of a persistent L2 order-book imbalance (bid depth / ask depth over the top levelsN levels) WHEN 15m momentum and Smart Money agree. LONG when book is bid-heavy (ratio >= imbalanceMin) + 15m up + SM long; SHORT on the mirror. NOT a scalper — the imbalance is entry-timing; the position is held with a wide DSL + 24h hard_timeout (microstructure is short-horizon). Edit wallet/strategyId/chatId.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "universe": ["BTC", "ETH", "SOL", "HYPE"],
+  "minScore": 5,
+  "levelsN": 10,
+  "imbalanceMin": 1.5,
+  "imbalanceStrong": 2.5,
+  "momMinPct": 0.1,
+  "smTiltMinPct": 55,
+  "marginPct": 0.15,
+  "leverage": 4
+}

--- a/marlin/references/skill-attribution.md
+++ b/marlin/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "marlin",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "marlin",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/marlin/runtime.yaml
+++ b/marlin/runtime.yaml
@@ -1,0 +1,181 @@
+name: marlin-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Marlin
+# v1.0.0" and lives in description + SKILL.md + _marlin_producer_version.
+version: 1.0.0
+description: >
+  MARLIN v1.0.0 — Order-Book Imbalance Momentum.
+
+  A persistent resting-depth imbalance in the L2 book is a near-term
+  pressure tell: bids >> asks = buy pressure, asks >> bids = sell pressure.
+  Marlin enters in the imbalance direction WHEN 15m momentum and Smart
+  Money agree. It is NOT a scalper — the imbalance is the entry-TIMING edge
+  on a momentum thesis; Marlin holds with a wide DSL (24h hard_timeout caps
+  the short-horizon thesis). Universe: BTC/ETH/SOL/HYPE.
+
+  Architecture (helpers-native): producer ticks every 180s, scores a
+  book-imbalance thesis (max ~9), emits MARLIN_BOOK_IMBALANCE via
+  SenpiClient.push_signal() when score >= 5. LLM gate is pass-through.
+
+  DSL: wide "let winners run" ladder + a 24h hard_timeout (microstructure
+  signals are short-horizon). Phase 1 max_loss 18%.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 200
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 4
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 180
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: marlin_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        imbalanceRatio: { type: number, required: false }
+        bidDepth: { type: number, required: false }
+        askDepth: { type: number, required: false }
+        mom15mPct: { type: number, required: false }
+        mom5mPct: { type: number, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: marlin_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${MARLIN_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [marlin_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # momentum entry must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING) and miss the move
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: marlin_signals
+    decision_prompt: |
+      You are Marlin's pass-through gate. Marlin uses an order-book imbalance
+      (bids >> asks = buy pressure, or the reverse) as the entry-timing edge
+      on a momentum thesis. The producer already applied every filter
+      (book imbalance >= threshold on one side, 15m momentum confirms that
+      side, SM direction agrees, SM tilt >= 55%, minScore 5). Honor the signal.
+
+      SIGNAL:
+      {{signal_marlin_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (preserve case).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 8 AND imbalanceRatio strongly one-sided AND smTiltPct >= 70
+      - 7-8:  score 6-7
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 8 ETH LONG, book_imbalance 2.8x, mom_15m +0.4%, SM aligned 66% — bid-heavy book + momentum + SM')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "MARLIN_BOOK_IMBALANCE ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — wide ladder + short-horizon outer bound) ──────
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 1440                   # 24h — book-imbalance momentum is short-horizon
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 120
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/marlin/scripts/marlin-producer.py
+++ b/marlin/scripts/marlin-producer.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+# Senpi MARLIN Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""MARLIN v1.0.0 — Order-Book Imbalance Momentum.
+
+A persistent resting-depth imbalance in the L2 order book is a near-term
+pressure tell: bids ≫ asks over the top levels = accumulation / buy
+pressure; asks ≫ bids = distribution / sell pressure. Marlin enters in the
+imbalance direction WHEN short-term price momentum and Smart Money agree.
+
+This is NOT a per-tick scalper. The order-book imbalance is the entry-TIMING
+edge on a momentum thesis — Marlin holds the position with a wide "let
+winners run" DSL (a 24h hard_timeout caps the short-horizon thesis). Trading
+the book as a scalp would just bleed fees; we time the entry with it and
+let the move work.
+
+LONG when: book is bid-heavy (imbalance >= imbalanceMin) AND 15m momentum is
+up AND SM net long. SHORT on the mirror. Universe: BTC/ETH/SOL/HYPE.
+
+Producer NEVER closes — DSL owns exits.
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import marlin_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "marlin_signals"
+SIGNAL_TYPE = "MARLIN_BOOK_IMBALANCE"
+
+DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL", "HYPE"]
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 5
+
+DEFAULT_LEVELS_N = 10               # top N book levels per side to sum
+DEFAULT_IMBALANCE_MIN = 1.5         # bid/ask depth ratio to call it bid-heavy (1/1.5 = ask-heavy)
+DEFAULT_IMBALANCE_STRONG = 2.5      # strongly-imbalanced bonus
+DEFAULT_MOM_MIN_PCT = 0.1          # 15m momentum magnitude that confirms the side
+DEFAULT_SM_TILT_MIN = 55
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("MARLIN_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Microstructure helpers (pure — unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def book_imbalance(asset_data, levels_n=DEFAULT_LEVELS_N):
+    """Return (imbalance_ratio, bid_depth, ask_depth) over the top `levels_n`
+    book levels per side. ratio > 1 = bid-heavy (buy pressure); < 1 =
+    ask-heavy (sell pressure). ratio is None when the book is unusable.
+
+    market_get_asset_data order_book shape: {"levels": [bids, asks]} where
+    each side is a list of {"px","sz","n"}; bids[0] is best bid, asks[0] best ask.
+    """
+    ob = (asset_data.get("data", {}) or {}).get("order_book", {}) or {}
+    levels = ob.get("levels") or []
+    if not isinstance(levels, list) or len(levels) < 2:
+        return None, 0.0, 0.0
+    bids = levels[0][:levels_n] if isinstance(levels[0], list) else []
+    asks = levels[1][:levels_n] if isinstance(levels[1], list) else []
+    bid_depth = sum(_f(l, "sz") for l in bids if isinstance(l, dict))
+    ask_depth = sum(_f(l, "sz") for l in asks if isinstance(l, dict))
+    if bid_depth <= 0 and ask_depth <= 0:
+        return None, bid_depth, ask_depth
+    if ask_depth <= 0:
+        return float("inf"), bid_depth, ask_depth
+    return bid_depth / ask_depth, bid_depth, ask_depth
+
+
+def imbalance_direction(ratio, imbalance_min):
+    """Map an imbalance ratio to a trade side, or None if too balanced.
+    bid-heavy (ratio >= min) → LONG; ask-heavy (ratio <= 1/min) → SHORT."""
+    if ratio is None or imbalance_min <= 0:
+        return None
+    if ratio >= imbalance_min:
+        return "LONG"
+    if ratio <= (1.0 / imbalance_min):
+        return "SHORT"
+    return None
+
+
+def price_move_pct(candles, n_bars=1):
+    if len(candles) < n_bars + 1:
+        return 0.0
+    old = _f(candles[-(n_bars + 1)], "close", "c")
+    new = _f(candles[-1], "close", "c")
+    if old <= 0:
+        return 0.0
+    return ((new - old) / old) * 100
+
+
+def volume_trend(candles, lookback=6):
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["5m", "15m"],
+        include_funding=False,
+        include_order_book=True,
+    )
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, entry_cfg):
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles_5m = data.get("data", {}).get("candles", {}).get("5m", [])
+    candles_15m = data.get("data", {}).get("candles", {}).get("15m", [])
+    if len(candles_15m) < 2 or len(candles_5m) < 2:
+        return None
+
+    levels_n = int(entry_cfg.get("levelsN", DEFAULT_LEVELS_N))
+    imb_min = float(entry_cfg.get("imbalanceMin", DEFAULT_IMBALANCE_MIN))
+    imb_strong = float(entry_cfg.get("imbalanceStrong", DEFAULT_IMBALANCE_STRONG))
+
+    # GATE 1 — order-book imbalance picks the side
+    ratio, bid_depth, ask_depth = book_imbalance(data, levels_n)
+    direction = imbalance_direction(ratio, imb_min)
+    if direction is None:
+        return None
+
+    # GATE 2 — short-term momentum must confirm the imbalance side
+    mom_15m = price_move_pct(candles_15m, 1)
+    mom_min = float(entry_cfg.get("momMinPct", DEFAULT_MOM_MIN_PCT))
+    if direction == "LONG" and mom_15m < mom_min:
+        return None
+    if direction == "SHORT" and mom_15m > -mom_min:
+        return None
+
+    # GATE 3 — Smart-Money agreement
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(entry_cfg.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    mom_5m = price_move_pct(candles_5m, 1)
+    vol_pct = volume_trend(candles_5m)
+    # display ratio (inf → large sentinel for telemetry)
+    disp_ratio = 99.0 if ratio == float("inf") else round(ratio, 3)
+
+    score = 0
+    reasons = []
+
+    # Imbalance magnitude (gate-confirmed) + strong bonus
+    score += 2
+    reasons.append(f"book_imbalance_{disp_ratio}x")
+    strong = (ratio == float("inf")) or (direction == "LONG" and ratio >= imb_strong) or \
+             (direction == "SHORT" and ratio <= (1.0 / imb_strong))
+    if strong:
+        score += 1
+        reasons.append("imbalance_strong")
+
+    # Momentum confirms (gate) + 5m alignment
+    score += 2
+    reasons.append(f"mom_15m_{mom_15m:+.2f}%")
+    if (direction == "LONG" and mom_5m > 0) or (direction == "SHORT" and mom_5m < 0):
+        score += 1
+        reasons.append(f"mom_5m_aligned_{mom_5m:+.2f}%")
+
+    # SM aligned (gate) + strong
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+    if sm_tilt >= 70:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    # Volume rising
+    if vol_pct > 10:
+        score += 1
+        reasons.append(f"vol_rising_{vol_pct:+.0f}%")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "imbalance_ratio": disp_ratio,
+        "bid_depth": round(bid_depth, 2),
+        "ask_depth": round(ask_depth, 2),
+        "mom_15m_pct": round(mom_15m, 3),
+        "mom_5m_pct": round(mom_5m, 3),
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": sm_tilt,
+        "volume_trend_pct": round(vol_pct, 2),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "imbalanceRatio": thesis.get("imbalance_ratio") or 0.0,
+        "bidDepth": thesis.get("bid_depth") or 0.0,
+        "askDepth": thesis.get("ask_depth") or 0.0,
+        "mom15mPct": thesis.get("mom_15m_pct") or 0.0,
+        "mom5mPct": thesis.get("mom_5m_pct") or 0.0,
+        "smDirection": thesis["sm_direction"],
+        "smTiltPct": thesis.get("sm_tilt_pct") or 0.0,
+        "volumeTrendPct": thesis.get("volume_trend_pct") or 0.0,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 9.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — multi-asset whitelist scan
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    universe = [a.upper() for a in config.get("universe", DEFAULT_UNIVERSE)]
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_marlin_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_marlin_producer_version": VERSION})
+        return
+
+    candidates = []
+    for asset in universe:
+        if asset in held_set:
+            continue
+        if cfg.was_recently_signaled(asset):
+            continue
+        thesis = build_thesis(asset, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no book-imbalance + momentum + SM alignment on universe",
+            "universe": universe,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_marlin_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_marlin_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=180,
+        name=f"marlin-producer-{_wallet_lock_id}",
+        tick_timeout=150,
+    )

--- a/marlin/scripts/marlin_config.py
+++ b/marlin/scripts/marlin_config.py
@@ -1,0 +1,221 @@
+"""MARLIN v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Order-Book Imbalance Momentum (microstructure). Multi-asset whitelist
+(BTC/ETH/SOL/HYPE). Enters in the direction of a persistent L2 order-book
+imbalance (bid depth vs ask depth over the top levels) WHEN 15m momentum
+and Smart Money agree. NOT a scalper — the imbalance is the entry-timing
+edge on a momentum thesis; the position is held with a wide DSL.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate
++ wide DSL Phase 2 ladder + 24h hard_timeout (microstructure is
+short-horizon). Mirrors the Wolverine v6.0.0 / Bison v3.0.1 pattern
+(race-window dedup, atomic write, simplified producer_daemon).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "marlin-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "marlin-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Marlin ticks every 300s; HYPE ALO fills
+# typically settle within 30-60s. 240s covers the full fill window
+# plus next-tick clearinghouseState refresh, so the on-chain
+# held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Marlin's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("marlin_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] marlin_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+#
+# Mirrors bison v3.0.1 / wolverine v6.0.0 pattern. After
+# push_signal(coin) returns OK, record_signal(coin) writes
+# {coin: epoch_seconds} to state/recent-signals.json. main() calls
+# was_recently_signaled(coin) BEFORE push_signal and skips emission
+# during the 30-90s gap between push_signal returning OK and the
+# resulting position appearing in clearinghouseState.
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[marlin-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/marlin/tests/test_signal.py
+++ b/marlin/tests/test_signal.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Unit tests for Marlin's pure signal functions (book_imbalance,
+imbalance_direction, price_move_pct). Stubs marlin_config +
+senpi_runtime_helpers so the producer loads without the helpers package
+or a runtime workspace. Run: python3 marlin/tests/test_signal.py
+"""
+import importlib.util
+import math
+import sys
+import types
+from pathlib import Path
+
+# ── Stub the top-level imports the producer makes ──
+_cfg = types.ModuleType("marlin_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["marlin_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "marlin-producer.py"
+_spec = importlib.util.spec_from_file_location("marlin_producer", _path)
+mp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mp)
+
+
+def _lvl(sz):
+    return {"px": 0, "sz": sz, "n": 1}
+
+
+def _book(bids, asks):
+    return {"data": {"order_book": {"levels": [bids, asks]}}}
+
+
+def test_book_imbalance_bid_heavy():
+    r, b, a = mp.book_imbalance(_book([_lvl(60), _lvl(40)], [_lvl(20), _lvl(20)]))
+    assert b == 100 and a == 40 and abs(r - 2.5) < 1e-9
+
+
+def test_book_imbalance_ask_heavy():
+    r, _, _ = mp.book_imbalance(_book([_lvl(20)], [_lvl(50), _lvl(30)]))
+    assert abs(r - 0.25) < 1e-9
+
+
+def test_book_imbalance_empty_and_missing():
+    assert mp.book_imbalance({"data": {"order_book": {"levels": []}}})[0] is None
+    assert mp.book_imbalance({})[0] is None
+
+
+def test_book_imbalance_no_asks_is_inf():
+    r, b, a = mp.book_imbalance(_book([_lvl(10)], []))
+    assert r == math.inf and a == 0.0
+
+
+def test_book_imbalance_levels_n_truncation():
+    bids = [_lvl(10) for _ in range(20)]
+    asks = [_lvl(10) for _ in range(20)]
+    r, b, a = mp.book_imbalance(_book(bids, asks), levels_n=5)
+    assert b == 50 and a == 50 and abs(r - 1.0) < 1e-9
+
+
+def test_imbalance_direction():
+    assert mp.imbalance_direction(2.5, 1.5) == "LONG"
+    assert mp.imbalance_direction(0.4, 1.5) == "SHORT"   # 0.4 <= 1/1.5
+    assert mp.imbalance_direction(1.0, 1.5) is None       # balanced
+    assert mp.imbalance_direction(None, 1.5) is None
+    assert mp.imbalance_direction(math.inf, 1.5) == "LONG"
+
+
+def test_price_move_pct():
+    assert abs(mp.price_move_pct([{"close": 100}, {"close": 110}], 1) - 10.0) < 1e-9
+    assert abs(mp.price_move_pct([{"close": 100}, {"close": 95}], 1) + 5.0) < 1e-9
+    assert mp.price_move_pct([{"close": 100}], 1) == 0.0
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -706,8 +706,7 @@ bid_depth, ask_depth = sum(l["sz"] for l in levels[0]), sum(l["sz"] for l in lev
 | Agent | Version | Asset / Universe | Description | Tags |
 |---|---|---|---|---|
 | **Piranha** | v1.0 | BTC/ETH/SOL/HYPE | Liquidation-cascade / forced-flow hunter — OI unwinding fast + violent move + thin book ⇒ ride the forced flow. Wide DSL + 24h hard_timeout. | OI velocity, Order book, Forced flow |
-
-*(Marlin — order-book-imbalance momentum — joins this family next.)*
+| **Marlin** | v1.0 | BTC/ETH/SOL/HYPE | Order-book-imbalance momentum — bid/ask resting-depth skew as the entry-TIMING edge on a momentum thesis (NOT a scalper); holds with a wide DSL + 24h hard_timeout. | Order book, Imbalance, Momentum |
 
 ---
 
@@ -832,12 +831,13 @@ XYZ markets (stocks / commodities / pre-IPO) trade **24/7 on Hyperliquid**, even
 - **Buy the dip *within* an uptrend** → 🟢 **Salamander** (pullback catcher).
 - **Leaderboard rank-jumps caught early** → **Jaguar** · **Orca** · **Roach**.
 - **Ride a liquidation cascade / forced flow** (OI unwinding fast + a violent move) → **Piranha** (microstructure / order-flow).
+- **Trade order-book pressure** (resting bid/ask depth skew, confirmed by momentum + SM) → **Marlin** (microstructure / order-flow).
 
 ### Layer 2F — Structural / neutral → what structure?
 
 - **BTC-led laggard rotation** (an alt that hasn't caught up to a BTC move yet) → **Mantis** (cross-asset lag).
 - **Volume / market-making** (not a directional bet) → **Turbine** (specialized).
-- *Expanding set — relative-value pairs, order-book-imbalance momentum (Marlin), and copy-the-copiers are being added. (Microstructure forced-flow is already live — see Piranha under Layer 2E.)*
+- *Expanding set — relative-value pairs and copy-the-copiers are being added. (Microstructure is already live — Piranha (forced flow) and Marlin (order-book imbalance) under Layer 2E.)*
 
 ### Run a current top performer (by live ROE)
 
@@ -961,6 +961,7 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | **Badger** | 4 — Multi-asset whitelist (OI-confirmed breakout) | BTC/ETH/SOL/HYPE. Takes a breakout only when rising open interest confirms it (new money, not a fakeout). Wide "let winners run" DSL |
 | **Egret** | 8 — Contrarian crowding-unwind (SM-divergence fader) | BTC/ETH/SOL/HYPE. Fades extreme SM crowding (≥70%) that price won't confirm. Tight DSL + maker-only entry + time-cuts on |
 | **Piranha** | 12 — Microstructure / order-flow | BTC/ETH/SOL/HYPE. Rides forced flow — OI unwinding fast + violent move + thin book ⇒ liquidation cascade. Wide DSL + 24h hard_timeout |
+| **Marlin** | 12 — Microstructure / order-flow | BTC/ETH/SOL/HYPE. Order-book imbalance (bid/ask depth skew) as entry-timing on a momentum thesis — not a scalper. Wide DSL + 24h hard_timeout |
 
 Sentinel runs an in-house producer that is not currently published to this repo; no public URL.
 


### PR DESCRIPTION
New strategy + **full pipeline** (skill → producer-patterns → decision tree → catalog), and the **first agent built with the superpowers methodology** — it ships with a real **logic test**, not just a compile check.

## Marlin
Reads the L2 order book — when resting depth is lopsided (bids ≫ asks or the reverse), enters in that direction **only when 15m momentum and Smart Money agree**, then holds with a wide DSL. **Deliberately not a scalper** (the fee-bleed lesson): the imbalance is *entry-timing* on a momentum thesis. Second agent in the microstructure/order-flow family (with Piranha).

## TDD layer (new)
`marlin/tests/test_signal.py` unit-tests the pure functions (`book_imbalance`, `imbalance_direction`, `price_move_pct`) against synthetic books — **7/7 pass**. Stubs `marlin_config` + `senpi_runtime_helpers` so it runs without the runtime workspace. This is the `verification-before-completion` upgrade the earlier agents lacked.

## Every step
- **Skill** — 8 files (incl. `tests/`); validated YAML/JSON/compile + data_block↔scanner **field parity** + 7/7 logic tests.
- **producer-patterns.md** — added to archetype **#12 Microstructure / order-flow** (agents table + roster; removed the "coming next" note).
- **Decision tree** — Layer 2E ("trade order-book pressure") + updated the expanding-set note.
- **catalog.json** — entry (`microstructure-order-flow`, $500 min).

Progress: **4 of 10** new strategies in main (Badger, Egret, Piranha, Marlin). Remaining: Chameleon, Cuckoo, Falcon, Osprey, Remora, Meerkat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)