### PR TITLE
Add Osprey v1.0.0 — cross-venue lag (crypto leader → XYZ equity proxy)

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -406,6 +406,21 @@
       "version": "6.0.0"
     },
     {
+      "id": "osprey",
+      "tracker_slug": "osprey",
+      "name": "Osprey \u2014 Cross-Venue Lag (Crypto \u2192 XYZ Equity)",
+      "emoji": "\ud83e\udd85",
+      "tagline": "When BTC moves, the crypto stocks (Coinbase, MicroStrategy, miners) lag on XYZ. Osprey measures each proxy's catch-up gap and trades it in the leader's direction.",
+      "group": "cross-asset-lag",
+      "sort_order": 2,
+      "min_budget": 500,
+      "risk_level": "aggressive",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/osprey",
+      "version": "1.0.0"
+    },
+    {
       "id": "marlin",
       "tracker_slug": "marlin",
       "name": "Marlin \u2014 Order-Book Imbalance Momentum",

--- a/osprey/README.md
+++ b/osprey/README.md
@@ -1,0 +1,134 @@
+# 🐟🦅 Osprey — Cross-Venue Lag (Crypto Leader → XYZ Equity Proxy)
+
+When **BTC moves and the crypto stocks haven't caught up yet.** Coinbase (COIN), MicroStrategy (MSTR) and miners trade on Hyperliquid XYZ, priced on a different venue from spot crypto — so a sharp BTC move shows up in those equities late. Osprey measures *how far behind* each proxy is (its catch-up gap) and bets it closes the gap.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+A crypto-correlated equity has a known beta to BTC (COIN ≈ 1.8×, MSTR ≈ 2.5×). When BTC jumps, the expected proxy move is `BTC move × beta`; XYZ pricing can trail spot crypto, so the actual proxy move lags. That difference is a measurable gap. **Distinct from Mantis:** Mantis trades crypto→crypto laggards from `market_get_cross_asset_flows`; Osprey trades the cross-**VENUE** crypto→XYZ-equity lag and self-computes the gap from candles.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Leader | BTC (configurable) |
+| Proxies | `xyz:COIN` (β 1.8) · `xyz:MSTR` (β 2.5) — operator-tunable |
+| Tick interval | 300s (5 min) |
+| Move lookback | 4 × 1h bars |
+| Min leader move | 2% |
+| Min catch-up gap | 2% (strong 5%) |
+| MIN_SCORE (producer) | 4 (out of ~7 max) |
+| LLM min_confidence | 7 |
+| Leverage | 4x default, max 10x |
+| Margin per trade | 15% of equity |
+| SM tilt minimum (bonus) | 55% (strong 70%) |
+| Max entries per day | 3 |
+| Per-asset cooldown | 360 min (6h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 22% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (let-winners-run — ride the catch-up)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 18% |
+| Phase 1 | retrace_threshold | 10 |
+| Time cuts | hard_timeout | **96h** |
+| Time cuts | weak_peak_cut | disabled |
+| Time cuts | dead_weight_cut | disabled |
+| Phase 2 | T0 → T4 | +10/0 · +20/45 · +35/65 · +55/78 · +90/88 |
+
+## Scanner pattern
+
+Extends the **Cross-asset lag detector** archetype (#9, Mantis) across venues — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data` (1h candles for the leader **and** each proxy), `leaderboard_get_markets` (SM). Stateless gap math. Pure functions unit-tested in `tests/test_signal.py` (`python3 osprey/tests/test_signal.py`).
+
+**Tuning:** the proxy list + betas live in `config/osprey-config.json`. Add/remove crypto-proxy XYZ equities as trade.xyz lists them, and calibrate each beta to its sensitivity to the leader. A proxy that returns no candles is skipped gracefully.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/osprey-producer.py | Long-lived daemon; emits OSPREY_CROSS_VENUE_LAG signals |
+| scripts/osprey_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/osprey-config.json | Operator-tunable defaults (leader, proxies, betas, thresholds, sizing) |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Osprey
+
+```bash
+mkdir -p /data/workspace/skills/osprey-strategy/{config,scripts,state,references}
+for f in scripts/osprey-producer.py scripts/osprey_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/osprey-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/osprey/$f" \
+    -o "/data/workspace/skills/osprey-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/osprey-strategy/config/osprey-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export OSPREY_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                           # required (user-scope; needed for leaderboard_get_markets)
+export OSPREY_DECISION_MODEL=<your-preferred-model>   # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/osprey-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/osprey-strategy/scripts/osprey-producer.py \
+  > /tmp/osprey-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 320  # wait one full tick
+tail -3 /tmp/osprey-producer.log | jq '._osprey_producer_version, .note // null, .best.gap_pct // null'
+# Expected: _osprey_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — leader BTC move ... below 2% threshold"` — common (the leader is quiet)
+- `"note": "WAITING — BTC moved +X% but no proxy still owes a catch-up gap"` — proxies already tracked
+- `"signals_pushed": 1, "best": { "coin": "xyz:COIN", "gap_pct": ..., "direction": "LONG"|"SHORT" }` — a lag fired
+
+## Changelog
+
+### v1.0.0 (2026-05-26) — initial release
+
+First fleet agent to trade a cross-VENUE lag (crypto spot → XYZ equity), extending Mantis's cross-asset-lag archetype. Let-winners-run DSL class (wide ladder, time-cuts off except a 96h hard_timeout), taker-true entry, no null numeric signal fields, self-computed catch-up gap (no dependence on cross_asset_flows), disown-safe launch, unit-tested signal functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/osprey/SKILL.md
+++ b/osprey/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: osprey-strategy
+description: >-
+  OSPREY v1.0.0 — Cross-Venue Lag (crypto leader → XYZ equity proxy). When a
+  crypto leader (BTC) makes a strong move, crypto-correlated equities priced on
+  Hyperliquid XYZ (Coinbase, MicroStrategy, miners) tend to follow — but on a
+  different venue, with a lag. Osprey measures each proxy's catch-up gap
+  (leader move × beta − the proxy's actual move) and trades the proxy in the
+  leader's direction when it still owes a gap. Distinct from Mantis (crypto→
+  crypto lag from cross_asset_flows); Osprey trades the cross-VENUE crypto→
+  XYZ-equity lag and self-computes the gap from candles. Let-winners-run DSL.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐟🦅 OSPREY v1.0.0 — Cross-Venue Lag (Crypto Leader → XYZ Equity Proxy)
+
+**When BTC moves, the crypto stocks haven't caught up yet.** Coinbase, MicroStrategy and the miners trade on Hyperliquid XYZ, priced on a different venue from spot crypto — so a sharp BTC move shows up in those equities late. Osprey measures *how far behind* each proxy is and bets it closes the gap.
+
+## Why this strategy exists
+
+A crypto-correlated equity has a known beta to BTC (COIN ≈ 1.8×, MSTR ≈ 2.5×). When BTC jumps, the *expected* proxy move is `BTC move × beta`. But XYZ pricing can trail spot crypto — especially around trade.xyz reference windows — so the proxy's *actual* move lags. That difference is a measurable, tradeable gap. **Distinct from Mantis:** Mantis trades crypto→crypto laggards surfaced by `market_get_cross_asset_flows`. Osprey trades the **cross-VENUE** crypto→XYZ-equity lag and **self-computes** the gap from candles, because `cross_asset_flows` only surfaces crypto laggards.
+
+## CRITICAL RULES
+
+### RULE 1: The leader must move first
+Each tick Osprey measures the leader's (BTC's) recent move over `moveLookbackBars` 1h candles. If `|move| < minLeaderMovePct` (default 2%), nothing happens — no leader move, no lag to trade.
+
+### RULE 2: The catch-up gap is the gate
+For each proxy: `expected = leader_move × beta`, `gap = expected − proxy_actual_move`. Entry requires `|gap| >= minGapPct` (default 2%) **AND** the gap shares the leader's sign (the proxy still owes catch-up *in the leader's direction*). A proxy that already moved proportionally — or overshot (gap flips sign) — is skipped; the catch-up is done.
+
+### RULE 3: Follow the leader
+Direction = the sign of the gap: leader up + proxy lagging up → **LONG** the proxy; leader down + proxy lagging down → **SHORT**. Osprey never fades the leader.
+
+### RULE 4: Producer enters. DSL exits.
+No `close_position` call site. Once a proxy starts tracking the leader the move can extend well past the modeled gap, so the DSL is the **let-winners-run** preset — wide ladder (T0 +10% / lock 0), `max_loss 18%`, time-cuts OFF except a **96h hard_timeout** (XYZ proxies can close the gap slowly across pricing windows). No `weak_peak_cut`.
+
+## How Osprey scores a trade
+
+**Gate:** leader move `>= minLeaderMovePct` AND a proxy gap `>= minGapPct` in the leader's direction.
+
+**Score components** (max ~7):
+
+| Signal | Points |
+|---|---|
+| Leader moved + proxy owes a gap (gate-confirmed) | +2 |
+| `|gap| >= strongGapPct` (default 5%) | +2 |
+| Smart Money on the proxy confirms direction (≥ `smTiltMinPct`) | +1 |
+| SM strongly tilted (≥ `smStrongTiltPct`) | +1 |
+| Proxy volume rising (> 15%) | +1 |
+
+**Floor:** `minScore: 4`. SM is often sparse on XYZ equities, so SM is a **bonus, not a gate**.
+
+## DSL preset (let-winners-run — ride the catch-up)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 18% |
+| Phase 1 | retrace_threshold | 10 |
+| Time cuts | hard_timeout | **96h** |
+| Time cuts | weak_peak_cut | DISABLED |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +10/0 · +20/45 · +35/65 · +55/78 · +90/88 |
+
+## Scanner pattern
+
+Extends the **Cross-asset lag detector** archetype (#9, Mantis) across venues — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data` (1h candles for the leader **and** each proxy — the producer signature), `leaderboard_get_markets` (SM on the proxy). Stateless gap math (no extra state cache). The pure functions (`move_pct`, `catchup_gap`, `lag_direction`) are unit-tested in `tests/test_signal.py`.
+
+**Tuning note:** the proxy list + betas are operator-tunable in `config/osprey-config.json`. Defaults are the most common crypto-proxy equities (`xyz:COIN`, `xyz:MSTR`); add/remove names as trade.xyz lists them, and calibrate each beta to its historical sensitivity to the leader. Any proxy that returns no candles is skipped gracefully.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-26) — initial release
+
+First fleet agent to trade a **cross-VENUE** lag (crypto spot → XYZ equity), extending Mantis's cross-asset-lag archetype. Built with the let-winners-run DSL class (wide ladder, time-cuts off except a 96h hard_timeout), taker-true entry, no null numeric signal fields, self-computed catch-up gap (no dependence on cross_asset_flows), and unit-tested pure functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/osprey/config/osprey-config.json
+++ b/osprey/config/osprey-config.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "OSPREY v1.0.0 — Cross-Venue Lag (crypto leader → XYZ equity proxy). Each tick measures the leader's recent move over moveLookbackBars 1h candles; if |move| >= minLeaderMovePct it checks each proxy's catch-up gap (leader move × beta − the proxy's own move). When |gap| >= minGapPct AND the gap shares the leader's sign (proxy still owes catch-up in the leader's direction), it trades the proxy in that direction. Wide let-winners-run DSL (96h hard_timeout). Edit wallet/strategyId/chatId; tune leader/proxies/betas/thresholds. Proxy list is operator-tunable — add/remove crypto-correlated XYZ equities and set each beta to the leader. Distinct from Mantis, which trades crypto→crypto laggards.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "leader": "BTC",
+  "proxies": [
+    { "proxy": "xyz:COIN", "beta": 1.8 },
+    { "proxy": "xyz:MSTR", "beta": 2.5 }
+  ],
+  "moveLookbackBars": 4,
+  "minLeaderMovePct": 2.0,
+  "minGapPct": 2.0,
+  "strongGapPct": 5.0,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "minScore": 4,
+  "marginPct": 0.15,
+  "leverage": 4
+}

--- a/osprey/references/skill-attribution.md
+++ b/osprey/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "osprey",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "osprey",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/osprey/runtime.yaml
+++ b/osprey/runtime.yaml
@@ -1,0 +1,190 @@
+name: osprey-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Osprey v1.0.0"
+# and lives in description + SKILL.md + _osprey_producer_version.
+version: 1.0.0
+description: >
+  OSPREY v1.0.0 — Cross-Venue Lag (crypto leader → XYZ equity proxy).
+
+  When a crypto leader (BTC) makes a strong move, crypto-correlated equities on
+  Hyperliquid XYZ (Coinbase, MicroStrategy, miners) tend to FOLLOW — but on a
+  different venue, with a lag. Osprey measures each proxy's catch-up gap
+  (leader move × beta − the proxy's actual move) and, when a proxy still owes a
+  gap in the leader's direction, enters the proxy in that direction.
+
+  Distinct from Mantis (#9 cross-asset lag), which trades crypto→crypto
+  laggards from market_get_cross_asset_flows. Osprey trades the CROSS-VENUE
+  crypto→XYZ-equity lag and self-computes the gap from candles.
+
+  Architecture (helpers-native): producer ticks every 300s, computes the
+  leader move + each proxy's catch-up gap, and emits OSPREY_CROSS_VENUE_LAG via
+  SenpiClient.push_signal() when a gap clears the threshold. LLM gate is
+  pass-through.
+
+  DSL: let-winners-run preset — wide ladder (T0 +10% / lock 0), max_loss 18%,
+  time-cuts OFF except a long hard_timeout (a catch-up move can extend).
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 200
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 90
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 360
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: osprey_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        leader: { type: string, required: false }
+        leaderMovePct: { type: number, required: false }
+        proxyMovePct: { type: number, required: false }
+        gapPct: { type: number, required: false }
+        beta: { type: number, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: osprey_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${OSPREY_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [osprey_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # enter while the gap is open — a maker order that rests (CREATE_ORDER_RESTING) misses the catch-up
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: osprey_signals
+    decision_prompt: |
+      You are Osprey's pass-through gate. Osprey trades a CROSS-VENUE lag: a
+      crypto leader (e.g. BTC) made a strong move, and a crypto-correlated XYZ
+      equity proxy (e.g. Coinbase/COIN) hasn't caught up yet. The producer
+      computed the catch-up gap (leader move × beta − proxy move) and confirmed
+      the proxy still owes a gap in the leader's direction. Honor the signal.
+
+      SIGNAL:
+      {{signal_osprey_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (keep the xyz: prefix and case).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-10x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 4 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+      - gapPct sign disagrees with direction (LONG needs gap > 0, SHORT needs gap < 0)
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 6 AND |gapPct| >= 5
+      - 7-8:  score 5
+      - 7:    score 4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 6 xyz:COIN LONG, BTC +4.2%, COIN only +1.1%, catch-up gap +6.4% — cross-venue lag')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "OSPREY_CROSS_VENUE_LAG ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — let-winners-run preset) ──────────────────────
+#
+# A catch-up move can extend well past the modeled gap once the proxy starts
+# tracking the leader. Let it run: wide ladder (T0 +10% / lock 0), max_loss
+# 18%, time-cuts OFF except a long hard_timeout. NO weak_peak_cut — XYZ proxies
+# can develop slowly across pricing windows.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760                   # 96h — the lag can take days to close across XYZ pricing windows
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 45 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+        - { trigger_pct: 90, lock_hw_pct: 88 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/osprey/scripts/osprey-producer.py
+++ b/osprey/scripts/osprey-producer.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+# Senpi OSPREY Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""OSPREY v1.0.0 — Cross-Venue Lag (crypto leader → XYZ equity proxy).
+
+When a crypto leader (BTC) makes a strong move, crypto-correlated equities
+priced on Hyperliquid XYZ — Coinbase (COIN), MicroStrategy (MSTR), miners —
+tend to FOLLOW, but on a different venue and with a lag (trade.xyz pricing can
+trail spot crypto, especially around its reference windows).
+
+Osprey measures each proxy's catch-up GAP each tick:
+
+    expected_move = leader_move_pct × proxy_beta
+    gap           = expected_move − proxy_actual_move
+
+A large gap in the LEADER'S direction means the proxy hasn't caught up yet:
+  leader +X% and gap still positive → proxy lagging up   → LONG proxy
+  leader −X% and gap still negative → proxy lagging down  → SHORT proxy
+If the proxy already moved proportionally (or overshot), the gap shrinks or
+flips sign → no trade.
+
+Distinct from Mantis (#9 cross-asset lag), which trades crypto→crypto laggards
+surfaced by market_get_cross_asset_flows. Osprey trades the CROSS-VENUE
+crypto→XYZ-equity lag and SELF-COMPUTES the gap from candles, because
+cross_asset_flows only surfaces crypto laggards. A catch-up move can extend, so
+the DSL is the let-winners-run preset. Producer NEVER closes — DSL owns exits.
+
+REQUIRES USER-SCOPE AUTH for leaderboard_get_markets.
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import osprey_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "osprey_signals"
+SIGNAL_TYPE = "OSPREY_CROSS_VENUE_LAG"
+
+MAX_LEVERAGE = 10
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 4
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+
+DEFAULT_LEADER = "BTC"
+# Proxy XYZ equities and their typical beta to the leader. Operator-tunable.
+DEFAULT_PROXIES = [
+    {"proxy": "xyz:COIN", "beta": 1.8},
+    {"proxy": "xyz:MSTR", "beta": 2.5},
+]
+DEFAULT_MOVE_LOOKBACK = 4            # 1h bars — the "recent move" window for both legs
+DEFAULT_MIN_LEADER_MOVE = 2.0       # leader must move at least this % to matter
+DEFAULT_MIN_GAP_PCT = 2.0           # proxy must still owe at least this % of catch-up
+DEFAULT_STRONG_GAP_PCT = 5.0
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("OSPREY_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure cross-venue lag math (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def move_pct(closes, lookback):
+    """% change of the latest close vs the close `lookback` bars ago.
+    None if insufficient data or the reference price is non-positive."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def catchup_gap(leader_move, proxy_move, beta):
+    """How much of the expected catch-up move the proxy still owes.
+    expected = leader_move × beta; gap = expected − actual."""
+    return (leader_move * beta) - proxy_move
+
+
+def lag_direction(leader_move, gap, min_leader_move, min_gap):
+    """Direction to trade the proxy so it profits from closing the gap.
+    None unless the leader moved enough AND the proxy still owes a gap in the
+    LEADER'S direction (same sign). An overshot proxy (gap flips sign) is
+    skipped — the catch-up is already done."""
+    if leader_move is None or gap is None:
+        return None
+    if abs(leader_move) < min_leader_move:
+        return None
+    if abs(gap) < min_gap:
+        return None
+    if (leader_move > 0) != (gap > 0):   # gap must share the leader's sign
+        return None
+    return "LONG" if gap > 0 else "SHORT"
+
+
+def volume_trend(candles, lookback=6):
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_candles(asset):
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return []
+    return data.get("data", {}).get("candles", {}).get("1h", [])
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — one proxy
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(proxy_cfg, leader_move, proxy_closes, proxy_candles, config):
+    proxy = proxy_cfg["proxy"]
+    beta = float(proxy_cfg.get("beta", 1.0))
+    lookback = int(config.get("moveLookbackBars", DEFAULT_MOVE_LOOKBACK))
+    min_leader = float(config.get("minLeaderMovePct", DEFAULT_MIN_LEADER_MOVE))
+    min_gap = float(config.get("minGapPct", DEFAULT_MIN_GAP_PCT))
+    strong_gap = float(config.get("strongGapPct", DEFAULT_STRONG_GAP_PCT))
+
+    proxy_move = move_pct(proxy_closes, lookback)
+    if proxy_move is None:
+        return None
+    gap = catchup_gap(leader_move, proxy_move, beta)
+    direction = lag_direction(leader_move, gap, min_leader, min_gap)
+    if direction is None:
+        return None
+
+    sm_dir, sm_tilt = fetch_sm_direction(proxy)
+    sm_min = float(config.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(config.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+    vol_trend = volume_trend(proxy_candles)
+
+    score = 0
+    reasons = [f"leader_{leader_move:+.1f}%", f"{proxy}_lag_{proxy_move:+.1f}%", f"gap_{gap:+.1f}%"]
+    score += 2  # leader moved + proxy owes a gap in the leader's direction (gate)
+    if abs(gap) >= strong_gap:
+        score += 2
+        reasons.append(f"gap_strong_{gap:+.1f}%")
+    # SM is often sparse on XYZ equities — agreement is a bonus, not a gate.
+    if sm_dir == direction and sm_tilt >= sm_min:
+        score += 1
+        reasons.append(f"sm_confirms_{sm_tilt:.0f}%")
+        if sm_tilt >= sm_strong:
+            score += 1
+            reasons.append("sm_strong")
+    if vol_trend > 15:
+        score += 1
+        reasons.append(f"vol_rising_{vol_trend:+.0f}%")
+
+    return {
+        "coin": proxy,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "leader_move_pct": round(leader_move, 2),
+        "proxy_move_pct": round(proxy_move, 2),
+        "gap_pct": round(gap, 2),
+        "beta": beta,
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": sm_tilt,
+        "volume_trend_pct": round(vol_trend, 2),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets, leader):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "leader": leader,
+        "leaderMovePct": thesis.get("leader_move_pct") or 0.0,
+        "proxyMovePct": thesis.get("proxy_move_pct") or 0.0,
+        "gapPct": thesis.get("gap_pct") or 0.0,
+        "beta": thesis.get("beta") or 0.0,
+        "smDirection": thesis.get("sm_direction") or "NONE",
+        "smTiltPct": thesis.get("sm_tilt_pct") or 0.0,
+        "volumeTrendPct": thesis.get("volume_trend_pct") or 0.0,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 7.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — measure leader move, score each proxy's catch-up gap
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    leader = config.get("leader", DEFAULT_LEADER)
+    proxies = config.get("proxies", DEFAULT_PROXIES)
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_osprey_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_osprey_producer_version": VERSION})
+        return
+
+    lookback = int(config.get("moveLookbackBars", DEFAULT_MOVE_LOOKBACK))
+    leader_candles = fetch_candles(leader)
+    leader_closes = [_f(c, "close", "c") for c in leader_candles]
+    leader_move = move_pct(leader_closes, lookback)
+    min_leader = float(config.get("minLeaderMovePct", DEFAULT_MIN_LEADER_MOVE))
+
+    if leader_move is None or abs(leader_move) < min_leader:
+        cfg.output({
+            "status": "ok",
+            "note": f"WAITING — leader {leader} move {leader_move if leader_move is not None else 'n/a'} below {min_leader}% threshold",
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_osprey_producer_version": VERSION,
+        })
+        return
+
+    candidates = []
+    for proxy_cfg in proxies:
+        proxy = proxy_cfg["proxy"].upper()
+        if proxy in held_set or cfg.was_recently_signaled(proxy):
+            continue
+        proxy_candles = fetch_candles(proxy_cfg["proxy"])
+        if len(proxy_candles) <= lookback:
+            continue
+        proxy_closes = [_f(c, "close", "c") for c in proxy_candles]
+        thesis = build_thesis(proxy_cfg, leader_move, proxy_closes, proxy_candles, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": f"WAITING — {leader} moved {leader_move:+.1f}% but no proxy still owes a catch-up gap",
+            "leader_move_pct": round(leader_move, 2),
+            "proxies": [p["proxy"] for p in proxies],
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_osprey_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: (c["score"], abs(c["gap_pct"])), reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets, leader)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "leader_move_pct": best["leader_move_pct"],
+            "proxy_move_pct": best["proxy_move_pct"],
+            "gap_pct": best["gap_pct"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "leader": leader,
+        "leader_move_pct": round(leader_move, 2),
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_osprey_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"osprey-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/osprey/scripts/osprey_config.py
+++ b/osprey/scripts/osprey_config.py
@@ -1,0 +1,222 @@
+"""OSPREY v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Cross-Venue Lag (crypto leader → XYZ equity proxy). When a crypto leader (BTC)
+makes a strong move, crypto-correlated equities priced on Hyperliquid XYZ
+(Coinbase, MicroStrategy, miners) tend to FOLLOW — but on a different venue,
+with a lag (trade.xyz pricing can trail spot crypto, especially around its
+reference windows). Osprey measures each proxy's catch-up GAP: expected move
+(leader move × the proxy's beta) minus the move it has actually made so far. A
+large gap in the leader's direction means the proxy hasn't caught up yet —
+Osprey enters in the leader's direction, betting it closes the gap.
+
+Distinct from Mantis (#9 cross-asset lag), which trades crypto→crypto laggards
+surfaced by market_get_cross_asset_flows. Osprey trades the CROSS-VENUE
+crypto→XYZ-equity lag and self-computes the gap from candles, because
+cross_asset_flows only surfaces crypto laggards.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+let-winners-run DSL (a catch-up move can extend). Stateless gap math (no extra
+state cache) plus the fleet-standard race-window dedup, atomic write,
+simplified producer_daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "osprey-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "osprey-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Osprey ticks every 300s; ALO fills typically settle
+# within 30-60s. 240s covers the full fill window plus the next-tick
+# clearinghouseState refresh, so the on-chain held-asset check picks up where
+# this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Osprey's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("osprey_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient failures
+    recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] osprey_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[osprey-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/osprey/tests/test_signal.py
+++ b/osprey/tests/test_signal.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Unit tests for Osprey's pure functions (move_pct, catchup_gap,
+lag_direction). Stubs osprey_config + senpi_runtime_helpers so the producer
+loads without the helpers package or a runtime workspace.
+Run: python3 osprey/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("osprey_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["osprey_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "osprey-producer.py"
+_spec = importlib.util.spec_from_file_location("osprey_producer", _path)
+op = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(op)
+
+
+def test_move_pct_known_value():
+    # close 4 bars ago = 100, latest = 105 → +5%
+    closes = [100, 101, 102, 103, 105]
+    assert abs(op.move_pct(closes, 4) - 5.0) < 1e-9
+
+
+def test_move_pct_insufficient_and_bad_ref():
+    assert op.move_pct([100, 101], 4) is None
+    assert op.move_pct([0, 1, 2, 3, 4], 4) is None  # ref <= 0
+
+
+def test_catchup_gap_math():
+    # leader +5%, beta 1.8, proxy only +2% → expected +9%, gap +7%
+    assert abs(op.catchup_gap(5.0, 2.0, 1.8) - 7.0) < 1e-9
+    # proxy overshot: leader +5%, beta 1.8, proxy +12% → expected +9%, gap -3%
+    assert abs(op.catchup_gap(5.0, 12.0, 1.8) - (-3.0)) < 1e-9
+
+
+def test_lag_direction_long_when_proxy_lags_up():
+    # leader up, proxy still owes upside → LONG
+    assert op.lag_direction(5.0, 7.0, 2.0, 2.0) == "LONG"
+
+
+def test_lag_direction_short_when_proxy_lags_down():
+    # leader down, proxy still owes downside → SHORT
+    assert op.lag_direction(-5.0, -7.0, 2.0, 2.0) == "SHORT"
+
+
+def test_lag_direction_skips_overshoot():
+    # leader up but proxy overshot (gap negative) → no trade
+    assert op.lag_direction(5.0, -3.0, 2.0, 2.0) is None
+
+
+def test_lag_direction_below_thresholds_and_none():
+    assert op.lag_direction(1.0, 7.0, 2.0, 2.0) is None     # leader move too small
+    assert op.lag_direction(5.0, 1.0, 2.0, 2.0) is None      # gap too small
+    assert op.lag_direction(None, 7.0, 2.0, 2.0) is None
+    assert op.lag_direction(5.0, None, 2.0, 2.0) is None
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -592,6 +592,7 @@ if flows.get("laggards"):
 | Agent | Version | Asset / Universe | Description | Tags |
 |---|---|---|---|---|
 | **Mantis** | v5.0 | Multi (BTC-led laggards) | When BTC moves >2% in 4h, identifies laggard alts with follow-rate ≥0.8 and enters for the catch-up close. Direction matches BTC's 4h move sign. Tick 60s. Often silent on quiet BTC days. | BTC-led, Follow-rate ≥0.8, Tick 60s |
+| **Osprey** | v1.0 | BTC → xyz: equity proxies | **Cross-VENUE variant.** When BTC moves, crypto-correlated XYZ equities (COIN, MSTR, miners) lag on the other venue. Osprey self-computes the catch-up gap (`leader move × beta − proxy move`) from candles — it does NOT use `cross_asset_flows` (which only surfaces crypto laggards) — and trades the proxy in the leader's direction while it still owes the gap. Wide let-winners-run DSL, 96h hard_timeout. Tick 300s. | Cross-venue, XYZ-equity, Beta-gap, Wide DSL, Self-computed |
 
 ---
 
@@ -864,6 +865,7 @@ XYZ markets (stocks / commodities / pre-IPO) trade **24/7 on Hyperliquid**, even
 ### Layer 2F — Structural / neutral → what structure?
 
 - **BTC-led laggard rotation** (an alt that hasn't caught up to a BTC move yet) → **Mantis** (cross-asset lag).
+- **Crypto stocks that lag a BTC move** (COIN / MSTR / miners on XYZ haven't caught up yet) → **Osprey** (cross-VENUE lag — self-computes the catch-up gap from each proxy's beta).
 - **Volume / market-making** (not a directional bet) → **Turbine** (specialized).
 - **Trade the spread between two coins** (a pair's ratio stretched far from its mean) → **Chameleon** (relative-value / pairs — ratio mean-reversion).
 - *Expanding set — copy-the-copiers is being added. Already live: microstructure (Piranha, Marlin — Layer 2E) and relative-value / pairs (Chameleon).*
@@ -993,6 +995,7 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | **Marlin** | 12 — Microstructure / order-flow | BTC/ETH/SOL/HYPE. Order-book imbalance (bid/ask depth skew) as entry-timing on a momentum thesis — not a scalper. Wide DSL + 24h hard_timeout |
 | **Chameleon** | 13 — Relative-value / pairs | ETH/BTC · SOL/ETH · SOL/BTC. Ratio mean-reversion — trades the high-beta leg when a pair's z-score extends ~2σ and starts reverting. Mean-reversion DSL |
 | **Falcon** | 3 — Single-asset XYZ specialist (event-detection layer) | xyz: conversion events. Detects the IPOP→equity flip (funding jumps ~100x, leverage cap lifts, throttle off) and rides post-conversion price-discovery momentum. Class-state + conversion-window cache. Wide let-winners-run DSL, 7d hard_timeout |
+| **Osprey** | 9 — Cross-asset lag detector (cross-VENUE variant) | BTC → xyz: equity proxies (COIN/MSTR/miners). Self-computes the catch-up gap (leader move × beta − proxy move) from candles; trades the proxy in the leader's direction while it owes the gap. NOT cross_asset_flows (crypto-only). Wide let-winners-run DSL, 96h hard_timeout |
 
 Sentinel runs an in-house producer that is not currently published to this repo; no public URL.
 


### PR DESCRIPTION
## Summary
- **Osprey** (#7 of the 10-agent build) — first fleet agent to trade a **cross-VENUE** lag (crypto spot → XYZ equity).
- When BTC makes a strong move, crypto-correlated XYZ equities (COIN/MSTR/miners) lag on the other venue. Osprey self-computes each proxy's catch-up gap (`leader move × beta − proxy move`) from candles and trades the proxy in the leader's direction while it still owes the gap.
- **Distinct from Mantis** (#9, crypto→crypto laggards from `cross_asset_flows`). Osprey does NOT use `cross_asset_flows` (crypto-only on the laggard side) — it extends archetype #9 across venues with self-computed gap math.
- DSL: **let-winners-run** preset (wide ladder, max_loss 18%, time-cuts off except a 96h hard_timeout). Taker-true entry; no null numeric signal fields; disown-safe launch. Proxy list + betas are operator-tunable with graceful skip on missing candles.
- Integrated into `producer-patterns.md` (archetype #9 roster, Layer 2F bullet, fleet roster mapping) and `catalog.json` (cross-asset-lag group, $500 min).

## Test plan
- [x] `python3 -m py_compile` producer + config — OK
- [x] `python3 osprey/tests/test_signal.py` — 7/7 pass (move_pct, catchup_gap, lag_direction incl. overshoot/threshold/None guards)
- [x] runtime.yaml parses + config.json parses
- [x] field-parity: data_block keys ⊆ scanner `fields` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)