### PR TITLE
fix(spider): count wallet equity once — kill 2x position sizing

### DIFF
--- a/spider/README.md
+++ b/spider/README.md
@@ -230,6 +230,20 @@ under `[spider-v5:swing]` / `[spider-v5:scalp]` on stderr.
 
 ## Changelog
 
+### v5.1.1 — Fix equity double-count (2x position sizing)
+
+`get_positions()` summed `marginSummary.accountValue` across the `main` and
+`xyz` clearinghouse sections. Those are **two views of one cross-margined
+wallet, not two collateral silos** — both report the whole wallet's equity,
+so summing **doubled** the equity used for sizing (`margin_usd =
+account_value * margin_pct`) and opened every position **2x too large**.
+Live impact: a freshly-funded swing leg opened ONDO/MRVL at ~$414 margin
+when ~$207 was intended → over-leverage → forced exits + fee bleed. Fix:
+take `accountValue` **once** via `max()` across the two views (exact whether
+the views mirror, one is empty, or positions exist on both sub-DEXs).
+`assetPositions` are still enumerated per-sub-DEX. No scoring/DSL/risk
+changes.
+
 ### v5.1.0 — Dynamic swing universe (auto-catch new AI IPOs)
 
 The swing leg's XYZ-equity universe is now **dynamic** instead of a fixed

--- a/spider/SKILL.md
+++ b/spider/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spider-strategy
 description: >-
-  SPIDER v5.1.0 — Two autonomous style legs on two wallets, one producer.
+  SPIDER v5.1.1 — Two autonomous style legs on two wallets, one producer.
   NOT a copy-trader: each leg scores its own universe to a STYLE and
   pushes signals; the runtime owns the LLM gate (pass-through), DSL
   exits, and all risk.guard_rails. SWING leg = Tech & AI multi-day
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: jason-goldberg
-  version: "5.1.0"
+  version: "5.1.1"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -160,9 +160,14 @@ leverage above the leg cap as a clamp-breach defense.
 
 XYZ equities/energy require `dex="xyz"` on `market_get_asset_data` (an
 empty dex errors with `Asset prefix "xyz" must match dex`). Main-DEX
-assets pass `dex=""`. `get_positions()` sums `accountValue` across both
-the `main` and `xyz` sub-DEX clearinghouse views, since each leg holds
-assets on both. Candle fields are HL-native (`o/h/l/c/v`).
+assets pass `dex=""`. The `main` and `xyz` sub-DEX sections are two
+VIEWS of ONE cross-margined wallet (not two collateral silos), so both
+report the same `accountValue`. `get_positions()` takes `accountValue`
+ONCE via `max()` across the two views — never sums it. Summing
+double-counts the balance and sizes every position 2x too large
+(`margin_usd = account_value * margin_pct`). `assetPositions` ARE
+per-sub-DEX, so those are enumerated across both. Candle fields are
+HL-native (`o/h/l/c/v`).
 
 ## Race-window dedup
 

--- a/spider/scripts/spider-producer.py
+++ b/spider/scripts/spider-producer.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-# Senpi SPIDER Producer v5.1.0
+# Senpi SPIDER Producer v5.1.1
 # Copyright 2026 Senpi (https://senpi.ai)
 # Licensed under Apache-2.0
 # Source: https://github.com/Senpi-ai/senpi-skills
-"""SPIDER v5.1.0 Producer — two autonomous style legs, one script.
+"""SPIDER v5.1.1 Producer — two autonomous style legs, one script.
 
 Spider runs TWO concurrent strategy wallets, each a distinct trading
 style. ONE producer script serves both; the SPIDER_LEG env var selects
@@ -55,7 +55,7 @@ import spider_config as cfg
 from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
 
 
-VERSION = "5.1.0"
+VERSION = "5.1.1"
 LEG = cfg.LEG
 SCANNER_NAME = f"spider_{LEG}_signals"
 SIGNAL_TYPE = "SPIDER_SWING_MOMENTUM" if LEG == "swing" else "SPIDER_SCALP_REVERSION"

--- a/spider/scripts/spider_config.py
+++ b/spider/scripts/spider_config.py
@@ -179,9 +179,17 @@ def get_clearinghouse(wallet):
 def get_positions(wallet):
     """Returns (account_value, [position_dicts]).
 
-    Sums marginSummary.accountValue across BOTH the 'main' and 'xyz'
-    sub-DEX views — Spider's swing leg holds XYZ equities and the scalp
-    leg holds XYZ energy, so both views matter.
+    The 'main' and 'xyz' clearinghouse sections are TWO VIEWS of ONE
+    cross-margined Senpi wallet, NOT two separate collateral silos. Both
+    views report the SAME marginSummary.accountValue (the whole wallet's
+    equity). So account_value is taken ONCE via max() across the two
+    sections — never summed. Summing double-counts the balance and makes
+    every position size 2x too large (margin_usd = account_value *
+    margin_pct downstream). max() is exact whether the views mirror
+    (equal → max is the shared value), one view is empty/0 (the populated
+    view wins), or positions are open on both sub-DEXs (still one shared
+    cross-margin balance). assetPositions ARE per-sub-DEX, so those are
+    still enumerated across both sections.
     """
     ch = get_clearinghouse(wallet)
     if not ch:
@@ -193,7 +201,7 @@ def get_positions(wallet):
         if not isinstance(s, dict):
             continue
         ms = s.get("marginSummary", {})
-        account_value += float(ms.get("accountValue", 0) or 0)
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
         for ap in s.get("assetPositions", []):
             pos = ap.get("position", ap)
             szi = float(pos.get("szi", 0) or 0)


### PR DESCRIPTION
## Summary

- `get_positions()` **summed** `marginSummary.accountValue` across the `main` and `xyz` clearinghouse sections. Those are **two views of one cross-margined Senpi wallet, not two collateral silos** — both report the whole wallet's equity. Summing doubled the equity used for sizing (`margin_usd = account_value * margin_pct`) → **every position opened 2x too large**.
- **Live impact:** a freshly-funded swing leg opened ONDO/MRVL at ~$414 margin when ~$207 was intended → over-leverage → forced exits + fee bleed (episode contained to -$45.59 / -3.7% of pool before halt).
- **Fix:** take `accountValue` **once** via `max()` across the two views — exact whether the views mirror (equal), one is empty (populated view wins), or positions exist on both sub-DEXs (one shared cross-margin balance). `assetPositions` are still enumerated per-sub-DEX.
- Bumps producer + SKILL version to **5.1.1**, corrects the SKILL.md XYZ-handling note (sum → max), adds README changelog. No scoring / DSL / risk changes.

## Test plan

- [x] `python3 -m py_compile spider/scripts/spider_config.py spider/scripts/spider-producer.py` → clean
- [ ] Live confirmation on relaunch: first swing entry margin ≈ $207 (28% × ~$740), **not** ~$414

🤖 Generated with [Claude Code](https://claude.com/claude-code)