### PR TITLE
fix(spider): scalp minNotionalUsd 500 -> 200 (leg could never trade)

### DIFF
--- a/spider/config/spider-scalp-config.json
+++ b/spider/config/spider-scalp-config.json
@@ -7,7 +7,7 @@
   "minScore": 4,
   "marginPct": 0.15,
   "scalpMaxLeverage": 5,
-  "minNotionalUsd": 500,
+  "minNotionalUsd": 200,
   "maxSlots": 4,
   "tickSeconds": 60,
   "rsiOversold": 30,


### PR DESCRIPTION
**Root cause of 'scalp never traded.'** The producer drops any candidate whose notional < `minNotionalUsd` (line ~674), after scoring. Scalp's notional = `marginPct 0.15 x 5x x account_value`:
- $474 wallet -> $355 < 500 -> dropped every tick
- $100 catalog min_budget -> $75 -> hopeless

So even setups that clear minScore 4 never emit. 500 was also inconsistent — scalp has smaller positions than swing (15%x5x vs 28%x10x) but a higher floor (500 vs 200). Matching swing at **200** makes scalp tradable at realistic funding ($474 -> $355 >= 200). Scoring code is unchanged and correct (`trend_structure` returns NEUTRAL, so minScore 4 is reachable).

Operators must re-pull `config/spider-scalp-config.json` and restart the scalp daemon to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)