### PR TITLE
feat(chameleon): Relative-Value / Pairs ratio mean-reversion

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -121,6 +121,21 @@
       "version": "1.0.0"
     },
     {
+      "id": "chameleon",
+      "tracker_slug": "chameleon",
+      "name": "Chameleon \u2014 Relative-Value / Pairs",
+      "emoji": "\ud83e\udd8e",
+      "tagline": "Trades the spread between two coins, not the market. When a pair ratio (ETH/BTC, SOL/ETH) stretches far from its mean, it bets on the snap-back via the high-beta leg.",
+      "group": "relative-value-pairs",
+      "sort_order": 1,
+      "min_budget": 500,
+      "risk_level": "moderate",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/chameleon",
+      "version": "1.0.0"
+    },
+    {
       "id": "cheetah",
       "tracker_slug": "cheetah",
       "name": "Cheetah \u2014 Multi-Signal Confluence Sniper",

--- a/chameleon/README.md
+++ b/chameleon/README.md
@@ -1,0 +1,130 @@
+# 🦎 Chameleon — Relative-Value / Pairs (Ratio Mean-Reversion)
+
+Trades the **spread between two coins**, not the market. When a pair's price ratio (ETH/BTC, SOL/ETH, SOL/BTC) stretches far from its mean (high z-score), Chameleon bets on the snap-back — taking a directional position on the high-beta leg in the reversion direction.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+Correlated majors move as a pack, but their *ratios* oscillate around a mean — and ratios revert far more reliably than outright prices. A 3-sigma ETH/BTC extension is a cleaner edge than guessing ETH's absolute direction. Chameleon measures the stretch (z-score over a lookback) and trades the reversion on the high-beta leg. **Single-position note:** a textbook pairs trade is two legs; the runtime is single-position, so Chameleon takes the directional high-beta leg instead, capturing most of the reversion edge.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Pairs | ETH/BTC (trade ETH), SOL/ETH (trade SOL), SOL/BTC (trade SOL) |
+| Tick interval | 300s (5 min) |
+| MIN_SCORE (producer) | 4 (out of ~7 max) |
+| LLM min_confidence | 7 |
+| Leverage | 4x default, max 5x |
+| Margin per trade | 15% of equity |
+| Ratio lookback | 48 × 1h bars (~2 days) |
+| z entry floor | 2.0 |
+| z strong | 3.0 |
+| SM tilt minimum (bonus) | 55% |
+| Max entries per day | 3 |
+| Per-asset cooldown | 360 min (6h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 20% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (mean-reversion — bank the snapback)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 15% |
+| Phase 1 | retrace_threshold | 6 |
+| Time cuts | hard_timeout | **48h** |
+| Time cuts | weak_peak_cut | **120 min / 2%** |
+| Time cuts | dead_weight_cut | disabled |
+| Phase 2 | T0 → T4 | +5/30 · +10/50 · +15/65 · +25/80 · +40/90 |
+
+## Scanner pattern
+
+**Relative-value / pairs** archetype — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data` (1h candles for *both* legs of each pair), `leaderboard_get_markets` (SM on the leg). Pure functions unit-tested in `tests/test_signal.py` (`python3 chameleon/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/chameleon-producer.py | Long-lived daemon; emits CHAMELEON_RATIO_REVERSION signals |
+| scripts/chameleon_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/chameleon-config.json | Operator-tunable defaults (wallet, pairs, z thresholds, sizing) |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Chameleon
+
+```bash
+mkdir -p /data/workspace/skills/chameleon-strategy/{config,scripts,state,references}
+for f in scripts/chameleon-producer.py scripts/chameleon_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/chameleon-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/chameleon/$f" \
+    -o "/data/workspace/skills/chameleon-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/chameleon-strategy/config/chameleon-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export CHAMELEON_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                              # required
+export CHAMELEON_DECISION_MODEL=<your-preferred-model>   # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/chameleon-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/chameleon-strategy/scripts/chameleon-producer.py \
+  > /tmp/chameleon-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 320  # wait one full tick
+tail -3 /tmp/chameleon-producer.log | jq '._chameleon_producer_version, .note // null, .best.zscore // null'
+# Expected: _chameleon_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no ratio extended past z-threshold with reversion starting"` — common (extensions are rare by design)
+- `"signals_pushed": 1, "best": { "coin": ..., "pair": "ETH/BTC", "zscore": ..., "direction": "LONG"|"SHORT" }` — reversion fired
+
+## Changelog
+
+### v1.0.0 (2026-05-22) — initial release
+
+First fleet agent to trade relative value (ratio mean-reversion) rather than a single asset's direction; introduces the relative-value/pairs archetype. Mean-reversion DSL class (tight ladder + time-cuts on), taker-fallback entry, no null numeric signal fields, disown-safe launch, unit-tested signal functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/chameleon/SKILL.md
+++ b/chameleon/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: chameleon-strategy
+description: >-
+  CHAMELEON v1.0.0 — Relative-Value / Pairs (ratio mean-reversion). When the
+  price ratio between two correlated assets extends far from its recent mean
+  (high |z-score|), it tends to revert. Chameleon trades the reversion via a
+  directional bet on the high-beta leg (the runtime is single-position, so
+  not a two-leg spread). Pairs: ETH/BTC (trade ETH), SOL/ETH (trade SOL),
+  SOL/BTC (trade SOL). Mean-reversion DSL — tight "bank the snapback" ladder,
+  48h hard_timeout, weak_peak_cut.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦎 CHAMELEON v1.0.0 — Relative-Value / Pairs (Ratio Mean-Reversion)
+
+**Trade the spread between two coins, not the market.** When ETH gets expensive relative to BTC (or SOL vs ETH), the ratio stretches — and ratios revert far more reliably than outright prices. Chameleon measures how stretched a pair's ratio is (z-score) and bets on the snap-back.
+
+## Why this strategy exists
+
+Correlated majors trade as a pack, but their *ratios* oscillate around a mean. A 3-sigma ETH/BTC extension is a much cleaner edge than guessing ETH's absolute direction — the pair's correlation does the work. This is the first fleet agent to trade **relative value** rather than a single asset's trend, funding, or order flow.
+
+**Single-position note:** a textbook pairs trade is two legs (long one, short the other) for true market-neutrality. The Senpi runtime is single-position, so Chameleon instead takes a **directional bet on the high-beta leg** in the reversion direction. It captures most of the reversion edge without needing spread-level position management.
+
+## CRITICAL RULES
+
+### RULE 1: The z-score is the gate
+For each pair (`numerator/denominator`), Chameleon computes the latest ratio's z-score vs its mean/std over `lookbackBars` 1h candles. Entry requires `|z| >= zEntryMin` (default 2.0). No extension, no trade.
+
+### RULE 2: Which leg, which direction
+It trades the configured **high-beta leg** (the more volatile asset — ETH in ETH/BTC, SOL in SOL/ETH). Direction profits from reversion:
+- **z high** (numerator rich): `leg == numerator → SHORT`; `leg == denominator → LONG`
+- **z low** (numerator cheap): `leg == numerator → LONG`; `leg == denominator → SHORT`
+
+### RULE 3: Reversion must be *starting*
+A bonus, not a gate, but important: the position only scores its "turning" point when `|z|` this bar is smaller than last bar — i.e., the ratio is already snapping back, not still extending. Don't catch a ratio mid-blowout.
+
+### RULE 4: Producer enters. DSL exits.
+No `close_position` call site. A ratio reversion is a **bounded** move, so the DSL is the mean-reversion preset — tight ladder (lock 30% at +5%), 48h `hard_timeout` + `weak_peak_cut`. Bank the snap-back; don't hold for a trend.
+
+## How Chameleon scores a trade
+
+**Gate:** `|z| >= zEntryMin` on at least one pair.
+
+**Score components** (max ~7):
+
+| Signal | Points |
+|---|---|
+| `|z| >= zEntryMin` (gate-confirmed) | +2 |
+| `|z| >= zStrong` (default 3.0) | +2 |
+| Ratio turning (reversion starting) | +1 |
+| Smart Money on the leg confirms the direction (≥ `smTiltMinPct`) | +1 |
+| Leg volume rising (> 10%) | +1 |
+
+**Floor:** `minScore: 4`.
+
+## DSL preset (mean-reversion — bank the snapback)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 15% |
+| Phase 1 | retrace_threshold | 6 |
+| Time cuts | hard_timeout | **48h** |
+| Time cuts | weak_peak_cut | **120 min / 2%** |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +5/30 · +10/50 · +15/65 · +25/80 · +40/90 |
+
+## Scanner pattern
+
+This introduces the **Relative-value / pairs** archetype — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data` (1h candles for *both* legs of each pair), `leaderboard_get_markets` (SM on the leg). The pure functions (`ratio_zscore`, `reversion_direction`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-22) — initial release
+
+First fleet agent to trade relative value (ratio mean-reversion) rather than a single asset's direction. Introduces the relative-value/pairs archetype. Built with the mean-reversion DSL class (tight ladder + time-cuts on), taker-fallback entry (enter at the extreme; maker-only risks CREATE_ORDER_RESTING and a missed reversion window), no null numeric signal fields, and unit-tested pure functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/chameleon/config/chameleon-config.json
+++ b/chameleon/config/chameleon-config.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "CHAMELEON v1.0.0 — Relative-Value / Pairs ratio mean-reversion. For each pair (numerator/denominator, plus the high-beta leg actually traded), computes the latest ratio's z-score vs its mean/std over lookbackBars 1h candles. When |z| >= zEntryMin AND the reversion is starting, trades the leg in the direction that profits as the ratio reverts (z high → numerator rich → SHORT the leg if leg==numerator, LONG if leg==denominator; mirror for z low). Mean-reversion DSL (tight ladder, 48h hard_timeout). Edit wallet/strategyId/chatId; tune pairs/thresholds.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "pairs": [
+    { "numerator": "ETH", "denominator": "BTC", "leg": "ETH" },
+    { "numerator": "SOL", "denominator": "ETH", "leg": "SOL" },
+    { "numerator": "SOL", "denominator": "BTC", "leg": "SOL" }
+  ],
+  "minScore": 4,
+  "lookbackBars": 48,
+  "zEntryMin": 2.0,
+  "zStrong": 3.0,
+  "smTiltMinPct": 55,
+  "marginPct": 0.15,
+  "leverage": 4
+}

--- a/chameleon/references/skill-attribution.md
+++ b/chameleon/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "chameleon",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "chameleon",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/chameleon/runtime.yaml
+++ b/chameleon/runtime.yaml
@@ -1,0 +1,184 @@
+name: chameleon-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Chameleon
+# v1.0.0" and lives in description + SKILL.md + _chameleon_producer_version.
+version: 1.0.0
+description: >
+  CHAMELEON v1.0.0 — Relative-Value / Pairs (ratio mean-reversion).
+
+  When the price ratio between two correlated assets extends far from its
+  recent mean (high |z-score|), it tends to revert. The runtime is
+  single-position, so Chameleon takes a directional bet on the high-beta
+  leg of the pair in the reversion direction (not a two-leg spread).
+  Pairs: ETH/BTC (trade ETH), SOL/ETH (trade SOL), SOL/BTC (trade SOL).
+
+  Architecture (helpers-native): producer ticks every 300s, computes a
+  ratio z-score per pair, emits CHAMELEON_RATIO_REVERSION via
+  SenpiClient.push_signal() when |z| >= zEntryMin and reversion is starting.
+  LLM gate is pass-through.
+
+  DSL: mean-reversion preset — tight "bank the snapback" ladder (lock 30%
+  at +5%), 48h hard_timeout + weak_peak_cut (a reversion resolves quickly
+  or the thesis failed). Phase 1 max_loss 15%.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 200
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 360
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: chameleon_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        pair: { type: string, required: false }
+        zscore: { type: number, required: false }
+        ratio: { type: number, required: false }
+        ratioMean: { type: number, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        legVolumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: chameleon_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${CHAMELEON_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [chameleon_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # enter at the extreme — a maker order that rests (CREATE_ORDER_RESTING) misses the reversion window
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: chameleon_signals
+    decision_prompt: |
+      You are Chameleon's pass-through gate. Chameleon trades a price-RATIO
+      mean-reversion: a pair's ratio (e.g. ETH/BTC) has stretched far from its
+      mean, and the producer takes the high-beta leg in the direction that
+      profits as the ratio snaps back. The producer applied every filter
+      (|z-score| >= zEntryMin, reversion starting, minScore). Honor the signal.
+
+      SIGNAL:
+      {{signal_chameleon_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (preserve case).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 4 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 6 AND |zscore| >= 3
+      - 7-8:  score 5
+      - 7:    score 4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 6 ETH SHORT, ETH/BTC z +3.1 (rich), ratio turning — relative-value reversion')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "CHAMELEON_RATIO_REVERSION ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — mean-reversion preset) ───────────────────────
+#
+# A ratio reversion is a bounded move — bank it. Tight ladder (lock 30% at
+# +5%), 48h hard_timeout + weak_peak_cut (a reversion resolves quickly or
+# the thesis failed). Phase 1 max_loss 15%.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880                   # 48h — reversion resolves or the thesis failed
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 120
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,  lock_hw_pct: 30 }
+        - { trigger_pct: 10, lock_hw_pct: 50 }
+        - { trigger_pct: 15, lock_hw_pct: 65 }
+        - { trigger_pct: 25, lock_hw_pct: 80 }
+        - { trigger_pct: 40, lock_hw_pct: 90 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/chameleon/scripts/chameleon-producer.py
+++ b/chameleon/scripts/chameleon-producer.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+# Senpi CHAMELEON Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""CHAMELEON v1.0.0 — Relative-Value / Pairs (ratio mean-reversion).
+
+When the price RATIO between two correlated assets extends far from its
+recent mean (a high |z-score|), it tends to revert. Chameleon trades that
+reversion — but the Senpi runtime is single-position, so instead of a
+two-leg market-neutral spread it takes a directional bet on the **high-beta
+leg** of the pair, in the direction that profits as the ratio snaps back.
+
+Pairs (config): ETH/BTC (trade ETH), SOL/ETH (trade SOL), SOL/BTC (trade SOL).
+  ratio = numerator/denominator.
+  z high (numerator rich)  → ratio reverts down → SHORT the leg if leg==num,
+                              LONG if leg==den.
+  z low  (numerator cheap) → ratio reverts up   → LONG the leg if leg==num,
+                              SHORT if leg==den.
+
+Mean-reversion class → tight "bank the snapback" DSL + 48h hard_timeout +
+weak_peak_cut (a reversion resolves quickly or the thesis failed). Producer
+NEVER closes — DSL owns exits.
+"""
+
+import hashlib
+import os
+import statistics
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import chameleon_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "chameleon_signals"
+SIGNAL_TYPE = "CHAMELEON_RATIO_REVERSION"
+
+# Each pair: numerator / denominator, and which leg we actually trade (high-beta).
+DEFAULT_PAIRS = [
+    {"numerator": "ETH", "denominator": "BTC", "leg": "ETH"},
+    {"numerator": "SOL", "denominator": "ETH", "leg": "SOL"},
+    {"numerator": "SOL", "denominator": "BTC", "leg": "SOL"},
+]
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 4
+
+DEFAULT_LOOKBACK_BARS = 48          # 1h bars (~2 days) for the ratio mean/std
+DEFAULT_Z_ENTRY_MIN = 2.0           # |z| to consider the ratio extended
+DEFAULT_Z_STRONG = 3.0
+DEFAULT_SM_TILT_MIN = 55
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("CHAMELEON_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure relative-value math (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def ratio_zscore(closes_a, closes_b, lookback):
+    """z-score of the latest A/B ratio vs the mean/stdev of the ratio over
+    the last `lookback` bars. Returns (z, ratio, mean, std) or None if data
+    is insufficient or the ratio has ~no variance."""
+    n = min(len(closes_a), len(closes_b))
+    if n < lookback:
+        return None
+    a = closes_a[-lookback:]
+    b = closes_b[-lookback:]
+    ratios = [x / y for x, y in zip(a, b) if y > 0]
+    if len(ratios) < lookback:
+        return None
+    mean = statistics.fmean(ratios)
+    std = statistics.pstdev(ratios)
+    if std <= 0:
+        return None
+    latest = ratios[-1]
+    return (latest - mean) / std, latest, mean, std
+
+
+def reversion_direction(z, leg, numerator, z_entry_min):
+    """Direction to trade `leg` so the position profits from the ratio
+    (numerator/denominator) reverting toward its mean. None if |z| too small."""
+    if z is None or abs(z) < z_entry_min:
+        return None
+    rich = z > 0   # ratio above mean → numerator expensive vs denominator
+    if leg == numerator:
+        return "SHORT" if rich else "LONG"
+    return "LONG" if rich else "SHORT"   # leg == denominator
+
+
+def volume_trend(candles, lookback=6):
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_candles(asset):
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return []
+    return data.get("data", {}).get("candles", {}).get("1h", [])
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — one pair
+# ═══════════════════════════════════════════════════════════════
+
+def build_pair_thesis(pair, closes_by_asset, candles_by_asset, entry_cfg):
+    num, den, leg = pair["numerator"], pair["denominator"], pair["leg"]
+    ca, cb = closes_by_asset.get(num), closes_by_asset.get(den)
+    if not ca or not cb:
+        return None
+    lookback = int(entry_cfg.get("lookbackBars", DEFAULT_LOOKBACK_BARS))
+    z_min = float(entry_cfg.get("zEntryMin", DEFAULT_Z_ENTRY_MIN))
+    z_strong = float(entry_cfg.get("zStrong", DEFAULT_Z_STRONG))
+
+    zr = ratio_zscore(ca, cb, lookback)
+    if zr is None:
+        return None
+    z, ratio, mean, std = zr
+    direction = reversion_direction(z, leg, num, z_min)
+    if direction is None:
+        return None
+
+    # Reversion must be starting, not still extending: |z| one bar ago > |z| now.
+    zr_prev = ratio_zscore(ca[:-1], cb[:-1], lookback)
+    turning = bool(zr_prev and abs(z) < abs(zr_prev[0]))
+
+    sm_dir, sm_tilt = fetch_sm_direction(leg)
+    sm_min = float(entry_cfg.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    leg_vol = volume_trend(candles_by_asset.get(leg, []))
+
+    score = 0
+    reasons = [f"{num}/{den}_z_{z:+.2f}"]
+    score += 2  # |z| >= z_min gate-confirmed
+    if abs(z) >= z_strong:
+        score += 2
+        reasons.append(f"z_extreme_{z:+.2f}")
+    if turning:
+        score += 1
+        reasons.append("ratio_turning")
+    if sm_dir == direction and sm_tilt >= sm_min:
+        score += 1
+        reasons.append(f"sm_confirms_{sm_tilt:.0f}%")
+    if leg_vol > 10:
+        score += 1
+        reasons.append(f"vol_rising_{leg_vol:+.0f}%")
+
+    return {
+        "coin": leg,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "pair": f"{num}/{den}",
+        "zscore": round(z, 3),
+        "ratio": round(ratio, 6),
+        "ratio_mean": round(mean, 6),
+        "turning": turning,
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": sm_tilt,
+        "leg_volume_trend_pct": round(leg_vol, 2),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "pair": thesis["pair"],
+        "zscore": thesis.get("zscore") or 0.0,
+        "ratio": thesis.get("ratio") or 0.0,
+        "ratioMean": thesis.get("ratio_mean") or 0.0,
+        "smDirection": thesis.get("sm_direction") or "NONE",
+        "smTiltPct": thesis.get("sm_tilt_pct") or 0.0,
+        "legVolumeTrendPct": thesis.get("leg_volume_trend_pct") or 0.0,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 7.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — scan all pairs, pick the most-extended reversion
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    pairs = config.get("pairs", DEFAULT_PAIRS)
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_chameleon_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_chameleon_producer_version": VERSION})
+        return
+
+    # Fetch 1h candles once per unique asset across all pairs.
+    assets = sorted({a for p in pairs for a in (p["numerator"], p["denominator"], p["leg"])})
+    candles_by_asset = {a: fetch_candles(a) for a in assets}
+    closes_by_asset = {
+        a: [_f(c, "close", "c") for c in candles_by_asset.get(a, [])]
+        for a in assets
+    }
+
+    candidates = []
+    for pair in pairs:
+        leg = pair["leg"].upper()
+        if leg in held_set or cfg.was_recently_signaled(leg):
+            continue
+        thesis = build_pair_thesis(pair, closes_by_asset, candles_by_asset, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no ratio extended past z-threshold with reversion starting",
+            "pairs": [f"{p['numerator']}/{p['denominator']}" for p in pairs],
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_chameleon_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "pair": best["pair"],
+            "zscore": best["zscore"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_chameleon_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"chameleon-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/chameleon/scripts/chameleon_config.py
+++ b/chameleon/scripts/chameleon_config.py
@@ -1,0 +1,215 @@
+"""CHAMELEON v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Relative-Value / Pairs (ratio mean-reversion). When the price RATIO between
+two correlated assets (ETH/BTC, SOL/ETH, SOL/BTC) extends far from its mean
+(z-score), Chameleon bets on reversion — trading the single high-beta leg in
+the direction that profits as the ratio snaps back. The runtime is
+single-position, so this is a directional relative-value bet, not a two-leg
+market-neutral spread.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+mean-reversion DSL (tight ladder, banks the snapback, 48h hard_timeout).
+Mirrors the Wolverine v6.0.0 / Bison v3.0.1 pattern (race-window dedup,
+atomic write, simplified producer_daemon).
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "chameleon-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "chameleon-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Chameleon ticks every 300s; ALO fills typically
+# settle within 30-60s. 240s covers the full fill window plus next-tick
+# clearinghouseState refresh, so the on-chain held-asset check picks up
+# where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Chameleon's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("chameleon_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient
+    failures recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] chameleon_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[chameleon-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/chameleon/tests/test_signal.py
+++ b/chameleon/tests/test_signal.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Unit tests for Chameleon's pure functions (ratio_zscore,
+reversion_direction). Stubs chameleon_config + senpi_runtime_helpers so the
+producer loads without the helpers package or a runtime workspace.
+Run: python3 chameleon/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("chameleon_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["chameleon_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "chameleon-producer.py"
+_spec = importlib.util.spec_from_file_location("chameleon_producer", _path)
+cp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cp)
+
+
+def test_ratio_zscore_known_value():
+    # ratios = [2,2,2,2,4] → mean 2.4, pstdev 0.8, latest 4 → z = 2.0
+    a = [2, 2, 2, 2, 4]
+    b = [1, 1, 1, 1, 1]
+    z, ratio, mean, std = cp.ratio_zscore(a, b, 5)
+    assert abs(z - 2.0) < 1e-9
+    assert abs(mean - 2.4) < 1e-9 and abs(std - 0.8) < 1e-9 and ratio == 4.0
+
+
+def test_ratio_zscore_flat_returns_none():
+    assert cp.ratio_zscore([3, 3, 3, 3], [1, 1, 1, 1], 4) is None  # std == 0
+
+
+def test_ratio_zscore_insufficient_returns_none():
+    assert cp.ratio_zscore([2, 2], [1, 1], 5) is None
+
+
+def test_reversion_direction_leg_is_numerator():
+    # rich (z>0): numerator expensive → SHORT the numerator leg; cheap → LONG
+    assert cp.reversion_direction(2.0, "ETH", "ETH", 2.0) == "SHORT"
+    assert cp.reversion_direction(-2.0, "ETH", "ETH", 2.0) == "LONG"
+
+
+def test_reversion_direction_leg_is_denominator():
+    # rich (z>0): denominator cheap → LONG the denominator leg; cheap → SHORT
+    assert cp.reversion_direction(2.0, "BTC", "ETH", 2.0) == "LONG"
+    assert cp.reversion_direction(-2.0, "BTC", "ETH", 2.0) == "SHORT"
+
+
+def test_reversion_direction_below_threshold_and_none():
+    assert cp.reversion_direction(1.0, "ETH", "ETH", 2.0) is None
+    assert cp.reversion_direction(None, "ETH", "ETH", 2.0) is None
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -712,6 +712,30 @@ bid_depth, ask_depth = sum(l["sz"] for l in levels[0]), sum(l["sz"] for l in lev
 
 ---
 
+### 13. Relative-value / pairs
+
+The first archetype to trade **relative value** instead of a single asset's direction. It measures how stretched a price *ratio* between two correlated assets is (z-score over a lookback) and bets on reversion — ratios mean-revert far more reliably than outright prices.
+
+```python
+# Per pair (numerator/denominator, plus the high-beta leg actually traded):
+ca = closes("ETH"); cb = closes("BTC")                 # 1h candles for BOTH legs
+z, ratio, mean, std = ratio_zscore(ca, cb, lookback=48)  # z of latest ratio vs its window
+# z high (numerator rich)  → ratio reverts down → SHORT leg if leg==numerator, LONG if leg==denominator
+# z low  (numerator cheap) → mirror.  Enter when |z| >= ~2 AND reversion is starting (|z| shrinking vs last bar).
+```
+
+**Single-position note:** a textbook pairs trade is two legs (long A / short B) for market-neutrality. The Senpi runtime is single-position, so this archetype takes the **directional high-beta leg** in the reversion direction — capturing most of the edge without spread-level position management.
+
+**When to use this pattern:** you believe two assets are tethered (BTC/ETH/SOL) and want to trade the *spread* reverting rather than guess absolute direction. Mean-reversion play → tight "bank the snapback" DSL + time-cuts ON (a reversion resolves fast or the thesis failed).
+
+**Agents in this family:**
+
+| Agent | Version | Asset / Universe | Description | Tags |
+|---|---|---|---|---|
+| **Chameleon** | v1.0 | ETH/BTC, SOL/ETH, SOL/BTC | Ratio mean-reversion — trades the high-beta leg when a pair's ratio z-score extends past ~2σ and starts reverting. Mean-reversion DSL. | Ratio z-score, Pairs, Mean-reversion |
+
+---
+
 ## Decision tree — help a user pick their first strategy
 
 This is the guided path an **onboarding agent** walks a new user through. Start broad ("what kind of trader do you want your agent to be?"), narrow **one layer at a time**, and land on a single deployable strategy. Ask one question, show 2–6 options, let them pick, then go deeper. Each leaf names a **real, installable agent** — beginners are routed to the **onboarding tier** (simpler scoring, conservative sizing); the *level up* line is the full-fleet version for once they're comfortable.
@@ -839,7 +863,8 @@ XYZ markets (stocks / commodities / pre-IPO) trade **24/7 on Hyperliquid**, even
 
 - **BTC-led laggard rotation** (an alt that hasn't caught up to a BTC move yet) → **Mantis** (cross-asset lag).
 - **Volume / market-making** (not a directional bet) → **Turbine** (specialized).
-- *Expanding set — relative-value pairs and copy-the-copiers are being added. (Microstructure is already live — Piranha (forced flow) and Marlin (order-book imbalance) under Layer 2E.)*
+- **Trade the spread between two coins** (a pair's ratio stretched far from its mean) → **Chameleon** (relative-value / pairs — ratio mean-reversion).
+- *Expanding set — copy-the-copiers is being added. Already live: microstructure (Piranha, Marlin — Layer 2E) and relative-value / pairs (Chameleon).*
 
 ### Run a current top performer (by live ROE)
 
@@ -964,6 +989,7 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | **Egret** | 8 — Contrarian crowding-unwind (SM-divergence fader) | BTC/ETH/SOL/HYPE. Fades extreme SM crowding (≥70%) that price won't confirm. Tight DSL + maker-only entry + time-cuts on |
 | **Piranha** | 12 — Microstructure / order-flow | BTC/ETH/SOL/HYPE. Rides forced flow — OI unwinding fast + violent move + thin book ⇒ liquidation cascade. Wide DSL + 24h hard_timeout |
 | **Marlin** | 12 — Microstructure / order-flow | BTC/ETH/SOL/HYPE. Order-book imbalance (bid/ask depth skew) as entry-timing on a momentum thesis — not a scalper. Wide DSL + 24h hard_timeout |
+| **Chameleon** | 13 — Relative-value / pairs | ETH/BTC · SOL/ETH · SOL/BTC. Ratio mean-reversion — trades the high-beta leg when a pair's z-score extends ~2σ and starts reverting. Mean-reversion DSL |
 
 Sentinel runs an in-house producer that is not currently published to this repo; no public URL.
 


### PR DESCRIPTION
New strategy + **full pipeline** + **new archetype #13**.

## Chameleon
First fleet agent to trade **relative value** instead of a single asset's direction. Measures how far a pair's price ratio (ETH/BTC, SOL/ETH, SOL/BTC) has stretched from its mean (z-score over 48× 1h bars) and bets on the snap-back. **Single-position note:** a textbook pairs trade is two legs; the runtime is single-position, so Chameleon takes the **directional high-beta leg** in the reversion direction — most of the edge without spread management.

Mean-reversion class → tight "bank the snapback" DSL + 48h hard_timeout + weak_peak_cut. Taker-fallback entry (enter at the extreme; maker-only risks missing the reversion window).

## TDD
`tests/test_signal.py` — `ratio_zscore` (hand-computed z=2.0 case) + `reversion_direction` (all 4 leg/direction combinations) → **6/6 pass**.

## Every step
- **Skill** — 8 files (incl. `tests/`); validated YAML/JSON/compile + field-parity + 6/6 logic tests.
- **producer-patterns.md** — new archetype **#13 Relative-value / pairs** + roster.
- **Decision tree** — Layer 2F ("trade the spread between two coins") + updated expanding-set note.
- **catalog.json** — entry (`relative-value-pairs` group, $500 min).

Progress: **5 of 10** in main (Badger, Egret, Piranha, Marlin, Chameleon). Remaining: Falcon, Osprey, Remora, Cuckoo, Meerkat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)