### PR TITLE
vulture v4.2.0: raise MIN_SCORE 9 → 10 (100-trade analysis)

### DIFF
--- a/vulture/README.md
+++ b/vulture/README.md
@@ -17,8 +17,8 @@ The long-tail edge is twofold: most predators cluster on majors + a tight altcoi
 | Asset universe | 25 small/mid-cap perps (see SKILL.md) |
 | Banned | BTC, ETH, SOL, all XYZ |
 | Tick interval | 60-180s |
-| MIN_SCORE (producer) | **9** (raised from 7 in v4.1.0 — see SKILL.md changelog for the 30-trade analysis) |
-| LLM min_confidence | **8** (raised from 7 in v4.1.0) |
+| MIN_SCORE (producer) | **10** (raised from 9 in v4.2.0; 7→9 in v4.1.0 — see SKILL.md changelog for the 100-trade analysis) |
+| LLM min_confidence | **9** (raised from 8 in v4.2.0) |
 | Max positions | 2 concurrent |
 | Margin per slot | 45% of equity (was a fixed $400; switched to budget-relative `margin_pct: 45`) |
 | Leverage tiers | 5x / 7x (score-scaled — `cautious` tier 3x removed in v4.1.0) |
@@ -161,6 +161,14 @@ tail -f /tmp/vulture-producer.log | jq -c 'select(.event=="daemon_tick_finished"
 Expected: `status=ok` every tick (60s interval).
 
 ## Changelog
+
+### v4.2.0 (2026-06-01) — MIN_SCORE 9 → 10
+
+A 100-trade aggregate showed every score bucket ≥10 net-positive (10/11/12 = **+$416.78** / 41 trades) and every bucket ≤9 net-negative (7/8/9 = **−$645.12** / 41 trades). Score 9 ran a 27.3% win rate at −3.32% avg ROE; score 10 was the single best bucket (+8.70% avg ROE, +$259.67 net). Raised `MIN_SCORE` 9→10 (producer) and `min_confidence` 8→9 (LLM gate); conviction sizing tier floor moved to 10. See SKILL.md changelog for the full table. NO thesis change — floor tightening only.
+
+### v4.1.0 (2026-05-29) — MIN_SCORE 7 → 9 (low-conviction cull)
+
+A 30-trade aggregate showed score 7–8 (n=15) ran 12.5%/28.6% win rates at −3.94%/−3.52% avg ROE. Raised `MIN_SCORE` 7→9 (producer) and `min_confidence` 7→8 (LLM gate); removed the `cautious` 3x sizing tier. NO thesis change — floor tightening only.
 
 ### v4.0.0 — senpi_runtime_helpers migration
 

--- a/vulture/SKILL.md
+++ b/vulture/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "4.1.0"
+  version: "4.2.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -138,7 +138,7 @@ FARTCOIN, MORPHO, NEAR, INJ, AVAX, LINK, DOGE
 | **Move ≥15% in direction (LATE_ENTRY_PENALTY)** | **-3** |
 | **Move ≥12% in direction (MOVE_EXTENDED)** | **-2** |
 
-**MIN_SCORE: 9** (raised from 7 in v4.1.0) — entry floor. A 30-trade aggregate showed score 7–8 buckets (n=15 combined) ran 12.5% / 28.6% win rates at -3.94% / -3.52% avg ROE — the DSL was chopping them at the Phase 1 hard stop before they did real damage, but they were still net-negative. Vulture now hunts strictly in the 9–12 conviction zone where wins concentrate. The scoring dimensions (especially HEAVY_FLOW requiring ≥18% SM concentration) do the real quality work above the floor.
+**MIN_SCORE: 10** (raised from 9 in v4.2.0; 7 → 9 in v4.1.0) — entry floor. A 100-trade aggregate made the boundary unambiguous: every score bucket ≥10 was net-positive (10/11/12 combined: **+$416.78** over 41 trades, 42–50% win rates) and every bucket ≤9 was net-negative (7/8/9 combined: **−$645.12** over 41 trades). Score 9 specifically ran a 27.3% win rate at −3.32% avg ROE. **Score 10 is the single best bucket** (+8.70% avg ROE, 50% win, +$259.67 net) — the floor is set to *keep* it. Vulture now hunts strictly in the 10–12 conviction zone. (Caveat: per-bucket n is small at the 9/10 boundary, but expectancy sign is consistent and the direction matches the v4.1.0 cull.) The scoring dimensions (especially HEAVY_FLOW requiring ≥18% SM concentration) do the real quality work above the floor.
 
 ---
 
@@ -147,9 +147,9 @@ FARTCOIN, MORPHO, NEAR, INJ, AVAX, LINK, DOGE
 | Score | Leverage | Tier |
 |---|---:|---|
 | ≥11 | 7x | apex (the right tail) |
-| 9–10 | 5x | conviction (the new floor tier in v4.1.0) |
+| 10 | 5x | conviction (floor tier as of v4.2.0 — the best historical bucket) |
 
-**v4.1.0 removed the `cautious` tier (score 7–8, 3x).** Below-floor signals are dropped at the producer now; that whole tier became unreachable. **Capped at 7x because small-cap liquidity can't support 20x.** Lemon can go 20x on BTC/ETH because slippage is <0.1%. Small caps can have 0.5%+ slippage per fill, which eats gains at 20x.
+**v4.1.0 removed the `cautious` tier (score 7–8, 3x); v4.2.0 raised the floor to 10 (score 9 culled).** Below-floor signals are dropped at the producer now; those tiers are unreachable. **Capped at 7x because small-cap liquidity can't support 20x.** Lemon can go 20x on BTC/ETH because slippage is <0.1%. Small caps can have 0.5%+ slippage per fill, which eats gains at 20x.
 
 ---
 
@@ -202,7 +202,7 @@ Both agents are "fleet alpha extractors" but via **opposite** philosophies:
 | hard_timeout | 480 min | 10,080 min (21x longer) |
 | dead_weight_cut | 20 min | 60 min |
 | Max leverage | 20x (apex) | 7x (liquidity limit) |
-| MIN_SCORE | 8 | 9 |
+| MIN_SCORE | 8 | 10 |
 
 **Both are bets on asymmetric payoff** — low win rate + big winners / tiny losers — but Lemon bets on mean reversion of exhausted crowds while Vulture bets on continuation of small-cap trends.
 
@@ -270,6 +270,21 @@ Send: "🦅 VULTURE v2.0 online. Long-Tail Momentum Rider. Riding small-cap tren
 ---
 
 ## Changelog
+
+### v4.2.0 (2026-06-01) — MIN_SCORE 9 → 10 (the boundary is exactly 10)
+
+A 100-trade aggregate, grouped by producer entry score:
+
+| Score | Trades | Avg ROE | Win Rate | Net PnL |
+|---:|---:|---:|---:|---:|
+| 12 |  7 | +4.80% | 42.9% |  +$97.47 |
+| 11 | 24 | +1.17% | 41.7% |  +$59.64 |
+| 10 | 10 | +8.70% | 50.0% | +$259.67 |
+|  9 | 11 | -3.32% | 27.3% | -$220.70 |
+|  8 | 16 | -5.07% | 12.5% | -$254.11 |
+|  7 | 14 | -1.99% | 21.4% | -$170.31 |
+
+The high-conviction tier (10/11/12, n=41) made **+$416.78**; the low tier (7/8/9, n=41) bled **−$645.12**. The split is clean: every bucket ≥10 is net-positive, every bucket ≤9 is net-negative. v4.1.0 had already culled 7–8 (−$424 of the bleed); this cut adds 9 (−$220, a 27.3% win rate but a clearly negative −3.32% avg ROE). **Score 10 is the single best bucket** (+8.70% avg ROE, +$259.67 net) — the floor is set to keep it, not cut it. Raised `MIN_SCORE` 9→10 at the producer and `min_confidence` 8→9 at the LLM gate; conviction sizing tier floor moved 9→10. (Caveat: n is small per bucket at the 9/10 boundary, but the expectancy sign is consistent and matches the v4.1.0 direction — re-evaluate after another ~50 trades.)
 
 ### v4.1.0 (2026-05-29) — MIN_SCORE 7 → 9 (low-conviction cull)
 

--- a/vulture/runtime.yaml
+++ b/vulture/runtime.yaml
@@ -114,7 +114,7 @@ actions:
     decision_mode: llm
     decision_model: "${VULTURE_DECISION_MODEL}"  # REQUIRED. Bare model name only — NO provider prefix. INVALID: "<provider>/<model>" (e.g. "google/...", "anthropic/...", "openai/...") — OpenClaw double-prefixes → 500 Unknown model. The LLM gate is a pass-through rubber-stamp (producer already applied every filter); any reliable structured-JSON model works. No default by design — operators pick their own.
     scanners: [vulture_signals]
-    min_confidence: 8                 # v4.1.0: raised from 7 — see decision_prompt CONFIDENCE SCORING
+    min_confidence: 9                 # v4.2.0: raised from 8 — see decision_prompt CONFIDENCE SCORING
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
@@ -147,7 +147,7 @@ actions:
 
       ## HARD SKIP CONDITIONS (output execute: false)
 
-      - score < 9 (producer floor; defensive — v4.1.0 raised from 7)
+      - score < 10 (producer floor; defensive — v4.2.0 raised from 9)
       - leverage <= 0 OR signal data missing (malformed)
       - heldAssets already contains this exact asset (duplicate position)
       - reasons array empty (malformed signal)
@@ -161,18 +161,21 @@ actions:
 
       ## CONFIDENCE SCORING
 
-      v4.1.0 — score 7-8 culled at the producer after a 30-trade analysis
-      showed those buckets ran 12.5% / 28.6% win rates with -3.94% / -3.52%
-      avg ROE. Vulture now hunts strictly in the 9-12 conviction zone:
+      v4.2.0 — score 7-9 culled at the producer after a 100-trade analysis.
+      Every score bucket >=10 was net-positive (10/11/12 = +$416.78 over 41
+      trades); every bucket <=9 was net-negative (7/8/9 = -$645.12 over 41
+      trades). Score 9 specifically ran a 27.3% win rate at -3.32% avg ROE.
+      Vulture now hunts strictly in the 10-12 conviction zone:
 
-      - 9-10: score >= 11 (apex tier, 7x leverage) AND HEAVY_FLOW or
+      - 10: score >= 11 (apex tier, 7x leverage) AND HEAVY_FLOW or
         STRONG_FLOW AND TREND_RUNNING/STRONG AND ACCELERATING
-      - 8: score 9-10 (conviction tier, 5x leverage) — producer has
+      - 9: score 10 (conviction tier, 5x leverage) — the single best
+        historical bucket (+8.70% avg ROE, 50% win). The producer has
         gated this; the signal IS the validation. Honor it unless a
         hard-skip applies.
-      - <8: producer floor (>=9) not cleared — should never reach you.
+      - <9: producer floor (>=10) not cleared — should never reach you.
 
-      Minimum confidence to execute is 8. Score 7-8 signals are dropped
+      Minimum confidence to execute is 9. Score 7-9 signals are dropped
       by the producer BEFORE reaching this gate; if one somehow reaches
       you, hard-skip.
 

--- a/vulture/scripts/vulture-producer.py
+++ b/vulture/scripts/vulture-producer.py
@@ -78,7 +78,7 @@ from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ign
 # reentrant; nested call raises BlockingIOError every tick.
 
 
-VERSION = "4.1.0"
+VERSION = "4.2.0"
 
 # Hardcoded — must match runtime.yaml external_scanner.name.
 SCANNER_NAME = "vulture_signals"
@@ -133,24 +133,28 @@ XYZ_BANNED = True
 # ═══════════════════════════════════════════════════════════════
 # SCORING CONFIG
 #
-# v4.1.0 — raised MIN_SCORE 7 → 9 after a 30-trade aggregate analysis showed
-# the low-conviction buckets weren't pulling their weight:
+# v4.2.0 — raised MIN_SCORE 9 → 10 after a 100-trade aggregate analysis.
+# The expectancy split by score bucket is unambiguous:
 #
-#   Score  7:  8 trades  | Avg ROE  -3.94%  | Win Rate  12.5%
-#   Score  8:  7 trades  | Avg ROE  -3.52%  | Win Rate  28.6%
-#   Score  9:  2 trades  | Avg ROE  -3.17%  | Win Rate  50.0%
-#   Score 10:  3 trades  | Avg ROE  +10.54% | Win Rate  66.7%
-#   Score 11:  5 trades  | Avg ROE  -1.04%  | Win Rate  60.0%
-#   Score 12:  4 trades  | Avg ROE  +5.56%  | Win Rate  25.0%   (the fat tail)
+#   Score 12:   7 trades | Avg ROE  +4.80% | Win 42.9% | Net  +$97.47
+#   Score 11:  24 trades | Avg ROE  +1.17% | Win 41.7% | Net  +$59.64
+#   Score 10:  10 trades | Avg ROE  +8.70% | Win 50.0% | Net +$259.67  <- best
+#   Score  9:  11 trades | Avg ROE  -3.32% | Win 27.3% | Net -$220.70
+#   Score  8:  16 trades | Avg ROE  -5.07% | Win 12.5% | Net -$254.11
+#   Score  7:  14 trades | Avg ROE  -1.99% | Win 21.4% | Net -$170.31
 #
-# Score 7-8 (n=15) was a clear culling signal — 12.5% / 28.6% win rates with
-# the DSL chopping each one at -3.5-3.9% avg before they did real damage.
-# Vulture now hunts strictly in the 9-12 conviction zone where wins
-# concentrate. The `cautious` sizing tier (score 7-8, 3x) is removed —
-# unreachable given the new floor.
+# High-conviction tier (10/11/12, n=41): +$416.78 clean realized profit,
+# 42-50% win rates. Low tier (7/8/9, n=41): -$645.12. The boundary is
+# exactly at 10: every bucket >=10 is net-positive, every bucket <=9 is
+# net-negative. v4.1.0 culled 7-8 (-$424); this cut adds 9 (-$220), which
+# kept a 27% win rate but a clearly negative -3.32% avg ROE expectancy.
+# Trading ONLY 10/11/12 over this window = +$416 with no low-conviction
+# drag. Caveat: per-bucket n is small (9-11 trades for the 9/10 boundary),
+# but expectancy sign is consistent and the direction matches v4.1.0.
+# Score 10 is the single best bucket — the floor is set to KEEP it.
 # ═══════════════════════════════════════════════════════════════
 
-MIN_SCORE = 9                   # Entry floor — score 7-8 culled (see analysis above)
+MIN_SCORE = 10                  # Entry floor — score 7-9 culled (see analysis above)
 MIN_SM_PCT = 3.0                # Asset must have at least 3% SM concentration
 MIN_SM_TRADERS = 15             # Small caps need lower threshold than majors
 MIN_4H_ALIGNED_PCT = 1.0        # 4h price must be aligned ≥1% in SM direction
@@ -160,7 +164,7 @@ MIN_15M_VELOCITY = 0.3          # 15m velocity must be actively building
 # Conviction-scaled leverage — small caps capped at 7x (low-liq slippage)
 SIZING_TIERS = [
     {"min_score": 11, "leverage": 7, "label": "apex"},        # Score 11-12: the right tail
-    {"min_score": 9,  "leverage": 5, "label": "conviction"},  # Score 9-10: the new floor tier
+    {"min_score": 10, "leverage": 5, "label": "conviction"},  # Score 10: the floor tier (best bucket)
 ]
 
 


### PR DESCRIPTION
## Summary
Mirrors the live Vulture agent's own 100-trade autopsy into the repo. The expectancy boundary sits exactly at score 10:

| Score | Trades | Avg ROE | Win | Net PnL |
|---:|---:|---:|---:|---:|
| 12 | 7 | +4.80% | 42.9% | +$97.47 |
| 11 | 24 | +1.17% | 41.7% | +$59.64 |
| 10 | 10 | +8.70% | 50.0% | +$259.67 |
| 9 | 11 | -3.32% | 27.3% | -$220.70 |
| 8 | 16 | -5.07% | 12.5% | -$254.11 |
| 7 | 14 | -1.99% | 21.4% | -$170.31 |

High-conviction tier (10/11/12, n=41): **+$416.78**. Low tier (7/8/9, n=41): **−$645.12**. Every bucket ≥10 is net-positive; every bucket ≤9 net-negative. v4.1.0 already culled 7–8 (−$424); this adds 9 (−$220, 27.3% win at negative expectancy). **Score 10 is the single best bucket** — the floor keeps it.

- `MIN_SCORE` 9 → 10 (producer)
- `min_confidence` 8 → 9 (LLM gate)
- conviction sizing tier floor 9 → 10
- 100-trade table + small-n caveat carried in producer comment, runtime gate prose, SKILL.md + README changelogs

NO thesis change — floor tightening only.

## Test plan
- [x] `py_compile` clean
- [x] `yaml.safe_load` OK
- [x] no lingering `MIN_SCORE = 9` / `score < 9` / `min_confidence: 8`