### PR TITLE
docs(pangolin): sync funding refs to v3.0.1 (hourly, 0.0000228 floor)

### DIFF
--- a/pangolin/README.md
+++ b/pangolin/README.md
@@ -6,7 +6,7 @@ Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
 
 ## Thesis
 
-When funding rates are elevated (>0.015%/8h ≈ 20% annualized), the crowd is paying to hold their position. Pangolin enters opposite to the funding direction — collecting funding every 8 hours while waiting for the crowded side to capitulate. Conservative 3-5x leverage, very wide DSL (12h hard timeout, 30% Phase 1 max_loss). Scans every Hyperliquid perp with OI > $1M (~60 assets), persistence ≥ 3 hours, regime-confirmed.
+When funding rates are elevated (≈20% annualized, i.e. ≥ 0.00228%/hr — Hyperliquid funding is **hourly**), the crowd is paying to hold their position. Pangolin enters opposite to the funding direction — collecting funding every hour while waiting for the crowded side to capitulate. Conservative 3-5x leverage, very wide DSL (12h hard timeout, 30% Phase 1 max_loss). Scans every Hyperliquid perp with OI > $1M (~60 assets), persistence ≥ 3 hours, regime-confirmed.
 
 Pangolin's horizon (24-48h funding fade) is the longest in the fleet. The bet is patient: the longer crowding persists at extreme funding, the more violent the unwind, and the more 8h funding payments accumulate as a base-rate carry. Phase 1 max_loss 30% (10% price buffer at 3x), Phase 2 ladder starts at 12% ROE (above MAVIA's normal wick noise), `weak_peak_cut` disabled (funding fade takes 24-48h).
 
@@ -17,7 +17,7 @@ Pangolin's horizon (24-48h funding fade) is the longest in the fleet. The bet is
 | Asset universe | All Hyperliquid perps with OI ≥ $1M (~60 assets); XYZ banned |
 | Tick interval | 300s (5 min) |
 | MIN_SCORE | 9 |
-| Funding threshold | ≥ 0.00015 (per-8h rate) |
+| Funding threshold | ≥ 0.0000228 per-hour (≈ 20% annualized; HL funding is hourly, ×8760) |
 | Persistence | ≥ 3 hours, regime confirms or neutral |
 | Leverage tiers | 3-5x (conservative) |
 | Per-asset cooldown | 240 min |
@@ -145,7 +145,7 @@ Expected: `status=ok` every tick (300s interval — Pangolin's longer cadence re
 
 **Why v2 mattered for Pangolin:** v1 entries were already maker-first, but v1 EXITS used MARKET orders (taker fees). v2 brought maker-first to exits too. Fee saving per trade is small (~$0.10-0.20) given Pangolin's small notional, but architectural alignment + runtime-managed lifecycle + declarative risk gates are the real win.
 
-**Thesis preserved verbatim from v1.5/v1.7:** funding rate ≥ 0.00015, persistence ≥ 3h, regime confirms or neutral, OI ≥ $1M, score ≥ 9, per-asset 240min cooldown, XYZ banned. Phase 1 max_loss 30% (10% price buffer at 3x), Phase 2 ladder starts at 12% ROE (above MAVIA's normal wick noise), `weak_peak_cut` disabled (funding fade takes 24-48h).
+**Thesis preserved from v1.5/v1.7** (funding floor recalibrated in v3.0.1): funding rate ≥ 0.0000228/hr (≈20% annualized; was 0.00015 under the old 8h convention), persistence ≥ 3h, regime confirms or neutral, OI ≥ $1M, score ≥ 9, per-asset 240min cooldown, XYZ banned. Phase 1 max_loss 30% (10% price buffer at 3x), Phase 2 ladder starts at 12% ROE (above MAVIA's normal wick noise), `weak_peak_cut` disabled (funding fade takes 24-48h).
 
 See [`SKILL.md`](SKILL.md) for full setup, env vars, and behavior expectations.
 

--- a/pangolin/SKILL.md
+++ b/pangolin/SKILL.md
@@ -6,10 +6,11 @@ description: >-
   subprocess to in-process SenpiClient. Pangolin is the canonical
   reference producer for the senpi_runtime_helpers SDK wrapper pattern.
   Thesis preserved verbatim from v2.2.0:
-  funding-fade entries opposite to elevated funding rates (>0.015%/8h
-  ≈ 20% annualized), persistence ≥3h, regime confirms or neutral.
-  Conservative 3-5x leverage, wide DSL (12h hard_timeout). Collects
-  funding every 8h while crowded positions mean-revert (24-48h thesis).
+  funding-fade entries opposite to elevated funding rates (≈20%
+  annualized, ≥0.0000228/hr — HL funding is hourly), persistence ≥3h,
+  regime confirms or neutral. Conservative 3-5x leverage, wide DSL
+  (12h hard_timeout). Collects funding hourly while crowded positions
+  mean-revert (24-48h thesis).
   Phase 2 v2.2 ratchet ladder T0 8/50, T1 16/65, T2 30/85, T3 50/92.
 license: MIT
 metadata:
@@ -44,7 +45,7 @@ An entirely new strategy archetype for the Predators fleet. No other agent trade
 **Why v2:** v1 entries were already maker-first (Pangolin shipped with FEE_OPTIMIZED_LIMIT in v1), but EXITS used MARKET orders. Per-trade fee saving from maker exits is small ($0.10-0.20 given Pangolin's small notional) but architectural alignment matters. The bigger v2 win is declarative risk + runtime-managed lifecycle.
 
 **Thesis preserved from v1.5/v1.7:**
-- Funding rate >= 0.00015 (~20% annualized)
+- Funding rate >= 0.0000228 per-hour (~20% annualized; recalibrated v3.0.1 — was 0.00015 under the old 8h convention)
 - Persistence >= 3 hours (reject fresh spikes)
 - Regime confirms fade OR is neutral (no fighting the crowd)
 - OI >= $1M (liquidity floor)

--- a/pangolin/config/pangolin-config.json
+++ b/pangolin/config/pangolin-config.json
@@ -15,7 +15,8 @@
   },
   "entry": {
     "minScore": 9,
-    "minFundingRate": 0.00015,
+    "minFundingRate": 0.0000228,
+    "_minFundingRate_note": "Per-hour rate (HL funding is hourly) ≈ 20% annualized. Live gate is the producer's MIN_FUNDING_RATE constant; this mirrors it. v3.0.1 recalibrated from 0.00015 (which was ~131% ann under hourly cadence).",
     "minOiUsd": 1000000,
     "minPersistenceHours": 3,
     "assetCooldownMinutes": 240,

--- a/pangolin/runtime.yaml
+++ b/pangolin/runtime.yaml
@@ -33,9 +33,10 @@ description: >
   v2.0 — v2-runtime-native rewrite + maker-exit fee recovery.
 
   Mission unchanged from v1.7: extreme funding rate fader. Enters
-  opposite to elevated funding (>0.015%/8h ≈ 20% annualized) on assets
-  where funding has been extreme for >= 3 hours AND the market regime
-  confirms (or is neutral). Collects funding every 8h while waiting
+  opposite to elevated funding (≈ 20% annualized, ≥ 0.0000228/hr — HL
+  funding is hourly) on assets where funding has been extreme for >= 3
+  hours AND the market regime confirms (or is neutral). Collects funding
+  hourly while waiting
   for crowded positions to mean-revert (24-48h thesis horizon).
 
   v2.0 architectural changes (no thesis change):


### PR DESCRIPTION
Follow-up to #318. The funding fix updated Pangolin's producer + changelog but left the **Thesis**, **Key-params table**, **SKILL.md frontmatter**, **runtime.yaml description**, and **config JSON** still citing the old `0.00015` / per-8h numbers — a public-doc contradiction.

Synced all current-state references to the hourly convention:
- Funding threshold `0.00015` → `0.0000228`/hr (≈20% annualized, ×8760)
- "every 8h" / "collects funding every 8 hours" → hourly
- `config/pangolin-config.json` `minFundingRate` mirrored to `0.0000228` + a note that the live gate is the producer's `MIN_FUNDING_RATE` constant (the config value isn't wired in, but it's no longer misleading)

Historical changelog references to `0.00015` are intentionally kept — they document the recalibration. JSON + YAML validated.