### PR TITLE
Add compatibility.json registry + compat-update/compat-lint workflows

### DIFF
--- a/.github/scripts/append-releases.mjs
+++ b/.github/scripts/append-releases.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Appends entries to compatibility.json for SKILL.md version bumps in the
+// just-pushed commit. Invoked by .github/workflows/compat-update.yml.
+//
+// Argv:
+//   [2] full 40-char hex SHA of the commit to record (typically ${{ github.sha }})
+// Env:
+//   CHANGED_FILES: newline-separated list of <skill>/SKILL.md paths that
+//                  changed in this push (flat layout — no skills/ prefix).
+//
+// Behaviour:
+//   - Skips silently if the SKILL.md version isn't three-part SemVer.
+//   - Skips silently if the skill isn't tracked in compatibility.json yet
+//     (only senpi-trading-runtime is tracked today; others are no-ops).
+//   - Errors hard if the skill IS tracked but the matching band doesn't
+//     exist — that means a human policy decision is needed (new runtimes
+//     array) and the bump should not be silently dropped.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+
+const sha = process.argv[2];
+if (!/^[0-9a-f]{40}$/.test(sha || "")) {
+  console.error(`append-releases: bad SHA argument: "${sha}" (must be 40-char hex)`);
+  process.exit(1);
+}
+
+const changedFiles = (process.env.CHANGED_FILES || "")
+  .split("\n")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+if (changedFiles.length === 0) {
+  console.log("append-releases: no SKILL.md files in CHANGED_FILES — nothing to do");
+  process.exit(0);
+}
+
+const compatPath = "compatibility.json";
+const compat = JSON.parse(readFileSync(compatPath, "utf8"));
+
+let appended = 0;
+let hadFatal = false;
+
+for (const file of changedFiles) {
+  // Flat layout: "<skill>/SKILL.md"
+  const m = file.match(/^([^/]+)\/SKILL\.md$/);
+  if (!m) {
+    console.log(`append-releases: ignoring non-skill path "${file}"`);
+    continue;
+  }
+  const skillName = m[1];
+
+  let skillMd;
+  try {
+    skillMd = readFileSync(file, "utf8");
+  } catch (err) {
+    console.log(`append-releases: cannot read ${file} (${err.code}) — skipping`);
+    continue;
+  }
+
+  const fmMatch = skillMd.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) {
+    console.log(`append-releases: no YAML frontmatter in ${file} — skipping`);
+    continue;
+  }
+
+  let fm;
+  try {
+    fm = parseYaml(fmMatch[1]);
+  } catch (err) {
+    console.log(`append-releases: YAML parse failed for ${file} (${err.message}) — skipping`);
+    continue;
+  }
+
+  const rawVersion = fm?.metadata?.version;
+  if (rawVersion == null) {
+    console.log(`append-releases: ${file} has no metadata.version — skipping`);
+    continue;
+  }
+  const version = String(rawVersion);
+
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    console.log(
+      `append-releases: ${file} version "${version}" is not three-part SemVer — skipping (not eligible for the registry)`
+    );
+    continue;
+  }
+
+  const skillEntries = compat[skillName];
+  if (!skillEntries) {
+    console.log(
+      `append-releases: skill "${skillName}" is not tracked in compatibility.json — skipping (add it manually to opt in)`
+    );
+    continue;
+  }
+
+  const [major, minor] = version.split(".");
+  const expectedBand = `${major}.${minor}`;
+  const band = skillEntries[expectedBand];
+  if (!band) {
+    console.error(
+      `append-releases: skill "${skillName}" is tracked but band "${expectedBand}" does not exist. ` +
+        `Add the band entry (with a runtimes array) to compatibility.json manually before bumping SKILL.md to ${version}.`
+    );
+    hadFatal = true;
+    continue;
+  }
+
+  if (!band.releases || typeof band.releases !== "object") {
+    band.releases = {};
+  }
+
+  if (band.releases[version]) {
+    if (band.releases[version] === sha) {
+      console.log(
+        `append-releases: ${skillName}/${expectedBand}/${version} already pinned to ${sha} — no-op`
+      );
+    } else {
+      console.error(
+        `append-releases: ${skillName}/${expectedBand}/${version} already exists with a different SHA ` +
+          `(${band.releases[version]} vs ${sha}). Refusing to overwrite — investigate manually.`
+      );
+      hadFatal = true;
+    }
+    continue;
+  }
+
+  band.releases[version] = sha;
+  console.log(`append-releases: appended ${skillName}/${expectedBand}/${version} = ${sha}`);
+  appended++;
+}
+
+if (hadFatal) {
+  process.exit(1);
+}
+
+if (appended === 0) {
+  console.log("append-releases: nothing appended — leaving compatibility.json untouched");
+  process.exit(0);
+}
+
+writeFileSync(compatPath, JSON.stringify(compat, null, 2) + "\n");
+console.log(`append-releases: wrote ${appended} new entr${appended === 1 ? "y" : "ies"} to compatibility.json`);

--- a/.github/scripts/append-releases.mjs
+++ b/.github/scripts/append-releases.mjs
@@ -106,7 +106,11 @@ for (const file of changedFiles) {
     continue;
   }
 
-  if (!band.releases || typeof band.releases !== "object") {
+  if (!band.releases || typeof band.releases !== "object" || Array.isArray(band.releases)) {
+    // compat-lint rejects arrays/non-objects on PR-time, so this branch is a
+    // defensive recovery rather than a normal code path. Reset to an empty
+    // object so the subsequent assignment isn't lost (JSON.stringify silently
+    // drops non-integer keys on arrays).
     band.releases = {};
   }
 
@@ -116,11 +120,20 @@ for (const file of changedFiles) {
         `append-releases: ${skillName}/${expectedBand}/${version} already pinned to ${sha} — no-op`
       );
     } else {
-      console.error(
+      // Skip, don't fail. This branch fires when:
+      //  (a) compat.json was hand-seeded with a pre-merge SHA (e.g. the
+      //      initial registry commit), then the merge fires this workflow
+      //      and github.sha is the merge commit — different from the seed.
+      //  (b) Someone edits SKILL.md without bumping the version (e.g. a
+      //      typo fix). Path-filter still triggers; version is unchanged.
+      // In both cases the registry already has a valid entry. compat-lint
+      // is the source of truth for "is the registered SHA self-consistent";
+      // we leave it alone here. Manual drift surfaces on the next
+      // compat.json PR via the lint.
+      console.log(
         `append-releases: ${skillName}/${expectedBand}/${version} already exists with a different SHA ` +
-          `(${band.releases[version]} vs ${sha}). Refusing to overwrite — investigate manually.`
+          `(registered ${band.releases[version]}, this push ${sha}) — leaving registry entry as-is`
       );
-      hadFatal = true;
     }
     continue;
   }

--- a/.github/scripts/validate-compat.mjs
+++ b/.github/scripts/validate-compat.mjs
@@ -3,11 +3,11 @@
 // on every PR that touches the file. Fails the PR with precise error
 // messages when entries are malformed.
 //
-// Checks every entry against the schema in
-// `/Users/yosephks/.claude/plans/senpi-skills-side-spec.md` §3:
+// Checks:
 //   1. Top-level value is an object of objects keyed by /^\d+\.\d+$/.
 //   2. runtimes entries match /^\d+\.\d+$/. A given runtime major.minor
-//      appears in at most one band across the entire file.
+//      appears in at most one band within a single skill — different skills
+//      can independently claim compatibility with the same runtime line.
 //   3. releases keys match /^\d+\.\d+\.\d+$/ and their major.minor equals
 //      the band key.
 //   4. releases values match /^[0-9a-f]{40}$/.
@@ -16,9 +16,15 @@
 //   6. <skill>/SKILL.md exists at that SHA, its YAML frontmatter parses,
 //      and its metadata.version equals the releases key.
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { parse as parseYaml } from "yaml";
+
+// Defense in depth: skill names become argv to `git show <sha>:<name>/SKILL.md`.
+// execFileSync already avoids the shell, but constraining the key shape catches
+// obviously-malformed registry entries up front and rules out git-arg injection
+// tricks (leading "-", path traversal, etc).
+const SKILL_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
 
 const compatPath = "compatibility.json";
 
@@ -37,15 +43,22 @@ if (compat === null || typeof compat !== "object" || Array.isArray(compat)) {
   reportAndExit();
 }
 
-// Map of runtime majorMinor -> "skillName/bandKey" that already claimed it.
-// A given runtime version must be served by exactly one band across the file.
-const seenRuntimes = new Map();
-
 for (const [skillName, bands] of Object.entries(compat)) {
+  if (!SKILL_NAME_RE.test(skillName)) {
+    errors.push(
+      `Skill key "${skillName}" must match ${SKILL_NAME_RE} (lowercase alphanumeric, hyphens, underscores).`
+    );
+    continue;
+  }
+
   if (bands === null || typeof bands !== "object" || Array.isArray(bands)) {
     errors.push(`Skill "${skillName}" value must be an object of bands.`);
     continue;
   }
+
+  // Per-skill: a runtime major.minor must be served by exactly one band of
+  // THIS skill. Different skills may independently claim the same runtime.
+  const seenRuntimes = new Map();
 
   for (const [bandKey, band] of Object.entries(bands)) {
     if (!/^\d+\.\d+$/.test(bandKey)) {
@@ -71,7 +84,7 @@ for (const [skillName, bands] of Object.entries(compat)) {
         const owner = seenRuntimes.get(rt);
         if (owner) {
           errors.push(
-            `Runtime "${rt}" is listed in both ${owner} and ${skillName}/${bandKey} — must appear in at most one band.`
+            `Runtime "${rt}" is listed in both ${owner} and ${skillName}/${bandKey} — within a single skill it must appear in at most one band.`
           );
         } else {
           seenRuntimes.set(rt, `${skillName}/${bandKey}`);
@@ -107,7 +120,9 @@ for (const [skillName, bands] of Object.entries(compat)) {
       }
 
       try {
-        execSync(`git cat-file -e ${sha}^{commit}`, { stdio: "pipe" });
+        // execFileSync (no shell) — sha is hex-validated above, but we use
+        // execFile across the board so registry keys can never reach a shell.
+        execFileSync("git", ["cat-file", "-e", `${sha}^{commit}`], { stdio: "pipe" });
       } catch {
         errors.push(
           `${skillName}/${bandKey}/${version}: SHA ${sha} is not reachable in this repository.`
@@ -118,7 +133,7 @@ for (const [skillName, bands] of Object.entries(compat)) {
       const skillMdPath = `${skillName}/SKILL.md`;
       let skillMdAtSha;
       try {
-        skillMdAtSha = execSync(`git show ${sha}:${skillMdPath}`, {
+        skillMdAtSha = execFileSync("git", ["show", `${sha}:${skillMdPath}`], {
           encoding: "utf8",
           stdio: ["ignore", "pipe", "pipe"],
         });

--- a/.github/scripts/validate-compat.mjs
+++ b/.github/scripts/validate-compat.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+// Validates compatibility.json. Invoked by .github/workflows/compat-lint.yml
+// on every PR that touches the file. Fails the PR with precise error
+// messages when entries are malformed.
+//
+// Checks every entry against the schema in
+// `/Users/yosephks/.claude/plans/senpi-skills-side-spec.md` §3:
+//   1. Top-level value is an object of objects keyed by /^\d+\.\d+$/.
+//   2. runtimes entries match /^\d+\.\d+$/. A given runtime major.minor
+//      appears in at most one band across the entire file.
+//   3. releases keys match /^\d+\.\d+\.\d+$/ and their major.minor equals
+//      the band key.
+//   4. releases values match /^[0-9a-f]{40}$/.
+//   5. Each SHA is reachable in the local repo (full history is fetched
+//      by the workflow).
+//   6. <skill>/SKILL.md exists at that SHA, its YAML frontmatter parses,
+//      and its metadata.version equals the releases key.
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+
+const compatPath = "compatibility.json";
+
+let compat;
+try {
+  compat = JSON.parse(readFileSync(compatPath, "utf8"));
+} catch (err) {
+  console.error(`compat-lint: cannot read/parse ${compatPath}: ${err.message}`);
+  process.exit(1);
+}
+
+const errors = [];
+
+if (compat === null || typeof compat !== "object" || Array.isArray(compat)) {
+  errors.push("Top-level value must be an object (skill -> bands).");
+  reportAndExit();
+}
+
+// Map of runtime majorMinor -> "skillName/bandKey" that already claimed it.
+// A given runtime version must be served by exactly one band across the file.
+const seenRuntimes = new Map();
+
+for (const [skillName, bands] of Object.entries(compat)) {
+  if (bands === null || typeof bands !== "object" || Array.isArray(bands)) {
+    errors.push(`Skill "${skillName}" value must be an object of bands.`);
+    continue;
+  }
+
+  for (const [bandKey, band] of Object.entries(bands)) {
+    if (!/^\d+\.\d+$/.test(bandKey)) {
+      errors.push(`Bad band key "${bandKey}" under skill "${skillName}" (must match \\d+\\.\\d+).`);
+      continue;
+    }
+
+    if (band === null || typeof band !== "object" || Array.isArray(band)) {
+      errors.push(`${skillName}/${bandKey}: band value must be an object.`);
+      continue;
+    }
+
+    // runtimes
+    const runtimes = band.runtimes;
+    if (!Array.isArray(runtimes) || runtimes.length === 0) {
+      errors.push(`${skillName}/${bandKey}: runtimes must be a non-empty array.`);
+    } else {
+      for (const rt of runtimes) {
+        if (typeof rt !== "string" || !/^\d+\.\d+$/.test(rt)) {
+          errors.push(`${skillName}/${bandKey}: bad runtime "${rt}" (must match \\d+\\.\\d+).`);
+          continue;
+        }
+        const owner = seenRuntimes.get(rt);
+        if (owner) {
+          errors.push(
+            `Runtime "${rt}" is listed in both ${owner} and ${skillName}/${bandKey} — must appear in at most one band.`
+          );
+        } else {
+          seenRuntimes.set(rt, `${skillName}/${bandKey}`);
+        }
+      }
+    }
+
+    // releases
+    const releases = band.releases;
+    if (releases === null || typeof releases !== "object" || Array.isArray(releases)) {
+      errors.push(`${skillName}/${bandKey}: releases must be an object.`);
+      continue;
+    }
+
+    for (const [version, sha] of Object.entries(releases)) {
+      if (!/^\d+\.\d+\.\d+$/.test(version)) {
+        errors.push(
+          `${skillName}/${bandKey}: release key "${version}" must be three-part SemVer.`
+        );
+        continue;
+      }
+      const [major, minor] = version.split(".");
+      if (`${major}.${minor}` !== bandKey) {
+        errors.push(
+          `${skillName}/${bandKey}: release "${version}" major.minor does not match band "${bandKey}".`
+        );
+      }
+      if (typeof sha !== "string" || !/^[0-9a-f]{40}$/.test(sha)) {
+        errors.push(
+          `${skillName}/${bandKey}/${version}: SHA "${sha}" must be a 40-char lowercase hex string.`
+        );
+        continue;
+      }
+
+      try {
+        execSync(`git cat-file -e ${sha}^{commit}`, { stdio: "pipe" });
+      } catch {
+        errors.push(
+          `${skillName}/${bandKey}/${version}: SHA ${sha} is not reachable in this repository.`
+        );
+        continue;
+      }
+
+      const skillMdPath = `${skillName}/SKILL.md`;
+      let skillMdAtSha;
+      try {
+        skillMdAtSha = execSync(`git show ${sha}:${skillMdPath}`, {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      } catch {
+        errors.push(
+          `${skillName}/${bandKey}/${version}: no ${skillMdPath} at SHA ${sha}.`
+        );
+        continue;
+      }
+
+      const fmMatch = skillMdAtSha.match(/^---\n([\s\S]*?)\n---/);
+      if (!fmMatch) {
+        errors.push(
+          `${skillName}/${bandKey}/${version}: ${skillMdPath} at SHA ${sha} has no YAML frontmatter.`
+        );
+        continue;
+      }
+
+      let fm;
+      try {
+        fm = parseYaml(fmMatch[1]);
+      } catch (err) {
+        errors.push(
+          `${skillName}/${bandKey}/${version}: YAML frontmatter parse error at SHA ${sha}: ${err.message}.`
+        );
+        continue;
+      }
+
+      const fileVersion = fm?.metadata?.version;
+      if (fileVersion == null) {
+        errors.push(
+          `${skillName}/${bandKey}/${version}: ${skillMdPath} at SHA ${sha} has no metadata.version field.`
+        );
+        continue;
+      }
+      if (String(fileVersion) !== version) {
+        errors.push(
+          `${skillName}/${bandKey}/${version}: ${skillMdPath} at SHA ${sha} says metadata.version "${fileVersion}", registry says "${version}".`
+        );
+      }
+    }
+  }
+}
+
+reportAndExit();
+
+function reportAndExit() {
+  if (errors.length > 0) {
+    console.error("compatibility.json validation failed:\n");
+    for (const e of errors) console.error("  - " + e);
+    process.exit(1);
+  }
+  console.log("compatibility.json OK");
+}

--- a/.github/workflows/compat-lint.yml
+++ b/.github/workflows/compat-lint.yml
@@ -1,0 +1,31 @@
+name: compat-lint
+
+# Validates compatibility.json on every PR that touches it. Blocks the PR
+# when entries are malformed (bad SHA, version mismatch, overlapping
+# runtime bands, etc). See `.github/scripts/validate-compat.mjs` for the
+# full check list — it implements the rules in §3 of the spec.
+
+on:
+  pull_request:
+    paths:
+      - 'compatibility.json'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history is required so we can resolve every SHA in the
+          # registry and `git show <sha>:<skill>/SKILL.md` against it.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install yaml parser
+        run: npm install yaml@2 --no-save --no-package-lock
+
+      - name: Validate compatibility.json
+        run: node .github/scripts/validate-compat.mjs

--- a/.github/workflows/compat-update.yml
+++ b/.github/workflows/compat-update.yml
@@ -10,8 +10,14 @@ name: compat-update
 on:
   push:
     branches: [main]
+    # Scope the trigger to skills that are actually tracked in
+    # compatibility.json. The append-releases.mjs script also gates on
+    # `compat[skillName]` existence (defense in depth), but listing the
+    # exact paths here keeps unrelated SKILL.md pushes from spinning up
+    # the workflow at all. When opting a new skill in, edit BOTH
+    # compatibility.json AND this paths list.
     paths:
-      - '*/SKILL.md'
+      - 'senpi-trading-runtime/SKILL.md'
 
 jobs:
   update-compat:

--- a/.github/workflows/compat-update.yml
+++ b/.github/workflows/compat-update.yml
@@ -1,0 +1,75 @@
+name: compat-update
+
+# Auto-appends a releases entry to compatibility.json whenever a
+# SKILL.md `metadata.version` is bumped on main. See
+# `.github/scripts/append-releases.mjs` for the per-file decision logic.
+#
+# The `[skip ci]` in the bot commit message is critical — without it
+# this workflow would trigger itself in an infinite loop.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '*/SKILL.md'
+
+jobs:
+  update-compat:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install yaml parser
+        run: npm install yaml@2 --no-save --no-package-lock
+
+      - name: Detect bumped SKILL.md files
+        id: detect
+        run: |
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.sha }}"
+          # On the first push to a new branch BEFORE may be all-zeros;
+          # diff against the empty tree to list every SKILL.md instead.
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            CHANGED=$(git ls-tree -r --name-only "$AFTER" | grep -E '^[^/]+/SKILL\.md$' || true)
+          else
+            CHANGED=$(git diff --name-only "$BEFORE" "$AFTER" | grep -E '^[^/]+/SKILL\.md$' || true)
+          fi
+          {
+            echo "changed_files<<__EOF__"
+            echo "$CHANGED"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+          if [ -z "$CHANGED" ]; then
+            echo "No SKILL.md changes detected."
+          else
+            echo "Changed SKILL.md files:"
+            echo "$CHANGED"
+          fi
+
+      - name: Append releases entries
+        if: steps.detect.outputs.changed_files != ''
+        env:
+          CHANGED_FILES: ${{ steps.detect.outputs.changed_files }}
+        run: node .github/scripts/append-releases.mjs "${{ github.sha }}"
+
+      - name: Commit and push
+        if: steps.detect.outputs.changed_files != ''
+        run: |
+          if git diff --quiet compatibility.json; then
+            echo "compatibility.json unchanged — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add compatibility.json
+          git commit -m "chore: auto-append compatibility entries [skip ci]"
+          git push

--- a/.github/workflows/compat-update.yml
+++ b/.github/workflows/compat-update.yml
@@ -19,6 +19,16 @@ on:
     paths:
       - 'senpi-trading-runtime/SKILL.md'
 
+# Serialize runs of this workflow. Each run does `git pull-style` work on main
+# (read compatibility.json -> append -> git push). If two tracked SKILL.md
+# pushes land back-to-back, parallel runs would both fetch the same base
+# state; the second push would fail with a non-fast-forward error and its
+# release entry would be lost. `cancel-in-progress: false` queues the second
+# run instead of cancelling it so both pushes get their entries.
+concurrency:
+  group: compat-update
+  cancel-in-progress: false
+
 jobs:
   update-compat:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,10 @@ Edit `compatibility.json` directly to remove the bad entry from `releases`. The 
 
 **Which skills are tracked today:**
 
-Only `senpi-trading-runtime` is in `compatibility.json` right now. The `compat-update` Action silently skips bumps for any skill not yet tracked, and silently skips bumps whose SKILL.md `metadata.version` is not three-part SemVer (`X.Y.Z`). To opt a new skill in, add a top-level entry with at least one band + `runtimes` array to `compatibility.json` manually.
+Only `senpi-trading-runtime` is in `compatibility.json` right now. The `compat-update` Action only fires on pushes that touch a tracked skill's `SKILL.md` (its `paths:` filter lists them explicitly) and additionally silently skips bumps whose `metadata.version` is not three-part SemVer (`X.Y.Z`). To opt a new skill in:
+
+1. Add a top-level entry to `compatibility.json` with at least one band + `runtimes` array.
+2. Add the new `<skill>/SKILL.md` path to `.github/workflows/compat-update.yml`'s `paths:` list so the workflow actually fires on its pushes.
 
 **Never:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,38 @@ A new skill is not complete until both files above exist with the correct `skill
 
 ---
 
+## Compatibility registry (`compatibility.json`)
+
+The senpi-trading-runtime auto-update gate reads `compatibility.json` at the repo root to decide which skill version to install for each runtime line. The file is **append-only for normal patch releases** — do not hand-edit `releases` maps when bumping a skill's version.
+
+**For a patch release (most common):**
+
+1. Bump the `metadata.version:` field in `<skill-name>/SKILL.md` (e.g. `2.2.0` → `2.2.1`).
+2. Push to `main`.
+3. The `compat-update` GitHub Action automatically appends `releases["2.2.1"] = <commit-sha>` to `compatibility.json` and commits back with `[skip ci]`.
+
+You should NOT edit `compatibility.json` directly for this case.
+
+**For a new band (skill major.minor bump):**
+
+If the new version jumps to a new major.minor (e.g. `2.2.x` → `2.3.0`), the band entry must be created first by a human. Open a PR that adds the new band to `compatibility.json` with its `runtimes: [...]` array, then push the SKILL.md bump. The `compat-update` Action errors out if it sees a SKILL.md version whose band doesn't already exist in the registry — that's intentional, because deciding which runtimes a new band supports is a policy call.
+
+**For a rollback (removing a bad release):**
+
+Edit `compatibility.json` directly to remove the bad entry from `releases`. The `compat-lint` CI workflow validates remaining entries on the PR. The runtime's next tick picks the next-highest version and converges users backward — no other changes needed.
+
+**Which skills are tracked today:**
+
+Only `senpi-trading-runtime` is in `compatibility.json` right now. The `compat-update` Action silently skips bumps for any skill not yet tracked, and silently skips bumps whose SKILL.md `metadata.version` is not three-part SemVer (`X.Y.Z`). To opt a new skill in, add a top-level entry with at least one band + `runtimes` array to `compatibility.json` manually.
+
+**Never:**
+
+- Type commit hashes by hand for patch releases. Let the Action do it.
+- Remove a band's `runtimes` array. That's a runtime-compatibility policy decision.
+- Use short SHAs anywhere. The runtime requires full 40-char hex SHAs.
+
+---
+
 ## Runtime npm package — `@senpi-ai/runtime` (NOT `@senpi/runtime`) on `main`
 
 **Any skill committed to `main` that references the runtime plugin MUST use `@senpi-ai/runtime`.** That's the production npm package — what end users install on their Railway / OpenClaw hosts. `latest = 1.1.0`. Source-of-truth: `senpi-trading-runtime/package.json` declares `name: "@senpi-ai/runtime"`.

--- a/compatibility.json
+++ b/compatibility.json
@@ -1,0 +1,13 @@
+{
+  "senpi-trading-runtime": {
+    "2.2": {
+      "runtimes": [
+        "1.0",
+        "1.1"
+      ],
+      "releases": {
+        "2.2.0": "3ae2d0926e2fb07bd5e7ecbcf70756eaa82fd01a"
+      }
+    }
+  }
+}

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -4,7 +4,7 @@ description: "The Senpi Trading Runtime OpenClaw plugin runs automated trading s
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.2"
+  version: "2.2.0"
   platform: senpi
   exchange: hyperliquid
 ---


### PR DESCRIPTION
## Summary

Implements the senpi-skills side of the runtime auto-update compatibility gate. The senpi-trading-runtime plugin will fetch this file from `raw.githubusercontent.com` on every skills-update tick to decide which skill version to install for each runtime line. Spec: `/Users/yosephks/.claude/plans/senpi-skills-side-spec.md`.

- **`compatibility.json`** (repo root) — seeded with `senpi-trading-runtime/2.2 → runtimes ["1.0", "1.1"], releases {"2.2.0": <SHA>}`.
- **`.github/workflows/compat-update.yml`** + **`.github/scripts/append-releases.mjs`** — push-to-`main` Action that auto-appends `releases[<new-version>] = <commit-sha>` to `compatibility.json` when a tracked skill's SKILL.md `metadata.version` is bumped. Bot commits back with `[skip ci]`.
- **`.github/workflows/compat-lint.yml`** + **`.github/scripts/validate-compat.mjs`** — PR-time validation lint that blocks malformed entries (bad SHA, version-vs-band mismatch, overlapping runtimes across bands, SKILL.md version doesn't match registry key at the referenced SHA, etc).
- **`CLAUDE.md`** — new "Compatibility registry" section covering the patch / new-band / rollback flows so AI-assisted skill edits don't hand-edit `releases` maps.

Also bumps `senpi-trading-runtime/SKILL.md` `metadata.version` `"2.2"` → `"2.2.0"` (separate commit) so the registry has a 3-part SemVer key to point at — the lint rule that requires `SKILL.md metadata.version === registry releases key at that SHA` would otherwise fail on day one.

## Notable divergences from the spec (agreed before implementing)

- **Flat layout `<name>/SKILL.md`**, not `skills/<name>/SKILL.md` — matches the actual repo. All globs/regexes/`git show` calls retargeted.
- **`metadata.version`, not top-level `version`** — the spec sketch had the wrong field placement. Both scripts read `fm.metadata?.version`.
- **Scope is `senpi-trading-runtime` only for now.** Five other skills ship 2-part versions (`owl 8.0`, `bald-eagle 5.0`, `jaguar 4.0`, `dire 2.0`, and previously `senpi-trading-runtime 2.2`). The auto-append script silently skips bumps from any skill not in `compatibility.json` and skips bumps whose version isn't 3-part SemVer. Opting a new skill in is a one-file edit (add it to `compatibility.json`).
- **One PR with all four pieces** instead of three sequential PRs (also pre-agreed).

## Test plan

Locally verified before pushing:

- [x] `validate-compat.mjs` passes against the seed `compatibility.json`.
- [x] `validate-compat.mjs` trips with precise messages on: unreachable SHA, SKILL.md ↔ registry version mismatch, overlapping runtimes across bands, bad band key (`"2"`), short SHA.
- [x] `append-releases.mjs` is idempotent (re-runs against an already-pinned entry produce no diff).
- [x] `append-releases.mjs` correctly appends a fresh `2.2.1 → <SHA>` entry when `senpi-trading-runtime/SKILL.md` is bumped.
- [x] `append-releases.mjs` skips untracked skills (`kodiak`), skips 2-part versions (`owl`), and errors out when a tracked skill bumps to a band that doesn't exist (`senpi-trading-runtime → 2.3.0` while only band `2.2` exists in the registry).

To verify on GitHub once this PR is up:

- [ ] `compat-lint` workflow run on this PR comes back green (it validates `compatibility.json` because this PR touches it).
- [ ] After merge: `compat-update` does NOT fire on the merge commit itself (the PR touches `compatibility.json` and CLAUDE.md, but `senpi-trading-runtime/SKILL.md` is touched in commit 1 and was last touched in the previous PR, so the path filter should still match on merge — confirm it either runs and no-ops cleanly or doesn't run at all).
- [ ] A follow-up trial bump of `senpi-trading-runtime/SKILL.md` from `2.2.0` → `2.2.1` on a feature branch + merge to `main` results in the bot commit `chore: auto-append compatibility entries [skip ci]` landing within ~30s.
- [ ] Coordinate with runtime team — once they ship their side, watch telemetry for `UpdateServiceUnreachable` clearing and zero `UpdateConfigError` / `UpdateContentMissing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New bot push workflow and registry govern runtime auto-update pins; mistakes affect which skill commit operators receive, though lint and append guards limit bad entries.
> 
> **Overview**
> Introduces a root **`compatibility.json`** registry so the trading runtime can map runtime lines to skill bands, supported runtimes, and pinned **full-SHA** releases. It is seeded for **`senpi-trading-runtime`** band `2.2` with runtimes `1.0`/`1.1` and release `2.2.0`.
> 
> **CI:** **`compat-lint`** runs on PRs that touch the file via **`validate-compat.mjs`** (schema, non-overlapping runtime bands per skill, reachable SHAs, and **`metadata.version`** on `<skill>/SKILL.md` at each pinned commit). **`compat-update`** on **`main`** (path-filtered to tracked **`SKILL.md`**) uses **`append-releases.mjs`** to append new three-part SemVer entries, then bot-commits with **`[skip ci]`**; queued concurrency avoids lost entries on back-to-back pushes.
> 
> **Docs / version:** **`CLAUDE.md`** documents patch vs new-band vs rollback flows. **`senpi-trading-runtime/SKILL.md`** **`metadata.version`** moves from **`2.2`** to **`2.2.0`** so lint can match registry keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049df724684afb26e74bdeae6a78d62ca8fb2eee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->