### PR TITLE
wolverine: v6.1.0 — widen Phase 1 retrace leash for HYPE volatility

### DIFF
--- a/wolverine/README.md
+++ b/wolverine/README.md
@@ -44,7 +44,7 @@ exits 100% price-action.
 | T4 | +75% | 75% |
 | T5 (apex) | +100% | 85% (was 85% @ +80%) |
 
-Phase 1: max_loss 20% / retrace 8% / 1 breach.
+Phase 1: max_loss 20% / retrace 15% / 1 breach. (v6.1.0: retrace 8→15 — at 5x the old 8-ROE-pt retrace was a 1.6% HYPE price leash that fired on intra-candle noise; 15 ≈ 3.0% price buffer, still below the 20% hard stop.)
 **Time-cuts:** `hard_timeout` / `weak_peak_cut` / `dead_weight_cut` all DISABLED.
 
 ## Scanner pattern
@@ -164,6 +164,25 @@ tail -f /tmp/wolverine-producer.log | jq -c 'select(.event=="daemon_tick_finishe
 Expected: `status=ok` every tick (180s interval). Tick `duration_ms` should be ~1-3s.
 
 ## Changelog
+
+### v6.1.0 (2026-06-01) — Phase 1 retrace leash widened for HYPE volatility
+
+One isolated DSL change: `exit.dsl_preset.phase1.retrace_threshold` **8 → 15**.
+NO scoring, gate, leverage, or Phase 2 change.
+
+During HYPE's run Wolverine caught a +16.4% ROE winner but missed the bulk of
+the move, with recent losses clustered at −5% to −9% ROE. Provable cause: at
+5x leverage an 8-ROE-point retrace is a **1.6% price leash** (8 ÷ 5), and HYPE
+wicks 3-5% intra-candle — so the single-breach retrace fired on noise and
+clipped winners before the wide Phase 2 ladder could ride them. 15 ROE pts ≈
+3.0% price leash at 5x (~2x the buffer), still below the 20% `max_loss_pct`
+hard stop so it stays a distinct trailing rule.
+
+This is the **only** change made: the recent sample is n=12 (score buckets
+n=2-4) — too thin to retune Phase 2 locks, the score floor, or
+`MIN_4H_STRUCTURE`. The retrace fix is defensible on stop-width-vs-volatility
+math alone, independent of sample size. Re-measure expectancy after 40-50
+trades before touching anything else.
 
 ### v6.0.0 (2026-05-18) — Patient-Conviction adoption (Bison v3.0.1 port)
 

--- a/wolverine/SKILL.md
+++ b/wolverine/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "6.0.0"
+  version: "6.1.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -23,7 +23,42 @@ metadata:
     - senpi_runtime_helpers
 ---
 
-# 🦡 WOLVERINE v6.0.0 — HYPE Patient-Conviction
+# 🦡 WOLVERINE v6.1.0 — HYPE Patient-Conviction
+
+## v6.1.0 (2026-06-01) — Phase 1 retrace leash widened for HYPE volatility
+
+**One isolated DSL change. NO scoring, gate, leverage, or Phase 2 change.**
+`exit.dsl_preset.phase1.retrace_threshold` **8 → 15**.
+
+**Why.** During HYPE's epic run Wolverine caught a +16.4% ROE winner but
+left the bulk of the move on the table, and its recent window ran a 25% win
+rate with losses clustered at −5% to −9% ROE. The provable structural cause:
+at 5x leverage an 8-ROE-point retrace is a **1.6% HYPE price leash** (8 ÷ 5).
+HYPE routinely wicks 3-5% inside a single 15m candle, so this single-breach
+(`consecutive_breaches_required: 1`) retrace fired on ordinary noise — exiting
+positions at small losses before they could become the BIG trend the wide
+Phase 2 "let winners run" ladder exists to ride. The −5% to −9% loss cluster
+is consistent with a trade peaking +2-3% ROE, pulling back 1.6% price, and
+tripping the 8-point retrace.
+
+**The fix.** 15 ROE pts = **~3.0% price leash at 5x** — roughly double the
+buffer, still well below the 20% `max_loss_pct` hard stop so it remains a
+distinct trailing-from-peak rule, not a collapse into the hard stop (which is
+why 15 and not the 20 that would equal max_loss).
+
+**Why ONLY this.** The recent window is n=12 (score buckets n=2-4) —
+statistically indistinguishable from a 50% win rate, far too thin to justify
+retuning Phase 2 locks, the entry score floor, or `MIN_4H_STRUCTURE`. This
+retrace fix is the one change defensible on **stop-width-vs-volatility math
+alone**, independent of sample size. Everything else waits for data.
+
+**Decision rule.** Re-measure expectancy after 40-50 trades. A let-winners-run
+trend agent is *supposed* to have a low win rate; it only fails if the wins
+can't clear the loss size. Break-even at a 25% win rate needs a 3:1 avg-win/
+avg-loss ratio (recent window was 1.56:1 — wins truncated). If, after this
+fix and a real sample, expectancy is still negative, the trend-follower
+archetype is wrong for HYPE and a rewrite is earned. Until then it's a
+mis-calibrated strategy, not a broken one.
 
 ## v6.0.0 (2026-05-18) — Patient-Conviction adoption (Bison v3.0.1 port)
 
@@ -121,7 +156,7 @@ driven). Other deltas should be preserved.
 - Multi-factor scoring (~17 max points): base-tech + SM concentration + SM velocity + funding alignment + funding regime + funding persistence + volume + OI velocity + BTC correlation + RSI room + 4h momentum bonus + move-exhaustion penalty
 - MIN_SCORE = 9 (config-overridable)
 - Conviction-tiered leverage: 5x apex (score ≥11) / 3x standard (≥9)
-- DSL preset preserved: time-cuts ALL DISABLED, Phase 1 max_loss 20% / retrace 8 / 3 breaches, Phase 2 ladder (10/15, 20/35, 35/55, 55/70, 80/85)
+- DSL preset preserved: time-cuts ALL DISABLED, Phase 1 max_loss 20% / retrace 8 (v6.1.0: → 15) / 3 breaches, Phase 2 ladder (10/15, 20/35, 35/55, 55/70, 80/85)
 
 **v3.0.1/3.0.2/3.0.4 v1-DSL fixes preserved:**
 - `dead_weight_cut`: DISABLED (single-asset has no rotation cost)

--- a/wolverine/runtime.yaml
+++ b/wolverine/runtime.yaml
@@ -4,6 +4,14 @@ name: wolverine-tracker
 # SKILL.md + _wolverine_producer_version. Do not set this to 6.x.x.
 version: 1.0.0
 description: >
+  WOLVERINE v6.1.0 (2026-06-01) — Phase 1 retrace leash widened for
+  HYPE volatility. retrace_threshold 8 -> 15: at 5x the old 8-ROE-point
+  retrace was a 1.6% price leash that fired on HYPE's 3-5% intra-candle
+  wicks, clipping winners before the wide Phase 2 ladder could ride
+  them. Scoring, gates, leverage, Phase 2 ladder, time-cuts all
+  UNCHANGED. Isolated DSL change; re-measure expectancy after 40-50
+  trades before touching anything justified by small-sample data.
+
   WOLVERINE v6.0.0 (2026-05-18) — Patient-Conviction adoption.
   Bison v3.0.1's pattern ported to HYPE single-asset: fewer entries,
   higher score floor, wider DSL ratchet so winners can run multi-day
@@ -78,7 +86,7 @@ description: >
     - RSI hard gates (74 LONG / 26 SHORT)
     - Multi-factor scoring + conviction tiers (5x apex / 3x standard)
     - DSL preset preserved exactly: time-cuts ALL DISABLED (v3.0.1/2/4),
-      Phase 1 max_loss 20% / retrace 8 / 3 breaches, Phase 2 ladder
+      Phase 1 max_loss 20% / retrace 8 (v6.1.0: -> 15) / 3 breaches, Phase 2 ladder
       10/15, 20/35, 35/55, 55/70, 80/85
 
   FLEET PATCHES:
@@ -242,7 +250,17 @@ exit:
     phase1:
       enabled: true
       max_loss_pct: 20.0
-      retrace_threshold: 8
+      # v6.1.0 (2026-06-01): retrace_threshold 8 -> 15. At 5x leverage an
+      # 8-ROE-point retrace is a 1.6% HYPE price leash (8 / 5x). HYPE wicks
+      # 3-5% intra-candle, so this single-breach retrace fired on noise and
+      # clipped winners before they could become the BIG trend the wide
+      # Phase 2 ladder is built to ride. 15 ROE pts = ~3.0% price leash at
+      # 5x (~2x the buffer), still well below the 20% max-loss hard stop so
+      # it stays a distinct trailing-from-peak rule rather than collapsing
+      # into the hard stop. Structural stop-width-vs-volatility fix —
+      # independent of the thin v6.0.0 sample. Isolated change so the
+      # 40-50 trade expectancy re-measurement attributes cleanly.
+      retrace_threshold: 15
       consecutive_breaches_required: 1
     phase2:
       enabled: true

--- a/wolverine/scripts/wolverine-producer.py
+++ b/wolverine/scripts/wolverine-producer.py
@@ -46,7 +46,7 @@ import wolverine_config as cfg
 from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "6.0.0"
+VERSION = "6.1.0"
 
 # Hardcoded — must match runtime.yaml external_scanner.name.
 SCANNER_NAME = "wolverine_signals"


### PR DESCRIPTION
## Summary
Single isolated DSL change: `exit.dsl_preset.phase1.retrace_threshold` **8 → 15**. NO scoring, gate, leverage, or Phase 2 change.

During HYPE's epic run Wolverine caught a +16.4% ROE winner but left the bulk of the move on the table, with recent losses clustered at −5% to −9% ROE. The **provable** structural cause (independent of sample size): at 5x leverage an 8-ROE-point retrace is a **1.6% HYPE price leash** (8 ÷ 5). HYPE wicks 3-5% intra-candle, so this single-breach (`consecutive_breaches_required: 1`) retrace fired on ordinary noise and clipped winners before they could become the BIG trend the wide Phase 2 "let winners run" ladder exists to ride.

`15` ROE pts ≈ **3.0% price leash at 5x** (~2x the buffer), still well below the 20% `max_loss_pct` hard stop so it stays a distinct trailing-from-peak rule rather than collapsing into the hard stop (which is why 15, not the 20 that would equal max_loss).

## Why only this one change
The recent window is **n=12** (score buckets n=2-4) — statistically indistinguishable from a 50% win rate, far too thin to justify retuning Phase 2 locks, the score floor, or `MIN_4H_STRUCTURE`. The retrace fix is the one change defensible on stop-width-vs-volatility math alone. A let-winners-run trend agent is *supposed* to run a low win rate; it only fails if wins can't clear loss size (break-even at 25% needs 3:1 avg-win/avg-loss; recent was 1.56:1 — wins truncated). **Decision rule:** re-measure expectancy after 40-50 trades; if still negative, the archetype is wrong for HYPE and a rewrite is earned. Until then it's mis-calibrated, not broken.

## Changes
- `runtime.yaml` `phase1.retrace_threshold` 8 → 15 (+ rationale comment, description header, historical-narrative annotations)
- `scripts/wolverine-producer.py` `VERSION` 6.0.0 → 6.1.0
- `SKILL.md` metadata + title + v6.1.0 changelog
- `README.md` DSL line + v6.1.0 changelog

## Test plan
- [x] `yaml.safe_load(runtime.yaml)` → phase1 retrace_threshold=15, Phase 2 ladder unchanged [(10,0),(20,25),(30,40),(50,60),(75,75),(100,85)]
- [x] `py_compile wolverine-producer.py` passes
- [x] grep — only annotated historical "retrace 8 (v6.1.0: → 15)" references remain; active config is 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)