### PR TITLE
fix(catalog): remove orphaned 'Proven Performers' + 4 empty groups; instruct agents not to invent quality tiers

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1,34 +1,7 @@
 {
-  "_version": "1.1",
-  "_updated": "2026-06-01",
-  "_instructions": "Agent reads this file to build the onboarding skill catalog. Group by 'group', sort within group by 'sort_order'. Infrastructure skills (DSL, fee optimizer, scanners) are never displayed. NOTE on 'min_budget': it is the realistic platform floor (~$100 is the minimum to trade at all on Hyperliquid) and a SUGGESTED comfortable starting size — it is NOT a hard gate. Never refuse to deploy a willing user who is at or above the platform floor: position size scales with budget via margin_pct, so any amount works (smaller budget = smaller positions). Offer to start small or watch first; never dead-end a user over budget.",
-  "groups": [
-    {
-      "id": "proven",
-      "emoji": "\ud83c\udfc6",
-      "label": "Proven Performers"
-    },
-    {
-      "id": "single",
-      "emoji": "\ud83c\udfaf",
-      "label": "Single-Asset Hunters"
-    },
-    {
-      "id": "multi",
-      "emoji": "\ud83d\udd2c",
-      "label": "Multi-Signal Strategies"
-    },
-    {
-      "id": "alt",
-      "emoji": "\ud83d\udd75\ufe0f",
-      "label": "Alternative Edge"
-    },
-    {
-      "id": "variant",
-      "emoji": "\ud83d\udd27",
-      "label": "Strategy Variants"
-    }
-  ],
+  "_version": "1.2",
+  "_updated": "2026-06-02",
+  "_instructions": "Agent reads this file to build the onboarding skill catalog. Group by each skill's 'group' field (the archetype slug \u2014 e.g. 'single-asset-alpha-hunter', 'contrarian-unwind', 'trader-follower'), sort within group by 'sort_order'. When displaying, humanize the archetype slug (e.g. 'single-asset-alpha-hunter' -> 'Single-Asset Alpha Hunters'). DO NOT INVENT quality tiers like 'Proven Performers', 'Top Picks', 'Best-in-Class' \u2014 there is no curated quality ranking in this catalog. Every live skill ships with the same standard runtime / DSL / risk-gate scaffolding; differentiation is by archetype and thesis only. Infrastructure skills (DSL, fee optimizer, scanners) are never displayed. NOTE on 'min_budget': it is the realistic platform floor (~$100 is the minimum to trade at all on Hyperliquid) and a SUGGESTED comfortable starting size \u2014 it is NOT a hard gate. Never refuse to deploy a willing user who is at or above the platform floor: position size scales with budget via margin_pct, so any amount works (smaller budget = smaller positions). Offer to start small or watch first; never dead-end a user over budget.",
   "skills": [
     {
       "id": "albatross",


### PR DESCRIPTION
## Why

Qwen agent labeled Albatross / Bald Eagle / Egret as **🏆 Proven Performers** in front of a user, then admitted under pushback: *\"I rearranged them into my own 'Proven Performers' category based on my judgment of which ones had the strongest track records.\"*

It wasn't an isolated model error — it was a **catalog data bug** that any agent would trip on:

- The catalog defined **5 display groups** (\`proven\`, \`single\`, \`multi\`, \`alt\`, \`variant\`) with labels + emoji.
- **Zero skills** in the catalog are tagged with any of those 5 group IDs.
- The 54 live skills use **15 different \`group\` values** (\`single-asset-alpha-hunter\`, \`contrarian-unwind\`, \`trader-follower\`, etc.) — **zero overlap** with the displayed taxonomy.
- The agent sees a 🏆 \"Proven Performers\" label, has to put something under it, invents assignments.

## What this PR does

- **Removes the entire orphaned \`groups[]\` array.** Agents now group by each skill's raw \`group\` field (which IS accurate) and humanize the slug for display.
- **Rewrites \`_instructions\`** to (a) state the new grouping rule, (b) **explicitly forbid inventing quality tiers** like \"Proven Performers\" / \"Top Picks\" / \"Best-in-Class\", and (c) note that every live skill ships with identical runtime / DSL / risk-gate scaffolding — differentiation is archetype + thesis only, not quality.
- **Bumps catalog version** 1.1 → 1.2, \`_updated\` to 2026-06-02.

## Safety

- 54 skills intact, 15 distinct group values intact.
- JSON validated.
- Grepped repo for downstream consumers of the 5-group taxonomy: zero (no other doc, code, or test references it). Safe to remove without sync.

If/when you want a curated quality tier in the future (option 3 from the discussion), it can be added back as a real surface with a real curation process — not a label sitting on top of empty data.