### PR TITLE
docs(strategy-creation): add composition contract — env vs config vs scanner emission

### DIFF
--- a/senpi-trading-runtime/references/strategy-creation.md
+++ b/senpi-trading-runtime/references/strategy-creation.md
@@ -23,6 +23,23 @@ A Senpi strategy is **a Python producer that emits signals + a `runtime.yaml` th
 
 If the user gave you full autonomy, **pick the archetype + preset yourself**. Otherwise, **prompt the user** to pick.
 
+## Composition contract — the three name spaces
+
+A skill bundle has **three** kinds of names. Confusing them is the most common authoring bug — and the most common silent compose-check failure downstream. Read this once before writing any code or YAML; everything below assumes you understand the distinction.
+
+| Kind | Looks like | Where it comes from | Authors should… |
+|---|---|---|---|
+| **Runtime / env injection** | `${WALLET_ADDRESS}`, `${TELEGRAM_CHAT_ID}`, `${<SKILL>_DECISION_MODEL}` — **ALL_CAPS** inside `${…}`, only in `runtime.yaml` | Injected by the runtime at start-up from the operator's environment (wallet, notifier config, decision-model name, etc.) | Use as-is in `runtime.yaml`. **Do not** define them in the producer. **Do not** invent new ones for thesis logic. |
+| **Config parameter** | Read inside the producer from `config/<skill>-config.json` (or via a config helper module like the example agent's `<skill>_config.py`) | The operator-tunable defaults you ship in `config/<skill>-config.json` | Define in the config JSON; reference in the producer. `runtime.yaml` does **not** typically refer to these — they're for the producer's own gating logic. |
+| **Scanner emission** | The `asset` / `direction` / `score` / `signal_type` kwargs and the top-level keys of the `data={…}` kwarg on `client.push_signal(…)` | Produced by the producer each tick | These are the fields the runtime / actions / exit DSL see. If `runtime.yaml` (or an action condition) needs to reference one, write it as `scanner.score`, `scanner.data.<field>`, etc. — **never** as `${UPPER_CASE}`. |
+
+**Rules of thumb (every authoring bug we've seen violates one of these):**
+
+- **Never use `${UPPER_CASE}` to mean "a field the scanner produces."** Reserve `${…}` for runtime/env injection only (and it's always ALL_CAPS).
+- **Never invent emission names like `${rsi_value}` and hope the runtime knows them.** Emit via `push_signal(data={"rsi_value": …})` and reference as `scanner.data.rsi_value` if `runtime.yaml` needs it.
+- **The top-level `push_signal` kwargs (`asset`, `direction`, `score`, `signal_type`) are the runtime's stable contract.** Keep them top-level; never nest them inside `data={…}` — the runtime rejects that with `INVALID_REQUEST`.
+- **Every key your producer puts in `data={…}` must be declared** in `runtime.yaml` under `scanners.config.fields`. Producer-side keys and YAML-declared fields are the same set; mismatches fail validation.
+
 ## Step 0 — Pre-flight (one parallel batch, ~5s)
 
 Make these read-only calls **in a single batch** (not three scattered waves) to ground the build in the user's actual account + current market state:


### PR DESCRIPTION
## Why

Follow-up to Ignas's [senpi-skill-doc-improvements](https://github.com/Senpi-ai/senpi-skills/) — Opus conversational-authoring eval saw **12/12 samples fail \`artifactsOk\`** on the same false-positive: the framework's compose check treated \`\${WALLET_ADDRESS}\` / \`\${TELEGRAM_CHAT_ID}\` / \`\${<SKILL>_DECISION_MODEL}\` as scanner-output field references because nothing in the docs distinguished the three name spaces:

| Kind | Syntax | Source |
|---|---|---|
| Runtime / env injection | \`\${ALL_CAPS}\` in \`runtime.yaml\` | Operator env at startup |
| Config parameter | Read from \`config/<skill>-config.json\` in the producer | Operator-tunable defaults you ship |
| Scanner emission | \`push_signal\` kwargs + \`data={…}\` keys | The producer at each tick |

Confusing these is the most common authoring bug — and the most common silent compose-check failure downstream. The framework-side fix shipped in [model-testing-framework#167](https://github.com/Senpi-ai/model-testing-framework/pull/167); this lands the convention authors *and* tooling can both validate against.

## What this PR does

Adds a **\"Composition contract\"** section to \`senpi-trading-runtime/references/strategy-creation.md\` — placed right after the steps overview and before Step 0, so it's read during the build (not afterwards). The section is a 3-row table mapping each name space to its syntax, source, and authoring rules, plus four rules-of-thumb that each cover one observed bug class.

Doc-only — no runtime behaviour or schema change. Documents what the runtime already enforces.

## Where (and why there)

Landed in \`strategy-creation.md\`, not \`SKILL.md\`. \`strategy-creation.md\` is the single self-contained authoring fetch the agent reads to build a bundle (#317 / #319 / #322 / #323). Putting the contract here means it's read inline during the build, not as a separate trip to SKILL.md.

## Not included

The other proposal in Ignas's doc (codify funding as per-8h, annualize with \`×3×365\`) is **rejected** on verification — HL's own docs state the field is per-hour (\`0.00125%/hr = 0.01%/8h = 11.6% APR\`), and the math + 24h sum-of-rates + HL fundingHistory all confirm \`×8760\` is correct. The numbers Ignas's agent cited as evidence (\`funding_regime.avg_funding_annualized = 2.57%\`, BTC excluded at \`min 5%\`) are real — but they reflect a **backend MCP aggregation bug** (the senpi-prod tools appear to use \`×3×365\` internally, which is what made the data look self-consistent at 8x too low). That's a separate ticket for the backend team.