### PR TITLE
Add Remora v1.0.0 — whale single-position mirror

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -631,6 +631,21 @@
       "version": "4.0.1"
     },
     {
+      "id": "remora",
+      "tracker_slug": "remora",
+      "name": "Remora \u2014 Whale Single-Position Mirror",
+      "emoji": "\ud83d\udc1f",
+      "tagline": "Ride the whales you choose. Names a hand-picked set of traders, takes each whale's biggest-conviction position, and mirrors the strongest \u2014 with a consensus boost when several agree.",
+      "group": "trader-follower",
+      "sort_order": 34,
+      "min_budget": 500,
+      "risk_level": "aggressive",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/remora",
+      "version": "1.0.0"
+    },
+    {
       "id": "turbine",
       "tracker_slug": "turbine",
       "name": "Turbine \u2014 Volume Engine + Runners",

--- a/remora/README.md
+++ b/remora/README.md
@@ -1,0 +1,139 @@
+# 🐟 Remora — Whale Single-Position Mirror
+
+**Ride the whales you choose.** Remora attaches to a small, hand-picked set of whale traders, finds each whale's biggest-conviction bet, and mirrors the strongest one — with a consensus boost when several whales pile into the same trade.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+The broad trader-followers (Raptor, Jackal, Spider) scan a *leaderboard universe* and synthesize a pick. Remora is the opposite: **you name the whales.** It mirrors their single highest-conviction position, so your exposure tracks specific traders you trust, and it leans hardest when those whales *agree*. **Distinct from Spider/Jackal/Raptor** (universe scanners) — Remora is a focused mirror of a set you control.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Whale set | **operator-supplied** (`config.whales`, no default) |
+| Tick interval | 600s (10 min) — whale positions change slowly |
+| Conviction metric | largest-notional open position per whale |
+| Min notional (dust filter) | $5,000 |
+| Consensus bonus | 2 whales → +2 · 3+ → +3 |
+| Whale-quality bonus | ELITE / RELIABLE tier → +1 |
+| MIN_SCORE (producer) | 4 (out of ~7 max) |
+| LLM min_confidence | 7 |
+| Leverage | 4x default, max 10x |
+| Margin per trade | 15% of equity |
+| Max entries per day | 3 |
+| Per-asset cooldown | 480 min (8h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 22% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (let-winners-run — with a staleness cap)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 18% |
+| Phase 1 | retrace_threshold | 10 |
+| Time cuts | hard_timeout | **120h (staleness cap)** |
+| Time cuts | weak_peak_cut | disabled |
+| Time cuts | dead_weight_cut | disabled |
+| Phase 2 | T0 → T4 | +10/0 · +20/45 · +35/65 · +55/78 · +90/88 |
+
+> ⚠️ Remora does **not yet mirror the whale's EXIT** — the 120h hard_timeout prevents holding a stale mirror indefinitely. A whale-exit mirror is a planned v1.1 enhancement.
+
+## Scanner pattern
+
+A focused variant of the **Trader-follower / hot-streak** archetype (#5) — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `leaderboard_get_trader_positions` (per whale; unwraps the nested `data.positions.positions` shape), `discovery_get_trader_state` (whale quality, optional). Pure functions unit-tested in `tests/test_signal.py` (`python3 remora/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/remora-producer.py | Long-lived daemon; emits REMORA_WHALE_MIRROR signals |
+| scripts/remora_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/remora-config.json | Operator config — **set `whales`** + thresholds + sizing |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Remora
+
+```bash
+mkdir -p /data/workspace/skills/remora-strategy/{config,scripts,state,references}
+for f in scripts/remora-producer.py scripts/remora_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/remora-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/remora/$f" \
+    -o "/data/workspace/skills/remora-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, chat ID, AND your whale set
+
+Edit `/data/workspace/skills/remora-strategy/config/remora-config.json`. **Remora trades nothing until you set `whales`:**
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId",
+  "whales": [
+    { "trader_id": "0xWhaleYouWantToRide1" },
+    { "trader_id": "0xWhaleYouWantToRide2" }
+  ]
+}
+```
+
+> Find good whales to ride with `discovery_get_top_traders` (historical track record) or `leaderboard_get_top` (current momentum), then paste their `trader_id` / wallet here.
+
+### Step 4 — Required env vars
+
+```bash
+export REMORA_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                           # required (user-scope; needed for leaderboard_get_trader_positions)
+export REMORA_DECISION_MODEL=<your-preferred-model>   # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/remora-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/remora-strategy/scripts/remora-producer.py \
+  > /tmp/remora-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 620  # wait one full tick
+tail -3 /tmp/remora-producer.log | jq '._remora_producer_version, .note // null, .best.coin // null'
+# Expected: _remora_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "no whales configured — set config.whales ..."` — you haven't set whales yet
+- `"note": "WAITING — no qualifying whale position to mirror"` — whales are flat / sub-dust
+- `"signals_pushed": 1, "best": { "coin": ..., "whale_count": ..., "direction": "LONG"|"SHORT" }` — a mirror fired
+
+## Changelog
+
+### v1.0.0 (2026-05-26) — initial release
+
+A focused single-position mirror of a hand-picked whale set, with a consensus multiplier — a deliberate contrast to the universe-scanning trader-followers. Let-winners-run DSL class (wide ladder, time-cuts off except a 120h staleness cap), taker-true entry, no null numeric signal fields, defensive nested-shape unwrapping, disown-safe launch, unit-tested signal functions. Whale-exit mirroring is a planned v1.1 enhancement.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/remora/SKILL.md
+++ b/remora/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: remora-strategy
+description: >-
+  REMORA v1.0.0 — Whale Single-Position Mirror. Rides a small, hand-picked set
+  of whale traders: each tick it pulls each whale's open positions, takes their
+  highest-conviction (largest-notional) position, and mirrors the strongest
+  (asset, direction) candidate — boosting the score when multiple whales agree
+  (consensus) and when a whale is ELITE/RELIABLE tier. Distinct from the broad
+  trader-followers (Raptor/Jackal/Spider) that scan a leaderboard universe;
+  Remora mirrors whales YOU choose. Let-winners-run DSL with a staleness cap.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐟 REMORA v1.0.0 — Whale Single-Position Mirror
+
+**Ride the whales you choose.** A remora fish attaches to a shark and goes where it goes. Remora attaches to a small, hand-picked set of whale traders — it finds each whale's biggest-conviction bet and mirrors the strongest one, with a consensus boost when several whales pile into the same trade.
+
+## Why this strategy exists
+
+The broad trader-followers (Raptor, Jackal, Spider) scan a *leaderboard universe* and synthesize a pick. That's powerful but opaque — you don't control whom you're following. Remora is the opposite: **you name the whales.** It mirrors their single highest-conviction position, so your exposure tracks specific traders you trust, and it leans hardest when those whales *agree*.
+
+## CRITICAL RULES
+
+### RULE 1: You pick the whales
+Remora trades nothing until `config.whales` is set to a list of `trader_id`s / wallets. There is no default whale set — these are *your* choices.
+
+### RULE 2: Highest conviction = largest notional
+For each whale, Remora takes their single **largest-notional** open position (`size × entry`, falling back to margin), above `minNotionalUsd` (default $5,000, to skip dust). That's the whale's strongest live bet.
+
+### RULE 3: Consensus is the edge multiplier
+Top positions are aggregated into `(asset, direction)` candidates across whales. The more whales independently hold the same asset+direction, the higher the score (2 whales → +2, 3+ → +3). One whale can be wrong; three agreeing is a much stronger signal.
+
+### RULE 4: Producer enters. DSL exits.
+No `close_position` call site. Whales hold winners, so the DSL is the **let-winners-run** preset — wide ladder (T0 +10% / lock 0), `max_loss 18%`, time-cuts OFF except a **120h hard_timeout** staleness cap. ⚠️ Remora does **not yet mirror the whale's EXIT** — the hard_timeout prevents holding a stale mirror indefinitely. A whale-exit mirror is a planned v1.1 enhancement.
+
+## How Remora scores a trade
+
+**Gate:** at least one configured whale holds a qualifying top position (above `minNotionalUsd`).
+
+**Score components** (max ~7):
+
+| Signal | Points |
+|---|---|
+| A tracked whale's top conviction position | +3 |
+| Consensus: 2 whales agree | +2 |
+| Consensus: 3+ whales agree | +3 |
+| Any agreeing whale is ELITE / RELIABLE tier | +1 |
+
+**Floor:** `minScore: 4` (so a single whale's top position clears the floor only if it is ELITE-tier; otherwise consensus is required).
+
+## DSL preset (let-winners-run — with a staleness cap)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 18% |
+| Phase 1 | retrace_threshold | 10 |
+| Time cuts | hard_timeout | **120h (staleness cap)** |
+| Time cuts | weak_peak_cut | DISABLED |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +10/0 · +20/45 · +35/65 · +55/78 · +90/88 |
+
+## Scanner pattern
+
+A focused variant of the **Trader-follower / hot-streak** archetype (#5) — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `leaderboard_get_trader_positions` (per whale — the producer signature; unwraps the nested `data.positions.positions` shape), `discovery_get_trader_state` (whale quality tier, optional). The pure functions (`position_notional`, `mirror_direction`, `top_position`, `consensus_bonus`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-26) — initial release
+
+A focused single-position mirror of a hand-picked whale set, with a consensus multiplier — a deliberate contrast to the universe-scanning trader-followers. Let-winners-run DSL class (wide ladder, time-cuts off except a 120h staleness cap), taker-true entry, no null numeric signal fields, defensive nested-shape unwrapping on `leaderboard_get_trader_positions`, and unit-tested pure functions. Whale-exit mirroring is a planned v1.1 enhancement.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/remora/config/remora-config.json
+++ b/remora/config/remora-config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "REMORA v1.0.0 — Whale Single-Position Mirror. Each tick pulls each configured whale's open positions (leaderboard_get_trader_positions), takes their highest-conviction (largest-notional) position above minNotionalUsd, aggregates across whales into (asset, direction) candidates, scores by consensus (how many whales agree) + whale quality (discovery_get_trader_state ELITE/RELIABLE tier when useWhaleQuality), and mirrors the strongest. Let-winners-run DSL with a 120h staleness cap. SET config.whales to the trader_ids/wallets you want to ride. Edit wallet/strategyId/chatId; tune thresholds. Distinct from the broad trader-followers (Raptor/Jackal/Spider) — Remora mirrors whales YOU choose.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "whales": [
+    { "trader_id": "0xWHALE_WALLET_OR_TRADER_ID_1" },
+    { "trader_id": "0xWHALE_WALLET_OR_TRADER_ID_2" }
+  ],
+  "useWhaleQuality": true,
+  "minNotionalUsd": 5000,
+  "minScore": 4,
+  "marginPct": 0.15,
+  "leverage": 4
+}

--- a/remora/references/skill-attribution.md
+++ b/remora/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "remora",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "remora",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/remora/runtime.yaml
+++ b/remora/runtime.yaml
@@ -1,0 +1,186 @@
+name: remora-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Remora v1.0.0"
+# and lives in description + SKILL.md + _remora_producer_version.
+version: 1.0.0
+description: >
+  REMORA v1.0.0 — Whale Single-Position Mirror.
+
+  Remora rides a small, hand-picked set of whale traders. Each tick it pulls
+  each whale's open positions, takes their highest-conviction (largest-notional)
+  position, aggregates across whales into (asset, direction) candidates, and
+  mirrors the strongest — boosting score when MULTIPLE whales agree (consensus)
+  and when a whale is ELITE/RELIABLE tier (discovery_get_trader_state).
+
+  Distinct from the broad trader-followers (Raptor/Jackal/Spider) that scan a
+  leaderboard universe. Remora mirrors whales YOU choose.
+
+  Architecture (helpers-native): producer ticks every 600s, gathers whale top
+  positions, scores by consensus + quality, and emits REMORA_WHALE_MIRROR via
+  SenpiClient.push_signal(). LLM gate is pass-through.
+
+  DSL: let-winners-run preset — wide ladder (T0 +10% / lock 0), max_loss 18%,
+  time-cuts OFF except a hard_timeout staleness cap (whales hold winners; let
+  it run, but don't hold a stale mirror forever).
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 200
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 96
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 90
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 480
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: remora_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        whaleCount: { type: number, required: false }
+        maxNotionalUsd: { type: number, required: false }
+        eliteTier: { type: boolean, required: false }
+        whales: { type: array, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: remora_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${REMORA_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [remora_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # mirror the whale's live exposure now — a maker order that rests (CREATE_ORDER_RESTING) drifts from the whale's entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: remora_signals
+    decision_prompt: |
+      You are Remora's pass-through gate. Remora MIRRORS a hand-picked set of
+      whale traders: it took each whale's highest-conviction open position and
+      surfaced the strongest (asset, direction) candidate, weighted by how many
+      whales agree (consensus) and whether they are ELITE/RELIABLE tier. Honor
+      the signal.
+
+      SIGNAL:
+      {{signal_remora_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (preserve case / any xyz: prefix).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-10x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 4 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+      - whaleCount < 1
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 6 AND whaleCount >= 2 (consensus) AND eliteTier true
+      - 7-8:  score 5
+      - 7:    score 4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 6 BTC LONG, 3 whales in consensus, max notional $1.2M, ELITE tier — whale mirror')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "REMORA_WHALE_MIRROR ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — let-winners-run preset) ──────────────────────
+#
+# Whales hold winners, so let the mirror run: wide ladder (T0 +10% / lock 0),
+# max_loss 18%, time-cuts OFF except a hard_timeout staleness cap (Remora does
+# not yet mirror the whale's EXIT, so the timeout prevents holding a stale
+# mirror indefinitely — a whale-exit mirror is a future enhancement). NO
+# weak_peak_cut.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 7200                   # 120h (5d) — staleness cap, since the whale's exit is not yet mirrored
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 45 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+        - { trigger_pct: 90, lock_hw_pct: 88 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/remora/scripts/remora-producer.py
+++ b/remora/scripts/remora-producer.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+# Senpi REMORA Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""REMORA v1.0.0 — Whale Single-Position Mirror.
+
+Remora rides a small, hand-picked set of whale traders the way a remora fish
+rides a shark. Each tick it:
+
+  1. Pulls each whale's open positions (leaderboard_get_trader_positions).
+  2. Picks each whale's highest-conviction (largest-notional) position.
+  3. Aggregates across whales into (asset, direction) candidates, counting how
+     many whales hold each — CONSENSUS is the edge multiplier.
+  4. Optionally validates whale quality (discovery_get_trader_state ELITE /
+     RELIABLE tier) as a scoring bonus.
+  5. Mirrors the highest-scoring candidate (same asset + direction), sized by
+     Remora's OWN margin %, leverage capped.
+
+Distinct from the broad trader-followers (Raptor/Jackal/Spider) that scan a
+leaderboard universe and synthesize. Remora is a focused MIRROR of whales YOU
+choose. Whales hold winners, so the DSL is the let-winners-run preset (wide
+ladder), with a hard_timeout as a staleness cap. Producer enters only — the DSL
+owns exits (a whale-exit mirror is a future enhancement).
+
+REQUIRES USER-SCOPE AUTH for leaderboard_get_trader_positions /
+discovery_get_trader_state.
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import remora_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "remora_signals"
+SIGNAL_TYPE = "REMORA_WHALE_MIRROR"
+
+MAX_LEVERAGE = 10
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 4
+DEFAULT_MIN_NOTIONAL_USD = 5000   # ignore dust positions
+# Whale-quality tiers that earn the discovery_get_trader_state bonus.
+QUALITY_TIERS = {"ELITE", "RELIABLE", "PROFITABLE"}
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("REMORA_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def safe_float(v, default=0.0):
+    try:
+        return float(v if v is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure mirror logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def position_notional(pos):
+    """USD notional of a position for conviction ranking: size × entry,
+    falling back to marginUsed, then to raw size."""
+    if not isinstance(pos, dict):
+        return 0.0
+    size = abs(safe_float(pos.get("szi", pos.get("size", 0))))
+    entry = safe_float(pos.get("entryPx", pos.get("entryPrice", pos.get("entry", 0))))
+    notional = size * entry
+    if notional > 0:
+        return notional
+    margin = abs(safe_float(pos.get("marginUsed", pos.get("margin", 0))))
+    return margin if margin > 0 else size
+
+
+def mirror_direction(pos):
+    """LONG / SHORT for a position (explicit direction/side field, else szi
+    sign). None if undeterminable."""
+    if not isinstance(pos, dict):
+        return None
+    d = str(pos.get("direction", pos.get("side", ""))).upper()
+    if d in ("LONG", "SHORT"):
+        return d
+    szi = safe_float(pos.get("szi", pos.get("size", 0)))
+    if szi > 0:
+        return "LONG"
+    if szi < 0:
+        return "SHORT"
+    return None
+
+
+def position_asset(pos):
+    if not isinstance(pos, dict):
+        return ""
+    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", ""))))).upper()
+
+
+def top_position(positions, min_notional=0.0):
+    """The single largest-notional position with a determinable direction and
+    notional >= min_notional. None if the whale holds nothing qualifying."""
+    best, best_n = None, -1.0
+    for p in positions or []:
+        if not isinstance(p, dict):
+            continue
+        if mirror_direction(p) is None or not position_asset(p):
+            continue
+        n = position_notional(p)
+        if n < min_notional:
+            continue
+        if n > best_n:
+            best_n, best = n, p
+    return best
+
+
+def consensus_bonus(count):
+    """Score bonus for how many whales independently hold the same
+    asset+direction. 3+ whales is a strong consensus."""
+    if count >= 3:
+        return 3
+    if count == 2:
+        return 2
+    return 0
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_whale_positions(trader_id):
+    """Returns a list of position dicts for one whale, unwrapping the
+    nested data.positions.positions shape."""
+    raw = cfg.mcp_call("leaderboard_get_trader_positions", trader_id=trader_id)
+    if not raw:
+        return []
+    if not isinstance(raw, dict):
+        return raw if isinstance(raw, list) else []
+    d = raw.get("data", raw)
+    if isinstance(d, list):
+        return d
+    if not isinstance(d, dict):
+        return []
+    rp = d.get("positions", d.get("top_positions", []))
+    if isinstance(rp, list):
+        return rp
+    if isinstance(rp, dict):  # nested one level deeper (observed shape)
+        nested = rp.get("positions", [])
+        return nested if isinstance(nested, list) else []
+    return []
+
+
+def fetch_whale_tier(trader_id):
+    """ELITE / RELIABLE / etc. for one whale, or None if unavailable."""
+    raw = cfg.mcp_call("discovery_get_trader_state", trader_id=trader_id)
+    if not raw or not isinstance(raw, dict):
+        return None
+    d = raw.get("data", raw)
+    if not isinstance(d, dict):
+        return None
+    tier = d.get("tier", d.get("classification", d.get("rating")))
+    return str(tier).upper() if tier else None
+
+
+# ═══════════════════════════════════════════════════════════════
+# Candidate aggregation
+# ═══════════════════════════════════════════════════════════════
+
+def gather_candidates(whales, config):
+    """For each whale, take their top position; aggregate into
+    (asset, direction) candidates with consensus count + max notional +
+    whale quality. Returns a list of candidate dicts."""
+    min_notional = float(config.get("minNotionalUsd", DEFAULT_MIN_NOTIONAL_USD))
+    use_tier = bool(config.get("useWhaleQuality", True))
+
+    agg = {}
+    for whale in whales:
+        trader_id = whale.get("trader_id") or whale.get("wallet") or whale
+        if not trader_id:
+            continue
+        positions = fetch_whale_positions(trader_id)
+        top = top_position(positions, min_notional)
+        if not top:
+            continue
+        asset = position_asset(top)
+        direction = mirror_direction(top)
+        notional = position_notional(top)
+        tier = fetch_whale_tier(trader_id) if use_tier else None
+
+        key = (asset, direction)
+        entry = agg.setdefault(key, {
+            "asset": asset, "direction": direction,
+            "count": 0, "max_notional": 0.0, "quality": False,
+            "whales": [],
+        })
+        entry["count"] += 1
+        entry["max_notional"] = max(entry["max_notional"], notional)
+        if tier in QUALITY_TIERS:
+            entry["quality"] = True
+        entry["whales"].append(str(trader_id)[:10])
+
+    return list(agg.values())
+
+
+def score_candidate(cand, config):
+    count = cand["count"]
+    score = 3  # a tracked whale's top conviction position
+    reasons = [f"{cand['asset']}_{cand['direction']}", f"whales_{count}", f"notional_${cand['max_notional']:,.0f}"]
+    cb = consensus_bonus(count)
+    if cb:
+        score += cb
+        reasons.append(f"consensus_{count}_whales")
+    if cand.get("quality"):
+        score += 1
+        reasons.append("elite_tier")
+    return score, reasons
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(cand, score, reasons, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = cand["asset"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": score,
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": cand["direction"],
+        "reasons": reasons,
+        "whaleCount": cand["count"],
+        "maxNotionalUsd": round(cand["max_notional"], 2),
+        "eliteTier": bool(cand.get("quality")),
+        "whales": cand.get("whales", []),
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=cand["direction"],
+            score=min(score / 7.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — gather whale tops, score, mirror the best
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    whales = config.get("whales", [])
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_remora_producer_version": VERSION})
+        return
+    if not whales:
+        cfg.output({
+            "status": "ok",
+            "note": "no whales configured — set config.whales to a list of trader_ids/wallets",
+            "_remora_producer_version": VERSION,
+        })
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_remora_producer_version": VERSION})
+        return
+
+    candidates = gather_candidates(whales, config)
+    scored = []
+    for cand in candidates:
+        if cand["asset"].upper() in held_set or cfg.was_recently_signaled(cand["asset"]):
+            continue
+        score, reasons = score_candidate(cand, config)
+        if score >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            scored.append((score, reasons, cand))
+
+    if not scored:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no qualifying whale position to mirror",
+            "whales_tracked": len(whales),
+            "candidates_seen": len(candidates),
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_remora_producer_version": VERSION,
+        })
+        return
+
+    # Highest score, tie-break by consensus count then notional.
+    scored.sort(key=lambda t: (t[0], t[2]["count"], t[2]["max_notional"]), reverse=True)
+    best_score, best_reasons, best = scored[0]
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, best_score, best_reasons, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["asset"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["asset"],
+            "direction": best["direction"],
+            "whale_count": best["count"],
+            "max_notional_usd": round(best["max_notional"], 2),
+            "elite_tier": bool(best.get("quality")),
+            "score": best_score,
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best_reasons[:5],
+        },
+        "candidates_count": len(scored),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_remora_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=600,   # 10min — whale positions change slowly
+        name=f"remora-producer-{_wallet_lock_id}",
+        tick_timeout=240,
+    )

--- a/remora/scripts/remora_config.py
+++ b/remora/scripts/remora_config.py
@@ -1,0 +1,220 @@
+"""REMORA v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Whale Single-Position Mirror. Remora rides on a configured set of whale traders
+the way a remora fish rides a shark: each tick it pulls each whale's open
+positions, picks their highest-conviction (largest-notional) position, and
+mirrors the strongest candidate — boosting the score when MULTIPLE whales agree
+on the same asset + direction (consensus). Optional whale-quality validation via
+discovery_get_trader_state (ELITE / RELIABLE tier) is a scoring bonus.
+
+Distinct from the broad trader-follower agents (Raptor/Jackal/Spider) that scan
+a leaderboard universe and synthesize. Remora is a focused MIRROR of a small
+hand-picked whale set — you choose whom to ride.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+let-winners-run DSL (whales hold winners; let it run, cap staleness with a
+hard_timeout). Producer enters only — the DSL owns exits (a whale-exit mirror is
+a future enhancement). Stateless candidate aggregation plus the fleet-standard
+race-window dedup, atomic write, simplified producer_daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "remora-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "remora-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Remora ticks every 600s; ALO fills typically settle
+# within 30-60s. 240s covers the full fill window plus the next-tick
+# clearinghouseState refresh, so the on-chain held-asset check picks up where
+# this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Remora's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("remora_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient failures
+    recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] remora_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[remora-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/remora/tests/test_signal.py
+++ b/remora/tests/test_signal.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Unit tests for Remora's pure functions (position_notional,
+mirror_direction, top_position, consensus_bonus). Stubs remora_config +
+senpi_runtime_helpers so the producer loads without the helpers package or a
+runtime workspace.
+Run: python3 remora/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("remora_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["remora_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "remora-producer.py"
+_spec = importlib.util.spec_from_file_location("remora_producer", _path)
+rp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(rp)
+
+
+def test_position_notional_size_times_entry():
+    assert abs(rp.position_notional({"szi": 2.0, "entryPx": 1000.0}) - 2000.0) < 1e-9
+
+
+def test_position_notional_falls_back_to_margin():
+    # no entry price → fall back to marginUsed
+    assert abs(rp.position_notional({"szi": 0, "marginUsed": 750.0}) - 750.0) < 1e-9
+
+
+def test_mirror_direction_explicit_and_szi():
+    assert rp.mirror_direction({"direction": "LONG"}) == "LONG"
+    assert rp.mirror_direction({"side": "short"}) == "SHORT"
+    assert rp.mirror_direction({"szi": 3.0}) == "LONG"
+    assert rp.mirror_direction({"szi": -3.0}) == "SHORT"
+    assert rp.mirror_direction({"szi": 0}) is None
+
+
+def test_top_position_picks_largest_notional():
+    positions = [
+        {"coin": "ETH", "szi": 1.0, "entryPx": 3000.0},     # 3000
+        {"coin": "BTC", "szi": 0.1, "entryPx": 90000.0},    # 9000 ← largest
+        {"coin": "SOL", "szi": 10.0, "entryPx": 150.0},     # 1500
+    ]
+    top = rp.top_position(positions)
+    assert rp.position_asset(top) == "BTC"
+
+
+def test_top_position_respects_min_notional():
+    positions = [{"coin": "DOGE", "szi": 100.0, "entryPx": 0.1}]  # notional 10
+    assert rp.top_position(positions, min_notional=5000.0) is None
+
+
+def test_top_position_empty_returns_none():
+    assert rp.top_position([]) is None
+    assert rp.top_position([{"coin": "", "szi": 0}]) is None  # no asset, no direction
+
+
+def test_consensus_bonus_tiers():
+    assert rp.consensus_bonus(1) == 0
+    assert rp.consensus_bonus(2) == 2
+    assert rp.consensus_bonus(3) == 3
+    assert rp.consensus_bonus(5) == 3
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -380,6 +380,7 @@ cfg._wrapper_client.push_signal(
 | **Jackal** | v1.0 | Multi (follows top traders) | Maintains an active trader pool, detects new entries, enriches each candidate with TA + funding regime. Strict per-trader contamination rules. | New-entry, TA, Funding |
 | **Spider** | v2.0 | Multi (arena-anchored) | Patient anchor sniper. Arena-leader overlap + SM-leaderboard universe + funding + relative strength. Single-leg, 7-day minimum hold, fee-aware. | Patient, Arena-anchor, 7d-hold |
 | **Albatross** | v1.0 | Arena leaders (multi-week composite) | **Onboarding tier.** Mirrors Senpi Arena leaders selected by composite conviction score: `0.3 × monthly_roe + 0.7 × mean(weekly_roe) − 0.5 × stdev(weekly_roe)`. Rewards multi-week persistence, penalizes lucky-week luck. Pool refreshes every 4h. **Requires user-scope auth token** (calls `strategy_list` + `discovery_get_trader_state` for other users). | Onboarding, Arena, Multi-week, Conviction-weighted, User-scope-auth-required |
+| **Remora** | v1.0 | Operator-picked whale set | **Hand-picked mirror.** You name the whales; Remora takes each whale's highest-conviction (largest-notional) position and mirrors the strongest, with a **consensus** multiplier (2 whales +2, 3+ +3) and an ELITE/RELIABLE-tier bonus. Contrast to the universe scanners above — exposure tracks traders YOU choose. Wide let-winners-run DSL + 120h staleness cap (whale-exit mirror is a future enhancement). Tick 600s. | Whale-mirror, Consensus, Operator-picked, Wide DSL |
 
 ---
 
@@ -842,6 +843,7 @@ Ask which one sentence sounds most like the user:
 
 - **Multi-week arena winners** (proven over a month, not one lucky week) → 🟢 **Albatross** (conviction-weighted leader pool).
 - **Live hot-streak traders** (whoever's hot right now) → **Raptor** · **Jackal** · **Spider** (arena-anchored).
+- **Specific whales YOU pick** (name the traders, mirror their biggest bet) → **Remora** — hand-picked whale mirror with a consensus boost when several agree.
 
 ### Layer 2D — Single-market specialist → which market?
 
@@ -996,6 +998,7 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | **Chameleon** | 13 — Relative-value / pairs | ETH/BTC · SOL/ETH · SOL/BTC. Ratio mean-reversion — trades the high-beta leg when a pair's z-score extends ~2σ and starts reverting. Mean-reversion DSL |
 | **Falcon** | 3 — Single-asset XYZ specialist (event-detection layer) | xyz: conversion events. Detects the IPOP→equity flip (funding jumps ~100x, leverage cap lifts, throttle off) and rides post-conversion price-discovery momentum. Class-state + conversion-window cache. Wide let-winners-run DSL, 7d hard_timeout |
 | **Osprey** | 9 — Cross-asset lag detector (cross-VENUE variant) | BTC → xyz: equity proxies (COIN/MSTR/miners). Self-computes the catch-up gap (leader move × beta − proxy move) from candles; trades the proxy in the leader's direction while it owes the gap. NOT cross_asset_flows (crypto-only). Wide let-winners-run DSL, 96h hard_timeout |
+| **Remora** | 5 — Trader-follower (hand-picked whale mirror) | Operator-picked whale set. Mirrors each whale's largest-notional position, scored by consensus (2 whales +2, 3+ +3) + ELITE-tier bonus. Unwraps the nested leaderboard_get_trader_positions shape. Wide let-winners-run DSL, 120h staleness cap |
 
 Sentinel runs an in-house producer that is not currently published to this repo; no public URL.
 


### PR DESCRIPTION
## Summary
- **Remora** (#8 of the 10-agent build) — a focused, operator-picked **whale mirror**, contrasting the universe-scanning trader-followers (Raptor/Jackal/Spider).
- You name the whales (`config.whales`). Each tick Remora pulls each whale's positions, takes their largest-notional bet, aggregates into `(asset, direction)` candidates, and mirrors the strongest — with a **consensus** multiplier (2 whales +2, 3+ +3) and an ELITE/RELIABLE-tier bonus.
- Focused variant of archetype #5 (Trader-follower). Reuses Spider's nested-shape unwrap for `leaderboard_get_trader_positions` (`data.positions.positions`).
- DSL: **let-winners-run** (wide ladder, max_loss 18%) + a 120h **staleness cap** (the whale-exit mirror is a planned v1.1; the timeout prevents holding a stale mirror). Taker-true entry; no null numeric signal fields; disown-safe launch.
- Integrated into `producer-patterns.md` (archetype #5 roster, Layer 2C bullet, fleet roster mapping) and `catalog.json` (trader-follower group, $500 min).

## Test plan
- [x] `python3 -m py_compile` producer + config — OK
- [x] `python3 remora/tests/test_signal.py` — 7/7 pass (position_notional, mirror_direction, top_position incl. min-notional/empty guards, consensus_bonus tiers)
- [x] runtime.yaml parses + config.json parses
- [x] field-parity: data_block keys ⊆ scanner `fields` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)