### PR TITLE
senpi-trading-runtime: bump 2.2 → 2.3 (deliver PR #289 to non-fleet boxes)

### DIFF
--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -4,7 +4,7 @@ description: "The Senpi Trading Runtime OpenClaw plugin runs automated trading s
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.2"
+  version: "2.3"
   platform: senpi
   exchange: hyperliquid
 ---


### PR DESCRIPTION
Version-only bump of `senpi-trading-runtime/SKILL.md` (`2.2` → `2.3`). **No code change.**

## Why
PR #289 (drop keep-alive pool + idempotency-gated `signal_post` retry) is already merged to `main` inside `senpi_runtime_helpers`. But skills-manager classifies on-box `2.2` == remote `2.2` as "none" and skips it — so a version bump is required to actually deliver the fix.

Bumping the minor version makes skills-manager **auto-apply** the update on every box with auto-update enabled (~60–70 min cascade).

## Scope of who this reaches
- **Fleet boxes** (the ones we own / can SSH): already **hand-upgraded** to helper `0.1.1` and producers restarted/verified — so this bump is a **no-op** for them.
- **Non-fleet boxes** (other users' boxes we do not touch by hand): this bump is the only delivery mechanism — they pick up #289 on their next auto-update tick.

## Notes
- Auto-update-disabled boxes will NOT receive this (intentional; documented separately).
- Major-version bumps only notify; this is a minor bump → auto-applies (patch/minor policy).

Merging tomorrow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/metadata-only version change with no application logic; main effect is skill package rollout timing via auto-update.
> 
> **Overview**
> Bumps **`senpi-trading-runtime/SKILL.md`** metadata **`version`** from **`2.2`** to **`2.3`**. There is **no runtime or helper code change** in this PR.
> 
> The bump exists so **skills-manager** treats on-box **`2.2`** as stale versus remote **`2.3`** and **auto-applies** the skill package on the next update tick. That is how **non-fleet** hosts receive helper fixes already merged on **`main`** (e.g. PR #289: drop keep-alive pool, idempotency-gated **`signal_post`** retry) when local and remote versions were both **`2.2`** and updates were skipped as **"none"**. Fleet boxes already hand-upgraded are expected to see this as a **no-op**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4701c0b6135c80866c395c9746861de720a1f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->