### PR TITLE
kestrel v3.0.3 — drop undeclared _kestrel_producer_version from signal payload

### DIFF
--- a/kestrel/README.md
+++ b/kestrel/README.md
@@ -137,6 +137,18 @@ Expected: `status=ok` every tick (300s interval — macro 1H candles change slow
 
 ## Changelog
 
+### v3.0.3 (2026-06-01) — drop undeclared `_kestrel_producer_version` from the signal payload
+
+**Bug.** `build_signal_data()` injected `_kestrel_producer_version` **inside the signal `data` block** — the object the runtime validates against the `external_scanner` `config.fields` declaration. That key is not (and should not be) a declared field, so the runtime rejected the signal:
+
+> `INVALID_REQUEST: External scanner 'kestrel_signals' received undeclared data field '_kestrel_producer_version'.`
+
+Kestrel was the **only** producer in the fleet that put its version tag in the validated payload — every other agent (cheetah, dire, …) keeps the tag in `cfg.output(...)` log lines only. The `senpi_runtime_helpers` SDK catches the rejection and lets the daemon tick finish `status:ok`, so the failure is invisible at the tick level — you only see it in the `signal_post … status:rejected` / `push_signal failed` log lines. Same *class* of silent-producer bug as v3.0.2 (a malformed signal field rejected by the runtime), different field.
+
+**Fix.** Removed the tag from `build_signal_data()`. It stays in all six `cfg.output(...)` log sites, so the running version is still visible in `/tmp/kestrel-producer.log` without polluting the validated signal contract — fleet-standard.
+
+**Do NOT "fix" this by declaring `_kestrel_producer_version` in `runtime.yaml`.** That bakes a producer-internal debug field into the scanner contract, which no other agent does. The producer-side removal is the correct fix; the data block must contain only declared fields.
+
 ### v3.0.2 (2026-05-29) — score-normalization bug fix (silent producer)
 
 **Bug:** the producer was passing the raw strategy-specific score (5–10+) as the **top-level** `score` kwarg to `SenpiClient.push_signal()`. The runtime requires that field to be in `[0, 1]` (it's the runtime's confidence band, not the strategy's raw score). Every `push_signal()` call failed with:

--- a/kestrel/SKILL.md
+++ b/kestrel/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0.2"
+  version: "3.0.3"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/kestrel/scripts/kestrel-producer.py
+++ b/kestrel/scripts/kestrel-producer.py
@@ -88,7 +88,7 @@ if _sdk_path not in sys.path:
 from senpi_runtime_helpers import producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "3.0.2"
+VERSION = "3.0.3"
 SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "kestrel_signals")
 SIGNAL_TYPE = "KESTREL_XYZ_BREAKOUT"
 
@@ -623,7 +623,16 @@ def build_signal_data(candidate, leverage, margin_usd, held_assets):
         "spreadPct": float(candidate["spread_pct"]),
         "reasons": " | ".join(candidate["reasons"]),
         "heldAssets": held_list,
-        "_kestrel_producer_version": VERSION,
+        # v3.0.3: _kestrel_producer_version is intentionally NOT in the
+        # signal `data` payload. The runtime's external_scanner validates
+        # the data block against config.fields; an undeclared key here is
+        # rejected with INVALID_REQUEST ("received undeclared data field
+        # '_kestrel_producer_version'"), which silently dropped EVERY
+        # Kestrel signal. The version tag stays in cfg.output(...) log
+        # lines only (fleet-standard — see cheetah/dire/etc.), so it's
+        # still visible in /tmp/kestrel-producer.log without polluting the
+        # validated signal contract. Do NOT re-add it here, and do NOT
+        # "fix" this by declaring the tag in runtime.yaml.
     }
 
 


### PR DESCRIPTION
## Summary
- `build_signal_data()` injected `_kestrel_producer_version` inside the signal `data` block — the object the runtime validates against the `external_scanner` `config.fields` allowlist. The undeclared key triggers `INVALID_REQUEST` ("received undeclared data field '_kestrel_producer_version'"), silently dropping **every** Kestrel signal. The helpers SDK catches the rejection so the daemon tick still reports `status:ok` — the failure only shows in the `signal_post … status:rejected` / `push_signal failed` log lines.
- Kestrel was the **only** fleet producer putting its version tag in the validated payload; cheetah/dire/etc. keep it in `cfg.output(...)` logs only. This is the same class of silent-producer bug as v3.0.2 (a malformed signal field rejected by the runtime), different field.
- Fix: removed the tag from `build_signal_data()`; retained in all six `cfg.output(...)` log sites so the running version stays visible in `/tmp/kestrel-producer.log`.
- **Do NOT** "fix" this by declaring the tag in `runtime.yaml` — that bakes a producer-internal debug field into the scanner contract, which no other agent does.

## Files
- `kestrel/scripts/kestrel-producer.py` — VERSION 3.0.2 → 3.0.3; remove tag from `build_signal_data()`; add in-code guard comment.
- `kestrel/SKILL.md` — metadata version 3.0.2 → 3.0.3.
- `kestrel/README.md` — v3.0.3 changelog entry.

## Test plan
- [x] `python3 -m py_compile kestrel/scripts/kestrel-producer.py`
- [x] Confirmed `build_signal_data()` returns only the 13 declared `config.fields`; the 6 remaining tag references are all `cfg.output(...)` log calls.
- [ ] Live: on next XYZ breakout, signal posts with `status:ok` (no `INVALID_REQUEST`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)