### PR TITLE
jaguar v4.0.2: relax dead_weight_cut 12 → 30min

### DIFF
--- a/jaguar/README.md
+++ b/jaguar/README.md
@@ -31,7 +31,7 @@ The discipline is asymmetric by P&L state: capped at 3 entries/day on RED days, 
 | Drawdown halt | 25% |
 | `hard_timeout` | 45 min |
 | `weak_peak_cut` | 25 min @ 3% min |
-| `dead_weight_cut` | 12 min |
+| `dead_weight_cut` | 30 min |
 | Entry order type | FEE_OPTIMIZED_LIMIT (30s timeout, ALO-then-taker) |
 | Exit order type | FEE_OPTIMIZED_LIMIT (60s timeout, ALO-then-taker) |
 
@@ -172,6 +172,14 @@ tail -f /tmp/jaguar-producer.log | jq -c 'select(.status=="ok")' | head -3
 Expected: `status=ok` every tick (180s interval). Heartbeat fields: `scanned`, `candidates`, `signals_pushed`, `min_score`, `elapsed_sec`, `_jaguar_producer_version`.
 
 ## Changelog
+
+### v4.0.2 (2026-05-29) — `dead_weight_cut` 12 → 30min
+
+**Symptom:** a GRASS LONG was cut at exactly 12:00 with price essentially flat ($0.4925 → $0.4924). `dead_weight_cut` fired on a position that hadn't failed — it just hadn't started moving yet — paying entry + exit fees for zero edge.
+
+**Diagnosis:** the v3.7 `dead_weight_cut: 12min` was too eager. A Striker rank-jump can take longer than 12min to accelerate; cutting that early converts "not moving yet" into a guaranteed fee loss. Per fleet HYPE-run lessons (fees are the biggest killer; momentum needs room before it accelerates), the 12min floor was chopping winners-in-waiting.
+
+**Fix:** `dead_weight_cut.interval_in_minutes` 12 → 30. At 30min, `weak_peak_cut` (25min @ 3% min) becomes the effective backstop for flat trades, and `dead_weight_cut` now only catches positions that DID peak but then went stagnant. `hard_timeout` (45min) and all scoring/gates unchanged. Hypothesis test — re-evaluate after ~50 more trades.
 
 ### v4.0.1 (2026-05-29) — order-of-operations bug fix (silent scanner)
 

--- a/jaguar/SKILL.md
+++ b/jaguar/SKILL.md
@@ -14,19 +14,39 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "4.0.1"
+  version: "4.0.2"
   platform: senpi
   exchange: hyperliquid
   requires:
     - senpi-trading-runtime
 ---
 
-# 🐆 JAGUAR v4.0.1 — Striker (helpers-native)
+# 🐆 JAGUAR v4.0.2 — Striker (helpers-native)
 
 **Plumbing-only migration from v3.7. NO thesis change.** v3.x striker
-scoring + DSL preset + risk.guard_rails preserved verbatim. Producer
+scoring + risk.guard_rails preserved verbatim. Producer
 flips to in-process `SenpiClient`, daemon replaces cron, runtime owns
-execution.
+execution. v4.0.2 relaxes one DSL time-cut (`dead_weight_cut` 12 → 30min);
+scoring and gates are untouched.
+
+## v4.0.2 changelog (2026-05-29) — dead_weight_cut 12 → 30min
+
+**Symptom:** a GRASS LONG was cut at exactly 12:00 with price essentially
+flat ($0.4925 → $0.4924) — `dead_weight_cut` fired on a position that
+hadn't failed, it just hadn't started moving yet. Entry + exit fees paid
+for zero edge.
+
+**Diagnosis:** the v3.7 `dead_weight_cut: 12min` was too eager. A Striker
+rank-jump can take longer than 12min to accelerate; cutting that early
+turns "not moving yet" into "guaranteed fee loss." Per fleet HYPE-run
+lessons (fees are the biggest killer; momentum needs room before it
+accelerates), the 12min floor was chopping winners-in-waiting.
+
+**Fix:** `dead_weight_cut.interval_in_minutes` 12 → 30. At 30min,
+`weak_peak_cut` (25min @ 3% min) becomes the effective backstop for flat
+trades, and `dead_weight_cut` now only catches positions that DID peak
+but then went stagnant. `hard_timeout` (45min) and all scoring/gates
+unchanged. Hypothesis test — re-evaluate after ~50 more trades.
 
 ## v4.0.1 changelog (2026-05-29) — order-of-operations bug fix
 
@@ -200,7 +220,7 @@ LLM gate's leverage echo is venue-safe (XMR=5x, etc.).
 |---|---|
 | hard_timeout | 45 min |
 | weak_peak_cut | 25 min @ 3% min |
-| dead_weight_cut | 12 min |
+| dead_weight_cut | 30 min (v4.0.2: was 12) |
 | Phase 1 max_loss_pct | 15.0 |
 | Phase 1 retrace_threshold | 8 |
 | Phase 1 consecutive_breaches_required | 1 |

--- a/jaguar/runtime.yaml
+++ b/jaguar/runtime.yaml
@@ -198,8 +198,18 @@ actions:
 
 # ── EXIT (DSL) ──
 # Striker trades are violent short-term explosions. Tight DSL: 45min
-# hard timeout, 12min dead weight, wide Phase 1 for volatility.
-# Preset preserved verbatim from v3.7.
+# hard timeout, 30min dead weight, wide Phase 1 for volatility.
+#
+# v4.0.2 (2026-05-29): dead_weight_cut relaxed 12 → 30min. The 12min
+# floor was chopping flat-but-not-yet-failed trades before the move had
+# a chance to start — e.g. a GRASS LONG cut at exactly 12:00 with price
+# essentially unchanged ($0.4925 → $0.4924), paying entry+exit fees for
+# zero edge. Per fleet HYPE-run lessons (fees are the biggest killer;
+# momentum needs room before it accelerates), 12min was too eager. At
+# 30min, weak_peak_cut (25min @ 3% min) becomes the effective backstop
+# for flat trades, and dead_weight_cut now only catches positions that
+# DID peak but then went stagnant. hard_timeout 45min unchanged.
+# Hypothesis test — re-evaluate after ~50 more trades.
 exit:
   engine: dsl
   interval_seconds: 30
@@ -220,7 +230,7 @@ exit:
       min_value: 3.0
     dead_weight_cut:
       enabled: true
-      interval_in_minutes: 12
+      interval_in_minutes: 30   # v4.0.2: 12 → 30 (12min chopped flat trades before they could move)
     phase1:
       enabled: true
       max_loss_pct: 15.0

--- a/jaguar/scripts/jaguar-producer.py
+++ b/jaguar/scripts/jaguar-producer.py
@@ -70,7 +70,7 @@ from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ign
 # reentrant; nested call raises BlockingIOError every tick.
 
 
-VERSION = "4.0.1"
+VERSION = "4.0.2"
 
 # Hardcoded — must match runtime.yaml external_scanner.name.
 SCANNER_NAME = "jaguar_signals"


### PR DESCRIPTION
## Summary
- **Symptom:** a GRASS LONG was cut at exactly 12:00 with price essentially flat ($0.4925 → $0.4924). `dead_weight_cut` fired on a position that hadn't failed — it just hadn't started moving yet — paying entry + exit fees for zero edge.
- **Diagnosis:** the v3.7 `dead_weight_cut: 12min` was too eager. A Striker rank-jump can take longer than 12min to accelerate; cutting that early converts "not moving yet" into a guaranteed fee loss. Per fleet HYPE-run lessons (fees are the biggest killer; momentum needs room before it accelerates), the 12min floor was chopping winners-in-waiting.
- **Fix:** `dead_weight_cut.interval_in_minutes` 12 → 30. At 30min, `weak_peak_cut` (25min @ 3% min) becomes the effective backstop for flat trades, and `dead_weight_cut` now only catches positions that DID peak but then went stagnant. `hard_timeout` (45min) and all scoring/gates unchanged.

DSL-only. NO thesis / scoring / gate change. Hypothesis test — re-evaluate after ~50 more trades.

## Test plan
- [x] `py_compile` clean
- [x] `yaml.safe_load` → `dead_weight_cut.interval_in_minutes == 30`
- [x] SKILL.md + README changelog + DSL tables synced to v4.0.2