### PR TITLE
Vulture v4.1.0 — MIN_SCORE 7→9 cull (mirror validated agent change)

### DIFF
--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -503,7 +503,7 @@ for asset in candidates:
 |---|---|---|---|---|
 | **Pangolin** | v1.4 | Multi (perps with OI > $3M) | Detects persistent extreme funding over hours and fades the crowd at exhaustion. Funding extremity + persistence duration + SM positioning + cooldowns. Quiet-hours gating (00–04 UTC). | Funding-fade, Tick 300s, Quiet-hours |
 | **Dog** | v2.0 | 4-coin whitelist | Fades crowded funding on a 4-coin watchlist. Regime hard-gate: skips entry when funding regime contradicts the fade direction. | 4-coin, Hard-gate, Regime |
-| **Vulture** | v2.3 | HYPE | HYPE funding-regime contrarian. Enriches each candidate with `market_get_funding_history` + held-position context. LLM gate is pass-through. | HYPE, Funding-hist, Contrarian |
+| **Vulture** | v4.1 | 25 small/mid-cap Hyperliquid perps (BTC/ETH/SOL/XYZ banned) | **Long-tail momentum rider** (full rewrite at v2.0 from the original HYPE-funding-contrarian — this row's archetype bucket is left for compatibility; Vulture's thesis is closer to a small-cap whitelist with momentum scoring). Score is composed of HEAVY_FLOW (SM concentration), trend persistence, multi-TF alignment, and 15m velocity. v4.1.0 raised MIN_SCORE 7→9 after a 30-trade analysis showed score 7–8 ran 12.5%/28.6% win rates at -3.94%/-3.52% avg ROE; conviction-scaled leverage 5x (score 9-10) / 7x (score 11+); cautious tier removed. | Small-cap, Long-tail, Conviction-scaled, MIN_SCORE 9 |
 
 ---
 
@@ -1024,7 +1024,7 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | Orca | 6 — Striker / rank-jump | Gen-1 vanilla Striker, FIRST_JUMP + volume + base scoring |
 | Pangolin | 7 — Funding-regime fade | Canonical |
 | Dog | 7 — Funding-regime fade | 4-coin whitelist with regime hard-gate |
-| Vulture | 7 — Funding-regime fade | HYPE funding-regime contrarian, funding-history + held-position enrichment |
+| Vulture | 7 — Funding-regime fade (legacy bucket; thesis is actually long-tail momentum on small caps since v2.0) | 25 small/mid-cap perps, conviction-scaled leverage 5x/7x. v4.1.0: MIN_SCORE 7→9 after 30-trade analysis culled the losing buckets |
 | Owl | 8 — Contrarian crowding-unwind | Canonical |
 | Lemon | 8 — Contrarian crowding-unwind | Degen Fader on crypto-majors + XYZ whitelist, MACRO_TREND_GATE |
 | Mantis | 9 — Cross-asset lag detector | Canonical |

--- a/vulture/README.md
+++ b/vulture/README.md
@@ -17,11 +17,11 @@ The long-tail edge is twofold: most predators cluster on majors + a tight altcoi
 | Asset universe | 25 small/mid-cap perps (see SKILL.md) |
 | Banned | BTC, ETH, SOL, all XYZ |
 | Tick interval | 60-180s |
-| MIN_SCORE (producer) | 7 |
-| LLM min_confidence | 7 |
+| MIN_SCORE (producer) | **9** (raised from 7 in v4.1.0 — see SKILL.md changelog for the 30-trade analysis) |
+| LLM min_confidence | **8** (raised from 7 in v4.1.0) |
 | Max positions | 2 concurrent |
-| Margin per slot | $400 |
-| Leverage tiers | 3x / 5x / 7x (score-scaled) |
+| Margin per slot | 45% of equity (was a fixed $400; switched to budget-relative `margin_pct: 45`) |
+| Leverage tiers | 5x / 7x (score-scaled — `cautious` tier 3x removed in v4.1.0) |
 | Max entries per day | 6 |
 | Per-asset cooldown | 240 min (4h) |
 | Daily loss limit | 10% |

--- a/vulture/SKILL.md
+++ b/vulture/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "4.0.1"
+  version: "4.1.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -138,19 +138,18 @@ FARTCOIN, MORPHO, NEAR, INJ, AVAX, LINK, DOGE
 | **Move ≥15% in direction (LATE_ENTRY_PENALTY)** | **-3** |
 | **Move ≥12% in direction (MOVE_EXTENDED)** | **-2** |
 
-**MIN_SCORE: 7** — entry floor. The scoring dimensions (especially HEAVY_FLOW requiring ≥18% SM concentration) do the real quality work.
+**MIN_SCORE: 9** (raised from 7 in v4.1.0) — entry floor. A 30-trade aggregate showed score 7–8 buckets (n=15 combined) ran 12.5% / 28.6% win rates at -3.94% / -3.52% avg ROE — the DSL was chopping them at the Phase 1 hard stop before they did real damage, but they were still net-negative. Vulture now hunts strictly in the 9–12 conviction zone where wins concentrate. The scoring dimensions (especially HEAVY_FLOW requiring ≥18% SM concentration) do the real quality work above the floor.
 
 ---
 
 ## Conviction-Scaled Leverage
 
-| Score | Leverage |
-|---|---:|
-| ≥11 | 7x |
-| ≥9 | 5x |
-| ≥7 | 3x |
+| Score | Leverage | Tier |
+|---|---:|---|
+| ≥11 | 7x | apex (the right tail) |
+| 9–10 | 5x | conviction (the new floor tier in v4.1.0) |
 
-**Capped at 7x because small-cap liquidity can't support 20x.** Lemon can go 20x on BTC/ETH because slippage is <0.1%. Small caps can have 0.5%+ slippage per fill, which eats gains at 20x.
+**v4.1.0 removed the `cautious` tier (score 7–8, 3x).** Below-floor signals are dropped at the producer now; that whole tier became unreachable. **Capped at 7x because small-cap liquidity can't support 20x.** Lemon can go 20x on BTC/ETH because slippage is <0.1%. Small caps can have 0.5%+ slippage per fill, which eats gains at 20x.
 
 ---
 
@@ -203,7 +202,7 @@ Both agents are "fleet alpha extractors" but via **opposite** philosophies:
 | hard_timeout | 480 min | 10,080 min (21x longer) |
 | dead_weight_cut | 20 min | 60 min |
 | Max leverage | 20x (apex) | 7x (liquidity limit) |
-| MIN_SCORE | 8 | 7 |
+| MIN_SCORE | 8 | 9 |
 
 **Both are bets on asymmetric payoff** — low win rate + big winners / tiny losers — but Lemon bets on mean reversion of exhausted crowds while Vulture bets on continuation of small-cap trends.
 
@@ -271,6 +270,21 @@ Send: "🦅 VULTURE v2.0 online. Long-Tail Momentum Rider. Riding small-cap tren
 ---
 
 ## Changelog
+
+### v4.1.0 (2026-05-29) — MIN_SCORE 7 → 9 (low-conviction cull)
+
+Aggregate analysis of the last 30 closed trades, grouped by producer entry score:
+
+| Score | Trades | Avg ROE  | Win Rate |
+|---:|---:|---:|---:|
+| 12 | 4 |  +5.56% | 25.0% (the fat tail — one +33.3% HYPE winner) |
+| 11 | 5 |  -1.04% | 60.0% |
+| 10 | 3 | +10.54% | 66.7% |
+|  9 | 2 |  -3.17% | 50.0% |
+|  8 | 7 |  -3.52% | 28.6% |
+|  7 | 8 |  -3.94% | 12.5% |
+
+Score 7–8 (n=15) ran a 12.5%/28.6% win rate at -3.94%/-3.52% avg ROE — the DSL was chopping each one at the Phase 1 hard stop before they did real damage, but they were still net-negative and were churning fees/attention. Score 9–12 (n=14) was where the wins concentrated. Raised `MIN_SCORE` 7→9 at the producer and `min_confidence` 7→8 at the LLM gate. Removed the `cautious` sizing tier (score 7-8, 3x) — unreachable now.
 
 ### v2.0 (2026-04-15) — **COMPLETE REWRITE**
 - Thesis flipped: contrarian fader → momentum rider

--- a/vulture/runtime.yaml
+++ b/vulture/runtime.yaml
@@ -1,7 +1,7 @@
 name: vulture-tracker
 # Runtime SCHEMA version must be major=1 per the senpi-trading-runtime
-# plugin. Strategy/skill is "Vulture v3.0.0" — lives in description +
-# SKILL.md + _vulture_producer_version. Do not set this to 3.x.x.
+# plugin. Strategy/skill is "Vulture v4.1.0" — lives in description +
+# SKILL.md + _vulture_producer_version. Do not set this to 4.x.x.
 version: 1.0.1
 description: >
   VULTURE v3.1.1 — observability fix: full ingest-failure logging.
@@ -114,7 +114,7 @@ actions:
     decision_mode: llm
     decision_model: "${VULTURE_DECISION_MODEL}"  # REQUIRED. Bare model name only — NO provider prefix. INVALID: "<provider>/<model>" (e.g. "google/...", "anthropic/...", "openai/...") — OpenClaw double-prefixes → 500 Unknown model. The LLM gate is a pass-through rubber-stamp (producer already applied every filter); any reliable structured-JSON model works. No default by design — operators pick their own.
     scanners: [vulture_signals]
-    min_confidence: 7
+    min_confidence: 8                 # v4.1.0: raised from 7 — see decision_prompt CONFIDENCE SCORING
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
@@ -147,33 +147,34 @@ actions:
 
       ## HARD SKIP CONDITIONS (output execute: false)
 
-      - score < 7 (producer should filter; defensive only)
+      - score < 9 (producer floor; defensive — v4.1.0 raised from 7)
       - leverage <= 0 OR signal data missing (malformed)
       - heldAssets already contains this exact asset (duplicate position)
       - reasons array empty (malformed signal)
 
       ## VULTURE'S THESIS
 
-      Long-tail momentum on small/mid-cap Hyperliquid perps. 38% WR
-      target with 6.15x profit factor — most trades are small losses
-      cut fast via 90-min dead_weight_cut, occasional right-tail winners
-      pay for everything. The producer is calibrated for THIS expectancy
-      profile. Don't add subjective second-guessing.
+      Long-tail momentum on small/mid-cap Hyperliquid perps. Most trades
+      are small losses cut fast via 90-min dead_weight_cut; occasional
+      right-tail winners pay for everything. The producer is calibrated
+      for THIS expectancy profile. Don't add subjective second-guessing.
 
       ## CONFIDENCE SCORING
 
+      v4.1.0 — score 7-8 culled at the producer after a 30-trade analysis
+      showed those buckets ran 12.5% / 28.6% win rates with -3.94% / -3.52%
+      avg ROE. Vulture now hunts strictly in the 9-12 conviction zone:
+
       - 9-10: score >= 11 (apex tier, 7x leverage) AND HEAVY_FLOW or
         STRONG_FLOW AND TREND_RUNNING/STRONG AND ACCELERATING
-      - 7-8: score >= 9 (conviction tier, 5x leverage) AND at least
-        STRONG_FLOW AND TREND_BUILDING+ AND 15M_BUILDING+
-      - 7: score 7-8 (cautious tier, 3x leverage) — producer has
-        gated this; the signal IS the validation. Honor it unless
-        a hard-skip applies.
-      - <7: producer floor not cleared — should never reach you.
+      - 8: score 9-10 (conviction tier, 5x leverage) — producer has
+        gated this; the signal IS the validation. Honor it unless a
+        hard-skip applies.
+      - <8: producer floor (>=9) not cleared — should never reach you.
 
-      Minimum confidence to execute is 7. The strategy needs the volume
-      of attempts to hit the right tail. Be permissive unless something
-      is structurally broken.
+      Minimum confidence to execute is 8. Score 7-8 signals are dropped
+      by the producer BEFORE reaching this gate; if one somehow reaches
+      you, hard-skip.
 
       ## OUTPUT FORMAT
 

--- a/vulture/scripts/vulture-producer.py
+++ b/vulture/scripts/vulture-producer.py
@@ -78,7 +78,7 @@ from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ign
 # reentrant; nested call raises BlockingIOError every tick.
 
 
-VERSION = "4.0.0"
+VERSION = "4.1.0"
 
 # Hardcoded — must match runtime.yaml external_scanner.name.
 SCANNER_NAME = "vulture_signals"
@@ -131,21 +131,36 @@ XYZ_BANNED = True
 
 
 # ═══════════════════════════════════════════════════════════════
-# SCORING CONFIG — preserved from v2.4 (proven on the +$117 ZEC trade)
+# SCORING CONFIG
+#
+# v4.1.0 — raised MIN_SCORE 7 → 9 after a 30-trade aggregate analysis showed
+# the low-conviction buckets weren't pulling their weight:
+#
+#   Score  7:  8 trades  | Avg ROE  -3.94%  | Win Rate  12.5%
+#   Score  8:  7 trades  | Avg ROE  -3.52%  | Win Rate  28.6%
+#   Score  9:  2 trades  | Avg ROE  -3.17%  | Win Rate  50.0%
+#   Score 10:  3 trades  | Avg ROE  +10.54% | Win Rate  66.7%
+#   Score 11:  5 trades  | Avg ROE  -1.04%  | Win Rate  60.0%
+#   Score 12:  4 trades  | Avg ROE  +5.56%  | Win Rate  25.0%   (the fat tail)
+#
+# Score 7-8 (n=15) was a clear culling signal — 12.5% / 28.6% win rates with
+# the DSL chopping each one at -3.5-3.9% avg before they did real damage.
+# Vulture now hunts strictly in the 9-12 conviction zone where wins
+# concentrate. The `cautious` sizing tier (score 7-8, 3x) is removed —
+# unreachable given the new floor.
 # ═══════════════════════════════════════════════════════════════
 
-MIN_SCORE = 7                   # Entry floor; scoring tiers do the real work
+MIN_SCORE = 9                   # Entry floor — score 7-8 culled (see analysis above)
 MIN_SM_PCT = 3.0                # Asset must have at least 3% SM concentration
 MIN_SM_TRADERS = 15             # Small caps need lower threshold than majors
 MIN_4H_ALIGNED_PCT = 1.0        # 4h price must be aligned ≥1% in SM direction
-MIN_1H_ALIGNED_PCT = 0.1        # v2.4 fix: 1h must be aligned (catches false breakouts)
+MIN_1H_ALIGNED_PCT = 0.1        # 1h must be aligned (catches false breakouts)
 MIN_15M_VELOCITY = 0.3          # 15m velocity must be actively building
 
 # Conviction-scaled leverage — small caps capped at 7x (low-liq slippage)
 SIZING_TIERS = [
-    {"min_score": 11, "leverage": 7,  "label": "apex"},
-    {"min_score": 9,  "leverage": 5,  "label": "conviction"},
-    {"min_score": 7,  "leverage": 3,  "label": "cautious"},
+    {"min_score": 11, "leverage": 7, "label": "apex"},        # Score 11-12: the right tail
+    {"min_score": 9,  "leverage": 5, "label": "conviction"},  # Score 9-10: the new floor tier
 ]
 
 


### PR DESCRIPTION
## Why
Vulture's agent ran an aggregate analysis on the last 30 closed trades grouped by producer entry score and identified that the bottom buckets weren't pulling their weight:

| Score | Trades | Avg ROE | Win Rate |
|---:|---:|---:|---:|
| 12 | 4 |  +5.56% | 25.0% (the fat tail — one +33.3% HYPE home run) |
| 11 | 5 |  -1.04% | 60.0% |
| 10 | 3 | +10.54% | 66.7% |
|  9 | 2 |  -3.17% | 50.0% |
|  8 | 7 |  -3.52% | 28.6% |
|  7 | 8 |  -3.94% | 12.5% |

Score 7–8 (n=15 combined) ran terrible win rates with consistently negative avg ROE. The DSL was chopping each one at the Phase 1 hard stop before they did real damage, but they were still net-negative and churning fees/attention.

Agent raised `MIN_SCORE` 7→9 on the live host and validated. This PR mirrors that change at the repo level so future operators inherit the improvement.

## What changed
- **`vulture-producer.py`** — `MIN_SCORE 7 → 9`, `VERSION 4.0.0 → 4.1.0`, removed the `cautious` sizing tier (score 7-8, 3x — unreachable now). Added the 30-trade table to the SCORING CONFIG header so the rationale is in-code.
- **`runtime.yaml`** — `min_confidence 7 → 8` (matches new producer floor with a 1-point buffer). Updated `decision_prompt` HARD SKIP, CONFIDENCE SCORING, and minimum-confidence text. Bumped header version comment.
- **`SKILL.md`** — metadata version → 4.1.0, MIN_SCORE paragraph rewritten with the data, Conviction-Scaled Leverage table dropped cautious row, Lemon-vs-Vulture comparison `MIN_SCORE 7 → 9`, added v4.1.0 changelog with the full data table.
- **`README.md`** — parameters table sync: MIN_SCORE 7→9, min_confidence 7→8, leverage tiers cleaned up (5x/7x), margin-per-slot description corrected to budget-relative (was a stale fixed \$400).
- **`producer-patterns.md`** — bumped roster row v2.3 → v4.1; corrected the description (still labeled HYPE-funding-contrarian — stale since v2.0; actual thesis is small-cap long-tail momentum on 25 perps). Noted the legacy bucket on the fleet-roster mapping row.

## Test plan
- [x] `python3 -m py_compile vulture/scripts/vulture-producer.py` — OK
- [x] `runtime.yaml` parses via `yaml.safe_load`
- [x] No stale `MIN_SCORE = 7` / `min_confidence: 7` / `"min_score": 7` references remain anywhere in `vulture/`
- [x] Producer's `SIZING_TIERS` no longer contains the `cautious` entry (unreachable given new floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)