### PR TITLE
Add Falcon v1.0.0 — conversion-event momentum (XYZ Pre-IPO → equity)

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "1.0",
-  "_updated": "2026-05-22",
+  "_updated": "2026-05-26",
   "_instructions": "Agent reads this file to build the onboarding skill catalog. Group by 'group', sort within group by 'sort_order'. Infrastructure skills (DSL, fee optimizer, scanners) are never displayed.",
   "groups": [
     {
@@ -373,6 +373,21 @@
       "base_skill": null,
       "branch": "main",
       "predators_url": "https://strategies.senpi.ai/bot/lemur",
+      "version": "1.0.0"
+    },
+    {
+      "id": "falcon",
+      "tracker_slug": "falcon",
+      "name": "Falcon \u2014 Conversion-Event Momentum (Pre-IPO \u2192 Equity)",
+      "emoji": "\ud83e\udd85",
+      "tagline": "Trades the moment a pre-IPO name goes public. Detects the IPOP\u2192equity conversion (funding jumps ~100x, throttle off) and rides the post-conversion price-discovery momentum.",
+      "group": "xyz-specialist",
+      "sort_order": 21,
+      "min_budget": 500,
+      "risk_level": "aggressive",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/falcon",
       "version": "1.0.0"
     },
     {

--- a/falcon/README.md
+++ b/falcon/README.md
@@ -1,0 +1,134 @@
+# 🦅 Falcon — Conversion-Event Momentum (XYZ Pre-IPO → Equity)
+
+Trades the **moment a pre-IPO name goes public.** When a Pre-IPO Perpetual (IPOP) converts to a standard equity perp, the funding rate jumps ~100x, the leverage cap lifts, and the trade.xyz Discovery-Bounds price throttle is removed — opening free price discovery. Falcon detects that exact transition and rides the post-conversion momentum.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+A pre-IPO perp is deliberately dampened — Discovery Bounds throttle how fast it can move. Conversion removes those guardrails all at once, and the first hours-to-days are pure price discovery as a real spot reference arrives and leverage opens up. That regime change is the edge, and it is detectable from the instrument's funding signature. **Distinct from Lemur:** Lemur trades the IPOP basket *while it is still an IPOP*; Falcon sits out the pre-listing phase and only fires *around the conversion*.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Universe | All `xyz:` instruments (auto-classified IPOP vs STANDARD) |
+| Tick interval | 600s (10 min) — conversions are rare; a window lasts days |
+| IPOP signature | `\|funding\| <= 1e-7` AND `max_leverage <= 5` |
+| Conversion window | 72h after the IPOP→STANDARD flip |
+| Momentum lookback | 6 × 1h bars |
+| Min momentum | 3% (strong 8%) |
+| MIN_SCORE (producer) | 5 (out of ~8 max) |
+| LLM min_confidence | 7 |
+| Leverage | 4x default, max 10x (auto-capped to the instrument) |
+| Margin per trade | 15% of equity |
+| SM tilt minimum (bonus) | 55% (strong 70%) |
+| Max entries per day | 2 |
+| Per-asset cooldown | 720 min (12h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 25% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (let-winners-run — ride the discovery)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 20% |
+| Phase 1 | retrace_threshold | 12 |
+| Time cuts | hard_timeout | **7d** |
+| Time cuts | weak_peak_cut | disabled |
+| Time cuts | dead_weight_cut | disabled |
+| Phase 2 | T0 → T4 | +10/0 · +20/40 · +35/60 · +60/75 · +100/85 |
+
+## Scanner pattern
+
+Extends the **Single-asset XYZ specialist** archetype with an event-detection layer — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_list_instruments(dex="xyz")` (classify + detect flips every tick — the producer signature), `market_get_asset_data` (1h candles for momentum/volume), `leaderboard_get_markets` (SM). Carries a class-state cache + a conversion-window cache (Badger/Piranha pattern). Pure functions unit-tested in `tests/test_signal.py` (`python3 falcon/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/falcon-producer.py | Long-lived daemon; emits FALCON_CONVERSION_MOMENTUM signals |
+| scripts/falcon_config.py | SDK probe + SenpiClient wrapper + recent-signals / class-state / conversion caches |
+| config/falcon-config.json | Operator-tunable defaults (wallet, signature thresholds, window, sizing) |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Falcon
+
+```bash
+mkdir -p /data/workspace/skills/falcon-strategy/{config,scripts,state,references}
+for f in scripts/falcon-producer.py scripts/falcon_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/falcon-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/falcon/$f" \
+    -o "/data/workspace/skills/falcon-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/falcon-strategy/config/falcon-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export FALCON_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                           # required (user-scope; needed for leaderboard_get_markets)
+export FALCON_DECISION_MODEL=<your-preferred-model>   # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/falcon-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/falcon-strategy/scripts/falcon-producer.py \
+  > /tmp/falcon-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 620  # wait one full tick
+tail -3 /tmp/falcon-producer.log | jq '._falcon_producer_version, .note // null, .best.coin // null'
+# Expected: _falcon_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no IPOP→equity conversion inside the eligibility window"` — the common steady state (conversions are rare; the first tick only seeds the class cache)
+- `"note": "WAITING — conversion(s) in window but no confirmed post-conversion momentum"` — a conversion happened, momentum hasn't developed yet
+- `"signals_pushed": 1, "best": { "coin": "xyz:...", "momentum_pct": ..., "direction": "LONG"|"SHORT" }` — a conversion fired
+
+**Note on first run:** Falcon detects flips by comparing each tick against the prior tick. The very first tick only *seeds* the class cache, so it can never report a conversion — that is expected. Detection begins on the second tick onward.
+
+## Changelog
+
+### v1.0.0 (2026-05-26) — initial release
+
+First fleet agent to trade an instrument-lifecycle event (the IPOP→equity conversion) rather than a price/flow signal. Let-winners-run DSL class (wide ladder, time-cuts off except a 7d hard_timeout), taker-true entry, no null numeric signal fields, Badger/Piranha state-cache pattern, disown-safe launch, unit-tested signal functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/falcon/SKILL.md
+++ b/falcon/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: falcon-strategy
+description: >-
+  FALCON v1.0.0 — Conversion-Event Momentum (XYZ Pre-IPO → equity). A Pre-IPO
+  Perpetual (IPOP) carries a structural funding signature (|funding| <= ~1e-7,
+  max_leverage <= 5) and is price-throttled by trade.xyz Discovery Bounds. When
+  the company IPOs the product CONVERTS to a standard equity perp — funding
+  jumps ~100x, the leverage cap lifts, the throttle is removed — opening free
+  price discovery. Falcon detects the IPOP→STANDARD flip and trades the
+  post-conversion momentum. Distinct from Lemur, which trades the IPOP basket
+  while it is still an IPOP. Wide let-winners-run DSL, 7d hard_timeout.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦅 FALCON v1.0.0 — Conversion-Event Momentum (XYZ Pre-IPO → Equity)
+
+**Trade the moment a pre-IPO name goes public.** When a company behind a Pre-IPO Perpetual (IPOP) finally IPOs, trade.xyz converts the product to a standard equity perp. The funding rate jumps ~100x, the leverage cap lifts, and the Discovery-Bounds price throttle is removed — flipping a tightly-pinned pre-listing product into a freely-discovering equity. Falcon catches that exact transition and rides the price-discovery move.
+
+## Why this strategy exists
+
+A pre-IPO perp is *deliberately* dampened — Discovery Bounds throttle how fast it can move, so its price hugs a slow drift. Conversion removes those guardrails all at once. The first hours and days after conversion are pure price discovery: a real spot reference arrives, leverage opens up, and the name often trends hard in one direction. That regime change is the edge, and it is **detectable** from the instrument's funding signature.
+
+**Distinct from Lemur:** Lemur trades the IPOP basket *while it is still an IPOP* (moderate DSL, multi-day directional discovery under Discovery Bounds). Falcon does the opposite — it sits out the pre-listing phase entirely and only fires *around the conversion*, when the throttle comes off.
+
+## CRITICAL RULES
+
+### RULE 1: The conversion flip is the gate
+Each tick Falcon classifies every `xyz:` instrument as **IPOP** (`|funding| <= ipopFundingMaxAbs` AND `max_leverage <= ipopMaxLeverageCap`) or **STANDARD** (funding normalized OR leverage cap lifted). It caches the classification and only acts when a tracked instrument **flips IPOP → STANDARD** since the last tick. A first sighting is never a flip — Falcon needs a known prior class.
+
+### RULE 2: The conversion window
+A detected flip stamps the instrument into a `conversionWindowHours` eligibility window (default 72h). Discovery momentum builds over hours-to-days, so Falcon stays eligible for the whole window — not just the single flip tick. After the window expires, the name is Bobcat's / standard-equity territory.
+
+### RULE 3: Momentum must confirm
+Inside the window, Falcon requires real directional momentum: `|move over momentumLookbackBars 1h bars| >= minMomentumPct` (default 3%). It then trades **in the momentum direction** (ride the discovery, don't fade it). No momentum → no trade, even with a fresh conversion.
+
+### RULE 4: Producer enters. DSL exits.
+No `close_position` call site. A discovery trend can run for days, so the DSL is the **let-winners-run** preset — wide ladder (T0 +10% / lock 0), `max_loss 20%`, time-cuts OFF except a **7d hard_timeout**. No `weak_peak_cut` — it would churn a slow-developing discovery move.
+
+## How Falcon scores a trade
+
+**Gate:** an IPOP→STANDARD flip inside the conversion window **AND** `|momentum| >= minMomentumPct`.
+
+**Score components** (max ~8):
+
+| Signal | Points |
+|---|---|
+| Inside window + momentum >= min (gate-confirmed) | +3 |
+| `|momentum| >= strongMomentumPct` (default 8%) | +2 |
+| Smart Money on the name confirms direction (≥ `smTiltMinPct`) | +1 |
+| SM strongly tilted (≥ `smStrongTiltPct`) | +1 |
+| Volume rising (> 15%) | +1 |
+
+**Floor:** `minScore: 5`. SM is often sparse on a freshly-listed name, so SM is a **bonus, not a gate**.
+
+## DSL preset (let-winners-run — ride the discovery)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 20% |
+| Phase 1 | retrace_threshold | 12 |
+| Time cuts | hard_timeout | **7d** |
+| Time cuts | weak_peak_cut | DISABLED |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +10/0 · +20/40 · +35/60 · +60/75 · +100/85 |
+
+## Scanner pattern
+
+Extends the **Single-asset XYZ specialist** archetype with an event-detection layer — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_list_instruments(dex="xyz")` (classify + detect flips every tick — the producer signature), `market_get_asset_data` (1h candles for momentum/volume), `leaderboard_get_markets` (SM on the name). It carries a class-state cache (`read_class_state`/`write_class_state`) and a conversion-window cache (`record_conversion`/`prune_conversions`), mirroring the Badger/Piranha state-cache pattern. The pure functions (`classify_instrument`, `detect_conversion`, `momentum_pct`, `conversion_direction`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-26) — initial release
+
+First fleet agent to trade an **instrument-lifecycle event** (the IPOP→equity conversion) rather than a price/flow signal. Built with the let-winners-run DSL class (wide ladder, time-cuts off except a 7d hard_timeout), taker-true entry (catch the discovery move; maker-only risks CREATE_ORDER_RESTING and a missed run), no null numeric signal fields, the Badger/Piranha state-cache pattern, and unit-tested pure functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/falcon/config/falcon-config.json
+++ b/falcon/config/falcon-config.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "FALCON v1.0.0 — Conversion-Event Momentum (XYZ Pre-IPO → equity). Each tick classifies every xyz instrument IPOP vs STANDARD by funding signature (|funding| <= ipopFundingMaxAbs AND max_leverage <= ipopMaxLeverageCap = IPOP; otherwise STANDARD), compares against a class cache, and stamps any IPOP→STANDARD flip into a conversionWindowHours eligibility window. Within the window it requires post-conversion price momentum (|move over momentumLookbackBars 1h bars| >= minMomentumPct) and trades in the momentum direction. Wide let-winners-run DSL (7d hard_timeout). Edit wallet/strategyId/chatId; tune thresholds. Distinct from Lemur, which trades the IPOP basket itself.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "ipopFundingMaxAbs": 1e-7,
+  "ipopMaxLeverageCap": 5,
+  "conversionWindowHours": 72,
+  "momentumLookbackBars": 6,
+  "minMomentumPct": 3.0,
+  "strongMomentumPct": 8.0,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "minScore": 5,
+  "marginPct": 0.15,
+  "leverage": 4
+}

--- a/falcon/references/skill-attribution.md
+++ b/falcon/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "falcon",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "falcon",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/falcon/runtime.yaml
+++ b/falcon/runtime.yaml
@@ -1,0 +1,191 @@
+name: falcon-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Falcon v1.0.0"
+# and lives in description + SKILL.md + _falcon_producer_version.
+version: 1.0.0
+description: >
+  FALCON v1.0.0 — Conversion-Event Momentum (XYZ Pre-IPO → equity).
+
+  A Pre-IPO Perpetual (IPOP) carries a structural funding signature
+  (|funding| <= ~1e-7, max_leverage <= 5) and is price-throttled by trade.xyz
+  Discovery Bounds. When the company IPOs the product CONVERTS to a standard
+  equity perp — funding jumps ~100x, the leverage cap lifts, the throttle is
+  removed — opening a window of free price discovery. Falcon detects the
+  IPOP→STANDARD flip and trades the post-conversion momentum.
+
+  Distinct from Lemur, which trades the IPOP basket WHILE it is still an IPOP.
+  Falcon only fires AROUND the conversion.
+
+  Architecture (helpers-native): producer ticks every 600s, classifies every
+  xyz instrument IPOP vs STANDARD, detects flips against a class cache, stamps
+  flips into a conversionWindowHours eligibility window, and emits
+  FALCON_CONVERSION_MOMENTUM via SenpiClient.push_signal() when confirmed
+  momentum develops. LLM gate is pass-through.
+
+  DSL: let-winners-run preset — wide ladder (T0 +10% / lock 0), max_loss 20%,
+  time-cuts OFF except a long hard_timeout (price discovery can trend for
+  days). Phase 1 retrace trailing only.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 200
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 96
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 2
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 120
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 720
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: falcon_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        momentumPct: { type: number, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        conversionEvent: { type: boolean, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: falcon_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${FALCON_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [falcon_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # enter the discovery move — a maker order that rests (CREATE_ORDER_RESTING) misses the post-conversion run
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: falcon_signals
+    decision_prompt: |
+      You are Falcon's pass-through gate. Falcon trades the CONVERSION EVENT of
+      a Hyperliquid XYZ Pre-IPO Perpetual (IPOP): the product just flipped from
+      IPOP to a standard equity perp (funding jumped ~100x, leverage cap lifted,
+      Discovery-Bounds price throttle removed), opening free price discovery. The
+      producer confirmed the flip is inside the eligibility window AND that
+      directional momentum has developed. Honor the signal.
+
+      SIGNAL:
+      {{signal_falcon_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (keep the xyz: prefix and case).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-10x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+      - conversionEvent is not true (Falcon ONLY trades post-conversion)
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 7 AND |momentumPct| >= 8
+      - 7-8:  score 5-6
+      - 7:    score 5 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 xyz:SPCX LONG, IPOP→equity conversion, momentum +11.2%, vol rising — post-conversion discovery')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "FALCON_CONVERSION_MOMENTUM ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — let-winners-run preset) ──────────────────────
+#
+# Post-conversion price discovery can trend for days as a real spot reference
+# arrives and the leverage cap lifts. Let it run: wide ladder (T0 +10% / lock
+# 0), max_loss 20%, time-cuts OFF except a long hard_timeout. Phase 1 retrace
+# trailing only. NO weak_peak_cut / dead_weight_cut — they would churn a
+# slow-developing discovery trend.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10080                  # 7d — a conversion discovery trend can run for days
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 12
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 40 }
+        - { trigger_pct: 35,  lock_hw_pct: 60 }
+        - { trigger_pct: 60,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/falcon/scripts/falcon-producer.py
+++ b/falcon/scripts/falcon-producer.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+# Senpi FALCON Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""FALCON v1.0.0 — Conversion-Event Momentum (XYZ Pre-IPO → equity).
+
+A Pre-IPO Perpetual (IPOP) on Hyperliquid XYZ carries a structural funding
+signature (|funding| <= ~1e-7, 1% multiplier; max_leverage <= 5) and is
+price-throttled by trade.xyz Discovery Bounds. When the underlying company
+IPOs, the product CONVERTS to a standard equity perp: funding jumps ~100x
+(~6.25e-8 → ~6.25e-6), the leverage cap lifts, and the Discovery-Bounds throttle
+is removed — opening a window of free price discovery.
+
+Falcon detects that transition and trades the post-conversion momentum:
+
+  1. Each tick, classify every xyz instrument IPOP vs STANDARD by funding sig.
+  2. Compare against the prior-tick class cache → detect IPOP→STANDARD flips.
+  3. A flip stamps the instrument into a conversionWindowHours eligibility
+     window (so momentum that develops over hours/days is still tradeable).
+  4. Within that window, require confirmed price momentum (and SM agreement)
+     and enter in the momentum direction.
+
+Distinct from Lemur, which trades the IPOP basket WHILE it is still an IPOP.
+Falcon only fires AROUND the conversion. Event/momentum class → WIDE
+"let winners run" DSL (price discovery can trend hard), taker-true entry,
+long hard_timeout. Producer NEVER closes — DSL owns exits.
+
+REQUIRES USER-SCOPE AUTH for leaderboard_get_markets.
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import falcon_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "falcon_signals"
+SIGNAL_TYPE = "FALCON_CONVERSION_MOMENTUM"
+
+MAX_LEVERAGE = 10
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 5
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+
+# IPOP funding signature (same heuristic Lemur uses to FIND IPOPs; Falcon uses
+# it to detect when one STOPS being an IPOP).
+DEFAULT_IPOP_FUNDING_MAX = 1e-7
+DEFAULT_IPOP_LEV_CAP = 5
+
+DEFAULT_MOMENTUM_LOOKBACK = 6       # 1h bars
+DEFAULT_MIN_MOMENTUM_PCT = 3.0      # |move| to call a discovery trend
+DEFAULT_STRONG_MOMENTUM_PCT = 8.0
+DEFAULT_CONVERSION_WINDOW_HOURS = 72   # how long after a flip an instrument stays eligible
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("FALCON_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure conversion/momentum logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def classify_instrument(funding_abs, max_leverage, ipop_funding_max, ipop_lev_cap):
+    """Classify an xyz equity instrument by its funding signature.
+
+    IPOP   = pre-listing product: |funding| <= ipop_funding_max AND
+             max_leverage <= ipop_lev_cap.
+    STANDARD = a normal equity perp: funding has normalized OR the leverage
+               cap has lifted.
+    Returns "IPOP" or "STANDARD"."""
+    try:
+        f = abs(float(funding_abs))
+        lev = int(max_leverage)
+    except (TypeError, ValueError):
+        return "STANDARD"
+    if f <= ipop_funding_max and lev <= ipop_lev_cap:
+        return "IPOP"
+    return "STANDARD"
+
+
+def detect_conversion(prev_class, curr_class):
+    """A conversion event is an IPOP that has become STANDARD since last tick.
+    Requires a known prior class (None prev = first sighting, not a flip)."""
+    return prev_class == "IPOP" and curr_class == "STANDARD"
+
+
+def momentum_pct(closes, lookback):
+    """% change of the latest close vs the close `lookback` bars ago.
+    None if insufficient data or the reference price is non-positive."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def conversion_direction(momentum, min_momentum_pct):
+    """Direction to trade post-conversion price discovery: ride the momentum.
+    None if momentum is missing or below the minimum magnitude."""
+    if momentum is None or abs(momentum) < min_momentum_pct:
+        return None
+    return "LONG" if momentum > 0 else "SHORT"
+
+
+def volume_trend(candles, lookback=6):
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Universe scan + conversion detection
+# ═══════════════════════════════════════════════════════════════
+
+def scan_instruments(config):
+    """Pull the xyz instrument list and classify each. Returns
+    {name: {"class": ..., "max_leverage": int, "funding": float, "vol_usd": float}}."""
+    raw = cfg.mcp_call("market_list_instruments", dex="xyz")
+    if not raw or not raw.get("success", True):
+        return {}
+    data = raw.get("data", raw)
+    instruments = data.get("instruments", data) if isinstance(data, dict) else data
+    if not isinstance(instruments, list):
+        return {}
+
+    ipop_funding_max = float(config.get("ipopFundingMaxAbs", DEFAULT_IPOP_FUNDING_MAX))
+    ipop_lev_cap = int(config.get("ipopMaxLeverageCap", DEFAULT_IPOP_LEV_CAP))
+
+    out = {}
+    for inst in instruments:
+        if not isinstance(inst, dict):
+            continue
+        name = inst.get("name", "")
+        if not name.startswith("xyz:"):
+            continue
+        if inst.get("is_delisted", False):
+            continue
+        ctx = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        funding_abs = abs(float(ctx.get("funding", 0)))
+        max_lev = int(inst.get("max_leverage", 5))
+        out[name] = {
+            "class": classify_instrument(funding_abs, max_lev, ipop_funding_max, ipop_lev_cap),
+            "max_leverage": max_lev,
+            "funding": funding_abs,
+            "vol_usd": float(ctx.get("dayNtlVlm", 0)),
+        }
+    return out
+
+
+def reconcile_conversions(scan, prev_state, config, now):
+    """Compare this scan against the prior class cache, stamp any new
+    IPOP→STANDARD flips into the conversion window, persist the new class
+    cache. Returns the set of instrument names currently inside the window."""
+    window_hours = float(config.get("conversionWindowHours", DEFAULT_CONVERSION_WINDOW_HOURS))
+
+    new_class_state = {}
+    for name, info in scan.items():
+        curr_class = info["class"]
+        prev_class = (prev_state.get(name) or {}).get("class")
+        if detect_conversion(prev_class, curr_class):
+            cfg.record_conversion(name, now)
+        new_class_state[name] = {"class": curr_class, "ts": now}
+
+    cfg.write_class_state(new_class_state)
+    live = cfg.prune_conversions(window_hours)
+    return set(live.keys())
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_candles(asset):
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return []
+    return data.get("data", {}).get("candles", {}).get("1h", [])
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — one freshly-converted instrument
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(name, scan_info, config):
+    candles = fetch_candles(name)
+    if len(candles) < 8:
+        return None
+    closes = [_f(c, "close", "c") for c in candles]
+
+    lookback = int(config.get("momentumLookbackBars", DEFAULT_MOMENTUM_LOOKBACK))
+    min_mom = float(config.get("minMomentumPct", DEFAULT_MIN_MOMENTUM_PCT))
+    strong_mom = float(config.get("strongMomentumPct", DEFAULT_STRONG_MOMENTUM_PCT))
+
+    mom = momentum_pct(closes, lookback)
+    direction = conversion_direction(mom, min_mom)
+    if direction is None:
+        return None
+
+    sm_dir, sm_tilt = fetch_sm_direction(name)
+    sm_min = float(config.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(config.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+    vol_trend = volume_trend(candles)
+
+    score = 0
+    reasons = [f"converted_ipop_to_equity", f"mom_{mom:+.1f}%"]
+    score += 3  # inside conversion window + momentum >= min (gate-confirmed)
+    if abs(mom) >= strong_mom:
+        score += 2
+        reasons.append(f"mom_strong_{mom:+.1f}%")
+    # SM is often sparse on a freshly-listed name — agreement is a bonus, not a gate.
+    if sm_dir == direction and sm_tilt >= sm_min:
+        score += 1
+        reasons.append(f"sm_confirms_{sm_tilt:.0f}%")
+        if sm_tilt >= sm_strong:
+            score += 1
+            reasons.append("sm_strong")
+    if vol_trend > 15:
+        score += 1
+        reasons.append(f"vol_rising_{vol_trend:+.0f}%")
+
+    return {
+        "coin": name,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "momentum_pct": round(mom, 2),
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": sm_tilt,
+        "volume_trend_pct": round(vol_trend, 2),
+        "max_leverage_cap": scan_info.get("max_leverage", MAX_LEVERAGE),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "momentumPct": thesis.get("momentum_pct") or 0.0,
+        "smDirection": thesis.get("sm_direction") or "NONE",
+        "smTiltPct": thesis.get("sm_tilt_pct") or 0.0,
+        "volumeTrendPct": thesis.get("volume_trend_pct") or 0.0,
+        "conversionEvent": True,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 8.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — detect conversions, score momentum, fire the best
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    now = time.time()
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_falcon_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_falcon_producer_version": VERSION})
+        return
+
+    scan = scan_instruments(config)
+    prev_state = cfg.read_class_state()
+    # Always reconcile (persists the class cache + stamps flips) even on the
+    # very first tick — the first tick just seeds the cache with no flips.
+    in_window = reconcile_conversions(scan, prev_state, config, now)
+
+    if not in_window:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no IPOP→equity conversion inside the eligibility window",
+            "tracked_instruments": len(scan),
+            "ipops_now": [n for n, i in scan.items() if i["class"] == "IPOP"],
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_falcon_producer_version": VERSION,
+        })
+        return
+
+    candidates = []
+    for name in sorted(in_window):
+        if name.upper() in held_set or cfg.was_recently_signaled(name):
+            continue
+        info = scan.get(name)
+        if not info:
+            continue  # converted name no longer listed
+        thesis = build_thesis(name, info, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — conversion(s) in window but no confirmed post-conversion momentum",
+            "conversions_in_window": sorted(in_window),
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_falcon_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    config_leverage = int(config.get("leverage", DEFAULT_LEVERAGE))
+    leverage = min(config_leverage, best.get("max_leverage_cap", MAX_LEVERAGE), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "momentum_pct": best["momentum_pct"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "conversions_in_window": sorted(in_window),
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_falcon_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=600,   # 10min — conversions are rare; a window lasts days
+        name=f"falcon-producer-{_wallet_lock_id}",
+        tick_timeout=240,
+    )

--- a/falcon/scripts/falcon_config.py
+++ b/falcon/scripts/falcon_config.py
@@ -1,0 +1,288 @@
+"""FALCON v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Conversion-Event Momentum (XYZ Pre-IPO → equity). Falcon watches Hyperliquid
+XYZ instruments and detects the moment a Pre-IPO Perpetual (IPOP) CONVERTS to a
+standard equity perp — the funding signature jumps ~100x (~6.25e-8 → ~6.25e-6)
+and the trade.xyz Discovery Bounds price throttle lifts. That transition opens a
+window of free price discovery; Falcon trades the post-conversion momentum.
+
+Distinct from Lemur (which trades the pre-IPO basket while it is STILL an IPOP).
+Falcon only fires AROUND the conversion — it requires a tracked IPOP→STANDARD
+class flip (or a freshly-listed standard equity, if enabled) plus confirmed
+momentum, then rides the discovery move with a WIDE "let winners run" DSL.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+momentum DSL (wide ladder, long hard_timeout). Mirrors the Badger/Piranha
+state-cache pattern (instrument-class cache + conversion-window cache) plus the
+fleet-standard race-window dedup, atomic write, simplified producer_daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "falcon-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "falcon-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+CLASS_STATE_PATH = STATE_DIR / "instrument-class.json"
+CONVERSIONS_PATH = STATE_DIR / "conversions.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Falcon ticks every 600s; ALO fills typically settle
+# within 30-60s. 240s covers the full fill window plus the next-tick
+# clearinghouseState refresh, so the on-chain held-asset check picks up where
+# this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Falcon's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("falcon_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient failures
+    recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] falcon_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+# ─── Instrument-class cache (detect IPOP → STANDARD conversion) ──
+#
+# market_list_instruments exposes funding + max_leverage per xyz instrument.
+# Falcon classifies each into IPOP vs STANDARD by the funding signature, then
+# compares against the prior-tick classification to detect the conversion flip.
+# Stores {name: {"class": "IPOP"|"STANDARD", "ts": epoch}}.
+
+def read_class_state():
+    if not CLASS_STATE_PATH.exists():
+        return {}
+    try:
+        with open(CLASS_STATE_PATH) as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def write_class_state(state):
+    try:
+        atomic_write(CLASS_STATE_PATH, state)
+    except OSError:
+        pass
+
+
+# ─── Conversion-window cache (stay eligible after the flip) ──────
+#
+# When Falcon detects an IPOP→STANDARD flip it stamps the instrument here so it
+# stays eligible to trade post-conversion momentum for conversionWindowHours,
+# not just on the single flip tick. Stores {name: detected_epoch}.
+
+def read_conversions():
+    if not CONVERSIONS_PATH.exists():
+        return {}
+    try:
+        with open(CONVERSIONS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def record_conversion(name, now=None):
+    if not name:
+        return
+    now = now if now is not None else time.time()
+    conv = read_conversions()
+    conv[name] = now
+    try:
+        atomic_write(CONVERSIONS_PATH, conv)
+    except OSError:
+        pass
+
+
+def prune_conversions(window_hours):
+    """Drop conversion stamps older than window_hours. Returns the live dict."""
+    cutoff = time.time() - (float(window_hours) * 3600.0)
+    conv = {k: v for k, v in read_conversions().items() if v >= cutoff}
+    try:
+        atomic_write(CONVERSIONS_PATH, conv)
+    except OSError:
+        pass
+    return conv
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[falcon-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/falcon/tests/test_signal.py
+++ b/falcon/tests/test_signal.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Unit tests for Falcon's pure functions (classify_instrument,
+detect_conversion, momentum_pct, conversion_direction). Stubs falcon_config +
+senpi_runtime_helpers so the producer loads without the helpers package or a
+runtime workspace.
+Run: python3 falcon/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("falcon_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.read_class_state = lambda: {}
+_cfg.write_class_state = lambda s: None
+_cfg.read_conversions = lambda: {}
+_cfg.record_conversion = lambda n, t=None: None
+_cfg.prune_conversions = lambda h: {}
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["falcon_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "falcon-producer.py"
+_spec = importlib.util.spec_from_file_location("falcon_producer", _path)
+fp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fp)
+
+IPOP_F = 1e-7
+IPOP_LEV = 5
+
+
+def test_classify_ipop_by_funding_and_leverage():
+    # tiny funding + low leverage cap → IPOP (pre-listing)
+    assert fp.classify_instrument(6.25e-8, 5, IPOP_F, IPOP_LEV) == "IPOP"
+
+
+def test_classify_standard_when_funding_normalizes():
+    # funding jumped ~100x → STANDARD even if leverage cap still 5
+    assert fp.classify_instrument(6.25e-6, 5, IPOP_F, IPOP_LEV) == "STANDARD"
+
+
+def test_classify_standard_when_leverage_lifts():
+    # leverage cap lifted above pre-listing → STANDARD even with tiny funding
+    assert fp.classify_instrument(6.25e-8, 10, IPOP_F, IPOP_LEV) == "STANDARD"
+
+
+def test_classify_bad_input_defaults_standard():
+    assert fp.classify_instrument(None, 5, IPOP_F, IPOP_LEV) == "STANDARD"
+
+
+def test_detect_conversion_only_on_ipop_to_standard():
+    assert fp.detect_conversion("IPOP", "STANDARD") is True
+    assert fp.detect_conversion("STANDARD", "STANDARD") is False
+    assert fp.detect_conversion("IPOP", "IPOP") is False
+    assert fp.detect_conversion(None, "STANDARD") is False  # first sighting, not a flip
+
+
+def test_momentum_pct_known_value():
+    # close 6 bars ago = 100, latest = 112 → +12%
+    closes = [100, 101, 102, 103, 104, 105, 112]
+    assert abs(fp.momentum_pct(closes, 6) - 12.0) < 1e-9
+
+
+def test_momentum_pct_insufficient_and_bad_ref():
+    assert fp.momentum_pct([100, 101], 6) is None
+    assert fp.momentum_pct([0, 1, 2, 3, 4, 5, 6], 6) is None  # ref <= 0
+
+
+def test_conversion_direction_rides_momentum():
+    assert fp.conversion_direction(12.0, 3.0) == "LONG"
+    assert fp.conversion_direction(-12.0, 3.0) == "SHORT"
+
+
+def test_conversion_direction_below_threshold_and_none():
+    assert fp.conversion_direction(1.5, 3.0) is None
+    assert fp.conversion_direction(None, 3.0) is None
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -254,6 +254,7 @@ cfg._wrapper_client.push_signal(
 |---|---|---|---|---|
 | **Dire** | v1.0 | xyz:BRENTOIL | BRENTOIL specialist. Adapted Kodiak framework with XYZ-tuned thresholds and wider phase-1 loss tolerances. Commodity-specific drawdown guardrails. | BRENTOIL, Wide DSL, XYZ |
 | **Lemur** | v1.0 | xyz:IPOPs (auto-discovered) | **Onboarding tier.** Auto-detects Pre-IPO Perpetuals (IPOPs) via the trade.xyz funding signature: `\|funding\| ≤ 1e-7 AND max_leverage ≤ 5` (1% funding multiplier vs 0.5 standard). Today: `xyz:SPCX`. Auto-expands when ANTHROPIC / OPENAI / STRIPE list. 24/7 trading, moderate DSL. Tick 900s (Discovery Bounds throttle moves). | Onboarding, IPOP, Auto-discover, Tick 900s, 24/7 |
+| **Falcon** | v1.0 | xyz: conversion events | **Event-detection layer.** Trades the IPOP→equity **conversion** itself, not the pre-listing basket. Classifies every xyz instrument IPOP vs STANDARD by funding signature, caches it, and fires when one **flips** (funding jumps ~100x, leverage cap lifts, Discovery Bounds throttle removed → free price discovery). Requires post-conversion momentum; rides it with a **wide let-winners-run DSL** (7d hard_timeout). Carries a class-state + conversion-window cache (Badger/Piranha pattern). Tick 600s. | IPOP, Conversion-event, Momentum, Wide DSL, State-cache |
 
 ---
 
@@ -789,7 +790,7 @@ Most first-time users can't say "I want a trend-follower" — they don't have th
 | **VIOLENT** move + OI unwinding fast (Hyperfeed lit up) | Microstructure → **Piranha** (*only if risk = "go big"*) |
 | Hyperfeed shows a **fresh rank-jump / breakout** | 🟢 **Hawk** (breakout) or **Jaguar** (rank-jump) |
 | User would rather **copy winners** / has no asset view | 🟢 **Albatross** (multi-week arena winners) |
-| Interest in **stocks / commodities** | 🟢 **Bobcat** (big-tech) · **Dire** (oil) · **Lemur** (pre-IPO) |
+| Interest in **stocks / commodities** | 🟢 **Bobcat** (big-tech) · **Dire** (oil) · **Lemur** (pre-IPO) · **Falcon** (the IPO moment) |
 | Nothing clean (chop + weak signals) | Default → **Hedgehog** basket, `balanced`, conservative sizing — or honestly say *"nothing's set up cleanly right now; want to start small and watch, or wait?"* |
 
 *Step 4 — size & advise (don't gate):* `min_budget` is a **guideline, not a gate — never refuse to deploy over it.** If the account is below a candidate's `min_budget`, still offer it, but flag it plainly (*"you're under the ~$X suggested floor, so positions will be small and have less room — you can start tiny now or fund more"*) and let the user decide. Never dead-end a willing user; offer to start small or watch first instead of saying "no." Set margin % + leverage + DSL preset from the risk answer (cautious → ~15% / 3x / `balanced`; aggressive → ~25% / 5x / `let_winners_run`). Whatever the size, tell them to **fund only what they can afford to lose.**
@@ -846,6 +847,7 @@ Ask which one sentence sounds most like the user:
 XYZ markets (stocks / commodities / pre-IPO) trade **24/7 on Hyperliquid**, even when TradFi is closed.
 
 - 🔥 **Pre-IPO names (IPOPs — SpaceX, etc.)** → 🟢 **Lemur** — trades pre-IPO perpetuals *before the company lists*; auto-discovers new IPOPs by their funding signature (today: SPCX/SpaceX; auto-expands as trade.xyz lists names like ANTHROPIC, OPENAI, STRIPE). One of Senpi's most distinctive capabilities.
+- 🔥 **The IPO moment itself (when a pre-IPO name goes public)** → **Falcon** — sits out the pre-listing phase and fires only *around the conversion*, when an IPOP flips to a standard equity perp (funding jumps ~100x, leverage cap lifts, the price throttle comes off → free price discovery). Rides the post-conversion momentum with a wide let-winners-run DSL. Pairs naturally with Lemur (Lemur holds the IPOP; Falcon trades its graduation).
 - **Big-tech stocks (XYZ equities)** → 🟢 **Bobcat** (NVDA/TSLA/AAPL/META/MSFT/GOOGL/…).
 - **Oil / metals / indices (XYZ)** → **Dire** (BRENTOIL) as the template — tune the asset string.
 - **Weekend stock-gap reconciliation** → 🟢 **Raccoon** (weekend-only XYZ snap-back, captures the Mon-open move).
@@ -990,6 +992,7 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | **Piranha** | 12 — Microstructure / order-flow | BTC/ETH/SOL/HYPE. Rides forced flow — OI unwinding fast + violent move + thin book ⇒ liquidation cascade. Wide DSL + 24h hard_timeout |
 | **Marlin** | 12 — Microstructure / order-flow | BTC/ETH/SOL/HYPE. Order-book imbalance (bid/ask depth skew) as entry-timing on a momentum thesis — not a scalper. Wide DSL + 24h hard_timeout |
 | **Chameleon** | 13 — Relative-value / pairs | ETH/BTC · SOL/ETH · SOL/BTC. Ratio mean-reversion — trades the high-beta leg when a pair's z-score extends ~2σ and starts reverting. Mean-reversion DSL |
+| **Falcon** | 3 — Single-asset XYZ specialist (event-detection layer) | xyz: conversion events. Detects the IPOP→equity flip (funding jumps ~100x, leverage cap lifts, throttle off) and rides post-conversion price-discovery momentum. Class-state + conversion-window cache. Wide let-winners-run DSL, 7d hard_timeout |
 
 Sentinel runs an in-house producer that is not currently published to this repo; no public URL.
 


### PR DESCRIPTION
## Summary
- **Falcon** (#6 of the 10-agent build) — first fleet agent to trade an **instrument-lifecycle event** rather than a price/flow signal.
- Classifies every `xyz:` instrument IPOP vs STANDARD by funding signature, caches the class, and fires when one **flips IPOP→STANDARD** (the IPO conversion: funding jumps ~100x, leverage cap lifts, Discovery-Bounds throttle removed → free price discovery). Stamps the flip into a 72h conversion-window and rides post-conversion momentum.
- **Distinct from Lemur** (which trades the IPOP basket *while still pre-IPO*); Falcon only fires *around the conversion*. Extends archetype #3 (Single-asset XYZ specialist) with an event-detection layer, reusing the Badger/Piranha state-cache pattern.
- DSL: **let-winners-run** preset (wide ladder, max_loss 20%, time-cuts off except a 7d hard_timeout). Taker-true entry; no null numeric signal fields; disown-safe launch.
- Integrated into `producer-patterns.md` (archetype #3 roster, Layer 2D pre-IPO bullet, fleet roster mapping) and `catalog.json` (xyz-specialist group, $500 min).

## Test plan
- [x] `python3 -m py_compile` producer + config — OK
- [x] `python3 falcon/tests/test_signal.py` — 9/9 pass (classify_instrument, detect_conversion, momentum_pct, conversion_direction)
- [x] runtime.yaml parses (yaml.safe_load) + config.json parses
- [x] field-parity: data_block keys ⊆ scanner `fields` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)