### PR TITLE
fleet-new: Caracal v1.0 — Volatility Hedge Fund (3 of 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,14 @@ Watches macro conditions and **classifies the market** into TREND_UP / TREND_DOW
 |---|---|---|---|
 | [coyote](coyote/) | v1.0 | BTC (positional) + universe (dispersion) | 3-regime classifier (TREND_UP / TREND_DOWN / CHOP) with vol-confirmation on the down side (crash = drop + vol spike, not slow grind). LONG BTC in TREND_UP, SHORT BTC in TREND_DOWN, no trade in CHOP. Regime + all 3 input metrics published on every tick. Balanced DSL. |
 
+## 17. Volatility / breakout-expansion
+
+Trades **movement, not direction** — fires when a coiled (low-volatility) name breaks its range with an expansion surge, and rides the break either way. Compression precedes expansion; a breakout from a coil follows through more than one in already-volatile tape.
+
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [caracal](caracal/) | v1.0 | Crypto (breakout book) + XYZ (catalyst book) | **Volatility Hedge Fund.** Two books, one producer: the **breakout** book rides coiled-spring breakouts in liquid crypto; the **catalyst** book runs the same compression→expansion engine on XYZ (oil / AI-infra / metals / indices), capturing macro vol events 24/7. Requires an ATR squeeze (recent/baseline ≤ 0.7–0.9) **and** a range break **and** an expansion surge (≥1.3–2.0×). Both directions. Strict 5x, tight early-locking DSL. Episodic by design — most ticks empty. |
+
 For full archetype theses, distinguishing MCP signatures, and code snippets, see [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md).
 
 > **Live fleet trackers:** [strategies.senpi.ai](https://strategies.senpi.ai) (all-time PnL) · [senpi.ai/arena](https://senpi.ai/arena) (weekly ROE). One agent — Sentinel — runs an in-house producer not published to this repo; it appears on the live trackers but has no source link here.

--- a/caracal/README.md
+++ b/caracal/README.md
@@ -1,0 +1,114 @@
+# 🐱 CARACAL v1.0 — Volatility Hedge Fund
+
+Two volatility-expansion **books** on two wallets, one producer, trading
+**both directions**. The **breakout** book rides coiled-spring breakouts in
+liquid crypto; the **catalyst** book runs the same compression→expansion
+engine on XYZ (equities / energy / metals / indices), capturing oil and
+AI-infra moves as direction-agnostic vol events, 24/7. See [SKILL.md](SKILL.md)
+for the full thesis and scoring.
+
+> **Fund the two books ~equally (50/50).** They harvest the same edge
+> (volatility expansion) on two universes; equal funding diversifies across
+> crypto and macro/equity vol.
+
+---
+
+## Install
+
+### Step 1 — Install the runtime plugin (provides `senpi_runtime_helpers`)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Caracal (both books)
+
+```bash
+mkdir -p /data/workspace/skills/caracal-strategy/{config,scripts,state,references}
+for f in scripts/caracal-producer.py scripts/caracal_config.py \
+         runtime-breakout.yaml runtime-catalyst.yaml \
+         config/caracal-breakout-config.json config/caracal-catalyst-config.json \
+         SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/caracal/$f" \
+    -o "/data/workspace/skills/caracal-strategy/$f"
+done
+```
+
+### Step 3 — Required env vars
+
+```bash
+export SENPI_AUTH_TOKEN=...
+export CARACAL_DECISION_MODEL=<your-preferred-model>      # bare model name, no provider prefix
+export TELEGRAM_CHAT_ID=...                               # optional
+
+export CARACAL_BREAKOUT_WALLET=<your-breakout-book-wallet>  # or set wallet in config/caracal-breakout-config.json
+export CARACAL_CATALYST_WALLET=<your-catalyst-book-wallet>  # or set wallet in config/caracal-catalyst-config.json
+```
+
+Each book also accepts an optional `CARACAL_BREAKOUT_STRATEGY_ID` /
+`CARACAL_CATALYST_STRATEGY_ID` (falls back to `strategyId` in the config).
+
+**Funding — BREAKOUT 50% / CATALYST 50%** of the combined pool (operator
+guideline; the runtime does not enforce a budget).
+
+### Step 4 — Register both runtimes, start both daemons
+
+Register each runtime YAML with the gateway (set env vars **before**
+registering so `${CARACAL_*}` resolve), then launch one daemon per book.
+
+```bash
+# BREAKOUT book (crypto)
+CARACAL_LEG=breakout \
+CARACAL_BREAKOUT_WALLET=$CARACAL_BREAKOUT_WALLET \
+SENPI_AUTH_TOKEN=$SENPI_AUTH_TOKEN \
+  setsid nohup python3 -u /data/workspace/skills/caracal-strategy/scripts/caracal-producer.py \
+  > /tmp/caracal-breakout.log 2>&1 < /dev/null &
+disown
+
+# CATALYST book (XYZ)
+CARACAL_LEG=catalyst \
+CARACAL_CATALYST_WALLET=$CARACAL_CATALYST_WALLET \
+SENPI_AUTH_TOKEN=$SENPI_AUTH_TOKEN \
+  setsid nohup python3 -u /data/workspace/skills/caracal-strategy/scripts/caracal-producer.py \
+  > /tmp/caracal-catalyst.log 2>&1 < /dev/null &
+disown
+```
+
+**Why `setsid` + `disown`:** `nohup` blocks SIGHUP, not SIGTERM. When an
+OpenClaw/shell session is torn down it SIGTERMs its process tree. `setsid`
+re-parents each daemon into a new session so it survives; `disown` detaches it
+from the shell job table. **For durable persistence**, add a cron keepalive
+that relaunches a book if its process is gone — the per-book fcntl lock makes a
+double-launch a safe no-op.
+
+---
+
+## Verify
+
+```bash
+pgrep -af caracal-producer.py           # expect 2 daemons (breakout + catalyst)
+tail -5 /tmp/caracal-breakout.log /tmp/caracal-catalyst.log
+```
+
+Each tick emits JSON: `scanned`, `candidates`, `signals_pushed`, `emitted`
+(with per-name `squeeze` = coil ratio and `surge` = expansion multiple). A book
+with no coiled breakout prints `WAITING — no coiled breakout cleared min score 5`
+(normal — Caracal is episodic by design; most ticks are empty).
+
+---
+
+## Notes
+
+- **Direction-agnostic** — both books trade LONG and SHORT; the direction is the
+  break direction, never a fixed bias.
+- **Episodic by design** — it only fires on a coil + break + surge, so most
+  ticks return empty. That's the edge (selectivity), not a bug.
+- **Tight DSL** — a failed breakout reverses fast, so phase1 cuts at 12% and
+  phase2 locks early (8% → 30%).
+- **XYZ is 24/7** — the catalyst book trades weekends (oil/indices/metals stay
+  active); no market-hours gating.
+- The producer **only opens** positions; the DSL ratchet engine owns all exits.
+
+## License
+
+Apache-2.0 — Copyright 2026 Senpi (https://senpi.ai)

--- a/caracal/SKILL.md
+++ b/caracal/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: caracal-strategy
+description: >-
+  CARACAL v1.0 — Volatility Hedge Fund. Two volatility-expansion books on
+  two wallets, one producer, trading BOTH directions. The BREAKOUT book
+  scans liquid crypto for names coiled in a low-volatility squeeze that
+  break their range, and rides the break; the CATALYST book runs the same
+  compression→expansion engine on XYZ (equities / energy / metals / indices)
+  — capturing oil-geopolitics and AI-infra moves as direction-agnostic vol
+  events, 24/7. The edge is VOLATILITY (compression precedes expansion), not
+  a directional view. NOT a copy-trader: each book scores its own universe
+  and pushes signals; the runtime owns the LLM gate (pass-through), DSL
+  exits, and all risk.guard_rails. CARACAL_LEG env selects the book.
+license: Apache-2.0
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐱 CARACAL v1.0 — Volatility Hedge Fund
+
+Caracal runs **two concurrent strategy wallets** that harvest **volatility
+expansion**. **One producer script** (`caracal-producer.py`) serves both; the
+`CARACAL_LEG` env var selects which book a given daemon is. It trades
+**movement, not direction** — each book takes the breakout long or short,
+whichever way it breaks.
+
+> **The edge is volatility.** Compression precedes expansion, and a breakout
+> *from a low-volatility coil* has higher follow-through than a breakout in
+> already-volatile tape. Caracal only fires when a name has been coiling
+> (recent ATR << baseline ATR) **and** breaks its range **and** the breakout
+> bar is an outsized move.
+
+| Book | Universe | Wallet env | Runtime | Scanner |
+|---|---|---|---|---|
+| `breakout` | Liquid main-DEX crypto | `CARACAL_BREAKOUT_WALLET` | `runtime-breakout.yaml` | `caracal_breakout_signals` |
+| `catalyst` | Liquid XYZ (equities/energy/metals/indices) | `CARACAL_CATALYST_WALLET` | `runtime-catalyst.yaml` | `caracal_catalyst_signals` |
+
+The two books differ only in **universe** (crypto vs XYZ) — they share the
+same volatility-breakout engine. The `catalyst` book turns Jason's macro
+themes (oil/Iran, AI infra) into **vol sources**: it rides whichever way the
+catalyst breaks, 24/7 (XYZ trades through weekends).
+
+## The volatility-breakout signal (both books)
+
+Each tick the producer scans the leg's liquid universe (top `universeMaxNames`
+by 24h volume) and, per name, fetches 1h+4h candles and computes:
+
+- **Range breakout** — current price vs the prior `breakoutBars` (default 20)
+  bar high/low. Break up → LONG; break down → SHORT. No break → skip.
+- **Compression precondition** — recent ATR (`recentBars`) ÷ baseline ATR
+  (`baseBars`). `≤ squeezeTight` (0.70) = tight coil; `≤ squeezeLoose` (0.90)
+  = mild coil; otherwise penalized (a break with no prior coil has less edge).
+- **Expansion surge** — breakout-bar true range ÷ baseline ATR. `≥ surgeStrong`
+  (2.0×) / `≥ surgeMod` (1.3×).
+- **Higher-TF agreement** — the break aligned with 4h structure follows through more.
+
+### Scoring (raw integer; `minScore` 5)
+
+| Component | Pts |
+|---|---|
+| Range breakout (the trigger) | +3 |
+| Compression coil | +2 (≤0.70) / +1 (≤0.90) / −1 (no coil) |
+| Expansion surge | +2 (≥2.0×) / +1 (≥1.3×) |
+| 4h agreement | +1 (with break) / −1 (against) |
+
+Direction is the break direction — both books trade LONG **and** SHORT.
+
+## Execution & exit (both books)
+
+- slots **3**, `margin_pct` **18%**, tick **300s**
+- **strict 5x** leverage clamp, then each asset's Hyperliquid venue max
+- DSL **tight fast-capture**: a failed breakout reverses fast, so cut quickly —
+  phase1 max_loss **12%** / retrace 7 / 1 breach; `weak_peak_cut` **ON** (3h @ 2.0),
+  `dead_weight_cut` **ON** (6h), `hard_timeout` **2d** (vol events resolve fast);
+  phase2 ladder `8%→lock30 / 18%→50 / 35%→68 / 60%→80 / 100%→90` (locks early —
+  expansion can round-trip)
+
+## Leverage clamping (both books)
+
+Desired = `maxLeverage` 5; clamped to each asset's HL venue max; the runtime
+gate rejects any leverage above 5.
+
+## XYZ handling
+
+The `catalyst` book trades XYZ — candle fetches route with `dex="xyz"` (the
+producer keys off the `xyz:` prefix). XYZ trades 24/7 on Hyperliquid, so there
+is **no** weekend gating (oil stayed active through recent geopolitics). The
+`main`/`xyz` clearinghouse sections are two VIEWS of ONE cross-margined wallet,
+so `get_positions()` takes `accountValue` ONCE via `max()` — never sums.
+
+## Risk gates (`risk.guard_rails`)
+
+| Gate | breakout | catalyst |
+|---|---|---|
+| daily_loss_limit_pct | 12 | 12 |
+| max_entries_per_day | 8 | 8 |
+| max_consecutive_losses | 5 | 5 |
+| cooldown_minutes | 45 | 45 |
+| drawdown_halt_pct | 20 | 20 |
+| per_asset_cooldown_minutes | 120 | 120 |
+| data_retention_hours | 72 | 72 |
+| drawdown_reset_on_day_rollover | true | true |
+
+Entries and exits both use `FEE_OPTIMIZED_LIMIT` (`ensure_execution_as_taker`
+true; 30s maker-first window — breakouts need timely fills).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `runtime-breakout.yaml` | Crypto breakout-book runtime spec |
+| `runtime-catalyst.yaml` | XYZ catalyst-book runtime spec |
+| `scripts/caracal-producer.py` | Book-aware producer daemon (one script, both books) |
+| `scripts/caracal_config.py` | Leg resolution + SenpiClient wrapper + helpers |
+| `config/caracal-breakout-config.json` | Crypto book tunables (squeeze/surge thresholds) |
+| `config/caracal-catalyst-config.json` | XYZ book tunables |
+
+## Operator install
+
+See [README.md](README.md) — the two books are two daemons
+(`CARACAL_LEG=breakout` and `CARACAL_LEG=catalyst`) on two **equally-funded**
+wallets, each with its own runtime YAML.
+
+## Hard rule for user-conversation Claude sessions
+
+User-conversation Claude sessions MUST NOT call any of:
+`create_position`, `close_position`, `edit_position`,
+`ratchet_stop_add`, `ratchet_stop_edit`, `ratchet_stop_delete`,
+`cancel_order`, `strategy_close`, `strategy_close_positions`.
+
+These tools are reserved for the **producer daemon** (entry path) and the
+**DSL ratchet engine** (exit path). User-conversation sessions are
+**read-only**. Each producer daemon handles real signals on its next tick.
+
+## License
+
+Apache-2.0 — Copyright 2026 Senpi (https://senpi.ai)

--- a/caracal/config/caracal-breakout-config.json
+++ b/caracal/config/caracal-breakout-config.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "CARACAL v1.0 BREAKOUT book — crypto vol compression->expansion. Each tick scans the liquid main-DEX crypto universe (top universeMaxNames by 24h volume) for names coiled in a low-volatility squeeze (recent ATR over baseBars-baseline ATR <= squeezeTight/squeezeLoose) that break their prior breakoutBars-bar range, and rides the break direction (LONG up / SHORT down) when an expansion surge confirms (breakout-bar TR / baseline ATR >= surgeMod/surgeStrong). BOTH directions. Leverage clamped to maxLeverage then HL venue max. Pairs with the CATALYST book (XYZ) on a SEPARATE wallet. Set wallet/strategyId/chatId. Runtime owns position tracking, caps, cooldowns, DSL via runtime-breakout.yaml. Producer launched with CARACAL_LEG=breakout.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "minScore": 5,
+  "marginPct": 0.18,
+  "maxLeverage": 5,
+  "maxSlots": 3,
+  "minNotionalUsd": 200,
+  "tickSeconds": 300,
+  "volFloorUsd": 20000000,
+  "universeMaxNames": 20,
+  "wantXyz": false,
+  "breakoutBars": 20,
+  "recentBars": 10,
+  "baseBars": 30,
+  "squeezeTight": 0.70,
+  "squeezeLoose": 0.90,
+  "surgeStrong": 2.0,
+  "surgeMod": 1.3,
+  "_persona": "Crypto coiled-spring breakouts — volatility compression precedes expansion; rides the break direction, both ways, strict 5x, tight fast-capture DSL (a failed breakout reverses fast)."
+}

--- a/caracal/config/caracal-catalyst-config.json
+++ b/caracal/config/caracal-catalyst-config.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "CARACAL v1.0 CATALYST book — XYZ event/catalyst vol compression->expansion. Same engine as the BREAKOUT book but on the XYZ DEX (equities / energy / metals / indices): scans the liquid XYZ universe (top universeMaxNames by 24h volume) for coiled names breaking their range, and rides the break direction. Captures oil-geopolitics and AI-infra moves as direction-agnostic volatility events, 24/7 (XYZ trades through weekends). wantXyz=true routes candle fetches with dex='xyz'. BOTH directions. Leverage clamped to maxLeverage then HL venue max. Pairs with the BREAKOUT book (crypto) on a SEPARATE wallet. Set wallet/strategyId/chatId. Runtime owns position tracking, caps, cooldowns, DSL via runtime-catalyst.yaml. Producer launched with CARACAL_LEG=catalyst.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "minScore": 5,
+  "marginPct": 0.18,
+  "maxLeverage": 5,
+  "maxSlots": 3,
+  "minNotionalUsd": 200,
+  "tickSeconds": 300,
+  "volFloorUsd": 3000000,
+  "universeMaxNames": 15,
+  "wantXyz": true,
+  "breakoutBars": 20,
+  "recentBars": 10,
+  "baseBars": 30,
+  "squeezeTight": 0.70,
+  "squeezeLoose": 0.90,
+  "surgeStrong": 2.0,
+  "surgeMod": 1.3,
+  "_persona": "XYZ catalyst breakouts — oil/AI-infra/metals/indices coiled-spring expansions captured as direction-agnostic vol events, 24/7, both ways, strict 5x, tight fast-capture DSL. Lower volFloorUsd (3M) because XYZ is thinner than crypto majors."
+}

--- a/caracal/references/skill-attribution.md
+++ b/caracal/references/skill-attribution.md
@@ -1,0 +1,68 @@
+# Caracal — Skill Attribution
+
+**Skill:** caracal-strategy v1.0.0
+**Author:** jason-goldberg
+**License:** Apache-2.0
+**Created:** 2026-06-03
+
+## What Caracal is
+
+The **Volatility** pillar of the four hedge-fund agents complementing Spider
+(directional). Octopus is Relative-Value; Camel is Carry; Caracal is
+Volatility; Elephant is Global Macro. Caracal adds a convexity / managed-futures
+return stream — it profits from *movement* (volatility expansion), independent
+of market direction.
+
+## Lineage
+
+- **Architecture** — the Spider/Octopus/Camel helpers-native two-leg pattern:
+  ONE leg-parameterized producer (`CARACAL_LEG`), two wallets, two runtime
+  YAMLs, `producer_daemon` + fcntl lock, `SenpiClient.push_signal()` ingest,
+  runtime-owned LLM gate + DSL + risk.
+- **Thesis** — volatility **compression precedes expansion**: a breakout from a
+  low-volatility coil has higher follow-through than a breakout in already-
+  volatile tape. Caracal trades the break direction (long or short) of a coiled
+  name when an expansion surge confirms.
+
+## Design decisions specific to Caracal
+
+- **Both legs trade both directions.** Unlike Octopus/Camel (fixed per-book
+  direction), Caracal's direction is the *break* direction — it is direction-
+  agnostic by construction, which is what makes it a true volatility play.
+- **Two universes, one engine.** The `breakout` book runs on main-DEX crypto;
+  the `catalyst` book runs the identical engine on XYZ (equities/energy/metals/
+  indices). The catalyst book converts macro themes (oil/Iran geopolitics, AI
+  infra) into vol sources — it rides whichever way the catalyst breaks, 24/7
+  (XYZ trades weekends; no market-hours gating per the XYZ-markets reference).
+- **Compression precondition is the edge.** Distinct from the fleet's existing
+  breakout agents (Hawk/Badger 4h breakouts, Stag parabolic) which fire on any
+  breakout. Caracal requires a prior ATR squeeze (recent/baseline ATR ≤ 0.7-0.9)
+  AND an expansion surge (breakout-bar TR ≥ 1.3-2.0× baseline ATR) — a coiled
+  spring, not a chase.
+- **Tight, early-locking DSL.** Volatility expansions can round-trip fast, so
+  phase1 cuts at 12% and phase2 starts locking at +8%→30%; stall-cuts ON; 2d
+  hard_timeout (vol events resolve fast).
+
+## Fleet-standard compliance
+
+- Max leverage **5x** (strict clamp + runtime gate defense).
+- Per-position margin **18%** (≤ 25% fleet cap).
+- Drawdown halt **20%**, `drawdown_reset_on_day_rollover: true`.
+- Mandatory DSL; entries + exits use `FEE_OPTIMIZED_LIMIT` with taker fallback.
+- Verbose per-tick JSON (never silent): `scanned / candidates / signals_pushed`
+  + per-name `squeeze` and `surge`.
+
+## Negative-lesson inputs
+
+- **Cobra antipattern** — fixed high leverage + rotation + no drawdown gate.
+  Caracal: strict 5x, episodic (only coiled breakouts), hard drawdown halt.
+- **Fees are the biggest killer** — Caracal is selective (coil + break + surge),
+  so most ticks are empty; `per_asset_cooldown` 120m + `max_entries_per_day` 8
+  bound turnover. Selectivity is the fee defense.
+- **Hard TP antipattern** — no fixed take-profit; the DSL ratchet owns exits
+  and lets a real expansion run while locking gains progressively.
+
+## Capital provenance
+
+New capital, funded **50/50** across the breakout (crypto) and catalyst (XYZ)
+wallets.

--- a/caracal/runtime-breakout.yaml
+++ b/caracal/runtime-breakout.yaml
@@ -1,0 +1,190 @@
+name: caracal-breakout-tracker
+# Top-level `version` is the SCHEMA version the senpi-trading-runtime
+# plugin expects (major=1). Skill version is "Caracal v1.0" — lives in
+# description + SKILL.md + _caracal_producer_version.
+version: 1.0.0
+description: >
+  CARACAL v1.0 (BREAKOUT book) — crypto volatility compression->expansion.
+
+  One of two volatility books. This book scans the liquid main-DEX crypto
+  universe for names coiled in a low-volatility squeeze (recent ATR << baseline
+  ATR) that break their recent range with an expansion surge, and rides the
+  break direction — LONG on an upside break, SHORT on a downside break. BOTH
+  directions. Pairs with the CATALYST book (XYZ, runtime-catalyst.yaml) on a
+  separate wallet. The edge is VOLATILITY (compression precedes expansion),
+  not a directional view.
+
+  Scoring (producer-side): range breakout, compression precondition (ATR
+  squeeze), expansion surge, higher-TF agreement. LONG or SHORT per the break.
+
+  Execution envelope:
+    - slots 3, margin_pct 18
+    - strict 5x leverage clamp, then each asset's HL venue max
+    - tight fast-capture DSL: a failed breakout reverses fast, so cut quickly
+      and lock gains as the expansion runs; 2d hard_timeout
+
+  Producer scores its universe and pushes signals via
+  SenpiClient.push_signal(); runtime LLM gate is pass-through; runtime owns
+  execution + DSL.
+
+strategy:
+  wallet: "${CARACAL_BREAKOUT_WALLET}"
+  # ── FUNDING SPLIT DEFAULT: BREAKOUT 50% / CATALYST 50% of the combined pool ──
+  # Fund the two vol books ~equally. This is a FUNDING guideline for the
+  # operator, NOT a runtime-enforced field. Per-position sizing is governed by
+  # margin_pct + slots below.
+  slots: 3
+  margin_pct: 18
+  trading_risk: moderate
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 8        # breakouts cluster; vol events are episodic
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 5
+    cooldown_minutes: 45
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_minutes: 120
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: caracal_breakout_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        squeeze: { type: number, required: false }
+        surge: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: caracal_breakout_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${CARACAL_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [caracal_breakout_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: caracal_breakout_signals
+    decision_prompt: |
+      You are Caracal's BREAKOUT-book pass-through gate. The producer scans the
+      liquid crypto universe for names coiled in a low-volatility squeeze that
+      break their recent range, and emits the break DIRECTION (LONG on an
+      upside break, SHORT on a downside break). It already applied the breakout
+      test, compression + surge scoring, the 5x leverage clamp, and held-asset
+      dedup. Honor the signal unless it is malformed.
+
+      SIGNAL:
+      {{signal_caracal_breakout_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY.
+      2. direction MUST be copied from signal.direction (LONG or SHORT — this book trades both).
+      3. leverage MUST be copied from signal.data.leverage.
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR leverage > 5 (clamp breach) OR marginUsd <= 0
+      - direction not in [LONG, SHORT]
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 7 AND no malformed fields
+      - 7-8:  score 5.5-6.9
+      - 7:    score 5-5.4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 ASSET LONG 5x, broke 20-bar high from a 0.62 coil, 2.4x surge — volatility expansion')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "CARACAL_VOL_BREAKOUT ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — tight vol-breakout capture) ──────────────────────────
+#
+# A failed breakout reverses fast, so cut quickly (tight phase1) and lock gains
+# as the expansion runs. Stall-cuts ON (a breakout that goes nowhere has
+# failed). 2d hard_timeout — vol events resolve fast.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880           # 2d — vol events resolve fast
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 180            # 3h — a stalled breakout has failed
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 7
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8, lock_hw_pct: 30 }
+        - { trigger_pct: 18, lock_hw_pct: 50 }
+        - { trigger_pct: 35, lock_hw_pct: 68 }
+        - { trigger_pct: 60, lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 90 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/caracal/runtime-catalyst.yaml
+++ b/caracal/runtime-catalyst.yaml
@@ -1,0 +1,188 @@
+name: caracal-catalyst-tracker
+# Top-level `version` is the SCHEMA version the senpi-trading-runtime
+# plugin expects (major=1). Skill version is "Caracal v1.0" — lives in
+# description + SKILL.md + _caracal_producer_version.
+version: 1.0.0
+description: >
+  CARACAL v1.0 (CATALYST book) — XYZ event/catalyst volatility expansion.
+
+  One of two volatility books. Same compression->expansion engine as the
+  BREAKOUT book, but on the XYZ DEX (equities / energy / metals / indices):
+  scans the liquid XYZ universe for coiled names breaking their range and
+  rides the break direction. Captures oil-geopolitics and AI-infra moves as
+  direction-agnostic volatility events, 24/7 (XYZ trades through weekends).
+  BOTH directions. Pairs with the BREAKOUT book (crypto, runtime-breakout.yaml)
+  on a separate wallet. The edge is VOLATILITY, not a directional view.
+
+  Scoring (producer-side): range breakout, compression precondition (ATR
+  squeeze), expansion surge, higher-TF agreement. LONG or SHORT per the break.
+
+  Execution envelope:
+    - slots 3, margin_pct 18
+    - strict 5x leverage clamp, then each asset's HL venue max
+    - tight fast-capture DSL: a failed breakout reverses fast; 2d hard_timeout
+
+  Producer scores its universe and pushes signals via
+  SenpiClient.push_signal(); runtime LLM gate is pass-through; runtime owns
+  execution + DSL.
+
+strategy:
+  wallet: "${CARACAL_CATALYST_WALLET}"
+  # ── FUNDING SPLIT DEFAULT: BREAKOUT 50% / CATALYST 50% of the combined pool ──
+  # Fund the two vol books ~equally. This is a FUNDING guideline for the
+  # operator, NOT a runtime-enforced field. Per-position sizing is governed by
+  # margin_pct + slots below.
+  slots: 3
+  margin_pct: 18
+  trading_risk: moderate
+  enabled: true
+
+risk:
+  data_retention_hours: 72
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 8
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 5
+    cooldown_minutes: 45
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_minutes: 120
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: caracal_catalyst_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        squeeze: { type: number, required: false }
+        surge: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: caracal_catalyst_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${CARACAL_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [caracal_catalyst_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: caracal_catalyst_signals
+    decision_prompt: |
+      You are Caracal's CATALYST-book pass-through gate. The producer scans the
+      liquid XYZ universe (equities / energy / metals / indices) for names
+      coiled in a low-volatility squeeze that break their recent range, and
+      emits the break DIRECTION (LONG on an upside break, SHORT on a downside
+      break). It already applied the breakout test, compression + surge scoring,
+      the 5x leverage clamp, and held-asset dedup. Honor the signal unless malformed.
+
+      SIGNAL:
+      {{signal_caracal_catalyst_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (preserve the xyz: prefix).
+      2. direction MUST be copied from signal.direction (LONG or SHORT — this book trades both).
+      3. leverage MUST be copied from signal.data.leverage.
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR leverage > 5 (clamp breach) OR marginUsd <= 0
+      - direction not in [LONG, SHORT]
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 7 AND no malformed fields
+      - 7-8:  score 5.5-6.9
+      - 7:    score 5-5.4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 xyz:BRENTOIL SHORT 5x, broke 20-bar low from a 0.58 coil, 2.7x surge — geopolitical vol expansion')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "CARACAL_VOL_CATALYST ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — tight vol-breakout capture) ──────────────────────────
+#
+# A failed breakout reverses fast, so cut quickly and lock gains as the
+# expansion runs. Stall-cuts ON. 2d hard_timeout — vol events resolve fast.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880           # 2d
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 180            # 3h
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 7
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8, lock_hw_pct: 30 }
+        - { trigger_pct: 18, lock_hw_pct: 50 }
+        - { trigger_pct: 35, lock_hw_pct: 68 }
+        - { trigger_pct: 60, lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 90 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/caracal/scripts/caracal-producer.py
+++ b/caracal/scripts/caracal-producer.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+# Senpi CARACAL Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under Apache-2.0
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""CARACAL v1.0.0 Producer — volatility compression->expansion, two books.
+
+Caracal harvests VOLATILITY: compression precedes expansion, and a breakout
+FROM a low-volatility coil has higher follow-through than a breakout in
+already-volatile tape. It trades MOVEMENT, not a directional view — each book
+takes the breakout long or short, whichever way it breaks. ONE producer
+script serves both books; the CARACAL_LEG env var selects which:
+
+  CARACAL_LEG=breakout  Crypto vol compression->expansion book.
+    Scans the liquid main-DEX crypto universe for names coiled in a
+    low-volatility squeeze (recent ATR << baseline ATR) that break their
+    recent range with an expansion surge, and rides the break direction.
+
+  CARACAL_LEG=catalyst  XYZ event/catalyst vol book.
+    Same engine on XYZ (equities / energy / metals / indices) — captures
+    oil-geopolitics and AI-infra moves as direction-agnostic volatility
+    events, 24/7 (XYZ trades through weekends).
+
+Signal = (range breakout) + (compression precondition) + (expansion surge) +
+(higher-TF agreement). Both directions. NOT a copy-trader. Each book scores
+its own universe and pushes signals via SenpiClient.push_signal(); runtime
+owns the LLM gate (pass-through), DSL exits, and all risk.guard_rails.
+
+Environment / config resolution:
+  CARACAL_LEG            — REQUIRED. "breakout" or "catalyst".
+  SENPI_AUTH_TOKEN       — REQUIRED. Bearer token for MCP + signal POST.
+  CARACAL_BREAKOUT_WALLET— breakout-book strategy wallet (or config.wallet)
+  CARACAL_CATALYST_WALLET— catalyst-book strategy wallet (or config.wallet)
+  CARACAL_DECISION_MODEL — bare LLM model name; resolved into runtime.yaml
+  SENPI_MCP_URL          — optional, default https://mcp.prod.senpi.ai/mcp
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import caracal_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+
+VERSION = "1.0.0"
+LEG = cfg.LEG  # "breakout" | "catalyst"
+SCANNER_NAME = f"caracal_{LEG}_signals"
+SIGNAL_TYPE = "CARACAL_VOL_BREAKOUT" if LEG == "breakout" else "CARACAL_VOL_CATALYST"
+
+# Score normalization divisor for the 0..1 ingest-ranking score. Max raw ~ 8.
+NORM_DIV = 8.0
+
+_DEFAULTS = {
+    "breakout": {
+        "minScore": 5,
+        "marginPct": 0.18,
+        "maxLeverage": 5,
+        "maxSlots": 3,
+        "minNotionalUsd": 200,
+        "tickSeconds": 300,
+        "volFloorUsd": 20000000,      # liquid main-DEX crypto
+        "universeMaxNames": 20,        # bounds per-tick candle fetches
+        "wantXyz": False,
+        "breakoutBars": 20,            # prior-range lookback for the break
+        "recentBars": 10,              # ATR window — "recent" vol
+        "baseBars": 30,                # ATR window — baseline vol
+        "squeezeTight": 0.70,          # recent/baseline ATR <= this = tight coil
+        "squeezeLoose": 0.90,          # ... <= this = mild coil
+        "surgeStrong": 2.0,            # breakout-bar TR / baseline ATR
+        "surgeMod": 1.3,
+    },
+    "catalyst": {
+        "minScore": 5,
+        "marginPct": 0.18,
+        "maxLeverage": 5,
+        "maxSlots": 3,
+        "minNotionalUsd": 200,
+        "tickSeconds": 300,
+        "volFloorUsd": 3000000,       # XYZ is less liquid than crypto majors
+        "universeMaxNames": 15,
+        "wantXyz": True,
+        "breakoutBars": 20,
+        "recentBars": 10,
+        "baseBars": 30,
+        "squeezeTight": 0.70,
+        "squeezeLoose": 0.90,
+        "surgeStrong": 2.0,
+        "surgeMod": 1.3,
+    },
+}[LEG]
+
+
+def _resolve_wallet():
+    wallet, _ = cfg.get_wallet_and_strategy()
+    return wallet
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical helpers
+# ═══════════════════════════════════════════════════════════════
+
+def _close(c):
+    return float(c.get("close", c.get("c", 0)) or 0)
+
+
+def _high(c):
+    return float(c.get("high", c.get("h", 0)) or 0)
+
+
+def _low(c):
+    return float(c.get("low", c.get("l", 0)) or 0)
+
+
+def trend_structure(candles, lookback=6):
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def true_range(c, prev_close):
+    h, l = _high(c), _low(c)
+    return max(h - l, abs(h - prev_close), abs(l - prev_close))
+
+
+def atr(candles, period):
+    """Average true range over the last `period` bars."""
+    if len(candles) < 2:
+        return 0.0
+    trs = []
+    for i in range(1, len(candles)):
+        trs.append(true_range(candles[i], _close(candles[i - 1])))
+    w = trs[-period:] if len(trs) >= period else trs
+    return sum(w) / len(w) if w else 0.0
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def get_universe_meta():
+    data = cfg.mcp_call("market_list_instruments")
+    out, canonical = {}, []
+    if not data:
+        return out, canonical
+    insts = data.get("data", data)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict):
+            continue
+        if inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or inst.get("context", {}).get("coin")
+        if not name:
+            continue
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ctx": inst.get("context", {}) if isinstance(inst.get("context"), dict) else {},
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+        canonical.append(name)
+    return out, canonical
+
+
+def fetch_candles(asset, intervals):
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=intervals,
+        dex=_dex_for(asset),
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return None
+    d = data.get("data", data)
+    return {"candles": d.get("candles", {}) or {}, "ctx": d.get("asset_context", {}) or {}}
+
+
+def day_vol(meta):
+    ctx = meta.get("ctx", {}) if meta else {}
+    try:
+        return float(ctx.get("dayNtlVlm", 0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+# ═══════════════════════════════════════════════════════════════
+# Volatility-breakout scoring — compression precedes expansion
+# ═══════════════════════════════════════════════════════════════
+
+def score_vol_breakout(asset, meta, config):
+    """Detect a range breakout from a low-volatility coil and ride the break
+    direction. Returns None if no breakout / not enough data."""
+    look = int(config.get("breakoutBars", _DEFAULTS["breakoutBars"]))
+    recent_bars = int(config.get("recentBars", _DEFAULTS["recentBars"]))
+    base_bars = int(config.get("baseBars", _DEFAULTS["baseBars"]))
+    sq_tight = float(config.get("squeezeTight", _DEFAULTS["squeezeTight"]))
+    sq_loose = float(config.get("squeezeLoose", _DEFAULTS["squeezeLoose"]))
+    surge_strong = float(config.get("surgeStrong", _DEFAULTS["surgeStrong"]))
+    surge_mod = float(config.get("surgeMod", _DEFAULTS["surgeMod"]))
+
+    md = fetch_candles(asset, ["1h", "4h"])
+    if not md:
+        return None
+    c1 = md["candles"].get("1h", [])
+    c4 = md["candles"].get("4h", [])
+    need = max(look, base_bars) + 2
+    if len(c1) < need or len(c4) < 6:
+        return None
+    highs = [_high(c) for c in c1]
+    lows = [_low(c) for c in c1]
+    closes = [_close(c) for c in c1]
+    price = closes[-1]
+
+    # Range breakout vs the prior `look` bars (excluding the current bar).
+    prior_high = max(highs[-(look + 1):-1])
+    prior_low = min(lows[-(look + 1):-1])
+    broke_up = price > prior_high
+    broke_dn = price < prior_low
+    if not (broke_up or broke_dn):
+        return None
+    direction = "LONG" if broke_up else "SHORT"
+
+    a_recent = atr(c1[-(recent_bars + 1):], recent_bars)
+    a_base = atr(c1[-(base_bars + 1):], base_bars)
+    squeeze = (a_recent / a_base) if a_base > 0 else 1.0
+    last_tr = true_range(c1[-1], closes[-2])
+    surge = (last_tr / a_base) if a_base > 0 else 0.0
+    trend4, _ = trend_structure(c4)
+
+    score = 0
+    reasons = [f"breakout_{'up' if broke_up else 'down'}"]
+    score += 3  # the breakout trigger
+
+    # Compression precondition — the edge. A coil scores; no coil is penalized.
+    if squeeze <= sq_tight:
+        score += 2
+        reasons.append(f"coil_{squeeze:.2f}")
+    elif squeeze <= sq_loose:
+        score += 1
+        reasons.append(f"coil_{squeeze:.2f}")
+    else:
+        score -= 1
+        reasons.append(f"no_coil_{squeeze:.2f}")
+
+    # Expansion surge — the breakout bar should be an outsized move.
+    if surge >= surge_strong:
+        score += 2
+        reasons.append(f"surge_{surge:.1f}x")
+    elif surge >= surge_mod:
+        score += 1
+        reasons.append(f"surge_{surge:.1f}x")
+
+    # Higher-TF agreement (a break with the 4h structure follows through more).
+    if (broke_up and trend4 == "BULLISH") or (broke_dn and trend4 == "BEARISH"):
+        score += 1
+        reasons.append(f"4h_{trend4.lower()}_agree")
+    elif (broke_up and trend4 == "BEARISH") or (broke_dn and trend4 == "BULLISH"):
+        score -= 1
+        reasons.append("4h_against")
+
+    return {
+        "coin": asset, "direction": direction, "score": score,
+        "reasons": reasons, "price": price,
+        "squeeze": squeeze, "surge": surge, "trend4h": trend4,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Leverage clamp + emit
+# ═══════════════════════════════════════════════════════════════
+
+def clamp_leverage(desired, meta):
+    venue = (meta or {}).get("max_leverage")
+    try:
+        venue = int(venue)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))
+
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        cfg.log("ERROR: strategy wallet not resolved")
+        return False
+    if thesis["coin"].upper() in {h.upper() for h in held_assets}:
+        return False
+
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "heldAssets": held_assets,
+        "trend4h": thesis.get("trend4h"),
+        "squeeze": round(thesis.get("squeeze", 0), 3),
+        "surge": round(thesis.get("surge", 0), 2),
+    }
+
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=thesis["coin"],
+            direction=thesis["direction"],
+            score=min(thesis["score"] / NORM_DIV, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        cfg.log(f"INGEST_REJECTED {thesis['coin']}: {e}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        cfg.log(f"INGEST_EXCEPTION {thesis['coin']}: {type(e).__name__}: {e}")
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# Universe — crypto (breakout) or XYZ (catalyst), liquid names only
+# ═══════════════════════════════════════════════════════════════
+
+def build_universe(config, meta_map, canonical):
+    """Liquid names on the leg's DEX, capped to universeMaxNames by 24h volume.
+    breakout -> main-DEX crypto; catalyst -> XYZ (equities/energy/metals/indices)."""
+    vol_floor = float(config.get("volFloorUsd", _DEFAULTS["volFloorUsd"]))
+    max_names = int(config.get("universeMaxNames", _DEFAULTS["universeMaxNames"]))
+    want_xyz = bool(config.get("wantXyz", _DEFAULTS["wantXyz"]))
+    seen, pool = set(), []
+    for name in canonical:
+        if not isinstance(name, str):
+            continue
+        is_xyz = name.lower().startswith("xyz:")
+        if is_xyz != want_xyz:
+            continue
+        key = name.upper()
+        if key in seen:
+            continue
+        meta = meta_map.get(name) or meta_map.get(key)
+        if not meta:
+            continue
+        vol = day_vol(meta)
+        if vol < vol_floor:
+            continue
+        seen.add(key)
+        pool.append((name, vol))
+    pool.sort(key=lambda x: x[1], reverse=True)
+    return [n for n, _ in pool[:max_names]]
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — single tick. NO inner scanner_lock; daemon owns it.
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "leg": LEG,
+                    "_caracal_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "leg": LEG, "note": "no account value",
+                    "_caracal_producer_version": VERSION})
+        return
+
+    min_score = config.get("minScore", _DEFAULTS["minScore"])
+    margin_pct = config.get("marginPct", _DEFAULTS["marginPct"])
+    max_lev = config.get("maxLeverage", _DEFAULTS["maxLeverage"])
+    max_slots = config.get("maxSlots", _DEFAULTS["maxSlots"])
+    min_notional = config.get("minNotionalUsd", _DEFAULTS["minNotionalUsd"])
+
+    open_slots = max_slots - len(held_assets)
+    if open_slots <= 0:
+        cfg.output({"status": "ok", "leg": LEG, "note": "slots full",
+                    "held_assets": held_assets, "max_slots": max_slots,
+                    "_caracal_producer_version": VERSION})
+        return
+
+    meta_map, canonical = get_universe_meta()
+    universe = build_universe(config, meta_map, canonical)
+
+    candidates = []
+    recently_skipped = []
+    for name in universe:
+        if name.upper() in held_set:
+            continue
+        if cfg.was_recently_signaled(name):
+            recently_skipped.append(name)
+            continue
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        thesis = score_vol_breakout(name, meta, config)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok", "leg": LEG,
+            "scanned": len(universe), "candidates": 0, "signals_pushed": 0,
+            "min_score": min_score, "held_assets": held_assets,
+            "recently_signaled_skipped": recently_skipped,
+            "note": f"WAITING — no coiled breakout cleared min score {min_score}",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_caracal_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    to_emit = candidates[:open_slots]
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = 0
+    emitted = []
+    for th in to_emit:
+        leverage = clamp_leverage(max_lev, th["_meta"])
+        notional = margin_usd * leverage
+        if leverage <= 0 or notional < min_notional:
+            continue
+        if push_signal(th, margin_usd, leverage, held_assets):
+            pushed += 1
+            cfg.record_signal(th["coin"])
+            emitted.append({
+                "coin": th["coin"], "direction": th["direction"],
+                "score": th["score"], "leverage": leverage,
+                "margin_usd": margin_usd, "squeeze": round(th["squeeze"], 2),
+                "surge": round(th["surge"], 2), "reasons": th["reasons"][:6],
+            })
+
+    cfg.output({
+        "status": "ok", "leg": LEG,
+        "scanned": len(universe), "candidates": len(candidates),
+        "open_slots": open_slots, "signals_pushed": pushed, "emitted": emitted,
+        "held_assets": held_assets, "recently_signaled_skipped": recently_skipped,
+        "account_value": round(account_value, 2),
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_caracal_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _lock_id = hashlib.sha256(
+        (STRATEGY_ADDRESS or LEG).lower().encode()
+    ).hexdigest()[:12]
+    _tick = int(cfg.load_config().get("tickSeconds", _DEFAULTS["tickSeconds"]))
+    producer_daemon(
+        fn=main,
+        interval_seconds=_tick,
+        name=f"caracal-{LEG}-producer-{_lock_id}",
+        tick_timeout=min(180, max(30, _tick - 10)),
+    )

--- a/caracal/scripts/caracal_config.py
+++ b/caracal/scripts/caracal_config.py
@@ -1,0 +1,333 @@
+"""CARACAL v1.0 — Shared config + MCP shim + helpers wrapper (LEG-AWARE).
+
+CARACAL — Volatility Hedge Fund. ONE producer script driven by the
+CARACAL_LEG env var into one of two volatility-expansion books (BOTH
+directions — it trades the breakout the way it breaks), each bound to its
+own wallet + runtime + DSL:
+
+  CARACAL_LEG=breakout -> Crypto vol compression->expansion book. Scans the
+                       liquid main-DEX crypto universe for names coiled in a
+                       low-volatility squeeze that break their recent range,
+                       and rides the expansion in the break direction.
+                       config/caracal-breakout-config.json -> caracal_breakout_signals
+  CARACAL_LEG=catalyst -> XYZ event/catalyst vol book. Same compression->
+                       expansion engine on XYZ (equities / energy / metals /
+                       indices) — captures oil-geopolitics and AI-infra moves
+                       as direction-agnostic volatility events, 24/7.
+                       config/caracal-catalyst-config.json -> caracal_catalyst_signals
+
+The edge is VOLATILITY: compression precedes expansion, and breakouts FROM a
+coil have higher follow-through than breakouts in already-volatile tape. It
+trades MOVEMENT, not a directional view — each book takes the breakout long
+or short, whichever way it breaks. Each book is a volatility-breakout scorer.
+
+This module owns: leg resolution, config load, the senpi_runtime_helpers
+client, the MCP call shim, account/position pulls, and the per-leg
+recent-signals race-dedup cache. The producer (caracal-producer.py) owns
+scoring + emit. The runtime owns the LLM gate, DSL exits, and all
+risk.guard_rails. NOT a copy-trader — each book scores its own universe.
+
+Plumbing: MCP calls + signal POSTs route through
+senpi_runtime_helpers.SenpiClient (in-process, direct HTTPS). No
+mcporter / openclaw subprocesses.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under Apache-2.0 — attribution required for derivative works
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ─── Leg resolution ──────────────────────────────────────────
+# One script, two legs. CARACAL_LEG selects the config file, the
+# scanner name, the wallet env var, and the recent-signals cache.
+LEG = (os.environ.get("CARACAL_LEG") or "breakout").strip().lower()
+if LEG not in ("breakout", "catalyst"):
+    raise RuntimeError(
+        f"CARACAL_LEG must be 'breakout' or 'catalyst' (got {LEG!r}). "
+        "Set it on the runtime host before starting the producer daemon."
+    )
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "caracal-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / f"caracal-{LEG}-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / f"recent-signals-{LEG}.json"
+# Generic per-leg state ledger (retained from the shared scaffold for
+# forward-compat; Caracal scans the live instrument board each tick, so it
+# does not use fresh-listing detection — these helpers are unused).
+XYZ_FIRST_SEEN_PATH = STATE_DIR / f"first-seen-{LEG}.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Per-leg wallet / strategy env var names. The runtime YAMLs bind
+# ${CARACAL_BREAKOUT_WALLET} / ${CARACAL_CATALYST_WALLET}; the producer reads
+# the same names so producer and runtime always agree on the wallet.
+_WALLET_ENV = "CARACAL_BREAKOUT_WALLET" if LEG == "breakout" else "CARACAL_CATALYST_WALLET"
+_STRATEGY_ENV = "CARACAL_BREAKOUT_STRATEGY_ID" if LEG == "breakout" else "CARACAL_CATALYST_STRATEGY_ID"
+
+# How long after a push_signal() we treat the asset as "in-flight" and
+# refuse to re-emit. 180s = 3x the typical ALO open fill window. Covers
+# the race between push_signal() returning OK and the resulting position
+# appearing in the next-tick clearinghouse pull. On-chain held-asset
+# check is the safety floor underneath this.
+RECENT_SIGNAL_TTL_SEC = 180
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+# senpi_runtime_helpers ships inside the senpi-trading-runtime skill.
+# Global skills install under ~/.openclaw/skills/ on standard hosts
+# (e.g. /data/.openclaw/skills/ on Railway). Some setups install user
+# skills under ${OPENCLAW_WORKSPACE}/skills/. Probe both in order.
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Caracal's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("caracal_wrapper_enabled", leg=LEG, sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Atomic Write ────────────────────────────────────────────
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def get_wallet_and_strategy():
+    """Resolve (wallet, strategyId) — leg env var first, config.json second."""
+    wallet = os.environ.get(_WALLET_ENV, "").strip()
+    strategy_id = os.environ.get(_STRATEGY_ENV, "").strip()
+    if not wallet or not strategy_id:
+        config = load_config()
+        wallet = wallet or (config.get("wallet") or "").strip()
+        strategy_id = strategy_id or (config.get("strategyId") or "").strip()
+    return wallet, strategy_id
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Direct MCP call via SenpiClient (in-process HTTPS). Returns the
+    unwrapped JSON document on success, or None if the wrapper raised."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[caracal-v1:{LEG}] mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+# Backward-compat alias — keeps legacy `cfg.mcporter_call(...)` call
+# sites working even though the transport is in-process now.
+mcporter_call = mcp_call
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts]).
+
+    The 'main' and 'xyz' clearinghouse sections are TWO VIEWS of ONE
+    cross-margined Senpi wallet, NOT two separate collateral silos. Both
+    views report the SAME marginSummary.accountValue (the whole wallet's
+    equity). So account_value is taken ONCE via max() across the two
+    sections — never summed. Summing double-counts the balance and makes
+    every position size 2x too large (margin_usd = account_value *
+    margin_pct downstream). max() is exact whether the views mirror
+    (equal → max is the shared value), one view is empty/0 (the populated
+    view wins), or positions are open on both sub-DEXs (still one shared
+    cross-margin balance). assetPositions ARE per-sub-DEX, so those are
+    still enumerated across both sections.
+    """
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0) or 0),
+                "margin": float(pos.get("marginUsed", 0) or 0),
+                "entryPrice": float(pos.get("entryPx", 0) or 0),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── recent-signals cache (held-asset dedup race-fix) ─────────
+#
+# Each successful push_signal(coin) writes {coin: epoch_seconds} to
+# recent-signals-<leg>.json. The producer checks this BEFORE scoring and
+# skips coins seen within RECENT_SIGNAL_TTL_SEC. This covers the gap
+# between push_signal returning OK and the resulting position appearing
+# in the next-tick clearinghouse pull. The on-chain held-asset check
+# (get_positions) is the safety floor underneath.
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    """Drop entries older than 4x TTL to keep the file bounded."""
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    """Mark `coin` as recently signaled. Writes atomically."""
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    """True if `coin` was pushed within `ttl_sec`."""
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+# ─── first-seen cache (generic; retained from the shared scaffold) ─────
+#
+# UNUSED by Caracal — kept for forward-compat with the shared producer
+# scaffold. Caracal scans the live instrument board each tick for coiled
+# breakouts, so it needs no fresh-listing detection. A derivative
+# that wants new-listing auto-catch can record when each instrument first
+# appeared. A name younger than a freshness window is auto-eligible even if it
+# isn't in the curated include-set. On the very first run (no state file)
+# every current name is treated as already-old so the auto-catch doesn't
+# fire across the whole board at once — only names that appear AFTER
+# deploy are "fresh".
+
+def read_first_seen():
+    """Return {name: epoch_seconds} of when each instrument was first seen."""
+    if not XYZ_FIRST_SEEN_PATH.exists():
+        return {}
+    try:
+        with open(XYZ_FIRST_SEEN_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def write_first_seen(data):
+    """Persist the first-seen map atomically. Best-effort."""
+    try:
+        atomic_write(XYZ_FIRST_SEEN_PATH, data)
+    except OSError:
+        pass
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[caracal-v1:{LEG}] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/catalog.json
+++ b/catalog.json
@@ -604,6 +604,21 @@
       "version": "1.0.0"
     },
     {
+      "id": "caracal",
+      "tracker_slug": "caracal",
+      "name": "Caracal — Volatility Hedge Fund",
+      "emoji": "🐱",
+      "tagline": "Trades volatility expansion, not direction: rides coiled-spring breakouts (low-vol squeeze -> range break -> surge) on two wallets — crypto and XYZ (oil / AI-infra / metals / indices), both long and short, 24/7.",
+      "group": "volatility-breakout",
+      "sort_order": 51,
+      "min_budget": 100,
+      "risk_level": "aggressive",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/caracal",
+      "version": "1.0.0"
+    },
+    {
       "id": "piranha",
       "tracker_slug": "piranha",
       "name": "Piranha \u2014 Liquidation-Cascade / Forced-Flow Hunter",

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -854,6 +854,31 @@ direction = regime_to_direction(regime)                       # LONG / SHORT / N
 
 ---
 
+### 17. Volatility / breakout-expansion
+
+Trades **movement, not direction**. The thesis is volatility regime: compression precedes expansion, and a breakout *from a low-volatility coil* follows through more than a breakout in already-volatile tape. Fires on the conjunction of (range breakout) + (ATR squeeze) + (expansion surge), and takes the break direction either way.
+
+```python
+# Per name (1h candles): is it coiled, did it break, was the break a surge?
+prior_high = max(highs[-21:-1]); prior_low = min(lows[-21:-1])
+broke = "LONG" if price > prior_high else ("SHORT" if price < prior_low else None)
+squeeze = atr(c[-11:], 10) / atr(c[-31:], 30)          # < 0.7-0.9 = coiled spring
+surge   = true_range(c[-1]) / atr(c[-31:], 30)          # >= 1.3-2.0x = real expansion
+# score = breakout(+3) + coil(+2/+1/-1) + surge(+2/+1) + 4h-agreement(+1/-1)
+```
+
+**Distinct from Hawk/Badger (4h breakouts) and Stag (parabolic):** those fire on *any* breakout; this archetype *requires a prior compression* (the coil) plus an expansion surge — a coiled spring, not a chase — and is direction-agnostic (both legs trade long and short). Tight, early-locking DSL: a failed breakout reverses fast.
+
+**When to use this pattern:** you want to harvest volatility expansion as a low-correlation return stream (convexity / managed-futures flavor) independent of market direction. Episodic by design — most ticks return empty.
+
+**Agents in this family:**
+
+| Agent | Version | Asset / Universe | Description | Tags |
+|---|---|---|---|---|
+| **Caracal** | v1.0 | Crypto (breakout book) + XYZ (catalyst book) | **Volatility Hedge Fund.** Two books on two wallets, one leg-parameterized producer (`CARACAL_LEG`): **breakout** rides coiled-spring breakouts in liquid main-DEX crypto; **catalyst** runs the same compression→expansion engine on XYZ (equities/energy/metals/indices), turning oil-geopolitics + AI-infra moves into direction-agnostic vol events, 24/7. Signal = range break + ATR squeeze (≤0.7-0.9) + expansion surge (≥1.3-2.0×) + 4h agreement; LONG or SHORT per the break. Strict 5x, tight early-locking DSL (12% phase1, lock at +8%→30%, 2d timeout). | Volatility, Compression-expansion, Both-direction, Two-universe, Episodic, Two-wallet |
+
+---
+
 ## Decision tree — help a user pick their first strategy
 
 This is the guided path an **onboarding agent** walks a new user through. Start broad ("what kind of trader do you want your agent to be?"), narrow **one layer at a time**, and land on a single deployable strategy. Ask one question, show 2–6 options, let them pick, then go deeper. Each leaf names a **real, installable agent** — beginners are routed to the **onboarding tier** (simpler scoring, conservative sizing); the *level up* line is the full-fleet version for once they're comfortable.


### PR DESCRIPTION
The **Volatility** pillar — fund 3 of 4, a new `volatility-breakout` archetype.

**Thesis — compression precedes expansion:** the BREAKOUT book rides coiled-spring breakouts in liquid crypto; the CATALYST book runs the same engine on XYZ (oil / AI-infra / metals / indices), turning macro moves into direction-agnostic vol events, 24/7. Fires only on (range break) + (ATR squeeze ≤0.7-0.9, a coil) + (expansion surge ≥1.3-2.0×) + 4h agreement. Rides the break direction either way.

**Distinct from existing breakout agents** (Hawk/Badger fire on any 4h breakout; Stag is parabolic): Caracal *requires a prior compression* — a coiled spring, not a chase — and is bidirectional.

**Fleet-standard:** strict 5x, 18% margin, tight early-locking DSL (12% phase1, lock +8%→30%, 2d timeout), verbose JSON, episodic (selectivity = fee defense). py_compile + JSON valid; no stale camel/spider paths; leverage ≤5. Registered in catalog (new group) + README §17 + producer-patterns §17.

Fund 4 (Elephant/Global-Macro) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)