### PR TITLE
Add Cuckoo v1.0.0 — copy-the-copiers meta-strategy follower (archetype #14)

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -646,6 +646,21 @@
       "version": "1.0.0"
     },
     {
+      "id": "cuckoo",
+      "tracker_slug": "cuckoo",
+      "name": "Cuckoo \u2014 Copy-the-Copiers (Meta-Strategy Follower)",
+      "emoji": "\ud83d\udc26",
+      "tagline": "Let the best strategies do the work. Auto-discovers the top-performing strategies and trades their performance-weighted consensus \u2014 the layer above trader-following.",
+      "group": "trader-follower",
+      "sort_order": 35,
+      "min_budget": 500,
+      "risk_level": "aggressive",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/cuckoo",
+      "version": "1.0.0"
+    },
+    {
       "id": "turbine",
       "tracker_slug": "turbine",
       "name": "Turbine \u2014 Volume Engine + Runners",

--- a/cuckoo/README.md
+++ b/cuckoo/README.md
@@ -1,0 +1,134 @@
+# 🐦 Cuckoo — Copy-the-Copiers (Meta-Strategy Follower)
+
+**Let the best strategies do the work.** Cuckoo follows the platform's top-performing *strategies* — which are themselves copy/algo/trader-following strategies — and rides whatever they agree on most, weighted by how well each one is actually doing.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+Following one trader (Remora) or a leaderboard universe (Raptor/Jackal/Spider) is one layer. Cuckoo is the layer *above*: it follows the top-performing **strategies** and captures the consensus of the consensus. When the best strategies independently pile into the same asset+direction, that agreement is a strong, self-cleaning signal — underperformers drop out of the top-N automatically, so the pool refreshes toward whatever is working. **Distinct from Remora** (operator-picked whales) — Cuckoo *auto-discovers* its pool.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Pool | top `topN` strategies by realized performance (auto-discovered) |
+| Tick interval | 600s (10 min) — top-strategy consensus drifts slowly |
+| topN | 12 |
+| Min strategies in agreement | 2 |
+| Min position notional (per vote) | $2,000 |
+| Weight formula | `clamp(1 + roi/50, 0.5, weightCap)` |
+| Weight cap (outlier guard) | 3.0 |
+| High-weight bonus threshold | 6.0 |
+| MIN_SCORE (producer) | 4 (out of ~6 max) |
+| LLM min_confidence | 7 |
+| Leverage | 4x default, max 10x |
+| Margin per trade | 15% of equity |
+| Max entries per day | 3 |
+| Per-asset cooldown | 480 min (8h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 22% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (let-winners-run — with a staleness cap)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 18% |
+| Phase 1 | retrace_threshold | 10 |
+| Time cuts | hard_timeout | **96h (staleness cap)** |
+| Time cuts | weak_peak_cut | disabled |
+| Time cuts | dead_weight_cut | disabled |
+| Phase 2 | T0 → T4 | +10/0 · +20/45 · +35/65 · +55/78 · +90/88 |
+
+> ⚠️ Cuckoo re-evaluates the consensus each tick but does **not yet mirror an EXIT** — the 96h hard_timeout prevents holding a stale consensus indefinitely. Exit-mirroring is a planned v1.1 enhancement.
+
+## Scanner pattern
+
+Introduces the **Meta-strategy follower / copy-the-copiers** archetype (#14) — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `discovery_get_top_strategies` (defensive multi-key unwrap), `leaderboard_get_trader_positions` (each strategy's positions; nested `data.positions.positions` shape). Pure functions unit-tested in `tests/test_signal.py` (`python3 cuckoo/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/cuckoo-producer.py | Long-lived daemon; emits CUCKOO_META_CONSENSUS signals |
+| scripts/cuckoo_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/cuckoo-config.json | Operator-tunable defaults (topN, minStrategies, weight cap, sizing) |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Cuckoo
+
+```bash
+mkdir -p /data/workspace/skills/cuckoo-strategy/{config,scripts,state,references}
+for f in scripts/cuckoo-producer.py scripts/cuckoo_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/cuckoo-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cuckoo/$f" \
+    -o "/data/workspace/skills/cuckoo-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/cuckoo-strategy/config/cuckoo-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export CUCKOO_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                           # required (user-scope; needed for discovery_get_top_strategies)
+export CUCKOO_DECISION_MODEL=<your-preferred-model>   # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/cuckoo-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/cuckoo-strategy/scripts/cuckoo-producer.py \
+  > /tmp/cuckoo-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 620  # wait one full tick
+tail -3 /tmp/cuckoo-producer.log | jq '._cuckoo_producer_version, .note // null, .best.coin // null'
+# Expected: _cuckoo_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no asset held by >= 2 top strategies in agreement"` — common (the top strategies are diversified)
+- `"signals_pushed": 1, "best": { "coin": ..., "strategy_count": ..., "direction": "LONG"|"SHORT" }` — a consensus fired
+
+## Changelog
+
+### v1.0.0 (2026-05-26) — initial release
+
+First fleet agent to follow the auto-discovered top STRATEGIES (not individual traders) and trade their performance-weighted consensus — the copy-the-copiers meta-layer, a new archetype. Let-winners-run DSL class (wide ladder, time-cuts off except a 96h staleness cap), taker-true entry, no null numeric signal fields, defensive multi-key shape unwrapping, disown-safe launch, unit-tested signal functions. Exit-mirroring is a planned v1.1 enhancement.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/cuckoo/SKILL.md
+++ b/cuckoo/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: cuckoo-strategy
+description: >-
+  CUCKOO v1.0.0 — Copy-the-Copiers (meta-strategy follower). Auto-discovers the
+  top strategies by realized performance (discovery_get_top_strategies), pulls
+  each one's current positions, and trades the asset + direction the top
+  performers agree on most — performance-weighted, so a stronger strategy gets
+  more say (capped so one outlier can't dominate). Because the strategies it
+  follows are themselves copy/algo strategies, Cuckoo copies the copiers.
+  Distinct from Remora (operator-picked whales) and the individual trader-
+  followers. NEW archetype #14. Let-winners-run DSL with a staleness cap.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐦 CUCKOO v1.0.0 — Copy-the-Copiers (Meta-Strategy Follower)
+
+**Let the best strategies do the work.** A cuckoo lays its eggs in other birds' nests. Cuckoo lets the platform's top-performing *strategies* find the trades, then rides whatever they agree on most — weighted by how well each one is actually doing.
+
+## Why this strategy exists
+
+Following a single trader (Remora) or a leaderboard universe (Raptor/Jackal/Spider) is one layer. Cuckoo is a layer *above* that: it follows the top-performing **strategies** — which are themselves copy/algo/trader-following strategies — so it captures the *consensus of the consensus*. When the best strategies on the platform are independently piling into the same asset+direction, that agreement is a strong, self-cleaning signal: underperformers fall out of the top-N automatically, so the pool refreshes toward whatever is working.
+
+## CRITICAL RULES
+
+### RULE 1: Auto-discovered, not hand-picked
+Cuckoo pulls the top `topN` strategies by realized performance every tick (`discovery_get_top_strategies`). There is no operator whale list (that's Remora) — the pool is *discovered* and refreshes as performance changes.
+
+### RULE 2: Performance-weighted consensus
+Each top strategy casts one vote per `(asset, direction)` it holds above `minNotionalUsd`, weighted by `performance_weight(roi) = clamp(1 + roi/50, 0.5, weightCap)`. A flat strategy weighs 1.0; a +100% strategy hits the cap; a losing strategy floors at 0.5. The cap stops one outlier from dominating.
+
+### RULE 3: Consensus is the gate
+Votes are tallied into `(asset, direction)` candidates. Entry requires at least `minStrategies` (default 2) top strategies in agreement — one strategy's position is never enough.
+
+### RULE 4: Producer enters. DSL exits.
+No `close_position` call site. The top strategies hold conviction positions, so the DSL is the **let-winners-run** preset — wide ladder (T0 +10% / lock 0), `max_loss 18%`, time-cuts OFF except a **96h hard_timeout** staleness cap. ⚠️ Cuckoo re-evaluates the consensus each tick but does **not yet mirror an EXIT** — the hard_timeout prevents holding a stale consensus indefinitely. Exit-mirroring is a planned v1.1 enhancement.
+
+## How Cuckoo scores a trade
+
+**Gate:** `>= minStrategies` top strategies hold the same `(asset, direction)`.
+
+**Score components** (max ~6):
+
+| Signal | Points |
+|---|---|
+| Held by at least one top strategy | +2 |
+| Consensus: 2 strategies agree | +1 |
+| Consensus: 3 strategies agree | +2 |
+| Consensus: 4+ strategies agree | +3 |
+| Aggregate consensus weight ≥ `highWeight` (default 6.0) | +1 |
+
+**Floor:** `minScore: 4` (so a 2-strategy consensus needs the high-weight bonus, or 3+ strategies, to clear).
+
+## DSL preset (let-winners-run — with a staleness cap)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 18% |
+| Phase 1 | retrace_threshold | 10 |
+| Time cuts | hard_timeout | **96h (staleness cap)** |
+| Time cuts | weak_peak_cut | DISABLED |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +10/0 · +20/45 · +35/65 · +55/78 · +90/88 |
+
+## Scanner pattern
+
+Introduces the **Meta-strategy follower / copy-the-copiers** archetype (#14) — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `discovery_get_top_strategies` (the producer signature; defensive multi-key unwrap of the strategy list), `leaderboard_get_trader_positions` (each top strategy's positions; unwraps the nested `data.positions.positions` shape). The pure functions (`performance_weight`, `mirror_direction`, `tally_consensus`, `consensus_score`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-26) — initial release
+
+First fleet agent to follow the auto-discovered top STRATEGIES (not individual traders) and trade their performance-weighted consensus — the copy-the-copiers meta-layer, a new archetype. Let-winners-run DSL class (wide ladder, time-cuts off except a 96h staleness cap), taker-true entry, no null numeric signal fields, defensive multi-key shape unwrapping on `discovery_get_top_strategies` + `leaderboard_get_trader_positions`, and unit-tested pure functions. Exit-mirroring is a planned v1.1 enhancement.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/cuckoo/config/cuckoo-config.json
+++ b/cuckoo/config/cuckoo-config.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "CUCKOO v1.0.0 — Copy-the-Copiers (meta-strategy follower). Each tick auto-discovers the top topN strategies by realized performance (discovery_get_top_strategies), pulls each strategy's current positions (leaderboard_get_trader_positions), and builds a PERFORMANCE-WEIGHTED consensus: each strategy casts one vote per (asset, direction) it holds above minNotionalUsd, weighted by performance_weight(roi) = clamp(1 + roi/50, 0.5, weightCap). It trades the highest weighted-consensus candidate that >= minStrategies top strategies agree on. Because those strategies are themselves copy/algo strategies, Cuckoo copies the copiers. Let-winners-run DSL with a 96h staleness cap. Edit wallet/strategyId/chatId; tune topN/minStrategies/thresholds. NEW archetype #14. Distinct from Remora (operator-picked whales).",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "topN": 12,
+  "minStrategies": 2,
+  "minNotionalUsd": 2000,
+  "weightCap": 3.0,
+  "highWeight": 6.0,
+  "minScore": 4,
+  "marginPct": 0.15,
+  "leverage": 4
+}

--- a/cuckoo/references/skill-attribution.md
+++ b/cuckoo/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "cuckoo",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "cuckoo",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/cuckoo/runtime.yaml
+++ b/cuckoo/runtime.yaml
@@ -1,0 +1,186 @@
+name: cuckoo-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Cuckoo v1.0.0"
+# and lives in description + SKILL.md + _cuckoo_producer_version.
+version: 1.0.0
+description: >
+  CUCKOO v1.0.0 — Copy-the-Copiers (meta-strategy follower).
+
+  Cuckoo auto-discovers the top strategies by realized performance
+  (discovery_get_top_strategies), pulls each one's current positions, and trades
+  the asset + direction the top performers agree on most — PERFORMANCE-WEIGHTED,
+  so a stronger strategy gets more say (capped so one outlier can't dominate).
+  Because the strategies it follows are themselves copy/algo strategies, Cuckoo
+  copies the copiers. NEW archetype #14.
+
+  Distinct from Remora (operator-picked whales) and the individual trader-
+  followers — Cuckoo follows the auto-discovered top STRATEGIES.
+
+  Architecture (helpers-native): producer ticks every 600s, builds a weighted
+  consensus across the top strategies' positions, and emits
+  CUCKOO_META_CONSENSUS via SenpiClient.push_signal() when enough top strategies
+  agree. LLM gate is pass-through.
+
+  DSL: let-winners-run preset — wide ladder (T0 +10% / lock 0), max_loss 18%,
+  time-cuts OFF except a hard_timeout staleness cap (follow conviction; let it
+  run, but don't hold a stale consensus forever).
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 200
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 96
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 90
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 480
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: cuckoo_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        strategyCount: { type: number, required: false }
+        consensusWeight: { type: number, required: false }
+        strategiesFollowed: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: cuckoo_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${CUCKOO_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [cuckoo_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # follow the live consensus now — a maker order that rests (CREATE_ORDER_RESTING) drifts from the top strategies' exposure
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: cuckoo_signals
+    decision_prompt: |
+      You are Cuckoo's pass-through gate. Cuckoo follows the auto-discovered
+      TOP STRATEGIES by performance: it built a performance-weighted consensus
+      across their open positions and surfaced the asset + direction they agree
+      on most. Honor the signal.
+
+      SIGNAL:
+      {{signal_cuckoo_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (preserve case / any xyz: prefix).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-10x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 4 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+      - strategyCount < 2 (consensus requires at least two top strategies)
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 5 AND strategyCount >= 3
+      - 7-8:  score 4-5
+      - 7:    score 4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 5 ETH LONG, 4 of the top strategies agree, weighted 7.2 — meta-consensus')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "CUCKOO_META_CONSENSUS ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — let-winners-run preset) ──────────────────────
+#
+# The top strategies hold conviction positions, so let the consensus run: wide
+# ladder (T0 +10% / lock 0), max_loss 18%, time-cuts OFF except a hard_timeout
+# staleness cap (Cuckoo re-evaluates the consensus each tick but does not yet
+# mirror an EXIT, so the timeout prevents holding a stale consensus forever).
+# NO weak_peak_cut.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760                   # 96h — staleness cap, since the consensus EXIT is not yet mirrored
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 45 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+        - { trigger_pct: 90, lock_hw_pct: 88 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/cuckoo/scripts/cuckoo-producer.py
+++ b/cuckoo/scripts/cuckoo-producer.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+# Senpi CUCKOO Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""CUCKOO v1.0.0 — Copy-the-Copiers (meta-strategy follower).
+
+Cuckoo lets the best-performing STRATEGIES on the platform do the work and rides
+their consensus. Each tick it:
+
+  1. Auto-discovers the top strategies by realized performance
+     (discovery_get_top_strategies).
+  2. Pulls each top strategy's current positions (leaderboard_get_trader_
+     positions on the strategy wallet).
+  3. Builds (asset, direction) candidates aggregated across strategies,
+     PERFORMANCE-WEIGHTED — a stronger strategy gets more say, capped so one
+     outlier can't dominate.
+  4. Trades the highest weighted-consensus candidate.
+
+This is a META layer: the strategies it follows are themselves copy/algo/
+trader-following strategies, so Cuckoo copies the copiers. NEW archetype #14.
+Distinct from Remora (operator-picked whales) and the individual trader-
+followers. Follow conviction → let-winners-run DSL (wide ladder + staleness
+cap). Producer enters only — the DSL owns exits.
+
+REQUIRES USER-SCOPE AUTH for discovery_get_top_strategies /
+leaderboard_get_trader_positions.
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import cuckoo_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "cuckoo_signals"
+SIGNAL_TYPE = "CUCKOO_META_CONSENSUS"
+
+MAX_LEVERAGE = 10
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 4
+DEFAULT_TOP_N = 12              # how many top strategies to follow
+DEFAULT_MIN_STRATEGIES = 2     # require at least this many agreeing
+DEFAULT_MIN_NOTIONAL_USD = 2000
+DEFAULT_WEIGHT_CAP = 3.0       # max per-strategy weight (outlier guard)
+DEFAULT_HIGH_WEIGHT = 6.0      # aggregate weight that earns the bonus point
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("CUCKOO_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def safe_float(v, default=0.0):
+    try:
+        return float(v if v is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure meta-consensus logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def performance_weight(roi_pct, cap=DEFAULT_WEIGHT_CAP):
+    """Map a strategy's ROI% to a follow weight in [0.5, cap]. A flat strategy
+    weighs 1.0; a +100% strategy hits the cap; a losing strategy floors at
+    0.5 (it still counts a little, but barely)."""
+    w = 1.0 + (safe_float(roi_pct) / 50.0)
+    if w < 0.5:
+        return 0.5
+    if w > cap:
+        return cap
+    return w
+
+
+def mirror_direction(pos):
+    """LONG / SHORT for a position (explicit direction/side field, else szi
+    sign). None if undeterminable."""
+    if not isinstance(pos, dict):
+        return None
+    d = str(pos.get("direction", pos.get("side", ""))).upper()
+    if d in ("LONG", "SHORT"):
+        return d
+    szi = safe_float(pos.get("szi", pos.get("size", 0)))
+    if szi > 0:
+        return "LONG"
+    if szi < 0:
+        return "SHORT"
+    return None
+
+
+def position_asset(pos):
+    if not isinstance(pos, dict):
+        return ""
+    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", ""))))).upper()
+
+
+def position_notional(pos):
+    if not isinstance(pos, dict):
+        return 0.0
+    size = abs(safe_float(pos.get("szi", pos.get("size", 0))))
+    entry = safe_float(pos.get("entryPx", pos.get("entryPrice", pos.get("entry", 0))))
+    notional = size * entry
+    if notional > 0:
+        return notional
+    margin = abs(safe_float(pos.get("marginUsed", pos.get("margin", 0))))
+    return margin if margin > 0 else size
+
+
+def tally_consensus(entries):
+    """Aggregate per-strategy votes into weighted (asset, direction) candidates.
+    `entries` = list of {"asset","direction","weight"}. Returns a dict keyed by
+    (asset, direction) -> {"asset","direction","count","weight"}."""
+    agg = {}
+    for e in entries:
+        asset = str(e.get("asset", "")).upper()
+        direction = e.get("direction")
+        if not asset or direction not in ("LONG", "SHORT"):
+            continue
+        weight = safe_float(e.get("weight"), 1.0)
+        key = (asset, direction)
+        rec = agg.setdefault(key, {"asset": asset, "direction": direction, "count": 0, "weight": 0.0})
+        rec["count"] += 1
+        rec["weight"] += weight
+    return agg
+
+
+def consensus_score(count, total_weight, high_weight=DEFAULT_HIGH_WEIGHT):
+    """Score a weighted-consensus candidate (max ~6)."""
+    score = 2  # held by at least one top strategy
+    if count >= 4:
+        score += 3
+    elif count >= 3:
+        score += 2
+    elif count == 2:
+        score += 1
+    if total_weight >= high_weight:
+        score += 1
+    return score
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers (defensive shape unwrapping)
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_top_strategies(top_n):
+    """Returns a list of {wallet, roi} for the top strategies by performance.
+    Unwraps the discovery response defensively (multi-key fallbacks)."""
+    raw = cfg.mcp_call("discovery_get_top_strategies", limit=top_n)
+    if not raw:
+        return []
+    d = raw.get("data", raw) if isinstance(raw, dict) else raw
+    items = d
+    if isinstance(d, dict):
+        items = d.get("strategies", d.get("top_strategies", d.get("results", [])))
+    if not isinstance(items, list):
+        return []
+    out = []
+    for it in items[:top_n]:
+        if not isinstance(it, dict):
+            continue
+        wallet = (
+            it.get("strategyWalletAddress")
+            or it.get("strategy_wallet")
+            or it.get("wallet")
+            or it.get("trader_id")
+            or it.get("address")
+        )
+        if not wallet:
+            continue
+        roi = safe_float(
+            it.get("roi", it.get("roe", it.get("totalPnlPct", it.get("totalPnl", 0))))
+        )
+        out.append({"wallet": str(wallet), "roi": roi})
+    return out
+
+
+def fetch_strategy_positions(wallet):
+    """Positions for one strategy, unwrapping the nested
+    data.positions.positions shape (same as Remora/Spider)."""
+    raw = cfg.mcp_call("leaderboard_get_trader_positions", trader_id=wallet)
+    if not raw:
+        return []
+    if not isinstance(raw, dict):
+        return raw if isinstance(raw, list) else []
+    d = raw.get("data", raw)
+    if isinstance(d, list):
+        return d
+    if not isinstance(d, dict):
+        return []
+    rp = d.get("positions", d.get("top_positions", []))
+    if isinstance(rp, list):
+        return rp
+    if isinstance(rp, dict):
+        nested = rp.get("positions", [])
+        return nested if isinstance(nested, list) else []
+    return []
+
+
+# ═══════════════════════════════════════════════════════════════
+# Candidate building
+# ═══════════════════════════════════════════════════════════════
+
+def gather_entries(strategies, config):
+    """One weighted vote per (strategy, asset, direction) for every qualifying
+    position the top strategies hold. Returns the entries list for
+    tally_consensus()."""
+    min_notional = float(config.get("minNotionalUsd", DEFAULT_MIN_NOTIONAL_USD))
+    cap = float(config.get("weightCap", DEFAULT_WEIGHT_CAP))
+    entries = []
+    for strat in strategies:
+        wallet = strat["wallet"]
+        weight = performance_weight(strat["roi"], cap)
+        positions = fetch_strategy_positions(wallet)
+        seen = set()  # dedupe within a strategy: one vote per asset+direction
+        for pos in positions:
+            asset = position_asset(pos)
+            direction = mirror_direction(pos)
+            if not asset or direction is None:
+                continue
+            if position_notional(pos) < min_notional:
+                continue
+            key = (asset, direction)
+            if key in seen:
+                continue
+            seen.add(key)
+            entries.append({"asset": asset, "direction": direction, "weight": weight})
+    return entries
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(cand, score, reasons, margin_usd, leverage, held_assets, strategies_followed):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = cand["asset"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": score,
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": cand["direction"],
+        "reasons": reasons,
+        "strategyCount": cand["count"],
+        "consensusWeight": round(cand["weight"], 2),
+        "strategiesFollowed": strategies_followed,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=cand["direction"],
+            score=min(score / 6.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — discover top strategies, weight consensus, follow the best
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    top_n = int(config.get("topN", DEFAULT_TOP_N))
+    min_strategies = int(config.get("minStrategies", DEFAULT_MIN_STRATEGIES))
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_cuckoo_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_cuckoo_producer_version": VERSION})
+        return
+
+    strategies = fetch_top_strategies(top_n)
+    if not strategies:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — discovery_get_top_strategies returned no strategies",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_cuckoo_producer_version": VERSION,
+        })
+        return
+
+    entries = gather_entries(strategies, config)
+    consensus = tally_consensus(entries)
+
+    scored = []
+    for cand in consensus.values():
+        if cand["count"] < min_strategies:
+            continue
+        if cand["asset"].upper() in held_set or cfg.was_recently_signaled(cand["asset"]):
+            continue
+        score = consensus_score(cand["count"], cand["weight"], float(config.get("highWeight", DEFAULT_HIGH_WEIGHT)))
+        if score >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            reasons = [
+                f"{cand['asset']}_{cand['direction']}",
+                f"top_strategies_{cand['count']}",
+                f"weighted_{cand['weight']:.1f}",
+            ]
+            scored.append((score, reasons, cand))
+
+    if not scored:
+        cfg.output({
+            "status": "ok",
+            "note": f"WAITING — no asset held by >= {min_strategies} top strategies in agreement",
+            "strategies_followed": len(strategies),
+            "candidates_seen": len(consensus),
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_cuckoo_producer_version": VERSION,
+        })
+        return
+
+    scored.sort(key=lambda t: (t[0], t[2]["weight"], t[2]["count"]), reverse=True)
+    best_score, best_reasons, best = scored[0]
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, best_score, best_reasons, margin_usd, leverage, held_assets, len(strategies))
+    if pushed:
+        cfg.record_signal(best["asset"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["asset"],
+            "direction": best["direction"],
+            "strategy_count": best["count"],
+            "consensus_weight": round(best["weight"], 2),
+            "score": best_score,
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best_reasons[:5],
+        },
+        "strategies_followed": len(strategies),
+        "candidates_count": len(scored),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_cuckoo_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=600,   # 10min — top-strategy consensus drifts slowly
+        name=f"cuckoo-producer-{_wallet_lock_id}",
+        tick_timeout=240,
+    )

--- a/cuckoo/scripts/cuckoo_config.py
+++ b/cuckoo/scripts/cuckoo_config.py
@@ -1,0 +1,221 @@
+"""CUCKOO v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Copy-the-Copiers (meta-strategy follower). A cuckoo lays its eggs in other
+birds' nests; Cuckoo lets the best-performing STRATEGIES on the platform do the
+work and rides their consensus. Each tick it auto-discovers the top strategies
+by realized performance (discovery_get_top_strategies), pulls each one's current
+positions, and trades the asset+direction the top performers agree on most —
+PERFORMANCE-WEIGHTED, so a stronger strategy gets more say (capped so one
+outlier can't dominate).
+
+This is a META layer: the strategies it follows are themselves
+copy/algo/trader-following strategies, so Cuckoo copies the copiers. Distinct
+from Remora (operator-picked whales) and the trader-followers (individual
+traders) — Cuckoo follows the auto-discovered top STRATEGIES.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+let-winners-run DSL (follow conviction; let it run). Stateless weighted
+aggregation plus the fleet-standard race-window dedup, atomic write, simplified
+producer_daemon. NEW archetype #14.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "cuckoo-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "cuckoo-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Cuckoo ticks every 600s; ALO fills typically settle
+# within 30-60s. 240s covers the full fill window plus the next-tick
+# clearinghouseState refresh, so the on-chain held-asset check picks up where
+# this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Cuckoo's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("cuckoo_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient failures
+    recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] cuckoo_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[cuckoo-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/cuckoo/tests/test_signal.py
+++ b/cuckoo/tests/test_signal.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Unit tests for Cuckoo's pure functions (performance_weight,
+mirror_direction, tally_consensus, consensus_score). Stubs cuckoo_config +
+senpi_runtime_helpers so the producer loads without the helpers package or a
+runtime workspace.
+Run: python3 cuckoo/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("cuckoo_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["cuckoo_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "cuckoo-producer.py"
+_spec = importlib.util.spec_from_file_location("cuckoo_producer", _path)
+cp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cp)
+
+
+def test_performance_weight_scaling_and_bounds():
+    assert abs(cp.performance_weight(0) - 1.0) < 1e-9       # flat strategy weighs 1.0
+    assert abs(cp.performance_weight(50) - 2.0) < 1e-9      # +50% → 2.0
+    assert cp.performance_weight(1000, cap=3.0) == 3.0      # capped
+    assert cp.performance_weight(-100) == 0.5               # floored
+
+
+def test_mirror_direction_explicit_and_szi():
+    assert cp.mirror_direction({"direction": "LONG"}) == "LONG"
+    assert cp.mirror_direction({"side": "short"}) == "SHORT"
+    assert cp.mirror_direction({"szi": 2.0}) == "LONG"
+    assert cp.mirror_direction({"szi": -2.0}) == "SHORT"
+    assert cp.mirror_direction({"szi": 0}) is None
+
+
+def test_tally_consensus_aggregates_weight_and_count():
+    entries = [
+        {"asset": "BTC", "direction": "LONG", "weight": 2.0},
+        {"asset": "btc", "direction": "LONG", "weight": 1.5},   # case-insensitive
+        {"asset": "BTC", "direction": "SHORT", "weight": 1.0},  # opposite side separate
+        {"asset": "ETH", "direction": "LONG", "weight": 3.0},
+    ]
+    agg = cp.tally_consensus(entries)
+    btc_long = agg[("BTC", "LONG")]
+    assert btc_long["count"] == 2 and abs(btc_long["weight"] - 3.5) < 1e-9
+    assert agg[("BTC", "SHORT")]["count"] == 1
+    assert agg[("ETH", "LONG")]["count"] == 1
+
+
+def test_tally_consensus_skips_bad_entries():
+    entries = [
+        {"asset": "", "direction": "LONG", "weight": 2.0},      # no asset
+        {"asset": "SOL", "direction": "FLAT", "weight": 2.0},   # bad direction
+    ]
+    assert cp.tally_consensus(entries) == {}
+
+
+def test_consensus_score_tiers():
+    # 1 strategy, low weight → base 2
+    assert cp.consensus_score(1, 1.0) == 2
+    # 2 strategies → +1 = 3
+    assert cp.consensus_score(2, 3.0) == 3
+    # 3 strategies → +2 = 4
+    assert cp.consensus_score(3, 5.0) == 4
+    # 4 strategies + high weight → 2 + 3 + 1 = 6
+    assert cp.consensus_score(4, 7.0, high_weight=6.0) == 6
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -739,6 +739,41 @@ z, ratio, mean, std = ratio_zscore(ca, cb, lookback=48)  # z of latest ratio vs 
 
 ---
 
+### 14. Meta-strategy follower / copy-the-copiers
+
+Follows not individual traders but the **top-performing strategies** on the platform — which are themselves copy/algo/trader-following strategies — and trades their **performance-weighted consensus**. The layer above trader-following: it captures the *consensus of the consensus*, and the pool self-cleans (underperformers fall out of the top-N automatically).
+
+```python
+strats = top_strategies(limit=12)                      # discovery_get_top_strategies, by realized PnL/ROI
+entries = []
+for s in strats:                                       # each strategy's live positions
+    w = performance_weight(s["roi"])                   # clamp(1 + roi/50, 0.5, cap) — stronger strategy, more say
+    for pos in trader_positions(s["wallet"]):          # leaderboard_get_trader_positions (nested data.positions.positions)
+        entries.append({"asset": asset(pos), "direction": dir(pos), "weight": w})
+consensus = tally_consensus(entries)                   # (asset,dir) -> {count, summed weight}
+# fire the highest weighted-consensus candidate that >= minStrategies agree on
+```
+
+| | |
+|---|---|
+| Producer-signature for fleet audit | `discovery_get_top_strategies` every tick (+ `leaderboard_get_trader_positions` per strategy) |
+| Typical tick interval | 600s (top-strategy consensus drifts slowly) |
+| Typical risk envelope | consensus-gated (≥2 top strategies agree), conviction-tier leverage, wide DSL + staleness cap |
+| Example agent | **Cuckoo** |
+| Example producer (full source) | https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cuckoo/scripts/cuckoo-producer.py |
+| Example `_config.py` | https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cuckoo/scripts/cuckoo_config.py |
+| Example runtime.yaml | https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/cuckoo/runtime.yaml |
+
+**When to use this pattern:** you trust the platform's *aggregate* of best strategies more than any one trader or your own read, and want exposure that auto-rotates toward whatever is currently working. **Requires user-scope auth** (`discovery_get_top_strategies` + `leaderboard_get_trader_positions` for other accounts).
+
+**Agents in this family:**
+
+| Agent | Version | Asset / Universe | Description | Tags |
+|---|---|---|---|---|
+| **Cuckoo** | v1.0 | Top-strategy consensus | Auto-discovers the top-N strategies by performance, builds a performance-weighted consensus across their positions, and trades what ≥2 of them agree on most. Wide let-winners-run DSL + 96h staleness cap. Tick 600s. | Meta-follower, Copy-the-copiers, Consensus, Performance-weighted, User-scope-auth-required |
+
+---
+
 ## Decision tree — help a user pick their first strategy
 
 This is the guided path an **onboarding agent** walks a new user through. Start broad ("what kind of trader do you want your agent to be?"), narrow **one layer at a time**, and land on a single deployable strategy. Ask one question, show 2–6 options, let them pick, then go deeper. Each leaf names a **real, installable agent** — beginners are routed to the **onboarding tier** (simpler scoring, conservative sizing); the *level up* line is the full-fleet version for once they're comfortable.
@@ -844,6 +879,7 @@ Ask which one sentence sounds most like the user:
 - **Multi-week arena winners** (proven over a month, not one lucky week) → 🟢 **Albatross** (conviction-weighted leader pool).
 - **Live hot-streak traders** (whoever's hot right now) → **Raptor** · **Jackal** · **Spider** (arena-anchored).
 - **Specific whales YOU pick** (name the traders, mirror their biggest bet) → **Remora** — hand-picked whale mirror with a consensus boost when several agree.
+- **The best strategies, automatically** (don't pick anyone — follow whatever's working) → **Cuckoo** — auto-discovers the top-performing strategies and trades their performance-weighted consensus (copy-the-copiers).
 
 ### Layer 2D — Single-market specialist → which market?
 
@@ -870,7 +906,7 @@ XYZ markets (stocks / commodities / pre-IPO) trade **24/7 on Hyperliquid**, even
 - **Crypto stocks that lag a BTC move** (COIN / MSTR / miners on XYZ haven't caught up yet) → **Osprey** (cross-VENUE lag — self-computes the catch-up gap from each proxy's beta).
 - **Volume / market-making** (not a directional bet) → **Turbine** (specialized).
 - **Trade the spread between two coins** (a pair's ratio stretched far from its mean) → **Chameleon** (relative-value / pairs — ratio mean-reversion).
-- *Expanding set — copy-the-copiers is being added. Already live: microstructure (Piranha, Marlin — Layer 2E) and relative-value / pairs (Chameleon).*
+- *Expanding set — already live: microstructure (Piranha, Marlin — Layer 2E), relative-value / pairs (Chameleon), and copy-the-copiers meta-following (Cuckoo — Layer 2C).*
 
 ### Run a current top performer (by live ROE)
 
@@ -999,6 +1035,7 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | **Falcon** | 3 — Single-asset XYZ specialist (event-detection layer) | xyz: conversion events. Detects the IPOP→equity flip (funding jumps ~100x, leverage cap lifts, throttle off) and rides post-conversion price-discovery momentum. Class-state + conversion-window cache. Wide let-winners-run DSL, 7d hard_timeout |
 | **Osprey** | 9 — Cross-asset lag detector (cross-VENUE variant) | BTC → xyz: equity proxies (COIN/MSTR/miners). Self-computes the catch-up gap (leader move × beta − proxy move) from candles; trades the proxy in the leader's direction while it owes the gap. NOT cross_asset_flows (crypto-only). Wide let-winners-run DSL, 96h hard_timeout |
 | **Remora** | 5 — Trader-follower (hand-picked whale mirror) | Operator-picked whale set. Mirrors each whale's largest-notional position, scored by consensus (2 whales +2, 3+ +3) + ELITE-tier bonus. Unwraps the nested leaderboard_get_trader_positions shape. Wide let-winners-run DSL, 120h staleness cap |
+| **Cuckoo** | 14 — Meta-strategy follower / copy-the-copiers | Auto-discovers the top-N strategies by performance and trades their performance-weighted consensus (weight = clamp(1 + roi/50, 0.5, cap)); gate ≥2 strategies agree. Wide let-winners-run DSL, 96h staleness cap. User-scope auth |
 
 Sentinel runs an in-house producer that is not currently published to this repo; no public URL.
 


### PR DESCRIPTION
## Summary
- **Cuckoo** (#9 of the 10-agent build) — first fleet agent to follow the auto-discovered top **strategies** (not individual traders) and trade their **performance-weighted consensus**. Introduces NEW archetype #14 (meta-strategy follower / copy-the-copiers).
- Each tick: top-N strategies by performance (`discovery_get_top_strategies`) → each one's positions (`leaderboard_get_trader_positions`) → one vote per `(asset, direction)` weighted by `clamp(1 + roi/50, 0.5, cap)` → fire what ≥`minStrategies` agree on most.
- The layer above trader-following: captures the consensus of the consensus, and the pool self-cleans as performance changes. Distinct from Remora (operator-picked whales).
- DSL: **let-winners-run** (wide ladder, max_loss 18%) + 96h **staleness cap** (exit-mirror is a planned v1.1). Taker-true entry; no null numeric signal fields; defensive multi-key shape unwrapping; disown-safe launch.
- Integrated into `producer-patterns.md` (NEW archetype #14, Layer 2C bullet, expanding-set note, fleet roster mapping) and `catalog.json` (trader-follower group, $500 min).

## Test plan
- [x] `python3 -m py_compile` producer + config — OK
- [x] `python3 cuckoo/tests/test_signal.py` — 5/5 pass (performance_weight bounds/scaling, mirror_direction, tally_consensus aggregation + bad-entry skip, consensus_score tiers)
- [x] runtime.yaml parses + config.json parses
- [x] field-parity: data_block keys ⊆ scanner `fields` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)