### PR TITLE
Add Stag + parabolic_runner DSL preset — ride HYPE-class runs without chop-outs

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Each tool's full schema (params, types, response shape) is in the MCP server its
 
 # Trading Strategy Skills
 
-The fleet — **40 skills across 14 producer archetypes**. Every skill targets runtime **1.1.0**. Bucketing matches [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md), the canonical archetype catalog.
+The fleet — **41 skills across 14 producer archetypes**. Every skill targets runtime **1.1.0**. Bucketing matches [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md), the canonical archetype catalog.
 
 Each row links to the skill's directory.
 
@@ -434,6 +434,7 @@ Strict whitelist of 3–6 majors, best-of-N selection per tick.
 | [sheep](sheep/) | v1.0 | BTC · ETH · SOL · HYPE | **Onboarding — long-only triple-stack.** Fires LONG only when 15m + 1h + 4h EMAs are all stacked bullishly. Never shorts. Balanced DSL + `weak_peak_cut` 6h/3%. |
 | [iguana](iguana/) | v1.0 | xyz:SP500 · xyz:XYZ100 | **Onboarding — XYZ index basket.** The simplest XYZ exposure — just the broad indices. Picks whichever has the stronger 4-day move past 1.5% and trades its direction. Balanced DSL + 48h hard_timeout. |
 | [sailfish](sailfish/) | v1.0 | BTC · ETH · SOL · HYPE | **Relative-strength rotator.** Ranks the universe by ~2.7d RS each tick; longs the leader iff leader RS ≥ 1% AND beats runner-up by ≥ 1.5pp (no whipsaw). Rotation via DSL exit + re-entry. Balanced DSL + 96h hard_timeout. |
+| [stag](stag/) | v1.0 | BTC · ETH · SOL · HYPE (often single-asset) | **Parabolic-run hunter.** Entry-side pair for the new `parabolic_runner` DSL preset (widest in the catalog: max_loss 25%, retrace 18, 2 breaches required, 14d outer bound). Strict 5-gate filter (200-SMA + 7d ≥25% + vol surge + acceleration + SM ≥60% LONG). LONG only. Operator-driven — most ticks return empty by design. Reference: HYPE 2026-05 (+60% in 16 days). |
 
 ## 5. Trader-follower / hot-streak
 

--- a/catalog.json
+++ b/catalog.json
@@ -121,6 +121,21 @@
       "version": "1.0.0"
     },
     {
+      "id": "stag",
+      "tracker_slug": "stag",
+      "name": "Stag \u2014 Parabolic-Run Hunter",
+      "emoji": "\ud83e\udd8c",
+      "tagline": "Ride HYPE-class +60% runs without getting chopped on the gyrations. Strict 5-gate entry filter pairs with the widest DSL preset in the catalog. Operator-driven \u2014 most ticks are empty by design.",
+      "group": "multi-asset-whitelist",
+      "sort_order": 45,
+      "min_budget": 500,
+      "risk_level": "aggressive",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/stag",
+      "version": "1.0.0"
+    },
+    {
       "id": "bald-eagle",
       "tracker_slug": "bald-eagle",
       "name": "Bald Eagle \u2014 XYZ Contrarian Fader",

--- a/senpi-trading-runtime/references/dsl-configuration.md
+++ b/senpi-trading-runtime/references/dsl-configuration.md
@@ -16,6 +16,7 @@ The DSL (Dynamic Stop-Loss) manages exit logic for open perpetual positions. It 
 | **`balanced`** ⭐ *default* | General-purpose / unsure | Breathes early, locks gradually, runner tier to +100%, 72h outer bound. |
 | **`mean_reversion`** | Faders / contrarian / range unwinds | Tight. Banks the bounded snapback fast (lock 30% at +5%), time-cuts ON — a fade resolves quickly or the thesis failed. |
 | **`scalp`** | High-frequency, fee-sensitive, fast in/out | Tightest. Fast profit locks, tight max-loss, short `hard_timeout` + `dead_weight_cut`. |
+| **`parabolic_runner`** | Single regime-selective parabolic-runner setups | Widest. Late first lock (+15%), light early ratchet, retrace 18, max_loss 25, 2 consecutive breaches required, 14d outer bound. **Bleeds in chop.** Built for HYPE-class +60% runs. |
 
 Full copy-paste blocks are in [DSL Presets](#dsl-presets) below and machine-readable in [`dsl-presets.yaml`](dsl-presets.yaml). Or skip presets entirely and hand-author every field — the schema is the same.
 
@@ -128,6 +129,33 @@ dsl_preset:
       - { trigger_pct: 10, lock_hw_pct: 70 }
       - { trigger_pct: 15, lock_hw_pct: 85 }
 ```
+
+### `parabolic_runner` — single regime-selective parabolic-runner setups
+
+Built for asymmetric parabolic moves (the HYPE 2026-05 +60% run is the reference) where standard DSL trails would chop out on 5–8% intraday gyrations. **Bleeds in chop — only deploy after you've identified the parabolic setup.** The [Stag agent](https://github.com/Senpi-ai/senpi-skills/tree/main/stag) is the canonical entry-side pair for this preset (strict 5-gate filter: 7d trend ≥ 25%, volume surge ≥ 1.5×, acceleration, structural trend, SM aligned).
+
+```yaml
+dsl_preset:
+  hard_timeout:
+    enabled: true
+    interval_in_minutes: 20160                # 14d — parabolic runs can extend 2-3 weeks
+  # weak_peak_cut + dead_weight_cut deliberately OFF — consolidations are NORMAL here
+  phase1:
+    enabled: true
+    max_loss_pct: 25.0                        # accept deeper initial drawdown to stay on the bus
+    retrace_threshold: 18                     # accommodate 5-8% intraday gyrations
+    consecutive_breaches_required: 2          # one bad bar doesn't trip
+  phase2:
+    enabled: true
+    tiers:
+      - { trigger_pct: 15,  lock_hw_pct: 0  }   # don't lock anything until +15% — let it build
+      - { trigger_pct: 30,  lock_hw_pct: 30 }   # light early lock
+      - { trigger_pct: 60,  lock_hw_pct: 55 }
+      - { trigger_pct: 120, lock_hw_pct: 72 }
+      - { trigger_pct: 250, lock_hw_pct: 85 }   # apex — only late lock takes most off the table
+```
+
+**Why not just widen `let_winners_run`?** `let_winners_run` is the right default for normal trend-followers (Beaver/Heron/Hummingbird/Vulture style). Pushing its retrace to 18 and adding `consecutive_breaches_required: 2` would make it bleed unnecessarily on normal 20–30% trend moves. `parabolic_runner` accepts that bleed *only when* you're targeting a 60%+ move that justifies the wider stop. The trade-off only pays in parabolic regimes — that's why Stag exists to gate it.
 
 ---
 

--- a/senpi-trading-runtime/references/dsl-presets.yaml
+++ b/senpi-trading-runtime/references/dsl-presets.yaml
@@ -117,3 +117,33 @@ presets:
           - { trigger_pct: 5,  lock_hw_pct: 50 }
           - { trigger_pct: 10, lock_hw_pct: 70 }
           - { trigger_pct: 15, lock_hw_pct: 85 }
+
+  parabolic_runner:
+    use_for: Single regime-selective parabolic-runner setups (Stag-class agents)
+    character: >-
+      Widest in the catalog. Built for asymmetric parabolic moves (the HYPE
+      2026-05 +60% run is the reference) where standard DSL trails would chop
+      out on 5-8% intraday gyrations. Late first lock (+15%, no early tier),
+      lighter early ratchet, wide retrace_threshold (18), requires 2
+      consecutive breaches so a single volatile bar doesn't trip Phase 1, and
+      a 14d hard_timeout outer bound to accommodate multi-week runs.
+      **Trade-off: bleeds in chop.** Deploy only when you've already
+      identified the parabolic setup — not as a default trend preset.
+    dsl_preset:
+      hard_timeout:
+        enabled: true
+        interval_in_minutes: 20160        # 14d — parabolic runs can extend 2-3 weeks
+      # weak_peak_cut + dead_weight_cut deliberately OFF — consolidations are NORMAL here
+      phase1:
+        enabled: true
+        max_loss_pct: 25.0                # accept deeper initial drawdown to stay on the bus
+        retrace_threshold: 18             # accommodate 5-8% intraday gyrations
+        consecutive_breaches_required: 2  # one bad bar doesn't trip
+      phase2:
+        enabled: true
+        tiers:
+          - { trigger_pct: 15,  lock_hw_pct: 0  }   # don't lock anything until +15% — let it build
+          - { trigger_pct: 30,  lock_hw_pct: 30 }   # light early lock
+          - { trigger_pct: 60,  lock_hw_pct: 55 }
+          - { trigger_pct: 120, lock_hw_pct: 72 }
+          - { trigger_pct: 250, lock_hw_pct: 85 }   # apex — only late lock takes most off the table

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -323,6 +323,7 @@ if best_candidate:
 | **Sheep** | v1.0 | BTC · ETH · SOL · HYPE | **Onboarding tier.** Long-only triple-EMA-stacked trend. Fires LONG only when `ema(fast) > ema(slow)` on ALL THREE timeframes (15m + 1h + 4h). Never shorts. A visual rule beginners can sanity-check on any chart. Balanced DSL + `weak_peak_cut` 6h/3%. | Onboarding, Long-only, Multi-timeframe, EMA-stack, Balanced DSL |
 | **Iguana** | v1.0 | xyz:SP500 · xyz:XYZ100 | **Onboarding tier — XYZ subset.** The simplest XYZ exposure in the fleet — just the broad indices. Picks whichever has the stronger 4-day move past the threshold and trades its direction. No stock-picking, no commodities, no pre-IPO. Closest thing to "an index fund, but 24/7." Balanced DSL + 48h hard_timeout for weekend pricing-gap risk. | Onboarding, XYZ-Macro, Index-only, Balanced DSL, hard_timeout 48h |
 | **Sailfish** | v1.0 | BTC · ETH · SOL · HYPE | Relative-Strength Rotator. Ranks the universe by ~2.7d RS each tick and longs the leader iff (a) leader's own RS ≥ 1% AND (b) it beats the runner-up by ≥ 1.5pp (no whipsaw on tight races). Runtime is single-position; "rotation" happens via DSL exit on the holdover + Sailfish's next-tick re-entry on the new leader. Momentum cousin of Chameleon's mean-reversion. Balanced DSL + 96h hard_timeout. | Momentum-rotation, RS-leader, Margin-gate, Balanced DSL |
+| **Stag** | v1.0 | BTC · ETH · SOL · HYPE (often deployed single-asset) | **Parabolic-Run Hunter.** Entry-side pair for the new `parabolic_runner` DSL preset (widest in the catalog: max_loss 25%, retrace 18, 2 consecutive breaches required, late first lock +15%, 14d outer bound). Strict 5-gate filter: (1) close > 200-bar 4h SMA AND 7d high within 48h, (2) 7d move ≥ 25% (the parabolic threshold), (3) 24h volume ≥ 1.5× trailing 7d, (4) 4d move ≥ 7d move / 2 (acceleration), (5) SM aligned LONG ≥ 60%. LONG only — parabolic crashes happen too fast for shorts. **Operator-driven** deployment: most ticks return empty by design. Reference setup: HYPE 2026-05 (+60% in 16 days). 1 entry/day max + 24h per-asset cooldown after bad takes. Tick 600s. | Parabolic, 5-gate, LONG-only, Operator-driven, parabolic_runner DSL |
 
 ---
 
@@ -871,6 +872,7 @@ Ask which one sentence sounds most like the user:
   - 🟢 Beginner: **Beaver** (BTC) · **Heron** (ETH) · **Hummingbird** (HYPE) — SM-gated 4h trend, wide DSL, simple scoring.
   - 🟢 Beginner — *long only, multi-timeframe agreement*: **Sheep** (BTC/ETH/SOL/HYPE). Fires LONG only when 15m + 1h + 4h EMAs are all stacked bullishly. Never shorts — for users intimidated by directional choice.
   - ⬆️ Level up — *rotation across majors*: **Sailfish** (RS leader). Always holds the strongest of BTC/ETH/SOL/HYPE; rotates via DSL exit + re-entry.
+  - 🎯 *Operator-driven — "I see a parabolic running, deploy something to ride it"*: **Stag** (parabolic-run hunter). Strict 5-gate entry filter (7d ≥ 25%, vol surge, acceleration, SM ≥60% LONG, structural trend); pairs with the widest DSL in the catalog (`parabolic_runner`: max_loss 25, retrace 18, 14d outer bound). Bleeds in chop — deploy only when you've identified the setup. Reference: HYPE 2026-05.
   - ⬆️ Level up: **Grizzly** (BTC) · **Polar** (ETH) · **Kodiak** (SOL) · **Wolverine** (HYPE) — Kodiak-family alpha hunters.
 - **A basket of majors** (BTC + ETH + SOL together).
   - 🟢 Beginner: **Hedgehog** (equal-weight basket, up to 3 at once).
@@ -1053,6 +1055,7 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | **Sheep** | 4 — Multi-asset whitelist (onboarding) | BTC/ETH/SOL/HYPE long-only triple-EMA-stacked trend. Fires only when 15m + 1h + 4h EMAs are all stacked bullishly. Balanced DSL + weak_peak_cut 6h/3% |
 | **Iguana** | 4 — Multi-asset whitelist (XYZ subset, onboarding) | xyz:SP500 + xyz:XYZ100. Simplest possible XYZ exposure — index-fund equivalent. Balanced DSL + 48h hard_timeout for weekend pricing-gap risk |
 | **Sailfish** | 4 — Multi-asset whitelist (momentum-rotation) | BTC/ETH/SOL/HYPE. Ranks by ~2.7d RS, longs the leader iff leader RS ≥ 1% AND beats runner-up by ≥ 1.5pp (no whipsaw). Rotation via DSL exit + re-entry. Balanced DSL + 96h hard_timeout |
+| **Stag** | 4 — Multi-asset whitelist (parabolic-run hunter, operator-driven) | BTC/ETH/SOL/HYPE (often single-asset). Strict 5-gate filter (7d ≥ 25% + vol surge + accel + 200-SMA + SM ≥60% LONG). LONG only. Entry-side pair for new `parabolic_runner` DSL preset (max_loss 25%, retrace 18, 2 breaches required, 14d outer bound). Reference: HYPE 2026-05 +60% in 16 days |
 
 Sentinel runs an in-house producer that is not currently published to this repo; no public URL.
 

--- a/stag/README.md
+++ b/stag/README.md
@@ -1,0 +1,149 @@
+# 🦌 Stag — Parabolic-Run Hunter
+
+**Ride HYPE-class runs without getting chopped on the gyrations.** Stag is the entry-side pair for the new `parabolic_runner` DSL preset. Strict 5-gate entry filter, then the widest DSL in the catalog holds the position through the 5–8% intraday pullbacks that would kill a normal trend trail.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+HYPE 2026-05: $40 → $65 over 16 days, with at least 5 distinct 5–10% intraday gyrations through the middle. Standard DSL trails would chop out on any of them. Stag's answer: **enter only when there's a real parabolic setup, then accept the gyrations.**
+
+**Trade-off named honestly:** the `parabolic_runner` preset bleeds in chop. If the parabolic doesn't materialize, Stag gives back more than `let_winners_run` would. The 5-gate filter is strict for exactly that reason — the only way the wide DSL pays is if you've correctly identified the setup.
+
+## Key parameters
+
+| Parameter | Default |
+|---|---|
+| Whitelist | BTC · ETH · SOL · HYPE (configurable; single-asset is also a common deploy) |
+| Tick interval | 600s (10 min) — parabolic conditions don't appear in 5 min |
+| 200-bar 4h SMA gate | required |
+| 7d high freshness gate | within last 48h (12 × 4h bars) |
+| 7d trend gate | ≥ 25% (the "parabolic" threshold) |
+| Volume surge gate | recent 24h ≥ 1.5× trailing 7d |
+| Acceleration gate | 4d move ≥ 7d move ÷ 2 |
+| SM LONG gate | ≥ 60% |
+| Direction | LONG only |
+| Leverage | 4x default, max 5x |
+| Margin per slot | 25% of equity |
+| Max entries per day | **1** (parabolic setups are rare) |
+| Per-asset cooldown | **1440 min (24h)** — don't re-enter after a bad take |
+| Daily loss limit | 18% |
+| Drawdown halt | 25% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: true) |
+
+## DSL preset (`parabolic_runner` — widest in the catalog)
+
+| Phase | Component | Setting | vs `let_winners_run` |
+|---|---|---|---|
+| Phase 1 | max_loss_pct | **25%** | 20% |
+| Phase 1 | retrace_threshold | **18** | 12 |
+| Phase 1 | consecutive_breaches_required | **2** | 1 |
+| Time cuts | hard_timeout | **14d** | (off) |
+| Time cuts | weak_peak_cut | disabled | disabled |
+| Time cuts | dead_weight_cut | disabled | disabled |
+| Phase 2 | T0 → T4 | +15/0 · +30/30 · +60/55 · +120/72 · +250/85 | +10/0 · +20/25 · +30/40 · +50/60 · +100/85 |
+
+## Scanner pattern
+
+Archetype #4 (Multi-asset whitelist) with strict 5-gate parabolic filtering. Primary MCP calls: `market_get_asset_data(candle_intervals=["4h"])` (needs ≥ 200 candles for the 200-bar SMA), `leaderboard_get_markets`. Pure functions unit-tested in `tests/test_signal.py` (`python3 stag/tests/test_signal.py`).
+
+## Operator workflow
+
+The point isn't just the code — it's the workflow:
+
+1. You notice a parabolic setting up on one asset (e.g. HYPE +30% over 7d, volume surging).
+2. Deploy Stag with that single asset: `whitelist: ["HYPE"]`, 25% margin, 4x leverage.
+3. Stag fires when its gates trip — could be same hour, could be next day.
+4. The wide DSL holds the position through the full run, including consolidations.
+5. When the run finishes (T4 tier ratchets in, or `max_loss_pct: 25` trips on a real reversal), Stag closes.
+6. Pause Stag until the next regime.
+
+Running a 4-asset basket as a passive scan also works, but the strict gates mean most ticks are silent.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, `parabolic_runner` DSL, `risk.guard_rails`) |
+| scripts/stag-producer.py | Long-lived daemon; emits STAG_PARABOLIC_RUNNER signals |
+| scripts/stag_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/stag-config.json | Operator-tunable defaults (whitelist, all 5 gate thresholds, sizing) |
+| tests/test_signal.py | 18 unit tests covering all gates |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Stag
+
+```bash
+mkdir -p /data/workspace/skills/stag-strategy/{config,scripts,state,references}
+for f in scripts/stag-producer.py scripts/stag_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/stag-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/stag/$f" \
+    -o "/data/workspace/skills/stag-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID — and optionally a single asset
+
+Edit `/data/workspace/skills/stag-strategy/config/stag-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId",
+  "whitelist": ["HYPE"]
+}
+```
+
+For operator-driven single-asset deploys, narrow `whitelist` to that asset.
+
+### Step 4 — Required env vars
+
+```bash
+export STAG_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                         # required (user-scope; needed for leaderboard_get_markets)
+export STAG_DECISION_MODEL=<your-preferred-model>   # bare model name; NO provider prefix
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/stag-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/stag-strategy/scripts/stag-producer.py \
+  > /tmp/stag-producer.log 2>&1 &
+disown
+```
+
+`disown` is essential — it detaches the daemon so a shell/session exit can't SIGTERM it.
+
+## Verification
+
+```bash
+sleep 620  # wait one full tick
+tail -3 /tmp/stag-producer.log | jq '._stag_producer_version, .note // null, .best.trend_pct // null'
+```
+
+A healthy first tick usually outputs:
+- `"note": "WAITING — no asset cleared all five parabolic gates"` — by far the most common state (intentional)
+- `"signals_pushed": 1, "best": { "coin": "HYPE", "trend_pct": 28.5, "vol_ratio": 1.8, ... }` when a setup is in place
+
+## Changelog
+
+### v1.0.0 (2026-05-28) — initial release
+
+First fleet agent paired with the new `parabolic_runner` DSL preset. Strict 5-gate filter (structural trend + 25% strength + 1.5× volume surge + acceleration + SM ≥60% LONG). LONG only. Aggressive risk tier with 1 max entry/day + 24h per-asset cooldown after a bad take. Taker-true entry, disown-safe launch, 18-test pure-function suite covering all gates.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/stag/SKILL.md
+++ b/stag/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: stag-strategy
+description: >-
+  STAG v1.0.0 — Parabolic-Run Hunter. The entry-side pair for the
+  parabolic_runner DSL preset. Enters LONG only when ALL FIVE gates pass:
+  structural trend (close > 200-bar 4h SMA + 7d high within 48h), 7d move
+  ≥ 25% (the parabolic threshold), 1.5x volume surge, acceleration (4d ≥ 7d/2),
+  AND Smart Money LONG ≥ 60%. Built for HYPE-class runs (+60% over 16 days)
+  where standard DSL trails would chop on 5-8% intraday gyrations.
+  Operator-driven: most ticks return empty by design.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🦌 STAG v1.0.0 — Parabolic-Run Hunter
+
+**Ride the HYPE-class runs without getting chopped out on the gyrations.** Stag is the entry-side pair for the new `parabolic_runner` DSL preset — enter only when there's a real parabolic-runner setup, then let the widest DSL in the catalog hold the position through the 5–8% intraday pullbacks that would kill a normal trend trail.
+
+## Why this strategy exists
+
+Reference setup: HYPE 2026-05, $40 → $65 over 16 days. Through the middle of that run (May 17–25) there are at least 5 distinct 5–10% intraday gyrations on the 1h chart. Standard fleet DSL trails would chop a position out on any of them, missing the rest of the run. The problem isn't the DSL — it's that the DSL is making **local-volatility decisions** when the trade calls for **structural-trend decisions**.
+
+Stag's answer is twofold:
+1. **Strict 5-gate entry** so we only fire when there's actually a parabolic to ride (not a normal 5–10% trend).
+2. **Ship paired with `parabolic_runner` DSL** — max_loss 25%, retrace 18, 2 consecutive breaches required, late first lock (+15%), light early tiers, 14d outer bound. Built specifically to accept the gyrations.
+
+The trade-off is honest: this preset **bleeds in chop**. If the parabolic doesn't materialize, Stag gives back more than `let_winners_run` would. That's why the 5-gate filter is strict — the only way the wide DSL pays is if you've correctly identified the setup.
+
+## CRITICAL RULES
+
+### RULE 1: All five entry gates required
+Each tick, for each whitelisted asset:
+
+| Gate | Threshold | Default | Purpose |
+|---|---|---|---|
+| **Structural trend** | close > 200-bar 4h SMA AND 7d high made within last 48h | — | filter chop and reversals |
+| **Strength** | 7d move ≥ `minTrendPct` | 25% | defines "parabolic" vs normal trend |
+| **Volume** | mean(last 6 4h bars) / mean(last 42 4h bars) ≥ `volSurgeRatio` | 1.5× | real participation, not drift |
+| **Acceleration** | 4d move ≥ 7d move ÷ 2 | — | recent half keeping pace or faster |
+| **SM aligned LONG** | ≥ `smTiltMinPct` | 60% | not contrarian — Stag rides crowded longs |
+
+If **any** gate fails, the asset is dropped. Most ticks return empty — that's the design.
+
+### RULE 2: LONG only
+Parabolic crashes happen too fast for momentum-style shorts. Stag is asymmetric.
+
+### RULE 3: Operator-driven deployment
+Stag is the tool you deploy *when you've already seen the setup forming.* Typical workflow:
+1. Operator notices a parabolic setting up on one asset (e.g. HYPE +30% over 7d, volume surging).
+2. Deploys Stag with that single asset: `whitelist: ["HYPE"]`, 25% margin, 4x leverage.
+3. Stag fires when its gates trip — could be same hour, could be next day.
+4. The wide DSL holds the position through the full run, including consolidations.
+5. When the run finishes (T4 tier ratchets in, or `max_loss_pct: 25` trips on a real reversal), Stag closes.
+6. Operator pauses Stag until the next regime.
+
+Running Stag on a 4-asset basket as a passive scan also works, but the strict gates mean most ticks will be silent.
+
+### RULE 4: Producer enters. DSL exits.
+No `close_position` call site. The DSL is the entire exit logic — and the WIDE DSL is the whole point of Stag's existence.
+
+## How Stag scores a trade
+
+**Gate:** all five entry gates passed.
+
+**Score components** (max ~7):
+
+| Signal | Points |
+|---|---|
+| All 5 gates passed (base) | +3 |
+| 7d trend ≥ `strongTrendPct` (default 40%) | +2 |
+| Accelerating (gate already required, but adds to score) | +1 |
+| Volume ratio ≥ 2.0× (vs the 1.5× gate threshold) | +1 |
+
+**Floor:** `minScore: 5`.
+
+## DSL preset (`parabolic_runner` — widest in the catalog)
+
+| Phase | Component | Setting |
+|---|---|---|
+| Phase 1 | max_loss_pct | **25%** (vs 20 in `let_winners_run`) |
+| Phase 1 | retrace_threshold | **18** (vs 12) |
+| Phase 1 | consecutive_breaches_required | **2** (vs 1) |
+| Time cuts | hard_timeout | **14d** outer bound |
+| Time cuts | weak_peak_cut | DISABLED |
+| Time cuts | dead_weight_cut | DISABLED |
+| Phase 2 | T0 → T4 | +15/0 · +30/30 · +60/55 · +120/72 · +250/85 |
+
+See [`senpi-trading-runtime/references/dsl-presets.yaml`](https://github.com/Senpi-ai/senpi-skills/blob/main/senpi-trading-runtime/references/dsl-presets.yaml) for the canonical preset.
+
+## Scanner pattern
+
+Archetype #4 (Multi-asset whitelist) with strict 5-gate parabolic filtering — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data(candle_intervals=["4h"])` per asset (needs ≥ 200 candles for the SMA), `leaderboard_get_markets` (SM gate). The pure functions (`pct_change`, `sma`, `is_above_sma`, `recent_high_bars_ago`, `volume_surge`, `is_accelerating`, `parabolic_score`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-28) — initial release
+
+First fleet agent paired with the new `parabolic_runner` DSL preset. Strict 5-gate filter (structural trend + 25% strength + 1.5× volume surge + acceleration + SM ≥60% LONG). LONG only. Aggressive risk tier with 1 max entry/day + 24h per-asset cooldown after a bad take. Taker-true entry, disown-safe launch, 18-test pure-function suite covering all gates.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/stag/config/stag-config.json
+++ b/stag/config/stag-config.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "STAG v1.0.0 — Parabolic-Run Hunter. The entry-side pair for the parabolic_runner DSL preset. Each tick iterates the whitelist and applies a strict 5-gate filter: (1) structural trend (close > 200-bar 4h SMA AND 7d high within last 48h); (2) strength (7d move >= minTrendPct, default 25% — the parabolic threshold); (3) volume surge (recent 6 4h bars / trailing 42 bars >= 1.5x); (4) acceleration (4d move >= 7d move / 2); (5) SM aligned LONG >= 60%. ALL must pass. LONG only. Picks the highest-scoring candidate. Designed to be deployed operator-driven — most ticks return empty by design. Reference setup: HYPE 2026-05 (+60% in 16 days). Edit wallet/strategyId/chatId; tune whitelist/thresholds. Aggressive risk tier. Tick 600s. Per-asset 24h cooldown after a bad take.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "whitelist": ["BTC", "ETH", "SOL", "HYPE"],
+  "smaPeriod": 200,
+  "trendLookbackBars": 42,
+  "accelLookbackBars": 24,
+  "freshHighBars": 12,
+  "minTrendPct": 25.0,
+  "strongTrendPct": 40.0,
+  "volRecentBars": 6,
+  "volBaselineBars": 42,
+  "volSurgeRatio": 1.5,
+  "smTiltMinPct": 60,
+  "minScore": 5,
+  "marginPct": 0.25,
+  "leverage": 4
+}

--- a/stag/references/skill-attribution.md
+++ b/stag/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "stag",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "stag",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/stag/runtime.yaml
+++ b/stag/runtime.yaml
@@ -1,0 +1,194 @@
+name: stag-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Stag v1.0.0"
+# and lives in description + SKILL.md + _stag_producer_version.
+version: 1.0.0
+description: >
+  STAG v1.0.0 — Parabolic-Run Hunter.
+
+  Reference setup: HYPE 2026-05, $40 → $65 over 16 days. Standard DSL trails
+  would chop a position out on the 5-8% intraday gyrations between May 17-25.
+  Stag is the entry-side pair for the `parabolic_runner` DSL preset — enter
+  only when there's a real parabolic-runner setup, then let the wide DSL hold
+  it through the gyrations.
+
+  ALL FIVE entry gates required:
+    1. Structural trend: close > 200-bar 4h SMA AND 7d high made within
+       the last 48h.
+    2. Strength: 7d move >= minTrendPct (default 25%, the parabolic threshold).
+    3. Volume: 24h volume >= 1.5x trailing 7d average.
+    4. Acceleration: 4d move >= 7d move / 2 (recent half at least as fast).
+    5. SM aligned LONG >= 60%.
+
+  LONG only — parabolic crashes happen too fast for momentum-style shorts.
+
+  Architecture (helpers-native): producer ticks every 600s, runs the 5-gate
+  filter per whitelisted asset, picks the highest-scoring candidate, and
+  emits STAG_PARABOLIC_RUNNER LONG. LLM gate is pass-through.
+
+  DSL: parabolic_runner preset — max_loss 25%, retrace 18, 2 consecutive
+  breaches required, late first lock (+15%), light early tiers, 14d outer
+  bound. NO weak_peak_cut, NO dead_weight_cut (consolidations are normal).
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_pct: 25            # % of account budget per slot — aggressive single-asset deployment
+  trading_risk: aggressive
+  enabled: true
+
+risk:
+  data_retention_hours: 360   # 15 days — covers the typical parabolic horizon
+  guard_rails:
+    daily_loss_limit_pct: 18
+    max_entries_per_day: 1   # parabolic setups are rare; one per day max
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 2  # tighter — Stag bleeds in chop; cool off fast
+    cooldown_minutes: 240
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 1440   # 24h — don't re-enter the same asset after a bad take
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: stag_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trendPct: { type: number, required: false }
+        shortStrengthPct: { type: number, required: false }
+        volRatio: { type: number, required: false }
+        highBarsAgo: { type: number, required: false }
+        smTiltPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: stag_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${STAG_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [stag_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true        # ride the parabolic NOW — a maker order that rests (CREATE_ORDER_RESTING) misses extension
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: stag_signals
+    decision_prompt: |
+      You are Stag's pass-through gate. Stag is a parabolic-run hunter —
+      it only fires when ALL FIVE gates pass (structural trend + 7d move >= 25%
+      + volume surge + acceleration + SM aligned LONG >= 60%). The producer
+      applied every filter. Honor the signal.
+
+      SIGNAL:
+      {{signal_stag_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY.
+      2. direction MUST be LONG (Stag never shorts).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - direction != LONG
+      - score < 5 (producer floor)
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets
+      - trendPct < 25 (parabolic threshold not cleared)
+      - smTiltPct < 60 (SM gate not cleared)
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 7 AND trendPct >= 40 AND volRatio >= 2.0
+      - 7-8:  score 5-6
+      - 7:    score 5 (producer floor) — the 5-gate signal IS the validation
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 HYPE LONG, 7d +52%, accelerating (4d +28%), vol 2.3x baseline, SM 68% LONG — parabolic-runner setup')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "LONG",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "STAG_PARABOLIC_RUNNER LONG — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — parabolic_runner preset) ─────────────────────
+#
+# Widest preset in the catalog. Built for asymmetric parabolic moves where
+# standard trails chop out on 5-8% intraday gyrations. Late first lock
+# (+15%), light early ratchet, retrace 18, max_loss 25, 2 consecutive
+# breaches required so a single volatile bar doesn't trip Phase 1, 14d outer
+# bound. NO weak_peak_cut, NO dead_weight_cut — consolidations are NORMAL
+# in parabolic runs.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 20160        # 14d — parabolic runs can extend 2-3 weeks
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 25.0                # accept deeper initial drawdown
+      retrace_threshold: 18             # accommodate 5-8% intraday gyrations
+      consecutive_breaches_required: 2  # one bad bar doesn't trip
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 15,  lock_hw_pct: 0  }   # don't lock anything until +15%
+        - { trigger_pct: 30,  lock_hw_pct: 30 }   # light early lock
+        - { trigger_pct: 60,  lock_hw_pct: 55 }
+        - { trigger_pct: 120, lock_hw_pct: 72 }
+        - { trigger_pct: 250, lock_hw_pct: 85 }   # apex tier
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/stag/scripts/stag-producer.py
+++ b/stag/scripts/stag-producer.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+# Senpi STAG Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""STAG v1.0.0 — Parabolic-Run Hunter.
+
+Reference setup: HYPE 2026-05, $40 → $65 over 16 days. Standard DSL trails
+would have chopped a position out on the 5-8% intraday gyrations between
+May 17-25. Stag is the entry-side pair for the `parabolic_runner` DSL preset
+— enter only when there's a real parabolic-runner setup, then let the wide
+DSL hold it through the gyrations.
+
+ALL FIVE gates required:
+
+  1. Structural trend: close > 200-bar 4h SMA AND 7d high made within last 48h
+  2. Strength:        7d move >= 25% (defines "parabolic" vs normal trend)
+  3. Volume:          recent 24h volume >= 1.5x trailing 7d average
+  4. Acceleration:    4d move >= 7d move / 2 (recent half at least as fast)
+  5. SM aligned:      Smart Money LONG >= 60%
+
+LONG only — parabolic crashes happen too fast for momentum-style shorts.
+
+Architecture: helpers-native producer + parabolic_runner DSL preset. Tick
+600s — these setups don't appear in 5 minutes. Per-asset cooldown 24h — don't
+re-enter the same asset after a bad take. Producer NEVER closes — DSL owns
+exits.
+
+REQUIRES USER-SCOPE AUTH for leaderboard_get_markets.
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import stag_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "stag_signals"
+SIGNAL_TYPE = "STAG_PARABOLIC_RUNNER"
+
+MAX_LEVERAGE = 5            # parabolic_runner DSL accepts 25% max_loss → at 5x that's 5% price stop
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 5
+
+DEFAULT_WHITELIST = ["BTC", "ETH", "SOL", "HYPE"]
+
+# Lookbacks (4h bars):
+DEFAULT_TREND_LOOKBACK = 42        # 7 days @ 4h
+DEFAULT_ACCEL_LOOKBACK = 24        # 4 days @ 4h
+DEFAULT_FRESH_HIGH_BARS = 12       # 48h — 7d high must be within last 48h
+DEFAULT_SMA_PERIOD = 200           # structural trend filter (~33 days @ 4h)
+
+DEFAULT_MIN_TREND_PCT = 25.0       # the "parabolic" threshold
+DEFAULT_STRONG_TREND_PCT = 40.0
+
+# Volume:
+DEFAULT_VOLUME_RECENT_BARS = 6     # 24h
+DEFAULT_VOLUME_BASELINE_BARS = 42  # 7d (same as trend lookback for symmetry)
+DEFAULT_VOLUME_SURGE_RATIO = 1.5
+
+DEFAULT_SM_TILT_MIN = 60.0
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("STAG_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure parabolic-detection logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def pct_change(closes, lookback):
+    """% change of the latest close vs the close `lookback` bars ago.
+    None if insufficient data or reference price is non-positive."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def sma(closes, period):
+    """Simple moving average over the last `period` closes. None if
+    insufficient data."""
+    if not closes or len(closes) < period:
+        return None
+    window = closes[-period:]
+    return sum(window) / period
+
+
+def is_above_sma(closes, period):
+    """True if the latest close is above the N-period SMA. False if
+    SMA can't be computed."""
+    s = sma(closes, period)
+    if s is None or not closes:
+        return False
+    return closes[-1] > s
+
+
+def recent_high_bars_ago(closes, lookback):
+    """How many bars back the highest close in `closes[-lookback-1:]` was
+    made. 0 = latest bar is the high. None if insufficient data."""
+    if not closes or len(closes) <= lookback:
+        return None
+    window = closes[-(lookback + 1):]
+    high_idx_in_window = max(range(len(window)), key=lambda i: window[i])
+    # bars_ago = distance from the end of the window to the high
+    return len(window) - 1 - high_idx_in_window
+
+
+def volume_surge(volumes, recent_bars, baseline_bars, min_ratio):
+    """True if mean(last `recent_bars`) / mean(last `baseline_bars`) >=
+    min_ratio. Returns (passed, ratio) — ratio is None on insufficient data."""
+    if not volumes or len(volumes) < baseline_bars:
+        return False, None
+    recent = volumes[-recent_bars:]
+    baseline = volumes[-baseline_bars:]
+    rmean = sum(recent) / len(recent) if recent else 0.0
+    bmean = sum(baseline) / len(baseline) if baseline else 0.0
+    if bmean <= 0:
+        return False, None
+    ratio = rmean / bmean
+    return (ratio >= min_ratio), ratio
+
+
+def is_accelerating(short_strength_pct, long_strength_pct):
+    """True if the shorter window's move is at least half the longer
+    window's move — i.e., the recent half is keeping pace or faster.
+    Both must be positive (we're gating LONG-only on bullish acceleration)."""
+    if short_strength_pct is None or long_strength_pct is None:
+        return False
+    if long_strength_pct <= 0:
+        return False
+    return short_strength_pct >= (long_strength_pct / 2.0)
+
+
+def parabolic_score(trend_pct, accelerating, vol_passed, vol_ratio, sm_aligned, strong_trend_pct):
+    """Composite score for a parabolic setup. Gate (caller-side) is all-5
+    pass; this scores HOW strong the setup is among passing candidates."""
+    score = 3   # base — all five gates passed
+    reasons = [f"trend_{trend_pct:+.1f}%"]
+    if trend_pct >= strong_trend_pct:
+        score += 2
+        reasons.append(f"strong_{trend_pct:+.1f}%")
+    if accelerating:
+        score += 1
+        reasons.append("accelerating")
+    if vol_passed and vol_ratio is not None:
+        if vol_ratio >= 2.0:
+            score += 1
+            reasons.append(f"vol_surge_{vol_ratio:.1f}x")
+        else:
+            reasons.append(f"vol_{vol_ratio:.1f}x")
+    if sm_aligned:
+        reasons.append("sm_aligned")
+    return score, reasons
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_candles(asset):
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return []
+    return data.get("data", {}).get("candles", {}).get("4h", [])
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — one asset, all five gates
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, config):
+    candles = fetch_candles(asset)
+    sma_period = int(config.get("smaPeriod", DEFAULT_SMA_PERIOD))
+    trend_lb = int(config.get("trendLookbackBars", DEFAULT_TREND_LOOKBACK))
+    accel_lb = int(config.get("accelLookbackBars", DEFAULT_ACCEL_LOOKBACK))
+    fresh_high_lb = int(config.get("freshHighBars", DEFAULT_FRESH_HIGH_BARS))
+
+    # Need enough candles for the deepest lookback (SMA, by default 200)
+    if len(candles) < max(sma_period, trend_lb) + 1:
+        return None
+
+    closes = [_f(c, "close", "c") for c in candles]
+    volumes = [_f(c, "volume", "v") for c in candles]
+
+    # Gate 1: structural trend — above 200-SMA AND 7d high within last 48h
+    above_sma = is_above_sma(closes, sma_period)
+    if not above_sma:
+        return None
+    high_bars_ago = recent_high_bars_ago(closes, trend_lb)
+    if high_bars_ago is None or high_bars_ago > fresh_high_lb:
+        return None
+
+    # Gate 2: strength — 7d move >= minTrendPct
+    trend_pct = pct_change(closes, trend_lb)
+    min_trend = float(config.get("minTrendPct", DEFAULT_MIN_TREND_PCT))
+    if trend_pct is None or trend_pct < min_trend:
+        return None
+
+    # Gate 3: volume surge
+    vol_recent = int(config.get("volRecentBars", DEFAULT_VOLUME_RECENT_BARS))
+    vol_base = int(config.get("volBaselineBars", DEFAULT_VOLUME_BASELINE_BARS))
+    vol_min = float(config.get("volSurgeRatio", DEFAULT_VOLUME_SURGE_RATIO))
+    vol_passed, vol_ratio = volume_surge(volumes, vol_recent, vol_base, vol_min)
+    if not vol_passed:
+        return None
+
+    # Gate 4: acceleration — recent half at least as fast as full window
+    short_strength = pct_change(closes, accel_lb)
+    accelerating = is_accelerating(short_strength, trend_pct)
+    if not accelerating:
+        return None
+
+    # Gate 5: SM aligned LONG >= threshold
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(config.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_aligned = (sm_dir == "LONG" and sm_tilt >= sm_min)
+    if not sm_aligned:
+        return None
+
+    # All 5 gates passed — score the setup
+    strong_trend = float(config.get("strongTrendPct", DEFAULT_STRONG_TREND_PCT))
+    score, reasons = parabolic_score(trend_pct, accelerating, vol_passed, vol_ratio, sm_aligned, strong_trend)
+
+    return {
+        "coin": asset,
+        "direction": "LONG",
+        "score": score,
+        "reasons": reasons,
+        "trend_pct": round(trend_pct, 2),
+        "short_strength_pct": round(short_strength, 2) if short_strength is not None else 0.0,
+        "vol_ratio": round(vol_ratio, 2) if vol_ratio is not None else 0.0,
+        "high_bars_ago": int(high_bars_ago),
+        "sm_tilt_pct": sm_tilt,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": "LONG",
+        "reasons": thesis["reasons"],
+        "trendPct": thesis.get("trend_pct") or 0.0,
+        "shortStrengthPct": thesis.get("short_strength_pct") or 0.0,
+        "volRatio": thesis.get("vol_ratio") or 0.0,
+        "highBarsAgo": thesis.get("high_bars_ago") or 0,
+        "smTiltPct": thesis.get("sm_tilt_pct") or 0.0,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction="LONG",
+            score=min(thesis["score"] / 7.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    whitelist = config.get("whitelist", DEFAULT_WHITELIST)
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_stag_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_stag_producer_version": VERSION})
+        return
+
+    candidates = []
+    for asset in whitelist:
+        a = str(asset).upper()
+        if a in held_set or cfg.was_recently_signaled(a):
+            continue
+        thesis = build_thesis(a, config)
+        if thesis and thesis["score"] >= int(config.get("minScore", DEFAULT_MIN_SCORE)):
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — no asset cleared all five parabolic gates",
+            "whitelist": whitelist,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_stag_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: (c["score"], c["trend_pct"]), reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.25))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": "LONG",
+            "trend_pct": best["trend_pct"],
+            "short_strength_pct": best["short_strength_pct"],
+            "vol_ratio": best["vol_ratio"],
+            "sm_tilt_pct": best["sm_tilt_pct"],
+            "score": best["score"],
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:6],
+        },
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_stag_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=600,   # 10min — parabolic conditions don't appear in 5min
+        name=f"stag-producer-{_wallet_lock_id}",
+        tick_timeout=240,
+    )

--- a/stag/scripts/stag_config.py
+++ b/stag/scripts/stag_config.py
@@ -1,0 +1,207 @@
+"""STAG v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Parabolic-Run Hunter. Stag is the entry-side pair for the parabolic_runner
+DSL preset. Its job is to enter LONG only when a real parabolic-runner setup
+is in place — established structural trend (price > 200-bar 4h SMA + fresh
+7d high), 7d move >= 25% (this defines "parabolic"), volume surging vs the
+7d baseline, acceleration (recent half at least as fast as full window), AND
+Smart Money aligned LONG >= 60%. All five gates required.
+
+The point isn't to fire often. The point is: when Stag does fire, the
+parabolic_runner DSL holds the position through the 5-8% intraday gyrations
+that would chop out a normal trend trail, and only releases at the structural
+breakdown or the late lock tiers.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+parabolic_runner DSL preset. Stateless evaluation + race-window dedup +
+24h per-asset cooldown (don't re-enter after a bad take). Producer NEVER
+closes — DSL owns exits.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "stag-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "stag-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Stag ticks every 600s; ALO fills typically settle
+# within 30-60s. 240s covers the full fill window plus the next-tick
+# clearinghouseState refresh.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Stag's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("stag_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def mcp_call(tool, **params):
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] stag_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[stag-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/stag/tests/test_signal.py
+++ b/stag/tests/test_signal.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Unit tests for Stag's pure functions (pct_change, sma, is_above_sma,
+recent_high_bars_ago, volume_surge, is_accelerating, parabolic_score).
+Stubs stag_config + senpi_runtime_helpers.
+Run: python3 stag/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("stag_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["stag_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "stag-producer.py"
+_spec = importlib.util.spec_from_file_location("stag_producer", _path)
+stg = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(stg)
+
+
+# ── pct_change ──────────────────────────────────────────────────
+
+def test_pct_change_known_value():
+    # 42 bars ago = 40, latest = 60 → +50%
+    closes = [40.0] * 43
+    closes[-1] = 60.0
+    assert abs(stg.pct_change(closes, 42) - 50.0) < 1e-9
+
+
+def test_pct_change_insufficient_and_bad_ref():
+    assert stg.pct_change([100, 101], 42) is None
+    closes = [0.0] * 43
+    assert stg.pct_change(closes, 42) is None
+
+
+# ── sma + is_above_sma ─────────────────────────────────────────
+
+def test_sma_simple_average():
+    closes = [10.0] * 200
+    assert stg.sma(closes, 200) == 10.0
+    closes2 = list(range(1, 201))  # 1..200, sum=20100, mean=100.5
+    assert abs(stg.sma(closes2, 200) - 100.5) < 1e-9
+
+
+def test_sma_insufficient_returns_none():
+    assert stg.sma([1, 2, 3], 200) is None
+
+
+def test_is_above_sma_true_when_latest_above_mean():
+    closes = list(range(1, 201))  # rising → latest (200) > mean (100.5)
+    assert stg.is_above_sma(closes, 200) is True
+    falling = list(range(200, 0, -1))  # falling → latest (1) < mean (100.5)
+    assert stg.is_above_sma(falling, 200) is False
+
+
+# ── recent_high_bars_ago ───────────────────────────────────────
+
+def test_recent_high_bars_ago_zero_when_latest_is_high():
+    closes = [10.0, 12, 14, 16, 18, 20]
+    # lookback 5 → window = closes[-6:] = all 6; high is at idx 5 (=20)
+    assert stg.recent_high_bars_ago(closes, 5) == 0
+
+
+def test_recent_high_bars_ago_counts_back_correctly():
+    # high made 3 bars ago
+    closes = [10.0, 12, 18, 20, 19, 18, 17]   # 20 at idx 3, latest idx 6, bars_ago = 3
+    assert stg.recent_high_bars_ago(closes, 6) == 3
+
+
+def test_recent_high_bars_ago_insufficient():
+    assert stg.recent_high_bars_ago([1, 2], 42) is None
+
+
+# ── volume_surge ───────────────────────────────────────────────
+
+def test_volume_surge_passes_when_recent_double_baseline():
+    # 36 bars @ 100 then 6 bars @ 200. baseline (all 42) mean = (3600 + 1200) / 42 ≈ 114.29.
+    # recent (last 6) mean = 200. ratio = 200 / 114.29 ≈ 1.75 → passes 1.5 threshold.
+    volumes = [100.0] * 36 + [200.0] * 6
+    passed, ratio = stg.volume_surge(volumes, recent_bars=6, baseline_bars=42, min_ratio=1.5)
+    expected_ratio = 200.0 / (4800.0 / 42.0)
+    assert passed is True
+    assert abs(ratio - expected_ratio) < 1e-9
+
+
+def test_volume_surge_explicit_math():
+    # baseline 10 bars: 6 zeros + 4 ones... too messy. Use clean values.
+    # baseline 10 bars all = 50; recent 2 bars = [100, 100] → recent mean 100, baseline mean (8*50 + 2*100)/10 = (400+200)/10 = 60
+    # ratio = 100/60 = 1.667 → passes 1.5
+    volumes = [50.0] * 8 + [100.0, 100.0]
+    passed, ratio = stg.volume_surge(volumes, recent_bars=2, baseline_bars=10, min_ratio=1.5)
+    assert passed is True
+    assert abs(ratio - (100.0 / 60.0)) < 1e-9
+
+
+def test_volume_surge_blocks_quiet():
+    # All flat → ratio 1.0 → blocked
+    volumes = [50.0] * 42
+    passed, ratio = stg.volume_surge(volumes, recent_bars=6, baseline_bars=42, min_ratio=1.5)
+    assert passed is False and abs(ratio - 1.0) < 1e-9
+
+
+def test_volume_surge_insufficient_returns_none_ratio():
+    passed, ratio = stg.volume_surge([1, 2], recent_bars=6, baseline_bars=42, min_ratio=1.5)
+    assert passed is False and ratio is None
+
+
+# ── is_accelerating ────────────────────────────────────────────
+
+def test_is_accelerating_recent_keeps_pace():
+    # 7d move +30%, 4d move +15% → 4d is exactly half the 7d → accelerating True
+    assert stg.is_accelerating(short_strength_pct=15.0, long_strength_pct=30.0) is True
+    # 4d move 20% > half of 7d 30% (15%) → still True
+    assert stg.is_accelerating(short_strength_pct=20.0, long_strength_pct=30.0) is True
+
+
+def test_is_accelerating_blocks_decelerating():
+    # 7d +30%, 4d only +5% → 4d is < half of 7d → decelerating
+    assert stg.is_accelerating(short_strength_pct=5.0, long_strength_pct=30.0) is False
+
+
+def test_is_accelerating_blocks_negative_long():
+    # Long-window trend is down → asymmetric LONG-only gate fails
+    assert stg.is_accelerating(short_strength_pct=10.0, long_strength_pct=-5.0) is False
+
+
+def test_is_accelerating_handles_none():
+    assert stg.is_accelerating(None, 10.0) is False
+    assert stg.is_accelerating(10.0, None) is False
+
+
+# ── parabolic_score ────────────────────────────────────────────
+
+def test_parabolic_score_base_plus_bonuses():
+    # All gates passing, trend moderate (25%), accelerating, vol 1.5x, sm aligned
+    score, reasons = stg.parabolic_score(25.0, True, True, 1.5, True, strong_trend_pct=40.0)
+    # base 3 + accel 1 = 4 (trend not strong, vol not surge ≥ 2x)
+    assert score == 4
+    assert "accelerating" in reasons
+
+
+def test_parabolic_score_strong_trend_bonus():
+    # Trend > strong threshold (40%) → +2
+    score, reasons = stg.parabolic_score(50.0, True, True, 2.5, True, strong_trend_pct=40.0)
+    # base 3 + strong 2 + accel 1 + vol_surge 1 = 7
+    assert score == 7
+    assert any("strong" in r for r in reasons)
+    assert any("vol_surge_2.5x" in r for r in reasons)
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)


### PR DESCRIPTION
## Diagnosed from the HYPE chart
HYPE 2026-05: \$40 → \$65 over 16 days, with 5+ distinct 5–10% intraday gyrations through the middle. Standard fleet DSL trails would chop a position out on any of them. The problem: existing presets make local-volatility decisions when parabolic runs call for structural-trend decisions.

## What ships

**1. New DSL preset `parabolic_runner` — widest in the catalog**
- `max_loss_pct: 25` (vs 20 in `let_winners_run`)
- `retrace_threshold: 18` (vs 12)
- `consecutive_breaches_required: 2` (vs 1) — one bad bar doesn't trip
- Phase 2 tiers: `+15/0 → +30/30 → +60/55 → +120/72 → +250/85` — late first lock, light early ratchet
- `hard_timeout: 14d` — parabolic runs can extend
- NO `weak_peak_cut`, NO `dead_weight_cut` — consolidations are NORMAL here
- **Trade-off named honestly in docs: bleeds in chop.** Deploy only when you've identified the setup.

**2. New agent `Stag 🦌` — the entry-side pair**
Strict 5-gate filter:
1. close > 200-bar 4h SMA AND 7d high within last 48h (structural trend)
2. 7d move ≥ 25% (the parabolic threshold)
3. 24h volume ≥ 1.5× trailing 7d (volume surge)
4. 4d move ≥ 7d move ÷ 2 (acceleration)
5. SM aligned LONG ≥ 60%

LONG only. Aggressive risk: 1 entry/day max + 24h per-asset cooldown after bad takes. Tick 600s. **Operator-driven** — most ticks return empty by design.

## Pairing principle (explicit in docs)
`parabolic_runner` ships **paired with Stag specifically** so the wide DSL is only deployed against the strict-gate entry. Standalone preset without Stag would be a maintenance liability — don't spread it across other agents whose theses don't require the gyration tolerance.

## Test plan
- [x] `python3 -m py_compile` producer + config — OK
- [x] `python3 stag/tests/test_signal.py` — **18/18 pass** (pct_change, sma, is_above_sma, recent_high_bars_ago, volume_surge, is_accelerating, parabolic_score)
- [x] runtime.yaml + config.json parse, dsl-presets.yaml parses with `parabolic_runner` present
- [x] field-parity AST-verified (top-level data_block keys ⊆ scanner fields)
- [x] Integrated into producer-patterns.md (archetype #4 family row + Layer 2A trend bullet + fleet roster mapping), dsl-presets.yaml + dsl-configuration.md (table row + new preset section), catalog.json, root README (41 skills total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)