### PR TITLE
kestrel v3.0.2: fix score-normalization bug silencing producer

### DIFF
--- a/kestrel/README.md
+++ b/kestrel/README.md
@@ -137,6 +137,16 @@ Expected: `status=ok` every tick (300s interval — macro 1H candles change slow
 
 ## Changelog
 
+### v3.0.2 (2026-05-29) — score-normalization bug fix (silent producer)
+
+**Bug:** the producer was passing the raw strategy-specific score (5–10+) as the **top-level** `score` kwarg to `SenpiClient.push_signal()`. The runtime requires that field to be in `[0, 1]` (it's the runtime's confidence band, not the strategy's raw score). Every `push_signal()` call failed with:
+
+> `push_signal: top-level score must be in [0, 1] (got 7.0)`
+
+**Impact:** **Kestrel hadn't traded in over a week** before the agent diagnosed this on 2026-05-29. The scanner was actively running and finding 0 candidates at score >= 5 *during the recent flat XYZ regime* — so the bug was hidden by a quiet market, but it would have silenced the agent even in active conditions. Within minutes of the live hot-patch the producer fired Score-7 `SHORT xyz:NVDA` (1H -2.38%, 4H -1.92% aligned, SM 5.0%, spread 0%).
+
+**Fix:** Normalize the raw score to `[0, 1]` for the top-level `score` kwarg (a Score-10 entry becomes 1.0, Score-5 becomes 0.5). The full raw score stays inside `data.score` so the LLM gate still sees the actual conviction tier when deciding execute/skip. Added a 12-line bug-explainer comment inside `push_signal()` so the contract is in-code for future edits.
+
 ### v3.0.0 — Plumbing-only migration from v2.0 (no thesis change)
 
 NO scoring change. NO threshold change. Producer ports onto `senpi_runtime_helpers` (in-process `SenpiClient`, no openclaw / mcporter subprocesses). Long-lived `producer_daemon` replaces the openclaw cron entry. v2.0.9 contamination rule applied: `KESTREL_WALLET` is the canonical env var (with `STRATEGY_ADDRESS` deprecation fallback).

--- a/kestrel/SKILL.md
+++ b/kestrel/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0.0"
+  version: "3.0.2"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/kestrel/scripts/kestrel-producer.py
+++ b/kestrel/scripts/kestrel-producer.py
@@ -88,7 +88,7 @@ if _sdk_path not in sys.path:
 from senpi_runtime_helpers import producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "3.0.1"
+VERSION = "3.0.2"
 SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "kestrel_signals")
 SIGNAL_TYPE = "KESTREL_XYZ_BREAKOUT"
 
@@ -628,11 +628,27 @@ def build_signal_data(candidate, leverage, margin_usd, held_assets):
 
 
 def push_signal(candidate, leverage, margin_usd, held_assets):
-    """v3.0.0: direct POST to runtime /signals via helpers SenpiClient."""
+    """v3.0.0: direct POST to runtime /signals via helpers SenpiClient.
+
+    v3.0.2 SCORE-NORMALIZATION FIX: the runtime requires the TOP-LEVEL
+    `score` kwarg to be in [0, 1] (it's the runtime's confidence band, not
+    the strategy's raw score). Kestrel's raw scoring stack is 5-10+, so
+    passing it verbatim caused every push_signal call to fail with:
+        push_signal: top-level score must be in [0, 1] (got 7.0)
+    The producer silently went without signals — and Kestrel hadn't traded
+    in over a week before the agent diagnosed this on 2026-05-29.
+
+    Fix: normalize the raw score to [0, 1] for the top-level kwarg (a
+    Score-10 entry becomes 1.0, Score-5 becomes 0.5). The full raw score
+    stays inside `data.score` so the LLM gate still sees the actual
+    conviction tier when deciding execute/skip.
+    """
     if not STRATEGY_ADDRESS:
         cfg.log("KESTREL_WALLET not set; cannot push signal")
         return False
     data_block = build_signal_data(candidate, leverage, margin_usd, held_assets)
+    raw_score = float(candidate["score"])
+    normalized = min(max(raw_score / 10.0, 0.0), 1.0)
     try:
         cfg._wrapper_client.push_signal(
             address=STRATEGY_ADDRESS,
@@ -640,7 +656,7 @@ def push_signal(candidate, leverage, margin_usd, held_assets):
             asset=f"xyz:{candidate['token']}",
             direction=candidate["direction"],
             signal_type=SIGNAL_TYPE,
-            score=float(candidate["score"]),
+            score=normalized,
             data=data_block,
         )
         return True


### PR DESCRIPTION
## Summary
- **Bug:** producer passed the raw strategy score (5-10+) as the top-level `score` kwarg to `SenpiClient.push_signal()`. The runtime requires that field in `[0, 1]` (its confidence band, not the strategy's raw score), so every call failed with `push_signal: top-level score must be in [0, 1] (got 7.0)`.
- **Impact:** Kestrel hadn't traded in over a week. Masked by a flat XYZ regime producing 0 candidates at score >= 5; would have silenced the agent in active conditions too. Within minutes of the live hot-patch the producer fired Score-7 `SHORT xyz:NVDA`.
- **Fix:** normalize raw score to `[0, 1]` for the top-level kwarg (Score-10 -> 1.0, Score-5 -> 0.5). Full raw score stays in `data.score` so the LLM gate still sees the actual conviction tier. Added an in-code bug-explainer so the `[0, 1]` contract travels with future edits.

Plumbing-only. NO thesis / scoring / threshold change. Ferries the live agent's hot-patch into the repo.

## Test plan
- [x] `py_compile` clean
- [x] raw 10 -> 1.0, raw 5 -> 0.5, clamped to [0,1]
- [x] SKILL.md + README changelog synced to v3.0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)