### PR TITLE
cheetah: v7.2.0 — disable DSL time cuts, let winners run

### DIFF
--- a/cheetah/README.md
+++ b/cheetah/README.md
@@ -30,18 +30,19 @@ While most rotation-style agents take any setup that crosses a single threshold,
 | Entry order type | FEE_OPTIMIZED_LIMIT |
 | Exit order type | FEE_OPTIMIZED_LIMIT |
 
-## DSL Phase 2 ladder (fleet-standard T0/T1)
+## DSL Phase 2 ladder ("let winners run")
 
 | Tier | Trigger (margin ROE) | Lock (% of HW) |
 |---|---|---|
-| T0 | +5% | 35% |
-| T1 | +10% | 50% |
-| T2 | +20% | 65% |
-| T3 | +35% | 80% |
-| T4 (apex) | +50% | 90% |
+| T0 | +10% | 0% |
+| T1 | +20% | 25% |
+| T2 | +30% | 40% |
+| T3 | +50% | 60% |
+| T4 | +75% | 75% |
+| T5 (apex) | +100% | 85% |
 
-Phase 1: max_loss 15% / retrace 6 / 3 consecutive breaches.
-Time cuts: hard_timeout 720min, weak_peak_cut 90min @ 3.0, dead_weight_cut 60min — all ENABLED (multi-asset rotation has opportunity cost).
+Phase 1: max_loss 15% / retrace 10 / 1 consecutive breach.
+Time cuts (v7.2.0): hard_timeout 720min ENABLED (12h fail-safe); weak_peak_cut + dead_weight_cut **DISABLED**. The 100-trade analysis showed the 60m/90m cuts were forcing exits before trenders could accelerate — the two big HYPE wins (+13.9%, +8.9%) only landed via the 12h timeout. T0 lock=0 lets a +10% mover retrace fully before any profit lock; the rare +50–100% move makes the book.
 
 ## Scanner pattern
 
@@ -197,6 +198,22 @@ Expected: every line shows `status=ok`.
 State files (`state/entry-log.jsonl`, `state/scan-history.json`, `state/quality-cache.json`, `state/cooldowns.json`, `state/trade-counter.json`) live under `state/<wallet-hash>/` — wallet-isolated.
 
 ## Changelog
+
+### v7.2.0 (2026-06-01) — DSL exit overhaul: disable time cuts, let winners run
+
+A 100-trade-by-score analysis showed entries are sound — win rate scales
+cleanly with score (40.0% @ 10 → 41.7% @ 11 / n=84 → 50.0% @ 12 → 55.6% @ 13)
+— but **Avg ROE was negative across EVERY bracket** (−1.90% / −0.35% / −0.20%
+/ −0.12%). Diagnosis: exits, not entries. "Death by a thousand cuts" — tight
+Phase 2 locks + 60m/90m time-cuts made it mechanically impossible to hold for
+a big win. The two HYPE longs that paid (+13.9%, +8.9%) only landed because
+they hit the 12h **hard timeout**, not a trailing stop or dead_weight_cut.
+Fix (mirrors live deploy): `weak_peak_cut` and `dead_weight_cut` **disabled**;
+`hard_timeout` (12h) kept as the sole time fail-safe; Phase 2 ladder already
+on the "let winners run" shape (T0 +10% / lock 0). Exit-mechanics only — NO
+change to scoring, MIN_SCORE, leverage, margin, or risk gates. Also syncs the
+README/SKILL DSL tables, which were stale (still showed the pre-2026-05-21
++5%/35% fleet-standard ladder).
 
 ### v7.0.0 — Plumbing-only migration (no thesis change)
 

--- a/cheetah/SKILL.md
+++ b/cheetah/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "7.1.2"
+  version: "7.2.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -22,9 +22,42 @@ metadata:
     - senpi_runtime_helpers
 ---
 
-# 🐆 CHEETAH v7.1.0 — Multi-Signal Confluence Sniper
+# 🐆 CHEETAH v7.2.0 — Multi-Signal Confluence Sniper
 
 **SM commits. Quality traders commit. Price confirms. Volume commits. All at once. Cheetah pounces once. The runtime DSL ratchets to lock the win.**
+
+## v7.2.0 (2026-06-01) — DSL exit overhaul: disable time cuts, let winners run
+
+**Entries are fine. Exits were the bottleneck.** A 100-trade-by-score
+analysis on the live wallet showed win rate scaling cleanly with score —
+40.0% @ score 10, 41.7% @ score 11 (n=84), 50.0% @ score 12, 55.6% @ score
+13 — confirming the accuracy filter works. But **Avg ROE was negative across
+EVERY score bracket** (−1.90% / −0.35% / −0.20% / −0.12%).
+
+| Score | Trades | Win rate | Avg ROE |
+|---|---:|---:|---:|
+| 10 | 5 | 40.0% | −1.90% |
+| 11 | 84 | 41.7% | −0.35% |
+| 12 | 2 | 50.0% | −0.20% |
+| 13 | 9 | 55.6% | −0.12% |
+
+**Diagnosis: "death by a thousand cuts."** The tight Phase 2 locks plus the
+60m/90m time-cuts made it mechanically impossible to hold for a big win —
+Cheetah took the full brunt of −15% stops / −5% chops but was forced to give
+up every +15% / +30% runner. The two big HYPE longs that actually paid
+(+13.9%, +8.9%) only landed because they hit the **12h hard timeout** — not a
+trailing stop, not a 60m dead_weight_cut. When forced to hold, the position
+printed.
+
+**Fix (mirrors the live deploy):**
+- `weak_peak_cut` → **disabled** (was 90m @ 3.0 — chopping winners-in-waiting)
+- `dead_weight_cut` → **disabled** (was 60m — forcing exits before trenders accelerate)
+- `hard_timeout` → **kept** (12h fail-safe — the one cut that captured the winners)
+- Phase 2 ladder already widened to the "let winners run" shape (T0 +10% / lock 0 → +100% / lock 85) on 2026-05-21
+
+Together this removes the glass ceiling so heavy trenders can run. NO change
+to scoring, MIN_SCORE, leverage tiers, margin, cooldowns, or risk gates —
+exit-mechanics only. Hypothesis test; re-evaluate after ~50 more trades.
 
 ## v7.1.1 (2026-05-11) — positions parser fix (patch)
 
@@ -108,23 +141,29 @@ Diff `held_assets` across ticks. When asset disappears from held set, record clo
 ### Reentrancy guard
 `producer_daemon` owns a per-tick `scanner_lock` with stale-PID auto-recovery — replaces v6.x's hand-rolled fcntl lockfile. Prevents two ticks racing.
 
-## DSL preset (v6.0 — fleet-standard T0/T1 ladder)
+## DSL preset (v7.2.0 — "let winners run" ladder, time cuts disabled)
 
 | Phase | Component | Setting |
 |---|---|---|
 | Phase 1 | max_loss_pct | 15% |
-| Phase 1 | retrace_threshold | 6 |
-| Phase 1 | consecutive_breaches | 3 |
-| Phase 2 T0 | trigger 5% / lock 35% | (fleet-standard, closes T0→T1 dead zone) |
-| Phase 2 T1 | trigger 10% / lock 50% | |
-| Phase 2 T2 | trigger 20% / lock 65% | |
-| Phase 2 T3 | trigger 35% / lock 80% | |
-| Phase 2 T4 | trigger 50% / lock 90% | (apex) |
-| hard_timeout | 720 min (12h) | enabled |
-| weak_peak_cut | 90 min, min 3.0 | enabled |
-| dead_weight_cut | 60 min | enabled |
+| Phase 1 | retrace_threshold | 10 (v6.x raise from 6) |
+| Phase 1 | consecutive_breaches | 1 |
+| Phase 2 T0 | trigger 10% / lock 0% | (lets a +10% mover retrace fully before any lock) |
+| Phase 2 T1 | trigger 20% / lock 25% | |
+| Phase 2 T2 | trigger 30% / lock 40% | |
+| Phase 2 T3 | trigger 50% / lock 60% | |
+| Phase 2 T4 | trigger 75% / lock 75% | |
+| Phase 2 T5 | trigger 100% / lock 85% | (apex) |
+| hard_timeout | 720 min (12h) | **enabled** (the only time cut left) |
+| weak_peak_cut | — | **disabled** (v7.2.0) |
+| dead_weight_cut | — | **disabled** (v7.2.0) |
 
-Time cuts kept: Cheetah is multi-asset rotation, NOT single-asset patience. Idle positions have opportunity cost.
+v7.2.0: weak_peak_cut + dead_weight_cut disabled. The 100-trade analysis
+showed the time cuts were the bottleneck — they forced exits before
+trenders could accelerate and capped the right-tail move that pays for
+everything. The two big HYPE wins (+13.9%, +8.9%) only landed via the 12h
+hard timeout, so that fail-safe is kept. Median trade gives back a bit;
+the right tail is now uncapped.
 
 ## Risk gates (`runtime.yaml` `risk.guard_rails`)
 

--- a/cheetah/runtime.yaml
+++ b/cheetah/runtime.yaml
@@ -220,21 +220,36 @@ exit:
     ensure_execution_as_taker: true
     execution_timeout_seconds: 60
   # DSL preset — Cheetah is high-conviction sniper with multi-hour holds.
-  # Time cuts kept (multi-asset rotation has opportunity cost — unlike
-  # single-asset patience agents Polar/Wolverine where time cuts are
-  # disabled). Phase 2 ladder uses fleet-standard T0/T1 patch (commit
-  # 6cad383 pattern: T0 trigger 5%, lock 35%; T1 trigger 10%, lock 50%).
+  # v7.2.0 (2026-06-01): 100-trade-by-score analysis showed ENTRIES are
+  # fine but EXITS were the bottleneck. Win rate scaled cleanly with score
+  # (40% @ score 10 → 55.6% @ score 13 — the accuracy filter works), yet
+  # Avg ROE was NEGATIVE across EVERY score bracket. Diagnosis: "death by a
+  # thousand cuts." The tight Phase 2 locks + the 60m/90m time-cuts made it
+  # mechanically impossible to hold for a big win — Cheetah took the full
+  # brunt of -15% stops / -5% chops but was forced to give up every +15% /
+  # +30% runner. The two big HYPE longs that actually paid (+13.9%, +8.9%)
+  # only landed because they hit the 12h HARD TIMEOUT — NOT a trailing stop,
+  # NOT a 60m dead_weight_cut. "When forced to hold, the position printed."
+  # FIX: disable weak_peak_cut + dead_weight_cut entirely; keep ONLY the 12h
+  # hard_timeout fail-safe (the one cut that captured the winners). Phase 2
+  # ladder already widened to the "let winners run" shape (T0 +10% / lock 0)
+  # on 2026-05-21 — together this removes the glass ceiling so heavy
+  # trenders can run. Hypothesis test — re-evaluate after ~50 more trades.
   dsl_preset:
     hard_timeout:
       enabled: true
-      interval_in_minutes: 720          # 12h fail-safe
+      interval_in_minutes: 720          # 12h fail-safe — the ONLY time cut
+                                        # left; it captured both big HYPE
+                                        # wins (+13.9%, +8.9%) when forced
+                                        # to hold.
     weak_peak_cut:
-      enabled: true
-      interval_in_minutes: 90
-      min_value: 3.0
+      enabled: false                    # v7.2.0: disabled — was chopping
+      interval_in_minutes: 90           # winners-in-waiting at 90m/3% and
+      min_value: 3.0                    # capping the right-tail move.
     dead_weight_cut:
-      enabled: true
-      interval_in_minutes: 60           # rotation cost: cut dead weight
+      enabled: false                    # v7.2.0: disabled — the 60m cut
+      interval_in_minutes: 60           # forced exits before trenders could
+                                        # accelerate. hard_timeout backstops.
     phase1:
       enabled: true
       max_loss_pct: 15.0

--- a/cheetah/scripts/cheetah-producer.py
+++ b/cheetah/scripts/cheetah-producer.py
@@ -124,7 +124,7 @@ import cheetah_config as cfg
 from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "7.1.2"
+VERSION = "7.2.0"
 SCANNER_NAME = "cheetah_signals"  # must match runtime.yaml external_scanner.name
 
 


### PR DESCRIPTION
## Summary
Mirrors Cheetah's live exit-mechanics fix into the repo. A 100-trade-by-score analysis showed **entries are sound** — win rate scales cleanly with score (40.0% @ 10 → 41.7% @ 11 / n=84 → 50.0% @ 12 → 55.6% @ 13) — but **Avg ROE was negative across EVERY bracket** (−1.90% / −0.35% / −0.20% / −0.12%). The bottleneck is exits, not entries: "death by a thousand cuts" — tight Phase 2 locks + the 60m/90m time-cuts made it mechanically impossible to hold for a big win. The two HYPE longs that actually paid (+13.9%, +8.9%) only landed because they hit the 12h **hard timeout**, not a trailing stop or dead_weight_cut.

## Changes
- `weak_peak_cut`: `enabled: true → false` (was 90m @ 3.0 — chopped winners-in-waiting)
- `dead_weight_cut`: `enabled: true → false` (was 60m — forced exits before trenders accelerate)
- `hard_timeout`: **kept** (12h fail-safe — the one cut that captured the winners)
- Phase 2 ladder already on the "let winners run" shape (T0 +10% / lock 0 → +100% / lock 85), unchanged
- Producer `VERSION` 7.1.2 → 7.2.0; SKILL.md metadata + title + changelog; README DSL table + changelog
- **Doc sync:** README/SKILL DSL tables were stale (still showed the pre-2026-05-21 +5%/35% fleet-standard ladder) — corrected to match runtime.yaml

Exit-mechanics only. **NO change** to scoring, MIN_SCORE, leverage tiers, margin, cooldowns, or risk gates.

## Test plan
- [x] `python3 -c yaml.safe_load(runtime.yaml)` passes
- [x] `py_compile cheetah-producer.py` passes
- [x] Confirmed DSL: hard_timeout=True, weak_peak_cut=False, dead_weight_cut=False, ladder=[(10,0),(20,25),(30,40),(50,60),(75,75),(100,85)]
- [x] grep — no stale "all ENABLED" / "time cuts kept" / old-ladder references remain (besides intentional changelog history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)