### PR TITLE
docs: reclassify Spider as a two-leg hedge fund (v5.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ Strict whitelist of 3–6 majors, best-of-N selection per tick.
 | [iguana](iguana/) | v1.0 | xyz:SP500 · xyz:XYZ100 | **Onboarding — XYZ index basket.** The simplest XYZ exposure — just the broad indices. Picks whichever has the stronger 4-day move past 1.5% and trades its direction. Balanced DSL + 48h hard_timeout. |
 | [sailfish](sailfish/) | v1.0 | BTC · ETH · SOL · HYPE | **Relative-strength rotator.** Ranks the universe by ~2.7d RS each tick; longs the leader iff leader RS ≥ 1% AND beats runner-up by ≥ 1.5pp (no whipsaw). Rotation via DSL exit + re-entry. Balanced DSL + 96h hard_timeout. |
 | [stag](stag/) | v1.0 | BTC · ETH · SOL · HYPE (often single-asset) | **Parabolic-run hunter.** Entry-side pair for the new `parabolic_runner` DSL preset (widest in the catalog: max_loss 25%, retrace 18, 2 breaches required, 14d outer bound). Strict 5-gate filter (200-SMA + 7d ≥25% + vol surge + acceleration + SM ≥60% LONG). LONG only. Operator-driven — most ticks return empty by design. Reference: HYPE 2026-05 (+60% in 16 days). |
+| [spider](spider/) | v5.1.1 | AI/Tech XYZ equities + crypto alts (swing) · BTC · ETH · SOL · HYPE + xyz:BRENTOIL/CL (scalp) | **Autonomous Hyperliquid hedge fund.** Two style legs on two wallets, one producer: a LONG-only AI/Tech momentum book (dynamic XYZ-equity universe, auto-catches fresh IPO/pre-IPO listings, 10x, wide let-winners-run DSL) **plus** a both-directions macro/majors mean-reversion counter-trading book (strict 5x, tight fast-capture DSL). Each leg scores its own universe; runtime owns LLM gate, DSL exits, and risk. |
 
 ## 5. Trader-follower / hot-streak
 
@@ -446,7 +447,6 @@ Top-trader pool + conviction-gated coat-tail entries.
 |---|---|---|---|
 | [raptor](raptor/) | v3.0 | Multi (top traders) | 24h-cached trader pool. Gates on reputation, position size, SM alignment, per-trader entry discipline. |
 | [jackal](jackal/) | v1.0 | Multi (top traders) | Active trader pool + new-entry detector. Enriches with TA + funding regime. |
-| [spider](spider/) | v2.0 | Multi (arena-anchored) | Patient anchor sniper — arena-leader overlap + SM universe + funding + relative strength. 7-day minimum hold. |
 | [remora](remora/) | v1.0 | Operator-picked whale set | **Hand-picked mirror.** You name the whales; Remora mirrors each one's largest-notional position, with a consensus boost when ≥2 agree + an ELITE-tier bonus. Wide DSL, 120h staleness cap. |
 
 ## 6. Striker / rank-jump

--- a/catalog.json
+++ b/catalog.json
@@ -738,17 +738,17 @@
     {
       "id": "spider",
       "tracker_slug": "spider",
-      "name": "Spider \u2014 Patient Anchor Sniper",
+      "name": "Spider \u2014 Autonomous Hyperliquid Hedge Fund",
       "emoji": "\ud83d\udd77\ufe0f",
-      "tagline": "Hold one high-conviction long anchor for at least 7 days while the rest of the fleet churns.",
-      "group": "trader-follower",
-      "sort_order": 33,
+      "tagline": "AI/Tech-focused long book + a macro/majors long-short counter-trading book \u2014 two style legs, two wallets, one producer.",
+      "group": "multi-asset-whitelist",
+      "sort_order": 46,
       "min_budget": 100,
       "risk_level": "moderate",
       "base_skill": null,
       "branch": "main",
       "predators_url": "https://strategies.senpi.ai/bot/spider",
-      "version": "4.0.1"
+      "version": "5.1.1"
     },
     {
       "id": "remora",

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -325,6 +325,7 @@ if best_candidate:
 | **Iguana** | v1.0 | xyz:SP500 · xyz:XYZ100 | **Onboarding tier — XYZ subset.** The simplest XYZ exposure in the fleet — just the broad indices. Picks whichever has the stronger 4-day move past the threshold and trades its direction. No stock-picking, no commodities, no pre-IPO. Closest thing to "an index fund, but 24/7." Balanced DSL + 48h hard_timeout for weekend pricing-gap risk. | Onboarding, XYZ-Macro, Index-only, Balanced DSL, hard_timeout 48h |
 | **Sailfish** | v1.0 | BTC · ETH · SOL · HYPE | Relative-Strength Rotator. Ranks the universe by ~2.7d RS each tick and longs the leader iff (a) leader's own RS ≥ 1% AND (b) it beats the runner-up by ≥ 1.5pp (no whipsaw on tight races). Runtime is single-position; "rotation" happens via DSL exit on the holdover + Sailfish's next-tick re-entry on the new leader. Momentum cousin of Chameleon's mean-reversion. Balanced DSL + 96h hard_timeout. | Momentum-rotation, RS-leader, Margin-gate, Balanced DSL |
 | **Stag** | v1.0 | BTC · ETH · SOL · HYPE (often deployed single-asset) | **Parabolic-Run Hunter.** Entry-side pair for the new `parabolic_runner` DSL preset (widest in the catalog: max_loss 25%, retrace 18, 2 consecutive breaches required, late first lock +15%, 14d outer bound). Strict 5-gate filter: (1) close > 200-bar 4h SMA AND 7d high within 48h, (2) 7d move ≥ 25% (the parabolic threshold), (3) 24h volume ≥ 1.5× trailing 7d, (4) 4d move ≥ 7d move / 2 (acceleration), (5) SM aligned LONG ≥ 60%. LONG only — parabolic crashes happen too fast for shorts. **Operator-driven** deployment: most ticks return empty by design. Reference setup: HYPE 2026-05 (+60% in 16 days). 1 entry/day max + 24h per-asset cooldown after bad takes. Tick 600s. | Parabolic, 5-gate, LONG-only, Operator-driven, parabolic_runner DSL |
+| **Spider** | v5.1.1 | AI/Tech XYZ equities + crypto alts (swing) · BTC · ETH · SOL · HYPE + xyz:BRENTOIL/CL (scalp) | **Autonomous Hyperliquid hedge fund — two style legs on two wallets, one leg-parameterized producer (`SPIDER_LEG`).** SWING: LONG-only AI/Tech multi-day momentum on a dynamic XYZ-equity universe (auto-catches fresh IPO/pre-IPO listings) + crypto alts; conviction 10x; wide let-winners-run DSL; low turnover. SCALP: both-directions macro/majors + energy mean-reversion counter-trading book; strict 5x; tight fast-capture DSL; high turnover. Each leg scores its own universe and pushes signals; the runtime owns the LLM gate, DSL exits, and risk. **Not a copy-trader** (v5.0 replaced the old single-leg anchor sniper). | Two-leg, Hedge-fund, AI/Tech-long, Macro-scalp, Both-direction, Dynamic-universe |
 
 ---
 
@@ -384,7 +385,6 @@ cfg._wrapper_client.push_signal(
 |---|---|---|---|---|
 | **Raptor** | v3.0 | Multi (follows top traders) | Caches top traders (24h), detects highest-conviction current positions, follows with gates on reputation + position size + SM alignment + per-trader entry discipline. Deduplicates repeated follows. | Coat-tail, 24h cache, Tick 60–180s |
 | **Jackal** | v1.0 | Multi (follows top traders) | Maintains an active trader pool, detects new entries, enriches each candidate with TA + funding regime. Strict per-trader contamination rules. | New-entry, TA, Funding |
-| **Spider** | v2.0 | Multi (arena-anchored) | Patient anchor sniper. Arena-leader overlap + SM-leaderboard universe + funding + relative strength. Single-leg, 7-day minimum hold, fee-aware. | Patient, Arena-anchor, 7d-hold |
 | **Albatross** | v1.0 | Arena leaders (multi-week composite) | **Onboarding tier.** Mirrors Senpi Arena leaders selected by composite conviction score: `0.3 × monthly_roe + 0.7 × mean(weekly_roe) − 0.5 × stdev(weekly_roe)`. Rewards multi-week persistence, penalizes lucky-week luck. Pool refreshes every 4h. **Requires user-scope auth token** (calls `strategy_list` + `discovery_get_trader_state` for other users). | Onboarding, Arena, Multi-week, Conviction-weighted, User-scope-auth-required |
 | **Remora** | v1.0 | Operator-picked whale set | **Hand-picked mirror.** You name the whales; Remora takes each whale's highest-conviction (largest-notional) position and mirrors the strongest, with a **consensus** multiplier (2 whales +2, 3+ +3) and an ELITE/RELIABLE-tier bonus. Contrast to the universe scanners above — exposure tracks traders YOU choose. Wide let-winners-run DSL + 120h staleness cap (whale-exit mirror is a future enhancement). Tick 600s. | Whale-mirror, Consensus, Operator-picked, Wide DSL |
 
@@ -963,7 +963,7 @@ Ask which one sentence sounds most like the user:
 ### Layer 2C — Copy-trading → who do you copy?
 
 - **Multi-week arena winners** (proven over a month, not one lucky week) → 🟢 **Albatross** (conviction-weighted leader pool).
-- **Live hot-streak traders** (whoever's hot right now) → **Raptor** · **Jackal** · **Spider** (arena-anchored).
+- **Live hot-streak traders** (whoever's hot right now) → **Raptor** · **Jackal**.
 - **Specific whales YOU pick** (name the traders, mirror their biggest bet) → **Remora** — hand-picked whale mirror with a consensus boost when several agree.
 - **The best strategies, automatically** (don't pick anyone — follow whatever's working) → **Cuckoo** — auto-discovers the top-performing strategies and trades their performance-weighted consensus (copy-the-copiers).
 
@@ -1091,7 +1091,7 @@ curl -fsSL https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/<agent>/
 | Bison | 4 — Multi-asset whitelist | Canonical (BTC/ETH/SOL) |
 | Raptor | 5 — Trader-follower | Canonical |
 | Jackal | 5 — Trader-follower | Active trader pool + new-entry detector, TA + funding enrichment |
-| Spider | 5 — Trader-follower (arena variant) | Arena-leader anchor + SM-leaderboard overlap, 7-day-hold thesis |
+| Spider | 4 — Multi-asset whitelist (two-leg hedge fund) | AI/Tech long book (swing) + macro/majors long-short counter-trading book (scalp); two wallets, one leg-parameterized producer |
 | Jaguar | 6 — Striker / rank-jump | Canonical |
 | Roach | 6 — Striker / rank-jump | FIRST_JUMP / IMMEDIATE_MOVER + volume |
 | Roach-B | 6 — Striker / rank-jump | Second wallet instance of the Roach producer |


### PR DESCRIPTION
## Summary
Spider was **stale and miscategorized in all three classification surfaces** — described as a single-leg *"Patient Anchor Sniper"* copy-trader (catalog v4.0.1, README v2.0, producer-patterns v2.0) in the **trader-follower** family. That is the exact category v5.0 deliberately left. v5.1.1 is a **two-leg autonomous Hyperliquid hedge fund** — an AI/Tech LONG book (swing) + a macro/majors long-short counter-trading book (scalp) — that scores its own universe and does **not** follow traders.

This is the stale doc that tripped an operator agent into reporting "Spider v4.0.1 Patient Anchor Sniper" before correcting itself against SKILL.md.

## Changes (3 files, aligned to the agreed positioning)
- **catalog.json** — name → `Spider — Autonomous Hyperliquid Hedge Fund`, `group` trader-follower → `multi-asset-whitelist`, `version` 4.0.1 → 5.1.1, new tagline + sort_order.
- **README.md** — moved row from §5 *Trader-follower* → §4 *Multi-asset whitelist*, v2.0 → v5.1.1, hedge-fund description.
- **senpi-trading-runtime/references/producer-patterns.md** — moved family-table row §5 → §4, removed Spider from the Layer-2C copy-trading routing list, updated the live-roster archetype mapping.

Historical "v4.0 anchor sniper" mentions in `spider/SKILL.md` / `spider/README.md` are intentionally kept as changelog context.

## Test plan
- [x] `catalog.json` validates as JSON
- [x] No remaining `trader-follower` / `arena-anchored` / `Patient anchor` Spider refs in the three surfaces
- [x] Spider now classified consistently as §4 multi-asset / two-leg hedge fund across catalog, README, and producer-patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)