### PR TITLE
fix(spider): swing drawdown_reset_on_day_rollover -> true

### DIFF
--- a/spider/SKILL.md
+++ b/spider/SKILL.md
@@ -188,7 +188,7 @@ filtering (`get_positions`) is the safety floor underneath.
 | drawdown_halt_pct | 25 | 20 |
 | per_asset_cooldown_minutes | 240 (4h) | 10 |
 | data_retention_hours | 168 (7d) | 72 |
-| drawdown_reset_on_day_rollover | false | false |
+| drawdown_reset_on_day_rollover | **true** | false |
 
 Entries and exits both use `FEE_OPTIMIZED_LIMIT` (`ensure_execution_as_taker`
 true; swing 60s maker-first window, scalp 20s).

--- a/spider/runtime-swing.yaml
+++ b/spider/runtime-swing.yaml
@@ -52,7 +52,7 @@ risk:
     max_consecutive_losses: 4
     cooldown_minutes: 90
     drawdown_halt_pct: 25
-    drawdown_reset_on_day_rollover: false   # Roach Sat-Sun bleed lesson
+    drawdown_reset_on_day_rollover: true    # let-winners-run leg: a closed winner's inflated PnL peak (e.g. a +100% runner) must not carry over and halt next-day entries while the leg is still net green
     per_asset_cooldown_minutes: 240          # 4h — avoid re-churning a name
 
 scanners:


### PR DESCRIPTION
Swing is a let-winners-run leg; a big unrealized winner inflates its total-PnL peak, and with `reset_on_day_rollover: false` that peak carried across the day and tripped the 25% drawdown halt after the winner closed — locking out a leg that's still +35% net. Today's intraday drawdown was only ~18%. Flipping to `true` for the swing leg only (scalp stays false).

Verified live: peak PnL $468 (MRVL unrealized high) → current $252 → 45.9% from carried peak = the exact halt the runtime reported.

**Caveat:** the runtime drawdown gate is TOTAL-PnL-based (realized+unrealized) with no realized-only option. Full fix for the 'don't count unrealized givebacks' principle is a runtime-engine change, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)