### PR TITLE
Wave 2 — Koala, Lynx, Coyote (3 strategies + 2 new archetypes #15 #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Each tool's full schema (params, types, response shape) is in the MCP server its
 
 # Trading Strategy Skills
 
-The fleet — **41 skills across 14 producer archetypes**. Every skill targets runtime **1.1.0**. Bucketing matches [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md), the canonical archetype catalog.
+The fleet — **44 skills across 16 producer archetypes**. Every skill targets runtime **1.1.0**. Bucketing matches [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md), the canonical archetype catalog.
 
 Each row links to the skill's directory.
 
@@ -360,6 +360,7 @@ Pick by what you want to trade. Each is its own self-contained skill directory a
 | Skill | Assets | Description |
 |---|---|---|
 | [tortoise](tortoise/) | BTC + ETH + SOL | **DCA scheduler.** Buys a fixed % of budget on a strict 24h cadence. No price prediction, no scoring — most-overdue past interval wins. LONG only. The most accessible trade in crypto: zero prediction skill required. |
+| [koala](koala/) | Single asset (default BTC) | **Set-and-forget HODL.** Fires one LONG signal per lifetime and holds with the widest DSL in any Senpi agent (max_loss 30%, retrace 25, 90d hard_timeout). No scoring, no decisions after deploy. The simplest possible Senpi agent — for users whose entire trading thesis is "I want to own BTC and have a safety net." |
 
 ### 🟣 Multi-week Arena Conviction Mirror
 
@@ -387,7 +388,7 @@ Senpi's distinctive moat — equity, commodity, and pre-IPO perps that retail ca
 
 ---
 
-# The 14 production archetypes
+# The 16 production archetypes
 
 Below are the production-tier strategies sorted by their producer-pattern archetype. See [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md) for the canonical pattern catalog. The onboarding tier above maps into these same archetypes (Beaver/Heron/Hummingbird are single-asset; Hedgehog/Hawk/Salamander/Bobcat are multi-asset whitelist; Albatross is trader-follower; Lemur/Raccoon are XYZ specialist).
 
@@ -412,6 +413,7 @@ One asset, six-gate entry validation, tight scoring, conviction-tiered leverage.
 | [grizzly](grizzly/) | v5.3 | BTC | BTC-tuned thresholds — calmer regime, tighter sizing. |
 | [polar](polar/) | v3.0 | ETH | ETH-tuned thresholds, deep confluence required. |
 | [wolverine](wolverine/) | v3.0 | HYPE | HYPE-tuned thresholds for its high-vol native profile. |
+| [koala](koala/) | v1.0 | Operator-chosen (default BTC) | **Onboarding tier — state-trigger variant.** No scoring, no `market_get_asset_data` call. Fires ONE LONG signal per lifetime and holds with the widest DSL in any Senpi agent (max_loss 30%, retrace 25, 90d hard_timeout). For users whose entire trading thesis is "I want to own BTC and have a safety net." |
 
 ## 3. Single-asset XYZ specialist
 
@@ -529,6 +531,22 @@ Follow not individual traders but the top-performing **strategies** — and trad
 | Skill | Version | Asset / Universe | Description |
 |---|---|---|---|
 | [cuckoo](cuckoo/) | v1.0 | Top-strategy consensus | Auto-discovers the top-N strategies by performance and trades what ≥2 of them agree on most, weighted by each one's ROI (capped so one outlier can't dominate). Wide DSL + 96h staleness cap. **User-scope auth.** |
+
+## 15. Self-tuning / adaptive-threshold agent
+
+The first archetype where the agent **modifies its own behavior based on its own trade history.** The agent runs a normal scoring producer but on a scheduled cron pulls its own closed-trade telemetry (via `audit_query`), buckets trades by entry score, and auto-raises `MIN_SCORE` when bottom buckets bleed. Productizes the [Vulture v4.1 manual cull](https://github.com/Senpi-ai/senpi-skills/pull/337) as a first-class pattern.
+
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [lynx](lynx/) | v1.0 | BTC · ETH · SOL · HYPE | Multi-asset momentum scorer with a 6h audit cron. Every audit: pull own closed trades, bucket by entry score, raise `MIN_SCORE` if any bucket at-or-above the floor has ≥8 samples averaging worse than -1% ROE. Caps at `maxMinScore: 7`. Logs every adjustment with bleeding-bucket evidence. **First fleet agent that modifies its own behavior based on its own track record.** |
+
+## 16. Regime classifier / meta-router
+
+Watches macro conditions and **classifies the market** into TREND_UP / TREND_DOWN / CHOP. Publishes the classification in every tick output — including ticks where no trade is taken. The "meta-router" framing is aspirational: future runtime work can let other agents subscribe to the regime channel as a gating input.
+
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [coyote](coyote/) | v1.0 | BTC (positional) + universe (dispersion) | 3-regime classifier (TREND_UP / TREND_DOWN / CHOP) with vol-confirmation on the down side (crash = drop + vol spike, not slow grind). LONG BTC in TREND_UP, SHORT BTC in TREND_DOWN, no trade in CHOP. Regime + all 3 input metrics published on every tick. Balanced DSL. |
 
 For full archetype theses, distinguishing MCP signatures, and code snippets, see [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md).
 

--- a/catalog.json
+++ b/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "1.0",
-  "_updated": "2026-05-28",
+  "_updated": "2026-05-29",
   "_instructions": "Agent reads this file to build the onboarding skill catalog. Group by 'group', sort within group by 'sort_order'. Infrastructure skills (DSL, fee optimizer, scanners) are never displayed.",
   "groups": [
     {
@@ -133,6 +133,36 @@
       "base_skill": null,
       "branch": "main",
       "predators_url": "https://strategies.senpi.ai/bot/stag",
+      "version": "1.0.0"
+    },
+    {
+      "id": "lynx",
+      "tracker_slug": "lynx",
+      "name": "Lynx \u2014 Adaptive MIN_SCORE Self-Tuner",
+      "emoji": "\ud83d\udc2f",
+      "tagline": "The Vulture v4.1 story productized. First fleet agent that modifies its own behavior based on its own trade history \u2014 every 6h Lynx audits its closed trades and raises MIN_SCORE if low-conviction buckets bleed.",
+      "group": "self-tuning",
+      "sort_order": 47,
+      "min_budget": 500,
+      "risk_level": "aggressive",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/lynx",
+      "version": "1.0.0"
+    },
+    {
+      "id": "coyote",
+      "tracker_slug": "coyote",
+      "name": "Coyote \u2014 Regime Classifier / Meta-Router",
+      "emoji": "\ud83d\udc3a",
+      "tagline": "The agent that asks \"what kind of market are we in?\" before anything else. Classifies TREND_UP / TREND_DOWN / CHOP and publishes the view on every tick. LONG BTC in TREND_UP, SHORT BTC in TREND_DOWN.",
+      "group": "regime-classifier",
+      "sort_order": 48,
+      "min_budget": 500,
+      "risk_level": "moderate",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/coyote",
       "version": "1.0.0"
     },
     {
@@ -794,6 +824,21 @@
       "branch": "main",
       "predators_url": "https://strategies.senpi.ai/bot/wolverine",
       "version": "6.0.0"
+    },
+    {
+      "id": "koala",
+      "tracker_slug": "koala",
+      "name": "Koala \u2014 Set-and-Forget HODL",
+      "emoji": "\ud83d\udc28",
+      "tagline": "The simplest possible Senpi agent. Pick an asset, fire LONG once, hold with the widest DSL in any Senpi agent. For users whose entire thesis is \"I want to own BTC and have a safety net.\"",
+      "group": "single-asset-hunter",
+      "sort_order": 46,
+      "min_budget": 500,
+      "risk_level": "conservative",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/koala",
+      "version": "1.0.0"
     }
   ]
 }

--- a/coyote/README.md
+++ b/coyote/README.md
@@ -1,0 +1,138 @@
+# 🐺 Coyote — Regime Classifier / Meta-Router
+
+**The agent that asks "what kind of market are we in?" before anything else.** Coyote watches macro conditions and classifies the market into TREND_UP / TREND_DOWN / CHOP. Takes LONG BTC in TREND_UP, SHORT BTC in TREND_DOWN, stays out in CHOP. Publishes the regime view on every tick.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/skills).
+
+## Thesis
+
+Every Senpi agent re-implements its own version of "should I be active right now?" — but the macro answer is shared across the fleet. Coyote centralizes it. **NEW archetype #16: Regime classifier / meta-router** — its classification is emitted on every tick output for both operators (today) and future regime-subscription runtime features (soon).
+
+## Key parameters
+
+| Parameter | Default |
+|---|---|
+| BTC asset | `BTC` |
+| Dispersion universe | BTC · ETH · SOL · HYPE |
+| Tick interval | 900s (15 min — regimes don't flip in 5 min) |
+| Trend lookback | 42 × 4h bars (7 days) |
+| Vol lookback | 42 × 4h bars (7 days) |
+| `trendUpThresholdPct` | 5.0 |
+| `trendDownThresholdPct` | 5.0 |
+| `maxVolForTrendPct` | 80% (TREND_UP requires vol ≤ this) |
+| `minVolForCrashPct` | 60% (TREND_DOWN requires vol ≥ this) |
+| Direction | LONG in TREND_UP, SHORT in TREND_DOWN, no trade in CHOP |
+| Leverage | 3x default, max 5x |
+| Margin per slot | 25% of equity |
+| Max entries per day | 2 (regimes are persistent) |
+| Per-asset cooldown | 360 min (6h) |
+| Daily loss limit | 15% |
+| Drawdown halt | 22% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (taker-true) |
+
+## DSL preset (`balanced`)
+
+Standard balanced — regimes hold for days; Coyote's positional bet rides them.
+
+## Scanner pattern
+
+NEW archetype #16: **Regime classifier / meta-router**. Primary MCP call: `market_get_asset_data` per universe asset (just for close prices). Pure functions unit-tested in `tests/test_signal.py` (`python3 coyote/tests/test_signal.py` — 14 tests).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, balanced DSL, `risk.guard_rails`) |
+| scripts/coyote-producer.py | Long-lived daemon; classifies regime + emits COYOTE_REGIME |
+| scripts/coyote_config.py | SDK probe + SenpiClient wrapper + recent-signals cache |
+| config/coyote-config.json | Operator-tunable defaults (regime thresholds) |
+| tests/test_signal.py | Unit tests for the regime-classification logic |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Coyote
+
+```bash
+mkdir -p /data/workspace/skills/coyote-strategy/{config,scripts,state,references}
+for f in scripts/coyote-producer.py scripts/coyote_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/coyote-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/coyote/$f" \
+    -o "/data/workspace/skills/coyote-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID
+
+Edit `/data/workspace/skills/coyote-strategy/config/coyote-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export COYOTE_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export COYOTE_DECISION_MODEL=<your-preferred-model>
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/coyote-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/coyote-strategy/scripts/coyote-producer.py \
+  > /tmp/coyote-producer.log 2>&1 &
+disown
+```
+
+## Verification
+
+```bash
+sleep 920  # wait one full tick
+tail -3 /tmp/coyote-producer.log | jq '._coyote_producer_version, .regime, .btc_7d_move_pct'
+```
+
+You should see the regime classification on every tick — even when there's no trade. Example outputs:
+
+- `{"regime": "CHOP", "btc_7d_move_pct": 1.2, "realized_vol_pct": 45.0}` — quiet market, no trade
+- `{"regime": "TREND_UP", "best": {"coin": "BTC", "direction": "LONG", ...}}` — uptrend confirmed, BTC LONG fired
+- `{"regime": "UNKNOWN", "btc_7d_move_pct": null}` — data unavailable (transient)
+
+## Reading Coyote's regime view in your other agents (operator workflow)
+
+For now (until regime-subscription lands in the runtime), the workflow is manual:
+
+```bash
+# Quick check from the command line:
+tail -1 /tmp/coyote-producer.log | jq '.regime'
+
+# Or watch it live:
+tail -f /tmp/coyote-producer.log | jq '.regime'
+```
+
+If Coyote says **TREND_UP**, your trend-followers (Beaver, Wolverine, Sheep) are most likely to pay. If **TREND_DOWN**, your contrarian agents are at higher risk (the crowd was on the wrong side). If **CHOP**, your faders (Egret, Owl) are in their happy place. Use the read to decide which agents to deploy or pause.
+
+## Changelog
+
+### v1.0.0 (2026-05-29) — initial release
+
+First fleet agent built around **macro-regime classification as a first-class capability**. Introduces archetype #16 (regime classifier / meta-router). Publishes regime on every tick. 14/14 unit tests covering all pure functions. Taker-true entry, disown-safe launch.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/coyote/SKILL.md
+++ b/coyote/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: coyote-strategy
+description: >-
+  COYOTE v1.0.0 — Regime Classifier / Meta-Router. Watches macro conditions
+  (BTC 7d trend, BTC realized volatility, cross-asset dispersion) and
+  classifies the market into TREND_UP / TREND_DOWN / CHOP. Takes LONG BTC
+  in TREND_UP, SHORT BTC in TREND_DOWN, stays out in CHOP. Publishes the
+  regime classification in every tick output so downstream tooling (and
+  future regime-subscription runtime features) can read Coyote's view.
+  NEW archetype #16: Regime classifier / meta-router.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐺 COYOTE v1.0.0 — Regime Classifier / Meta-Router
+
+**The agent that asks "what kind of market are we in?" before anything else.** Coyote watches macro conditions and classifies the market into TREND_UP / TREND_DOWN / CHOP. It takes a single positional expression of its regime view — and publishes that view on every tick.
+
+## Why this strategy exists
+
+Every Senpi agent currently re-implements its own version of "should I be active right now?" Vulture has a HEAVY_FLOW gate. Wolverine has a multi-timeframe alignment check. Tortoise just buys regardless. None of them share a *centralized* view of the macro regime — they each make local calls.
+
+Coyote is the start of fixing that. Its classification is **emitted in every signal data block** (and in every tick output, including when no trade fires), so:
+- **Today**: operators can read Coyote's regime view directly to inform manual decisions about which agents to enable/pause.
+- **Soon (runtime work pending)**: other agents will be able to *subscribe* to Coyote's regime channel as a gating input, so e.g. Tortoise auto-pauses in TREND_DOWN and Stag auto-enables in TREND_UP.
+
+The "meta-router" framing is aspirational for v1 — Coyote also takes its own regime-positional trade so it has skin in its own calls.
+
+## CRITICAL RULES
+
+### RULE 1: Three regimes, two trades
+Coyote classifies into exactly three states:
+
+| Regime | Trigger | Action |
+|---|---|---|
+| **TREND_UP** | BTC 7d move ≥ `trendUpThresholdPct` (default 5%) AND realized vol ≤ `maxVolForTrendPct` (default 80%) | LONG BTC |
+| **TREND_DOWN** | BTC 7d move ≤ −`trendDownThresholdPct` (default 5%) AND realized vol ≥ `minVolForCrashPct` (default 60%) | SHORT BTC |
+| **CHOP** | otherwise | no trade |
+
+TREND_DOWN explicitly requires *high* volatility — Coyote distinguishes a "panic crash" (sharp drop + vol spike) from a "slow grind down" (small drop, low vol, which is just CHOP). This avoids shorting orderly pullbacks.
+
+### RULE 2: Always publish the regime
+Even when no trade is taken (CHOP / UNKNOWN), the producer outputs the regime classification + all three input metrics (BTC 7d move %, realized vol %, dispersion %) in its tick result. Operators can read `tail /tmp/coyote-producer.log | jq .regime` at any moment.
+
+### RULE 3: Dispersion is informational (for now)
+Cross-asset dispersion (stdev of recent returns across the universe) is computed and published but doesn't currently enter the gate logic. Future versions may use it to refine regime detection (e.g. high dispersion + flat BTC = "rotation regime"). For v1 it's there for operator visibility.
+
+### RULE 4: Producer NEVER closes
+DSL owns exits. Coyote enters at the regime transition; the DSL trail manages the position through the regime's life.
+
+### RULE 5: Regimes are persistent — don't churn
+`per_asset_cooldown_minutes: 360` (6h) and `max_entries_per_day: 2` so Coyote doesn't flip back and forth on noise. Real regimes last days or weeks; a clean classification doesn't change ticks-over-ticks.
+
+## How Coyote computes regime
+
+Three pure metrics, all from `market_get_asset_data` 4h candles:
+
+- **`btc_7d_pct`** = `% change of latest BTC close vs the close 42 4h-bars ago` (7 days)
+- **`realized_vol_pct`** = `stdev of log returns × sqrt(2190) × 100` (annualized, 4h bars assume 24/7 trading)
+- **`dispersion_pct`** = `stdev of recent returns across {BTC, ETH, SOL, HYPE}` (cross-sectional)
+
+Then a 4-way switch: `classify_regime(btc_move, vol, ...thresholds) → TREND_UP / TREND_DOWN / CHOP / UNKNOWN`. UNKNOWN fires when input data is missing.
+
+## DSL preset (`balanced`)
+
+Standard balanced. Regimes hold for days; Coyote's positional bet rides them.
+
+## Scanner pattern
+
+NEW archetype #16: **Regime classifier / meta-router** — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP call: `market_get_asset_data` per universe asset (just for close prices). The pure functions (`pct_move`, `realized_vol_pct`, `dispersion_pct`, `classify_regime`, `regime_to_direction`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-29) — initial release
+
+First fleet agent built around **macro-regime classification as a first-class capability**. Introduces archetype #16 (regime classifier / meta-router). Publishes regime on every tick. Takes its own positional bet so it has skin in its own classification. 14/14 unit tests covering all pure functions. Taker-true entry, disown-safe launch.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/coyote/config/coyote-config.json
+++ b/coyote/config/coyote-config.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "COYOTE v1.0.0 — Regime Classifier / Meta-Router. Each tick computes BTC 7d move + annualized realized vol + cross-asset dispersion across the dispersionUniverse, then classifies the market: TREND_UP (BTC 7d >= trendUpThresholdPct AND vol <= maxVolForTrendPct), TREND_DOWN (BTC 7d <= -trendDownThresholdPct AND vol >= minVolForCrashPct), CHOP (otherwise). Routes to LONG BTC / SHORT BTC / no trade. Regime classification is published in every signal data block (and in every WAITING output) so operators can read Coyote's regime view at any tick. NEW archetype #16: Regime classifier / meta-router. Tick 900s. Balanced DSL. Edit wallet/strategyId/chatId; tune regime thresholds.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "btcAsset": "BTC",
+  "dispersionUniverse": ["BTC", "ETH", "SOL", "HYPE"],
+  "trendLookbackBars": 42,
+  "volLookbackBars": 42,
+  "dispersionLookbackBars": 24,
+  "trendUpThresholdPct": 5.0,
+  "trendDownThresholdPct": 5.0,
+  "maxVolForTrendPct": 80.0,
+  "minVolForCrashPct": 60.0,
+  "marginPct": 0.25,
+  "leverage": 3
+}

--- a/coyote/references/skill-attribution.md
+++ b/coyote/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "coyote",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "coyote",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/coyote/runtime.yaml
+++ b/coyote/runtime.yaml
@@ -1,0 +1,179 @@
+name: coyote-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Coyote v1.0.0"
+# and lives in description + SKILL.md + _coyote_producer_version.
+version: 1.0.0
+description: >
+  COYOTE v1.0.0 — Regime Classifier / Meta-Router.
+
+  Coyote watches macro conditions (BTC 7d trend strength, BTC realized
+  volatility, cross-asset dispersion) and classifies the market into
+  TREND_UP / TREND_DOWN / CHOP. In TREND_UP it takes LONG BTC; in TREND_DOWN
+  it takes SHORT BTC; in CHOP it stays out and publishes its regime view
+  for operator visibility.
+
+  NEW archetype #16: Regime classifier / meta-router. The classification is
+  emitted in every signal data block so downstream tooling (and future
+  regime-subscription runtime features) can read Coyote's regime channel.
+
+  Architecture (helpers-native): producer ticks every 900s (15min — regimes
+  don't flip in 5 minutes). Computes pct_move + annualized realized vol +
+  cross-asset dispersion. Classify, route, emit. Producer NEVER closes —
+  DSL owns exits.
+
+  DSL: balanced preset. Coyote takes regime-positional bets; standard
+  trend/contrarian DSL serves both directions.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_pct: 25            # % of account budget per slot — single regime bet
+  trading_risk: balanced
+  enabled: true
+
+risk:
+  data_retention_hours: 168
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 2     # regimes are persistent — don't churn
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 360       # 6h between regime trades
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 360
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: coyote_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        regime: { type: string, required: false }
+        btc7dMovePct: { type: number, required: false }
+        realizedVolPct: { type: number, required: false }
+        dispersionPct: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: coyote_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${COYOTE_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [coyote_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true        # regime is established; enter NOW
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: coyote_signals
+    decision_prompt: |
+      You are Coyote's pass-through gate. Coyote classifies the market into
+      TREND_UP / TREND_DOWN / CHOP and only sends a signal when a directional
+      regime is identified. The producer already classified; honor the regime.
+
+      SIGNAL:
+      {{signal_coyote_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (always BTC in v1).
+      2. direction MUST be copied from signal.direction (LONG for TREND_UP,
+         SHORT for TREND_DOWN).
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - regime != "TREND_UP" AND regime != "TREND_DOWN"
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: regime is TREND_UP/TREND_DOWN AND |btc7dMovePct| >= 8
+      - 7-8:  regime cleared the producer thresholds
+      - <7:   regime did not clear (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'TREND_UP regime: BTC +8.3% over 7d, realized vol 52% — long BTC')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "COYOTE_REGIME ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — balanced) ────────────────────────────────────
+#
+# Regime trades hold for the duration of the regime. Balanced ladder +
+# weak_peak_cut so a stalled regime trade gets cut.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 7200           # 5d
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 30 }
+        - { trigger_pct: 35,  lock_hw_pct: 50 }
+        - { trigger_pct: 60,  lock_hw_pct: 70 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/coyote/scripts/coyote-producer.py
+++ b/coyote/scripts/coyote-producer.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# Senpi COYOTE Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""COYOTE v1.0.0 — Regime Classifier / Meta-Router.
+
+Coyote watches macro conditions and classifies the market into TREND_UP /
+TREND_DOWN / CHOP, based on:
+
+  - BTC 7d move magnitude (trend strength)
+  - BTC realized volatility (recent stdev of log returns)
+  - Cross-asset dispersion (standard deviation of recent returns across the
+    monitored universe — high = mixed market, low = synchronized)
+
+Regime rules (in order):
+
+  TREND_UP   : btc_7d_move >= trendUpThresholdPct AND realized_vol <= maxVolForTrendPct
+  TREND_DOWN : btc_7d_move <= -trendDownThresholdPct AND realized_vol >= minVolForCrashPct
+  CHOP       : anything else
+
+In TREND_UP, Coyote takes a LONG BTC position. In TREND_DOWN, SHORT BTC.
+In CHOP, no signal — but the regime is still published in the producer
+output so operators can read Coyote's regime view at any tick.
+
+NEW archetype #16: Regime classifier / meta-router. The "meta" framing is
+aspirational — once the runtime supports regime-subscription, other agents
+will be able to gate on Coyote's regime channel directly.
+
+Architecture: helpers-native producer + balanced DSL. Stateless regime
+computation + race-window dedup + 6h per-asset cooldown (regime regimes
+don't flip in five minutes). Producer NEVER closes — DSL owns exits.
+
+REQUIRES USER-SCOPE AUTH for leaderboard_get_markets.
+"""
+
+import hashlib
+import math
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import coyote_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "coyote_signals"
+SIGNAL_TYPE = "COYOTE_REGIME"
+
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 3
+
+DEFAULT_BTC = "BTC"
+DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL", "HYPE"]   # used for dispersion
+
+# 4h-bar lookbacks:
+DEFAULT_TREND_LOOKBACK = 42            # 7d
+DEFAULT_VOL_LOOKBACK = 42              # 7d realized vol
+DEFAULT_DISPERSION_LOOKBACK = 24       # 4d dispersion
+
+# Regime thresholds (operator-tunable; defaults conservative):
+DEFAULT_TREND_UP_THRESHOLD_PCT = 5.0
+DEFAULT_TREND_DOWN_THRESHOLD_PCT = 5.0   # symmetric default
+DEFAULT_MAX_VOL_FOR_TREND_PCT = 80.0     # annualized realized vol cap for TREND_UP
+DEFAULT_MIN_VOL_FOR_CRASH_PCT = 60.0     # vol floor for TREND_DOWN to confirm crash regime
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("COYOTE_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure regime-classification logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def pct_move(closes, lookback):
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def realized_vol_pct(closes, lookback, bars_per_year=2190):
+    """Annualized realized volatility (stdev of log returns × sqrt(N)),
+    expressed as a percentage. `bars_per_year` defaults to 2190 (4h bars,
+    24/7 trading). None if insufficient data."""
+    if not closes or len(closes) < lookback + 1:
+        return None
+    series = closes[-(lookback + 1):]
+    log_returns = []
+    for prev, curr in zip(series[:-1], series[1:]):
+        if prev is None or prev <= 0 or curr is None or curr <= 0:
+            continue
+        log_returns.append(math.log(curr / prev))
+    if len(log_returns) < 2:
+        return None
+    mean = sum(log_returns) / len(log_returns)
+    var = sum((r - mean) ** 2 for r in log_returns) / (len(log_returns) - 1)
+    stdev = math.sqrt(var)
+    return stdev * math.sqrt(bars_per_year) * 100.0
+
+
+def dispersion_pct(returns_by_asset):
+    """Cross-sectional dispersion: stdev of returns across assets.
+    `returns_by_asset` is a dict {asset: recent_return_pct}.
+    High dispersion = mixed market; low = synchronized. Returns None if
+    fewer than 2 assets have data."""
+    values = [r for r in returns_by_asset.values() if r is not None]
+    if len(values) < 2:
+        return None
+    mean = sum(values) / len(values)
+    var = sum((v - mean) ** 2 for v in values) / (len(values) - 1)
+    return math.sqrt(var)
+
+
+def classify_regime(btc_7d_pct, realized_vol_pct_value,
+                    trend_up_threshold, trend_down_threshold,
+                    max_vol_for_trend, min_vol_for_crash):
+    """Classify the market regime from BTC trend strength + realized vol.
+
+    Returns one of: "TREND_UP" | "TREND_DOWN" | "CHOP" | "UNKNOWN".
+    UNKNOWN is returned if required inputs are missing.
+    """
+    if btc_7d_pct is None or realized_vol_pct_value is None:
+        return "UNKNOWN"
+    if btc_7d_pct >= trend_up_threshold and realized_vol_pct_value <= max_vol_for_trend:
+        return "TREND_UP"
+    if btc_7d_pct <= -trend_down_threshold and realized_vol_pct_value >= min_vol_for_crash:
+        return "TREND_DOWN"
+    return "CHOP"
+
+
+def regime_to_direction(regime):
+    """Map a regime classification to an entry direction. None if no trade."""
+    if regime == "TREND_UP":
+        return "LONG"
+    if regime == "TREND_DOWN":
+        return "SHORT"
+    return None
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_candles(asset):
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return []
+    return data.get("data", {}).get("candles", {}).get("4h", [])
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(direction, regime, btc_move, vol, dispersion, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    if DEFAULT_BTC in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": 5,
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": direction,
+        "reasons": [f"regime_{regime}", f"btc_7d_{btc_move:+.1f}%", f"vol_{vol:.0f}%"],
+        "regime": regime,
+        "btc7dMovePct": float(btc_move) or 0.0,
+        "realizedVolPct": float(vol) or 0.0,
+        "dispersionPct": float(dispersion) if dispersion is not None else 0.0,
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=DEFAULT_BTC,
+            direction=direction,
+            score=0.7,
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED BTC: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION BTC: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    btc_asset = config.get("btcAsset", DEFAULT_BTC)
+    universe = config.get("dispersionUniverse", DEFAULT_UNIVERSE)
+
+    trend_lb = int(config.get("trendLookbackBars", DEFAULT_TREND_LOOKBACK))
+    vol_lb = int(config.get("volLookbackBars", DEFAULT_VOL_LOOKBACK))
+    disp_lb = int(config.get("dispersionLookbackBars", DEFAULT_DISPERSION_LOOKBACK))
+
+    trend_up_th = float(config.get("trendUpThresholdPct", DEFAULT_TREND_UP_THRESHOLD_PCT))
+    trend_dn_th = float(config.get("trendDownThresholdPct", DEFAULT_TREND_DOWN_THRESHOLD_PCT))
+    max_vol_trend = float(config.get("maxVolForTrendPct", DEFAULT_MAX_VOL_FOR_TREND_PCT))
+    min_vol_crash = float(config.get("minVolForCrashPct", DEFAULT_MIN_VOL_FOR_CRASH_PCT))
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_coyote_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_coyote_producer_version": VERSION})
+        return
+
+    # Fetch BTC candles for trend + vol
+    btc_candles = fetch_candles(btc_asset)
+    btc_closes = [_f(c, "close", "c") for c in btc_candles]
+    btc_move = pct_move(btc_closes, trend_lb)
+    btc_vol = realized_vol_pct(btc_closes, vol_lb)
+
+    # Fetch all universe candles for dispersion (each asset's recent return)
+    returns_by_asset = {}
+    for a in universe:
+        cd = fetch_candles(a) if a != btc_asset else btc_candles
+        closes = [_f(c, "close", "c") for c in cd]
+        returns_by_asset[a] = pct_move(closes, disp_lb)
+    disp = dispersion_pct(returns_by_asset)
+
+    regime = classify_regime(btc_move, btc_vol, trend_up_th, trend_dn_th, max_vol_trend, min_vol_crash)
+    direction = regime_to_direction(regime)
+
+    # Always publish regime view (even when no trade)
+    if direction is None:
+        cfg.output({
+            "status": "ok",
+            "note": f"REGIME={regime} — no positional expression (CHOP or UNKNOWN)",
+            "regime": regime,
+            "btc_7d_move_pct": round(btc_move, 2) if btc_move is not None else None,
+            "realized_vol_pct": round(btc_vol, 1) if btc_vol is not None else None,
+            "dispersion_pct": round(disp, 2) if disp is not None else None,
+            "returns_by_asset": {k: (round(v, 2) if v is not None else None) for k, v in returns_by_asset.items()},
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_coyote_producer_version": VERSION,
+        })
+        return
+
+    if btc_asset.upper() in {h.upper() for h in held_assets} or cfg.was_recently_signaled(btc_asset):
+        cfg.output({
+            "status": "ok",
+            "note": f"REGIME={regime}, direction={direction}, but BTC already held or recently signaled",
+            "regime": regime,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_coyote_producer_version": VERSION,
+        })
+        return
+
+    margin_pct = float(config.get("marginPct", 0.25))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(direction, regime, btc_move, btc_vol, disp, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(btc_asset)
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": btc_asset,
+            "direction": direction,
+            "regime": regime,
+            "btc_7d_move_pct": round(btc_move, 2),
+            "realized_vol_pct": round(btc_vol, 1),
+            "dispersion_pct": round(disp, 2) if disp is not None else None,
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+        },
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_coyote_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=900,   # 15min — regimes don't flip in 5 minutes
+        name=f"coyote-producer-{_wallet_lock_id}",
+        tick_timeout=180,
+    )

--- a/coyote/scripts/coyote_config.py
+++ b/coyote/scripts/coyote_config.py
@@ -1,0 +1,206 @@
+"""COYOTE v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Regime Classifier / Meta-Router. Coyote watches macro conditions (BTC trend,
+realized vol, cross-asset dispersion, funding regime) and classifies the
+market into TREND_UP / TREND_DOWN / CHOP. It then takes a single positional
+expression of that regime: LONG BTC during TREND_UP, SHORT BTC during
+TREND_DOWN, stay out during CHOP.
+
+The regime classification is emitted as a top-level field in the signal data
+block — so operators (and downstream tooling) can read Coyote's regime view
+on every tick, even when no trade is taken. The "meta-router" framing is
+aspirational for now: future runtime work can let other agents subscribe to
+Coyote's regime channel as a gating input.
+
+NEW archetype #16: Regime classifier / meta-router.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+balanced DSL (Coyote takes single-asset positional bets on its own regime
+call). Stateless regime computation + race-window dedup. Producer NEVER
+closes — DSL owns exits.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "coyote-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "coyote-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Coyote's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("coyote_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def mcp_call(tool, **params):
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] coyote_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[coyote-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/coyote/tests/test_signal.py
+++ b/coyote/tests/test_signal.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Unit tests for Coyote's pure functions (pct_move, realized_vol_pct,
+dispersion_pct, classify_regime, regime_to_direction). Stubs coyote_config +
+senpi_runtime_helpers.
+Run: python3 coyote/tests/test_signal.py
+"""
+import importlib.util
+import math
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("coyote_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["coyote_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "coyote-producer.py"
+_spec = importlib.util.spec_from_file_location("coyote_producer", _path)
+co = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(co)
+
+
+# ── pct_move ───────────────────────────────────────────────────
+
+def test_pct_move_known_value():
+    closes = [100.0] * 43
+    closes[-1] = 110.0
+    assert abs(co.pct_move(closes, 42) - 10.0) < 1e-9
+
+
+def test_pct_move_insufficient_and_bad_ref():
+    assert co.pct_move([1, 2, 3], 42) is None
+    assert co.pct_move([0.0] * 43, 42) is None
+
+
+# ── realized_vol_pct ───────────────────────────────────────────
+
+def test_realized_vol_constant_series_is_zero():
+    # Flat series → zero realized vol
+    closes = [100.0] * 50
+    v = co.realized_vol_pct(closes, lookback=42)
+    assert v is not None
+    assert abs(v) < 1e-9
+
+
+def test_realized_vol_oscillating_series_is_positive():
+    # +1% / -1% alternation has real variance
+    closes = [100.0]
+    for i in range(50):
+        # alternate up/down
+        prev = closes[-1]
+        closes.append(prev * 1.01 if i % 2 == 0 else prev * 0.99)
+    v = co.realized_vol_pct(closes, lookback=42)
+    assert v is not None and v > 0
+
+
+def test_realized_vol_insufficient_returns_none():
+    assert co.realized_vol_pct([100, 101], lookback=42) is None
+
+
+# ── dispersion_pct ─────────────────────────────────────────────
+
+def test_dispersion_pct_synchronized_market_low():
+    # All assets moved exactly the same → near-zero dispersion
+    returns = {"BTC": 5.0, "ETH": 5.0, "SOL": 5.0, "HYPE": 5.0}
+    d = co.dispersion_pct(returns)
+    assert d is not None and d < 1e-9
+
+
+def test_dispersion_pct_mixed_market_high():
+    # Assets diverge → positive dispersion
+    returns = {"BTC": 5.0, "ETH": -3.0, "SOL": 12.0, "HYPE": -8.0}
+    d = co.dispersion_pct(returns)
+    assert d is not None and d > 5.0
+
+
+def test_dispersion_pct_insufficient_returns_none():
+    # Only one asset with data → cannot compute
+    assert co.dispersion_pct({"BTC": 5.0}) is None
+    assert co.dispersion_pct({"BTC": None, "ETH": None}) is None
+
+
+# ── classify_regime ────────────────────────────────────────────
+
+def test_classify_regime_trend_up():
+    # BTC +8% over 7d, vol moderate (50% annualized) → TREND_UP
+    assert co.classify_regime(8.0, 50.0, 5.0, 5.0, 80.0, 60.0) == "TREND_UP"
+
+
+def test_classify_regime_trend_down_requires_vol_confirmation():
+    # BTC -8% with HIGH vol (70%) → TREND_DOWN (crash regime confirmed)
+    assert co.classify_regime(-8.0, 70.0, 5.0, 5.0, 80.0, 60.0) == "TREND_DOWN"
+    # BTC -8% but LOW vol (40%) — slow grind down doesn't qualify as TREND_DOWN
+    assert co.classify_regime(-8.0, 40.0, 5.0, 5.0, 80.0, 60.0) == "CHOP"
+
+
+def test_classify_regime_trend_up_blocked_by_vol():
+    # BTC +8% but vol is 100% (extreme) → not a clean uptrend → CHOP
+    assert co.classify_regime(8.0, 100.0, 5.0, 5.0, 80.0, 60.0) == "CHOP"
+
+
+def test_classify_regime_below_thresholds_is_chop():
+    # Small trend, moderate vol → CHOP
+    assert co.classify_regime(2.0, 50.0, 5.0, 5.0, 80.0, 60.0) == "CHOP"
+
+
+def test_classify_regime_missing_inputs():
+    assert co.classify_regime(None, 50.0, 5.0, 5.0, 80.0, 60.0) == "UNKNOWN"
+    assert co.classify_regime(8.0, None, 5.0, 5.0, 80.0, 60.0) == "UNKNOWN"
+
+
+# ── regime_to_direction ────────────────────────────────────────
+
+def test_regime_to_direction_mapping():
+    assert co.regime_to_direction("TREND_UP") == "LONG"
+    assert co.regime_to_direction("TREND_DOWN") == "SHORT"
+    assert co.regime_to_direction("CHOP") is None
+    assert co.regime_to_direction("UNKNOWN") is None
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/koala/README.md
+++ b/koala/README.md
@@ -1,0 +1,125 @@
+# 🐨 Koala — Set-and-Forget Trail HODL
+
+**The simplest possible Senpi agent.** Pick an asset. Fire LONG once. Hold with an ultra-wide DSL trail. Done.
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+For users whose entire trading thesis is *"I want to own BTC and have a safety net, and I don't want anything else."* No scoring, no scheduling, no multi-timeframe analysis. One asset, one entry, one stop.
+
+## Key parameters
+
+| Parameter | Default |
+|---|---|
+| Asset | BTC (configurable: ETH/SOL/HYPE/anything) |
+| Direction | LONG only |
+| fireOnceMode | **true** (lifetime one-shot) |
+| reEntryCooldownHours | 168 (7d, only if fireOnceMode=false) |
+| Margin per position | 50% of equity |
+| Leverage | 2x default, max 3x |
+| Tick interval | 1800s (30 min) — no urgency |
+| Max entries per day | 1 |
+| Daily loss limit | 20% (permissive — Koala rides drawdowns) |
+| Drawdown halt | 35% |
+| Entry order type | FEE_OPTIMIZED_LIMIT (**maker-preferred** — save fees, no urgency) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (maker-preferred) |
+
+## DSL preset (ultra-wide custom — the widest in any Senpi agent)
+
+| Component | Setting | vs `parabolic_runner` |
+|---|---|---|
+| `max_loss_pct` | **30%** | 25% |
+| `retrace_threshold` | **25** | 18 |
+| `consecutive_breaches_required` | **3** | 2 |
+| `hard_timeout` | **90d** | 14d |
+| `weak_peak_cut` | disabled | disabled |
+| `dead_weight_cut` | disabled | disabled |
+| Phase 2 T0 → T4 | +20/0 · +50/30 · +100/50 · +200/70 · +500/85 | +15/0 · +30/30 · +60/55 · +120/72 · +250/85 |
+
+This preset is **not** in `dsl-presets.yaml` — it's Koala-specific. The point is to *not* cut on normal corrections; it only releases on catastrophic reversal or after 3 months.
+
+## Scanner pattern
+
+A **state-trigger variant** of archetype #2 (Single-asset alpha hunter). No `market_get_asset_data` call — Koala's "scanner" is a check against the persisted state file. Pure functions unit-tested in `tests/test_signal.py` (`python3 koala/tests/test_signal.py`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, ultra-wide DSL, `risk.guard_rails`) |
+| scripts/koala-producer.py | Long-lived daemon; emits a single KOALA_HODL signal |
+| scripts/koala_config.py | SDK probe + SenpiClient wrapper + entry-state cache |
+| config/koala-config.json | Operator-tunable defaults (asset, mode, sizing) |
+| tests/test_signal.py | Unit tests for the entry-decision logic |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Koala
+
+```bash
+mkdir -p /data/workspace/skills/koala-strategy/{config,scripts,state,references}
+for f in scripts/koala-producer.py scripts/koala_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/koala-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/koala/$f" \
+    -o "/data/workspace/skills/koala-strategy/$f"
+done
+```
+
+### Step 3 — Configure (the only meaningful choice is `asset`)
+
+Edit `/data/workspace/skills/koala-strategy/config/koala-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId",
+  "asset": "BTC"
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export KOALA_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...
+export KOALA_DECISION_MODEL=<your-preferred-model>
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/koala-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/koala-strategy/scripts/koala-producer.py \
+  > /tmp/koala-producer.log 2>&1 &
+disown
+```
+
+## Verification
+
+```bash
+sleep 1820  # wait one full tick
+tail -3 /tmp/koala-producer.log | jq '._koala_producer_version, .note // null, .best.coin // null'
+```
+
+A healthy first tick fires immediately (state file doesn't exist yet, fire-once condition met). You'll see `"signals_pushed": 1, "best": { "coin": "BTC", ... }`. After that, every subsequent tick will output `"HOLDING — BTC is currently in the position; DSL owns exits"` until either the DSL exits (90d at the outer bound) or you tear it down.
+
+## Changelog
+
+### v1.0.0 (2026-05-29) — initial release
+
+First fleet agent with **no price-side scoring at all**. State-file-driven single-shot entry, ultra-wide custom DSL (max_loss 30%, retrace 25, 90d hard_timeout, super-late Phase 2 ladder), fire-once mode by default. Maker-preferred entry. Disown-safe launch, 8/8 unit tests covering both fire-once and re-entry-cooldown branches.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/koala/SKILL.md
+++ b/koala/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: koala-strategy
+description: >-
+  KOALA v1.0.0 — Set-and-Forget Trail HODL. The simplest possible Senpi
+  agent. Pick an asset (default BTC). Fire LONG once on deploy. Hold with an
+  ultra-wide DSL trail (max_loss 30%, retrace 25, 90d hard_timeout). Done.
+  No scoring, no scheduling, no multi-timeframe analysis. For users whose
+  entire trading thesis is "I want to own BTC and have a safety net."
+  Onboarding tier.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐨 KOALA v1.0.0 — Set-and-Forget Trail HODL
+
+**The simplest possible Senpi agent.** Pick an asset. Fire LONG once. Hold. Forever-ish.
+
+## Why this strategy exists
+
+Tortoise is close to "buy and hold" but it has a cadence — every 24h it might buy more. Beaver/Heron/Hummingbird are trend followers — they read the market and decide. Hedgehog holds a basket — multiple decisions. None of them give the user the answer to *"I just want to own BTC and have a safety net, and I don't want anything else."*
+
+Koala is that answer. **One asset, one entry, one stop.**
+
+## CRITICAL RULES
+
+### RULE 1: One asset, configured by the operator
+Default is BTC. Operators set `asset: "ETH"` or `asset: "SOL"` if they want something else. There's no whitelist scan — Koala doesn't pick.
+
+### RULE 2: LONG only, fixed sizing
+Margin 50% of equity (default). Leverage 2x (default, max 3x). No scoring, no conviction tiers — *the choice to deploy Koala IS the bet*.
+
+### RULE 3: Fire-once mode is the default
+Koala persists a `koala-state.json` file that records `first_entry_at`. In **fire-once mode** (the default), Koala fires exactly one entry per lifetime — even if the DSL eventually exits, the producer stays silent forever after.
+
+Operators who want a cycling deploy (buy / DSL-exits / buy again after a cooldown) can set `fireOnceMode: false` and a `reEntryCooldownHours` (default 7 days). Koala then re-enters once the configured cooldown has elapsed since the last detected exit.
+
+### RULE 4: Ultra-wide DSL is the entire exit logic
+The widest DSL in the catalog:
+
+| Component | Setting |
+|---|---|
+| `max_loss_pct` | **30%** (vs `let_winners_run`'s 20, `parabolic_runner`'s 25) |
+| `retrace_threshold` | **25** (vs `parabolic_runner`'s 18) |
+| `consecutive_breaches_required` | **3** (vs 1-2 elsewhere) |
+| `hard_timeout` | **90d** (3 months) |
+| `weak_peak_cut` | DISABLED |
+| `dead_weight_cut` | DISABLED |
+| Phase 2 ladder | +20/0 → +50/30 → +100/50 → +200/70 → +500/85 |
+
+This is deliberately wider than `parabolic_runner` because Koala's job is to *not* cut on normal corrections. It only releases on catastrophic reversal or after 3 months.
+
+### RULE 5: Producer NEVER closes
+DSL owns exits. Always. If the DSL trail trips, the position closes, and (in fire-once mode) Koala never re-enters. In re-entry mode, Koala waits for the cooldown.
+
+## How Koala works internally
+
+1. **Tick 1** (30 min after deploy): `koala-state.json` doesn't exist. `should_enter` returns True. Fires LONG. Writes `first_entry_at = now`. Records entry.
+2. **Subsequent ticks while holding**: `koala-state.json` has `first_entry_at`. The asset is currently in `held_assets`. Producer outputs `HOLDING` and does nothing.
+3. **If the DSL eventually exits** (say 60 days in): Position disappears from `held_assets`. The producer's next tick detects the change, records `last_exit_at` in state.
+4. **After exit, fire-once mode**: `should_enter` returns False (because `first_entry_at` is set). Producer outputs `WAITING — fire-once mode AND already entered once`. Stays silent forever.
+5. **After exit, re-entry mode**: `should_enter` returns False until `reEntryCooldownHours` elapses, then returns True on the next tick.
+
+## Scanner pattern
+
+A **state-trigger variant** of archetype #2 (Single-asset alpha hunter) — see `senpi-trading-runtime/references/producer-patterns.md`. Unlike Beaver/Heron/Hummingbird/Wolverine which score price action per tick, Koala's "scanner" is a state-file check. No `market_get_asset_data` call. The pure functions (`should_enter`, `record_entry`, `record_exit`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-29) — initial release
+
+First fleet agent with **no price-side scoring at all**. State-file-driven single-shot entry, ultra-wide custom DSL (max_loss 30%, retrace 25, 90d hard_timeout, super-late Phase 2 ladder), fire-once mode by default. Maker-preferred entry (no urgency). Disown-safe launch, 8/8 unit tests covering both fire-once and re-entry-cooldown branches.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/koala/config/koala-config.json
+++ b/koala/config/koala-config.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "KOALA v1.0.0 — Set-and-Forget Trail HODL. The simplest possible Senpi agent. Pick an asset (default BTC). Fire LONG once on deploy. Hold with an ultra-wide DSL trail (max_loss 30%, retrace 25, 90d hard_timeout). Done. fireOnceMode=true means lifetime one-shot (the default and the recommended posture). Set fireOnceMode=false with a reEntryCooldownHours to enable a 'buy / DSL-exits / buy again' cycle. Producer ticks every 1800s — no urgency. Maker-preferred entry (Koala is patient — save fees). Edit wallet/strategyId/chatId; optionally pick a different asset.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "asset": "BTC",
+  "fireOnceMode": true,
+  "reEntryCooldownHours": 168,
+  "marginPct": 0.50,
+  "leverage": 2
+}

--- a/koala/references/skill-attribution.md
+++ b/koala/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "koala",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "koala",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/koala/runtime.yaml
+++ b/koala/runtime.yaml
@@ -1,0 +1,176 @@
+name: koala-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Koala v1.0.0"
+# and lives in description + SKILL.md + _koala_producer_version.
+version: 1.0.0
+description: >
+  KOALA v1.0.0 — Set-and-Forget Trail HODL.
+
+  The simplest possible Senpi agent. Pick an asset (default BTC). Fire LONG
+  once on deploy. Hold with an ultra-wide DSL trail. Done.
+
+  No scoring, no multi-timeframe analysis, no SM gates. The only decision the
+  operator makes is "which asset?" Fire-once mode by default (lifetime
+  one-shot); operators who want a cycling deploy can set fireOnceMode=false
+  with a reEntryCooldownHours.
+
+  Architecture (helpers-native): producer ticks every 1800s (30min) — no
+  urgency — checks the persisted entry state, and either fires LONG once or
+  holds silent. Producer NEVER closes — the wide DSL is the entire exit
+  logic.
+
+  DSL: ultra-wide custom — max_loss 30%, retrace 25, 90d hard_timeout. Built
+  to NOT cut on ordinary corrections; only releases on catastrophic reversal
+  or 3-month timeout.
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_pct: 50            # % of account budget — one chunky position
+  trading_risk: conservative
+  enabled: true
+
+risk:
+  data_retention_hours: 2160     # 90 days
+  guard_rails:
+    daily_loss_limit_pct: 20    # very permissive — Koala is meant to ride drawdowns
+    max_entries_per_day: 1
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 2
+    cooldown_minutes: 60
+    drawdown_halt_pct: 35        # tolerates a 35% margin drawdown
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 60
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: koala_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: koala_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${KOALA_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [koala_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false        # Koala is patient — let it rest as maker, save fees
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: koala_signals
+    decision_prompt: |
+      You are Koala's pass-through gate. Koala is a HODL agent — it fires
+      ONE LONG signal per lifetime (or per cooldown). The producer already
+      checked the state file. Honor the signal.
+
+      SIGNAL:
+      {{signal_koala_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY.
+      2. direction MUST be LONG.
+      3. leverage MUST be copied from signal.data.leverage (1-3x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - direction != LONG
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets
+
+      ## CONFIDENCE SCORING
+
+      Always confidence 7. Koala has no scoring; the state-file decision
+      IS the validation.
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": 7,
+        "reasoning": "concrete sentence (e.g. 'BTC HODL — first entry, set-and-forget')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "LONG",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "KOALA_HODL — entry"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — ultra-wide custom) ────────────────────────────
+#
+# The widest DSL in any Senpi agent. max_loss 30% (accepts a 30% margin
+# drawdown before the catastrophic stop), retrace_threshold 25 (massive
+# room from peak), 90d hard_timeout (3 months — set-and-forget means long
+# horizon), NO weak_peak_cut, NO dead_weight_cut, super-late Phase 2 ladder.
+# This preset is intentionally not in dsl-presets.yaml — it's Koala-specific
+# and not appropriate for any other thesis.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: false
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 129600     # 90d — set-and-forget
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 30.0              # 30% margin loss tolerated
+      retrace_threshold: 25           # huge room from peak
+      consecutive_breaches_required: 3  # 3 confirmations before the catastrophic stop trips
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 20,  lock_hw_pct: 0  }   # no lock until +20%
+        - { trigger_pct: 50,  lock_hw_pct: 30 }
+        - { trigger_pct: 100, lock_hw_pct: 50 }
+        - { trigger_pct: 200, lock_hw_pct: 70 }
+        - { trigger_pct: 500, lock_hw_pct: 85 }   # apex — only locks in late-stage
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/koala/scripts/koala-producer.py
+++ b/koala/scripts/koala-producer.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# Senpi KOALA Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""KOALA v1.0.0 — Set-and-Forget Trail HODL.
+
+The simplest possible Senpi agent. Pick an asset (default BTC). Fire LONG
+once on deploy. Hold with an ultra-wide DSL trail. Done.
+
+No scoring. No multi-timeframe analysis. No SM gates. No funding regime.
+Just: "is the configured asset currently held by this wallet? If not, fire
+a LONG signal at fixed margin / leverage."
+
+If `fireOnceMode` is true (default), Koala fires ONCE EVER (lifetime). The
+state file tracks first_entry_at; subsequent ticks see the entry and stay
+silent even after the DSL eventually exits.
+
+If `fireOnceMode` is false, Koala will re-enter after `reEntryCooldownHours`
+since the last exit — useful for operators who want a "buy / DSL-exits /
+buy again" cycle.
+
+Producer NEVER closes — the wide DSL (max_loss 30%, retrace 25, 90d
+hard_timeout) is the entire exit logic. Built for operators whose entire
+trading thesis is "I want to own BTC and have a safety net."
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import koala_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "koala_signals"
+SIGNAL_TYPE = "KOALA_HODL"
+
+DEFAULT_ASSET = "BTC"
+DEFAULT_LEVERAGE = 2
+MAX_LEVERAGE = 3              # Koala is HODL, not gambling
+DEFAULT_MARGIN_PCT = 0.50     # 50% of equity — one chunky position
+DEFAULT_FIRE_ONCE = True
+DEFAULT_RE_ENTRY_COOLDOWN_HOURS = 168.0   # 7d if re-entry is enabled
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("KOALA_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure entry-decision logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def should_enter(state, fire_once, re_entry_cooldown_hours, now_ts):
+    """Decide whether Koala should emit an entry signal RIGHT NOW.
+
+    - state: koala-state.json contents
+    - fire_once: True → only one entry ever
+    - re_entry_cooldown_hours: minimum hours between exit and next entry
+                              (only relevant if fire_once is False)
+    - now_ts: epoch seconds (current time)
+
+    Returns True if Koala should emit; False otherwise.
+    """
+    first_entry_at = state.get("first_entry_at") if state else None
+
+    if fire_once:
+        # Lifetime one-shot — fire if and only if we've never entered.
+        return first_entry_at is None
+
+    # Re-entry allowed. Two conditions for "should fire":
+    #   1. Never entered → fire immediately.
+    #   2. Last exit happened ≥ cooldown ago.
+    if first_entry_at is None:
+        return True
+
+    last_exit_at = state.get("last_exit_at") if state else None
+    if last_exit_at is None:
+        # We've entered before but never recorded an exit → position must
+        # still be held (or the close went undetected). Don't fire again.
+        return False
+
+    try:
+        last_exit = float(last_exit_at)
+    except (TypeError, ValueError):
+        return False
+
+    cooldown_sec = float(re_entry_cooldown_hours) * 3600.0
+    return (now_ts - last_exit) >= cooldown_sec
+
+
+def record_entry(state, now_ts):
+    """Pure: return a new state dict with the entry recorded."""
+    new_state = dict(state or {})
+    if not new_state.get("first_entry_at"):
+        new_state["first_entry_at"] = float(now_ts)
+    new_state["last_entry_at"] = float(now_ts)
+    new_state["total_entries"] = int(new_state.get("total_entries", 0)) + 1
+    return new_state
+
+
+def record_exit(state, now_ts):
+    """Pure: return a new state dict with the exit recorded."""
+    new_state = dict(state or {})
+    new_state["last_exit_at"] = float(now_ts)
+    return new_state
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(asset, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        return False
+    if asset.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": 5,    # fixed — Koala has no scoring; this satisfies the schema
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": "LONG",
+        "reasons": ["hodl_first_entry"],
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=asset,
+            direction="LONG",
+            score=0.7,
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {asset}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {asset}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — check state, fire if eligible
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    asset = str(config.get("asset", DEFAULT_ASSET)).upper()
+    fire_once = bool(config.get("fireOnceMode", DEFAULT_FIRE_ONCE))
+    cooldown_hours = float(config.get("reEntryCooldownHours", DEFAULT_RE_ENTRY_COOLDOWN_HOURS))
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_koala_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_koala_producer_version": VERSION})
+        return
+
+    state = cfg.read_koala_state()
+    now = time.time()
+
+    # Detect a closed position: if Koala had a first_entry but the asset is
+    # no longer held, log the exit.
+    if state.get("first_entry_at") and asset not in held_set and state.get("last_exit_at") is None:
+        # An exit happened since the last tick — record it.
+        state = record_exit(state, now)
+        cfg.write_koala_state(state)
+
+    # If currently held → do nothing (DSL is in charge)
+    if asset in held_set:
+        cfg.output({
+            "status": "ok",
+            "note": f"HOLDING — {asset} is currently in the position; DSL owns exits",
+            "asset": asset,
+            "first_entry_at": state.get("first_entry_at"),
+            "total_entries": state.get("total_entries", 0),
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_koala_producer_version": VERSION,
+        })
+        return
+
+    if not should_enter(state, fire_once, cooldown_hours, now):
+        # Decision: not eligible. Output the reason for ops visibility.
+        if fire_once:
+            reason = f"fire-once mode AND already entered once (first_entry_at={state.get('first_entry_at')})"
+        else:
+            last_exit = state.get("last_exit_at")
+            if last_exit is None:
+                reason = "re-entry mode but no exit recorded yet (position state ambiguous)"
+            else:
+                wait_left_h = max(0, (cooldown_hours * 3600 - (now - float(last_exit))) / 3600.0)
+                reason = f"re-entry cooldown active ({wait_left_h:.1f}h remaining)"
+        cfg.output({
+            "status": "ok",
+            "note": f"WAITING — {reason}",
+            "asset": asset,
+            "fire_once_mode": fire_once,
+            "state": state,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_koala_producer_version": VERSION,
+        })
+        return
+
+    if cfg.was_recently_signaled(asset):
+        cfg.output({
+            "status": "ok",
+            "note": "WAITING — recently signaled (race-window dedup)",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_koala_producer_version": VERSION,
+        })
+        return
+
+    margin_pct = float(config.get("marginPct", DEFAULT_MARGIN_PCT))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(asset, margin_usd, leverage, held_assets)
+    if pushed:
+        cfg.record_signal(asset)
+        state = record_entry(state, now)
+        # Clear last_exit_at — new lifecycle started
+        state["last_exit_at"] = None
+        cfg.write_koala_state(state)
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": asset,
+            "direction": "LONG",
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "first_entry_at": state.get("first_entry_at"),
+            "total_entries": state.get("total_entries"),
+        },
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_koala_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=1800,   # 30min — Koala has no urgency
+        name=f"koala-producer-{_wallet_lock_id}",
+        tick_timeout=120,
+    )

--- a/koala/scripts/koala_config.py
+++ b/koala/scripts/koala_config.py
@@ -1,0 +1,225 @@
+"""KOALA v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Set-and-Forget Trail HODL. The simplest possible Senpi agent: pick a single
+asset, fire LONG once on deploy, hold with an ultra-wide DSL trail. No
+scoring, no scheduling, no multi-timeframe analysis. The only decision the
+operator makes is "which asset?"
+
+For users whose entire trading thesis is "I want to own BTC and have a
+safety net." Koala is the answer in code form.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+ultra-wide DSL (max_loss 30%, retrace 25, 90d hard_timeout). Persisted
+entry-history cache (`koala-state.json`) so a single deploy fires once.
+Producer NEVER closes — the wide DSL is the entire exit logic.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "koala-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "koala-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+KOALA_STATE_PATH = STATE_DIR / "koala-state.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Race-window dedup TTL. Koala ticks every 1800s (30min) — slow by design.
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+# ─── senpi_runtime_helpers ───
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Koala's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("koala_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def mcp_call(tool, **params):
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] koala_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+# ─── Koala state (entries + exits — for re-entry-cooldown logic) ──
+
+def read_koala_state():
+    if not KOALA_STATE_PATH.exists():
+        return {"first_entry_at": None, "last_entry_at": None, "last_exit_at": None, "total_entries": 0}
+    try:
+        with open(KOALA_STATE_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {"first_entry_at": None, "last_entry_at": None, "last_exit_at": None, "total_entries": 0}
+        return data
+    except (json.JSONDecodeError, OSError):
+        return {"first_entry_at": None, "last_entry_at": None, "last_exit_at": None, "total_entries": 0}
+
+
+def write_koala_state(state):
+    try:
+        atomic_write(KOALA_STATE_PATH, state)
+    except OSError:
+        pass
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[koala-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/koala/tests/test_signal.py
+++ b/koala/tests/test_signal.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Unit tests for Koala's pure functions (should_enter, record_entry,
+record_exit). Stubs koala_config + senpi_runtime_helpers.
+Run: python3 koala/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("koala_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.read_koala_state = lambda: {}
+_cfg.write_koala_state = lambda s: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["koala_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "koala-producer.py"
+_spec = importlib.util.spec_from_file_location("koala_producer", _path)
+kp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(kp)
+
+NOW = 1_700_000_000.0
+HOUR = 3600.0
+
+
+def test_should_enter_fresh_state_fire_once():
+    # Brand-new deploy, fire-once mode → enter
+    state = {}
+    assert kp.should_enter(state, fire_once=True, re_entry_cooldown_hours=168, now_ts=NOW) is True
+
+
+def test_should_enter_fresh_state_re_entry_mode():
+    # Brand-new deploy, re-entry mode → also enter
+    state = {}
+    assert kp.should_enter(state, fire_once=False, re_entry_cooldown_hours=168, now_ts=NOW) is True
+
+
+def test_should_enter_blocks_after_entry_in_fire_once():
+    # Fire-once + already entered → block forever
+    state = {"first_entry_at": NOW - 30 * 24 * HOUR}   # 30 days ago
+    assert kp.should_enter(state, fire_once=True, re_entry_cooldown_hours=168, now_ts=NOW) is False
+
+
+def test_should_enter_blocks_re_entry_when_no_exit_recorded():
+    # Re-entry mode, entered before, but no exit recorded → position is still
+    # held (or close went undetected) → don't double-enter
+    state = {"first_entry_at": NOW - 10 * 24 * HOUR}
+    assert kp.should_enter(state, fire_once=False, re_entry_cooldown_hours=168, now_ts=NOW) is False
+
+
+def test_should_enter_re_entry_during_cooldown():
+    # Re-entry mode, exited 3 days ago, cooldown is 7 days → still blocked
+    state = {"first_entry_at": NOW - 30 * 24 * HOUR, "last_exit_at": NOW - 3 * 24 * HOUR}
+    assert kp.should_enter(state, fire_once=False, re_entry_cooldown_hours=168, now_ts=NOW) is False
+
+
+def test_should_enter_re_entry_after_cooldown():
+    # Re-entry mode, exited 8 days ago, cooldown is 7 days → can re-enter
+    state = {"first_entry_at": NOW - 30 * 24 * HOUR, "last_exit_at": NOW - 8 * 24 * HOUR}
+    assert kp.should_enter(state, fire_once=False, re_entry_cooldown_hours=168, now_ts=NOW) is True
+
+
+def test_record_entry_sets_first_entry_only_once():
+    # First entry → first_entry_at is set
+    s1 = kp.record_entry({}, NOW)
+    assert s1["first_entry_at"] == NOW
+    assert s1["last_entry_at"] == NOW
+    assert s1["total_entries"] == 1
+    # Second entry (a re-entry) → first_entry_at stays at original, last_entry_at advances
+    s2 = kp.record_entry(s1, NOW + 86400)
+    assert s2["first_entry_at"] == NOW       # unchanged
+    assert s2["last_entry_at"] == NOW + 86400
+    assert s2["total_entries"] == 2
+
+
+def test_record_exit_sets_last_exit():
+    state = {"first_entry_at": NOW - 86400, "last_entry_at": NOW - 86400, "total_entries": 1}
+    s2 = kp.record_exit(state, NOW)
+    assert s2["last_exit_at"] == NOW
+    # Doesn't disturb other fields
+    assert s2["first_entry_at"] == NOW - 86400
+    assert s2["total_entries"] == 1
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/lynx/README.md
+++ b/lynx/README.md
@@ -1,0 +1,152 @@
+# 🐯 Lynx — Adaptive MIN_SCORE Self-Tuner
+
+**The Vulture v4.1 story productized.** Lynx is a momentum agent that audits its own closed-trade history every 6 hours and raises its own MIN_SCORE when low-conviction buckets bleed. **First fleet agent that modifies its own behavior based on its own trade history.**
+
+Part of [Senpi Trading Skills](https://github.com/Senpi-ai/senpi-skills).
+
+## Thesis
+
+When Vulture's agent ran the 30-trade audit that led to [v4.1's MIN_SCORE 7→9 cull](https://github.com/Senpi-ai/senpi-skills/pull/337), it did so by hand. The fix worked. Lynx asks: *why is that operation manual?*
+
+Lynx bakes the same audit into a scheduled cron. Every 6h it pulls its own `audit_query` history, buckets trades by entry score, and auto-raises MIN_SCORE if a bucket at-or-above the current floor is bleeding (avg ROE below threshold, with enough samples).
+
+## Key parameters
+
+| Parameter | Default |
+|---|---|
+| Whitelist | BTC · ETH · SOL · HYPE |
+| `initialMinScore` | 4 (permissive — gives the audit data to work with) |
+| `maxMinScore` | 7 (hard ceiling) |
+| `auditEverySec` | 21600 (6h) |
+| `auditLimit` | 200 (max closed trades per audit) |
+| `minBucketN` | 8 (need at least this many trades to act on a bucket) |
+| `bucketBleedThresholdPct` | -1.0 (avg ROE below this → cull) |
+| Tick interval | 300s (5 min) |
+| Leverage | 3x default, max 5x |
+| Margin per slot | 20% of equity |
+| Max entries per day | 4 |
+| Per-asset cooldown | 240 min |
+| Entry order type | FEE_OPTIMIZED_LIMIT (ensureExecutionAsTaker: **true**) |
+| Exit order type | FEE_OPTIMIZED_LIMIT (taker-true) |
+
+## DSL preset (`let_winners_run` — momentum-class)
+
+Standard momentum let-winners-run. The Lynx innovation is in entry, not exit.
+
+## Scanner pattern
+
+NEW archetype #15: **Self-tuning / adaptive-threshold agent**. Primary MCP calls: `market_get_asset_data` per whitelisted asset, `leaderboard_get_markets` (SM gate), `audit_query` (the self-tuning audit — every 6h). Pure functions unit-tested in `tests/test_signal.py` (`python3 lynx/tests/test_signal.py` — 19 tests covering both self-tuning and scoring logic).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| runtime.yaml | Runtime spec (scanners, actions, let-winners-run DSL, `risk.guard_rails`) |
+| scripts/lynx-producer.py | Long-lived daemon; emits LYNX_ADAPTIVE_MOMENTUM + runs the periodic audit |
+| scripts/lynx_config.py | SDK probe + SenpiClient wrapper + lynx-state cache (MIN_SCORE + audit log) |
+| config/lynx-config.json | Operator-tunable defaults (audit interval, thresholds, whitelist) |
+| tests/test_signal.py | 19 unit tests covering self-tuning + scoring |
+
+## Install
+
+### Step 1 — Install the senpi-trading-runtime skill (one-time per host)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Lynx
+
+```bash
+mkdir -p /data/workspace/skills/lynx-strategy/{config,scripts,state,references}
+for f in scripts/lynx-producer.py scripts/lynx_config.py \
+         runtime.yaml SKILL.md README.md references/skill-attribution.md \
+         config/lynx-config.json; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lynx/$f" \
+    -o "/data/workspace/skills/lynx-strategy/$f"
+done
+```
+
+### Step 3 — Configure wallet, strategy ID, chat ID, AND Senpi user ID
+
+The `senpiUserId` is what enables the self-tuning audit. Without it, Lynx runs with `initialMinScore` forever.
+
+Find your Senpi user ID via `user_get_me` or by checking your arena leaderboard entry (the `senpiUserId` field).
+
+Edit `/data/workspace/skills/lynx-strategy/config/lynx-config.json`:
+
+```json
+{
+  "strategyId": "your-strategy-id",
+  "wallet": "0xYourStrategyWallet",
+  "chatId": "YourTelegramChatId",
+  "senpiUserId": "M..."
+}
+```
+
+### Step 4 — Required env vars
+
+```bash
+export LYNX_WALLET=<your-strategy-wallet>
+export SENPI_AUTH_TOKEN=...                         # required (user-scope; needed for audit_query + leaderboard_get_markets)
+export LYNX_DECISION_MODEL=<your-preferred-model>
+```
+
+### Step 5 — Create the runtime + start the daemon
+
+```bash
+openclaw senpi runtime create --path /data/workspace/skills/lynx-strategy/runtime.yaml
+openclaw senpi runtime list
+
+nohup python3 -u /data/workspace/skills/lynx-strategy/scripts/lynx-producer.py \
+  > /tmp/lynx-producer.log 2>&1 &
+disown
+```
+
+## Verification
+
+```bash
+sleep 320  # wait one full tick
+tail -3 /tmp/lynx-producer.log | jq '._lynx_producer_version, .current_min_score, .audit // null'
+```
+
+Watch the state file to see Lynx learn:
+
+```bash
+cat /data/workspace/skills/lynx-strategy/state/lynx-state.json | jq '.current_min_score, .adjustments | length'
+```
+
+Initial state: `current_min_score: 4`, `adjustments: []`. After Lynx has accumulated enough trades in losing buckets, the audit fires and the adjustment is logged.
+
+## Watching Lynx adapt
+
+The interesting thing to watch isn't any single trade — it's the **adjustments log over time**. Each entry looks like:
+
+```json
+{
+  "ts": 1717000000.0,
+  "prev": 4,
+  "new": 5,
+  "trades_examined": 47,
+  "bleeding_buckets": [
+    {
+      "score": 4,
+      "stats": { "n": 12, "avg_roe_pct": -2.3, "win_rate_pct": 25.0 }
+    }
+  ]
+}
+```
+
+Read that as: *"At this timestamp, after examining 47 closed trades, Lynx noticed Score-4 trades had 12 samples averaging -2.3% ROE with a 25% win rate. So Lynx raised its floor from 4 to 5."*
+
+That's the agent learning, in your state file.
+
+## Changelog
+
+### v1.0.0 (2026-05-29) — initial release
+
+First fleet agent to **modify its own behavior based on its own trade history**. Productizes the Vulture v4.1 manual cull as a scheduled audit. Introduces archetype #15 (self-tuning agent). 19/19 unit tests covering both the self-tuning logic and the scoring logic. Taker-true entry, disown-safe launch.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).

--- a/lynx/SKILL.md
+++ b/lynx/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: lynx-strategy
+description: >-
+  LYNX v1.0.0 — Adaptive MIN_SCORE Self-Tuner. The Vulture v4.1 story
+  productized into a first-class agent pattern. Runs a simple BTC/ETH/SOL/HYPE
+  momentum scorer; every 6h pulls its own closed-trade history via
+  audit_query, buckets trades by score, and auto-raises MIN_SCORE if any
+  bucket at-or-above the floor is bleeding. The same operation Vulture's
+  agent ran by hand, but on a scheduled cron. NEW archetype #15:
+  Self-tuning / adaptive-threshold agent.
+license: MIT
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐯 LYNX v1.0.0 — Adaptive MIN_SCORE Self-Tuner
+
+**The Vulture v4.1 story productized.** Lynx is a momentum agent that audits its own closed-trade history every 6 hours and raises its own MIN_SCORE when low-conviction buckets bleed.
+
+## Why this strategy exists
+
+When Vulture's autonomous agent ran the [30-trade audit that led to v4.1](https://github.com/Senpi-ai/senpi-skills/pull/337), it manually identified that Score 7–8 trades had been net-negative and raised `MIN_SCORE` 7→9 by hand. The fix worked. The question Lynx asks: *why is that operation manual?*
+
+Lynx bakes the same operation into a scheduled cron. Every `auditEverySec` (default 6h), it:
+
+1. Pulls its own closed-trade history via `audit_query(user_ids=[senpiUserId], action_type="close", limit=auditLimit)`
+2. Parses the entry score from each trade's `ai_reasoning` field
+3. Buckets trades by score and computes `{n, avg_roe_pct, win_rate_pct}` per bucket
+4. Identifies the **highest-scoring bucket at or above the current floor** that has `n >= minBucketN` AND `avg_roe_pct < bucketBleedThresholdPct`
+5. If found, recommends `MIN_SCORE = that_bucket + 1` (capped at `maxMinScore`)
+6. If the recommendation moves by at least the hysteresis (1), persists the new MIN_SCORE and logs the adjustment
+
+This is the **first fleet agent that modifies its own behavior based on its own trade history**. The same loop the Vulture team ran by hand — but every 6 hours, automatically, on every Lynx instance.
+
+## CRITICAL RULES
+
+### RULE 1: Self-tuning is gated on `senpiUserId`
+The audit requires `audit_query` with the operator's Senpi user ID. If `config.senpiUserId` is empty, Lynx **still runs** (using `initialMinScore`) but the audit is skipped and the tick output notes `"no senpiUserId — self-tuning disabled"`. The operator can find their ID via `user_get_me` or `arena_leaderboard`.
+
+### RULE 2: Lynx never *lowers* its own MIN_SCORE
+The `should_update_threshold` function only acts on raises (hysteresis ≥ +1). A floor that has worked won't be relaxed by a quiet period. Lynx ratchets up; it never ratchets down.
+
+### RULE 3: The cap is hard
+`maxMinScore` (default 7) is an absolute ceiling. Even if every bucket up to 7 bleeds, Lynx won't go above 7 — at which point the operator should diagnose the underlying scoring logic rather than keep raising the floor.
+
+### RULE 4: Adjustments are logged forever
+Each successful raise is appended to `state.adjustments` with timestamp, previous and new floor, bleeding-bucket evidence, and the audit's trade-count. The state file is the audit trail.
+
+### RULE 5: Producer NEVER closes
+DSL owns exits. Lynx's innovation is in **entry selection**, not exit management — exits use the proven `let_winners_run` ladder.
+
+## How Lynx scores a trade
+
+Composite of 4 components (max ~8):
+
+| Component | Points |
+|---|---|
+| 4h trend strength: `|move| >= 4%` → +3, `>= 2%` → +2, `>= 1%` → +1 | up to 3 |
+| 1h confirmation: 1h move aligned with 4h direction, `|move| >= 0.5%` | +2 |
+| Smart Money aligned: SM tilts in direction, `>= smTiltMinPct` (55%) | +2 |
+| Volume rising: 12h vol vs 36h baseline ratio `>= 1.3` | +1 |
+
+Initial `MIN_SCORE: 4` (permissive — gives the audit data to work with). Auto-tunes up to `maxMinScore: 7`. Operators see the current MIN_SCORE in every tick's output (`currentMinScore` field) — so they can watch Lynx learn live.
+
+## DSL preset (`let_winners_run` — momentum-class)
+
+Standard momentum-class let-winners-run: max_loss 20%, retrace 12, 7d hard_timeout, no weak_peak_cut, Phase 2 ladder +10/0 → +20/25 → +35/50 → +60/70 → +100/85. The Lynx innovation is in entry, not exit.
+
+## Scanner pattern
+
+NEW archetype #15: **Self-tuning / adaptive-threshold agent** — see `senpi-trading-runtime/references/producer-patterns.md`. Primary MCP calls: `market_get_asset_data` per whitelisted asset (the producer signature), `leaderboard_get_markets` (SM gate), `audit_query` (the self-tuning audit — every 6h). The pure functions (`parse_score_from_reasoning`, `compute_bucket_stats`, `recommend_min_score`, `should_update_threshold`, `pct_move`, `trend_direction`, `lynx_score`) are unit-tested in `tests/test_signal.py`.
+
+## Operator install
+
+See [README.md](README.md).
+
+## Changelog
+
+### v1.0.0 (2026-05-29) — initial release
+
+First fleet agent to **modify its own behavior based on its own trade history**. Productizes the Vulture v4.1 manual cull as a scheduled audit. Introduces archetype #15 (self-tuning agent). 19/19 unit tests covering both the self-tuning logic (parse_score, compute_bucket_stats, recommend_min_score, should_update_threshold) and the scoring logic (pct_move, trend_direction, lynx_score). Taker-true entry, disown-safe launch.
+
+## License
+
+MIT — Copyright 2026 Senpi (https://senpi.ai).
+
+## Skill Attribution
+
+When creating a strategy, include `skill_name` and `skill_version`. See `references/skill-attribution.md`.

--- a/lynx/config/lynx-config.json
+++ b/lynx/config/lynx-config.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "LYNX v1.0.0 — Adaptive MIN_SCORE Self-Tuner. The Vulture v4.1 story productized. Runs a simple BTC/ETH/SOL/HYPE momentum scorer (max ~8). Every auditEverySec (default 6h = 21600s) calls audit_query for its own closed-trade history, buckets the trades by entry score, and auto-raises MIN_SCORE if any bucket >= current floor has minBucketN samples AND avg ROE < bucketBleedThresholdPct. Caps at maxMinScore. NEW archetype #15: Self-tuning agent. REQUIRES senpiUserId to enable the self-tuning audit — otherwise the agent runs with the initialMinScore forever (and emits a 'no senpiUserId' notice each tick). Find your senpiUserId via user_get_me or arena_leaderboard. Edit wallet/strategyId/chatId/senpiUserId; tune thresholds.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "senpiUserId": "",
+  "whitelist": ["BTC", "ETH", "SOL", "HYPE"],
+  "initialMinScore": 4,
+  "maxMinScore": 7,
+  "auditEverySec": 21600,
+  "auditLimit": 200,
+  "minBucketN": 8,
+  "bucketBleedThresholdPct": -1.0,
+  "smTiltMinPct": 55,
+  "marginPct": 0.20,
+  "leverage": 3
+}

--- a/lynx/references/skill-attribution.md
+++ b/lynx/references/skill-attribution.md
@@ -1,0 +1,22 @@
+# Skill Attribution
+
+When calling `strategy_create` or `strategy_create_custom_strategy`, always include:
+
+```json
+"skill_name": "lynx",
+"skill_version": "1.0.0"
+```
+
+This is required for attribution and tracking. Example:
+
+```json
+{
+  "tool": "strategy_create_custom_strategy",
+  "args": {
+    "initialBudget": 500,
+    "positions": [],
+    "skill_name": "lynx",
+    "skill_version": "1.0.0"
+  }
+}
+```

--- a/lynx/runtime.yaml
+++ b/lynx/runtime.yaml
@@ -1,0 +1,186 @@
+name: lynx-tracker
+# Top-level `version` is the SCHEMA version expected by the
+# senpi-trading-runtime plugin (major=1). Skill version is "Lynx v1.0.0"
+# and lives in description + SKILL.md + _lynx_producer_version.
+version: 1.0.0
+description: >
+  LYNX v1.0.0 — Adaptive MIN_SCORE Self-Tuner.
+
+  The Vulture v4.1 story productized into a first-class agent pattern. Lynx
+  runs a simple multi-asset momentum scorer (BTC/ETH/SOL/HYPE; max ~8) and,
+  every auditEverySec (default 6h), pulls its own closed-trade history via
+  audit_query, buckets the trades by score, and auto-raises MIN_SCORE if
+  any bucket at-or-above the current floor has accumulated minBucketN
+  samples AND is averaging worse than bucketBleedThresholdPct.
+
+  The same operation Vulture's agent ran by hand for v4.1, but on a
+  scheduled cron. NEW archetype #15: Self-tuning / adaptive-threshold agent.
+
+  Architecture (helpers-native): producer ticks every 300s. Each tick:
+  (a) runs the self-tuning audit if due, (b) iterates the whitelist
+  applying the current MIN_SCORE, (c) emits LYNX_ADAPTIVE_MOMENTUM for the
+  highest-scoring candidate. State persisted: current_min_score +
+  adjustments log.
+
+  DSL: let-winners-run preset (momentum thesis).
+
+strategy:
+  wallet: "${WALLET_ADDRESS}"
+  slots: 1
+  margin_pct: 20
+  trading_risk: aggressive
+  enabled: true
+
+risk:
+  data_retention_hours: 168
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 4
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_minutes: 60
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_minutes: 240
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: lynx_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        currentMinScore: { type: number, required: false }
+        trend4hPct: { type: number, required: false }
+        trend1hPct: { type: number, required: false }
+        smDirection: { type: string, required: false }
+        smTiltPct: { type: number, required: false }
+        volRising: { type: boolean, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: lynx_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${LYNX_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [lynx_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: lynx_signals
+    decision_prompt: |
+      You are Lynx's pass-through gate. Lynx is the self-tuning momentum
+      agent — its MIN_SCORE adapts based on its own closed-trade history.
+      The producer applied the CURRENT MIN_SCORE (visible in signal.data.
+      currentMinScore) and confirmed this candidate cleared it. Honor the
+      signal.
+
+      SIGNAL:
+      {{signal_lynx_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY.
+      2. direction MUST be copied from signal.direction.
+      3. leverage MUST be copied from signal.data.leverage (1-5x).
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - leverage <= 0 OR marginUsd <= 0
+      - signal.asset already in signal.data.heldAssets
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      Lynx's CURRENT MIN_SCORE is dynamic — it represents Lynx's own
+      learned floor of where its scoring system has historically produced
+      positive expectancy. The signal cleared that floor.
+
+      - 9-10: score >= currentMinScore + 2 (well above floor)
+      - 7-8:  score >= currentMinScore (at floor — the signal IS the validation)
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      Return JSON:
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 6 BTC LONG, trend4hPct +3.2%, current MIN_SCORE 5 — above floor')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "LYNX_ADAPTIVE_MOMENTUM ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — let-winners-run preset) ──────────────────────
+#
+# Standard momentum-class let-winners-run. The Lynx innovation is in entry
+# selection, not exit management — exits use the proven wide ladder.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10080            # 7d
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 12
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 35,  lock_hw_pct: 50 }
+        - { trigger_pct: 60,  lock_hw_pct: 70 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/lynx/scripts/lynx-producer.py
+++ b/lynx/scripts/lynx-producer.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+# Senpi LYNX Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""LYNX v1.0.0 — Adaptive MIN_SCORE Self-Tuner.
+
+Lynx is the Vulture v4.1 story productized into a first-class agent pattern.
+It runs a simple multi-asset momentum scorer on BTC/ETH/SOL/HYPE, and every
+N ticks runs an audit on its own closed-trade history (via audit_query). If
+any score bucket at or below the current floor has accumulated `minBucketN`
+samples AND is averaging worse than `bucketBleedThresholdPct`, Lynx
+auto-raises its MIN_SCORE above that bucket and logs the adjustment.
+
+The same operation Vulture's agent ran by hand for v4.1, but on a scheduled
+cron, with the same 30-trade-table style of analysis. NEW archetype #15:
+Self-tuning / adaptive-threshold agent.
+
+Scoring (max ~8): 4h trend strength (+3), 1h confirmation (+2), SM aligned
+(+2), volume rising (+1). Initial MIN_SCORE 4 (permissive — gives the
+auto-tuner data to work with). Auto-tunes up to maxMinScore (default 7).
+
+Producer NEVER closes — DSL owns exits. LLM gate is pass-through. Wide
+let-winners-run DSL since this is a momentum agent.
+
+REQUIRES USER-SCOPE AUTH for leaderboard_get_markets + audit_query.
+"""
+
+import hashlib
+import os
+import re
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import lynx_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+VERSION = "1.0.0"
+SCANNER_NAME = "lynx_signals"
+SIGNAL_TYPE = "LYNX_ADAPTIVE_MOMENTUM"
+
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 3
+DEFAULT_INITIAL_MIN_SCORE = 4
+DEFAULT_MAX_MIN_SCORE = 7         # upper bound — Lynx never tunes above this
+DEFAULT_AUDIT_EVERY_SEC = 21600   # 6h between audits (each audit is one MCP call)
+DEFAULT_MIN_BUCKET_N = 8          # need at least this many trades in a bucket to act
+DEFAULT_BUCKET_BLEED_PCT = -1.0   # bucket avg ROE below this → cull
+DEFAULT_AUDIT_LIMIT = 200         # max closed-position records to pull per audit
+
+DEFAULT_WHITELIST = ["BTC", "ETH", "SOL", "HYPE"]
+DEFAULT_SM_TILT_MIN = 55
+
+
+def _resolve_wallet():
+    env_val = (os.environ.get("LYNX_WALLET") or "").strip()
+    if env_val:
+        return env_val
+    try:
+        return (cfg.load_config().get("wallet") or "").strip()
+    except Exception:
+        return ""
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+def _f(c, primary, alt=None, default=0.0):
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure self-tuning logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+_SCORE_RE = re.compile(r"\bscore[:\s=]+(\d+)\b", re.IGNORECASE)
+
+
+def parse_score_from_reasoning(text):
+    """Extract `score N` from ai_reasoning text. Looks for 'score 5' or
+    'score: 5' or 'Score=5' (case-insensitive). Returns int or None."""
+    if not text or not isinstance(text, str):
+        return None
+    m = _SCORE_RE.search(text)
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except (ValueError, IndexError):
+        return None
+
+
+def compute_bucket_stats(trades):
+    """Bucket trades by score and compute per-bucket stats.
+
+    Each trade: {"score": int, "roe_pct": float} (other fields ignored).
+
+    Returns {score: {"n": int, "avg_roe_pct": float, "win_rate_pct": float}}.
+    Trades with no score are dropped (no bucket). Win = ROE > 0.
+    """
+    buckets = {}
+    for t in trades or []:
+        if not isinstance(t, dict):
+            continue
+        s = t.get("score")
+        if s is None:
+            continue
+        try:
+            score = int(s)
+            roe = float(t.get("roe_pct", 0))
+        except (TypeError, ValueError):
+            continue
+        b = buckets.setdefault(score, {"n": 0, "total_roe": 0.0, "wins": 0})
+        b["n"] += 1
+        b["total_roe"] += roe
+        if roe > 0:
+            b["wins"] += 1
+    out = {}
+    for score, b in buckets.items():
+        out[score] = {
+            "n": b["n"],
+            "avg_roe_pct": (b["total_roe"] / b["n"]) if b["n"] else 0.0,
+            "win_rate_pct": (b["wins"] * 100.0 / b["n"]) if b["n"] else 0.0,
+        }
+    return out
+
+
+def recommend_min_score(bucket_stats, current_min_score, min_bucket_n, bucket_bleed_pct, max_min_score):
+    """Decide whether to raise MIN_SCORE based on the bucket stats.
+
+    Rule: find the HIGHEST score bucket at-or-above the current floor that
+    has accumulated `min_bucket_n` samples AND is bleeding (avg_roe_pct
+    below `bucket_bleed_pct`). If found, recommend MIN_SCORE = that score + 1
+    (so the next eligible bucket starts above it). Caps at `max_min_score`.
+    If no bucket meets the bleed criterion, returns the current_min_score.
+    """
+    bleeding_floors = [
+        score for score, stats in bucket_stats.items()
+        if score >= current_min_score
+        and stats["n"] >= min_bucket_n
+        and stats["avg_roe_pct"] < bucket_bleed_pct
+    ]
+    if not bleeding_floors:
+        return current_min_score
+    highest_bleeding = max(bleeding_floors)
+    recommended = highest_bleeding + 1
+    return min(recommended, max_min_score)
+
+
+def should_update_threshold(current, recommended, hysteresis=1):
+    """Only update if the recommended threshold is at least `hysteresis`
+    above the current. Prevents flapping on small noise."""
+    if recommended is None or current is None:
+        return False
+    return recommended >= current + hysteresis
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure scoring logic (unit-tested in tests/test_signal.py)
+# ═══════════════════════════════════════════════════════════════
+
+def pct_move(closes, lookback):
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def trend_direction(strength_pct, threshold):
+    if strength_pct is None or abs(strength_pct) < threshold:
+        return None
+    return "LONG" if strength_pct > 0 else "SHORT"
+
+
+def lynx_score(trend_strength_4h, trend_1h_aligned, sm_aligned, volume_rising):
+    """Compose a Lynx score from boolean / magnitude inputs.
+
+    - 4h trend strength: +3 if |move| >= 4%, +2 if >= 2%, +1 if >= 1%
+    - 1h confirmation:   +2 if aligned to 4h direction
+    - SM aligned:        +2 if SM tilts in same direction past threshold
+    - Volume rising:     +1 if recent vol > prior baseline
+
+    Max ~8. Floor is operator-tunable via MIN_SCORE.
+    """
+    s = 0
+    if trend_strength_4h is None:
+        return 0
+    abs_t = abs(trend_strength_4h)
+    if abs_t >= 4.0:
+        s += 3
+    elif abs_t >= 2.0:
+        s += 2
+    elif abs_t >= 1.0:
+        s += 1
+    if trend_1h_aligned:
+        s += 2
+    if sm_aligned:
+        s += 2
+    if volume_rising:
+        s += 1
+    return s
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_market_data(asset):
+    return cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=["1h", "4h"],
+        include_funding=False,
+        include_order_book=False,
+    )
+
+
+def fetch_sm_direction(asset):
+    raw = cfg.mcp_call("leaderboard_get_markets")
+    if not raw or not raw.get("success", True):
+        return None, 0.0
+    markets = raw.get("data", raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+def fetch_closed_trades(user_id, limit):
+    """Pull closed-trade records via audit_query. Returns a list of
+    {score, roe_pct, ts} (best-effort extraction; missing fields = None)."""
+    if not user_id:
+        return []
+    raw = cfg.mcp_call(
+        "audit_query",
+        user_ids=[user_id],
+        action_type="close",
+        limit=int(limit),
+    )
+    if not raw:
+        return []
+    d = raw.get("data", raw) if isinstance(raw, dict) else raw
+    entries = d if isinstance(d, list) else (d.get("entries", d.get("results", [])) if isinstance(d, dict) else [])
+    out = []
+    for e in entries or []:
+        if not isinstance(e, dict):
+            continue
+        reasoning = e.get("ai_reasoning") or e.get("reasoning") or ""
+        score = parse_score_from_reasoning(reasoning)
+        roe = e.get("roe_pct") or e.get("pnl_pct") or e.get("roi_pct")
+        try:
+            roe_v = float(roe) if roe is not None else 0.0
+        except (TypeError, ValueError):
+            roe_v = 0.0
+        ts = e.get("ts") or e.get("timestamp") or e.get("created_at")
+        out.append({"score": score, "roe_pct": roe_v, "ts": ts})
+    return out
+
+
+# ═══════════════════════════════════════════════════════════════
+# Self-tuning audit (the centerpiece)
+# ═══════════════════════════════════════════════════════════════
+
+def run_audit_if_due(config, state, now):
+    """If the audit interval has elapsed, pull closed trades, compute bucket
+    stats, and possibly update MIN_SCORE. Returns updated state + the
+    audit summary (or None if skipped)."""
+    audit_every = float(config.get("auditEverySec", DEFAULT_AUDIT_EVERY_SEC))
+    last_audit_at = state.get("last_audit_at")
+    if last_audit_at is not None:
+        try:
+            if (now - float(last_audit_at)) < audit_every:
+                return state, None
+        except (TypeError, ValueError):
+            pass
+
+    user_id = config.get("senpiUserId")
+    if not user_id:
+        return state, {"skipped": "no senpiUserId in config — set it to enable self-tuning"}
+
+    trades = fetch_closed_trades(user_id, int(config.get("auditLimit", DEFAULT_AUDIT_LIMIT)))
+    bucket_stats = compute_bucket_stats(trades)
+    current_min = int(state.get("current_min_score") or config.get("initialMinScore", DEFAULT_INITIAL_MIN_SCORE))
+    min_n = int(config.get("minBucketN", DEFAULT_MIN_BUCKET_N))
+    bleed_pct = float(config.get("bucketBleedThresholdPct", DEFAULT_BUCKET_BLEED_PCT))
+    max_min = int(config.get("maxMinScore", DEFAULT_MAX_MIN_SCORE))
+
+    recommended = recommend_min_score(bucket_stats, current_min, min_n, bleed_pct, max_min)
+    state = dict(state)
+    state["last_audit_at"] = float(now)
+    state["audit_count"] = int(state.get("audit_count", 0)) + 1
+
+    audit_summary = {
+        "trades_examined": len(trades),
+        "trades_with_score": sum(1 for t in trades if t.get("score") is not None),
+        "bucket_stats": {str(k): v for k, v in sorted(bucket_stats.items(), reverse=True)},
+        "current_min_score": current_min,
+        "recommended_min_score": recommended,
+        "updated": False,
+    }
+
+    if should_update_threshold(current_min, recommended):
+        adjustments = list(state.get("adjustments", []))
+        adjustments.append({
+            "ts": float(now),
+            "prev": current_min,
+            "new": recommended,
+            "trades_examined": len(trades),
+            "bleeding_buckets": [
+                {"score": s, "stats": v}
+                for s, v in bucket_stats.items()
+                if s >= current_min and v["n"] >= min_n and v["avg_roe_pct"] < bleed_pct
+            ],
+        })
+        state["adjustments"] = adjustments
+        state["current_min_score"] = recommended
+        audit_summary["updated"] = True
+
+    return state, audit_summary
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — one asset
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, current_min_score, config):
+    data = fetch_market_data(asset)
+    if not data or not data.get("success", True):
+        return None
+    candles = data.get("data", {}).get("candles", {})
+    closes_4h = [_f(c, "close", "c") for c in candles.get("4h", [])]
+    closes_1h = [_f(c, "close", "c") for c in candles.get("1h", [])]
+    if len(closes_4h) < 8 or len(closes_1h) < 8:
+        return None
+
+    move_4h = pct_move(closes_4h, 6)    # 24h on 4h bars
+    move_1h = pct_move(closes_1h, 4)    # 4h on 1h bars
+    direction = trend_direction(move_4h, 1.0)
+    if direction is None:
+        return None
+    one_h_aligned = (move_1h is not None) and ((move_1h > 0) == (move_4h > 0)) and (abs(move_1h) >= 0.5)
+
+    sm_dir, sm_tilt = fetch_sm_direction(asset)
+    sm_min = float(config.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_aligned = (sm_dir == direction and sm_tilt >= sm_min)
+
+    # Volume surge
+    vols = [_f(c, "volume", "v") for c in candles.get("4h", [])]
+    vol_rising = False
+    if len(vols) >= 12:
+        recent = sum(vols[-3:]) / 3
+        baseline = sum(vols[-12:-3]) / 9
+        vol_rising = baseline > 0 and (recent / baseline) >= 1.3
+
+    score = lynx_score(move_4h, one_h_aligned, sm_aligned, vol_rising)
+    if score < current_min_score:
+        return None
+
+    reasons = [f"trend4h_{move_4h:+.1f}%", f"score_{score}", f"floor_{current_min_score}"]
+    if one_h_aligned:
+        reasons.append("1h_aligned")
+    if sm_aligned:
+        reasons.append(f"sm_{sm_tilt:.0f}%")
+    if vol_rising:
+        reasons.append("vol_rising")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_4h_pct": round(move_4h, 2),
+        "trend_1h_pct": round(move_1h, 2) if move_1h is not None else 0.0,
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": sm_tilt,
+        "vol_rising": vol_rising,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Signal emit
+# ═══════════════════════════════════════════════════════════════
+
+def push_signal(thesis, margin_usd, leverage, held_assets, current_min_score):
+    if not STRATEGY_ADDRESS:
+        return False
+    coin = thesis["coin"]
+    if coin.upper() in {h.upper() for h in held_assets}:
+        return False
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "currentMinScore": current_min_score,
+        "trend4hPct": thesis.get("trend_4h_pct") or 0.0,
+        "trend1hPct": thesis.get("trend_1h_pct") or 0.0,
+        "smDirection": thesis.get("sm_direction") or "NONE",
+        "smTiltPct": thesis.get("sm_tilt_pct") or 0.0,
+        "volRising": bool(thesis.get("vol_rising")),
+        "heldAssets": held_assets,
+    }
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=coin,
+            direction=thesis["direction"],
+            score=min(thesis["score"] / 8.0, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        print(f"INGEST_REJECTED {coin}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:  # noqa: BLE001
+        print(f"INGEST_EXCEPTION {coin}: {type(e).__name__}: {e}", file=sys.stderr)
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+    whitelist = config.get("whitelist", DEFAULT_WHITELIST)
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "_lynx_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "note": "no account value", "_lynx_producer_version": VERSION})
+        return
+
+    state = cfg.read_lynx_state()
+    initial_min = int(config.get("initialMinScore", DEFAULT_INITIAL_MIN_SCORE))
+    if state.get("current_min_score") is None:
+        state["current_min_score"] = initial_min
+
+    now = time.time()
+    # Run audit if due (the self-tuning step)
+    state, audit_summary = run_audit_if_due(config, state, now)
+    if audit_summary is not None:
+        cfg.write_lynx_state(state)
+
+    current_min_score = int(state.get("current_min_score", initial_min))
+
+    candidates = []
+    for asset in whitelist:
+        a = str(asset).upper()
+        if a in held_set or cfg.was_recently_signaled(a):
+            continue
+        thesis = build_thesis(a, current_min_score, config)
+        if thesis:
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok",
+            "note": f"WAITING — no asset cleared current MIN_SCORE={current_min_score}",
+            "current_min_score": current_min_score,
+            "audit": audit_summary,
+            "held_assets": held_assets,
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_lynx_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda c: (c["score"], abs(c["trend_4h_pct"])), reverse=True)
+    best = candidates[0]
+
+    margin_pct = float(config.get("marginPct", 0.20))
+    leverage = min(int(config.get("leverage", DEFAULT_LEVERAGE)), MAX_LEVERAGE)
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = push_signal(best, margin_usd, leverage, held_assets, current_min_score)
+    if pushed:
+        cfg.record_signal(best["coin"])
+
+    cfg.output({
+        "status": "ok",
+        "signals_pushed": 1 if pushed else 0,
+        "best": {
+            "coin": best["coin"],
+            "direction": best["direction"],
+            "score": best["score"],
+            "current_min_score": current_min_score,
+            "leverage": leverage,
+            "margin_usd": margin_usd,
+            "reasons": best["reasons"][:5],
+        },
+        "audit": audit_summary,
+        "candidates_count": len(candidates),
+        "held_assets": held_assets,
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_lynx_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _wallet_lock_id = (
+        hashlib.sha256(STRATEGY_ADDRESS.lower().encode()).hexdigest()[:12]
+        if STRATEGY_ADDRESS
+        else "unset"
+    )
+    producer_daemon(
+        fn=main,
+        interval_seconds=300,
+        name=f"lynx-producer-{_wallet_lock_id}",
+        tick_timeout=240,
+    )

--- a/lynx/scripts/lynx_config.py
+++ b/lynx/scripts/lynx_config.py
@@ -1,0 +1,241 @@
+"""LYNX v1.0.0 — Shared config + MCP shim + helpers wrapper.
+
+Adaptive MIN_SCORE Self-Tuner. Lynx is the Vulture v4.1 story productized.
+It runs a simple multi-asset momentum scorer on BTC/ETH/SOL/HYPE, persists
+its current MIN_SCORE in a state file, and every N ticks runs an audit on
+its own closed-trade history (via Senpi MCP audit_query). If any score
+bucket below the current floor has accumulated enough samples AND is bleeding,
+Lynx automatically raises MIN_SCORE above that bucket.
+
+NEW archetype #15: Self-tuning / adaptive-threshold agent. The agent
+implements reinforcement learning on its own scoring threshold — the same
+operation Vulture's agent ran by hand for v4.1, but on a scheduled audit.
+
+Architecture: helpers-native producer + senpi-trading-runtime LLM gate +
+let-winners-run DSL. Persisted state caches: `lynx-state.json` (current
+MIN_SCORE + audit history) and `recent-signals.json` (race-window dedup).
+Producer NEVER closes — DSL owns exits.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "lynx-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / "lynx-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / "recent-signals.json"
+LYNX_STATE_PATH = STATE_DIR / "lynx-state.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+RECENT_SIGNAL_TTL_SEC = 240
+
+
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Lynx's MCP calls and signal POST "
+            "both require it. Set it on the runtime host before starting the "
+            "producer daemon."
+        )
+    client = SenpiClient()
+    log_event("lynx_wrapper_enabled", sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def mcp_call(tool, **params):
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[senpi_helpers] lynx_mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value += float(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0)),
+                "margin": float(pos.get("marginUsed", 0)),
+                "entryPrice": float(pos.get("entryPx", 0)),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+def atomic_write(path, data):
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+# ─── Lynx state — current MIN_SCORE + audit history ──────────
+
+def read_lynx_state():
+    if not LYNX_STATE_PATH.exists():
+        return {
+            "current_min_score": None,         # None = use initialMinScore from config
+            "last_audit_at": None,
+            "audit_count": 0,
+            "adjustments": [],                 # [{ts, prev, new, reasoning}]
+        }
+    try:
+        with open(LYNX_STATE_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {
+                "current_min_score": None,
+                "last_audit_at": None,
+                "audit_count": 0,
+                "adjustments": [],
+            }
+        return data
+    except (json.JSONDecodeError, OSError):
+        return {
+            "current_min_score": None,
+            "last_audit_at": None,
+            "audit_count": 0,
+            "adjustments": [],
+        }
+
+
+def write_lynx_state(state):
+    try:
+        atomic_write(LYNX_STATE_PATH, state)
+    except OSError:
+        pass
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[lynx-v1] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/lynx/tests/test_signal.py
+++ b/lynx/tests/test_signal.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Unit tests for Lynx's pure functions — self-tuning logic
+(parse_score_from_reasoning, compute_bucket_stats, recommend_min_score,
+should_update_threshold) AND scoring logic (pct_move, trend_direction,
+lynx_score). Stubs lynx_config + senpi_runtime_helpers.
+Run: python3 lynx/tests/test_signal.py
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_cfg = types.ModuleType("lynx_config")
+_cfg.load_config = lambda: {}
+_cfg.mcp_call = lambda *a, **k: None
+_cfg.get_positions = lambda w: (0, [])
+_cfg.was_recently_signaled = lambda c: False
+_cfg.record_signal = lambda c: None
+_cfg.read_lynx_state = lambda: {}
+_cfg.write_lynx_state = lambda s: None
+_cfg.output = lambda d: None
+_cfg._wrapper_client = types.SimpleNamespace(push_signal=lambda **k: None)
+sys.modules["lynx_config"] = _cfg
+
+_helpers = types.ModuleType("senpi_runtime_helpers")
+class SenpiClientError(Exception):
+    pass
+_helpers.SenpiClientError = SenpiClientError
+_helpers.producer_daemon = lambda **k: None
+sys.modules["senpi_runtime_helpers"] = _helpers
+
+_path = Path(__file__).resolve().parent.parent / "scripts" / "lynx-producer.py"
+_spec = importlib.util.spec_from_file_location("lynx_producer", _path)
+lx = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lx)
+
+
+# ── parse_score_from_reasoning ─────────────────────────────────
+
+def test_parse_score_from_reasoning_lowercase():
+    assert lx.parse_score_from_reasoning("score 7 BTC LONG, trend strong") == 7
+
+
+def test_parse_score_from_reasoning_capital_with_colon():
+    assert lx.parse_score_from_reasoning("Score: 11 (apex tier)") == 11
+
+
+def test_parse_score_from_reasoning_equals_sign():
+    assert lx.parse_score_from_reasoning("SCORE=4, marginal setup") == 4
+
+
+def test_parse_score_from_reasoning_missing_returns_none():
+    assert lx.parse_score_from_reasoning("trade closed at +5%") is None
+    assert lx.parse_score_from_reasoning("") is None
+    assert lx.parse_score_from_reasoning(None) is None
+
+
+# ── compute_bucket_stats ───────────────────────────────────────
+
+def test_compute_bucket_stats_basic():
+    trades = [
+        {"score": 7, "roe_pct": -3.0},
+        {"score": 7, "roe_pct": -5.0},
+        {"score": 7, "roe_pct": +2.0},
+        {"score": 10, "roe_pct": +12.0},
+        {"score": 10, "roe_pct": +8.0},
+    ]
+    stats = lx.compute_bucket_stats(trades)
+    assert stats[7]["n"] == 3
+    assert abs(stats[7]["avg_roe_pct"] - (-2.0)) < 1e-9    # (-3 + -5 + 2) / 3
+    assert abs(stats[7]["win_rate_pct"] - (100.0 / 3)) < 1e-6
+    assert stats[10]["n"] == 2
+    assert abs(stats[10]["avg_roe_pct"] - 10.0) < 1e-9
+    assert stats[10]["win_rate_pct"] == 100.0
+
+
+def test_compute_bucket_stats_drops_no_score():
+    trades = [
+        {"score": None, "roe_pct": -5.0},
+        {"score": 8, "roe_pct": -2.0},
+    ]
+    stats = lx.compute_bucket_stats(trades)
+    assert list(stats.keys()) == [8]
+
+
+def test_compute_bucket_stats_handles_empty():
+    assert lx.compute_bucket_stats([]) == {}
+    assert lx.compute_bucket_stats(None) == {}
+
+
+# ── recommend_min_score ────────────────────────────────────────
+
+def test_recommend_min_score_raises_when_bucket_bleeds():
+    # Current floor is 4. Score 5 bucket has 10 trades averaging -3% → bleed.
+    # → recommend 5 + 1 = 6.
+    stats = {
+        4: {"n": 5, "avg_roe_pct": -0.5, "win_rate_pct": 40},   # not enough n
+        5: {"n": 10, "avg_roe_pct": -3.0, "win_rate_pct": 20},   # bleeding
+        7: {"n": 8, "avg_roe_pct": +5.0, "win_rate_pct": 60},
+    }
+    assert lx.recommend_min_score(stats, current_min_score=4, min_bucket_n=8, bucket_bleed_pct=-1.0, max_min_score=9) == 6
+
+
+def test_recommend_min_score_holds_when_no_bleed():
+    stats = {
+        5: {"n": 10, "avg_roe_pct": +2.0, "win_rate_pct": 60},
+        7: {"n": 8, "avg_roe_pct": +5.0, "win_rate_pct": 60},
+    }
+    assert lx.recommend_min_score(stats, current_min_score=5, min_bucket_n=8, bucket_bleed_pct=-1.0, max_min_score=9) == 5
+
+
+def test_recommend_min_score_ignores_below_floor():
+    # A bucket BELOW the current floor is already culled — don't double-act on it
+    stats = {
+        3: {"n": 20, "avg_roe_pct": -5.0, "win_rate_pct": 10},   # below floor — ignore
+        5: {"n": 10, "avg_roe_pct": +3.0, "win_rate_pct": 60},
+    }
+    assert lx.recommend_min_score(stats, current_min_score=4, min_bucket_n=8, bucket_bleed_pct=-1.0, max_min_score=9) == 4
+
+
+def test_recommend_min_score_caps_at_max():
+    # Bleeding bucket at score 8 would recommend 9; max is 7 → cap at 7
+    stats = {
+        8: {"n": 10, "avg_roe_pct": -3.0, "win_rate_pct": 20},
+    }
+    assert lx.recommend_min_score(stats, current_min_score=4, min_bucket_n=8, bucket_bleed_pct=-1.0, max_min_score=7) == 7
+
+
+def test_recommend_min_score_picks_highest_bleeding():
+    # Multiple bleeding buckets → recommend above the HIGHEST one
+    stats = {
+        5: {"n": 10, "avg_roe_pct": -2.0, "win_rate_pct": 20},   # bleeding
+        6: {"n": 10, "avg_roe_pct": -3.0, "win_rate_pct": 15},   # bleeding (higher)
+        7: {"n": 8, "avg_roe_pct": +5.0, "win_rate_pct": 60},
+    }
+    # Highest bleeding = 6, recommended = 7
+    assert lx.recommend_min_score(stats, current_min_score=4, min_bucket_n=8, bucket_bleed_pct=-1.0, max_min_score=9) == 7
+
+
+# ── should_update_threshold ────────────────────────────────────
+
+def test_should_update_threshold_hysteresis():
+    assert lx.should_update_threshold(4, 5) is True       # raised by 1, hysteresis met
+    assert lx.should_update_threshold(4, 4) is False      # no change
+    assert lx.should_update_threshold(4, 6) is True       # raised by 2
+    assert lx.should_update_threshold(4, 3) is False      # would lower (never)
+
+
+def test_should_update_threshold_handles_none():
+    assert lx.should_update_threshold(None, 5) is False
+    assert lx.should_update_threshold(4, None) is False
+
+
+# ── pct_move / trend_direction / lynx_score ───────────────────
+
+def test_pct_move_known_value():
+    closes = [100.0] * 7
+    closes[-1] = 105.0
+    assert abs(lx.pct_move(closes, 6) - 5.0) < 1e-9
+
+
+def test_trend_direction_thresholds():
+    assert lx.trend_direction(2.0, 1.0) == "LONG"
+    assert lx.trend_direction(-2.0, 1.0) == "SHORT"
+    assert lx.trend_direction(0.5, 1.0) is None
+
+
+def test_lynx_score_full_stack():
+    # 4h +5% (>= 4 → +3) + 1h aligned (+2) + SM aligned (+2) + vol rising (+1) = 8
+    assert lx.lynx_score(5.0, True, True, True) == 8
+
+
+def test_lynx_score_partial():
+    # 4h +1.5% (>= 1 but < 2 → +1) + no 1h + no SM + no vol = 1
+    assert lx.lynx_score(1.5, False, False, False) == 1
+
+
+def test_lynx_score_no_trend():
+    assert lx.lynx_score(None, True, True, True) == 0
+
+
+if __name__ == "__main__":
+    import traceback
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in tests:
+        try:
+            fn()
+            passed += 1
+            print(f"  PASS {fn.__name__}")
+        except Exception:
+            print(f"  FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"{passed}/{len(tests)} passed")
+    sys.exit(0 if passed == len(tests) else 1)

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -202,6 +202,7 @@ If your target asset is one of these four, use that example directly. If your ta
 | **Grizzly** | v5.3 | BTC | Kodiak template tuned for BTC's lower-volatility, higher-liquidity regime. Same six-gate confluence, calmer thresholds, tighter sizing. | BTC, Low-vol, Blue-chip |
 | **Polar** | v3.0 | ETH | Kodiak template tuned for ETH. Same six-gate framework with ETH-specific volatility and liquidity calibration. | ETH, 6-gate, Single-slot |
 | **Wolverine** | v3.0 | HYPE | Kodiak ported to HYPE — Hyperliquid's native token. Six-gate validation with HYPE-tuned thresholds for its high-vol profile. | HYPE, High-vol, Sharp moves |
+| **Koala** | v1.0 | Operator-chosen single asset (default BTC) | **Onboarding tier — state-trigger variant.** No scoring, no multi-timeframe analysis, no market_get_asset_data call — just a state-file check. Fires ONE LONG signal per lifetime (fire-once mode) and holds with the widest DSL in any Senpi agent (max_loss 30%, retrace 25, 90d hard_timeout). Operators who want a cycling deploy set `fireOnceMode: false` with a `reEntryCooldownHours` (default 7d). For users whose entire trading thesis is "I want to own BTC and have a safety net." | Onboarding, HODL, Fire-once, Ultra-wide DSL, No-scoring |
 | **Beaver** | v1.0 | BTC | **Onboarding tier.** Simplified 5-component scoring (max ~9), single SM-direction gate, wide Bison-pattern DSL. The "first strategy" for new users. | Onboarding, BTC, SM-gate, Tick 300s |
 | **Heron** | v1.0 | ETH | Beaver fork — ETH instead of BTC. Same scaffold + scoring. | Onboarding, ETH, SM-gate, Tick 300s |
 | **Hummingbird** | v1.0 | HYPE | Beaver fork — HYPE instead of BTC. Same scaffold + scoring. | Onboarding, HYPE, SM-gate, Tick 300s |
@@ -780,6 +781,77 @@ consensus = tally_consensus(entries)                   # (asset,dir) -> {count, 
 
 ---
 
+### 15. Self-tuning / adaptive-threshold agent
+
+The first archetype where the agent **modifies its own behavior based on its own trade history**. The agent runs a normal scoring producer with a configured `MIN_SCORE`, but on a scheduled cron it pulls its own closed-trade telemetry (via `audit_query`), buckets the trades by entry score, and auto-raises `MIN_SCORE` if any bucket at-or-above the current floor has accumulated enough samples AND is averaging below the bleed threshold.
+
+This is the Vulture v4.1 manual cull turned into a first-class agent pattern. See [the Vulture v4.1 PR](https://github.com/Senpi-ai/senpi-skills/pull/337) for the source story.
+
+```python
+# Each tick, if audit interval has elapsed:
+trades = mcp_call("audit_query", user_ids=[senpi_user_id], action_type="close", limit=200)
+bucket_stats = compute_bucket_stats(trades)            # {score: {n, avg_roe_pct, win_rate_pct}}
+recommended = recommend_min_score(bucket_stats, current_min, min_n=8, bleed_pct=-1.0, max_min=7)
+if should_update_threshold(current_min, recommended):
+    state["current_min_score"] = recommended
+    state["adjustments"].append({...})                # full audit-trail log
+```
+
+| | |
+|---|---|
+| Producer-signature for fleet audit | `market_get_asset_data` per asset (scoring) + `audit_query` per audit interval (self-tuning) |
+| Typical tick interval | 300s (5min) for scoring; audit every 6h |
+| Typical risk envelope | small whitelist of crypto majors, conviction-tier leverage, MIN_SCORE ratchets upward only (never lowers) |
+| Example agent | **Lynx** |
+| Example producer (full source) | https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lynx/scripts/lynx-producer.py |
+| Example `_config.py` | https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lynx/scripts/lynx_config.py |
+| Example runtime.yaml | https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/lynx/runtime.yaml |
+
+**When to use this pattern:** the agent has a known scoring system AND the data exists (via `audit_query`) to measure which score buckets pay. Caveat: works best when there's enough volume to fill score buckets within an actionable window — for slow / low-frequency strategies, the auto-tune is starved for data. Requires user-scope auth.
+
+**Agents in this family:**
+
+| Agent | Version | Asset / Universe | Description | Tags |
+|---|---|---|---|---|
+| **Lynx** | v1.0 | BTC · ETH · SOL · HYPE | Multi-asset momentum scorer (max ~8) with a periodic self-tuning audit. Every 6h pulls own closed trades, buckets by entry score, raises `MIN_SCORE` if a bucket at-or-above the floor has ≥8 trades averaging worse than -1% ROE. Caps at `maxMinScore: 7`. Logs every adjustment with bleeding-bucket evidence. | Self-tuning, Adaptive-MIN_SCORE, Audit-cron, RL-on-threshold, User-scope-auth-required |
+
+---
+
+### 16. Regime classifier / meta-router
+
+The first archetype built around **macro-regime classification as a first-class signal**. The agent computes BTC trend strength + realized volatility + cross-asset dispersion, classifies the market into `{TREND_UP / TREND_DOWN / CHOP / UNKNOWN}`, and publishes the classification in every tick output — including ticks where no trade is taken.
+
+For v1, the classifier also takes its own regime-positional trade so it has skin in its own call. The "meta-router" framing is aspirational: future runtime work can let other agents *subscribe* to the regime channel as a gating input (e.g. Tortoise auto-pauses in TREND_DOWN; Stag auto-enables in TREND_UP).
+
+```python
+btc_move = pct_move(btc_closes, lookback=42)            # 7d on 4h bars
+btc_vol  = realized_vol_pct(btc_closes, lookback=42)    # annualized
+dispersion = dispersion_pct({asset: pct_move(...) for asset in universe})  # cross-sectional
+
+regime = classify_regime(btc_move, btc_vol, ...thresholds)   # TREND_UP / TREND_DOWN / CHOP / UNKNOWN
+direction = regime_to_direction(regime)                       # LONG / SHORT / None
+```
+
+| | |
+|---|---|
+| Producer-signature for fleet audit | `market_get_asset_data` per universe asset (just for close prices) |
+| Typical tick interval | 900s (15min — regimes don't flip in 5 minutes) |
+| Typical risk envelope | 1 slot, conservative leverage, 6h cooldown between regime trades |
+| Example agent | **Coyote** |
+| Example producer (full source) | https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/coyote/scripts/coyote-producer.py |
+| Example `_config.py` | https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/coyote/scripts/coyote_config.py |
+| Example runtime.yaml | https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/coyote/runtime.yaml |
+
+**When to use this pattern:** you want a single agent making a single macro call ("is the market trending up / down / sideways?") and everything else flowing from there. The classification is the deliverable; the trade is a consequence.
+
+**Agents in this family:**
+
+| Agent | Version | Asset / Universe | Description | Tags |
+|---|---|---|---|---|
+| **Coyote** | v1.0 | BTC (positional) + BTC/ETH/SOL/HYPE (dispersion universe) | 3-regime classifier (TREND_UP / TREND_DOWN / CHOP) with explicit volatility-confirmation on the down side (crash = price drop + vol spike, not slow grind). LONG BTC in TREND_UP, SHORT BTC in TREND_DOWN, no trade in CHOP. Regime classification + all three input metrics published on every tick. Balanced DSL. Tick 900s. | Regime-classifier, Meta-router, Macro, Vol-aware, Published-on-every-tick, User-scope-auth-required |
+
+---
+
 ## Decision tree — help a user pick their first strategy
 
 This is the guided path an **onboarding agent** walks a new user through. Start broad ("what kind of trader do you want your agent to be?"), narrow **one layer at a time**, and land on a single deployable strategy. Ask one question, show 2–6 options, let them pick, then go deeper. Each leaf names a **real, installable agent** — beginners are routed to the **onboarding tier** (simpler scoring, conservative sizing); the *level up* line is the full-fleet version for once they're comfortable.
@@ -873,6 +945,8 @@ Ask which one sentence sounds most like the user:
   - 🟢 Beginner — *long only, multi-timeframe agreement*: **Sheep** (BTC/ETH/SOL/HYPE). Fires LONG only when 15m + 1h + 4h EMAs are all stacked bullishly. Never shorts — for users intimidated by directional choice.
   - ⬆️ Level up — *rotation across majors*: **Sailfish** (RS leader). Always holds the strongest of BTC/ETH/SOL/HYPE; rotates via DSL exit + re-entry.
   - 🎯 *Operator-driven — "I see a parabolic running, deploy something to ride it"*: **Stag** (parabolic-run hunter). Strict 5-gate entry filter (7d ≥ 25%, vol surge, acceleration, SM ≥60% LONG, structural trend); pairs with the widest DSL in the catalog (`parabolic_runner`: max_loss 25, retrace 18, 14d outer bound). Bleeds in chop — deploy only when you've identified the setup. Reference: HYPE 2026-05.
+  - 🟢 *Even simpler — "I just want to own BTC and have a safety net"*: **Koala** (set-and-forget HODL). One asset, one entry per lifetime, the widest DSL in any Senpi agent (max_loss 30%, retrace 25, 90d hard_timeout). No scoring, no decisions after deploy. The simplest possible Senpi agent.
+  - 🧠 *Advanced — "watch the agent learn from its own trades"*: **Lynx** (adaptive MIN_SCORE self-tuner). Productizes the Vulture v4.1 manual cull as a scheduled audit. Every 6h Lynx pulls its own closed-trade history and raises its MIN_SCORE if a bucket below the floor is bleeding. First fleet agent that modifies its own behavior based on its own track record.
   - ⬆️ Level up: **Grizzly** (BTC) · **Polar** (ETH) · **Kodiak** (SOL) · **Wolverine** (HYPE) — Kodiak-family alpha hunters.
 - **A basket of majors** (BTC + ETH + SOL together).
   - 🟢 Beginner: **Hedgehog** (equal-weight basket, up to 3 at once).
@@ -1056,6 +1130,9 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | **Iguana** | 4 — Multi-asset whitelist (XYZ subset, onboarding) | xyz:SP500 + xyz:XYZ100. Simplest possible XYZ exposure — index-fund equivalent. Balanced DSL + 48h hard_timeout for weekend pricing-gap risk |
 | **Sailfish** | 4 — Multi-asset whitelist (momentum-rotation) | BTC/ETH/SOL/HYPE. Ranks by ~2.7d RS, longs the leader iff leader RS ≥ 1% AND beats runner-up by ≥ 1.5pp (no whipsaw). Rotation via DSL exit + re-entry. Balanced DSL + 96h hard_timeout |
 | **Stag** | 4 — Multi-asset whitelist (parabolic-run hunter, operator-driven) | BTC/ETH/SOL/HYPE (often single-asset). Strict 5-gate filter (7d ≥ 25% + vol surge + accel + 200-SMA + SM ≥60% LONG). LONG only. Entry-side pair for new `parabolic_runner` DSL preset (max_loss 25%, retrace 18, 2 breaches required, 14d outer bound). Reference: HYPE 2026-05 +60% in 16 days |
+| **Koala** | 2 — Single-asset alpha hunter (state-trigger variant, onboarding) | Operator-chosen single asset (default BTC). No scoring — state-file fire-once entry, then the widest DSL in any Senpi agent (max_loss 30%, retrace 25, 90d hard_timeout). The simplest possible Senpi agent |
+| **Lynx** | 15 — Self-tuning / adaptive-threshold agent | BTC/ETH/SOL/HYPE. Simple momentum scorer with a 6h audit cron that pulls own closed-trade history via audit_query, buckets by entry score, and raises MIN_SCORE if a bucket below the floor is bleeding. First fleet agent that modifies its own behavior based on its own track record |
+| **Coyote** | 16 — Regime classifier / meta-router | BTC (positional) + BTC/ETH/SOL/HYPE (dispersion universe). 3-regime classifier (TREND_UP / TREND_DOWN / CHOP) with vol-confirmation on the down side. Publishes regime + all input metrics on every tick. LONG BTC in TREND_UP, SHORT BTC in TREND_DOWN, no trade in CHOP |
 
 Sentinel runs an in-house producer that is not currently published to this repo; no public URL.
 


### PR DESCRIPTION
## Summary
Three agents from opposite ends of the sophistication spectrum, deliberately shipped together to show the range:

### 🐨 Koala — Set-and-Forget HODL (onboarding tier, archetype #2 variant)
The simplest possible Senpi agent. State-trigger entry — no scoring, no `market_get_asset_data` call. Fires ONE LONG signal per lifetime and holds with the **widest DSL in any Senpi agent** (max_loss 30%, retrace 25, 90d hard_timeout). For users whose entire trading thesis is *"I want to own BTC and have a safety net."* Maker-preferred entry (no urgency).
- 8/8 unit tests (fire-once + re-entry-cooldown branches)

### 🐯 Lynx — Adaptive MIN_SCORE Self-Tuner (NEW archetype #15)
**The Vulture v4.1 manual cull productized into a scheduled cron.** Runs a simple BTC/ETH/SOL/HYPE momentum scorer (max ~8) and every 6h pulls own closed-trade history via `audit_query`, buckets by entry score, raises `MIN_SCORE` if a bucket at-or-above the floor has ≥8 samples averaging worse than -1% ROE. Hysteresis prevents flapping. Caps at `maxMinScore=7`. Every adjustment logged to state with bleeding-bucket evidence.
- **First fleet agent that modifies its own behavior based on its own track record.**
- 19/19 unit tests (self-tuning + scoring logic)

### 🐺 Coyote — Regime Classifier / Meta-Router (NEW archetype #16)
Watches BTC trend + realized vol + cross-asset dispersion. Classifies into TREND_UP / TREND_DOWN / CHOP / UNKNOWN. LONG BTC in TREND_UP, SHORT BTC in TREND_DOWN, no trade in CHOP. TREND_DOWN explicitly requires HIGH vol (crash regime: drop + vol spike, not slow grind) — avoids shorting orderly pullbacks. Classification + all 3 input metrics published in **every tick output**, even when no trade fires.
- 14/14 unit tests

## Test plan
- [x] All 3 producers compile (`python3 -m py_compile`)
- [x] All 3 test suites pass — **41/41 combined** (8 + 19 + 14)
- [x] runtime.yaml parses + config.json parses for all 3
- [x] field-parity AST-verified (top-level data_block keys ⊆ scanner fields)
- [x] Integrated into producer-patterns.md (NEW archetypes #15 + #16 with full templates + Koala in archetype #2 + 3 fleet-roster-mapping rows + Layer 2A decision-tree bullets), root README (count → 44 skills / 16 archetypes; archetype sections #15 + #16 added; Koala in both archetype #2 table AND onboarding tier), catalog.json (3 new entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)