### PR TITLE
Convert all strategy slot sizing from fixed USD → % of budget (margin_pct)

### DIFF
--- a/albatross/runtime.yaml
+++ b/albatross/runtime.yaml
@@ -31,7 +31,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 3
-  margin_per_slot: 150
+  margin_pct: 15        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/badger/runtime.yaml
+++ b/badger/runtime.yaml
@@ -32,7 +32,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 250
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/bald-eagle/runtime.yaml
+++ b/bald-eagle/runtime.yaml
@@ -11,7 +11,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 2
-  margin_per_slot: 250
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/beaver/runtime.yaml
+++ b/beaver/runtime.yaml
@@ -35,7 +35,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: balanced
   enabled: true
 

--- a/bison/runtime.yaml
+++ b/bison/runtime.yaml
@@ -45,7 +45,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 3
-  margin_per_slot: 250            # baseline; LLM passes conviction-tier marginUsd from signal
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: moderate
   enabled: true
 

--- a/bobcat/runtime.yaml
+++ b/bobcat/runtime.yaml
@@ -35,7 +35,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 3
-  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: balanced
   enabled: true
 

--- a/chameleon/runtime.yaml
+++ b/chameleon/runtime.yaml
@@ -24,7 +24,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 200
+  margin_pct: 20        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/cheetah/runtime.yaml
+++ b/cheetah/runtime.yaml
@@ -61,7 +61,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 250
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/condor/runtime.yaml
+++ b/condor/runtime.yaml
@@ -44,7 +44,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 500           # baseline; LLM passes score-tier marginUsd from signal
+  margin_pct: 50        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: moderate
   enabled: true
 

--- a/cuckoo/runtime.yaml
+++ b/cuckoo/runtime.yaml
@@ -28,7 +28,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 200
+  margin_pct: 20        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/dire/runtime.yaml
+++ b/dire/runtime.yaml
@@ -51,7 +51,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 250
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/dog/runtime.yaml
+++ b/dog/runtime.yaml
@@ -49,7 +49,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 300
+  margin_pct: 30        # % of account budget per slot (scales with any budget)
   trading_risk: conservative
   enabled: true
 

--- a/egret/runtime.yaml
+++ b/egret/runtime.yaml
@@ -28,7 +28,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 200
+  margin_pct: 20        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/falcon/runtime.yaml
+++ b/falcon/runtime.yaml
@@ -29,7 +29,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 200
+  margin_pct: 20        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/grizzly/runtime.yaml
+++ b/grizzly/runtime.yaml
@@ -56,7 +56,7 @@ strategy:
   wallet: "${WALLET_ADDRESS}"
   budget: 1000
   slots: 1
-  margin_per_slot: 500
+  margin_pct: 50        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   default_leverage: 10                            # conviction-scaled in producer (10x apex/conviction, 7x default)
   enabled: true

--- a/hawk/runtime.yaml
+++ b/hawk/runtime.yaml
@@ -35,7 +35,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: balanced
   enabled: true
 

--- a/hedgehog/runtime.yaml
+++ b/hedgehog/runtime.yaml
@@ -35,7 +35,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 3
-  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: balanced
   enabled: true
 

--- a/heron/runtime.yaml
+++ b/heron/runtime.yaml
@@ -35,7 +35,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: balanced
   enabled: true
 

--- a/hummingbird/runtime.yaml
+++ b/hummingbird/runtime.yaml
@@ -35,7 +35,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: balanced
   enabled: true
 

--- a/jackal/runtime.yaml
+++ b/jackal/runtime.yaml
@@ -40,7 +40,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 2
-  margin_per_slot: 300
+  margin_pct: 30        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   default_leverage: 5
   enabled: true

--- a/jaguar/runtime.yaml
+++ b/jaguar/runtime.yaml
@@ -42,7 +42,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 2
-  margin_per_slot: 500
+  margin_pct: 50        # % of account budget per slot (scales with any budget)
   trading_risk: aggressive
   enabled: true
 

--- a/kestrel/runtime.yaml
+++ b/kestrel/runtime.yaml
@@ -45,7 +45,7 @@ strategy:
   wallet: "${WALLET_ADDRESS}"
   budget: 1000
   slots: 2                                    # 2-position macro book
-  margin_per_slot: 300                        # 30% per slot
+  margin_pct: 30        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/kodiak/runtime.yaml
+++ b/kodiak/runtime.yaml
@@ -46,7 +46,7 @@ strategy:
   wallet: "${WALLET_ADDRESS}"
   budget: 1000
   slots: 1                                       # single-asset, single position
-  margin_per_slot: 200                           # 20% of $1k starting budget per slot
+  margin_pct: 20        # % of account budget per slot (scales with any budget)
   trading_risk: aggressive
   default_leverage: 5                            # v6.0 KEY FIX — was 10 in v5.1
   enabled: true

--- a/lemon/runtime.yaml
+++ b/lemon/runtime.yaml
@@ -11,7 +11,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 300
+  margin_pct: 30        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/lemur/runtime.yaml
+++ b/lemur/runtime.yaml
@@ -35,7 +35,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 2
-  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: balanced
   enabled: true
 

--- a/mantis/runtime.yaml
+++ b/mantis/runtime.yaml
@@ -48,7 +48,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 2
-  margin_per_slot: 250            # baseline; LLM passes tier-based marginUsd from signal
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: moderate
   enabled: true
 

--- a/marlin/runtime.yaml
+++ b/marlin/runtime.yaml
@@ -23,7 +23,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 200
+  margin_pct: 20        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/meerkat/runtime.yaml
+++ b/meerkat/runtime.yaml
@@ -27,7 +27,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 200
+  margin_pct: 20        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/orca/runtime.yaml
+++ b/orca/runtime.yaml
@@ -12,7 +12,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 3
-  margin_per_slot: 180
+  margin_pct: 18        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/osprey/runtime.yaml
+++ b/osprey/runtime.yaml
@@ -27,7 +27,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 200
+  margin_pct: 20        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/otter/runtime.yaml
+++ b/otter/runtime.yaml
@@ -65,7 +65,7 @@ strategy:
   wallet: "${WALLET_ADDRESS}"
   budget: 1000
   slots: 2
-  margin_per_slot: 250
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   default_leverage: 5                            # conviction-scaled in producer (5/7/10 by score)
   enabled: true

--- a/owl/runtime.yaml
+++ b/owl/runtime.yaml
@@ -57,7 +57,7 @@ strategy:
   wallet: "${WALLET_ADDRESS}"
   budget: 1000
   slots: 2
-  margin_per_slot: 250
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   default_leverage: 8                            # conviction-scaled in producer (7/8/10 by score)
   enabled: true

--- a/pangolin/runtime.yaml
+++ b/pangolin/runtime.yaml
@@ -74,7 +74,7 @@ strategy:
   wallet: "${WALLET_ADDRESS}"
   budget: 1000
   slots: 2
-  margin_per_slot: 250                           # 25% of $1k starting budget per slot
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: conservative                     # funding fade is patient — no aggression
   default_leverage: 3                            # crowded unwinds are violent; 3x default per v1
   enabled: true

--- a/piranha/runtime.yaml
+++ b/piranha/runtime.yaml
@@ -24,7 +24,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 200
+  margin_pct: 20        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/polar/runtime.yaml
+++ b/polar/runtime.yaml
@@ -60,7 +60,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 500
+  margin_pct: 50        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/python/runtime.yaml
+++ b/python/runtime.yaml
@@ -11,7 +11,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 2
-  margin_per_slot: 250
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/raccoon/runtime.yaml
+++ b/raccoon/runtime.yaml
@@ -35,7 +35,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 3
-  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: balanced
   enabled: true
 

--- a/raptor/runtime.yaml
+++ b/raptor/runtime.yaml
@@ -13,7 +13,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 2
-  margin_per_slot: 250
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/remora/runtime.yaml
+++ b/remora/runtime.yaml
@@ -26,7 +26,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 200
+  margin_pct: 20        # % of account budget per slot (scales with any budget)
   trading_risk: balanced
   enabled: true
 

--- a/roach/runtime.yaml
+++ b/roach/runtime.yaml
@@ -51,7 +51,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 2                                       # v1.3 hardcoded MAX_POSITIONS=1 lockdown; v2 reopens to 2 for diversification without overcommit
-  margin_per_slot: 250                           # ~25% of $1k starting budget per slot
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   default_leverage: 7                            # v1.1 ceiling preserved (was 10x in v1.0; fee burn at 10x was material)
   enabled: true

--- a/salamander/runtime.yaml
+++ b/salamander/runtime.yaml
@@ -35,7 +35,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 250                    # baseline; producer passes config-tier marginUsd via signal data
+  margin_pct: 25        # baseline % of account budget; producer/LLM passes the tier marginUsd via signal
   trading_risk: balanced
   enabled: true
 

--- a/scorpion/runtime.yaml
+++ b/scorpion/runtime.yaml
@@ -99,7 +99,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 2
-  margin_per_slot: 250
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/senpi-trading-runtime/references/momentum-guarded-strategy.md
+++ b/senpi-trading-runtime/references/momentum-guarded-strategy.md
@@ -41,7 +41,7 @@ notifications:
 strategy:
   wallet: "${STRATEGY_WALLET_ADDRESS}"
   slots: 3
-  margin_per_slot: 300
+  margin_pct: 25            # % of account budget per slot — scales with any budget (prefer over fixed margin_per_slot)
   trading_risk: moderate
   enabled: true
 

--- a/senpi-trading-runtime/references/strategy-creation.md
+++ b/senpi-trading-runtime/references/strategy-creation.md
@@ -29,7 +29,7 @@ Make these read-only calls **in a single batch** (not three scattered waves) to 
 
 ```
 user_get_me            # who am I / auth sanity
-account_get_portfolio  # available capital → informs margin_per_slot
+account_get_portfolio  # available capital → informs margin_pct sizing
 strategy_list          # existing strategies (avoid wallet/name collisions)
 market_get_funding_regime    # current regime — sanity-check a funding/contrarian thesis
 market_list_instruments      # tradeable universe + per-asset context (see shape in Step 2)
@@ -205,7 +205,7 @@ description: <<<ONE_LINE_THESIS>>>   # e.g. "Fade the most-crowded funding on li
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1                       # max concurrent positions
-  margin_per_slot: 200           # USD per position (or use margin_pct)
+  margin_pct: 20                 # % of account budget per slot — scales with any budget (preferred over fixed margin_per_slot USD)
   enabled: true
 
 notifications:

--- a/senpi-trading-runtime/references/strategy-examples.md
+++ b/senpi-trading-runtime/references/strategy-examples.md
@@ -92,7 +92,7 @@ description: Wide stops, long time windows for swing trading.
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 3
-  margin_per_slot: 300
+  margin_pct: 25            # % of account budget per slot — scales with any budget
   trading_risk: conservative
   enabled: true
 
@@ -164,7 +164,7 @@ description: Tight stops, fast cuts for active trading.
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 4
-  margin_per_slot: 100
+  margin_pct: 10            # % of account budget per slot — 4 × 10% = 40% committed, scales with any budget
   trading_risk: aggressive
   enabled: true
 

--- a/senpi-trading-runtime/references/yaml-schema.md
+++ b/senpi-trading-runtime/references/yaml-schema.md
@@ -37,6 +37,8 @@ The `strategy` block tells the runtime which wallet to trade and how much capita
 | `slots` | Max concurrent positions | no |
 | `margin_per_slot` | Fixed USD margin per position | no |
 | `margin_pct` | Margin as % of account (positive, max 100) | no |
+
+> **Prefer `margin_pct` over `margin_per_slot`.** Operators fund a strategy with any budget (≥ $100, no upper bound), so a fixed USD `margin_per_slot` either over- or under-commits depending on their balance. `margin_pct` sizes each slot as a share of the actual account and scales correctly with any budget. Keep `slots × margin_pct ≤ 100` so total committed margin stays within the account.
 | `trading_risk` | Risk profile: `conservative`, `moderate`, or `aggressive` | no |
 | `default_leverage` | Leverage multiplier | no |
 | `leverage_multipliers` | Per-risk-level leverage overrides: `{ conservative?, moderate?, aggressive? }` | no |

--- a/spider/runtime.yaml
+++ b/spider/runtime.yaml
@@ -57,7 +57,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 1000        # 100% on single anchor (operator-tunable)
+  margin_pct: 100        # % of account budget on the single anchor (operator-tunable)
   trading_risk: moderate
   enabled: true
 

--- a/vulture/runtime.yaml
+++ b/vulture/runtime.yaml
@@ -59,7 +59,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 2
-  margin_per_slot: 400
+  margin_pct: 45        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 

--- a/wolverine/runtime.yaml
+++ b/wolverine/runtime.yaml
@@ -89,7 +89,7 @@ description: >
 strategy:
   wallet: "${WALLET_ADDRESS}"
   slots: 1
-  margin_per_slot: 250
+  margin_pct: 25        # % of account budget per slot (scales with any budget)
   trading_risk: moderate
   enabled: true
 


### PR DESCRIPTION
## Why
Operators fund a strategy with **any** budget (≥ $100, no upper bound). A fixed-USD `margin_per_slot` either over- or under-commits depending on their balance — e.g. a $400/slot strategy is 80% of a $500 account but 4% of a $10k account. `margin_pct` sizes each slot as a share of the actual account and scales with any budget. (Mirrors the change Jason made on the live Vulture host → 45%/slot.)

## What changed
- **45 runtime.yaml** converted: `margin_per_slot <USD>` → `margin_pct <%>`, using the fleet's implied **$1,000 reference budget** (250→25%, 500→50%, 200→20%, 180→18%, …).
  - **Vulture pinned to 45%** to match the live host.
  - **Spider** kept at 100% (single anchor, operator-tunable).
  - All `slots × margin_pct ≤ 100%` (Jaguar 2×50, Spider 1×100 are the ceilings).
- Producers were **already** budget-relative (`margin_usd = account_value × marginPct`); this only fixes the runtime-side baseline that was a fixed dollar.
- **Docs** steered to `margin_pct` to prevent recurrence: `yaml-schema.md` (added a "prefer `margin_pct`" callout), `strategy-creation.md`, `strategy-examples.md`, `momentum-guarded-strategy.md` template.

## Deliberately NOT converted
**Turbine** (volume engine) uses `margin_per_slot` as a fixed **volume clip size** and derives slot *count* from `effective_slots = int(account_value / margin_per_slot)` — that auto-downsize formula IS its budget-adaptation. Converting it would break the mechanism and change volume generation. Flagged for review.

## Test plan
- [x] All 45 converted runtime.yaml parse (`yaml.safe_load`)
- [x] No `margin_per_slot` remains in any directional strategy runtime.yaml (only the schema field-table row + prose + the new "prefer" comments reference the old field name by design)
- [x] `slots × margin_pct ≤ 100` for every agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)