### PR TITLE
Spider: 60/40 swing/scalp funding-split default

### DIFF
--- a/spider/README.md
+++ b/spider/README.md
@@ -182,6 +182,14 @@ Each leg also accepts an optional `SPIDER_SWING_STRATEGY_ID` /
 `SPIDER_SCALP_STRATEGY_ID` (falls back to the `strategyId` field in the
 matching config file).
 
+**Recommended funding split — SWING 60% / SCALP 40%** of the combined Spider
+pool. Swing is the fee-efficient, asymmetric-upside leg (low turnover,
+let-winners-run, plus the dynamic-universe edge), so it carries the larger
+share. Scalp is **fee-sensitive** and funded small to validate net-of-fees
+before scaling — raise its share only after it proves out. This is an operator
+funding guideline (documented in each `runtime-*.yaml` `strategy:` block); the
+runtime does not pull or enforce a budget, so fund the two wallets accordingly.
+
 ### Step 4 — Register both runtimes, start both daemons
 
 Register each runtime YAML with the gateway (per your host's runtime-register

--- a/spider/runtime-scalp.yaml
+++ b/spider/runtime-scalp.yaml
@@ -40,6 +40,13 @@ description: >
 
 strategy:
   wallet: "${SPIDER_SCALP_WALLET}"
+  # ── FUNDING SPLIT DEFAULT: SWING 60% / SCALP 40% of the combined pool ──
+  # Scalp takes the SMALLER 40% share: it is FEE-SENSITIVE (30 entries/day) and
+  # unproven net-of-fees, so it is funded small to validate before scaling. Raise
+  # its share only after net-of-fees proves out over several weeks. Swing carries
+  # the larger 60% (see runtime-swing.yaml). This is a FUNDING guideline for the
+  # operator (how to split capital across the two wallets), NOT a runtime-enforced
+  # field. Per-position sizing is governed by margin_pct + slots below.
   slots: 4
   margin_pct: 15          # 4 x 15 = 60% max committed; small scalp size
   trading_risk: moderate

--- a/spider/runtime-swing.yaml
+++ b/spider/runtime-swing.yaml
@@ -30,6 +30,14 @@ description: >
 
 strategy:
   wallet: "${SPIDER_SWING_WALLET}"
+  # ── FUNDING SPLIT DEFAULT: SWING 60% / SCALP 40% of the combined pool ──
+  # Swing carries the LARGER 60% share: it is the fee-efficient, asymmetric-
+  # upside leg (low turnover, let-winners-run DSL, plus the dynamic-universe
+  # edge that auto-catches fresh AI IPOs). Scalp takes 40% — it is fee-sensitive
+  # and funded small to validate net-of-fees first (see runtime-scalp.yaml).
+  # This is a FUNDING guideline for the operator (how to split capital across the
+  # two wallets), NOT a runtime-enforced field. Per-position sizing is governed
+  # by margin_pct + slots below.
   slots: 3
   margin_pct: 28          # 3 x 28 = 84% max committed; leaves headroom
   trading_risk: moderate


### PR DESCRIPTION
## Summary
- Bakes the recommended combined-pool funding split **SWING 60% / SCALP 40%** into both `runtime-*.yaml` `strategy:` blocks and the README install step.
- Swing carries the larger share: fee-efficient (low turnover, let-winners-run), asymmetric upside, plus the v5.1 dynamic-universe edge. Scalp takes 40% — fee-sensitive (30 entries/day) and funded small to validate net-of-fees before scaling.
- Encoded as a YAML **comment**, not a runtime key — the runtime does not pull/enforce a budget, and an unrecognized key risks schema-validator rejection. Pure operator funding guidance; no behavior change.

## Test plan
- [x] `runtime-swing.yaml` / `runtime-scalp.yaml` parse clean (`yaml.safe_load`)
- [x] No code/schema changes — `strategy:` keys (slots, margin_pct, wallet) untouched
- [x] README funding note matches YAML comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)