### PR TITLE
Fix dynamic daily-cap phantom-drawdown throttle (kestrel/owl/pangolin)

### DIFF
--- a/kestrel/README.md
+++ b/kestrel/README.md
@@ -137,6 +137,12 @@ Expected: `status=ok` every tick (300s interval — macro 1H candles change slow
 
 ## Changelog
 
+### v3.0.4 (2026-06-02) — dynamic daily-cap baseline fix (phantom-drawdown throttle)
+
+**Bug.** `STARTING_BUDGET` was hardcoded to the `$1,000` fleet default and used as the drawdown baseline for the P&L-aware dynamic daily-entry cap. Any wallet funded **below** `$1,000` was read as a proportional loss — e.g. a `$499` deposit scored as `−50%` PnL and slammed the cap to `~0` entries/day, so the agent silently sat out valid breakouts (observed live: a `GOOGL` setup skipped with `note: "daily cap reached: 1/0 (PnL -50.9%)"` while the account was actually healthy).
+
+**Fix.** The baseline is now resolved per-tick from the operator's **actual deployed capital** via `resolve_starting_budget()`: config `startingBudget` override → persisted first-tick equity (`state/equity-baseline.json`) → current account value. Funding **any** amount now reads as `~0%` PnL at deploy, so the cap reflects real performance, not deposit size. No thesis change; the cap tiers are untouched. After a top-up, reset the baseline by setting config `startingBudget` or deleting `state/equity-baseline.json`. The hardcoded `1000.0` constant remains only as a last-resort fallback and is never used on the live path.
+
 ### v3.0.3 (2026-06-01) — drop undeclared `_kestrel_producer_version` from the signal payload
 
 **Bug.** `build_signal_data()` injected `_kestrel_producer_version` **inside the signal `data` block** — the object the runtime validates against the `external_scanner` `config.fields` declaration. That key is not (and should not be) a declared field, so the runtime rejected the signal:

--- a/kestrel/SKILL.md
+++ b/kestrel/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0.3"
+  version: "3.0.4"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/kestrel/scripts/kestrel-producer.py
+++ b/kestrel/scripts/kestrel-producer.py
@@ -88,7 +88,7 @@ if _sdk_path not in sys.path:
 from senpi_runtime_helpers import producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "3.0.3"
+VERSION = "3.0.4"
 SCANNER_NAME = os.environ.get("EXTERNAL_SCANNER_NAME", "kestrel_signals")
 SIGNAL_TYPE = "KESTREL_XYZ_BREAKOUT"
 
@@ -170,7 +170,38 @@ LEVERAGE_TIERS = [
 ]
 DEFAULT_LEVERAGE = 3
 
+# Last-resort fallback only. The live drawdown baseline is resolved per-tick
+# by resolve_starting_budget() from the operator's ACTUAL deployed capital.
+# A hardcoded fleet default mislabels sub-default funding as a phantom
+# drawdown (e.g. $499 funded reads as -50% and throttles the cap to ~0/day).
 STARTING_BUDGET = 1000.0
+_EQUITY_BASELINE_FILE = _STATE_DIR / "equity-baseline.json"
+
+
+def resolve_starting_budget(account_value):
+    """Drawdown baseline for the dynamic daily cap, resolved from REAL
+    deployed capital — never a hardcoded fleet default.
+    Order: config 'startingBudget' override > persisted first-tick equity
+    > capture current account value now. Funding ANY amount then reads as
+    ~0% PnL at deploy. Reset after a top-up by setting config startingBudget
+    or deleting state/equity-baseline.json."""
+    cfg_budget = safe_float(cfg.load_config().get("startingBudget"), 0.0)
+    if cfg_budget > 0:
+        return cfg_budget
+    try:
+        with open(_EQUITY_BASELINE_FILE) as f:
+            saved = safe_float(json.load(f).get("baseline"), 0.0)
+        if saved > 0:
+            return saved
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+    if account_value and account_value > 0:
+        cfg.atomic_write(str(_EQUITY_BASELINE_FILE), {
+            "baseline": round(float(account_value), 2),
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+        })
+        return float(account_value)
+    return float(account_value) if account_value else 1.0
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -717,9 +748,10 @@ def main():
 
     # ── Daily cap (P&L-aware dynamic) ──
     tc = load_trade_counter()
-    dyn_cap = get_dynamic_daily_cap(account_value)
+    starting_budget = resolve_starting_budget(account_value)
+    dyn_cap = get_dynamic_daily_cap(account_value, starting_budget)
     if tc.get("entries", 0) >= dyn_cap:
-        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
+        pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
         cfg.output({
             "status": "ok",
             "note": f"daily cap reached: {tc.get('entries')}/{dyn_cap} (PnL {pnl_pct:+.1f}%)",

--- a/owl/README.md
+++ b/owl/README.md
@@ -189,6 +189,12 @@ ls -la /data/workspace/skills/owl-strategy/state/<wallet-hash>/
 
 ## Changelog
 
+### v8.0.1 (2026-06-02) — dynamic daily-cap baseline fix (phantom-drawdown freeze)
+
+**Bug.** `STARTING_BUDGET` was hardcoded to the `$1,000` fleet default and used as the drawdown baseline for the dynamic daily-entry cap. Any wallet funded **below** `$1,000` was read as a proportional loss — and because Owl's drawdown circuit breaker returns **0 entries below −25%**, any Owl funded under `~$750` was **fully frozen** (0 trades/day), while funding under `~$950` was throttled. The agent looked healthy but never traded.
+
+**Fix.** The baseline is now resolved per-tick from the operator's **actual deployed capital** via `resolve_starting_budget()`: config `startingBudget` override → persisted first-tick equity (`state/equity-baseline.json`) → current account value. Funding **any** amount now reads as `~0%` PnL at deploy. `get_dynamic_daily_cap()` takes the resolved baseline as a parameter (was reading the module constant). No thesis change; the cap/breaker tiers are untouched. Reset after a top-up via config `startingBudget` or by deleting `state/equity-baseline.json`.
+
 ### v8.0.0 — senpi_runtime_helpers migration
 
 **Plumbing-only migration. NO thesis change.** v7.1's crowding/exhaustion scoring, persistence gates, MACRO_TREND_GATE, conviction leverage tiers (7/8/10), MIN_COMBINED_SCORE 12, 6h post-loss cooldown, dynamic daily cap, XYZ ban, DSL preset are all preserved verbatim.

--- a/owl/SKILL.md
+++ b/owl/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: jason-goldberg
-  version: "8.0"
+  version: "8.0.1"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/owl/scripts/owl-producer.py
+++ b/owl/scripts/owl-producer.py
@@ -68,7 +68,7 @@ import owl_config as cfg
 from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "8.0.0"
+VERSION = "8.0.1"
 # Hardcoded — must match runtime.yaml external_scanner.name.
 SCANNER_NAME = "owl_signals"
 # Signal type passed explicitly to push_signal(). Don't rely on the
@@ -127,7 +127,12 @@ MIN_COMBINED_SCORE = 12               # v6.0: lowered 14→12
 BELOW_THRESHOLD_TOLERANCE = 2         # v5.3: 2 consecutive below-threshold scans before clear
 ASSET_COOLDOWN_MINUTES = 360          # 6h post-loss
 MIN_FUNDING_ANNUALIZED_PCT = 12       # v5.2 (was 20)
+# Last-resort fallback only. The live drawdown baseline is resolved per-tick
+# by resolve_starting_budget() from the operator's ACTUAL deployed capital.
+# A hardcoded fleet default mislabels sub-default funding as a phantom
+# drawdown (e.g. funding < $750 reads as < -25% and FREEZES the cap to 0/day).
 STARTING_BUDGET = 1000.0
+_EQUITY_BASELINE_FILE = _STATE_DIR / "equity-baseline.json"
 XYZ_BANNED = True                     # Owl's score_crowding uses funding + SM long_pct
                                        # calibrated on crypto data shape; XYZ funding/SM
                                        # dynamics are different. Lemon v1.3 lifted
@@ -167,11 +172,39 @@ def get_leverage_for_score(score):
     return DEFAULT_LEVERAGE
 
 
-def get_dynamic_daily_cap(account_value, day_realized_pnl=0):
+def resolve_starting_budget(account_value):
+    """Drawdown baseline for the dynamic daily cap, resolved from REAL
+    deployed capital — never a hardcoded fleet default.
+    Order: config 'startingBudget' override > persisted first-tick equity
+    > capture current account value now. Funding ANY amount then reads as
+    ~0% PnL at deploy. Reset after a top-up by setting config startingBudget
+    or deleting state/equity-baseline.json."""
+    cfg_budget = safe_float(cfg.load_config().get("startingBudget"), 0.0)
+    if cfg_budget > 0:
+        return cfg_budget
+    try:
+        with open(_EQUITY_BASELINE_FILE) as f:
+            saved = safe_float(json.load(f).get("baseline"), 0.0)
+        if saved > 0:
+            return saved
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+    if account_value and account_value > 0:
+        cfg.atomic_write(str(_EQUITY_BASELINE_FILE), {
+            "baseline": round(float(account_value), 2),
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+        })
+        return float(account_value)
+    return float(account_value) if account_value else 1.0
+
+
+def get_dynamic_daily_cap(account_value, day_realized_pnl=0, starting_budget=STARTING_BUDGET):
     """v6.x dynamicSlots: 2 base, 3 at +$150 day PnL, 4 at +$400.
     Drawdown circuit breaker: 0 entries below -25% (matches runtime
     guard_rails.drawdown_halt_pct), 1 below -15%, 2 below -5%."""
-    pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
+    if starting_budget <= 0:
+        starting_budget = STARTING_BUDGET
+    pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
     if pnl_pct < -25:
         return 0  # HARD STOP — also enforced by runtime guard_rails
     if pnl_pct < -15:
@@ -672,9 +705,10 @@ def main():
 
     # 2. Producer-side dynamic daily cap (defense-in-depth alongside runtime)
     tc = load_trade_counter()
-    dyn_cap = get_dynamic_daily_cap(account_value, tc.get("realizedPnl", 0))
+    starting_budget = resolve_starting_budget(account_value)
+    dyn_cap = get_dynamic_daily_cap(account_value, tc.get("realizedPnl", 0), starting_budget)
     if tc.get("entries", 0) >= dyn_cap:
-        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
+        pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
         cfg.output({
             "status": "ok",
             "note": f"dynamic cap reached: entries {tc.get('entries')}/{dyn_cap} (PnL {pnl_pct:+.1f}%)",

--- a/pangolin/README.md
+++ b/pangolin/README.md
@@ -123,6 +123,12 @@ Expected: `status=ok` every tick (300s interval — Pangolin's longer cadence re
 
 ## Changelog
 
+### v3.0.2 (2026-06-02) — dynamic daily-cap baseline fix (phantom-drawdown throttle)
+
+**Bug.** `STARTING_BUDGET` was hardcoded to the `$1,000` fleet default and used as the drawdown baseline for the P&L-aware dynamic daily-entry cap. Any wallet funded **below** `$1,000` was read as a proportional loss — e.g. a `$499` deposit scored as `−50%` PnL and slammed the cap to `~0` entries/day, so the agent silently sat out valid funding-fade setups.
+
+**Fix.** The baseline is now resolved per-tick from the operator's **actual deployed capital** via `resolve_starting_budget()`: config `startingBudget` override → persisted first-tick equity (`state/equity-baseline.json`) → current account value. Funding **any** amount now reads as `~0%` PnL at deploy. No thesis change; the cap tiers are untouched. Reset after a top-up via config `startingBudget` or by deleting `state/equity-baseline.json`. The hardcoded `1000.0` constant remains only as a last-resort fallback.
+
 ### v3.0.1 — funding annualization fix
 
 **Bug fix + threshold recalibration.** Hyperliquid funding is charged **hourly**, so annualized funding is `rate × 24 × 365 (×8760)`, not `× 3 × 365`. Two corrections:

--- a/pangolin/SKILL.md
+++ b/pangolin/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: MIT
 metadata:
   author: jason-goldberg
-  version: "3.0.1"
+  version: "3.0.2"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/pangolin/scripts/pangolin-producer.py
+++ b/pangolin/scripts/pangolin-producer.py
@@ -126,7 +126,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import pangolin_config as cfg
 
 
-VERSION = "3.0.1"  # single source of truth; matches SKILL.md frontmatter
+VERSION = "3.0.2"  # single source of truth; matches SKILL.md frontmatter
 
 # v2.0.0: Agent-specific wallet env var. NO fallback to STRATEGY_ADDRESS
 # (contamination risk per Turbine v2.0.9 fix — see feedback_mcp_auth_is_fleet_wide.md).
@@ -180,7 +180,12 @@ POST_CLOSE_COOLDOWN_MINUTES = 240     # v2.1.2 — post-CLOSE cooldown.
                                       # which is silently not enforcing in the runtime.
                                       # Producer-side backstop until the runtime gate
                                       # is fixed.
+# Last-resort fallback only. The live drawdown baseline is resolved per-tick
+# by resolve_starting_budget() from the operator's ACTUAL deployed capital.
+# A hardcoded fleet default mislabels sub-default funding as a phantom
+# drawdown (e.g. $499 funded reads as -50% and throttles the cap to ~0/day).
 STARTING_BUDGET = 1000.0
+_EQUITY_BASELINE_FILE = _STATE_DIR / "equity-baseline.json"
 XYZ_BANNED = True                     # never trade equities
 
 # Leverage tiers — preserved from v1.4
@@ -207,6 +212,32 @@ def get_leverage_for_score(score):
         if score >= tier["min_score"]:
             return tier["leverage"]
     return DEFAULT_LEVERAGE
+
+
+def resolve_starting_budget(account_value):
+    """Drawdown baseline for the dynamic daily cap, resolved from REAL
+    deployed capital — never a hardcoded fleet default.
+    Order: config 'startingBudget' override > persisted first-tick equity
+    > capture current account value now. Funding ANY amount then reads as
+    ~0% PnL at deploy. Reset after a top-up by setting config startingBudget
+    or deleting state/equity-baseline.json."""
+    cfg_budget = safe_float(cfg.load_config().get("startingBudget"), 0.0)
+    if cfg_budget > 0:
+        return cfg_budget
+    try:
+        with open(_EQUITY_BASELINE_FILE) as f:
+            saved = safe_float(json.load(f).get("baseline"), 0.0)
+        if saved > 0:
+            return saved
+    except (FileNotFoundError, json.JSONDecodeError):
+        pass
+    if account_value and account_value > 0:
+        cfg.atomic_write(str(_EQUITY_BASELINE_FILE), {
+            "baseline": round(float(account_value), 2),
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+        })
+        return float(account_value)
+    return float(account_value) if account_value else 1.0
 
 
 def get_dynamic_daily_cap(account_value, starting_budget=STARTING_BUDGET):
@@ -793,9 +824,10 @@ def main():
 
     # Producer-side dynamic daily cap (v1 carryover; runtime ceiling at 12)
     tc = load_trade_counter()
-    dyn_cap = get_dynamic_daily_cap(account_value)
+    starting_budget = resolve_starting_budget(account_value)
+    dyn_cap = get_dynamic_daily_cap(account_value, starting_budget)
     if tc.get("entries", 0) >= dyn_cap:
-        pnl_pct = ((account_value - STARTING_BUDGET) / STARTING_BUDGET) * 100
+        pnl_pct = ((account_value - starting_budget) / starting_budget) * 100
         cfg.output({
             "status": "ok",
             "note": f"dynamic cap reached: entries {tc.get('entries')}/{dyn_cap} (PnL {pnl_pct:+.1f}%)",


### PR DESCRIPTION
## The bug
The P&L-aware dynamic daily-entry cap in kestrel, owl, and pangolin measured drawdown against a **hardcoded** `STARTING_BUDGET = 1000.0` (the fleet default). Any wallet funded below $1,000 was misread as a proportional loss:

| Deposit | Phantom PnL vs $1000 | kestrel/pangolin cap | owl cap |
|---|---|---|---|
| $499 | −50% | **0** (was 8) | **0** (was 2) |
| $200 | −80% | **0** (was 8) | **0** (was 2) |
| $1000 | 0% | 8 (unchanged) | 2 (unchanged) |

Result: agents funded below the fleet default silently sat out valid setups. Owl is worst — its breaker returns **0 entries below −25%**, so any Owl funded under ~$750 was **fully frozen**. Caught live on a `kestrel-tracker` instance funded with $499 (`note: "daily cap reached: 1/0 (PnL -50.9%)"` while the account was healthy).

## The fix
New `resolve_starting_budget()` derives the baseline **per-tick from the operator's actual deployed capital**:
`config startingBudget` override → persisted first-tick equity (`state/equity-baseline.json`) → current account value.

So funding *any* amount reads as ~0% PnL at deploy; the cap reflects real performance, not deposit size. The hardcoded `1000.0` remains only as a last-resort fallback and is never used on the live path. **No thesis change** — cap tiers untouched. Reset after a top-up via config `startingBudget` or by deleting `state/equity-baseline.json`.

Aligns with the fleet rule: *never hardcode wallet-specific values.*

## Versions
- kestrel `3.0.3 → 3.0.4`
- owl `8.0.0 → 8.0.1`
- pangolin `3.0.1 → 3.0.2`

## Validation
- `py_compile` clean on all three producers.
- Before/after cap math verified (table above); divide-by-zero guarded (`resolve_starting_budget` never returns 0; owl coerces a 0 baseline back to the fallback).
- Legacy `scorpion/legacy-v1` and `jackal/legacy-v1` scanners carry the same constant but are dead (v1, not deployed) — left untouched.

## Live blast radius (needs operator ferry to pull)
Any kestrel/owl/pangolin instance funded below $1,000 is currently under-trading or frozen. Operators must re-pull the producer + restart to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)