### PR TITLE
Add Wave 1 — Tortoise, Sheep, Iguana, Sailfish (4 new strategies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,13 +330,13 @@ Each tool's full schema (params, types, response shape) is in the MCP server its
 
 # Trading Strategy Skills
 
-The fleet — **36 skills across 14 producer archetypes**. Every skill targets runtime **1.1.0**. Bucketing matches [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md), the canonical archetype catalog.
+The fleet — **40 skills across 14 producer archetypes**. Every skill targets runtime **1.1.0**. Bucketing matches [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md), the canonical archetype catalog.
 
 Each row links to the skill's directory.
 
 ## 🎯 Onboarding tier — new to Senpi? Start here.
 
-Ten v1.0 strategies designed for first-time operators. All share the same scaffold: **helpers-native producer + Smart-Money direction gate via `leaderboard_get_markets` + DSL Phase 1 floor + Phase 2 ratchet ladder + race-window dedup**. Each opens LONG or SHORT (no long-only), uses simple 5-component scoring (max ~9), and lets the runtime own all exit logic.
+Thirteen v1.0 strategies designed for first-time operators. Most share the same scaffold: **helpers-native producer + Smart-Money direction gate via `leaderboard_get_markets` + DSL Phase 1 floor + Phase 2 ratchet ladder + race-window dedup**, with simple scoring and runtime-owned exits. A few deliberately break that mold — **Sheep** is long-only triple-EMA-stack (no shorts), and **Tortoise** has no scoring at all (DCA cadence is the signal).
 
 Pick by what you want to trade. Each is its own self-contained skill directory at the repo root.
 
@@ -347,12 +347,19 @@ Pick by what you want to trade. Each is its own self-contained skill directory a
 | [beaver](beaver/) | BTC | **Default first strategy.** 4h trend + Smart-Money direction gate. Wide Bison-pattern DSL (T0 lock 0 → T5 lock 85). |
 | [heron](heron/) | ETH | Same shape as Beaver, ETH. |
 | [hummingbird](hummingbird/) | HYPE | Same shape, HYPE. |
+| [sheep](sheep/) | BTC · ETH · SOL · HYPE | **Long-only triple-EMA-stack.** Fires LONG only when 15m + 1h + 4h EMAs are all stacked bullishly. Never shorts — for users who want trend exposure without learning what shorts are. |
 
 ### 🔵 Diversified Crypto Basket
 
 | Skill | Assets | Description |
 |---|---|---|
 | [hedgehog](hedgehog/) | BTC + ETH + SOL | Equal-weight basket, each asset directional independently. BTC long + ETH short is allowed. Up to 3 simultaneous positions, per-position DSL. |
+
+### 🟤 Accumulation (no prediction, no scoring)
+
+| Skill | Assets | Description |
+|---|---|---|
+| [tortoise](tortoise/) | BTC + ETH + SOL | **DCA scheduler.** Buys a fixed % of budget on a strict 24h cadence. No price prediction, no scoring — most-overdue past interval wins. LONG only. The most accessible trade in crypto: zero prediction skill required. |
 
 ### 🟣 Multi-week Arena Conviction Mirror
 
@@ -376,6 +383,7 @@ Senpi's distinctive moat — equity, commodity, and pre-IPO perps that retail ca
 | [lemur](lemur/) | Pre-IPO Perpetuals (IPOPs) | **Auto-discovers IPOPs** via the trade.xyz funding signature (\|funding\| ≤ 1e-7 AND max_leverage ≤ 5). Today: xyz:SPCX. Auto-expands when ANTHROPIC / OPENAI / STRIPE list. |
 | [bobcat](bobcat/) | Big tech | NVDA / TSLA / AAPL / META / MSFT / GOOGL / AMZN / AMD / MU / INTC / TSM / ORCL. 4h trend + SM. 48h hard timeout for the weekend pricing gap. |
 | [raccoon](raccoon/) | All XYZ (excl. IPOPs) | **Weekend-only.** Fri 22:00 UTC → Mon 00:00 UTC. Captures the Mon-open reconciliation snap-back when trade.xyz external pricing resumes after the 50h internal-oracle window. |
+| [iguana](iguana/) | xyz:SP500 · xyz:XYZ100 | **Broad indices only — no stock-picking.** Trades whichever has the stronger 4-day move past 1.5%. The closest thing to an index fund, but 24/7 on Hyperliquid. |
 
 ---
 
@@ -422,6 +430,10 @@ Strict whitelist of 3–6 majors, best-of-N selection per tick.
 |---|---|---|---|
 | [bison](bison/) | v1.0 | BTC · ETH · SOL | Iterates BTC / ETH / SOL per tick, fires the best-scoring above MIN_SCORE. Tick 300s. |
 | [badger](badger/) | v1.0 | BTC · ETH · SOL · HYPE | Takes a breakout only when **rising open interest** confirms it (new money, not a fakeout). OI-state cache. Wide "let winners run" DSL. |
+| [tortoise](tortoise/) | v1.0 | BTC · ETH · SOL | **Onboarding — DCA scheduler.** Buys a fixed % of budget on a strict 24h cadence. No price prediction, no scoring. Most-overdue past interval wins. LONG only. Wide DSL + 30d hard_timeout for compounding. |
+| [sheep](sheep/) | v1.0 | BTC · ETH · SOL · HYPE | **Onboarding — long-only triple-stack.** Fires LONG only when 15m + 1h + 4h EMAs are all stacked bullishly. Never shorts. Balanced DSL + `weak_peak_cut` 6h/3%. |
+| [iguana](iguana/) | v1.0 | xyz:SP500 · xyz:XYZ100 | **Onboarding — XYZ index basket.** The simplest XYZ exposure — just the broad indices. Picks whichever has the stronger 4-day move past 1.5% and trades its direction. Balanced DSL + 48h hard_timeout. |
+| [sailfish](sailfish/) | v1.0 | BTC · ETH · SOL · HYPE | **Relative-strength rotator.** Ranks the universe by ~2.7d RS each tick; longs the leader iff leader RS ≥ 1% AND beats runner-up by ≥ 1.5pp (no whipsaw). Rotation via DSL exit + re-entry. Balanced DSL + 96h hard_timeout. |
 
 ## 5. Trader-follower / hot-streak
 

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "1.0",
-  "_updated": "2026-05-26",
+  "_updated": "2026-05-28",
   "_instructions": "Agent reads this file to build the onboarding skill catalog. Group by 'group', sort within group by 'sort_order'. Infrastructure skills (DSL, fee optimizer, scanners) are never displayed.",
   "groups": [
     {
@@ -58,6 +58,66 @@
       "base_skill": null,
       "branch": "main",
       "predators_url": "https://strategies.senpi.ai/bot/badger",
+      "version": "1.0.0"
+    },
+    {
+      "id": "tortoise",
+      "tracker_slug": "tortoise",
+      "name": "Tortoise \u2014 DCA Scheduler",
+      "emoji": "\ud83d\udc22",
+      "tagline": "Slow and steady wins the race. Buys a fixed % of budget on a 24h cadence \u2014 no prediction, no scoring. The most accessible trade in crypto: zero prediction skill required.",
+      "group": "multi-asset-whitelist",
+      "sort_order": 41,
+      "min_budget": 500,
+      "risk_level": "conservative",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/tortoise",
+      "version": "1.0.0"
+    },
+    {
+      "id": "sheep",
+      "tracker_slug": "sheep",
+      "name": "Sheep \u2014 Long-Only Triple-EMA-Stacked Trend",
+      "emoji": "\ud83d\udc11",
+      "tagline": "Long-only trend follower. Fires only when 15m + 1h + 4h EMAs are all stacked bullishly. Never shorts \u2014 for users intimidated by directional choice.",
+      "group": "multi-asset-whitelist",
+      "sort_order": 42,
+      "min_budget": 500,
+      "risk_level": "conservative",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/sheep",
+      "version": "1.0.0"
+    },
+    {
+      "id": "iguana",
+      "tracker_slug": "iguana",
+      "name": "Iguana \u2014 XYZ Macro Index Trend",
+      "emoji": "\ud83e\udd8e",
+      "tagline": "Stock-market exposure on Hyperliquid without picking stocks. Trend-follows xyz:SP500 + xyz:XYZ100. Closest thing to an index fund, but 24/7.",
+      "group": "multi-asset-whitelist",
+      "sort_order": 43,
+      "min_budget": 500,
+      "risk_level": "conservative",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/iguana",
+      "version": "1.0.0"
+    },
+    {
+      "id": "sailfish",
+      "tracker_slug": "sailfish",
+      "name": "Sailfish \u2014 Relative-Strength Rotator",
+      "emoji": "\ud83d\udc20",
+      "tagline": "Always hold the strongest major. Ranks BTC/ETH/SOL/HYPE by ~2.7d relative strength; longs the leader iff it beats the runner-up by \u22651.5pp.",
+      "group": "multi-asset-whitelist",
+      "sort_order": 44,
+      "min_budget": 500,
+      "risk_level": "moderate",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/sailfish",
       "version": "1.0.0"
     },
     {

--- a/iguana/README.md
+++ b/iguana/README.md
@@ -1,0 +1,124 @@
+# 🦎 Iguana — XYZ Macro Index Trend
+
+**Stock-market exposure on Hyperliquid without picking stocks.** Iguana trend-follows `xyz:SP500` + `xyz:XYZ100`. Two assets, one decision per tick. Closest thing to an index-fund equivalent, but 24/7.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+Bobcat picks 12 stocks. Bald-Eagle / Kestrel do macro multi-asset contrarian fade. Dire is single-commodity. Lemur / Falcon handle pre-IPO. None give the *simplest* equity exposure — *"I just want the broad market."* Iguana is that.
+
+## Key parameters
+
+| Parameter | Default |
+|---|---|
+| Whitelist | `xyz:SP500` · `xyz:XYZ100` |
+| Tick interval | 300s (5 min) |
+| Trend lookback | 24 × 4h bars (4 days) |
+| Min trend (gate) | 1.5% |
+| Strong trend (bonus) | 4% |
+| Leverage | 3x default, max 5x |
+| Margin per slot | 20% of equity |
+| Max entries per day | 2 |
+| Per-asset cooldown | 360 min (6h) |
+| Daily loss limit | 12% |
+| Drawdown halt | 20% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (balanced — XYZ-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 12% |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | **48h (weekend gap)** |
+| Time cuts | weak_peak_cut | **8h / 3.0** |
+| Time cuts | dead_weight_cut | disabled |
+| Phase 2 | T0 → T4 | +5/0 · +10/40 · +18/60 · +30/75 · +50/85 |
+
+## Scanner pattern
+
+Archetype #4 (Multi-asset whitelist, XYZ subset). Primary MCP call: `market_get_asset_data(candle_intervals=["4h"])` per index. Pure functions unit-tested in `tests/test_signal.py` (`python3 iguana/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/iguana-producer.py | Long-lived daemon; emits IGUANA_INDEX_TREND signals |
+| scripts/iguana_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/iguana-config.json | Operator-tunable defaults (whitelist, trend thresholds) |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Iguana
+
+```bash
+mkdir -p /data/workspace/skills/iguana-strategy/{config,scripts,state,references}
+for f in scripts/iguana-producer.py scripts/iguana_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/iguana-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/iguana/$f" \
+    -o "/data/workspace/skills/iguana-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/iguana-strategy/config/iguana-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export IGUANA_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export IGUANA_DECISION_MODEL=<your-preferred-model>
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/iguana-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/iguana-strategy/scripts/iguana-producer.py \
+  > /tmp/iguana-producer.log 2>&1 &
+disown
+```
+
+## Verification
+
+```bash
+sleep 320
+tail -3 /tmp/iguana-producer.log | jq '._iguana_producer_version, .note // null, .best.trend_pct // null'
+```
+
+A healthy first tick usually outputs:
+- `"note": "WAITING — neither index has a 4d move past 1.5%"` (chop)
+- `"signals_pushed": 1, "best": { "coin": "xyz:SP500", "trend_pct": ..., "direction": "LONG"|"SHORT" }`
+
+## Changelog
+
+### v1.0.0 (2026-05-28) — initial release
+
+The simplest possible XYZ exposure in the fleet. No stock-picking; just broad indices in trend direction. Balanced DSL + 48h hard_timeout for weekend gap. Taker-true entry, disown-safe launch, unit-tested pure functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/iguana/SKILL.md
+++ b/iguana/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: iguana-strategy
+description: >-
+  IGUANA v1.0.0 — XYZ Macro Index Trend. Trend-follows the broad XYZ indices
+  xyz:SP500 + xyz:XYZ100. No stock-picking, no commodities — just the broad
+  indices, in whichever direction has the stronger 4-day move. The simplest
+  possible XYZ exposure, closest thing to an index-fund equivalent (but 24/7
+  on Hyperliquid). Onboarding tier. Balanced DSL + 48h hard_timeout for
+  weekend pricing-gap risk.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦎 IGUANA v1.0.0 — XYZ Macro Index Trend
+
+**Stock-market exposure on Hyperliquid without picking stocks.** Iguana trend-follows `xyz:SP500` + `xyz:XYZ100`. Two assets, one decision per tick. The closest thing to an index-fund equivalent, but 24/7.
+
+## Why this strategy exists
+
+The fleet covers XYZ from several angles: **Bobcat** picks 12 big-tech stocks; **Bald-Eagle / Kestrel** do XYZ macro multi-asset contrarian fade; **Dire** specializes in a single commodity (BRENTOIL); **Lemur / Falcon** handle pre-IPO and conversion events. None of them deliver the **simplest** equity exposure — *"I just want the broad market."* Iguana is that.
+
+## CRITICAL RULES
+
+### RULE 1: Indices only, no picks
+Whitelist defaults to **just two assets**: `xyz:SP500` and `xyz:XYZ100`. No individual stocks, no commodities, no pre-IPO names. Iguana is the index-fund equivalent.
+
+### RULE 2: 4-day trend strength gates entry
+For each index the producer computes `% change over the last 24 × 4h bars` (4 days). The strongest move **past `minTrendPct` (default 1.5%)** is the candidate. Both indices below threshold → no signal.
+
+### RULE 3: Direction follows the trend
+LONG if the 4d move is positive, SHORT if negative. Iguana is direction-agnostic on the way in — it just trades whichever side the broad market is taking.
+
+### RULE 4: Producer enters. DSL exits.
+No `close_position` call site. DSL is **balanced** preset + **48h `hard_timeout`** to accommodate the XYZ weekend pricing-gap risk + **`weak_peak_cut` 8h/3%** to bail from flat-but-tired positions before the weekend.
+
+## How Iguana scores a trade
+
+**Gate:** at least one index has `|4d trend| >= minTrendPct`.
+
+**Score components** (max ~6):
+
+| Signal | Points |
+|---|---|
+| Trend past `minTrendPct` (gate-confirmed) | +3 |
+| Trend past `strongTrendPct` (default 4%) | +2 |
+| Volume rising > 15% | +1 |
+
+**Floor:** `minScore: 4`.
+
+## DSL preset (balanced — XYZ-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 12% |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | **48h (weekend gap)** |
+| Time cuts | weak_peak_cut | **8h / 3.0** |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +5/0 · +10/40 · +18/60 · +30/75 · +50/85 |
+
+## Scanner pattern
+
+Archetype #4 (Multi-asset whitelist, XYZ subset). Primary MCP call: `market_get_asset_data(candle_intervals=["4h"])` per index. Stateless. The pure functions (`trend_strength`, `trend_direction`, `pick_strongest_trend`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-28) — initial release
+
+The simplest possible XYZ exposure in the fleet. No stock-picking; just broad indices in trend direction. Balanced DSL + 48h hard_timeout for weekend gap. Taker-true entry, disown-safe launch, unit-tested pure functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/iguana/config/iguana-config.json
+++ b/iguana/config/iguana-config.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "IGUANA v1.0.0 — XYZ Macro Index Trend. Each tick computes 4d trend strength (% change over trendLookbackBars 4h candles, default 24 = 4 days) for each whitelisted XYZ index. The strongest move past minTrendPct (default 1.5%) is fired in its direction. Score boosts from trend magnitude and rising volume. Two assets (SP500 + XYZ100), one decision. The simplest possible XYZ exposure — closest thing to an index fund, but 24/7 on Hyperliquid. ONBOARDING TIER. Balanced DSL + 48h hard_timeout for XYZ weekend pricing-gap risk. Edit wallet/strategyId/chatId; tune whitelist/thresholds.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "whitelist": ["xyz:SP500", "xyz:XYZ100"],
+  "trendLookbackBars": 24,
+  "minTrendPct": 1.5,
+  "strongTrendPct": 4.0,
+  "minScore": 4,
+  "marginPct": 0.20,
+  "leverage": 3
+}

--- a/iguana/references/skill-attribution.md
+++ b/iguana/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "iguana",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "iguana",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/iguana/runtime.yaml
+++ b/iguana/runtime.yaml
@@ -1,0 +1,175 @@
+name: iguana-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Iguana v1.0.0"
+# and lives in description + SKILL.md + _iguana_producer_version.
+version: 1.0.0
+description: >
+  IGUANA v1.0.0 — XYZ Macro Index Trend.
+
+  "I want stock-market exposure on Hyperliquid without picking stocks."
+
+  Iguana trend-follows the broad XYZ indices xyz:SP500 + xyz:XYZ100. Two
+  assets, one decision per tick — picks the stronger 4-day move past the
+  threshold and trades in its direction. No stock-picking, no commodities,
+  no pre-IPO. The closest thing to an index-fund equivalent on Hyperliquid.
+
+  Architecture (helpers-native): producer ticks every 300s, computes 4d trend
+  strength per index, picks the strongest above minTrendPct, and emits
+  IGUANA_INDEX_TREND. LLM gate is pass-through.
+
+  DSL: balanced + 48h hard_timeout (XYZ pricing-gap risk on weekends).
+  ONBOARDING TIER.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_pct: 20            # % of account budget per slot (scales with any budget)
+  trading_risk: conservative
+  enabled: true
+
+risk:
+  data_retention_hours: 96
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 2
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 90
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 360
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: iguana_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trendPct: { type: number, required: false }
+        volumeTrendPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: iguana_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${IGUANA_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [iguana_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # ride the trend NOW — a maker order that rests (CREATE_ORDER_RESTING) misses extension
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: iguana_signals
+    decision_prompt: |
+      You are Iguana's pass-through gate. Iguana trends the broad XYZ indices
+      (SP500, XYZ100). The producer identified the strongest 4-day move past
+      the trend threshold and entered in its direction. Honor the signal.
+
+      SIGNAL:
+      {{signal_iguana_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (keep the xyz: prefix).
+      2. direction MUST be copied from signal.direction (LONG or SHORT).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 4 (producer floor)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets
+      - direction sign disagrees with trendPct sign
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 5 AND |trendPct| >= 4
+      - 7-8:  score 4
+      - 7:    score 4 (producer floor) — the signal IS the validation
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 5 xyz:SP500 LONG, 4d trend +3.2%, volume rising — broad-market uptrend')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "IGUANA_INDEX_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — balanced, XYZ-tuned) ─────────────────────────
+#
+# Index trends extend over days/weeks; 48h hard_timeout accommodates the
+# weekend pricing-gap risk on XYZ. weak_peak_cut bails from flat-but-tired
+# positions before the weekend gap.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880           # 48h — XYZ weekend pricing-gap risk
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,  lock_hw_pct: 0 }
+        - { trigger_pct: 10, lock_hw_pct: 40 }
+        - { trigger_pct: 18, lock_hw_pct: 60 }
+        - { trigger_pct: 30, lock_hw_pct: 75 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/iguana/scripts/iguana-producer.py
+++ b/iguana/scripts/iguana-producer.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+# Senpi IGUANA Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""IGUANA v1.0.0 — XYZ Macro Index Trend.
+
+"I want stock-market exposure on Hyperliquid without picking stocks."
+
+Iguana trend-follows the broad XYZ indices `xyz:SP500` + `xyz:XYZ100`. No
+stock-picking, no commodities, no pre-IPO. Two assets, one decision per tick.
+
+Closest thing to an index-fund equivalent — but 24/7. ONBOARDING TIER.
+
+Architecture (helpers-native): producer ticks every 300s, computes a 4h trend
+strength per index, picks the stronger if both align (or the lone strong one),
+and emits IGUANA_INDEX_TREND in the trend's direction. LLM gate is pass-through.
+
+DSL: balanced + 48h hard_timeout (XYZ weekend pricing-gap risk).
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import iguana_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "iguana_signals"
+SIGNAL_TYPE = "IGUANA_INDEX_TREND"
+
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 3
+DEFAULT_MIN_SCORE = 4
+
+DEFAULT_WHITELIST = ["xyz:SP500", "xyz:XYZ100"]
+DEFAULT_TREND_LOOKBACK = 24    # 24 × 4h bars = 4 days
+DEFAULT_MIN_TREND_PCT = 1.5    # minimum |4-day move| to call it a trend
+DEFAULT_STRONG_TREND_PCT = 4.0
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("IGUANA_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure index-trend logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def trend_strength(closes, lookback):
+    """% change of the latest close vs the close `lookback` bars ago.
+    None if insufficient data or the reference price is non-positive."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def trend_direction(strength, min_pct):
+    """Direction implied by trend strength. None if magnitude below threshold."""
+    if strength is None or abs(strength) < min_pct:
+        return None
+    return "LONG" if strength > 0 else "SHORT"
+
+
+def pick_strongest_trend(per_asset_strength, min_pct):
+    """Among {asset: strength}, return the asset with the highest |strength|
+    above min_pct. Returns (asset, strength) or None."""
+    best, best_mag = None, -1.0
+    for asset, strength in per_asset_strength.items():
+        if strength is None:
+            continue
+        mag = abs(strength)
+        if mag < min_pct:
+            continue
+        if mag > best_mag:
+            best_mag, best = mag, (asset, strength)
+    return best
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_candles(asset):
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return []
+    return data.get("data", {}).get("candles", {}).get("4h", [])
+
+
+def volume_trend(candles, lookback=6):
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, strength, candles, config):
+    min_pct = float(config.get("minTrendPct", DEFAULT_MIN_TREND_PCT))
+    strong_pct = float(config.get("strongTrendPct", DEFAULT_STRONG_TREND_PCT))
+
+    direction = trend_direction(strength, min_pct)
+    if direction is None:
+        return None
+
+    vol = volume_trend(candles)
+
+    score = 3   # base — trend strength above min
+    reasons = [f"{asset}_4d_trend_{strength:+.1f}%"]
+    if abs(strength) >= strong_pct:
+        score += 2
+        reasons.append(f"trend_strong_{strength:+.1f}%")
+    if vol > 15:
+        score += 1
+        reasons.append(f"vol_rising_{vol:+.0f}%")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_pct": round(strength, 2),
+        "volume_trend_pct": round(vol, 2),
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "trendPct": thesis.get("trend_pct") or 0.0,
+        "volumeTrendPct": thesis.get("volume_trend_pct") or 0.0,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 6.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    whitelist = config.get("whitelist", DEFAULT_WHITELIST)
+    lookback = int(config.get("trendLookbackBars", DEFAULT_TREND_LOOKBACK))
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_iguana_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_iguana_producer_version": VERSION})
+        return
+
+    candles_by_asset = {}
+    strength_by_asset = {}
+    for asset in whitelist:
+        if asset.upper() in held_set or cfg.was_recently_signaled(asset):
+            continue
+        candles = fetch_candles(asset)
+        if len(candles) <= lookback:
+            continue
+        closes = [_f(c, "close", "c") for c in candles]
+        candles_by_asset[asset] = candles
+        strength_by_asset[asset] = trend_strength(closes, lookback)
+
+    min_pct = float(config.get("minTrendPct", DEFAULT_MIN_TREND_PCT))
+    picked = pick_strongest_trend(strength_by_asset, min_pct)
+    if picked is None:
+        cfg.output({
+            "status": "ok",
+            "note": f"WAITING — neither index has a 4d move past {min_pct}%",
+            "whitelist": whitelist,
+            "strength": {k: round(v, 2) if v is not None else None for k, v in strength_by_asset.items()},
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_iguana_producer_version": VERSION,
+        })
+        return
+
+    asset, strength = picked
+    thesis = build_thesis(asset, strength, candles_by_asset[asset], config)
+    if thesis is None or thesis["score"] < int(config.get("minScore", DEFAULT_MIN_SCORE)):
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — pick cleared trend gate but missed minScore",
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_iguana_producer_version": VERSION,
+        })
+        return
+
+    margin_pct = float(config.get("marginPct", 0.20))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(thesis, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(thesis["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": thesis["coin"],
+            "direction": thesis["direction"],
+            "trend_pct": thesis["trend_pct"],
+            "score": thesis["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": thesis["reasons"][:5],
+        },
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_iguana_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"iguana-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/iguana/scripts/iguana_config.py
+++ b/iguana/scripts/iguana_config.py
@@ -1,0 +1,196 @@
+"""IGUANA v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+XYZ Macro Index Trend. Iguana is the simplest possible XYZ equity exposure:
+trend-follow the broad indices `xyz:SP500` + `xyz:XYZ100`. No stock picking,
+no commodities, no pre-IPO. Two assets, one decision per tick. The closest
+thing to "an index fund, but 24/7 on Hyperliquid."
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+balanced DSL with a 48h hard_timeout (XYZ pricing gap risk on weekends).
+Stateless scoring + race-window dedup. Onboarding tier.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "iguana-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "iguana-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Iguana's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("iguana_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def mcp_call(tool, **params):
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] iguana_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[iguana-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/iguana/tests/test_signal.py
+++ b/iguana/tests/test_signal.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Unit tests for Iguana's pure functions (trend_strength, trend_direction,
+pick_strongest_trend). Stubs iguana_config + senpi_runtime_helpers.
+Run: python3 iguana/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("iguana_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["iguana_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "iguana-producer.py"
+_spec = importlib.util.spec_from_file_location("iguana_producer", _path)
+ip = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ip)
+
+
+def test_trend_strength_known_value():
+    # 24 bars ago close = 100, latest = 105 → +5%
+    closes = list(range(80, 105))   # 25 values, [0]=80...[24]=104? Let me recompute
+    # Actually I want closes[-25] = 100 and closes[-1] = 105.
+    closes = [100.0] * 25
+    closes[-1] = 105.0
+    assert abs(ip.trend_strength(closes, 24) - 5.0) < 1e-9
+
+
+def test_trend_strength_insufficient_and_bad_ref():
+    assert ip.trend_strength([100, 101], 24) is None
+    closes = [0.0] * 25
+    assert ip.trend_strength(closes, 24) is None     # ref <= 0
+
+
+def test_trend_direction_thresholds():
+    assert ip.trend_direction(3.0, 1.5) == "LONG"
+    assert ip.trend_direction(-3.0, 1.5) == "SHORT"
+    assert ip.trend_direction(1.0, 1.5) is None      # below threshold
+    assert ip.trend_direction(None, 1.5) is None
+
+
+def test_pick_strongest_trend_chooses_biggest_magnitude():
+    strength = {"xyz:SP500": 2.0, "xyz:XYZ100": -4.5}
+    picked = ip.pick_strongest_trend(strength, 1.5)
+    assert picked == ("xyz:XYZ100", -4.5)    # larger magnitude wins regardless of sign
+
+
+def test_pick_strongest_trend_filters_below_threshold():
+    strength = {"xyz:SP500": 0.5, "xyz:XYZ100": -1.0}
+    assert ip.pick_strongest_trend(strength, 1.5) is None
+
+
+def test_pick_strongest_trend_handles_none_strengths():
+    strength = {"xyz:SP500": None, "xyz:XYZ100": 2.0}
+    picked = ip.pick_strongest_trend(strength, 1.5)
+    assert picked == ("xyz:XYZ100", 2.0)
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/sailfish/README.md
+++ b/sailfish/README.md
@@ -1,0 +1,126 @@
+# 🐠 Sailfish — Relative-Strength Rotator (Crypto Majors)
+
+**Always hold the strongest major.** Sailfish ranks BTC/ETH/SOL/HYPE by ~2.7-day relative strength every tick and longs the leader. When the held position eventually exits via the DSL trail, the next tick re-evaluates — and *that's* the rotation.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+Chameleon trades mean-reversion between paired majors. Sailfish trades the momentum half of relative strength — when one major decisively outperforms, leadership tends to extend. The fleet had no momentum-rotation agent; Sailfish fills it.
+
+## Key parameters
+
+| Parameter | Default |
+|---|---|
+| Whitelist | BTC · ETH · SOL · HYPE |
+| Tick interval | 300s (5 min) |
+| RS lookback | 16 × 4h bars (~2.7 days) |
+| Min leader RS | 1.0% |
+| Leader margin vs runner-up | 1.5pp |
+| Direction | LONG only |
+| Leverage | 3x default, max 5x |
+| Margin per slot | 20% of equity |
+| Max entries per day | 2 |
+| Per-asset cooldown | 360 min (6h) |
+| Daily loss limit | 12% |
+| Drawdown halt | 20% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (balanced — leadership-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 12% |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | **96h** |
+| Time cuts | weak_peak_cut | **8h / 3.0** |
+| Time cuts | dead_weight_cut | disabled |
+| Phase 2 | T0 → T4 | +8/0 · +15/40 · +25/60 · +40/75 · +70/85 |
+
+## Scanner pattern
+
+Archetype #4 (Multi-asset whitelist) with relative-strength scoring. Primary MCP call: `market_get_asset_data(candle_intervals=["4h"])` per asset. Pure functions unit-tested in `tests/test_signal.py` (`python3 sailfish/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/sailfish-producer.py | Long-lived daemon; emits SAILFISH_RS_LEADER signals |
+| scripts/sailfish_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/sailfish-config.json | Operator-tunable defaults (whitelist, RS lookback, gates) |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Sailfish
+
+```bash
+mkdir -p /data/workspace/skills/sailfish-strategy/{config,scripts,state,references}
+for f in scripts/sailfish-producer.py scripts/sailfish_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/sailfish-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/sailfish/$f" \
+    -o "/data/workspace/skills/sailfish-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/sailfish-strategy/config/sailfish-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export SAILFISH_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export SAILFISH_DECISION_MODEL=<your-preferred-model>
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/sailfish-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/sailfish-strategy/scripts/sailfish-producer.py \
+  > /tmp/sailfish-producer.log 2>&1 &
+disown
+```
+
+## Verification
+
+```bash
+sleep 320
+tail -3 /tmp/sailfish-producer.log | jq '._sailfish_producer_version, .note // null, .best.leader_rs_pct // null'
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no clear leader (insufficient RS or margin)"` (chop / tight race)
+- `"note": "HOLDING — <ASSET> is the current leader and we already own it"`
+- `"signals_pushed": 1, "best": { "coin": ..., "leader_rs_pct": ..., "margin_vs_runner_up_pp": ... }`
+
+## Changelog
+
+### v1.0.0 (2026-05-28) — initial release
+
+First fleet agent for momentum rotation across the majors. Margin-vs-runner-up gate prevents whipsaw on tight races. DSL-mediated rotation. Taker-true entry, disown-safe launch, unit-tested pure functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/sailfish/SKILL.md
+++ b/sailfish/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: sailfish-strategy
+description: >-
+  SAILFISH v1.0.0 — Relative-Strength Rotator (Crypto Majors). Ranks
+  BTC/ETH/SOL/HYPE by ~2.7d relative strength each tick and longs the leader,
+  with a margin-vs-runner-up gate to avoid whipsaw on tight races. Runtime is
+  single-position and producer never closes — when the held position exits
+  via the DSL trail, the next tick re-evaluates and enters the new leader.
+  That's the "rotation". Distinct from Chameleon (pair mean-reversion);
+  Sailfish is momentum-rotation.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐠 SAILFISH v1.0.0 — Relative-Strength Rotator (Crypto Majors)
+
+**Always hold the strongest major.** Sailfish ranks BTC/ETH/SOL/HYPE by ~2.7-day relative strength every tick and longs the leader. When the held position eventually exits via the DSL trail, the next tick re-evaluates — and *that's* the rotation.
+
+## Why this strategy exists
+
+Chameleon trades **mean-reversion** between paired majors (when ratios stretch, they revert). Sailfish trades the **momentum** half of relative strength — when one major is decisively outperforming the others, leadership tends to extend. The fleet had no momentum-rotation agent; Sailfish fills it.
+
+## CRITICAL RULES
+
+### RULE 1: Relative strength is the rank, not the threshold
+Each tick the producer computes `% change over rsLookbackBars × 4h` per asset, sorts descending. The top of the list is the candidate — but candidacy alone isn't enough (see Rule 2).
+
+### RULE 2: Two gates protect against whipsaw
+- **Leader RS gate**: the leader's *own* RS must be `>= minLeaderRsPct` (default 1.0%). A flat or negative leader (everyone's down) is no leader at all.
+- **Margin gate**: leader must beat the runner-up by `>= leaderMarginPct` (default 1.5pp). A 0.2pp lead is whipsaw bait — Sailfish stays out.
+
+### RULE 3: "Rotation" via DSL exit + re-entry
+The runtime is single-position. The producer never closes. So when leadership changes while we hold the old leader, Sailfish does **nothing immediately** — the existing position's DSL trail (max_loss, retrace, weak_peak_cut at 8h/3%) eventually exits the stalled holdover, and the next tick re-evaluates. If the new leader still clears the gates, Sailfish enters it. This is intentional: rotating mid-position would mean trading taker-on-taker on every leadership change, paying spreads + fees for whipsaw. DSL-mediated rotation only fires when the old leader is genuinely done.
+
+### RULE 4: Producer enters. DSL exits.
+Same as every fleet agent. DSL is **balanced** preset + **96h `hard_timeout`** so leadership has room to extend.
+
+## How Sailfish scores a trade
+
+**Gate:** leader passes both RS and margin thresholds.
+
+**Score components** (max ~6):
+
+| Signal | Points |
+|---|---|
+| Leader clears both gates (gate-confirmed) | +3 |
+| Leader's RS `>= 4%` | +1 |
+| Margin vs runner-up `>= 3pp` | +1 |
+| Re-entering after a prior DSL exit (post-rotation) | flag only |
+
+**Floor:** `minScore: 4`.
+
+## DSL preset (balanced — leadership-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 12% |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | **96h** |
+| Time cuts | weak_peak_cut | **8h / 3.0** |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +8/0 · +15/40 · +25/60 · +40/75 · +70/85 |
+
+## Scanner pattern
+
+Archetype #4 (Multi-asset whitelist) with relative-strength scoring — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP call: `market_get_asset_data(candle_intervals=["4h"])` per asset. Stateless ranking. The pure functions (`relative_strength`, `rank_assets`, `leader_above_runner_up`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-28) — initial release
+
+First fleet agent for momentum **rotation** across the majors. Margin-vs-runner-up gate prevents whipsaw on tight races. DSL-mediated rotation (no mid-position closes — leadership change is realized via the DSL trail's natural exit + Sailfish's next-tick re-evaluation). Taker-true entry, disown-safe launch, unit-tested pure functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/sailfish/config/sailfish-config.json
+++ b/sailfish/config/sailfish-config.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "SAILFISH v1.0.0 — Relative-Strength Rotator (Crypto Majors). Each tick ranks the whitelist (default BTC/ETH/SOL/HYPE) by RS — % change over rsLookbackBars 4h candles (default 16 = ~2.7 days). The leader is taken iff (a) its own RS >= minLeaderRsPct (default 1.0%, leader must actually be up) AND (b) it beats the runner-up by >= leaderMarginPct (default 1.5pp, no whipsaw on tight races). Producer never closes — when the held position exits via the DSL trail, the next tick re-evaluates and enters the new leader. That's the 'rotation'. Distinct from Chameleon (pair mean-reversion); Sailfish is momentum-rotation. Balanced DSL + 96h hard_timeout.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "whitelist": ["BTC", "ETH", "SOL", "HYPE"],
+  "rsLookbackBars": 16,
+  "minLeaderRsPct": 1.0,
+  "leaderMarginPct": 1.5,
+  "minScore": 4,
+  "marginPct": 0.20,
+  "leverage": 3
+}

--- a/sailfish/references/skill-attribution.md
+++ b/sailfish/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "sailfish",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "sailfish",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/sailfish/runtime.yaml
+++ b/sailfish/runtime.yaml
@@ -1,0 +1,184 @@
+name: sailfish-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Sailfish v1.0.0"
+# and lives in description + SKILL.md + _sailfish_producer_version.
+version: 1.0.0
+description: >
+  SAILFISH v1.0.0 — Relative-Strength Rotator (Crypto Majors).
+
+  "Always hold the strongest major."
+
+  Each tick Sailfish ranks BTC/ETH/SOL/HYPE by ~2.7d relative strength and
+  longs the leader iff (a) leader's own RS >= minLeaderRsPct AND (b) leader
+  beats the runner-up by leaderMarginPct (no whipsaw on tight races). The
+  runtime is single-position and the producer never closes — when the
+  existing position naturally exits via the DSL trail, Sailfish enters the
+  new leader on the next tick (this is the "rotation").
+
+  Distinct from Chameleon (relative-value mean-reversion of pair ratios) —
+  Sailfish is momentum rotation: follow the strongest.
+
+  Architecture (helpers-native): producer ticks every 300s, computes RS per
+  asset, picks the leader past the gates, and emits SAILFISH_RS_LEADER.
+  LLM gate is pass-through.
+
+  DSL: balanced + 96h hard_timeout so leadership can play out.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_pct: 20            # % of account budget per slot (scales with any budget)
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 96
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 2
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 120
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 360
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: sailfish_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        leaderRsPct: { type: number, required: false }
+        leaderMarginPct: { type: number, required: false }
+        rankSnapshot: { type: array, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: sailfish_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${SAILFISH_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [sailfish_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # ride the leader NOW — a maker order that rests (CREATE_ORDER_RESTING) misses extension
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: sailfish_signals
+    decision_prompt: |
+      You are Sailfish's pass-through gate. Sailfish always wants to hold the
+      strongest major. The producer confirmed the leader is up (RS >= floor)
+      AND beats the runner-up by the margin threshold (no whipsaw). Honor the
+      signal.
+
+      SIGNAL:
+      {{signal_sailfish_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY.
+      2. direction MUST be LONG.
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - direction != LONG
+      - score < 4 (producer floor)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets
+      - leaderRsPct <= 0 (leader not actually up)
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 5 AND leaderMarginPct >= 3
+      - 7-8:  score 4
+      - 7:    score 4 (producer floor) — the signal IS the validation
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 5 HYPE LONG, RS +6.2%, beats runner-up BTC by 3.4pp — clear leader')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "LONG",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "SAILFISH_RS_LEADER LONG — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — balanced, leadership-tuned) ──────────────────
+#
+# Leadership can extend for days. Balanced ladder + 96h hard_timeout so a
+# leader can finish its run before staleness cuts it. weak_peak_cut bails
+# from a leader that's stalled. The natural DSL exit on a stalled leader is
+# what triggers Sailfish's "rotation" — the next tick re-evaluates and enters
+# the new leader.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760           # 96h — leadership can extend
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 0 }
+        - { trigger_pct: 15, lock_hw_pct: 40 }
+        - { trigger_pct: 25, lock_hw_pct: 60 }
+        - { trigger_pct: 40, lock_hw_pct: 75 }
+        - { trigger_pct: 70, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/sailfish/scripts/sailfish-producer.py
+++ b/sailfish/scripts/sailfish-producer.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+# Senpi SAILFISH Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""SAILFISH v1.0.0 — Relative-Strength Rotator (Crypto Majors).
+
+"Always hold the strongest major."
+
+Each tick Sailfish ranks BTC/ETH/SOL/HYPE by 4h relative strength and longs
+the strongest. The runtime is single-position and the producer never closes
+(DSL owns exits), so "rotation" here means: enter the current leader when a
+slot is open. When the existing position naturally exits via the DSL trail,
+Sailfish enters the new leader on the next tick.
+
+Distinct from Chameleon (relative-value mean-reversion of pair ratios) —
+Sailfish is **momentum rotation**: follow the strongest. To avoid leadership
+whipsaw, the producer requires the leader to be margin > leaderMarginPct
+ahead of the runner-up (default 1.5%).
+
+Architecture: helpers-native producer + balanced DSL with a 96h hard_timeout
+so leadership can play out. Stateless ranking + race-window dedup. Producer
+NEVER closes — DSL owns exits.
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import sailfish_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "sailfish_signals"
+SIGNAL_TYPE = "SAILFISH_RS_LEADER"
+
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 3
+DEFAULT_MIN_SCORE = 4
+
+DEFAULT_WHITELIST = ["BTC", "ETH", "SOL", "HYPE"]
+DEFAULT_RS_LOOKBACK = 16        # 16 × 4h bars = ~2.7 days
+DEFAULT_MIN_LEADER_RS_PCT = 1.0  # leader's own RS must be >= this %
+DEFAULT_LEADER_MARGIN_PCT = 1.5  # leader must beat the runner-up by this much
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("SAILFISH_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure relative-strength logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def relative_strength(closes, lookback):
+    """% change of the latest close vs the close `lookback` bars ago.
+    Used as a single-asset RS proxy; ranking sorts these across the universe.
+    None if insufficient data or ref price is non-positive."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def rank_assets(strength_by_asset):
+    """Sort {asset: strength} by strength descending. Assets with None
+    strength are dropped. Returns list of (asset, strength)."""
+    pairs = [(a, s) for a, s in strength_by_asset.items() if s is not None]
+    pairs.sort(key=lambda t: t[1], reverse=True)
+    return pairs
+
+
+def leader_above_runner_up(ranked, min_leader_rs_pct, margin_pct):
+    """Given a ranked list of (asset, strength), return the leader iff:
+      1. leader's own RS >= min_leader_rs_pct (leader must actually be up), AND
+      2. leader - runner_up >= margin_pct (clean separation, no whipsaw).
+    If there's only one ranked asset, the margin requirement defaults to met.
+    Returns (asset, strength, margin_vs_runner_up) or None."""
+    if not ranked:
+        return None
+    leader_asset, leader_rs = ranked[0]
+    if leader_rs < min_leader_rs_pct:
+        return None
+    if len(ranked) == 1:
+        return (leader_asset, leader_rs, float('inf'))
+    runner_rs = ranked[1][1]
+    margin = leader_rs - runner_rs
+    if margin < margin_pct:
+        return None
+    return (leader_asset, leader_rs, margin)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_candles(asset):
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return []
+    return data.get("data", {}).get("candles", {}).get("4h", [])
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(asset, leader_rs, margin_vs_runner, score, reasons, margin_usd, leverage, held_assets, ranked):
+    if not STRATEGY_ADDRESS:
+        return False
+    if asset.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": score,
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": "LONG",
+        "reasons": reasons,
+        "leaderRsPct": float(leader_rs) or 0.0,
+        "leaderMarginPct": float(margin_vs_runner) if margin_vs_runner != float('inf') else 0.0,
+        "rankSnapshot": [{"asset": a, "rs": round(s, 2)} for a, s in ranked[:6]],
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=asset,
+            direction="LONG",
+            score=min(score / 6.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {asset}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {asset}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    whitelist = config.get("whitelist", DEFAULT_WHITELIST)
+    lookback = int(config.get("rsLookbackBars", DEFAULT_RS_LOOKBACK))
+    min_leader_rs = float(config.get("minLeaderRsPct", DEFAULT_MIN_LEADER_RS_PCT))
+    margin_pct_threshold = float(config.get("leaderMarginPct", DEFAULT_LEADER_MARGIN_PCT))
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_sailfish_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_sailfish_producer_version": VERSION})
+        return
+
+    strength_by_asset = {}
+    for asset in whitelist:
+        candles = fetch_candles(asset)
+        if len(candles) <= lookback:
+            continue
+        closes = [_f(c, "close", "c") for c in candles]
+        strength_by_asset[asset.upper()] = relative_strength(closes, lookback)
+
+    ranked = rank_assets(strength_by_asset)
+    picked = leader_above_runner_up(ranked, min_leader_rs, margin_pct_threshold)
+
+    if picked is None:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no clear leader (insufficient RS or margin)",
+            "ranked": [{"asset": a, "rs": round(s, 2)} for a, s in ranked],
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_sailfish_producer_version": VERSION,
+        })
+        return
+
+    leader_asset, leader_rs, margin_vs_runner = picked
+
+    if leader_asset in held_set:
+        cfg.output({
+            "status": "ok",
+            "note": f"HOLDING — {leader_asset} is the current leader and we already own it",
+            "ranked": [{"asset": a, "rs": round(s, 2)} for a, s in ranked],
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_sailfish_producer_version": VERSION,
+        })
+        return
+
+    if cfg.was_recently_signaled(leader_asset):
+        cfg.output({
+            "status": "ok",
+            "note": f"WAITING — {leader_asset} is the leader but recently-signaled (race-window dedup)",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_sailfish_producer_version": VERSION,
+        })
+        return
+
+    # Score
+    score = 3   # base — leader cleared both RS and margin gates
+    reasons = [f"{leader_asset}_rs_{leader_rs:+.2f}%", f"margin_vs_runner_up_{margin_vs_runner:+.2f}pp"]
+    if leader_rs >= 4.0:
+        score += 1
+        reasons.append("leader_strong")
+    if margin_vs_runner >= 3.0:
+        score += 1
+        reasons.append("dominant_margin")
+    if held_assets:
+        # Re-entering after a prior position exited — leadership has either
+        # confirmed the holdover OR rotated. Either way it's a fresh decision.
+        reasons.append("post_dsl_re_entry")
+
+    if score < int(config.get("minScore", DEFAULT_MIN_SCORE)):
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — leader cleared margin but missed minScore",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_sailfish_producer_version": VERSION,
+        })
+        return
+
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_pct = float(config.get("marginPct", 0.20))
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(leader_asset, leader_rs, margin_vs_runner, score, reasons,
+                         margin_usd, leverage, held_assets, ranked)
+    if pushed:
+        cfg.record_signal(leader_asset)
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": leader_asset,
+            "direction": "LONG",
+            "leader_rs_pct": round(leader_rs, 2),
+            "margin_vs_runner_up_pp": round(margin_vs_runner, 2) if margin_vs_runner != float('inf') else None,
+            "score": score,
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": reasons[:5],
+        },
+        "ranked": [{"asset": a, "rs": round(s, 2)} for a, s in ranked],
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_sailfish_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"sailfish-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/sailfish/scripts/sailfish_config.py
+++ b/sailfish/scripts/sailfish_config.py
@@ -1,0 +1,199 @@
+"""SAILFISH v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Relative-Strength Rotator (Crypto Majors). Sailfish ranks BTC/ETH/SOL/HYPE by
+4h relative strength each tick and longs the strongest. The runtime is
+single-position and the producer never closes (DSL owns exits), so "rotation"
+here means: enter the current leader when a slot is open. When the existing
+position naturally exits via the DSL trail, Sailfish enters the new leader
+next tick. Distinct from Chameleon (relative-value mean-reversion of pair
+ratios) — Sailfish is momentum rotation: follow the strongest.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+balanced DSL with a 96h hard_timeout so leadership changes can play out via
+natural DSL exit + Sailfish re-entry. Stateless ranking + race-window dedup.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "sailfish-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "sailfish-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Sailfish's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("sailfish_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def mcp_call(tool, **params):
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] sailfish_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[sailfish-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/sailfish/tests/test_signal.py
+++ b/sailfish/tests/test_signal.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Unit tests for Sailfish's pure functions (relative_strength, rank_assets,
+leader_above_runner_up). Stubs sailfish_config + senpi_runtime_helpers.
+Run: python3 sailfish/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("sailfish_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["sailfish_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "sailfish-producer.py"
+_spec = importlib.util.spec_from_file_location("sailfish_producer", _path)
+sf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sf)
+
+
+def test_relative_strength_known_value():
+    closes = [100.0] * 17
+    closes[-1] = 103.0
+    assert abs(sf.relative_strength(closes, 16) - 3.0) < 1e-9
+
+
+def test_relative_strength_insufficient_and_bad_ref():
+    assert sf.relative_strength([100, 101], 16) is None
+    closes = [0.0] * 17
+    assert sf.relative_strength(closes, 16) is None
+
+
+def test_rank_assets_sorts_desc_and_drops_none():
+    strength = {"BTC": 2.0, "ETH": -1.0, "SOL": None, "HYPE": 5.5}
+    ranked = sf.rank_assets(strength)
+    assert ranked == [("HYPE", 5.5), ("BTC", 2.0), ("ETH", -1.0)]
+
+
+def test_leader_above_runner_up_passes_clean_lead():
+    # HYPE +5.5, BTC +2.0 → margin 3.5pp, leader RS 5.5 > 1.0 → pass
+    ranked = [("HYPE", 5.5), ("BTC", 2.0), ("ETH", -1.0)]
+    out = sf.leader_above_runner_up(ranked, min_leader_rs_pct=1.0, margin_pct=1.5)
+    assert out == ("HYPE", 5.5, 3.5)
+
+
+def test_leader_above_runner_up_blocks_whipsaw():
+    # Leader only 0.2pp ahead of runner-up → below 1.5pp margin → reject
+    ranked = [("HYPE", 2.0), ("BTC", 1.8)]
+    assert sf.leader_above_runner_up(ranked, min_leader_rs_pct=1.0, margin_pct=1.5) is None
+
+
+def test_leader_above_runner_up_blocks_weak_leader():
+    # Leader's own RS below min → reject even if margin is wide
+    ranked = [("BTC", 0.5), ("ETH", -3.0)]
+    assert sf.leader_above_runner_up(ranked, min_leader_rs_pct=1.0, margin_pct=1.5) is None
+
+
+def test_leader_above_runner_up_solo_leader_passes_if_strong():
+    # Only one asset has data → margin defaults to inf
+    ranked = [("BTC", 3.0)]
+    out = sf.leader_above_runner_up(ranked, min_leader_rs_pct=1.0, margin_pct=1.5)
+    assert out is not None and out[0] == "BTC" and out[1] == 3.0
+
+
+def test_leader_above_runner_up_empty_returns_none():
+    assert sf.leader_above_runner_up([], 1.0, 1.5) is None
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -319,6 +319,10 @@ if best_candidate:
 | **Salamander** | v1.0 | BTC · ETH · SOL | **Onboarding tier.** Multi-asset whitelist with pullback-detection scoring (3-7% counter-move in established 4h trend). **Asymmetric DSL** — wider Phase 1 (10%), tight Phase 2 (T0 +5% / lock 30%). | Onboarding, Pullback, Asymmetric DSL |
 | **Bobcat** | v1.0 | xyz: big-tech (NVDA · TSLA · AAPL · META · MSFT · GOOGL · AMZN · AMD · MU · INTC · TSM · ORCL) | **Onboarding tier.** Bison-pattern on XYZ big tech equities. 4h trend + SM agreement. 48h hard_timeout for the weekend pricing gap. | Onboarding, XYZ-Big-Tech, hard_timeout 48h |
 | **Raccoon** | v1.0 | All XYZ excl. IPOPs | **Onboarding tier — weekend-gated.** ONLY fires Fri 22:00 UTC → Mon 00:00 UTC, the trade.xyz no-external-price window. Captures the Mon-open reconciliation snap-back when external pricing resumes. Tight DSL, 48h hard_timeout forces Mon-open exit. | Onboarding, XYZ-Weekend, Reconciliation, Time-gated |
+| **Tortoise** | v1.0 | BTC · ETH · SOL | **Onboarding tier — time-trigger variant.** DCA scheduler. Doesn't call `market_get_asset_data` for scoring — its "scanner" is a clock. Each tick checks per-asset DCA history; the most-overdue past the interval (default 24h) wins. LONG only. Persisted DCA-history cache. Maker-preferred entry (DCA isn't urgent). Wide let-winners-run DSL + 30d hard_timeout for compounding. THE most beginner-accessible trade — zero prediction skill required. | Onboarding, DCA, Time-trigger, No-prediction, Wide DSL |
+| **Sheep** | v1.0 | BTC · ETH · SOL · HYPE | **Onboarding tier.** Long-only triple-EMA-stacked trend. Fires LONG only when `ema(fast) > ema(slow)` on ALL THREE timeframes (15m + 1h + 4h). Never shorts. A visual rule beginners can sanity-check on any chart. Balanced DSL + `weak_peak_cut` 6h/3%. | Onboarding, Long-only, Multi-timeframe, EMA-stack, Balanced DSL |
+| **Iguana** | v1.0 | xyz:SP500 · xyz:XYZ100 | **Onboarding tier — XYZ subset.** The simplest XYZ exposure in the fleet — just the broad indices. Picks whichever has the stronger 4-day move past the threshold and trades its direction. No stock-picking, no commodities, no pre-IPO. Closest thing to "an index fund, but 24/7." Balanced DSL + 48h hard_timeout for weekend pricing-gap risk. | Onboarding, XYZ-Macro, Index-only, Balanced DSL, hard_timeout 48h |
+| **Sailfish** | v1.0 | BTC · ETH · SOL · HYPE | Relative-Strength Rotator. Ranks the universe by ~2.7d RS each tick and longs the leader iff (a) leader's own RS ≥ 1% AND (b) it beats the runner-up by ≥ 1.5pp (no whipsaw on tight races). Runtime is single-position; "rotation" happens via DSL exit on the holdover + Sailfish's next-tick re-entry on the new leader. Momentum cousin of Chameleon's mean-reversion. Balanced DSL + 96h hard_timeout. | Momentum-rotation, RS-leader, Margin-gate, Balanced DSL |
 
 ---
 
@@ -789,6 +793,7 @@ Most first-time users can't say "I want a trend-follower" — they don't have th
 
 **A. Express lane — "just pick something simple for me."** The user wants the agent to decide. Recommend the conservative default and go straight to deploy:
 - **Default first strategy → Hedgehog** (equal-weight BTC+ETH+SOL trend, diversified) — or **Beaver** (BTC only) for the simplest single-asset version.
+- Variant — *"I just want to accumulate over time, no thinking"* → **Tortoise** (DCA scheduler). Buys a fixed % on cadence; predicts nothing. The easiest possible answer for users who don't want a strategy thesis at all.
 - Settings: **`balanced` DSL preset, 20% margin, 3x leverage** — the simplest, most-liquid, lowest-leverage starting point.
 - Frame it honestly — **never say "safe."** *"I'll start you on a simple trend-follower on the major coins — it holds them while they're trending and steps out when they stall. It's the lowest-complexity, lowest-leverage place to begin — not risk-free (no strategy is; any single trade can lose), just the least to think about while you learn. We'll tune it the moment you've watched it run."*
 
@@ -823,7 +828,9 @@ Most first-time users can't say "I want a trend-follower" — they don't have th
 
 | What the signals say | Recommend |
 |---|---|
-| Asset **TRENDING** + SM **aligned** (same dir, ≥55%) | Trend-follower on that asset — 🟢 Beaver/Heron/Hummingbird, or **Hedgehog** basket if no single standout |
+| Asset **TRENDING** + SM **aligned** (same dir, ≥55%) | Trend-follower on that asset — 🟢 Beaver/Heron/Hummingbird, 🟢 **Sheep** for long-only triple-EMA-stack, or **Hedgehog** basket if no single standout |
+| **Just want to accumulate** (no thesis, no timing) | 🟢 **Tortoise** (DCA scheduler — fixed % on cadence; predicts nothing) |
+| Interest in **broad equity exposure** (no stock-picking) | 🟢 **Iguana** (xyz:SP500 + xyz:XYZ100 trend) |
 | **RANGEBOUND** + SM **extreme & one-sided** (≥70%) price won't confirm | Fader → **Egret** |
 | **VIOLENT** move + OI unwinding fast (Hyperfeed lit up) | Microstructure → **Piranha** (*only if risk = "go big"*) |
 | Hyperfeed shows a **fresh rank-jump / breakout** | 🟢 **Hawk** (breakout) or **Jaguar** (rank-jump) |
@@ -862,6 +869,8 @@ Ask which one sentence sounds most like the user:
 
 - **One major coin** — pick BTC / ETH / SOL / HYPE.
   - 🟢 Beginner: **Beaver** (BTC) · **Heron** (ETH) · **Hummingbird** (HYPE) — SM-gated 4h trend, wide DSL, simple scoring.
+  - 🟢 Beginner — *long only, multi-timeframe agreement*: **Sheep** (BTC/ETH/SOL/HYPE). Fires LONG only when 15m + 1h + 4h EMAs are all stacked bullishly. Never shorts — for users intimidated by directional choice.
+  - ⬆️ Level up — *rotation across majors*: **Sailfish** (RS leader). Always holds the strongest of BTC/ETH/SOL/HYPE; rotates via DSL exit + re-entry.
   - ⬆️ Level up: **Grizzly** (BTC) · **Polar** (ETH) · **Kodiak** (SOL) · **Wolverine** (HYPE) — Kodiak-family alpha hunters.
 - **A basket of majors** (BTC + ETH + SOL together).
   - 🟢 Beginner: **Hedgehog** (equal-weight basket, up to 3 at once).
@@ -889,6 +898,7 @@ XYZ markets (stocks / commodities / pre-IPO) trade **24/7 on Hyperliquid**, even
 - 🔥 **Pre-IPO names (IPOPs — SpaceX, etc.)** → 🟢 **Lemur** — trades pre-IPO perpetuals *before the company lists*; auto-discovers new IPOPs by their funding signature (today: SPCX/SpaceX; auto-expands as trade.xyz lists names like ANTHROPIC, OPENAI, STRIPE). One of Senpi's most distinctive capabilities.
 - 🔥 **The IPO moment itself (when a pre-IPO name goes public)** → **Falcon** — sits out the pre-listing phase and fires only *around the conversion*, when an IPOP flips to a standard equity perp (funding jumps ~100x, leverage cap lifts, the price throttle comes off → free price discovery). Rides the post-conversion momentum with a wide let-winners-run DSL. Pairs naturally with Lemur (Lemur holds the IPOP; Falcon trades its graduation).
 - **Big-tech stocks (XYZ equities)** → 🟢 **Bobcat** (NVDA/TSLA/AAPL/META/MSFT/GOOGL/…).
+- **Just the broad indices (no stock-picking)** → 🟢 **Iguana** (xyz:SP500 + xyz:XYZ100). The closest thing to an index fund, but 24/7. Beginners who want stock-market exposure without choosing individual names.
 - **Oil / metals / indices (XYZ)** → **Dire** (BRENTOIL) as the template — tune the asset string.
 - **Weekend stock-gap reconciliation** → 🟢 **Raccoon** (weekend-only XYZ snap-back, captures the Mon-open move).
 - **A specific crypto major** → see Layer 2A (Kodiak family).
@@ -933,7 +943,7 @@ Once a strategy is chosen, confirm three things with the user, then deploy:
 2. **DSL preset** — `balanced` (the smart default) for most; `let_winners_run` for conviction trend-holders; `mean_reversion` for faders; `scalp` for high-frequency. See [`dsl-presets.yaml`](dsl-presets.yaml).
 3. **Config + launch** — set wallet / chat / decision-model, then `openclaw senpi runtime create` + the disown-safe daemon launch. Each agent's README has the exact steps.
 
-> **First-strategy rule of thumb:** pick an **onboarding-tier** agent (🟢 above — Beaver/Heron/Hummingbird/Hedgehog/Hawk/Salamander/Albatross/Lemur/Bobcat/Raccoon), keep the **`balanced`** DSL preset, size at 20–25% margin / ≤5x. Graduate to fleet agents once they've watched one run.
+> **First-strategy rule of thumb:** pick an **onboarding-tier** agent (🟢 above — Beaver/Heron/Hummingbird/Hedgehog/Hawk/Salamander/Albatross/Lemur/Bobcat/Raccoon/Tortoise/Sheep/Iguana), keep the **`balanced`** DSL preset (or `let_winners_run` for Tortoise), size at 20–25% margin / ≤5x. Graduate to fleet agents once they've watched one run.
 
 ---
 
@@ -1039,6 +1049,10 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | **Remora** | 5 — Trader-follower (hand-picked whale mirror) | Operator-picked whale set. Mirrors each whale's largest-notional position, scored by consensus (2 whales +2, 3+ +3) + ELITE-tier bonus. Unwraps the nested leaderboard_get_trader_positions shape. Wide let-winners-run DSL, 120h staleness cap |
 | **Cuckoo** | 14 — Meta-strategy follower / copy-the-copiers | Auto-discovers the top-N strategies by performance and trades their performance-weighted consensus (weight = clamp(1 + roi/50, 0.5, cap)); gate ≥2 strategies agree. Wide let-winners-run DSL, 96h staleness cap. User-scope auth |
 | **Meerkat** | 6 — Striker / rank-jump (momentum-event-feed variant) | Reads leaderboard_get_momentum_events directly; snipes the freshest (≤30min), highest-tier (3 ≥10% · 2 ≥5%) momentum events in the move's direction. SM + volume bonuses. Wide let-winners-run DSL + short 36h hard_timeout. Tick 120s. User-scope auth |
+| **Tortoise** | 4 — Multi-asset whitelist (time-trigger variant, onboarding) | DCA scheduler — time-trigger, no `market_get_asset_data` for scoring. Most-overdue past interval wins. LONG only. Wide DSL + 30d hard_timeout. Persisted DCA-history cache |
+| **Sheep** | 4 — Multi-asset whitelist (onboarding) | BTC/ETH/SOL/HYPE long-only triple-EMA-stacked trend. Fires only when 15m + 1h + 4h EMAs are all stacked bullishly. Balanced DSL + weak_peak_cut 6h/3% |
+| **Iguana** | 4 — Multi-asset whitelist (XYZ subset, onboarding) | xyz:SP500 + xyz:XYZ100. Simplest possible XYZ exposure — index-fund equivalent. Balanced DSL + 48h hard_timeout for weekend pricing-gap risk |
+| **Sailfish** | 4 — Multi-asset whitelist (momentum-rotation) | BTC/ETH/SOL/HYPE. Ranks by ~2.7d RS, longs the leader iff leader RS ≥ 1% AND beats runner-up by ≥ 1.5pp (no whipsaw). Rotation via DSL exit + re-entry. Balanced DSL + 96h hard_timeout |
 
 Sentinel runs an in-house producer that is not currently published to this repo; no public URL.
 

--- a/sheep/README.md
+++ b/sheep/README.md
@@ -1,0 +1,125 @@
+# 🐑 Sheep — Long-Only Triple-EMA-Stacked Trend
+
+**Buy crypto only when it's clearly going up across every timeframe.** Sheep fires LONG only when the fast EMA is above the slow EMA on all three timeframes (15m + 1h + 4h). Never shorts.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+Most trend agents pick one timeframe. Sheep insists on three. Fewer trades, but each is "obviously up" to any chart reader. For beginners who want a long-only trend follower without learning what shorts are.
+
+## Key parameters
+
+| Parameter | Default |
+|---|---|
+| Whitelist | BTC · ETH · SOL · HYPE |
+| EMA fast / slow | 9 / 21 |
+| Timeframes | 15m + 1h + 4h |
+| Min stacked frames | 3 (require all) |
+| Direction | LONG only |
+| Tick interval | 300s (5 min) |
+| Leverage | 3x default, max 5x |
+| Margin per slot | 20% of equity |
+| Max entries per day | 3 |
+| Per-asset cooldown | 240 min (4h) |
+| Daily loss limit | 12% |
+| Drawdown halt | 20% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (balanced — trend-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 12% |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | 72h |
+| Time cuts | weak_peak_cut | **6h / 3.0** |
+| Time cuts | dead_weight_cut | disabled |
+| Phase 2 | T0 → T4 | +8/0 · +15/40 · +25/60 · +40/75 · +70/85 |
+
+## Scanner pattern
+
+Archetype #4 (Multi-asset whitelist). Primary MCP calls: `market_get_asset_data(candle_intervals=["15m","1h","4h"])` + `leaderboard_get_markets`. Pure functions unit-tested in `tests/test_signal.py` (`python3 sheep/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/sheep-producer.py | Long-lived daemon; emits SHEEP_TRIPLE_EMA_LONG signals |
+| scripts/sheep_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/sheep-config.json | Operator-tunable defaults (whitelist, EMA periods, thresholds) |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Sheep
+
+```bash
+mkdir -p /data/workspace/skills/sheep-strategy/{config,scripts,state,references}
+for f in scripts/sheep-producer.py scripts/sheep_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/sheep-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/sheep/$f" \
+    -o "/data/workspace/skills/sheep-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/sheep-strategy/config/sheep-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export SHEEP_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export SHEEP_DECISION_MODEL=<your-preferred-model>
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/sheep-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/sheep-strategy/scripts/sheep-producer.py \
+  > /tmp/sheep-producer.log 2>&1 &
+disown
+```
+
+## Verification
+
+```bash
+sleep 320
+tail -3 /tmp/sheep-producer.log | jq '._sheep_producer_version, .note // null, .best.spread_4h_pct // null'
+```
+
+A healthy first tick usually outputs one of:
+- `"note": "WAITING — no whitelisted asset has a full 15m+1h+4h EMA-stacked-bullish setup"` (most common in chop)
+- `"signals_pushed": 1, "best": { "coin": ..., "stack_score": 3, "spread_4h_pct": ... }`
+
+## Changelog
+
+### v1.0.0 (2026-05-28) — initial release
+
+First fleet agent to require multi-timeframe agreement before any trade fires. Long-only by design (no short logic, no LLM-gate short branch). Balanced DSL with `weak_peak_cut` so stalled trends get cut. Taker-true entry, disown-safe launch, unit-tested pure functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/sheep/SKILL.md
+++ b/sheep/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: sheep-strategy
+description: >-
+  SHEEP v1.0.0 — Long-Only Triple-EMA-Stacked Trend. Fires LONG only when the
+  fast EMA is above the slow EMA on ALL THREE timeframes (15m + 1h + 4h) for
+  an asset in BTC/ETH/SOL/HYPE. Never shorts. A triple-timeframe stack is a
+  visual rule a beginner can sanity-check on any chart. Onboarding tier.
+  Balanced DSL.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐑 SHEEP v1.0.0 — Long-Only Triple-EMA-Stacked Trend
+
+**Buy crypto only when it's clearly going up across every timeframe.** Sheep fires LONG only when the fast EMA is above the slow EMA on all three timeframes (15m + 1h + 4h). Never shorts. Removes the *"what's a short?"* cognitive load.
+
+## Why this strategy exists
+
+Most trend agents in the fleet pick a single timeframe (Beaver/Heron/Hummingbird → 4h; Hawk → 7d breakout; Salamander → 4h pullback). Sheep insists on **agreement across three timeframes** before firing — a stricter filter, fewer trades, but each is "obviously up" by any chart reader's standard. For beginners who want a long-only trend follower without learning what shorts are, Sheep is the answer.
+
+## CRITICAL RULES
+
+### RULE 1: Triple stack OR nothing
+For each whitelisted asset, the producer checks `ema(fast) > ema(slow)` on **15m**, **1h**, AND **4h**. By default it requires **all three** (`minStackedFrames: 3`). One timeframe stacked is not enough.
+
+### RULE 2: LONG only
+Sheep never shorts. The LLM gate hard-skips any non-LONG direction (defensive).
+
+### RULE 3: Score boosts from spread magnitude + SM
+Score = 3 (base, full stack) + bonuses for wider 4h spread (`≥1%`), wider 1h spread (`≥0.5%`), and SM aligned LONG (≥55%, +1 strong if ≥70%). Floor `minScore: 4` so a clean spread or SM agreement clears.
+
+### RULE 4: Producer enters. DSL exits.
+No `close_position` call site. DSL is the **balanced** preset — `max_loss 12%`, 72h `hard_timeout`, `weak_peak_cut` enabled at 6h/3% so flat-but-fading trends get cut. Trends extend; Sheep participates in extension while protecting against reversal.
+
+## How Sheep scores a trade
+
+**Gate:** triple stack confirmed (`stack_score >= minStackedFrames`).
+
+**Score components** (max ~8):
+
+| Signal | Points |
+|---|---|
+| Full triple-stack (gate-confirmed) | +3 |
+| 4h fast/slow spread ≥ 1% | +1 |
+| 1h fast/slow spread ≥ 0.5% | +1 |
+| SM LONG ≥ smTiltMinPct (55%) | +1 |
+| SM LONG ≥ smStrongTiltPct (70%) | +1 |
+
+**Floor:** `minScore: 4`.
+
+## DSL preset (balanced — trend-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 12% |
+| Phase 1 | retrace_threshold | 8 |
+| Time cuts | hard_timeout | 72h |
+| Time cuts | weak_peak_cut | **6h / 3.0** |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +8/0 · +15/40 · +25/60 · +40/75 · +70/85 |
+
+## Scanner pattern
+
+Archetype #4 (Multi-asset whitelist) — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data(candle_intervals=["15m","1h","4h"])` per asset, `leaderboard_get_markets` (SM bonus). The pure functions (`ema`, `is_stacked_bullish`, `stack_score`, `fast_slow_spread`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-28) — initial release
+
+First fleet agent to require multi-timeframe agreement before any trade fires. Long-only by design (no short logic, no LLM-gate short branch). Standard balanced DSL with `weak_peak_cut` so stalled trends get cut. Unit-tested pure functions (EMA convergence, stack score, fast/slow spread sign).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/sheep/config/sheep-config.json
+++ b/sheep/config/sheep-config.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "SHEEP v1.0.0 — Long-Only Triple-EMA-Stacked Trend. Each tick iterates the whitelist (default BTC/ETH/SOL/HYPE) and checks whether the emaFast (default 9) > emaSlow (default 21) on ALL THREE timeframes (15m, 1h, 4h). Only fires LONG when minStackedFrames timeframes confirm (default 3 = all). Score boosts from 4h/1h spread magnitude and SM tilt; SM is a bonus, never a gate. ONBOARDING TIER. Balanced DSL. Edit wallet/strategyId/chatId; tune whitelist/EMA periods.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "whitelist": ["BTC", "ETH", "SOL", "HYPE"],
+  "emaFast": 9,
+  "emaSlow": 21,
+  "minStackedFrames": 3,
+  "smTiltMinPct": 55,
+  "smStrongTiltPct": 70,
+  "minScore": 4,
+  "marginPct": 0.20,
+  "leverage": 3
+}

--- a/sheep/references/skill-attribution.md
+++ b/sheep/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "sheep",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "sheep",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/sheep/runtime.yaml
+++ b/sheep/runtime.yaml
@@ -1,0 +1,180 @@
+name: sheep-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Sheep v1.0.0"
+# and lives in description + SKILL.md + _sheep_producer_version.
+version: 1.0.0
+description: >
+  SHEEP v1.0.0 — Long-Only Triple-EMA-Stacked Trend.
+
+  "Buy crypto only when it's clearly going up across every timeframe."
+
+  Sheep fires LONG only when the fast EMA is above the slow EMA on ALL THREE
+  timeframes (15m, 1h, 4h) for an asset in BTC/ETH/SOL/HYPE. Never shorts.
+  A triple-timeframe stack is a visual rule a beginner can sanity-check on
+  any chart.
+
+  Architecture (helpers-native): producer ticks every 300s, checks each
+  whitelisted asset's 15m+1h+4h EMA stack, scores by 4h spread + SM
+  agreement, and emits SHEEP_TRIPLE_EMA_LONG via SenpiClient.push_signal().
+  LLM gate is pass-through.
+
+  DSL: balanced preset. ONBOARDING TIER.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_pct: 20            # % of account budget per slot (scales with any budget)
+  trading_risk: conservative
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: sheep_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        spread4hPct: { type: number, required: false }
+        spread1hPct: { type: number, required: false }
+        stackScore: { type: number, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: sheep_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${SHEEP_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [sheep_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true         # ride the trend NOW — a maker order that rests (CREATE_ORDER_RESTING) misses extension
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: sheep_signals
+    decision_prompt: |
+      You are Sheep's pass-through gate. Sheep fires LONG only when the fast
+      EMA is above the slow EMA on all three timeframes (15m + 1h + 4h). The
+      producer applied every filter (stack >= minStackedFrames, minScore).
+      Honor the signal.
+
+      SIGNAL:
+      {{signal_sheep_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY.
+      2. direction MUST be LONG (Sheep never shorts).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - direction != LONG
+      - score < 4 (producer floor)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - stackScore < 3 (Sheep requires full triple stack)
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 6 AND spread4hPct >= 1.0 AND SM confirms
+      - 7-8:  score 5
+      - 7:    score 4 (producer floor) — the signal IS the validation
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 6 BTC LONG, 15m+1h+4h EMAs stacked, 4h spread +2.1%, SM confirms — clean uptrend')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "LONG",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "SHEEP_TRIPLE_EMA_LONG — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — balanced preset) ─────────────────────────────
+#
+# Trends extend; Sheep wants to participate in extension while protecting
+# against reversal. Balanced ladder + max_loss 12% + weak_peak_cut to bail
+# from flat-but-tired positions.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 4320           # 72h — trends can develop over days
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 0 }
+        - { trigger_pct: 15, lock_hw_pct: 40 }
+        - { trigger_pct: 25, lock_hw_pct: 60 }
+        - { trigger_pct: 40, lock_hw_pct: 75 }
+        - { trigger_pct: 70, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/sheep/scripts/sheep-producer.py
+++ b/sheep/scripts/sheep-producer.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# Senpi SHEEP Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""SHEEP v1.0.0 — Long-Only Triple-EMA-Stacked Trend.
+
+"Buy crypto only when it's clearly going up across every timeframe."
+
+Sheep fires LONG only when the fast EMA is above the slow EMA on ALL THREE
+timeframes (15m, 1h, 4h) for an asset in the configured whitelist. When the
+stack breaks on any timeframe, the entry signal stops. Never shorts —
+removing the "what's a short?" cognitive load is the whole point.
+
+A triple-timeframe EMA stack is a visual rule a beginner can sanity-check on
+any chart: each higher timeframe's fast line should be above its slow line,
+all three simultaneously. ONBOARDING TIER.
+
+Architecture: helpers-native producer + balanced DSL. Stateless scoring +
+race-window dedup. Producer NEVER closes — DSL owns exits.
+
+REQUIRES USER-SCOPE AUTH for leaderboard_get_markets (SM bonus).
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import sheep_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "sheep_signals"
+SIGNAL_TYPE = "SHEEP_TRIPLE_EMA_LONG"
+
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 3
+DEFAULT_MIN_SCORE = 4
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+
+DEFAULT_WHITELIST = ["BTC", "ETH", "SOL", "HYPE"]
+DEFAULT_EMA_FAST = 9
+DEFAULT_EMA_SLOW = 21
+DEFAULT_MIN_STACKED_FRAMES = 3   # require ALL three timeframes
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("SHEEP_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure EMA + stack logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def ema(closes, period):
+    """Exponential moving average. Returns the final EMA value, or None for
+    insufficient data."""
+    if not closes or len(closes) < period:
+        return None
+    k = 2.0 / (period + 1.0)
+    # Seed with the SMA of the first `period` closes — the classic init.
+    seed = sum(closes[:period]) / period
+    ema_val = seed
+    for c in closes[period:]:
+        ema_val = (c - ema_val) * k + ema_val
+    return ema_val
+
+
+def is_stacked_bullish(closes, fast_period, slow_period):
+    """True if fast EMA > slow EMA on this single timeframe. Stacked-bullish
+    on one timeframe alone is not the full Sheep signal — combine across
+    timeframes via stack_score()."""
+    f = ema(closes, fast_period)
+    s = ema(closes, slow_period)
+    if f is None or s is None:
+        return False
+    return f > s
+
+
+def stack_score(stacks_per_timeframe):
+    """Given a list of per-timeframe stack booleans (e.g. [True, True, True]
+    for 15m+1h+4h all stacked-bullish), return how many are stacked. Sheep
+    requires this >= minStackedFrames to fire (default 3 = all)."""
+    return sum(1 for s in stacks_per_timeframe if s)
+
+
+def fast_slow_spread(closes, fast_period, slow_period):
+    """% spread of fast EMA above slow EMA on this timeframe. Negative when
+    fast is below slow. None for insufficient data."""
+    f = ema(closes, fast_period)
+    s = ema(closes, slow_period)
+    if f is None or s is None or s <= 0:
+        return None
+    return ((f - s) / s) * 100.0
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["15m", "1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — one asset
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, config):
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles = data.get("data", {}).get("candles", {})
+    closes_15m = [_f(c, "close", "c") for c in candles.get("15m", [])]
+    closes_1h = [_f(c, "close", "c") for c in candles.get("1h", [])]
+    closes_4h = [_f(c, "close", "c") for c in candles.get("4h", [])]
+
+    fast = int(config.get("emaFast", DEFAULT_EMA_FAST))
+    slow = int(config.get("emaSlow", DEFAULT_EMA_SLOW))
+    min_stacked = int(config.get("minStackedFrames", DEFAULT_MIN_STACKED_FRAMES))
+
+    stacks = [
+        is_stacked_bullish(closes_15m, fast, slow),
+        is_stacked_bullish(closes_1h, fast, slow),
+        is_stacked_bullish(closes_4h, fast, slow),
+    ]
+    score = stack_score(stacks)
+    if score < min_stacked:
+        return None
+
+    # Spread tier — wider 4h spread = stronger trend
+    spread_4h = fast_slow_spread(closes_4h, fast, slow) or 0.0
+    spread_1h = fast_slow_spread(closes_1h, fast, slow) or 0.0
+
+    # SM is a bonus, not a gate
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(config.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(config.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+
+    s = 3   # base for full triple-stack
+    reasons = [f"{asset}_stack_15m_1h_4h", f"spread_4h_{spread_4h:+.2f}%"]
+    if spread_4h >= 1.0:
+        s += 1
+        reasons.append("trend_strong_4h")
+    if spread_1h >= 0.5:
+        s += 1
+        reasons.append("trend_strong_1h")
+    if sm_dir == "LONG" and sm_tilt >= sm_min:
+        s += 1
+        reasons.append(f"sm_long_{sm_tilt:.0f}%")
+        if sm_tilt >= sm_strong:
+            s += 1
+            reasons.append("sm_strong")
+
+    return {
+        "coin": asset,
+        "direction": "LONG",
+        "score": s,
+        "reasons": reasons,
+        "spread_4h_pct": round(spread_4h, 2),
+        "spread_1h_pct": round(spread_1h, 2),
+        "stack_score": score,
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": sm_tilt,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": "LONG",
+        "reasons": thesis["reasons"],
+        "spread4hPct": thesis.get("spread_4h_pct") or 0.0,
+        "spread1hPct": thesis.get("spread_1h_pct") or 0.0,
+        "stackScore": thesis.get("stack_score") or 0,
+        "smDirection": thesis.get("sm_direction") or "NONE",
+        "smTiltPct": thesis.get("sm_tilt_pct") or 0.0,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction="LONG",
+            score=min(thesis["score"] / 8.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — iterate whitelist, find the strongest triple-stack LONG
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    whitelist = config.get("whitelist", DEFAULT_WHITELIST)
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_sheep_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_sheep_producer_version": VERSION})
+        return
+
+    candidates = []
+    for asset in whitelist:
+        a = str(asset).upper()
+        if a in held_set or cfg.was_recently_signaled(a):
+            continue
+        thesis = build_thesis(a, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no whitelisted asset has a full 15m+1h+4h EMA-stacked-bullish setup",
+            "whitelist": whitelist,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_sheep_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: (c["score"], c["spread_4h_pct"]), reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.20))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": "LONG",
+            "stack_score": best["stack_score"],
+            "spread_4h_pct": best["spread_4h_pct"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_sheep_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"sheep-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/sheep/scripts/sheep_config.py
+++ b/sheep/scripts/sheep_config.py
@@ -1,0 +1,196 @@
+"""SHEEP v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Long-Only Triple-EMA-Stacked Trend Follower. Sheep fires LONG only when the
+4h + 1h + 15m EMAs are stacked bullishly on a small crypto-major basket
+(BTC/ETH/SOL/HYPE). Never shorts. A triple-timeframe stack is a visual rule
+beginners can sanity-check on any chart.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+balanced DSL. Stateless scoring plus the fleet-standard race-window dedup,
+atomic write, simplified producer_daemon. Onboarding tier.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "sheep-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "sheep-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Sheep's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("sheep_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def mcp_call(tool, **params):
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] sheep_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[sheep-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/sheep/tests/test_signal.py
+++ b/sheep/tests/test_signal.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Unit tests for Sheep's pure functions (ema, is_stacked_bullish,
+stack_score, fast_slow_spread). Stubs sheep_config + senpi_runtime_helpers.
+Run: python3 sheep/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("sheep_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["sheep_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "sheep-producer.py"
+_spec = importlib.util.spec_from_file_location("sheep_producer", _path)
+sp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sp)
+
+
+def test_ema_constant_series_equals_constant():
+    # EMA of a constant series is the constant
+    closes = [100.0] * 30
+    assert abs(sp.ema(closes, 9) - 100.0) < 1e-9
+    assert abs(sp.ema(closes, 21) - 100.0) < 1e-9
+
+
+def test_ema_rising_series_lags_below_latest():
+    # Linearly rising series: EMA should be < latest close (it's smoothed)
+    closes = list(range(1, 31))  # 1..30
+    e = sp.ema(closes, 9)
+    assert e is not None
+    assert e < 30.0    # below the latest
+    assert e > 20.0    # but tracking up
+
+
+def test_ema_insufficient_data_returns_none():
+    assert sp.ema([1, 2, 3], 9) is None
+    assert sp.ema([], 9) is None
+
+
+def test_is_stacked_bullish_rising_and_falling():
+    rising = list(range(1, 31))
+    falling = list(range(30, 0, -1))
+    assert sp.is_stacked_bullish(rising, 9, 21) is True     # fast EMA above slow on rising series
+    assert sp.is_stacked_bullish(falling, 9, 21) is False   # fast below slow on falling
+
+
+def test_stack_score_counts_trues():
+    assert sp.stack_score([True, True, True]) == 3
+    assert sp.stack_score([True, False, True]) == 2
+    assert sp.stack_score([False, False, False]) == 0
+    assert sp.stack_score([]) == 0
+
+
+def test_fast_slow_spread_sign_and_magnitude():
+    rising = list(range(1, 31))
+    spread = sp.fast_slow_spread(rising, 9, 21)
+    assert spread is not None and spread > 0     # positive spread on rising series
+    falling = list(range(30, 0, -1))
+    neg = sp.fast_slow_spread(falling, 9, 21)
+    assert neg is not None and neg < 0
+
+
+def test_fast_slow_spread_insufficient_returns_none():
+    assert sp.fast_slow_spread([1, 2, 3], 9, 21) is None
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/tortoise/README.md
+++ b/tortoise/README.md
@@ -1,0 +1,127 @@
+# 🐢 Tortoise — DCA Scheduler
+
+**Slow and steady wins the race.** Tortoise buys a fixed % of your budget on a strict time cadence (every 24 hours by default) on a small basket (BTC/ETH/SOL by default). No prediction, no timing, no second-guessing — the most-overdue asset wins each tick.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+DCA (dollar-cost averaging) is the most accessible trade in crypto. Every other Senpi agent makes a prediction. Tortoise predicts nothing — it just buys on cadence. For users intimidated by *"which signal, which timeframe, which side,"* Tortoise is the answer.
+
+## Key parameters
+
+| Parameter | Default |
+|---|---|
+| Assets | BTC · ETH · SOL (configurable) |
+| Cadence | every 24 hours per asset |
+| Direction | LONG only |
+| Tick interval | 1800s (30 min) — slow by design |
+| Margin per buy | 8% of equity |
+| Leverage | 2x default, max 3x |
+| Slots | 3 (one per asset) |
+| Per-asset cooldown | 60 min (race-window safety) |
+| Daily loss limit | 10% |
+| Drawdown halt | 18% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (maker-preferred — DCA isn't urgent) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (maker-preferred) |
+
+## DSL preset (let-winners-run — accumulation-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 15% |
+| Phase 1 | retrace_threshold | 10 |
+| Time cuts | hard_timeout | **30 days** |
+| Time cuts | weak_peak_cut | disabled |
+| Time cuts | dead_weight_cut | disabled |
+| Phase 2 | T0 → T4 | +10/0 · +25/50 · +50/70 · +100/85 · +200/92 |
+
+## Scanner pattern
+
+A **time-trigger variant** of archetype #4 (Multi-asset whitelist) — see `senpi-trading-runtime/references/producer-patterns.md`. Unlike Bison/Hawk/Salamander, Tortoise doesn't call `market_get_asset_data` for scoring — its "scanner" is a clock. State: persisted DCA-history cache. Pure functions unit-tested in `tests/test_signal.py` (`python3 tortoise/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, DSL preset, `risk.guard_rails`) |
+| scripts/tortoise-producer.py | Long-lived daemon; emits TORTOISE_DCA signals |
+| scripts/tortoise_config.py | SDK probe + SenpiClient wrapper + DCA-history cache |
+| config/tortoise-config.json | Operator-tunable defaults (assets, intervalHours, marginPct) |
+| tests/test_signal.py | Unit tests for the pure signal functions |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Tortoise
+
+```bash
+mkdir -p /data/workspace/skills/tortoise-strategy/{config,scripts,state,references}
+for f in scripts/tortoise-producer.py scripts/tortoise_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/tortoise-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/tortoise/$f" \
+    -o "/data/workspace/skills/tortoise-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/tortoise-strategy/config/tortoise-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+Optional: change `assets`, `intervalHours`, `marginPct` to suit your plan.
+
+### Step 4 — Required env vars
+
+```bash
+export TORTOISE_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export TORTOISE_DECISION_MODEL=<your-preferred-model>
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/tortoise-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/tortoise-strategy/scripts/tortoise-producer.py \
+  > /tmp/tortoise-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 1820  # wait one full tick
+tail -3 /tmp/tortoise-producer.log | jq '._tortoise_producer_version, .note // null, .best.coin // null'
+```
+
+A healthy first tick on a brand-new setup fires immediately (never-DCA'd assets are always due) — you should see `"signals_pushed": 1` and `best.coin = "BTC"` (or whatever's first in your `assets` list).
+
+Subsequent ticks within the same interval window output `"WAITING — no asset past its DCA interval"` with `next_due_in_min`. This is correct — cadence is the whole signal.
+
+## Changelog
+
+### v1.0.0 (2026-05-28) — initial release
+
+First fleet agent that makes **no price prediction**. Time-trigger DCA on a small whitelist, persisted history cache for cadence tracking, always-LONG, let-winners-run DSL with a 30-day hard_timeout so accumulation compounds. Maker-preferred entry (DCA isn't urgent → save fees). Disown-safe launch, unit-tested pure functions.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/tortoise/SKILL.md
+++ b/tortoise/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: tortoise-strategy
+description: >-
+  TORTOISE v1.0.0 — DCA Scheduler. Slow and steady wins the race. Buys a fixed
+  % of budget on a strict time cadence (every intervalHours) on a small basket
+  — BTC alone, or BTC/ETH/SOL. No price prediction, no scoring, no timing —
+  the oldest-overdue asset wins each tick. THE most beginner-accessible trade
+  in crypto. Onboarding tier. Let-winners-run DSL, 30d hard_timeout so
+  accumulation compounds.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐢 TORTOISE v1.0.0 — DCA Scheduler
+
+**Slow and steady wins the race.** Tortoise buys a fixed % of your budget on a strict time cadence — every 24 hours by default, on BTC/ETH/SOL by default. No prediction, no timing, no second-guessing. The most-overdue asset wins each tick. Everything else is silent.
+
+## Why this strategy exists
+
+DCA (dollar-cost averaging) is the single most accessible trade in crypto and it had no fleet representative. Every other Senpi agent makes a prediction (trend, breakout, contrarian, funding, basis, lag). Tortoise predicts nothing — it just buys on cadence. For users intimidated by "which signal, which timeframe, which side," Tortoise is the answer: *"I just want to accumulate over time without thinking about it."*
+
+## CRITICAL RULES
+
+### RULE 1: Cadence is the only signal
+Each asset has a per-asset "last DCA timestamp" persisted in state. When `elapsed_seconds_since_last_dca >= intervalHours × 3600`, that asset is due. A never-DCA'd asset is **always due** (so a fresh setup starts buying immediately, then the cadence takes over).
+
+### RULE 2: Most-overdue wins
+If multiple assets are due in the same tick, the one whose elapsed time exceeds the interval by the most wins. Never-DCA'd assets out-rank any DCA'd asset.
+
+### RULE 3: Always LONG
+DCA = accumulate. Tortoise never shorts. The LLM gate hard-skips any non-LONG direction (defensive — the producer only emits LONG, but the gate enforces it).
+
+### RULE 4: Producer enters. DSL exits.
+No `close_position` call site. DCA is meant to compound, so the DSL is the **let-winners-run** preset with a **30-day** `hard_timeout` — accumulated longs are only released when:
+- They retrace from a peak (Phase 1 trailing),
+- They breach `max_loss_pct: 15%` (Phase 1 floor),
+- They hit a Phase 2 lock tier and roll back to it,
+- Or they hit 30 days old (the staleness cap).
+
+No `weak_peak_cut` — flat-but-not-failing accumulation should not be churned.
+
+## How Tortoise sizes a buy
+
+Every fire is the same: `margin_pct × account_value` (default 8% per buy) at the configured leverage (default 2x). No conviction tiers. The "scoring" is a fixed score=5/leverage=2x/margin=8% — confidence comes from cadence repetition, not signal magnitude.
+
+A representative DCA program at defaults (BTC+ETH+SOL, 24h cadence, 8% margin, 2x):
+- 3 buys per day total (one per asset)
+- ~21 buys per week
+- After 1 week: ~170% of account in *margin* (assuming none have exited). The 2x leverage gives ~340% notional exposure.
+- The DSL Phase-2 ladder locks gains as positions appreciate, so old accumulation gets banked while new buys keep adding.
+
+## DSL preset (let-winners-run — accumulation-tuned)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | 15% |
+| Phase 1 | retrace_threshold | 10 |
+| Time cuts | hard_timeout | **30d (compound, don't churn)** |
+| Time cuts | weak_peak_cut | DISABLED |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +10/0 · +25/50 · +50/70 · +100/85 · +200/92 |
+
+## Scanner pattern
+
+A **time-trigger variant** of archetype #4 (Multi-asset whitelist) — see `senpi-trading-runtime/references/producer-patterns.md`. Unlike Bison/Hedgehog/Hawk/Salamander which score price action per tick, Tortoise's "scanner" is purely a clock — `market_get_asset_data` isn't even called. Primary state: a persisted DCA-history cache (`read_dca_history` / `record_dca`). The pure functions (`seconds_since`, `is_dca_due`, `pick_next_dca_asset`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-28) — initial release
+
+First fleet agent that makes **no price prediction**. Time-trigger DCA on a small whitelist, persisted history cache for cadence tracking, always-LONG, let-winners-run DSL with a 30-day hard_timeout so accumulation compounds. Unit-tested pure functions (oldest-overdue selection + never-DCA'd-wins guarantee).
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/tortoise/config/tortoise-config.json
+++ b/tortoise/config/tortoise-config.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "TORTOISE v1.0.0 — DCA Scheduler. Each tick checks how long since each whitelisted asset's last DCA buy (history persisted across restarts). The most-overdue asset past the interval is fired LONG at marginPct of equity. Never-DCA'd assets always win over any DCA'd asset (so a fresh setup starts buying immediately, then the cadence takes over). Onboarding tier — zero prediction skill required. Wide let-winners-run DSL with a 30d hard_timeout so accumulation compounds. Edit wallet/strategyId/chatId; tune assets/intervalHours/marginPct. Default: BTC+ETH+SOL every 24h at 8% margin per buy.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "assets": ["BTC", "ETH", "SOL"],
+  "intervalHours": 24,
+  "marginPct": 0.08,
+  "leverage": 2
+}

--- a/tortoise/references/skill-attribution.md
+++ b/tortoise/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "tortoise",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "tortoise",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/tortoise/runtime.yaml
+++ b/tortoise/runtime.yaml
@@ -1,0 +1,173 @@
+name: tortoise-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Tortoise v1.0.0"
+# and lives in description + SKILL.md + _tortoise_producer_version.
+version: 1.0.0
+description: >
+  TORTOISE v1.0.0 — DCA Scheduler.
+
+  "Slow and steady wins the race." Tortoise buys a fixed % of budget on a
+  strict time cadence (every intervalHours) on a small basket — BTC alone or
+  BTC/ETH/SOL. No price prediction, no scoring, no timing. The oldest-overdue
+  asset wins each tick; everything else is silent.
+
+  The most beginner-accessible trade in crypto: zero prediction skill required.
+
+  Architecture (helpers-native): producer ticks every 1800s (30min), checks each
+  asset's DCA cadence against a persisted history cache, and emits a
+  TORTOISE_DCA LONG signal for the most-overdue asset. LLM gate is pass-through.
+
+  DSL: let-winners-run preset — wide ladder, very long hard_timeout (30d) so
+  accumulation can compound. Default leverage 2x. ONBOARDING TIER.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 3                  # Tortoise accumulates over time across 3 assets
+  margin_pct: 8             # % of account budget per DCA buy — repeated, so total commit grows over time (scales with any budget)
+  trading_risk: conservative
+  enabled: true
+
+risk:
+  data_retention_hours: 720    # 30 days — DCA's whole point is long-horizon
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 6     # 3 assets × ~2 DCA cycles allowed/day at default cadence
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 5
+    cooldown_minutes: 30
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 60
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: tortoise_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        intervalSec: { type: number, required: false }
+        elapsedSec: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: tortoise_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${TORTOISE_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [tortoise_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # DCA isn't urgent — let it rest as maker to save fees
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: tortoise_signals
+    decision_prompt: |
+      You are Tortoise's pass-through gate. Tortoise is a DCA (dollar-cost
+      averaging) scheduler. The producer confirmed the asset's DCA interval has
+      elapsed since the last buy. There is NO price-based scoring — cadence
+      alone is the signal. Honor it.
+
+      SIGNAL:
+      {{signal_tortoise_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY.
+      2. direction MUST be LONG (Tortoise only accumulates).
+      3. leverage MUST be copied from signal.data.leverage (1-3x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - direction != LONG
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets (duplicate)
+
+      ## CONFIDENCE SCORING
+
+      Every DCA signal is the same — the cadence IS the validation.
+      - Always confidence 7. There is no high-conviction tier; there is no low-conviction tier.
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": 7,
+        "reasoning": "concrete sentence citing signal values (e.g. 'BTC DCA — elapsed 26h since last buy at 24h cadence')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "LONG",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "TORTOISE_DCA LONG — cadence due"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — let-winners-run preset, accumulation-tuned) ──
+#
+# DCA accumulates over time. Wide ladder + VERY long hard_timeout (30d). Lock
+# tiers bank gains gradually so a deep drawdown doesn't wipe accumulated
+# entries, but we never cut a winner just because it's old. No weak_peak_cut.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: false
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 43200          # 30d — DCA is meant to compound
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 25, lock_hw_pct: 50 }
+        - { trigger_pct: 50, lock_hw_pct: 70 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+        - { trigger_pct: 200, lock_hw_pct: 92 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/tortoise/scripts/tortoise-producer.py
+++ b/tortoise/scripts/tortoise-producer.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# Senpi TORTOISE Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""TORTOISE v1.0.0 — DCA Scheduler.
+
+"Slow and steady wins the race."
+
+Tortoise buys a fixed % of budget on a strict time cadence (every
+intervalHours) on a small basket — BTC alone, or BTC/ETH/SOL. No price
+prediction, no scoring, no timing. Each tick:
+
+  1. For each whitelisted asset, check how long since the last DCA buy.
+  2. The asset that is MOST overdue (longest since last DCA, past the interval)
+     is the candidate.
+  3. If something is due → emit a LONG signal sized at marginPct of equity.
+  4. Otherwise → silent. The DSL trail handles profit-taking on existing
+     accumulation; Tortoise only handles entry.
+
+Default direction: LONG. THE most accessible trade in crypto — zero prediction
+skill required. Onboarding tier. Producer NEVER closes — the DSL owns exits.
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import tortoise_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "tortoise_signals"
+SIGNAL_TYPE = "TORTOISE_DCA"
+
+MAX_LEVERAGE = 3              # DCA is accumulation, not leverage
+DEFAULT_LEVERAGE = 2
+DEFAULT_DIRECTION = "LONG"    # DCA = accumulate longs
+
+DEFAULT_ASSETS = ["BTC", "ETH", "SOL"]
+DEFAULT_INTERVAL_HOURS = 24.0   # one DCA per asset per day
+DEFAULT_MARGIN_PCT = 0.08       # 8% per buy → at 3 assets × 1/day, accumulates ~170%/week in MARGIN (account scales)
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("TORTOISE_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure DCA-scheduler logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def seconds_since(last_dca_ts, now_ts):
+    """Seconds elapsed since the last DCA event. None for unknown
+    (never-DCA'd) assets — they should be treated as MAXIMALLY overdue."""
+    if last_dca_ts is None:
+        return None
+    try:
+        return max(0.0, float(now_ts) - float(last_dca_ts))
+    except (TypeError, ValueError):
+        return None
+
+
+def is_dca_due(elapsed_sec, interval_sec):
+    """True if the DCA interval has elapsed OR this asset has never been
+    DCA'd (elapsed_sec=None). Never-DCA'd assets are always due."""
+    if elapsed_sec is None:
+        return True
+    return elapsed_sec >= interval_sec
+
+
+def pick_next_dca_asset(assets, last_dca_by_asset, interval_sec, now_ts):
+    """Among `assets`, pick the one that is most overdue (longest time since
+    last DCA, past the interval). Never-DCA'd assets win over any DCA'd asset.
+    Returns the asset symbol or None if nothing is due."""
+    best_asset, best_elapsed = None, -1.0
+    for asset in assets:
+        key = str(asset).upper()
+        last = last_dca_by_asset.get(key)
+        elapsed = seconds_since(last, now_ts)
+        if not is_dca_due(elapsed, interval_sec):
+            continue
+        # Never-DCA'd asset (elapsed is None) → treat as infinitely overdue
+        # so it wins over any DCA'd asset. Use a sentinel sortable above any
+        # real elapsed value.
+        rank = float('inf') if elapsed is None else elapsed
+        if rank > best_elapsed:
+            best_elapsed = rank
+            best_asset = key
+    return best_asset
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(asset, margin_usd, leverage, held_assets, elapsed_sec, interval_sec):
+    if not STRATEGY_ADDRESS:
+        return False
+    if asset.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": 5,        # producer-fixed (DCA has no scoring — every fire is "valid by cadence")
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": DEFAULT_DIRECTION,
+        "reasons": [
+            "dca_cadence",
+            f"elapsed_{int(elapsed_sec or 0)}s",
+            f"interval_{int(interval_sec)}s",
+        ],
+        "intervalSec": float(interval_sec),
+        "elapsedSec": float(elapsed_sec or 0.0),
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=asset,
+            direction=DEFAULT_DIRECTION,
+            score=0.7,        # static — DCA conviction comes from cadence, not scoring
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {asset}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {asset}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — check cadence, pick the most-overdue, fire
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    assets = config.get("assets", DEFAULT_ASSETS)
+    interval_hours = float(config.get("intervalHours", DEFAULT_INTERVAL_HOURS))
+    interval_sec = interval_hours * 3600.0
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_tortoise_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_tortoise_producer_version": VERSION})
+        return
+
+    now = time.time()
+    history = cfg.read_dca_history()
+    # Filter: an asset already held is not a candidate (no duplicate stacking).
+    eligible = [a for a in assets if str(a).upper() not in held_set and not cfg.was_recently_signaled(a)]
+
+    chosen = pick_next_dca_asset(eligible, history, interval_sec, now)
+    if chosen is None:
+        next_due_in = next_due_seconds(eligible, history, interval_sec, now)
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no asset past its DCA interval (or all in cooldown/held)",
+            "next_due_in_min": round(next_due_in / 60.0, 1) if next_due_in is not None else None,
+            "assets": assets,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_tortoise_producer_version": VERSION,
+        })
+        return
+
+    elapsed = seconds_since(history.get(chosen), now)
+    margin_pct = float(config.get("marginPct", DEFAULT_MARGIN_PCT))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(chosen, margin_usd, leverage, held_assets, elapsed, interval_sec)
+    if pushed:
+        cfg.record_signal(chosen)
+        cfg.record_dca(chosen, now)
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": chosen,
+            "direction": DEFAULT_DIRECTION,
+            "elapsed_hours": round((elapsed or 0) / 3600.0, 2),
+            "interval_hours": interval_hours,
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+        },
+        "assets": assets,
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_tortoise_producer_version": VERSION,
+    })
+
+
+def next_due_seconds(assets, history, interval_sec, now):
+    """Seconds until the next eligible asset comes due (for the WAITING
+    diagnostic). None if every asset is already past-due (then we should
+    have fired)."""
+    soonest = None
+    for asset in assets:
+        last = history.get(str(asset).upper())
+        if last is None:
+            return 0
+        wait = (interval_sec - (now - last))
+        if wait <= 0:
+            return 0
+        if soonest is None or wait < soonest:
+            soonest = wait
+    return soonest
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=1800,   # 30min — DCA is slow by design; cadence is the signal
+        name=f"tortoise-producer-{_wallet_lock_id}",
+        tick_timeout=120,
+    )

--- a/tortoise/scripts/tortoise_config.py
+++ b/tortoise/scripts/tortoise_config.py
@@ -1,0 +1,245 @@
+"""TORTOISE v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+DCA Scheduler. "Slow and steady wins the race." Tortoise buys a fixed % of
+budget on a strict time cadence (every intervalHours) on a small basket — BTC
+alone or BTC/ETH/SOL. No price prediction, no scoring, no timing — just
+time-triggered accumulation. The oldest-overdue asset wins each tick.
+
+THE most beginner-accessible trade in crypto: zero prediction skill required.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+let-winners-run DSL (very long hard_timeout — DCA is meant to accumulate, not
+chase). Carries a DCA-history cache (read_dca_history / record_dca) plus the
+fleet-standard race-window dedup, atomic write, simplified producer_daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "tortoise-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "tortoise-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+DCA_HISTORY_PATH = STATE_DIR / "dca-history.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Tortoise ticks every 1800s (30min) — slow by design;
+# ALO fills typically settle within 30-60s. 240s covers the full fill window
+# plus the next-tick clearinghouseState refresh.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Tortoise's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("tortoise_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Call a Senpi MCP tool via the helpers wrapper. Returns the JSON
+    document on success, or None if the wrapper raised (transient failures
+    recover on the next tick)."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] tortoise_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts])."""
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── Atomic write + recent-signals race-window dedup ─────────
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+# ─── DCA history cache (per-asset last-DCA timestamps) ───────
+#
+# Tortoise's whole job is "wait for the interval to elapse, then buy." That
+# decision needs durable state — when did we last DCA each asset? Persisted
+# {ASSET: epoch_seconds}.
+
+def read_dca_history():
+    if not DCA_HISTORY_PATH.exists():
+        return {}
+    try:
+        with open(DCA_HISTORY_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k.upper(): float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def record_dca(asset, ts=None):
+    if not asset:
+        return
+    ts = ts if ts is not None else time.time()
+    history = read_dca_history()
+    history[asset.upper()] = float(ts)
+    try:
+        atomic_write(DCA_HISTORY_PATH, history)
+    except OSError:
+        pass
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[tortoise-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/tortoise/tests/test_signal.py
+++ b/tortoise/tests/test_signal.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unit tests for Tortoise's pure functions (seconds_since, is_dca_due,
+pick_next_dca_asset). Stubs tortoise_config + senpi_runtime_helpers.
+Run: python3 tortoise/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("tortoise_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.read_dca_history = lambda: {}
+_cfg.record_dca = lambda a, t=None: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["tortoise_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "tortoise-producer.py"
+_spec = importlib.util.spec_from_file_location("tortoise_producer", _path)
+tp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tp)
+
+NOW = 1_700_000_000.0
+HOUR = 3600.0
+DAY = 86400.0
+
+
+def test_seconds_since_known_and_unknown():
+    assert tp.seconds_since(NOW - 600, NOW) == 600
+    assert tp.seconds_since(None, NOW) is None
+    assert tp.seconds_since("oops", NOW) is None
+    # Defensive: future timestamp clamps to 0 (clock skew safety)
+    assert tp.seconds_since(NOW + 100, NOW) == 0.0
+
+
+def test_is_dca_due_threshold_and_unknown():
+    interval = DAY
+    assert tp.is_dca_due(DAY + 1, interval) is True
+    assert tp.is_dca_due(DAY, interval) is True       # >=, not >
+    assert tp.is_dca_due(DAY - 1, interval) is False
+    assert tp.is_dca_due(None, interval) is True      # never-DCA'd is always due
+
+
+def test_pick_next_dca_oldest_overdue_wins():
+    # BTC last 25h ago, ETH last 30h ago, SOL last 12h ago (not due), interval 24h
+    history = {"BTC": NOW - 25 * HOUR, "ETH": NOW - 30 * HOUR, "SOL": NOW - 12 * HOUR}
+    chosen = tp.pick_next_dca_asset(["BTC", "ETH", "SOL"], history, DAY, NOW)
+    assert chosen == "ETH"   # most overdue past the interval
+
+
+def test_pick_next_dca_never_dcad_beats_recent_overdue():
+    # HYPE has never been DCA'd → should beat BTC that's only 25h overdue
+    history = {"BTC": NOW - 25 * HOUR}
+    chosen = tp.pick_next_dca_asset(["BTC", "HYPE"], history, DAY, NOW)
+    assert chosen == "HYPE"
+
+
+def test_pick_next_dca_none_when_all_in_window():
+    # Everyone DCA'd recently → nothing due
+    history = {"BTC": NOW - 10 * HOUR, "ETH": NOW - 5 * HOUR}
+    assert tp.pick_next_dca_asset(["BTC", "ETH"], history, DAY, NOW) is None
+
+
+def test_pick_next_dca_empty_assets():
+    assert tp.pick_next_dca_asset([], {}, DAY, NOW) is None
+
+
+def test_pick_next_dca_case_normalized():
+    # Asset symbols in config can be lowercase; history is upper-cased
+    history = {"BTC": NOW - 25 * HOUR}
+    chosen = tp.pick_next_dca_asset(["btc"], history, DAY, NOW)
+    assert chosen == "BTC"
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)


### PR DESCRIPTION
## Summary
Wave 1 of the 10-strategy gap-filler set proposed against the 14-archetype coverage map. All four fit archetype #4 (Multi-asset whitelist) but each fills a documented gap the existing fleet didn't cover:

- **🐢 Tortoise — DCA Scheduler.** Time-trigger variant: no `market_get_asset_data` scoring, just a clock + a persisted DCA-history cache. Most-overdue past 24h wins. LONG only. Wide DSL + 30d hard_timeout. **The first fleet agent that makes no price prediction.** Onboarding tier.
- **🐑 Sheep — Long-Only Triple-EMA-Stacked Trend.** BTC/ETH/SOL/HYPE; fires LONG only when 15m + 1h + 4h EMAs are all stacked bullishly. **First fleet agent to require multi-timeframe agreement.** Onboarding tier.
- **🦎 Iguana — XYZ Macro Index Trend.** `xyz:SP500` + `xyz:XYZ100`, no stock-picking. The simplest XYZ exposure in the fleet. Balanced DSL + 48h hard_timeout for weekend gap. Onboarding tier.
- **🐠 Sailfish — Relative-Strength Rotator.** Ranks BTC/ETH/SOL/HYPE by ~2.7d RS; longs the leader iff (a) leader RS ≥1% AND (b) leader beats runner-up by ≥1.5pp (no whipsaw). **First fleet agent for momentum rotation across the majors.** Momentum cousin of Chameleon.

All four ship with fleet discipline: helpers-native producer, `margin_pct` sizing, taker-true entry (Tortoise maker-preferred — DCA isn't urgent), no null numeric signal fields, disown-safe launch.

## Test plan
- [x] `python3 -m py_compile` on all 8 producer/config files — OK
- [x] Pure-function unit tests — **28/28 pass** (Tortoise 7, Sheep 7, Iguana 6, Sailfish 8)
- [x] runtime.yaml parses + config.json parses for all 4
- [x] field-parity: data_block top-level keys ⊆ scanner `fields` (AST-verified for Sailfish where regex false-positives on nested keys)
- [x] Integrated into producer-patterns.md (archetype #4 family rows, Layer 0 express-lane, Layer 2A trend, Layer 2D XYZ, contextual-routing table, fleet roster mapping), root README (40 skills total; archetype #4 table + onboarding tier with new "Accumulation" subsection), and catalog.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)