### PR TITLE
Jaguar v4.0.1 — order-of-operations bug fix (silent-scanner regression)

### DIFF
--- a/jaguar/README.md
+++ b/jaguar/README.md
@@ -173,6 +173,14 @@ Expected: `status=ok` every tick (180s interval). Heartbeat fields: `scanned`, `
 
 ## Changelog
 
+### v4.0.1 (2026-05-29) — order-of-operations bug fix (silent scanner)
+
+**Bug:** v4.0 appended `current_scan` to `history["scans"]` BEFORE calling `detect_striker_signals()`. Inside the detection function, `prev_scans[-1]` returned the same scan that was just appended — so every asset's `rank_jump` computed as `current_rank − current_rank = 0`. No asset ever met `STRIKER_MIN_RANK_JUMP`. **The scanner went completely silent.**
+
+A historical-replay test on the bug missed **25 valid signals over 2 days**, including spikes on VVV, XMR, and GRASS. The agent diagnosed it from its own diagnostics on 2026-05-29 and hot-patched the live host (immediately found 3 candidates and fired Score-11 GRASS LONG — `FIRST_JUMP #34→#15`). This commit ferries the fix into the repo.
+
+**Fix:** Reordered `main()` to **detect first, then append**: detection now runs against history that doesn't yet include the current scan; the current scan is appended only after detection so it becomes the *prior* on the next tick. First-ever-scan guard added to seed history without trying to detect.
+
 ### v4.0.0 — helpers-native plumbing migration
 
 Plumbing-only migration from v3.7. NO thesis change. v3.x striker scoring + DSL preset + `risk.guard_rails` preserved verbatim. Producer flips to in-process `SenpiClient`, daemon replaces cron, runtime owns execution.

--- a/jaguar/SKILL.md
+++ b/jaguar/SKILL.md
@@ -14,19 +14,45 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "4.0"
+  version: "4.0.1"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🐆 JAGUAR v4.0.0 — Striker (helpers-native)
+# 🐆 JAGUAR v4.0.1 — Striker (helpers-native)
 
 **Plumbing-only migration from v3.7. NO thesis change.** v3.x striker
 scoring + DSL preset + risk.guard_rails preserved verbatim. Producer
 flips to in-process `SenpiClient`, daemon replaces cron, runtime owns
 execution.
+
+## v4.0.1 changelog (2026-05-29) — order-of-operations bug fix
+
+**Bug:** v4.0 appended `current_scan` to `history["scans"]` BEFORE calling
+`detect_striker_signals()`. Inside the detection function, `prev_scans[-1]`
+then returned the same scan that was just appended — so every asset's
+`rank_jump` computed as `current_rank − current_rank = 0`. No asset ever
+met `STRIKER_MIN_RANK_JUMP`. **The scanner went completely silent.**
+
+**Impact:** A historical-replay test on the bug missed 25 valid signals over
+2 days, including spikes on VVV, XMR, and GRASS. The agent diagnosed the
+bug from its own diagnostics on 2026-05-29 ("score 11 GRASS LONG —
+FIRST_JUMP #34→#15" fired within minutes of the hot-patch) and the fix
+is now ferried into the repo.
+
+**Fix:** Reordered `main()`:
+1. Build `current_scan`
+2. Load history
+3. If history is empty, seed it and return early (first-ever scan)
+4. **Call `detect_striker_signals(current_scan, history)` FIRST** — so
+   `prev_scans[-1]` returns the actual previous scan
+5. Append `current_scan` to history AFTER detection
+6. Save history
+
+The detect-then-append sequence is now the contract; future
+`jaguar-producer.py` edits must preserve it.
 
 ## v4.0.0 changelog
 

--- a/jaguar/scripts/jaguar-producer.py
+++ b/jaguar/scripts/jaguar-producer.py
@@ -70,7 +70,7 @@ from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ign
 # reentrant; nested call raises BlockingIOError every tick.
 
 
-VERSION = "4.0.0"
+VERSION = "4.0.1"
 
 # Hardcoded — must match runtime.yaml external_scanner.name.
 SCANNER_NAME = "jaguar_signals"
@@ -578,13 +578,28 @@ def main():
         }))
         return
 
-    # Build scan snapshot, append, persist
+    # Build scan snapshot
+    #
+    # v4.0.1 ORDER-OF-OPERATIONS FIX: detect FIRST, then append.
+    #
+    # Bug: prior to v4.0.1, the producer appended `current_scan` to
+    # history["scans"] BEFORE calling detect_striker_signals(). Inside the
+    # detection function, `prev_scans[-1]` then returned the SAME scan that
+    # was just appended — so every asset's `rank_jump` computed as
+    # current_rank - current_rank = 0. No asset ever met STRIKER_MIN_RANK_JUMP
+    # and the scanner went completely silent. In a historical-replay test,
+    # this dropped 25 valid signals over 2 days (VVV/XMR/GRASS spikes among
+    # them). The agent's own diagnosis on 2026-05-29; ferried into the repo.
+    #
+    # Correct order: detect (with the still-prior history), THEN append the
+    # current scan for the next tick to compare against.
     current_scan = build_scan_snapshot(markets)
     history = load_scan_history()
-    history["scans"].append(current_scan)
-    save_scan_history(history)
 
-    if len(history["scans"]) < 2:
+    # First-ever scan? Seed history and return — nothing to compare against yet.
+    if not history.get("scans"):
+        history["scans"] = [current_scan]
+        save_scan_history(history)
         print(json.dumps({
             "status": "ok",
             "scanned": len(markets),
@@ -596,8 +611,12 @@ def main():
         }))
         return
 
-    # Detect Striker signals (full v3.7 logic preserved)
+    # Detect Striker signals against the previous scan (now actually prior, not self)
     candidates = detect_striker_signals(current_scan, history)
+
+    # Append current scan AFTER detection so the next tick has a real prior.
+    history["scans"].append(current_scan)
+    save_scan_history(history)
 
     if not candidates:
         elapsed = time.time() - run_start


### PR DESCRIPTION
## The bug (diagnosed by Jaguar's own agent)
v4.0 appended `current_scan` to `history["scans"]` BEFORE calling `detect_striker_signals()`. Inside the detection function, `prev_scans[-1]` then returned the same scan that was just appended — so every asset's `rank_jump` computed as `current_rank − current_rank = 0`. No asset ever met `STRIKER_MIN_RANK_JUMP`. **The scanner went completely silent for ~a week.**

## Impact
Historical-replay test on the bug missed **25 valid signals over 2 days**, including spikes on **VVV, XMR, GRASS**. Jaguar diagnosed it from its own logs on 2026-05-29 and hot-patched the live host. Immediately after the patch it found 3 candidates and fired:

> *score 11 STRIKER GRASS LONG — FIRST_JUMP #34→#15*

This PR ferries that fix into the repo so future Jaguar deployments inherit the correct behavior.

## The fix (3 files)

**`jaguar/scripts/jaguar-producer.py`** — reordered `main()` to **detect-then-append**:

```python
current_scan = build_scan_snapshot(markets)
history = load_scan_history()

# First-ever scan? Seed history and return — nothing to compare against yet.
if not history.get("scans"):
    history["scans"] = [current_scan]
    save_scan_history(history)
    return

# Detect Striker signals against the previous scan (now actually prior, not self)
candidates = detect_striker_signals(current_scan, history)

# Append current scan AFTER detection so the next tick has a real prior.
history["scans"].append(current_scan)
save_scan_history(history)
```

The bug-explainer comment is in-code so future edits can't drop the contract silently. `VERSION` bumped `4.0.0 → 4.0.1`.

**`jaguar/SKILL.md`** — metadata version `4.0 → 4.0.1`, dedicated v4.0.1 changelog section explaining the bug + impact + fix.

**`jaguar/README.md`** — Changelog entry for operators.

## Test plan
- [x] `python3 -m py_compile jaguar/scripts/jaguar-producer.py` — OK
- [x] Visually confirmed the new ordering: line ~615 `detect_striker_signals()` runs before line ~618 `history["scans"].append()`
- [x] First-ever-scan guard added — seed history with `[current_scan]` and return; no detection attempted with empty history

🤖 Generated with [Claude Code](https://claude.com/claude-code)