### PR TITLE
Add Meerkat v1.0.0 — momentum-event sniper (#10/10)

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -586,6 +586,21 @@
       "version": "3.0.1"
     },
     {
+      "id": "meerkat",
+      "tracker_slug": "meerkat",
+      "name": "Meerkat \u2014 Momentum-Event Sniper",
+      "emoji": "\ud83e\udda6",
+      "tagline": "Stand sentry, pop the instant something moves. Snipes the freshest, highest-tier momentum events off the Senpi event feed before the move is broadly known.",
+      "group": "striker-rank-jump",
+      "sort_order": 31,
+      "min_budget": 500,
+      "risk_level": "aggressive",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/meerkat",
+      "version": "1.0.0"
+    },
+    {
       "id": "salamander",
       "tracker_slug": "salamander",
       "name": "Salamander \u2014 Pullback Catcher",

--- a/meerkat/README.md
+++ b/meerkat/README.md
@@ -1,0 +1,131 @@
+# 🦦 Meerkat — Momentum-Event Sniper
+
+**Stand sentry, pop the instant something moves.** Meerkat watches the Senpi momentum-event feed and snipes the freshest, highest-tier momentum events the instant they fire — entering in the move's direction before it's broadly known.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+The momentum-event feed (`leaderboard_get_momentum_events`) surfaces assets that just made a sharp move in the 4h rolling window — the earliest, cleanest read on *fresh* momentum. The edge decays fast, so Meerkat's job is **speed + selectivity**: only the strongest tiers, only while they're fresh. **Distinct from the rank-jump strikers** (Jaguar/Orca/Roach, which score a leaderboard universe) — Meerkat reads the event feed directly.
+
+## Key parameters
+
+| Parameter | Value |
+|---|---|
+| Source | `leaderboard_get_momentum_events` (4h rolling-window events) |
+| Tick interval | 120s (2 min) — momentum is time-sensitive |
+| Tier classification | 3 ≥ 10% · 2 ≥ 5% · else 1 (by `|momentum|`) |
+| Min tier (gate) | 2 (set 3 for a pure tier-3 sniper) |
+| Freshness gate | event age ≤ 30 min |
+| MIN_SCORE (producer) | 4 (out of ~7 max) |
+| LLM min_confidence | 7 |
+| Leverage | 4x default, max 10x |
+| Margin per trade | 15% of equity |
+| SM tilt minimum (bonus) | 55% (strong 70%) |
+| Max entries per day | 4 |
+| Per-asset cooldown | 240 min (4h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 22% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (let-winners-run — momentum-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 18% |
+| Phase 1 | retrace_threshold | 10 |
+| Time cuts | hard_timeout | **36h (short — momentum is time-bounded)** |
+| Time cuts | weak_peak_cut | disabled |
+| Time cuts | dead_weight_cut | disabled |
+| Phase 2 | T0 → T4 | +10/0 · +20/45 · +35/65 · +55/78 · +90/88 |
+
+## Scanner pattern
+
+A focused, event-driven variant of the **Striker / rank-jump detector** archetype (#6) — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `leaderboard_get_momentum_events` (defensive multi-key unwrap), `leaderboard_get_markets` (SM), `market_get_asset_data` (volume). Pure functions unit-tested in `tests/test_signal.py` (`python3 meerkat/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/meerkat-producer.py | Long-lived daemon; emits MEERKAT_MOMENTUM_EVENT signals |
+| scripts/meerkat_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/meerkat-config.json | Operator-tunable defaults (tiers, freshness, thresholds, sizing) |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Meerkat
+
+```bash
+mkdir -p /data/workspace/skills/meerkat-strategy/{config,scripts,state,references}
+for f in scripts/meerkat-producer.py scripts/meerkat_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/meerkat-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/meerkat/$f" \
+    -o "/data/workspace/skills/meerkat-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/meerkat-strategy/config/meerkat-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export MEERKAT_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                            # required (user-scope; needed for leaderboard_get_momentum_events)
+export MEERKAT_DECISION_MODEL=<your-preferred-model>   # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/meerkat-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/meerkat-strategy/scripts/meerkat-producer.py \
+  > /tmp/meerkat-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 130  # wait one full tick
+tail -3 /tmp/meerkat-producer.log | jq '._meerkat_producer_version, .note // null, .best.tier // null'
+# Expected: _meerkat_producer_version = "1.0.0"
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no momentum events in the feed"` — quiet market
+- `"note": "WAITING — no fresh tier>=minTier momentum event cleared minScore"` — events exist but none strong/fresh enough
+- `"signals_pushed": 1, "best": { "coin": ..., "tier": 3, "direction": "LONG"|"SHORT" }` — a snipe fired
+
+## Changelog
+
+### v1.0.0 (2026-05-26) — initial release
+
+First fleet agent driven directly off the momentum-event feed — a tier + freshness sniper, contrasting the universe-scanning rank-jump strikers. Let-winners-run DSL class (wide ladder, short 36h hard_timeout since momentum is time-bounded), taker-true entry, no null numeric signal fields, defensive multi-key shape unwrapping, disown-safe launch, unit-tested signal functions (including epoch-seconds-vs-milliseconds handling).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/meerkat/SKILL.md
+++ b/meerkat/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: meerkat-strategy
+description: >-
+  MEERKAT v1.0.0 — Momentum-Event Sniper. Watches the Senpi momentum-event feed
+  (leaderboard_get_momentum_events — the 4h rolling-window momentum / rank-jump
+  events) and snipes the freshest, highest-tier events the moment they fire,
+  entering in the momentum direction before the move is broadly known. Tier
+  (event magnitude) + freshness gate the entry; SM alignment + rising volume
+  are confirmation bonuses. Distinct from the Striker / rank-jump agents
+  (Jaguar/Orca/Roach) which score a leaderboard universe. Let-winners-run DSL
+  with a short hard_timeout.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦦 MEERKAT v1.0.0 — Momentum-Event Sniper
+
+**Stand sentry, pop the instant something moves.** A meerkat watches the horizon and reacts the moment it spots motion. Meerkat watches the Senpi momentum-event feed and snipes the freshest, highest-tier momentum events the instant they fire — entering in the move's direction before it's broadly known.
+
+## Why this strategy exists
+
+The momentum-event feed (`leaderboard_get_momentum_events`) surfaces assets that just made a sharp move in the 4h rolling window — the earliest, cleanest read on *fresh* momentum. The edge decays fast: an event that's already 30+ minutes old is half-known. Meerkat's whole job is **speed + selectivity** — only the strongest tiers, only while they're fresh.
+
+## CRITICAL RULES
+
+### RULE 1: Tier is the backbone
+Each event's `|momentum|` is classified into a tier: **3** (strongest, `>= tier3MinPct`, default 10%), **2** (`>= tier2MinPct`, default 5%), else **1**. Entry requires `tier >= minTier` (default 2; set to 3 for a pure tier-3 sniper). Weak events never fire.
+
+### RULE 2: Freshness is the sniper edge
+Entry requires the event to be fresh — `age <= maxEventAgeMinutes` (default 30). An event with no timestamp is treated as fresh (the feed only returns current-window events). Stale momentum is somebody else's trade.
+
+### RULE 3: Confirmation is a bonus, not a gate
+SM alignment (top-trader tilt on the same side) and rising 1h volume each add to the score but are **not required** — momentum events fire faster than SM data updates, so Meerkat won't wait for them.
+
+### RULE 4: Producer enters. DSL exits.
+No `close_position` call site. A fresh momentum burst can extend, so the DSL is the **let-winners-run** preset — wide ladder (T0 +10% / lock 0), `max_loss 18%`. But momentum is time-bounded: a **short 36h hard_timeout** cuts a burst that hasn't paid out (a stalled momentum trade is a failed one). No `weak_peak_cut`.
+
+## How Meerkat scores a trade
+
+**Gate:** `tier >= minTier` AND fresh.
+
+**Score components** (max ~7):
+
+| Signal | Points |
+|---|---|
+| Tier (1 / 2 / 3) | +1 / +2 / +3 |
+| Fresh (age ≤ max) | +2 |
+| Smart Money confirms direction (≥ `smTiltMinPct`) | +1 |
+| SM strongly tilted (≥ `smStrongTiltPct`) | +1 |
+| 1h volume rising (> 15%) | +1 |
+
+**Floor:** `minScore: 4` (so a tier-2 fresh event clears; a tier-1 event never does).
+
+## DSL preset (let-winners-run — momentum-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 18% |
+| Phase 1 | retrace_threshold | 10 |
+| Time cuts | hard_timeout | **36h (short — momentum is time-bounded)** |
+| Time cuts | weak_peak_cut | DISABLED |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +10/0 · +20/45 · +35/65 · +55/78 · +90/88 |
+
+## Scanner pattern
+
+A focused, event-driven variant of the **Striker / rank-jump detector** archetype (#6) — see `senpi-trading-runtime/references/producer-patterns.md`. Where the strikers (Jaguar/Orca/Roach) score a universe of leaderboard rank-jumps, Meerkat reads the momentum-event feed directly. Primary MCP calls: `leaderboard_get_momentum_events` (the producer signature; defensive multi-key unwrap), `leaderboard_get_markets` (SM), `market_get_asset_data` (volume confirmation). The pure functions (`event_age_minutes`, `event_direction`, `momentum_tier`, `event_score`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-26) — initial release
+
+First fleet agent driven directly off the momentum-event feed — a tier + freshness sniper, contrasting the universe-scanning rank-jump strikers. Let-winners-run DSL class (wide ladder, short 36h hard_timeout since momentum is time-bounded), taker-true entry, no null numeric signal fields, defensive multi-key shape unwrapping on `leaderboard_get_momentum_events`, and unit-tested pure functions (including epoch-seconds-vs-milliseconds handling).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/meerkat/config/meerkat-config.json
+++ b/meerkat/config/meerkat-config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "MEERKAT v1.0.0 — Momentum-Event Sniper. Each tick pulls the Senpi momentum-event feed (leaderboard_get_momentum_events, 4h rolling-window momentum/rank-jump events). For each event it classifies |momentum| into a tier (3 >= tier3MinPct, 2 >= tier2MinPct, else 1), measures freshness (minutes since the event; an event with no timestamp is treated as fresh since the feed only returns current-window events), and extracts direction. Gate: tier >= minTier AND fresh (age <= maxEventAgeMinutes). Scores by tier + freshness + SM alignment + rising volume, snipes the best in the momentum direction. Let-winners-run DSL with a SHORT 36h hard_timeout. Edit wallet/strategyId/chatId; tune tiers/freshness/thresholds. Set minTier=3 for a pure tier-3 sniper. Distinct from the Striker/rank-jump agents (Jaguar/Orca/Roach).",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "minTier": 2,
+  "tier2MinPct": 5.0,
+  "tier3MinPct": 10.0,
+  "maxEventAgeMinutes": 30.0,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "minScore": 4,
+  "marginPct": 0.15,
+  "leverage": 4
+}

--- a/meerkat/references/skill-attribution.md
+++ b/meerkat/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "meerkat",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "meerkat",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/meerkat/runtime.yaml
+++ b/meerkat/runtime.yaml
@@ -1,0 +1,187 @@
+name: meerkat-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Meerkat v1.0.0"
+# and lives in description + SKILL.md + _meerkat_producer_version.
+version: 1.0.0
+description: >
+  MEERKAT v1.0.0 — Momentum-Event Sniper.
+
+  Meerkat watches the Senpi momentum-event feed (leaderboard_get_momentum_events
+  — 4h rolling-window momentum / rank-jump events) and snipes the FRESHEST,
+  HIGHEST-TIER events the moment they fire, entering in the momentum direction
+  before the move is broadly known. Tier (event magnitude) + freshness gate the
+  entry; SM alignment + rising volume are confirmation bonuses.
+
+  Distinct from the Striker / rank-jump agents (Jaguar/Orca/Roach) which score a
+  leaderboard universe — Meerkat is driven directly off the momentum-event feed.
+
+  Architecture (helpers-native): producer ticks every 120s (momentum is
+  time-sensitive), classifies each event's tier + freshness, and emits
+  MEERKAT_MOMENTUM_EVENT via SenpiClient.push_signal() for the best fresh,
+  high-tier event. LLM gate is pass-through.
+
+  DSL: let-winners-run preset — wide ladder (T0 +10% / lock 0), max_loss 18%,
+  with a SHORT hard_timeout (a momentum burst that hasn't paid out fast is
+  stale) and no weak_peak_cut.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_per_slot: 200
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 48
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 4
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 45
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: meerkat_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        tier: { type: number, required: false }
+        magnitudePct: { type: number, required: false }
+        ageMin: { type: number, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volRising: { type: boolean, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: meerkat_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${MEERKAT_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [meerkat_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # snipe the move NOW — a maker order that rests (CREATE_ORDER_RESTING) misses a fast momentum burst
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: meerkat_signals
+    decision_prompt: |
+      You are Meerkat's pass-through gate. Meerkat SNIPES momentum events: the
+      Senpi momentum-event feed just fired a fresh, high-tier event, and the
+      producer entered in the momentum direction. The producer applied every
+      filter (tier >= minTier, freshness, minScore). Honor the signal.
+
+      SIGNAL:
+      {{signal_meerkat_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (preserve case / any xyz: prefix).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-10x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 4 (producer floor; defensive)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+      - tier < 2 (Meerkat only snipes tier 2+ momentum)
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 6 AND tier == 3
+      - 7-8:  score 5
+      - 7:    score 4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 6 SOL LONG, tier 3 momentum +12.4%, fresh 4min, SM confirms — momentum-event snipe')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "MEERKAT_MOMENTUM_EVENT ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — let-winners-run preset, momentum-tuned) ──────
+#
+# A fresh momentum burst can extend, so let it run: wide ladder (T0 +10% /
+# lock 0), max_loss 18%. But momentum is time-bounded — a burst that hasn't
+# paid out within ~36h is stale, so a SHORT hard_timeout cuts it. No
+# weak_peak_cut (it would churn a burst that's consolidating before extending).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2160                   # 36h — a momentum burst pays out fast or it is stale
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 45 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+        - { trigger_pct: 90, lock_hw_pct: 88 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/meerkat/scripts/meerkat-producer.py
+++ b/meerkat/scripts/meerkat-producer.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+# Senpi MEERKAT Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""MEERKAT v1.0.0 — Momentum-Event Sniper.
+
+Meerkat watches the Senpi momentum-event feed (leaderboard_get_momentum_events
+— the 4h rolling-window momentum / rank-jump events) and snipes the FRESHEST,
+HIGHEST-TIER events the moment they fire, entering in the momentum direction
+before the move is broadly known.
+
+Each tick:
+  1. Pull the momentum-event feed.
+  2. For each event: classify magnitude into a TIER (1/2/3), measure FRESHNESS
+     (minutes since it fired), extract direction.
+  3. Gate: tier >= minTier AND fresh (age <= maxEventAgeMinutes).
+  4. Score by tier + freshness + SM alignment + volume, pick the best, enter in
+     the momentum direction.
+
+Distinct from the Striker / rank-jump agents (Jaguar/Orca/Roach) which score a
+leaderboard universe; Meerkat is driven directly off the momentum-event feed.
+A fresh momentum event can extend, so the DSL is the let-winners-run preset
+(wide ladder + a short hard_timeout — momentum that hasn't paid out fast is
+stale). Producer NEVER closes — DSL owns exits.
+
+REQUIRES USER-SCOPE AUTH for leaderboard_get_momentum_events /
+leaderboard_get_markets.
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import meerkat_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "meerkat_signals"
+SIGNAL_TYPE = "MEERKAT_MOMENTUM_EVENT"
+
+MAX_LEVERAGE = 10
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 4
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+
+DEFAULT_MIN_TIER = 2                 # snipe tier 2+ (tier 3 = strongest)
+DEFAULT_TIER2_MIN_PCT = 5.0         # |momentum| for tier 2
+DEFAULT_TIER3_MIN_PCT = 10.0        # |momentum| for tier 3
+DEFAULT_MAX_EVENT_AGE_MIN = 30.0    # freshness gate — snipe just-formed events
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("MEERKAT_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def safe_float(v, default=0.0):
+    try:
+        return float(v if v is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure momentum-event logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def event_age_minutes(event_ts, now_ts):
+    """Minutes since an event fired. event_ts may be epoch seconds or
+    milliseconds. None if missing/unparseable."""
+    if event_ts is None:
+        return None
+    try:
+        ts = float(event_ts)
+    except (TypeError, ValueError):
+        return None
+    if ts <= 0:
+        return None
+    if ts > 1e12:        # milliseconds → seconds
+        ts /= 1000.0
+    return (now_ts - ts) / 60.0
+
+
+def event_direction(event):
+    """LONG / SHORT for a momentum event: explicit direction/side, else the
+    sign of the momentum/change magnitude. None if undeterminable."""
+    if not isinstance(event, dict):
+        return None
+    d = str(event.get("direction", event.get("side", ""))).upper()
+    if d in ("LONG", "SHORT"):
+        return d
+    mag = safe_float(
+        event.get("momentum", event.get("change_pct", event.get("changePct", event.get("delta", 0))))
+    )
+    if mag > 0:
+        return "LONG"
+    if mag < 0:
+        return "SHORT"
+    return None
+
+
+def momentum_tier(magnitude_pct, tier2_min, tier3_min):
+    """Classify |momentum| into a tier: 3 (strongest) >= tier3_min,
+    2 >= tier2_min, else 1."""
+    m = abs(safe_float(magnitude_pct))
+    if m >= tier3_min:
+        return 3
+    if m >= tier2_min:
+        return 2
+    return 1
+
+
+def event_score(tier, fresh, sm_aligned, vol_rising):
+    """Score a momentum event (max ~7). Tier is the backbone; freshness is the
+    sniper edge; SM + volume are confirmation bonuses."""
+    score = {1: 1, 2: 2, 3: 3}.get(tier, 0)
+    if fresh:
+        score += 2
+    if sm_aligned:
+        score += 1
+    if vol_rising:
+        score += 1
+    return score
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers (defensive shape unwrapping)
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_momentum_events():
+    raw = cfg.mcp_call("leaderboard_get_momentum_events")
+    if not raw:
+        return []
+    if isinstance(raw, list):
+        return raw
+    d = raw.get("data", raw)
+    if isinstance(d, list):
+        return d
+    if isinstance(d, dict):
+        ev = d.get("events", d.get("momentum_events", d.get("results", [])))
+        return ev if isinstance(ev, list) else []
+    return []
+
+
+def event_asset(event):
+    if not isinstance(event, dict):
+        return ""
+    return str(event.get("token", event.get("coin", event.get("asset", event.get("symbol", ""))))).upper()
+
+
+def event_magnitude(event):
+    if not isinstance(event, dict):
+        return 0.0
+    return safe_float(
+        event.get("momentum", event.get("change_pct", event.get("changePct", event.get("delta", 0))))
+    )
+
+
+def event_timestamp(event):
+    if not isinstance(event, dict):
+        return None
+    return event.get("ts", event.get("timestamp", event.get("time", event.get("created_at"))))
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+def fetch_volume_rising(asset):
+    """True if the asset's recent 1h volume is rising vs the prior window."""
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return False
+    candles = data.get("data", {}).get("candles", {}).get("1h", [])
+    if len(candles) < 6:
+        return False
+    vols = [safe_float(c.get("volume", c.get("v", 0))) for c in candles[-6:]]
+    recent = sum(vols[-3:]) / 3
+    earlier = sum(vols[:3]) / 3
+    return earlier > 0 and (recent - earlier) / earlier > 0.15
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — one event
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(event, config, now):
+    asset = event_asset(event)
+    if not asset:
+        return None
+    direction = event_direction(event)
+    if direction is None:
+        return None
+
+    mag = event_magnitude(event)
+    tier2 = float(config.get("tier2MinPct", DEFAULT_TIER2_MIN_PCT))
+    tier3 = float(config.get("tier3MinPct", DEFAULT_TIER3_MIN_PCT))
+    tier = momentum_tier(mag, tier2, tier3)
+    if tier < int(config.get("minTier", DEFAULT_MIN_TIER)):
+        return None
+
+    age = event_age_minutes(event_timestamp(event), now)
+    max_age = float(config.get("maxEventAgeMinutes", DEFAULT_MAX_EVENT_AGE_MIN))
+    # No timestamp → treat as fresh (feed only returns current-window events).
+    fresh = age is None or age <= max_age
+    if not fresh:
+        return None
+
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(config.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(config.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+    sm_aligned = (sm_dir == direction and sm_tilt >= sm_min)
+    vol_rising = fetch_volume_rising(asset)
+
+    score = event_score(tier, fresh, sm_aligned, vol_rising)
+    reasons = [f"momentum_event_{direction}", f"tier_{tier}", f"mag_{mag:+.1f}%"]
+    if fresh:
+        reasons.append("fresh" if age is None else f"fresh_{age:.0f}min")
+    if sm_aligned:
+        reasons.append(f"sm_confirms_{sm_tilt:.0f}%")
+        if sm_tilt >= sm_strong:
+            score += 1
+            reasons.append("sm_strong")
+    if vol_rising:
+        reasons.append("vol_rising")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "tier": tier,
+        "magnitude_pct": round(mag, 2),
+        "age_min": round(age, 1) if age is not None else None,
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": sm_tilt,
+        "vol_rising": vol_rising,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "tier": thesis["tier"],
+        "magnitudePct": thesis.get("magnitude_pct") or 0.0,
+        "ageMin": thesis.get("age_min") if thesis.get("age_min") is not None else 0.0,
+        "smDirection": thesis.get("sm_direction") or "NONE",
+        "smTiltPct": thesis.get("sm_tilt_pct") or 0.0,
+        "volRising": bool(thesis.get("vol_rising")),
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 7.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — snipe the freshest, highest-tier momentum event
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    now = time.time()
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_meerkat_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_meerkat_producer_version": VERSION})
+        return
+
+    events = fetch_momentum_events()
+    if not events:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no momentum events in the feed",
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_meerkat_producer_version": VERSION,
+        })
+        return
+
+    candidates = []
+    for event in events:
+        asset = event_asset(event)
+        if not asset or asset.upper() in held_set or cfg.was_recently_signaled(asset):
+            continue
+        thesis = build_thesis(event, config, now)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no fresh tier>=minTier momentum event cleared minScore",
+            "events_seen": len(events),
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_meerkat_producer_version": VERSION,
+        })
+        return
+
+    # Highest score, tie-break by tier then magnitude.
+    candidates.sort(key=lambda c: (c["score"], c["tier"], abs(c["magnitude_pct"])), reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.15))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "tier": best["tier"],
+            "magnitude_pct": best["magnitude_pct"],
+            "age_min": best["age_min"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "candidates_count": len(candidates),
+        "events_seen": len(events),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_meerkat_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=120,   # 2min — momentum events are time-sensitive; snipe fast
+        name=f"meerkat-producer-{_wallet_lock_id}",
+        tick_timeout=90,
+    )

--- a/meerkat/scripts/meerkat_config.py
+++ b/meerkat/scripts/meerkat_config.py
@@ -1,0 +1,219 @@
+"""MEERKAT v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Momentum-Event Sniper. A meerkat stands sentry and pops up the instant it spots
+movement. Meerkat watches the Senpi momentum-event feed
+(leaderboard_get_momentum_events — the 4h rolling-window momentum/rank-jump
+events) and snipes the FRESHEST, HIGHEST-TIER events the moment they fire,
+entering in the momentum direction before the move is broadly known.
+
+Distinct from the Striker / rank-jump agents (Jaguar/Orca/Roach) which score a
+universe of leaderboard rank-jumps. Meerkat is event-driven off the momentum
+feed directly: tier (event magnitude) + freshness gate the entry, so it only
+fires on strong, just-formed momentum.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+let-winners-run DSL (a fresh momentum event can extend). Stateless event
+scoring plus the fleet-standard race-window dedup, atomic write, simplified
+producer_daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "meerkat-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "meerkat-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Meerkat ticks every 120s (momentum events are
+# time-sensitive); ALO fills typically settle within 30-60s. 240s covers the
+# full fill window plus the next-tick clearinghouseState refresh, so the
+# on-chain held-asset check picks up where this cache leaves off.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Meerkat's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("meerkat_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient failures
+    recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001 — transport / protocol surface
+        sys.stderr.write(
+            f"[senpi_helpers] meerkat_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[meerkat-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/meerkat/tests/test_signal.py
+++ b/meerkat/tests/test_signal.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Unit tests for Meerkat's pure functions (event_age_minutes,
+event_direction, momentum_tier, event_score). Stubs meerkat_config +
+senpi_runtime_helpers so the producer loads without the helpers package or a
+runtime workspace.
+Run: python3 meerkat/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("meerkat_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["meerkat_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "meerkat-producer.py"
+_spec = importlib.util.spec_from_file_location("meerkat_producer", _path)
+mp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mp)
+
+
+def test_event_age_minutes_seconds_and_millis():
+    now = 1_700_000_000.0   # realistic 2023 epoch so the ms value clears the 1e12 detector
+    assert abs(mp.event_age_minutes(now - 600, now) - 10.0) < 1e-9        # 600s ago = 10min
+    # millisecond timestamp (now-600s expressed in ms) → same 10min
+    assert abs(mp.event_age_minutes((now - 600) * 1000.0, now) - 10.0) < 1e-9
+
+
+def test_event_age_minutes_bad_input():
+    assert mp.event_age_minutes(None, 1_700_000_000.0) is None
+    assert mp.event_age_minutes("oops", 1_700_000_000.0) is None
+    assert mp.event_age_minutes(0, 1_700_000_000.0) is None
+
+
+def test_event_direction_explicit_and_magnitude():
+    assert mp.event_direction({"direction": "LONG"}) == "LONG"
+    assert mp.event_direction({"side": "short"}) == "SHORT"
+    assert mp.event_direction({"momentum": 8.0}) == "LONG"
+    assert mp.event_direction({"change_pct": -8.0}) == "SHORT"
+    assert mp.event_direction({"momentum": 0}) is None
+
+
+def test_momentum_tier_thresholds():
+    assert mp.momentum_tier(12.0, 5.0, 10.0) == 3   # >= tier3
+    assert mp.momentum_tier(7.0, 5.0, 10.0) == 2    # >= tier2
+    assert mp.momentum_tier(3.0, 5.0, 10.0) == 1    # below both
+    assert mp.momentum_tier(-12.0, 5.0, 10.0) == 3  # uses magnitude
+
+
+def test_event_score_components():
+    # tier 3 + fresh + sm + vol = 3 + 2 + 1 + 1 = 7
+    assert mp.event_score(3, True, True, True) == 7
+    # tier 2 + fresh only = 2 + 2 = 4
+    assert mp.event_score(2, True, False, False) == 4
+    # tier 1 not fresh = 1
+    assert mp.event_score(1, False, False, False) == 1
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -449,6 +449,7 @@ save_rank_history(current_ranks)
 | **Roach** | v1.0 | Multi (Strikers) | Striker-only signal emitter. FIRST_JUMP / IMMEDIATE_MOVER detection with volume floor. Producer pushes signals only; runtime handles execution. | Striker, FIRST_JUMP, Volume-floor |
 | **Roach-B** | v1.0 | Multi (Strikers) | Second wallet instance of the Roach producer. Same FIRST_JUMP / IMMEDIATE_MOVER thesis on a separate strategy wallet. | Striker, Roach-pattern, Multi-wallet |
 | **Orca** | v1.0 | Multi (Strikers) | Gen-1 vanilla Striker — FIRST_JUMP + volume + base scoring. The original Striker template before per-asset specializations. | Striker, Vanilla-Gen-1, FIRST_JUMP |
+| **Meerkat** | v1.0 | Multi (momentum-event feed) | **Event-feed variant.** Reads `leaderboard_get_momentum_events` directly (not the `_markets` rank table) and snipes the freshest, highest-tier events: tier (3 ≥10% · 2 ≥5%) + freshness (≤30min) gate; SM + volume are bonuses. Wide let-winners-run DSL + SHORT 36h hard_timeout (momentum is time-bounded). Tick 120s. | Momentum-event, Tier-sniper, Freshness-gate, Wide DSL, Tick 120s |
 
 ---
 
@@ -897,6 +898,7 @@ XYZ markets (stocks / commodities / pre-IPO) trade **24/7 on Hyperliquid**, even
 - **Break of the 7-day high/low (majors)** → 🟢 **Hawk** (breakout buyer / breakdown seller) · **Badger** (OI-confirmed).
 - **Buy the dip *within* an uptrend** → 🟢 **Salamander** (pullback catcher).
 - **Leaderboard rank-jumps caught early** → **Jaguar** · **Orca** · **Roach**.
+- **Fresh momentum events the instant they fire** (snipe the strongest, just-formed moves off the momentum feed) → **Meerkat** (tier + freshness sniper).
 - **Ride a liquidation cascade / forced flow** (OI unwinding fast + a violent move) → **Piranha** (microstructure / order-flow).
 - **Trade order-book pressure** (resting bid/ask depth skew, confirmed by momentum + SM) → **Marlin** (microstructure / order-flow).
 
@@ -1036,6 +1038,7 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | **Osprey** | 9 — Cross-asset lag detector (cross-VENUE variant) | BTC → xyz: equity proxies (COIN/MSTR/miners). Self-computes the catch-up gap (leader move × beta − proxy move) from candles; trades the proxy in the leader's direction while it owes the gap. NOT cross_asset_flows (crypto-only). Wide let-winners-run DSL, 96h hard_timeout |
 | **Remora** | 5 — Trader-follower (hand-picked whale mirror) | Operator-picked whale set. Mirrors each whale's largest-notional position, scored by consensus (2 whales +2, 3+ +3) + ELITE-tier bonus. Unwraps the nested leaderboard_get_trader_positions shape. Wide let-winners-run DSL, 120h staleness cap |
 | **Cuckoo** | 14 — Meta-strategy follower / copy-the-copiers | Auto-discovers the top-N strategies by performance and trades their performance-weighted consensus (weight = clamp(1 + roi/50, 0.5, cap)); gate ≥2 strategies agree. Wide let-winners-run DSL, 96h staleness cap. User-scope auth |
+| **Meerkat** | 6 — Striker / rank-jump (momentum-event-feed variant) | Reads leaderboard_get_momentum_events directly; snipes the freshest (≤30min), highest-tier (3 ≥10% · 2 ≥5%) momentum events in the move's direction. SM + volume bonuses. Wide let-winners-run DSL + short 36h hard_timeout. Tick 120s. User-scope auth |
 
 Sentinel runs an in-house producer that is not currently published to this repo; no public URL.
 


### PR DESCRIPTION
## Summary
- **Meerkat** (#10 — the final agent of the 10-agent build) — reads the Senpi momentum-event feed (`leaderboard_get_momentum_events`) directly and snipes the freshest, highest-tier events the instant they fire.
- Tier (3 ≥10% · 2 ≥5% by `|momentum|`) + freshness (≤30 min) gate the entry; SM alignment + rising volume are confirmation **bonuses**, not gates (momentum fires faster than SM updates).
- Event-feed variant of archetype #6 (Striker/rank-jump): the strikers (Jaguar/Orca/Roach) score the `_markets` rank table; Meerkat reads the event feed.
- DSL: **let-winners-run** (wide ladder, max_loss 18%) with a **short 36h hard_timeout** (a momentum burst pays out fast or it's stale). Taker-true entry; no null numeric signal fields; defensive multi-key unwrap; epoch-seconds-vs-ms handling; disown-safe launch.
- Integrated into `producer-patterns.md` (archetype #6 roster, Layer 2E bullet, fleet roster mapping) and `catalog.json` (striker-rank-jump group, $500 min).

## Test plan
- [x] `python3 -m py_compile` producer + config — OK
- [x] `python3 meerkat/tests/test_signal.py` — 5/5 pass (event_age_minutes sec+ms, bad-input, event_direction, momentum_tier, event_score). RED-GREEN caught an unrealistic-epoch test bug.
- [x] runtime.yaml parses + config.json parses
- [x] field-parity: data_block keys ⊆ scanner `fields` — OK

## Completes the 10-agent build
Badger · Egret · Piranha · Marlin · Chameleon · Falcon · Osprey · Remora · Cuckoo · **Meerkat**

🤖 Generated with [Claude Code](https://claude.com/claude-code)