### PR TITLE
docs: bifurcate strategy intent — operational MCP vs. strategic template-first picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,23 @@ This repo is almost entirely AI-generated. The rules below exist because they ha
 
 ---
 
-## ▶ Writing or editing a trading strategy? Start here
+## ▶ User wants help with a "strategy"? Classify the intent FIRST
+
+The word "strategy" is overloaded in Senpi and the wrong path is the most common silent failure. Two paths, opposite code:
+
+- **Operational** — "Buy me HYPE 10x", "Open a short on BTC", "Copy this trader". The user named the position or trader. **Execute via MCP `strategy_create_custom_strategy`** (multi-asset positions) **or `strategy_create`** (copy-trader). Purely functional — no recommendation, no template, no producer code.
+- **Strategic** — "Help me pick a strategy", "What should I trade?", "Build a trading strategy", "Recommend a strategy". The user wants help deciding. **Template-first picker:** recommend 2–3 fits from `catalog.json` + `senpi-trading-runtime/references/producer-patterns.md`, install via `install_skill`. **Fallback** (only if no template fits): author a new one via `senpi-trading-runtime/references/strategy-creation.md`.
+- **Ambiguous** — ask the user before acting. A single disambiguation question costs nothing.
+
+**The canonical router with the full picker flow and the what-never-to-do list:** [`senpi-entrypoint/references/strategy-intent-routing.md`](senpi-entrypoint/references/strategy-intent-routing.md). Every surface points there.
+
+**Never default to `strategy_create_custom_strategy` for an ambiguous "what should I trade?"** That tool is for specific positions the user named. Using it as the default for strategic queries is the exact failure mode the router exists to prevent.
+
+---
+
+## ▶ Writing or editing a trading strategy (the build-new-autonomous-agent path)? Start here
+
+This section applies only to the **strategic / build-from-scratch** path above — *not* to operational MCP position-opening.
 
 Do **not** improvise a strategy from scratch. **Read one doc first: [`senpi-trading-runtime/references/strategy-creation.md`](senpi-trading-runtime/references/strategy-creation.md).** It's the self-contained fast path — the 5-step flow, the producer-only-emits-signals invariant, an archetype→example→DSL-preset table, an inline producer skeleton, a complete `runtime.yaml`, the DSL presets, and the gotchas, all in a single fetch. You should not need to browse the repo to produce a working strategy.
 

--- a/senpi-entrypoint/references/post-onboarding.md
+++ b/senpi-entrypoint/references/post-onboarding.md
@@ -149,9 +149,35 @@ Which sounds interesting? I can explain any in detail or deploy one right now.
 
 **When a new strategy is added to the MCP:** it appears automatically in the leaderboard. No agent code changes needed.
 
-### If user says "Build a new trading strategy" or "build a strategy" or "custom strategy" or "create a strategy"
+### If user says "help me pick a strategy", "what should I trade", "recommend a strategy", "build a trading strategy", or similar open-ended intent
 
-Building a real, deployable strategy means building it on the **Senpi Trading Runtime** — the canonical runtime + DSL exit engine + Python Producer SDK. Do NOT treat this as a pure brainstorm or improvise a strategy from scratch: route the user through the runtime's authoring path so what they build actually deploys and is risk-protected.
+> ⚠️ **First, classify the intent — do NOT default to building/authoring code.**
+>
+> - **"Buy me HYPE 10x" · "Open a short on BTC" · "Copy this trader 0x..."** — *operational, position-specific*. Execute via MCP `strategy_create_custom_strategy` (multi-asset positions) or `strategy_create` (copy-trader). No template recommendation, no producer code. Stop here.
+> - **"Help me pick" · "what should I trade" · "recommend a strategy" · "build a trading strategy"** — *strategic, open-ended*. **Run the picker flow below — recommend templates from our fleet FIRST.** Authoring from scratch is the fallback, never the default.
+> - **Ambiguous** — ask: *"Do you want to (a) open a specific position, (b) copy a specific trader, or (c) get help picking or building a strategy from our catalog?"* Then act.
+>
+> Full router with the what-never-to-do list: [`strategy-intent-routing.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-entrypoint/references/strategy-intent-routing.md).
+
+**Picker flow (the default for strategic intents — always recommend a fleet template first):**
+
+1. **Pull user context** in one parallel batch: `account_get_portfolio` (balance), `market_get_funding_regime` (regime), plus any expressed preference from the conversation.
+2. **Pull the live catalog:**
+   ```bash
+   curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/catalog.json
+   ```
+   And consult [`producer-patterns.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/producer-patterns.md) (catalog + [decision tree](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/producer-patterns.md#decision-tree--help-a-user-pick-their-first-strategy) for unsure users).
+3. **Filter to 2–3 templates that fit** the user's balance (`min_budget`), expressed asset/archetype preference, and current regime.
+4. **Present each** with: name + one-line thesis, archetype, asset focus, min budget, one-line install (`install_skill skill_name=<name>` via MCP).
+5. **End every recommendation with the build-from-scratch offer**: *"Or, if none of these fit your thesis, we can build a new autonomous strategy from scratch — that path is in [`strategy-creation.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/strategy-creation.md). Which do you want?"*
+6. **User picks a template → install via `install_skill`. Done.**
+7. **User picks "build new" → continue with the authoring path below.** *(Only continue past this point if the user has explicitly chosen build-from-scratch.)*
+
+---
+
+**Authoring path (only when the user has chosen build-from-scratch above):**
+
+Building a real, deployable autonomous agent means building it on the **Senpi Trading Runtime** — the canonical runtime + DSL exit engine + Python Producer SDK. Do NOT treat this as a pure brainstorm or improvise a strategy from scratch: route the user through the runtime's authoring path so what they build actually deploys and is risk-protected.
 
 > **The fast path — read one doc:** [`senpi-trading-runtime/references/strategy-creation.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/strategy-creation.md). It's self-contained: the 5-step flow, an inline producer skeleton, a complete `runtime.yaml`, the DSL presets, an archetype→example map, and the gotchas — in a single fetch. The steps below are the same path expanded; if you read `strategy-creation.md` you have everything you need.
 

--- a/senpi-entrypoint/references/skill-recommendations.md
+++ b/senpi-entrypoint/references/skill-recommendations.md
@@ -15,6 +15,20 @@ Then match their goal to the table below.
 
 | User goal | Recommended skill | Asset focus |
 |---|---|---|
+**⚠️ Before matching: classify the user's intent.** *Operational* ("buy me HYPE 10x", "copy this trader") goes to MCP tools, not to a skill. *Strategic* ("help me pick", "what should I trade") goes to the template-first picker + build fallback. Full router: [`strategy-intent-routing.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-entrypoint/references/strategy-intent-routing.md).
+
+**Operational intents — no skill, just MCP:**
+
+| User goal | Path |
+|---|---|
+| Open a specific position ("Buy me HYPE 10x", "go short BTC at 3x") | MCP `strategy_create_custom_strategy` — execute directly, no template |
+| Copy a named trader ("mirror 0x...", "copy this OG") | MCP `strategy_create` — copy-trader, no template |
+
+**Strategic intents — template-first, then build fallback:**
+
+| User goal | Recommended skill | Asset focus |
+|---|---|---|
+| **Help me pick a strategy / what should I trade / recommend a strategy** | **Run the picker flow** (see [`post-onboarding.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-entrypoint/references/post-onboarding.md)): pull balance + regime, filter the catalog + [`producer-patterns.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/producer-patterns.md), recommend 2–3 fleet templates, install via `install_skill`. **Always offer build-from-scratch as the last option.** | — |
 | BTC, maximum conviction, multi-timeframe trend | Grizzly (`grizzly`) | BTC |
 | SOL alpha hunter, single-asset focus | Kodiak (`kodiak`) | SOL |
 | ETH alpha hunter, hybrid hyperfeed + structure | Polar (`polar`) | ETH |
@@ -22,7 +36,7 @@ Then match their goal to the table below.
 | Multi-market active trader (crypto + XYZ) | Scorpion (`scorpion`) | Multi |
 | Contrarian — fade crowded trades at exhaustion | Owl (`owl`) | Multi |
 | Multi-market scanner, single strongest signal | Hawk (`hawk`) | Multi |
-| Build a new strategy from scratch | **`senpi-trading-runtime`** — read [`references/strategy-creation.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/strategy-creation.md) first (self-contained fast path) | — |
+| Build a new autonomous strategy from scratch (no fleet template fits) | **`senpi-trading-runtime`** — read [`references/strategy-creation.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/strategy-creation.md) first (self-contained fast path) | — |
 
 For any goal not covered above, query `list_strategies` for the current live fleet and match on the strategy's own thesis/tagline.
 

--- a/senpi-entrypoint/references/strategy-intent-routing.md
+++ b/senpi-entrypoint/references/strategy-intent-routing.md
@@ -1,0 +1,76 @@
+# Strategy Intent Routing — operational vs. strategic
+
+**When a user mentions a "strategy" or trading action, FIRST classify the intent.** Two paths, very different code, very different docs. Picking the wrong one is the failure mode. The word "strategy" is overloaded in this product — same word, opposite paths — so the routing has to be deliberate.
+
+## The two intents (and the disambiguation rule)
+
+| The user says... | They mean... | Path |
+|---|---|---|
+| "Buy me 10x HYPE long" · "Open a short on BTC" · "Go long ETH at 3x" · "Open a strategy with 50% BTC long / 50% ETH long" — **any specific position, asset + direction + size** | **Operational** — execute a position right now | **MCP `strategy_create_custom_strategy`** (multi-asset positions the runtime then manages). Purely functional — no recommendation, no template, no producer code. |
+| "Copy this trader" · "Mirror 0x..." · "Follow this user's trades" — **explicit copy-trading intent on a named target** | **Operational — copy** | **MCP `strategy_create`** (mirror an existing trader) |
+| "Help me pick a strategy" · "What should I trade?" · "Build a trading strategy" · "Recommend a strategy" · "I want to start trading but don't know how" · "Help me decide" — **open-ended strategy intent, no specific position named** | **Strategic** — pick a fleet template, or author a new one | **Template-first picker flow** (below). **Never** default to `strategy_create_custom_strategy` here. |
+
+**If the intent is ambiguous, ASK the user before acting:**
+
+> "Do you want to (a) open a specific position you already have in mind, (b) copy a specific trader, or (c) get help choosing or building a trading strategy from our catalog?"
+
+That single question costs nothing and prevents the entire failure mode this doc exists to address.
+
+## Path 1 — Operational (MCP, direct execution)
+
+The user knows what they want; the agent just executes.
+
+- **Specific position(s):** call `strategy_create_custom_strategy` with the assets + directions + leverage they specified.
+- **Copy a trader:** call `strategy_create` with the trader address they named.
+
+**No template recommendation, no fleet pitch, no producer code, no `strategy-creation.md`.** The user already picked. Don't overthink it.
+
+## Path 2 — Strategic (template-first picker → build fallback)
+
+When the user wants help **deciding** — not executing a known position — the default flow is **always recommend a template from our fleet first**, then offer to build a new one if no template fits. The fleet templates are validated, deployable, and exist precisely so users don't start from zero.
+
+### Picker flow (default)
+
+1. **Pull user context** in one parallel read-only batch:
+   - `account_get_portfolio` → available balance
+   - `market_get_funding_regime` → current regime (sanity-check the thesis)
+   - From the conversation: any expressed preference (asset bias, risk appetite, horizon)
+
+2. **Pull the live fleet catalog:**
+   ```bash
+   CATALOG=$(curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/catalog.json)
+   ```
+   And read [`senpi-trading-runtime/references/producer-patterns.md`](../../senpi-trading-runtime/references/producer-patterns.md) for archetype context. The catalog has the installable list with `min_budget`, asset focus, and thesis tagline per agent; `producer-patterns.md` has the archetype catalog and the decision tree for "I don't know what I want."
+
+3. **Filter to 2–3 templates that fit:**
+   - `min_budget` ≤ user's available balance
+   - Archetype aligns with any expressed preference (use the [decision tree](../../senpi-trading-runtime/references/producer-patterns.md#decision-tree--help-a-user-pick-their-first-strategy) when the user is unsure)
+   - Asset focus aligns if the user named an asset
+   - Current regime is consistent with the strategy's thesis (don't recommend a funding-fade in a flat funding regime)
+
+4. **Present each template** with: name + tagline, archetype, asset focus, min budget, the one-line install command (`install_skill skill_name=<name>` via MCP). Two or three options — not the whole catalog. Pick the best fits.
+
+5. **End with the build-from-scratch offer, every time:**
+
+   > "Or, if none of these fit your thesis, we can build a new autonomous strategy from scratch — that path is in [`strategy-creation.md`](../../senpi-trading-runtime/references/strategy-creation.md). Which do you want?"
+
+6. **User picks a template → install via `install_skill`.** Done.
+
+7. **User picks "build new" → route to [`strategy-creation.md`](../../senpi-trading-runtime/references/strategy-creation.md).** That doc is self-contained — read it once, build the bundle, hand off to the operator to deploy.
+
+## What NEVER to do
+
+- **Never default to `strategy_create_custom_strategy` for an ambiguous "what should I trade?" or "help me pick" query.** That tool is for specific positions the user named. Using it as the default for strategic queries surfaces a manual-position basket where the user wanted *strategy recommendations* — the exact failure mode this doc exists to prevent.
+- **Never skip the template recommendation.** Always surface fleet templates first when the intent is strategic. Building from scratch is the fallback, not the default.
+- **Never improvise positions** ("I think you should short HYPE/ETH/BTC") in response to a strategic query. That's the operational tool's job and the user didn't ask for a manual position basket.
+- **Never read `strategy-creation.md` for an operational request.** It's the authoring path for new autonomous agents — wrong layer entirely if the user just wants to open a position.
+
+## Quick reference
+
+| Intent | First step | Tool / doc |
+|---|---|---|
+| Open a specific position | Execute it | MCP `strategy_create_custom_strategy` |
+| Copy a named trader | Execute it | MCP `strategy_create` |
+| Help me pick a strategy | Run the picker flow above | `producer-patterns.md` + `catalog.json` → `install_skill` |
+| Build a new strategy from scratch | Read the build doc | [`strategy-creation.md`](../../senpi-trading-runtime/references/strategy-creation.md) |
+| Ambiguous | Ask the user to disambiguate | (this doc's three-option question) |

--- a/senpi-onboard/references/post-onboarding.md
+++ b/senpi-onboard/references/post-onboarding.md
@@ -148,9 +148,35 @@ Which sounds interesting? I can explain any in detail or deploy one right now.
 
 **When a new strategy is added to the MCP:** it appears automatically in the leaderboard. No agent code changes needed.
 
-### If user says "Build a new trading strategy" or "build a strategy" or "custom strategy" or "create a strategy"
+### If user says "help me pick a strategy", "what should I trade", "recommend a strategy", "build a trading strategy", or similar open-ended intent
 
-Building a real, deployable strategy means building it on the **Senpi Trading Runtime** — the canonical runtime + DSL exit engine + Python Producer SDK. Do NOT treat this as a pure brainstorm or improvise a strategy from scratch: route the user through the runtime's authoring path so what they build actually deploys and is risk-protected.
+> ⚠️ **First, classify the intent — do NOT default to building/authoring code.**
+>
+> - **"Buy me HYPE 10x" · "Open a short on BTC" · "Copy this trader 0x..."** — *operational, position-specific*. Execute via MCP `strategy_create_custom_strategy` (multi-asset positions) or `strategy_create` (copy-trader). No template recommendation, no producer code. Stop here.
+> - **"Help me pick" · "what should I trade" · "recommend a strategy" · "build a trading strategy"** — *strategic, open-ended*. **Run the picker flow below — recommend templates from our fleet FIRST.** Authoring from scratch is the fallback, never the default.
+> - **Ambiguous** — ask: *"Do you want to (a) open a specific position, (b) copy a specific trader, or (c) get help picking or building a strategy from our catalog?"* Then act.
+>
+> Full router with the what-never-to-do list: [`strategy-intent-routing.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-entrypoint/references/strategy-intent-routing.md).
+
+**Picker flow (the default for strategic intents — always recommend a fleet template first):**
+
+1. **Pull user context** in one parallel batch: `account_get_portfolio` (balance), `market_get_funding_regime` (regime), plus any expressed preference from the conversation.
+2. **Pull the live catalog:**
+   ```bash
+   curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/catalog.json
+   ```
+   And consult [`producer-patterns.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/producer-patterns.md) (catalog + [decision tree](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/producer-patterns.md#decision-tree--help-a-user-pick-their-first-strategy) for unsure users).
+3. **Filter to 2–3 templates that fit** the user's balance (`min_budget`), expressed asset/archetype preference, and current regime.
+4. **Present each** with: name + one-line thesis, archetype, asset focus, min budget, one-line install (`install_skill skill_name=<name>` via MCP).
+5. **End every recommendation with the build-from-scratch offer**: *"Or, if none of these fit your thesis, we can build a new autonomous strategy from scratch — that path is in [`strategy-creation.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/strategy-creation.md). Which do you want?"*
+6. **User picks a template → install via `install_skill`. Done.**
+7. **User picks "build new" → continue with the authoring path below.** *(Only continue past this point if the user has explicitly chosen build-from-scratch.)*
+
+---
+
+**Authoring path (only when the user has chosen build-from-scratch above):**
+
+Building a real, deployable autonomous agent means building it on the **Senpi Trading Runtime** — the canonical runtime + DSL exit engine + Python Producer SDK. Do NOT treat this as a pure brainstorm or improvise a strategy from scratch: route the user through the runtime's authoring path so what they build actually deploys and is risk-protected.
 
 > **The fast path — read one doc:** [`senpi-trading-runtime/references/strategy-creation.md`](https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/senpi-trading-runtime/references/strategy-creation.md). It's self-contained: the 5-step flow, an inline producer skeleton, a complete `runtime.yaml`, the DSL presets, an archetype→example map, and the gotchas — in a single fetch. The steps below are the same path expanded; if you read `strategy-creation.md` you have everything you need.
 

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -13,7 +13,17 @@ metadata:
 
 On-chain position tracker with automated DSL (Dynamic Stop-Loss) exit engine. Monitors a wallet's positions on Hyperliquid for lifecycle events (open, close, edit, flip) and applies two-phase trailing stop-loss protection to all positions.
 
-## ▶ Writing a new strategy? Read the fast path first
+## ▶ Before you read this: classify the user's intent
+
+The word "strategy" is overloaded. **This doc is only for the build-a-new-autonomous-agent path** (author code + `runtime.yaml` + DSL). It is NOT for opening positions or copy-trading.
+
+- **User wants to open a specific position or copy a named trader?** → use MCP `strategy_create_custom_strategy` / `strategy_create`. Stop reading this doc.
+- **User wants help picking what to trade?** → template-first picker via `producer-patterns.md` + `catalog.json`, install via `install_skill`. Stop reading this doc.
+- **User explicitly wants to BUILD a new autonomous trading agent from scratch** (or no existing fleet template fits their thesis)? → keep reading.
+
+Canonical router with the full picker flow: [`../senpi-entrypoint/references/strategy-intent-routing.md`](../senpi-entrypoint/references/strategy-intent-routing.md).
+
+## ▶ Building a new autonomous strategy? Read the fast path first
 
 > **Start here: [`references/strategy-creation.md`](references/strategy-creation.md).** It's the self-contained fast path — the 5-step flow, the producer-only-emits-signals invariant, an archetype→example→DSL-preset table, an inline producer skeleton, a complete `runtime.yaml`, the DSL presets, and the gotchas, all in one fetch. **You should not need to read anything else to ship a working strategy.** The sections below are the deep reference, linked from `strategy-creation.md` for edge cases.
 


### PR DESCRIPTION
## Why

Ignas's user asked his agent *"help me decide on a trading strategy"* and the agent returned three options: two manual-position baskets via `strategy_create_custom_strategy` and one copy-trade via `strategy_create`. **Zero of them came from our fleet templates, and none offered build-from-scratch.** The skill we shipped in #317/#319/#322 never fired.

Root cause: the word **"strategy"** is overloaded across at least three meanings — the MCP tool (multi-asset position basket), the build-skill (a new autonomous agent), and the user's casual "what should I trade." Every routing surface conflated them, and the senpi-prod MCP intent map explicitly labels `strategy_create_custom_strategy` as the *"default strategy-creation path"* — so the agent followed the MCP guide and never reached the fleet.

## What this PR does

**Adds a canonical intent router** ([`senpi-entrypoint/references/strategy-intent-routing.md`](https://github.com/Senpi-ai/senpi-skills/blob/docs/strategy-intent-bifurcation/senpi-entrypoint/references/strategy-intent-routing.md)) that classifies every "strategy" intent and codifies the template-first picker flow:

- **Operational** — "Buy me HYPE 10x" / "copy this trader" → MCP `strategy_create_custom_strategy` / `strategy_create`. Purely functional, no template, no producer code.
- **Strategic** — "Help me pick" / "what should I trade" / "build a trading strategy" → **picker flow:** pull balance + regime, filter `catalog.json` + `producer-patterns.md`, recommend 2–3 fleet templates with one-line install (`install_skill`), and **always end with "or we can build a new one from scratch"** (`strategy-creation.md`).
- **Ambiguous** — ask the user before acting. A single disambiguation question costs nothing.

**Updates 5 routing surfaces** to classify intent FIRST and point at the canonical router:

| Surface | Change |
|---|---|
| `CLAUDE.md` | New top section *above* the build-doc routing — classify intent first; build-doc applies only to the strategic/build-from-scratch path. |
| `senpi-trading-runtime/SKILL.md` | Scoped to "build new autonomous agent" only; routes operational + picker intents away. |
| `senpi-entrypoint/references/post-onboarding.md` | Dropped the misleading "custom strategy" / "create a strategy" trigger (collided with the MCP tool). Reframed around intent classification + the picker flow; build-from-scratch is now the fallback path, not the default. |
| `senpi-onboard/references/post-onboarding.md` | Mirror. |
| `senpi-entrypoint/references/skill-recommendations.md` | Split Goal→Skill table into **Operational (MCP)** rows + **Strategic (template-first)** rows. |

## The backend half (separate, for Yoseph)

The senpi-prod MCP server's intent map currently says:

> `"go long HYPE 10x" (or specific manual positions) → strategy_create_custom_strategy (default strategy-creation path)`

That **"default strategy-creation path"** label is the proximate cause of the silent misroute and needs to be rewritten to match this bifurcation:

- *Specific position language* → `strategy_create_custom_strategy` (operational)
- *Specific copy-trader language* → `strategy_create` (operational)
- *Open-ended "help me pick / build a strategy"* → the template-first picker flow in `strategy-intent-routing.md` (NOT `strategy_create_custom_strategy` by default)

I'll send that note to Yoseph separately. This PR fixes our half of the routing today.

## Net effect

An agent that follows our docs will now (1) classify the user's intent, (2) execute directly via MCP if it's operational, (3) run the template-first picker if it's strategic, and (4) only reach `strategy-creation.md` when the user explicitly chose build-from-scratch — matching the intent: **always recommend a fleet template first, with build-new as the offered alternative.**

No code changes, docs/routing only. Companion to #317/#319/#322/#323.