### PR TITLE
fleet-new: Octopus v1.0 — Market-Neutral Hedge Fund (1 of 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ Trade the spread between two correlated assets, not a single asset's direction.
 | Skill | Version | Asset / Universe | Description |
 |---|---|---|---|
 | [chameleon](chameleon/) | v1.0 | ETH/BTC · SOL/ETH · SOL/BTC | Ratio mean-reversion — trades the high-beta leg when a pair's ratio z-score extends past ~2σ and starts reverting. Single-position directional bet (not a two-leg spread). Mean-reversion DSL (tight ladder, 48h). |
+| [octopus](octopus/) | v1.0 | Liquid crypto cross-section (long + short books) | **Market-Neutral Hedge Fund.** Two equally-funded single-direction books on two wallets, one producer: longs the relative leaders (top relative-strength, trend-confirmed) and shorts the relative laggards (bottom RS, trend-confirmed) of the liquid main-DEX cross-section. Net ~beta-neutral — harvests **dispersion** (leaders minus laggards), not market direction. Strict 5x, moderate DSL with stall-cuts ON. |
 
 ## 14. Meta-strategy follower / copy-the-copiers
 

--- a/catalog.json
+++ b/catalog.json
@@ -214,6 +214,21 @@
       "version": "1.0.0"
     },
     {
+      "id": "octopus",
+      "tracker_slug": "octopus",
+      "name": "Octopus — Market-Neutral Hedge Fund",
+      "emoji": "🐙",
+      "tagline": "Longs the relative leaders and shorts the relative laggards of the liquid crypto cross-section on two equally-funded wallets — net ~beta-neutral, harvesting dispersion (leaders minus laggards), not market direction.",
+      "group": "relative-value-pairs",
+      "sort_order": 49,
+      "min_budget": 100,
+      "risk_level": "moderate",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/octopus",
+      "version": "1.0.0"
+    },
+    {
       "id": "cheetah",
       "tracker_slug": "cheetah",
       "name": "Cheetah \u2014 Multi-Signal Confluence Sniper",

--- a/octopus/README.md
+++ b/octopus/README.md
@@ -1,0 +1,132 @@
+# 🐙 OCTOPUS v1.0 — Market-Neutral Hedge Fund
+
+Two single-direction **books** on two wallets, one producer. The **long**
+book longs the relative leaders of the liquid crypto cross-section; the
+**short** book shorts the relative laggards. Equal funding → the notionals
+offset → the fund is ~beta-neutral, and the return is driven by the
+**dispersion** (leaders minus laggards). See [SKILL.md](SKILL.md) for the
+full thesis and scoring.
+
+> **Fund-level neutrality requires equal funding.** Fund the two wallets
+> 50/50. If one book is over-funded the fund becomes directional.
+
+---
+
+## Install
+
+### Step 1 — Install the runtime plugin (provides `senpi_runtime_helpers`)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Octopus (both books)
+
+```bash
+mkdir -p /data/workspace/skills/octopus-strategy/{config,scripts,state,references}
+for f in scripts/octopus-producer.py scripts/octopus_config.py \
+         runtime-long.yaml runtime-short.yaml \
+         config/octopus-long-config.json config/octopus-short-config.json \
+         SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/octopus/$f" \
+    -o "/data/workspace/skills/octopus-strategy/$f"
+done
+```
+
+### Step 3 — Required env vars
+
+Both books share the auth token, decision model, and (optional) Telegram chat
+id. Each book binds its own wallet:
+
+```bash
+export SENPI_AUTH_TOKEN=...
+export OCTOPUS_DECISION_MODEL=<your-preferred-model>    # bare model name, no provider prefix
+export TELEGRAM_CHAT_ID=...                             # optional, for trade notifications
+
+export OCTOPUS_LONG_WALLET=<your-long-book-wallet>      # or set wallet in config/octopus-long-config.json
+export OCTOPUS_SHORT_WALLET=<your-short-book-wallet>    # or set wallet in config/octopus-short-config.json
+```
+
+Each book also accepts an optional `OCTOPUS_LONG_STRATEGY_ID` /
+`OCTOPUS_SHORT_STRATEGY_ID` (falls back to the `strategyId` field in the
+matching config file).
+
+**Funding — LONG 50% / SHORT 50% of the combined pool.** Equal funding is
+what keeps the fund market-neutral; the two books' notional exposures offset.
+This is an operator funding guideline (documented in each `runtime-*.yaml`
+`strategy:` block); the runtime does not pull or enforce a budget.
+
+### Step 4 — Register both runtimes, start both daemons
+
+Register each runtime YAML with the gateway (per your host's runtime-register
+flow — set the env vars **before** registering so `${OCTOPUS_*}` resolve), then
+launch one producer daemon per book. `OCTOPUS_LEG` selects the book.
+
+```bash
+# LONG book
+OCTOPUS_LEG=long \
+OCTOPUS_LONG_WALLET=$OCTOPUS_LONG_WALLET \
+SENPI_AUTH_TOKEN=$SENPI_AUTH_TOKEN \
+  setsid nohup python3 -u /data/workspace/skills/octopus-strategy/scripts/octopus-producer.py \
+  > /tmp/octopus-long.log 2>&1 < /dev/null &
+disown
+
+# SHORT book
+OCTOPUS_LEG=short \
+OCTOPUS_SHORT_WALLET=$OCTOPUS_SHORT_WALLET \
+SENPI_AUTH_TOKEN=$SENPI_AUTH_TOKEN \
+  setsid nohup python3 -u /data/workspace/skills/octopus-strategy/scripts/octopus-producer.py \
+  > /tmp/octopus-short.log 2>&1 < /dev/null &
+disown
+```
+
+**Why `setsid` + `disown`:** `nohup` only blocks SIGHUP, not SIGTERM. When an
+OpenClaw/shell session is torn down it SIGTERMs its process tree. `setsid`
+re-parents each daemon into a new session so it survives session teardown;
+`disown` detaches it from the shell job table. Env vars are passed inline so
+each daemon's environment is self-contained.
+
+**For durable persistence** (survives host restarts + auto-restarts on death),
+add a cron keepalive that relaunches a book if its process is gone — the
+producer's per-book fcntl lock makes a double-launch a safe no-op.
+
+---
+
+## Verify
+
+```bash
+pgrep -af octopus-producer.py            # expect 2 daemons (long + short)
+tail -5 /tmp/octopus-long.log /tmp/octopus-short.log
+```
+
+Each tick emits JSON: `scanned`, `ranked_pool`, `candidates`, `signals_pushed`,
+`mean_rs_24h`, `emitted` (with per-name `excess` = relative strength). A book
+that finds no qualifying name prints `WAITING — no name cleared min score 5`
+(normal when the cross-section has no trend-confirmed leader/laggard).
+
+---
+
+## Sizing sanity check
+
+`margin_usd` per slot should be **≈20% of that book's wallet** (`margin_pct`
+20). For a book to place an order, `margin_usd × leverage ≥ minNotionalUsd`
+(200). At 5x that needs only `account_value × 0.20 × 5 ≥ 200` → **≥ $200**
+wallet, so any realistic funding trades. Each book fills up to 4 slots
+(4 × 20% = 80% committed, 20% buffer).
+
+---
+
+## Notes
+
+- **Universe** is the live liquid main-DEX crypto board (`dayNtlVlm ≥ $20M`),
+  rebuilt every tick — no hardcoded asset list to go stale.
+- **XYZ equities are excluded** — Octopus ranks crypto dispersion; XYZ is
+  Spider's domain.
+- **Stall-cuts are ON** (weak_peak / dead_weight): a position whose relative
+  trend mean-reverts is recycled into a fresher name rather than ridden.
+- The producer **only opens** positions; the DSL ratchet engine owns all
+  exits. Restarting a producer never touches an open position's stop.
+
+## License
+
+Apache-2.0 — Copyright 2026 Senpi (https://senpi.ai)

--- a/octopus/SKILL.md
+++ b/octopus/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: octopus-strategy
+description: >-
+  OCTOPUS v1.0 — Market-Neutral Hedge Fund. Two single-direction books on
+  two wallets, one producer. The LONG book ranks the live liquid main-DEX
+  crypto cross-section by 24h relative strength and LONGS the strongest,
+  trend-confirmed names; the SHORT book mirror-images it and SHORTS the
+  weakest, trend-confirmed laggards. The two books net to ~beta-neutral —
+  the edge is DISPERSION (leaders minus laggards), not market direction.
+  NOT a copy-trader: each book scores its own universe and pushes signals;
+  the runtime owns the LLM gate (pass-through), DSL exits, and all
+  risk.guard_rails. OCTOPUS_LEG env selects the book.
+license: Apache-2.0
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐙 OCTOPUS v1.0 — Market-Neutral Hedge Fund
+
+Octopus runs **two concurrent strategy wallets** whose net market exposure
+is ~zero. **One producer script** (`octopus-producer.py`) serves both; the
+`OCTOPUS_LEG` env var selects which book a given daemon is. Each book binds
+to its own wallet, runtime YAML, DSL, and risk envelope.
+
+> **The edge is dispersion, not direction.** Octopus longs the relative
+> leaders and shorts the relative laggards of the same liquid crypto
+> cross-section. Long-book gains + short-book gains capture the **spread**
+> between strong and weak names while the long and short notionals offset
+> market beta. In a HYPE-dominates / alts-crushed regime the long book
+> gravitates to the leaders and the short book to the carnage — market-neutrally.
+
+| Book | Style | Wallet env | Runtime | Scanner |
+|---|---|---|---|---|
+| `long` | Cross-sectional relative-strength LONG | `OCTOPUS_LONG_WALLET` | `runtime-long.yaml` | `octopus_long_signals` |
+| `short` | Cross-sectional relative-weakness SHORT | `OCTOPUS_SHORT_WALLET` | `runtime-short.yaml` | `octopus_short_signals` |
+
+## How market-neutral is achieved
+
+Octopus does **not** emit atomic pairs. Neutrality emerges at the **fund
+level**: two equally-funded single-direction books. The long book holds a
+basket of leaders; the short book holds a basket of laggards. With balanced
+funding (50/50) and balanced sizing (both `margin_pct 20`, `slots 4`), the
+long and short notionals roughly offset, so the portfolio's net beta ≈ 0 and
+its return is driven by the **dispersion** between the two baskets. Each book
+has its own wallet + DSL, so a position exiting on one side does not force the
+other — the books re-balance continuously as leadership rotates.
+
+## The relative-strength rank (shared by both books)
+
+Each tick the producer pulls the live instrument board **once** and computes,
+for every liquid main-DEX perp (`dayNtlVlm ≥ volFloorUsd`, default $20M), its
+**24h return** from `markPx` vs `prevDayPx`. The **universe mean** of those
+returns is "the market." Each asset's **excess = own 24h − universe mean** is
+its cross-sectional relative strength. This rank costs **zero candle fetches**.
+Only the top (long) / bottom (short) `rankPoolSize` names by excess (default
+12) then get 1h+4h candles pulled for absolute-trend confirmation — bounding
+per-tick fetches.
+
+## LONG book — long the leaders (trend-confirmed)
+
+### Scoring (raw integer; `minScore` 5)
+
+| Component | Pts | Source |
+|---|---|---|
+| Relative strength (excess) | +3 (≥2×`rsThresholdPct`) / +2 (≥1×) / +1 (≥0) / **disqualify** (<0) | 24h excess vs cross-section |
+| 4h trend structure | +2 BULLISH / **disqualify** BEARISH | 4h candles |
+| 1h trend confirmation | +1 BULLISH / −1 BEARISH | 1h candles |
+| Own absolute momentum | +1 (24h ≥ 0) / −1 (< 0) | instrument ctx |
+| RSI blow-off guard | −2 (RSI > `rsiOverbought` 80) | 1h RSI |
+
+Disqualifies any name that is a relative *under*performer or in a 4h
+downtrend — it never longs a "least-bad" laggard in a crash.
+
+## SHORT book — short the laggards (trend-confirmed)
+
+### Scoring (raw integer; `minScore` 5)
+
+| Component | Pts | Source |
+|---|---|---|
+| Relative weakness (excess) | +3 (≤−2×`rsThresholdPct`) / +2 (≤−1×) / +1 (≤0) / **disqualify** (>0) | 24h excess vs cross-section |
+| 4h trend structure | +2 BEARISH / **disqualify** BULLISH | 4h candles |
+| 1h trend confirmation | +1 BEARISH / −1 BULLISH | 1h candles |
+| Own absolute momentum | +1 (24h ≤ 0) / −1 (> 0) | instrument ctx |
+| RSI capitulation guard | −2 (RSI < `rsiOversold` 20) | 1h RSI |
+
+Disqualifies any name that is a relative *out*performer or in a 4h uptrend —
+it never shorts a rising leader.
+
+## Execution & exit (both books)
+
+- slots **4**, `margin_pct` **20%** (4 × 20 = 80% max committed), tick **300s**
+- **strict 5x** leverage clamp, then to each asset's Hyperliquid venue max
+- DSL **moderate dispersion management**: phase1 max_loss **14%** / retrace 8 / 1 breach; `weak_peak_cut` **ON** (6h @ 2.0), `dead_weight_cut` **ON** (12h), `hard_timeout` **4d**; phase2 ladder `8%→lock0 / 18%→40 / 35%→60 / 60%→78 / 100%→88`
+- stall-cuts are **ON** by design: a position whose relative trend mean-reverts should be recycled into a fresher leader/laggard, not ridden indefinitely.
+
+## Leverage clamping (both books)
+
+Desired leverage = the book cap (`maxLeverage` 5). The producer clamps to each
+asset's **Hyperliquid venue max** from `market_list_instruments`. The runtime
+decision gate also rejects any leverage above 5 as a clamp-breach defense.
+
+## XYZ handling
+
+Octopus ranks the **main-DEX crypto** cross-section only — XYZ equities are
+excluded (no clean cross-sectional peer group, and they're Spider's domain).
+The `main` and `xyz` clearinghouse sections are two VIEWS of ONE
+cross-margined wallet, so `get_positions()` takes `accountValue` ONCE via
+`max()` across the two — never sums it (summing double-counts and sizes 2x
+too large).
+
+## Race-window dedup
+
+Each `push_signal(coin)` is recorded in `state/recent-signals-<leg>.json`
+(per-book). The producer skips any coin seen within 180s before scoring —
+covering the gap between a push returning OK and the position appearing in the
+next-tick clearinghouse pull. On-chain held-asset filtering is the safety floor.
+
+## Risk gates (`risk.guard_rails`)
+
+| Gate | long | short |
+|---|---|---|
+| daily_loss_limit_pct | 12 | 12 |
+| max_entries_per_day | 6 | 6 |
+| max_consecutive_losses | 4 | 4 |
+| cooldown_minutes | 60 | 60 |
+| drawdown_halt_pct | 20 | 20 |
+| per_asset_cooldown_minutes | 180 | 180 |
+| data_retention_hours | 120 | 120 |
+| drawdown_reset_on_day_rollover | true | true |
+
+Entries and exits both use `FEE_OPTIMIZED_LIMIT` (`ensure_execution_as_taker`
+true; 45s maker-first window).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `runtime-long.yaml` | Long-book runtime spec (wallet, DSL, risk, LLM gate) |
+| `runtime-short.yaml` | Short-book runtime spec |
+| `scripts/octopus-producer.py` | Book-aware producer daemon (one script, both books) |
+| `scripts/octopus_config.py` | Leg resolution + SenpiClient wrapper + helpers |
+| `config/octopus-long-config.json` | Long-book tunables (universe floor, RS threshold) |
+| `config/octopus-short-config.json` | Short-book tunables |
+
+## Operator install
+
+See [README.md](README.md) — the two books are two daemons
+(`OCTOPUS_LEG=long` and `OCTOPUS_LEG=short`) on two **equally-funded** wallets,
+each with its own runtime YAML. Equal funding is what keeps the fund neutral.
+
+## Hard rule for user-conversation Claude sessions
+
+User-conversation Claude sessions MUST NOT call any of:
+`create_position`, `close_position`, `edit_position`,
+`ratchet_stop_add`, `ratchet_stop_edit`, `ratchet_stop_delete`,
+`cancel_order`, `strategy_close`, `strategy_close_positions`.
+
+These tools are reserved for the **producer daemon** (entry path) and the
+**DSL ratchet engine** (exit path). User-conversation sessions are
+**read-only**. Each producer daemon handles real signals on its next tick.
+
+## License
+
+Apache-2.0 — Copyright 2026 Senpi (https://senpi.ai)

--- a/octopus/config/octopus-long-config.json
+++ b/octopus/config/octopus-long-config.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "OCTOPUS v1.0 LONG book — cross-sectional dispersion LONG leg of the market-neutral fund. Each tick ranks the live liquid main-DEX crypto cross-section by 24h RELATIVE STRENGTH (excess return vs the universe mean) and LONGS the strongest names, but only when absolute trend confirms (4h structure bullish + positive own momentum) so it never longs a least-bad laggard in a crash. Only the top rankPoolSize names by RS get candles pulled for confirmation. Leverage clamped to maxLeverage then each asset's HL venue max. Pairs with the SHORT book (octopus-short-config.json) on a SEPARATE wallet; the two books net to ~beta-neutral. Set wallet/strategyId/chatId. Runtime owns position tracking, caps, cooldowns, DSL via runtime-long.yaml. Producer launched with OCTOPUS_LEG=long.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "minScore": 5,
+  "marginPct": 0.20,
+  "maxLeverage": 5,
+  "maxSlots": 4,
+  "minNotionalUsd": 200,
+  "tickSeconds": 300,
+  "volFloorUsd": 20000000,
+  "universeMaxNames": 40,
+  "rankPoolSize": 12,
+  "rsThresholdPct": 3.0,
+  "rsiOverbought": 80,
+  "_persona": "Long the leaders — cross-sectional relative-strength LONG book, trend-confirmed, strict 5x cap, 4-name basket, net-neutral against the SHORT book. Funding split default: 50/50 long/short of the combined Octopus pool to keep net exposure ~0."
+}

--- a/octopus/config/octopus-short-config.json
+++ b/octopus/config/octopus-short-config.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "OCTOPUS v1.0 SHORT book — cross-sectional dispersion SHORT leg of the market-neutral fund. Each tick ranks the live liquid main-DEX crypto cross-section by 24h RELATIVE WEAKNESS (negative excess return vs the universe mean) and SHORTS the weakest names, but only when absolute trend confirms (4h structure bearish + negative own momentum) so it never shorts a relative outperformer that's still rising. Only the bottom rankPoolSize names by RS get candles pulled for confirmation. Leverage clamped to maxLeverage then each asset's HL venue max. Pairs with the LONG book (octopus-long-config.json) on a SEPARATE wallet; the two books net to ~beta-neutral. Set wallet/strategyId/chatId. Runtime owns position tracking, caps, cooldowns, DSL via runtime-short.yaml. Producer launched with OCTOPUS_LEG=short.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "minScore": 5,
+  "marginPct": 0.20,
+  "maxLeverage": 5,
+  "maxSlots": 4,
+  "minNotionalUsd": 200,
+  "tickSeconds": 300,
+  "volFloorUsd": 20000000,
+  "universeMaxNames": 40,
+  "rankPoolSize": 12,
+  "rsThresholdPct": 3.0,
+  "rsiOversold": 20,
+  "_persona": "Short the laggards — cross-sectional relative-weakness SHORT book, trend-confirmed, strict 5x cap, 4-name basket, net-neutral against the LONG book. Funding split default: 50/50 long/short of the combined Octopus pool to keep net exposure ~0."
+}

--- a/octopus/references/skill-attribution.md
+++ b/octopus/references/skill-attribution.md
@@ -1,0 +1,74 @@
+# Octopus — Skill Attribution
+
+**Skill:** octopus-strategy v1.0.0
+**Author:** jason-goldberg
+**License:** Apache-2.0
+**Created:** 2026-06-03
+
+## What Octopus is
+
+The first **market-neutral** fund in the Senpi fleet. Octopus is one of the
+four hedge-fund pillars built to complement Spider (a directional equity-style
+fund): **Relative Value (Octopus)**, Carry, Volatility, and Global Macro. The
+fleet was almost entirely directional before this — Octopus adds a near-zero-beta,
+low-correlation return stream.
+
+## Lineage
+
+- **Architecture** — the Spider v5.1 helpers-native two-leg pattern: ONE
+  leg-parameterized producer (`OCTOPUS_LEG`), two wallets, two runtime YAMLs,
+  `senpi_runtime_helpers.producer_daemon` with an fcntl reentrancy lock,
+  `SenpiClient.push_signal()` ingest, runtime-owned LLM gate + DSL + risk.
+  Spider's two-wallet structure was validated live (a +35% long book) before
+  Octopus reused it.
+- **Thesis** — classic cross-sectional **dispersion / relative-value**: long
+  the leaders, short the laggards of one liquid peer group, sized so the
+  notionals offset. Returns come from the spread, not market direction.
+
+## Design decisions specific to Octopus
+
+- **Neutrality at the fund level, not via atomic pairs.** The Senpi runtime
+  emits one position per signal, so Octopus achieves neutrality with two
+  equally-funded single-direction books rather than paired orders. Simpler,
+  fits the runtime, and lets each side's DSL manage independently. Trade-off:
+  the hedge is statistical (balanced baskets), not a locked 1:1 pair — equal
+  funding is the operator's responsibility.
+- **One-call relative-strength rank.** 24h excess return is computed from the
+  instrument board (`markPx`/`prevDayPx`) for the whole cross-section in a
+  single call — no per-asset candle fetch for the rank. Only the top/bottom
+  `rankPoolSize` names get candles for trend confirmation. Bounds per-tick cost.
+- **Absolute-trend confirmation on both sides.** Relative strength alone would
+  long the "least-bad" laggard in a crash and short the "least-good" leader in
+  a melt-up. Octopus requires the 4h structure to confirm (bullish for longs,
+  bearish for shorts) and the name's own 24h momentum to agree — so it trades
+  genuine leaders and genuine laggards, not just relative ones.
+- **Stall-cuts ON.** Unlike a let-winners-run momentum leg, a dispersion
+  position whose relative trend mean-reverts should be recycled. `weak_peak_cut`
+  and `dead_weight_cut` are enabled to rotate stale names out of the basket.
+
+## Fleet-standard compliance
+
+- Max leverage **5x** (strict clamp + runtime gate defense).
+- Per-position margin **20%** (≤ 25% fleet cap).
+- Drawdown halt **20%**, `drawdown_reset_on_day_rollover: true` (a closed
+  dispersion winner's spiked PnL peak must not lock out next-day entries — the
+  lesson learned on Spider's swing book).
+- Mandatory DSL on every position; entries + exits use `FEE_OPTIMIZED_LIMIT`
+  with taker fallback.
+- Verbose per-tick JSON output (never silent) — every scan emits
+  `scanned / ranked_pool / candidates / signals_pushed / mean_rs_24h`.
+
+## Negative-lesson inputs
+
+- **Cobra antipattern** — fixed 10x + rotation + no drawdown gate = fee-driven
+  death spiral. Octopus answers each: strict 5x, low/moderate turnover (basket
+  rotation gated by `per_asset_cooldown` + `max_entries_per_day`), hard drawdown halt.
+- **Fees are the biggest killer** — dispersion is not a high-frequency rotation
+  scanner. Entries are gated to leadership/laggard *changes*, not every tick.
+- **Equity double-count / sizing-off-equity** (Spider June 2026) — `get_positions()`
+  takes `accountValue` once via `max()`; sizing is `account_value × margin_pct`.
+
+## Capital provenance
+
+New capital, funded **50/50** across the long and short wallets. Equal funding
+is structural: it is what keeps the fund beta-neutral.

--- a/octopus/runtime-long.yaml
+++ b/octopus/runtime-long.yaml
@@ -1,0 +1,192 @@
+name: octopus-long-tracker
+# Top-level `version` is the SCHEMA version the senpi-trading-runtime
+# plugin expects (major=1). Skill version is "Octopus v1.0" — lives in
+# description + SKILL.md + _octopus_producer_version.
+version: 1.0.0
+description: >
+  OCTOPUS v1.0 (LONG book) — cross-sectional dispersion, market-neutral fund.
+
+  One of two single-direction books. This book ranks the live liquid
+  main-DEX crypto cross-section by 24h RELATIVE STRENGTH (excess return vs
+  the universe mean) and LONGS the strongest names — but only when absolute
+  trend confirms (4h structure bullish + positive own momentum), so it never
+  longs a least-bad laggard in a crash. Pairs with the SHORT book
+  (runtime-short.yaml) on a separate wallet; the two net to ~beta-neutral.
+  The edge is DISPERSION (leaders minus laggards), not market direction.
+
+  Scoring (producer-side): cross-sectional relative-strength rank, 4h + 1h
+  absolute-trend confirmation, own-momentum sign, RSI blow-off guard. LONG only.
+
+  Execution envelope:
+    - slots 4 (a basket of leaders), margin_pct 20
+    - strict 5x leverage clamp, then each asset's HL venue max
+    - moderate DSL: cut reversers, lock profit on extension, stall-cuts ON
+      (a mean-reverted spread should exit), 4d hard_timeout staleness cap
+
+  Producer scores its universe and pushes signals via
+  SenpiClient.push_signal(); runtime LLM gate is pass-through; runtime owns
+  execution + DSL.
+
+strategy:
+  wallet: "${OCTOPUS_LONG_WALLET}"
+  # ── FUNDING SPLIT DEFAULT: LONG 50% / SHORT 50% of the combined pool ──
+  # The two books must be funded ~equally so their notional exposure offsets
+  # and the fund stays beta-neutral. This is a FUNDING guideline for the
+  # operator (how to split capital across the two wallets), NOT a runtime-
+  # enforced field. Per-position sizing is governed by margin_pct + slots.
+  slots: 4
+  margin_pct: 20          # 4 x 20 = 80% max committed; leaves headroom
+  trading_risk: moderate
+  enabled: true
+
+risk:
+  data_retention_hours: 120
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6        # basket rotation as leadership shifts
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true    # dispersion winners spike then settle; don't let a closed leader's peak halt next-day entries while net green
+    per_asset_cooldown_minutes: 180
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: octopus_long_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        excess: { type: number, required: false }
+        own24h: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: octopus_long_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${OCTOPUS_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [octopus_long_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: octopus_long_signals
+    decision_prompt: |
+      You are Octopus's LONG-book pass-through gate. The producer ranks the
+      liquid crypto cross-section by relative strength and LONGS the
+      strongest, trend-confirmed names (the fund is market-neutral: a SHORT
+      book runs the weakest names on a separate wallet). The producer already
+      applied the RS rank, 4h/1h trend confirmation, the 5x leverage clamp,
+      and held-asset dedup. Honor the signal unless it is malformed.
+
+      SIGNAL:
+      {{signal_octopus_long_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY.
+      2. direction MUST be "LONG" (this is the long book).
+      3. leverage MUST be copied from signal.data.leverage.
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR leverage > 5 (clamp breach) OR marginUsd <= 0
+      - direction != "LONG"
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 7 AND no malformed fields
+      - 7-8:  score 5.5-6.9
+      - 7:    score 5-5.4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 HYPE LONG 5x, RS lead +6.2% vs cross-section, 4h BULLISH — dispersion leader')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "LONG",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "OCTOPUS_DISPERSION_LONG — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — moderate dispersion management) ──────────────────────
+#
+# A dispersion leg rides a relative trend. Cut reversers, lock profit as the
+# relative move extends, and exit stalled positions (the spread mean-reverted).
+# Stall-cuts are ON — unlike a let-winners-run momentum leg, a dispersion
+# position that stops working should be recycled into a fresher leader.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760           # 4d staleness cap
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h — cut a leader that peaked then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 720            # 12h — recycle a position going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 14.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8, lock_hw_pct: 0 }
+        - { trigger_pct: 18, lock_hw_pct: 40 }
+        - { trigger_pct: 35, lock_hw_pct: 60 }
+        - { trigger_pct: 60, lock_hw_pct: 78 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/octopus/runtime-short.yaml
+++ b/octopus/runtime-short.yaml
@@ -1,0 +1,193 @@
+name: octopus-short-tracker
+# Top-level `version` is the SCHEMA version the senpi-trading-runtime
+# plugin expects (major=1). Skill version is "Octopus v1.0" — lives in
+# description + SKILL.md + _octopus_producer_version.
+version: 1.0.0
+description: >
+  OCTOPUS v1.0 (SHORT book) — cross-sectional dispersion, market-neutral fund.
+
+  One of two single-direction books. This book ranks the live liquid
+  main-DEX crypto cross-section by 24h RELATIVE WEAKNESS (negative excess
+  return vs the universe mean) and SHORTS the weakest names — but only when
+  absolute trend confirms (4h structure bearish + negative own momentum), so
+  it never shorts a relative outperformer that's still rising. Pairs with the
+  LONG book (runtime-long.yaml) on a separate wallet; the two net to
+  ~beta-neutral. The edge is DISPERSION (leaders minus laggards), not market
+  direction. In an alts-crushed regime this book gravitates to the carnage.
+
+  Scoring (producer-side): cross-sectional relative-weakness rank, 4h + 1h
+  absolute-trend confirmation, own-momentum sign, RSI capitulation guard. SHORT only.
+
+  Execution envelope:
+    - slots 4 (a basket of laggards), margin_pct 20
+    - strict 5x leverage clamp, then each asset's HL venue max
+    - moderate DSL: cut squeezes, lock profit on extension, stall-cuts ON
+      (a mean-reverted spread should exit), 4d hard_timeout staleness cap
+
+  Producer scores its universe and pushes signals via
+  SenpiClient.push_signal(); runtime LLM gate is pass-through; runtime owns
+  execution + DSL.
+
+strategy:
+  wallet: "${OCTOPUS_SHORT_WALLET}"
+  # ── FUNDING SPLIT DEFAULT: LONG 50% / SHORT 50% of the combined pool ──
+  # The two books must be funded ~equally so their notional exposure offsets
+  # and the fund stays beta-neutral. This is a FUNDING guideline for the
+  # operator (how to split capital across the two wallets), NOT a runtime-
+  # enforced field. Per-position sizing is governed by margin_pct + slots.
+  slots: 4
+  margin_pct: 20          # 4 x 20 = 80% max committed; leaves headroom
+  trading_risk: moderate
+  enabled: true
+
+risk:
+  data_retention_hours: 120
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6        # basket rotation as weakness shifts
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_minutes: 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true    # dispersion winners spike then settle; don't let a closed laggard-short's peak halt next-day entries while net green
+    per_asset_cooldown_minutes: 180
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: octopus_short_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        excess: { type: number, required: false }
+        own24h: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: octopus_short_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${OCTOPUS_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [octopus_short_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: octopus_short_signals
+    decision_prompt: |
+      You are Octopus's SHORT-book pass-through gate. The producer ranks the
+      liquid crypto cross-section by relative weakness and SHORTS the
+      weakest, trend-confirmed laggards (the fund is market-neutral: a LONG
+      book runs the strongest names on a separate wallet). The producer already
+      applied the RS rank, 4h/1h trend confirmation, the 5x leverage clamp,
+      and held-asset dedup. Honor the signal unless it is malformed.
+
+      SIGNAL:
+      {{signal_octopus_short_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY.
+      2. direction MUST be "SHORT" (this is the short book).
+      3. leverage MUST be copied from signal.data.leverage.
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR leverage > 5 (clamp breach) OR marginUsd <= 0
+      - direction != "SHORT"
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 7 AND no malformed fields
+      - 7-8:  score 5.5-6.9
+      - 7:    score 5-5.4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 ASSET SHORT 5x, RS lag -7.1% vs cross-section, 4h BEARISH — dispersion laggard')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "SHORT",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "OCTOPUS_DISPERSION_SHORT — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — moderate dispersion management) ──────────────────────
+#
+# A dispersion leg rides a relative trend. Cut squeezes, lock profit as the
+# relative move extends, and exit stalled positions (the spread mean-reverted).
+# Stall-cuts are ON — a short that stops working should be recycled into a
+# fresher laggard.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760           # 4d staleness cap
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h — cut a laggard-short that peaked then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 720            # 12h — recycle a position going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 14.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8, lock_hw_pct: 0 }
+        - { trigger_pct: 18, lock_hw_pct: 40 }
+        - { trigger_pct: 35, lock_hw_pct: 60 }
+        - { trigger_pct: 60, lock_hw_pct: 78 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/octopus/scripts/octopus-producer.py
+++ b/octopus/scripts/octopus-producer.py
@@ -1,0 +1,569 @@
+#!/usr/bin/env python3
+# Senpi OCTOPUS Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under Apache-2.0
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""OCTOPUS v1.0.0 Producer — market-neutral dispersion, two books, one script.
+
+Octopus runs TWO concurrent strategy wallets that together net to
+~beta-neutral. ONE producer script serves both; the OCTOPUS_LEG env var
+selects which book this process is:
+
+  OCTOPUS_LEG=long   Cross-sectional dispersion LONG book.
+    Ranks the live liquid crypto cross-section by RELATIVE STRENGTH
+    (24h excess return vs the universe mean) and LONGS the strongest
+    names — but only when absolute trend confirms (4h structure bullish),
+    so it never longs a "least-bad" laggard in a crash.
+
+  OCTOPUS_LEG=short  Cross-sectional dispersion SHORT book.
+    Mirror image: ranks by relative WEAKNESS and SHORTS the laggards,
+    but only when absolute trend confirms (4h structure bearish), so it
+    never shorts a relative outperformer that's still rising.
+
+The edge is DISPERSION, not direction. Long the strong + short the weak =
+net market exposure ~0, harvesting the spread between leaders and
+laggards. In a HYPE-dominates / alts-crushed regime the long book gravitates
+to the leaders and the short book to the carnage, market-neutrally.
+
+NOT a copy-trader. Each book scores its own universe to a STYLE and pushes
+signals via SenpiClient.push_signal(). The runtime owns the LLM gate
+(pass-through), DSL exits, and all risk.guard_rails. Leverage is clamped to
+the book cap (maxLeverage) and then to each asset's Hyperliquid venue max.
+
+Efficiency: the relative-strength rank is computed once per tick from the
+instrument board (markPx / prevDayPx in the context — no per-asset candle
+fetch). Only the top/bottom `rankPoolSize` names then get candles pulled for
+absolute-trend confirmation, bounding per-tick fetches.
+
+Environment / config resolution:
+  OCTOPUS_LEG            — REQUIRED. "long" or "short".
+  SENPI_AUTH_TOKEN      — REQUIRED. Bearer token for MCP + signal POST.
+  OCTOPUS_LONG_WALLET   — long-book strategy wallet (or config.wallet)
+  OCTOPUS_SHORT_WALLET  — short-book strategy wallet (or config.wallet)
+  OCTOPUS_DECISION_MODEL— bare LLM model name; resolved into runtime.yaml
+  SENPI_MCP_URL         — optional, default https://mcp.prod.senpi.ai/mcp
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import octopus_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+
+VERSION = "1.0.0"
+LEG = cfg.LEG  # "long" | "short"
+SCANNER_NAME = f"octopus_{LEG}_signals"
+SIGNAL_TYPE = "OCTOPUS_DISPERSION_LONG" if LEG == "long" else "OCTOPUS_DISPERSION_SHORT"
+DIRECTION = "LONG" if LEG == "long" else "SHORT"
+
+# Score normalization divisor for the 0..1 ingest-ranking score. The RAW
+# integer score is what the runtime decision_prompt gates on; the
+# normalized value only ranks signals. Max raw ~ 3+2+1+1 = 7 (+ guards).
+NORM_DIV = 9.0
+
+# Per-leg defaults (config.json overrides every one of these). The two
+# books are symmetric — same universe, same sizing — they only differ in
+# the direction they take and the sign of the relative-strength filter.
+_DEFAULTS = {
+    "long": {
+        "minScore": 5,
+        "marginPct": 0.20,
+        "maxLeverage": 5,
+        "maxSlots": 4,
+        "minNotionalUsd": 200,
+        "tickSeconds": 300,
+        "volFloorUsd": 20000000,      # liquid main-DEX perps only
+        "universeMaxNames": 40,        # cap the cross-section
+        "rankPoolSize": 12,            # top-N by RS to confirm with candles
+        "rsThresholdPct": 3.0,         # excess return for full RS points
+        "rsiOverbought": 80,           # don't chase a blow-off long
+    },
+    "short": {
+        "minScore": 5,
+        "marginPct": 0.20,
+        "maxLeverage": 5,
+        "maxSlots": 4,
+        "minNotionalUsd": 200,
+        "tickSeconds": 300,
+        "volFloorUsd": 20000000,
+        "universeMaxNames": 40,
+        "rankPoolSize": 12,
+        "rsThresholdPct": 3.0,
+        "rsiOversold": 20,             # don't short a capitulation bottom
+    },
+}[LEG]
+
+
+def _resolve_wallet():
+    wallet, _ = cfg.get_wallet_and_strategy()
+    return wallet
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical helpers (close=c, high=h, low=l on HL candles)
+# ═══════════════════════════════════════════════════════════════
+
+def _close(c):
+    return float(c.get("close", c.get("c", 0)) or 0)
+
+
+def _high(c):
+    return float(c.get("high", c.get("h", 0)) or 0)
+
+
+def _low(c):
+    return float(c.get("low", c.get("l", 0)) or 0)
+
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def get_universe_meta():
+    """Return (meta_map, canonical_names).
+
+    meta_map double-keys each instrument by name + name.upper() for cheap
+    lookups. canonical_names is the deduped list of original instrument
+    names (used to build the cross-section). Reads venue max leverage +
+    context (markPx / prevDayPx / dayNtlVlm) from one instrument-board call.
+    """
+    data = cfg.mcp_call("market_list_instruments")
+    out, canonical = {}, []
+    if not data:
+        return out, canonical
+    insts = data.get("data", data)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict):
+            continue
+        if inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or inst.get("context", {}).get("coin")
+        if not name:
+            continue
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ctx": inst.get("context", {}) if isinstance(inst.get("context"), dict) else {},
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+        canonical.append(name)
+    return out, canonical
+
+
+def fetch_candles(asset, intervals):
+    """Pull candles for `asset` at the requested intervals. Returns
+    {"candles": {iv: [...]}, "ctx": {...}} or None on failure."""
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=intervals,
+        dex=_dex_for(asset),
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return None
+    d = data.get("data", data)
+    return {"candles": d.get("candles", {}) or {}, "ctx": d.get("asset_context", {}) or {}}
+
+
+def ret_24h(meta):
+    """24h return % from the instrument context (markPx vs prevDayPx)."""
+    ctx = meta.get("ctx", {}) if meta else {}
+    try:
+        mark = float(ctx.get("markPx", 0) or 0)
+        prev = float(ctx.get("prevDayPx", 0) or 0)
+    except (TypeError, ValueError):
+        return None
+    if prev <= 0 or mark <= 0:
+        return None
+    return (mark - prev) / prev * 100.0
+
+
+def day_vol(meta):
+    ctx = meta.get("ctx", {}) if meta else {}
+    try:
+        return float(ctx.get("dayNtlVlm", 0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+# ═══════════════════════════════════════════════════════════════
+# Dispersion scoring — long the strong / short the weak, trend-confirmed
+# ═══════════════════════════════════════════════════════════════
+
+def score_dispersion(asset, meta, excess, config):
+    """Score one candidate for the current book.
+
+    `excess` is the asset's 24h return minus the universe-mean 24h return
+    (its cross-sectional relative strength). The LONG book wants large
+    positive excess + a bullish absolute trend; the SHORT book wants large
+    negative excess + a bearish absolute trend. Returns None to disqualify.
+    """
+    md = fetch_candles(asset, ["1h", "4h"])
+    if not md:
+        return None
+    c1 = md["candles"].get("1h", [])
+    c4 = md["candles"].get("4h", [])
+    if len(c1) < 8 or len(c4) < 6:
+        return None
+    closes1 = [_close(c) for c in c1]
+    price = closes1[-1]
+    own = ret_24h(meta)
+    if own is None:
+        own = 0.0
+
+    trend4, s4 = trend_structure(c4)
+    trend1, s1 = trend_structure(c1)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(config.get("rsThresholdPct", _DEFAULTS["rsThresholdPct"]))
+
+    score = 0
+    reasons = []
+
+    if LEG == "long":
+        # Relative strength: must be a positive outperformer.
+        if excess < 0:
+            return None
+        if excess >= 2 * rs_thresh:
+            score += 3
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        else:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        # Absolute trend confirmation — never long into a downtrend.
+        if trend4 == "BEARISH":
+            return None
+        if trend4 == "BULLISH":
+            score += 2
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # Absolute momentum (true leadership, not least-bad in a crash).
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # Blow-off guard.
+        rsi_ob = float(config.get("rsiOverbought", _DEFAULTS["rsiOverbought"]))
+        if rsi > rsi_ob:
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        if excess > 0:
+            return None
+        if excess <= -2 * rs_thresh:
+            score += 3
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        else:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        if trend4 == "BULLISH":
+            return None
+        if trend4 == "BEARISH":
+            score += 2
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        # Capitulation guard — don't short an oversold bottom.
+        rsi_os = float(config.get("rsiOversold", _DEFAULTS["rsiOversold"]))
+        if rsi < rsi_os:
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset, "direction": DIRECTION, "score": score,
+        "reasons": reasons, "price": price, "rsi": rsi,
+        "trend4h": trend4, "trend1h": trend1, "excess": excess, "own24h": own,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Leverage clamp + emit
+# ═══════════════════════════════════════════════════════════════
+
+def clamp_leverage(desired, meta):
+    """Clamp desired leverage to the asset's Hyperliquid venue max."""
+    venue = (meta or {}).get("max_leverage")
+    try:
+        venue = int(venue)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))
+
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        cfg.log("ERROR: strategy wallet not resolved")
+        return False
+    if thesis["coin"].upper() in {h.upper() for h in held_assets}:
+        return False
+
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "heldAssets": held_assets,
+        "trend4h": thesis.get("trend4h"),
+        "excess": round(thesis.get("excess", 0), 2),
+        "own24h": round(thesis.get("own24h", 0), 2),
+    }
+
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=thesis["coin"],
+            direction=thesis["direction"],
+            score=min(thesis["score"] / NORM_DIV, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        cfg.log(f"INGEST_REJECTED {thesis['coin']}: {e}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        cfg.log(f"INGEST_EXCEPTION {thesis['coin']}: {type(e).__name__}: {e}")
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# Universe — the liquid main-DEX crypto cross-section (both books share it)
+# ═══════════════════════════════════════════════════════════════
+
+def build_universe(config, meta_map, canonical):
+    """Resolve the liquid main-DEX crypto cross-section to rank this tick.
+
+    A name qualifies if it is a main-DEX perp (no xyz: prefix) and liquid
+    (dayNtlVlm >= volFloorUsd). Capped to the top universeMaxNames by 24h
+    volume. XYZ equities are excluded — Octopus ranks crypto dispersion;
+    XYZ has no clean cross-sectional peer group here.
+    """
+    vol_floor = float(config.get("volFloorUsd", _DEFAULTS["volFloorUsd"]))
+    max_names = int(config.get("universeMaxNames", _DEFAULTS["universeMaxNames"]))
+    seen, pool = set(), []
+    for name in canonical:
+        if not isinstance(name, str) or name.lower().startswith("xyz:"):
+            continue
+        key = name.upper()
+        if key in seen:
+            continue
+        meta = meta_map.get(name) or meta_map.get(key)
+        if not meta:
+            continue
+        vol = day_vol(meta)
+        if vol < vol_floor:
+            continue
+        seen.add(key)
+        pool.append((name, vol))
+    pool.sort(key=lambda x: x[1], reverse=True)
+    return [n for n, _ in pool[:max_names]]
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — single tick. NO inner scanner_lock; daemon owns it.
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "leg": LEG,
+                    "_octopus_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "leg": LEG, "note": "no account value",
+                    "_octopus_producer_version": VERSION})
+        return
+
+    min_score = config.get("minScore", _DEFAULTS["minScore"])
+    margin_pct = config.get("marginPct", _DEFAULTS["marginPct"])
+    max_lev = config.get("maxLeverage", _DEFAULTS["maxLeverage"])
+    max_slots = config.get("maxSlots", _DEFAULTS["maxSlots"])
+    min_notional = config.get("minNotionalUsd", _DEFAULTS["minNotionalUsd"])
+    rank_pool = int(config.get("rankPoolSize", _DEFAULTS["rankPoolSize"]))
+
+    open_slots = max_slots - len(held_assets)
+    if open_slots <= 0:
+        cfg.output({"status": "ok", "leg": LEG, "note": "slots full",
+                    "held_assets": held_assets, "max_slots": max_slots,
+                    "_octopus_producer_version": VERSION})
+        return
+
+    meta_map, canonical = get_universe_meta()
+    universe = build_universe(config, meta_map, canonical)
+
+    # ── Cross-sectional relative-strength rank (one pass, no candle fetch) ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = ret_24h(meta)
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 5:
+        cfg.output({"status": "ok", "leg": LEG, "scanned": len(universe),
+                    "candidates": 0, "signals_pushed": 0,
+                    "note": "WAITING — cross-section too thin to rank",
+                    "elapsed_sec": round(time.time() - run_start, 2),
+                    "_octopus_producer_version": VERSION})
+        return
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    # LONG book confirms the strongest; SHORT book confirms the weakest.
+    rs.sort(key=lambda x: x[1], reverse=(LEG == "long"))
+    pool = rs[:rank_pool]
+
+    candidates = []
+    recently_skipped = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if cfg.was_recently_signaled(name):
+            recently_skipped.append(name)
+            continue
+        excess = own - mean_rs
+        thesis = score_dispersion(name, meta, excess, config)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok", "leg": LEG,
+            "scanned": len(universe), "ranked_pool": len(pool), "candidates": 0,
+            "signals_pushed": 0, "min_score": min_score,
+            "mean_rs_24h": round(mean_rs, 2), "held_assets": held_assets,
+            "recently_signaled_skipped": recently_skipped,
+            "note": f"WAITING — no name cleared min score {min_score}",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_octopus_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    to_emit = candidates[:open_slots]
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = 0
+    emitted = []
+    for th in to_emit:
+        leverage = clamp_leverage(max_lev, th["_meta"])
+        notional = margin_usd * leverage
+        if leverage <= 0 or notional < min_notional:
+            continue
+        if push_signal(th, margin_usd, leverage, held_assets):
+            pushed += 1
+            cfg.record_signal(th["coin"])
+            emitted.append({
+                "coin": th["coin"], "direction": th["direction"],
+                "score": th["score"], "leverage": leverage,
+                "margin_usd": margin_usd, "excess": round(th["excess"], 2),
+                "reasons": th["reasons"][:6],
+            })
+
+    cfg.output({
+        "status": "ok", "leg": LEG,
+        "scanned": len(universe), "ranked_pool": len(pool),
+        "candidates": len(candidates), "open_slots": open_slots,
+        "signals_pushed": pushed, "emitted": emitted,
+        "mean_rs_24h": round(mean_rs, 2), "held_assets": held_assets,
+        "recently_signaled_skipped": recently_skipped,
+        "account_value": round(account_value, 2),
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_octopus_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    # Long-lived daemon. producer_daemon owns the per-tick scanner_lock with
+    # stale-PID auto-recovery. The lock id encodes leg + wallet so the long
+    # and short book daemons never collide.
+    _lock_id = hashlib.sha256(
+        (STRATEGY_ADDRESS or LEG).lower().encode()
+    ).hexdigest()[:12]
+    _tick = int(cfg.load_config().get("tickSeconds", _DEFAULTS["tickSeconds"]))
+    producer_daemon(
+        fn=main,
+        interval_seconds=_tick,
+        name=f"octopus-{LEG}-producer-{_lock_id}",
+        tick_timeout=min(180, max(30, _tick - 10)),
+    )

--- a/octopus/scripts/octopus_config.py
+++ b/octopus/scripts/octopus_config.py
@@ -1,0 +1,329 @@
+"""OCTOPUS v1.0 — Shared config + MCP shim + helpers wrapper (LEG-AWARE).
+
+OCTOPUS — Market-Neutral Hedge Fund. ONE producer script driven by the
+OCTOPUS_LEG env var into one of two single-direction books, each bound to
+its own wallet + runtime + DSL:
+
+  OCTOPUS_LEG=long   -> Cross-sectional dispersion LONG book. Longs the
+                        strongest relative-strength names in the liquid
+                        crypto cross-section (trend-confirmed).
+                        config/octopus-long-config.json  -> octopus_long_signals
+  OCTOPUS_LEG=short  -> Cross-sectional dispersion SHORT book. Shorts the
+                        weakest relative-strength names (trend-confirmed
+                        laggards / the carnage).
+                        config/octopus-short-config.json -> octopus_short_signals
+
+The two books net to ~beta-neutral at the fund level: long the strong,
+short the weak, harvest the SPREAD (dispersion). Each book is a normal
+single-direction style scorer.
+
+This module owns: leg resolution, config load, the senpi_runtime_helpers
+client, the MCP call shim, account/position pulls, and the per-leg
+recent-signals race-dedup cache. The producer (octopus-producer.py) owns
+scoring + emit. The runtime owns the LLM gate, DSL exits, and all
+risk.guard_rails. NOT a copy-trader — each book scores its own universe.
+
+Plumbing: MCP calls + signal POSTs route through
+senpi_runtime_helpers.SenpiClient (in-process, direct HTTPS). No
+mcporter / openclaw subprocesses.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under Apache-2.0 — attribution required for derivative works
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ─── Leg resolution ──────────────────────────────────────────
+# One script, two legs. OCTOPUS_LEG selects the config file, the
+# scanner name, the wallet env var, and the recent-signals cache.
+LEG = (os.environ.get("OCTOPUS_LEG") or "long").strip().lower()
+if LEG not in ("long", "short"):
+    raise RuntimeError(
+        f"OCTOPUS_LEG must be 'long' or 'short' (got {LEG!r}). "
+        "Set it on the runtime host before starting the producer daemon."
+    )
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "octopus-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / f"octopus-{LEG}-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / f"recent-signals-{LEG}.json"
+# Generic per-leg state ledger (retained from the shared scaffold for
+# forward-compat; Octopus's universe is the live liquid crypto board so
+# it does not use fresh-listing detection — these helpers are unused).
+XYZ_FIRST_SEEN_PATH = STATE_DIR / f"first-seen-{LEG}.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Per-leg wallet / strategy env var names. The runtime YAMLs bind
+# ${OCTOPUS_LONG_WALLET} / ${OCTOPUS_SHORT_WALLET}; the producer reads
+# the same names so producer and runtime always agree on the wallet.
+_WALLET_ENV = "OCTOPUS_LONG_WALLET" if LEG == "long" else "OCTOPUS_SHORT_WALLET"
+_STRATEGY_ENV = "OCTOPUS_LONG_STRATEGY_ID" if LEG == "long" else "OCTOPUS_SHORT_STRATEGY_ID"
+
+# How long after a push_signal() we treat the asset as "in-flight" and
+# refuse to re-emit. 180s = 3x the typical ALO open fill window. Covers
+# the race between push_signal() returning OK and the resulting position
+# appearing in the next-tick clearinghouse pull. On-chain held-asset
+# check is the safety floor underneath this.
+RECENT_SIGNAL_TTL_SEC = 180
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+# senpi_runtime_helpers ships inside the senpi-trading-runtime skill.
+# Global skills install under ~/.openclaw/skills/ on standard hosts
+# (e.g. /data/.openclaw/skills/ on Railway). Some setups install user
+# skills under ${OPENCLAW_WORKSPACE}/skills/. Probe both in order.
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Octopus's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("octopus_wrapper_enabled", leg=LEG, sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Atomic Write ────────────────────────────────────────────
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def get_wallet_and_strategy():
+    """Resolve (wallet, strategyId) — leg env var first, config.json second."""
+    wallet = os.environ.get(_WALLET_ENV, "").strip()
+    strategy_id = os.environ.get(_STRATEGY_ENV, "").strip()
+    if not wallet or not strategy_id:
+        config = load_config()
+        wallet = wallet or (config.get("wallet") or "").strip()
+        strategy_id = strategy_id or (config.get("strategyId") or "").strip()
+    return wallet, strategy_id
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Direct MCP call via SenpiClient (in-process HTTPS). Returns the
+    unwrapped JSON document on success, or None if the wrapper raised."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[octopus-v1:{LEG}] mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+# Backward-compat alias — keeps legacy `cfg.mcporter_call(...)` call
+# sites working even though the transport is in-process now.
+mcporter_call = mcp_call
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts]).
+
+    The 'main' and 'xyz' clearinghouse sections are TWO VIEWS of ONE
+    cross-margined Senpi wallet, NOT two separate collateral silos. Both
+    views report the SAME marginSummary.accountValue (the whole wallet's
+    equity). So account_value is taken ONCE via max() across the two
+    sections — never summed. Summing double-counts the balance and makes
+    every position size 2x too large (margin_usd = account_value *
+    margin_pct downstream). max() is exact whether the views mirror
+    (equal → max is the shared value), one view is empty/0 (the populated
+    view wins), or positions are open on both sub-DEXs (still one shared
+    cross-margin balance). assetPositions ARE per-sub-DEX, so those are
+    still enumerated across both sections.
+    """
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0) or 0),
+                "margin": float(pos.get("marginUsed", 0) or 0),
+                "entryPrice": float(pos.get("entryPx", 0) or 0),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── recent-signals cache (held-asset dedup race-fix) ─────────
+#
+# Each successful push_signal(coin) writes {coin: epoch_seconds} to
+# recent-signals-<leg>.json. The producer checks this BEFORE scoring and
+# skips coins seen within RECENT_SIGNAL_TTL_SEC. This covers the gap
+# between push_signal returning OK and the resulting position appearing
+# in the next-tick clearinghouse pull. The on-chain held-asset check
+# (get_positions) is the safety floor underneath.
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    """Drop entries older than 4x TTL to keep the file bounded."""
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    """Mark `coin` as recently signaled. Writes atomically."""
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    """True if `coin` was pushed within `ttl_sec`."""
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+# ─── first-seen cache (generic; retained from the shared scaffold) ─────
+#
+# UNUSED by Octopus — kept for forward-compat with the shared producer
+# scaffold. Octopus's universe is the live liquid crypto board (ranked by
+# relative strength), so it needs no fresh-listing detection. A derivative
+# that wants new-listing auto-catch can record when each instrument first
+# appeared. A name younger than a freshness window is auto-eligible even if it
+# isn't in the curated include-set. On the very first run (no state file)
+# every current name is treated as already-old so the auto-catch doesn't
+# fire across the whole board at once — only names that appear AFTER
+# deploy are "fresh".
+
+def read_first_seen():
+    """Return {name: epoch_seconds} of when each instrument was first seen."""
+    if not XYZ_FIRST_SEEN_PATH.exists():
+        return {}
+    try:
+        with open(XYZ_FIRST_SEEN_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def write_first_seen(data):
+    """Persist the first-seen map atomically. Best-effort."""
+    try:
+        atomic_write(XYZ_FIRST_SEEN_PATH, data)
+    except OSError:
+        pass
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[octopus-v1:{LEG}] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -734,7 +734,7 @@ z, ratio, mean, std = ratio_zscore(ca, cb, lookback=48)  # z of latest ratio vs 
 # z low  (numerator cheap) → mirror.  Enter when |z| >= ~2 AND reversion is starting (|z| shrinking vs last bar).
 ```
 
-**Single-position note:** a textbook pairs trade is two legs (long A / short B) for market-neutrality. The Senpi runtime is single-position, so this archetype takes the **directional high-beta leg** in the reversion direction — capturing most of the edge without spread-level position management.
+**Single-position note:** a textbook pairs trade is two legs (long A / short B) for market-neutrality. The Senpi runtime is single-position, so this archetype takes the **directional high-beta leg** in the reversion direction (Chameleon) — OR achieves neutrality at the **fund level** with two equally-funded single-direction books, a long book + a short book, whose notionals offset (Octopus). The latter is cross-sectional **dispersion** (long the leaders, short the laggards of one peer group) rather than a single ratio.
 
 **When to use this pattern:** you believe two assets are tethered (BTC/ETH/SOL) and want to trade the *spread* reverting rather than guess absolute direction. Mean-reversion play → tight "bank the snapback" DSL + time-cuts ON (a reversion resolves fast or the thesis failed).
 
@@ -743,6 +743,7 @@ z, ratio, mean, std = ratio_zscore(ca, cb, lookback=48)  # z of latest ratio vs 
 | Agent | Version | Asset / Universe | Description | Tags |
 |---|---|---|---|---|
 | **Chameleon** | v1.0 | ETH/BTC, SOL/ETH, SOL/BTC | Ratio mean-reversion — trades the high-beta leg when a pair's ratio z-score extends past ~2σ and starts reverting. Mean-reversion DSL. | Ratio z-score, Pairs, Mean-reversion |
+| **Octopus** | v1.0 | Liquid crypto cross-section (long + short books) | **Market-Neutral Hedge Fund.** Two equally-funded single-direction books, one leg-parameterized producer (`OCTOPUS_LEG`): longs the relative leaders (top relative-strength, trend-confirmed) and shorts the relative laggards (bottom RS, trend-confirmed) of the liquid main-DEX cross-section. Net ~beta-neutral at the FUND level, harvesting cross-sectional DISPERSION rather than a single ratio. RS rank computed once from the instrument board (no per-asset fetch); only top/bottom names get candles. Strict 5x, moderate DSL with stall-cuts ON. | Cross-sectional, Dispersion, Market-neutral, Long+short books, Two-wallet |
 
 ---
 


### PR DESCRIPTION
First **market-neutral** fund in the fleet — the Relative-Value pillar of the four hedge-fund agents complementing Spider. Built on Spider's validated helpers-native two-leg pattern (one leg-parameterized producer, two wallets).

**Thesis — cross-sectional dispersion:** the LONG book longs the relative leaders (top 24h excess return vs the liquid crypto cross-section), the SHORT book shorts the relative laggards. Equal funding → notionals offset → net ~beta-neutral; the return is the **spread** (leaders − laggards), not market direction. Both books require absolute trend confirmation (4h structure + own momentum) so they trade genuine leaders/laggards. RS rank is computed once from the instrument board (no per-asset candle fetch); only top/bottom names get candles.

**Fleet-standard:** strict 5x, 20% margin, 20% drawdown halt, `drawdown_reset_on_day_rollover: true`, mandatory DSL, taker fallback, verbose per-tick JSON, stall-cuts ON.

**Validation:** `py_compile` clean on both .py; both config JSONs valid; catalog.json valid; no stray spider/swing/scalp paths; leverage ≤ 5 / margin 20% confirmed. Registered in catalog.json + top-level README + producer-patterns (relative-value group).

Funds 2-4 (Camel/Carry, Caracal/Volatility, Elephant/Global-Macro) follow on the same scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)