### PR TITLE
fleet-new: Elephant v1.0 — Global-Macro Hedge Fund (4 of 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,14 @@ Trades **movement, not direction** — fires when a coiled (low-volatility) name
 |---|---|---|---|
 | [caracal](caracal/) | v1.0 | Crypto (breakout book) + XYZ (catalyst book) | **Volatility Hedge Fund.** Two books, one producer: the **breakout** book rides coiled-spring breakouts in liquid crypto; the **catalyst** book runs the same compression→expansion engine on XYZ (oil / AI-infra / metals / indices), capturing macro vol events 24/7. Requires an ATR squeeze (recent/baseline ≤ 0.7–0.9) **and** a range break **and** an expansion surge (≥1.3–2.0×). Both directions. Strict 5x, tight early-locking DSL. Episodic by design — most ticks empty. |
 
+## 18. Global macro / cross-asset
+
+Trades the macro asset complex — equity indices, precious metals, energy, FX — plus BTC as the macro risk asset. These move on macro **regime**, not crypto noise.
+
+| Skill | Version | Asset / Universe | Description |
+|---|---|---|---|
+| [elephant](elephant/) | v1.0 | XYZ indices/metals/energy/FX + BTC (trend + fade books) | **Global-Macro Hedge Fund.** Two books, one producer, over a curated macro whitelist: the **trend** book rides the medium-term multi-TF macro trend (4h backbone + 1h + momentum), the **fade** book fades short-TF macro over-extensions back to regime (RSI/stretch with a 4h knife guard). Both directions. Aware of oil/Iran + the AI-equity bid as *macro* (not chases). Trend = wide let-it-run DSL (7d); fade = tight fast-capture (2d). Strict 5x, 24/7 (XYZ). |
+
 For full archetype theses, distinguishing MCP signatures, and code snippets, see [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md).
 
 > **Live fleet trackers:** [strategies.senpi.ai](https://strategies.senpi.ai) (all-time PnL) · [senpi.ai/arena](https://senpi.ai/arena) (weekly ROE). One agent — Sentinel — runs an in-house producer not published to this repo; it appears on the live trackers but has no source link here.

--- a/catalog.json
+++ b/catalog.json
@@ -619,6 +619,21 @@
       "version": "1.0.0"
     },
     {
+      "id": "elephant",
+      "tracker_slug": "elephant",
+      "name": "Elephant — Global-Macro Hedge Fund",
+      "emoji": "🐘",
+      "tagline": "Trades the cross-asset macro complex — equity indices, metals, energy, FX (all on XYZ) + BTC — on two wallets: a trend book rides the durable macro direction, a fade book catches macro over-extensions reverting to regime. Both directions, 24/7.",
+      "group": "global-macro",
+      "sort_order": 52,
+      "min_budget": 100,
+      "risk_level": "moderate",
+      "base_skill": null,
+      "branch": "main",
+      "predators_url": "https://strategies.senpi.ai/bot/elephant",
+      "version": "1.0.0"
+    },
+    {
       "id": "piranha",
       "tracker_slug": "piranha",
       "name": "Piranha \u2014 Liquidation-Cascade / Forced-Flow Hunter",

--- a/elephant/README.md
+++ b/elephant/README.md
@@ -1,0 +1,110 @@
+# 🐘 ELEPHANT v1.0 — Global-Macro Hedge Fund
+
+Two macro **books** on two wallets, one producer, over the cross-asset macro
+complex — equity indices, precious metals, energy, FX (all on XYZ) plus BTC.
+The **trend** book rides the medium-term macro trend; the **fade** book fades
+macro over-extensions back to regime. Both trade both directions. See
+[SKILL.md](SKILL.md) for the full thesis and scoring.
+
+> **Funding default: TREND 60% / FADE 40%.** The trend book is the
+> fee-efficient let-it-run engine and carries the larger share; the fade book
+> turns over faster and is funded smaller.
+
+---
+
+## Install
+
+### Step 1 — Install the runtime plugin (provides `senpi_runtime_helpers`)
+
+```bash
+npx skills add https://github.com/Senpi-ai/senpi-skills --skill senpi-trading-runtime -g -y
+```
+
+### Step 2 — Pull Elephant (both books)
+
+```bash
+mkdir -p /data/workspace/skills/elephant-strategy/{config,scripts,state,references}
+for f in scripts/elephant-producer.py scripts/elephant_config.py \
+         runtime-trend.yaml runtime-fade.yaml \
+         config/elephant-trend-config.json config/elephant-fade-config.json \
+         SKILL.md README.md; do
+  curl -fsSL "https://raw.githubusercontent.com/Senpi-ai/senpi-skills/main/elephant/$f" \
+    -o "/data/workspace/skills/elephant-strategy/$f"
+done
+```
+
+### Step 3 — Required env vars
+
+```bash
+export SENPI_AUTH_TOKEN=...
+export ELEPHANT_DECISION_MODEL=<your-preferred-model>     # bare model name, no provider prefix
+export TELEGRAM_CHAT_ID=...                               # optional
+
+export ELEPHANT_TREND_WALLET=<your-trend-book-wallet>     # or set wallet in config/elephant-trend-config.json
+export ELEPHANT_FADE_WALLET=<your-fade-book-wallet>       # or set wallet in config/elephant-fade-config.json
+```
+
+Each book also accepts an optional `ELEPHANT_TREND_STRATEGY_ID` /
+`ELEPHANT_FADE_STRATEGY_ID` (falls back to `strategyId` in the config).
+
+**Funding — TREND 60% / FADE 40%** of the combined pool (operator guideline;
+the runtime does not enforce a budget).
+
+### Step 4 — Register both runtimes, start both daemons
+
+Register each runtime YAML with the gateway (set env vars **before**
+registering so `${ELEPHANT_*}` resolve), then launch one daemon per book.
+
+```bash
+# TREND book
+ELEPHANT_LEG=trend \
+ELEPHANT_TREND_WALLET=$ELEPHANT_TREND_WALLET \
+SENPI_AUTH_TOKEN=$SENPI_AUTH_TOKEN \
+  setsid nohup python3 -u /data/workspace/skills/elephant-strategy/scripts/elephant-producer.py \
+  > /tmp/elephant-trend.log 2>&1 < /dev/null &
+disown
+
+# FADE book
+ELEPHANT_LEG=fade \
+ELEPHANT_FADE_WALLET=$ELEPHANT_FADE_WALLET \
+SENPI_AUTH_TOKEN=$SENPI_AUTH_TOKEN \
+  setsid nohup python3 -u /data/workspace/skills/elephant-strategy/scripts/elephant-producer.py \
+  > /tmp/elephant-fade.log 2>&1 < /dev/null &
+disown
+```
+
+**Why `setsid` + `disown`:** `nohup` blocks SIGHUP, not SIGTERM. When an
+OpenClaw/shell session is torn down it SIGTERMs its process tree. `setsid`
+re-parents each daemon into a new session so it survives; `disown` detaches it
+from the shell job table. **For durable persistence**, add a cron keepalive
+that relaunches a book if its process is gone — the per-book fcntl lock makes a
+double-launch a safe no-op.
+
+---
+
+## Verify
+
+```bash
+pgrep -af elephant-producer.py          # expect 2 daemons (trend + fade)
+tail -5 /tmp/elephant-trend.log /tmp/elephant-fade.log
+```
+
+Each tick emits JSON: `scanned`, `candidates`, `signals_pushed`, `emitted`. A
+book with no qualifying macro name prints `WAITING — no macro name cleared min
+score N` (normal — the macro complex moves slowly).
+
+---
+
+## Notes
+
+- **Universe is a curated macro whitelist** (indices/metals/energy/FX + BTC),
+  intersected with the live board so unavailable names are skipped — it does
+  NOT pull in AI/Tech equities (that's Spider's domain).
+- **XYZ is 24/7** — the macro books trade weekends (indices/metals/oil stay active).
+- **Trend book = wide DSL** (let macro trends run, 7d timeout); **fade book =
+  tight DSL** (bank the snapback, 2d timeout).
+- The producer **only opens** positions; the DSL ratchet engine owns all exits.
+
+## License
+
+Apache-2.0 — Copyright 2026 Senpi (https://senpi.ai)

--- a/elephant/SKILL.md
+++ b/elephant/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: elephant-strategy
+description: >-
+  ELEPHANT v1.0 — Global-Macro Hedge Fund. Two macro books on two wallets,
+  one producer, over the cross-asset macro complex — equity indices, precious
+  metals, energy, FX (all on XYZ) plus BTC as the macro risk asset. The TREND
+  book rides the medium-term multi-timeframe macro trend (both directions);
+  the FADE book fades short-TF macro over-extensions back to regime (both
+  directions, with a knife guard). The edge is GLOBAL MACRO — the cross-asset
+  complex moves on regime, not crypto noise. NOT a copy-trader: each book
+  scores its own universe and pushes signals; the runtime owns the LLM gate
+  (pass-through), DSL exits, and all risk.guard_rails. ELEPHANT_LEG env
+  selects the book.
+license: Apache-2.0
+metadata:
+  author: jason-goldberg
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+  requires:
+    - senpi-trading-runtime>=1.1.0
+    - senpi_runtime_helpers
+---
+
+# 🐘 ELEPHANT v1.0 — Global-Macro Hedge Fund
+
+Elephant trades the **cross-asset macro complex** — equity indices, precious
+metals, energy, FX (all on XYZ) plus **BTC** as the macro risk asset — which
+moves on macro regime, not crypto noise. **One producer script**
+(`elephant-producer.py`) serves both books; the `ELEPHANT_LEG` env var selects
+which book a given daemon is. It is **aware of the themes** (oil/Iran, the
+AI-equity bid, risk-on/off) and trades them **as macro**, not as momentum chases.
+
+| Book | Style | Wallet env | Runtime | Scanner |
+|---|---|---|---|---|
+| `trend` | Macro multi-TF trend, both directions | `ELEPHANT_TREND_WALLET` | `runtime-trend.yaml` | `elephant_trend_signals` |
+| `fade` | Macro mean-reversion, both directions | `ELEPHANT_FADE_WALLET` | `runtime-fade.yaml` | `elephant_fade_signals` |
+
+The two books are complementary: the trend book rides durable macro direction;
+the fade book catches macro over-extensions. On separate wallets, they never
+conflict — a name in a macro uptrend can still print a short-term overbought fade.
+
+## The macro universe (both books)
+
+A **curated macro whitelist** (`config.allowedAssets`), intersected each tick
+with the live instrument board so unavailable names are skipped:
+
+- **Indices** (XYZ): SP500, XYZ100, JP225, KR200, NIFTY, IBOV
+- **Metals** (XYZ): GOLD, SILVER, PLATINUM, COPPER
+- **Energy** (XYZ): BRENTOIL, CL, NATGAS
+- **FX** (XYZ): EUR, JPY, GBP, DXY
+- **Crypto macro**: BTC
+
+This is the asset complex none of the other funds focus on — true global macro.
+XYZ trades 24/7 on Hyperliquid, so the macro book runs through weekends.
+
+## TREND book — ride the macro trend (both directions)
+
+### Scoring (raw integer; `minScore` 5)
+
+| Component | Pts | Source |
+|---|---|---|
+| 4h trend backbone | +3 (sets direction: BULLISH→LONG / BEARISH→SHORT) / **skip** NEUTRAL | 4h candles |
+| 1h confirmation | +2 (confirms) / −1 (opposes) | 1h candles |
+| 24h momentum | +2 (≥`momThresholdPct` 1.5%) / +1 (≥0) — sign matches direction | instrument ctx |
+| RSI room | +1 (not overbought for a long / not oversold for a short) | 1h RSI |
+
+A NEUTRAL 4h structure = no clean macro trend → the book waits.
+
+## FADE book — fade macro over-extensions (both directions)
+
+### Scoring (raw integer; `minScore` 4)
+
+Picks the more-extreme side (oversold → LONG, overbought → SHORT):
+
+| Component | Pts |
+|---|---|
+| RSI extreme | +3 (≤20 / ≥80) / +2 (≤25 / ≥75) / +1 (≤`rsiOversold` 30 / ≥`rsiOverbought` 70) |
+| Stretch from 20-bar 1h MA | +2 (≥2×`stretchThresholdPct` 1.0%) / +1 (≥1×) |
+| 4h regime knife guard | +1 (fading **with** a higher-TF mean-reversion bias) / −2 (against a strong macro trend) |
+
+The −2 knife guard keeps it from fading a strong macro trend (don't short a
+ripping oil breakout, don't long a collapsing index).
+
+## Execution & exit
+
+- both books: slots **3**, **strict 5x** clamp (indices/metals/FX cap low at venue), tick **300s**
+- **TREND** `margin_pct` **18%** — DSL **wide let-it-run** (macro trends are slow + persistent): phase1 max_loss **18%**, **all time-cuts OFF**, `hard_timeout` **7d**; phase2 `12%→0 / 25%→45 / 45%→65 / 75%→80 / 120%→90`
+- **FADE** `margin_pct` **15%** — DSL **tight fast-capture** (a reversion resolves fast): phase1 max_loss **8%**, `weak_peak_cut` **ON** (4h @ 1.5), `dead_weight_cut` **ON** (8h), `hard_timeout` **2d**; phase2 `4%→35 / 8%→55 / 15%→70 / 28%→85`
+
+## XYZ handling
+
+Most of the macro complex is XYZ — candle fetches route with `dex="xyz"` (the
+producer keys off the `xyz:` prefix). XYZ trades 24/7 (no market-hours gating).
+The `main`/`xyz` clearinghouse sections are two VIEWS of ONE cross-margined
+wallet, so `get_positions()` takes `accountValue` ONCE via `max()` — never sums.
+
+## Risk gates (`risk.guard_rails`)
+
+| Gate | trend | fade |
+|---|---|---|
+| daily_loss_limit_pct | 12 | 10 |
+| max_entries_per_day | 4 | 12 |
+| max_consecutive_losses | 4 | 5 |
+| cooldown_minutes | 90 | 45 |
+| drawdown_halt_pct | 22 | 18 |
+| per_asset_cooldown_minutes | 360 | 120 |
+| data_retention_hours | 168 | 96 |
+| drawdown_reset_on_day_rollover | true | true |
+
+Entries and exits both use `FEE_OPTIMIZED_LIMIT` (`ensure_execution_as_taker` true).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `runtime-trend.yaml` | Trend-book runtime spec (wide let-it-run DSL) |
+| `runtime-fade.yaml` | Fade-book runtime spec (tight fast-capture DSL) |
+| `scripts/elephant-producer.py` | Book-aware producer daemon (one script, both books) |
+| `scripts/elephant_config.py` | Leg resolution + SenpiClient wrapper + helpers |
+| `config/elephant-trend-config.json` | Trend-book tunables (macro whitelist, momentum) |
+| `config/elephant-fade-config.json` | Fade-book tunables (RSI/stretch thresholds) |
+
+## Operator install
+
+See [README.md](README.md) — the two books are two daemons
+(`ELEPHANT_LEG=trend` and `ELEPHANT_LEG=fade`) on two wallets (default 60/40
+trend/fade funding), each with its own runtime YAML.
+
+## Hard rule for user-conversation Claude sessions
+
+User-conversation Claude sessions MUST NOT call any of:
+`create_position`, `close_position`, `edit_position`,
+`ratchet_stop_add`, `ratchet_stop_edit`, `ratchet_stop_delete`,
+`cancel_order`, `strategy_close`, `strategy_close_positions`.
+
+These tools are reserved for the **producer daemon** (entry path) and the
+**DSL ratchet engine** (exit path). User-conversation sessions are
+**read-only**. Each producer daemon handles real signals on its next tick.
+
+## License
+
+Apache-2.0 — Copyright 2026 Senpi (https://senpi.ai)

--- a/elephant/config/elephant-fade-config.json
+++ b/elephant/config/elephant-fade-config.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "ELEPHANT v1.0 FADE book — macro mean-reversion leg of the global-macro fund. Each tick scores the macro whitelist (XYZ equity indices / metals / energy / FX + BTC, intersected with the live board) on short-TF over-extension: picks the more-extreme side (oversold -> LONG, overbought -> SHORT) from 1h RSI extreme + stretch from the 20-bar 1h MA, with a 4h regime filter (never fades a strong macro trend — knife guard). BOTH directions. Leverage clamped to maxLeverage then HL venue max. Pairs with the TREND book (elephant-trend-config.json) on a SEPARATE wallet. Set wallet/strategyId/chatId. Runtime owns position tracking, caps, cooldowns, DSL via runtime-fade.yaml. Producer launched with ELEPHANT_LEG=fade.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "allowedAssets": ["BTC", "xyz:SP500", "xyz:XYZ100", "xyz:JP225", "xyz:KR200", "xyz:NIFTY", "xyz:IBOV", "xyz:GOLD", "xyz:SILVER", "xyz:PLATINUM", "xyz:COPPER", "xyz:BRENTOIL", "xyz:CL", "xyz:NATGAS", "xyz:EUR", "xyz:JPY", "xyz:GBP", "xyz:DXY"],
+  "minScore": 4,
+  "marginPct": 0.15,
+  "maxLeverage": 5,
+  "maxSlots": 3,
+  "minNotionalUsd": 200,
+  "tickSeconds": 300,
+  "rsiOversold": 30,
+  "rsiOverbought": 70,
+  "stretchThresholdPct": 1.0,
+  "_persona": "Global-macro mean-reversion — fades RSI extremes + stretch on the macro complex back toward the mean, with a 4h knife guard so it never fights a strong macro trend, both directions, strict 5x, tight fast-capture DSL. allowedAssets is the macro complex; names not live on the board are skipped automatically."
+}

--- a/elephant/config/elephant-trend-config.json
+++ b/elephant/config/elephant-trend-config.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "ELEPHANT v1.0 TREND book — macro trend leg of the global-macro fund. Each tick scores the macro whitelist (XYZ equity indices / metals / energy / FX + BTC, intersected with the live instrument board) on its medium-term multi-timeframe trend: the 4h structure is the macro backbone (BULLISH -> LONG, BEARISH -> SHORT, NEUTRAL -> skip), confirmed by 1h structure + 24h momentum + RSI room. BOTH directions. Leverage clamped to maxLeverage then each asset's HL venue max (indices/metals/FX cap low). Pairs with the FADE book (elephant-fade-config.json) on a SEPARATE wallet. Set wallet/strategyId/chatId. Runtime owns position tracking, caps, cooldowns, DSL via runtime-trend.yaml. Producer launched with ELEPHANT_LEG=trend.",
+  "strategyId": "",
+  "wallet": "",
+  "chatId": "",
+  "allowedAssets": ["BTC", "xyz:SP500", "xyz:XYZ100", "xyz:JP225", "xyz:KR200", "xyz:NIFTY", "xyz:IBOV", "xyz:GOLD", "xyz:SILVER", "xyz:PLATINUM", "xyz:COPPER", "xyz:BRENTOIL", "xyz:CL", "xyz:NATGAS", "xyz:EUR", "xyz:JPY", "xyz:GBP", "xyz:DXY"],
+  "minScore": 5,
+  "marginPct": 0.18,
+  "maxLeverage": 5,
+  "maxSlots": 3,
+  "minNotionalUsd": 200,
+  "tickSeconds": 300,
+  "momThresholdPct": 1.5,
+  "rsiOverbought": 75,
+  "rsiOversold": 25,
+  "_persona": "Global-macro trend — rides clean multi-day trends on indices/metals/energy/FX + BTC, both directions, strict 5x, WIDE let-it-run DSL (macro trends are slow + persistent). allowedAssets is the macro complex; names not live on the board are skipped automatically."
+}

--- a/elephant/references/skill-attribution.md
+++ b/elephant/references/skill-attribution.md
@@ -1,0 +1,68 @@
+# Elephant — Skill Attribution
+
+**Skill:** elephant-strategy v1.0.0
+**Author:** jason-goldberg
+**License:** Apache-2.0
+**Created:** 2026-06-03
+
+## What Elephant is
+
+The **Global Macro** pillar — the fourth and final of the four hedge-fund
+agents complementing Spider (directional). Octopus is Relative-Value; Camel is
+Carry; Caracal is Volatility; Elephant is Global Macro. Elephant adds a
+cross-asset macro return stream over the asset classes none of the other funds
+focus on — equity indices, precious metals, energy, FX — plus BTC as the macro
+risk asset.
+
+## Lineage
+
+- **Architecture** — the Spider/Octopus/Camel/Caracal helpers-native two-leg
+  pattern: ONE leg-parameterized producer (`ELEPHANT_LEG`), two wallets, two
+  runtime YAMLs, `producer_daemon` + fcntl lock, `SenpiClient.push_signal()`
+  ingest, runtime-owned LLM gate + DSL + risk.
+- **Thesis** — global macro: the cross-asset complex moves on regime, not crypto
+  noise. A `trend` book rides the durable macro direction (multi-TF trend); a
+  `fade` book catches macro over-extensions reverting to regime.
+
+## Design decisions specific to Elephant
+
+- **The universe is the differentiator.** A curated macro whitelist (XYZ
+  indices / metals / energy / FX + BTC), intersected with the live instrument
+  board so dead names are skipped. Deliberately excludes AI/Tech equities (those
+  are Spider's domain) — Elephant is the *macro* complex, not single stocks.
+- **Two complementary books, both bidirectional.** Trend and fade on the same
+  universe but different timeframes/conditions (4h backbone trend vs 1h RSI/
+  stretch reversion) — they never contradict because they operate on different
+  signals and separate wallets. Together they harvest macro across regimes.
+- **Theme-aware, not theme-chasing.** Oil/Iran shows up as an *energy macro
+  trend* (or a fade of an over-extension); the AI-equity bid shows up as an
+  *index macro trend*. Elephant trades these as macro direction/reversion, never
+  as a momentum chase of the headline.
+- **Asymmetric DSL by book.** Trend = wide let-it-run (macro trends are slow +
+  persistent; all time-cuts off, 7d timeout). Fade = tight fast-capture (a
+  reversion resolves fast or the thesis failed; stall-cuts on, 2d timeout).
+
+## Fleet-standard compliance
+
+- Max leverage **5x** (strict clamp + runtime gate defense; indices/metals/FX
+  cap lower at venue and the clamp respects it).
+- Per-position margin **18% (trend) / 15% (fade)** (≤ 25% fleet cap).
+- Drawdown halt **22% (trend) / 18% (fade)**, `drawdown_reset_on_day_rollover: true`.
+- Mandatory DSL; entries + exits use `FEE_OPTIMIZED_LIMIT` with taker fallback.
+- Verbose per-tick JSON (never silent): `scanned / candidates / signals_pushed`.
+
+## Negative-lesson inputs
+
+- **Cobra antipattern** — fixed high leverage + rotation + no drawdown gate.
+  Elephant: strict 5x, low turnover on the trend book (slow macro, 4 entries/day),
+  hard drawdown halt.
+- **Fees are the biggest killer** — the trend book is fee-efficient (slow,
+  let-it-run); the fade book is the higher-turnover one and is funded smaller
+  (40%) and capped tighter (`per_asset_cooldown` 120m) to keep fees in check.
+- **XYZ markets trade 24/7** — no market-hours gating; the macro complex
+  (indices/metals/oil) stays active through weekends.
+
+## Capital provenance
+
+New capital, funded **60/40** across the trend and fade wallets (the
+fee-efficient trend engine carries the larger share).

--- a/elephant/runtime-fade.yaml
+++ b/elephant/runtime-fade.yaml
@@ -1,0 +1,187 @@
+name: elephant-fade-tracker
+# Top-level `version` is the SCHEMA version the senpi-trading-runtime
+# plugin expects (major=1). Skill version is "Elephant v1.0" — lives in
+# description + SKILL.md + _elephant_producer_version.
+version: 1.0.0
+description: >
+  ELEPHANT v1.0 (FADE book) — global-macro mean-reversion.
+
+  One of two macro books. This book fades short-TF over-extensions on the
+  cross-asset macro complex (XYZ equity indices / metals / energy / FX + BTC)
+  back toward the mean: it picks the more-extreme side (oversold -> LONG,
+  overbought -> SHORT) from 1h RSI extreme + stretch from the 20-bar MA, with a
+  4h regime filter (knife guard) so it never fades a strong macro trend. BOTH
+  directions. Pairs with the TREND book (runtime-trend.yaml) on a separate
+  wallet. The edge is GLOBAL MACRO over-extension reverting to regime.
+
+  Scoring (producer-side): RSI extreme, stretch from MA, 4h regime knife guard.
+  LONG oversold / SHORT overbought.
+
+  Execution envelope:
+    - slots 3, margin_pct 15
+    - strict 5x leverage clamp, then each asset's HL venue max
+    - tight fast-capture DSL: a reversion resolves fast or the thesis failed
+
+  Producer scores its universe and pushes signals via
+  SenpiClient.push_signal(); runtime LLM gate is pass-through; runtime owns
+  execution + DSL.
+
+strategy:
+  wallet: "${ELEPHANT_FADE_WALLET}"
+  # ── FUNDING SPLIT DEFAULT: TREND 60% / FADE 40% of the combined pool ──
+  # The fade book is higher-turnover and funded smaller; the trend book carries
+  # the larger share. This is a FUNDING guideline for the operator, NOT a
+  # runtime-enforced field. Per-position sizing is governed by margin_pct + slots.
+  slots: 3
+  margin_pct: 15
+  trading_risk: moderate
+  enabled: true
+
+risk:
+  data_retention_hours: 96
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 12       # mean-reversion turns over faster
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 5
+    cooldown_minutes: 45
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_minutes: 120
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: elephant_fade_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        stretchPct: { type: number, required: false }
+        rsi: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: elephant_fade_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${ELEPHANT_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [elephant_fade_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: elephant_fade_signals
+    decision_prompt: |
+      You are Elephant's FADE-book pass-through gate. The producer fades
+      short-TF over-extensions on the cross-asset macro complex (indices /
+      metals / energy / FX + BTC) and emits the fade DIRECTION (LONG an
+      oversold extreme, SHORT an overbought extreme), with a 4h knife guard
+      already applied so it never fades a strong macro trend. It also applied
+      the 5x leverage clamp and held-asset dedup. Honor the signal unless malformed.
+
+      SIGNAL:
+      {{signal_elephant_fade_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (preserve any xyz: prefix).
+      2. direction MUST be copied from signal.direction (LONG or SHORT — this book trades both).
+      3. leverage MUST be copied from signal.data.leverage.
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 4 (producer floor; defensive)
+      - leverage <= 0 OR leverage > 5 (clamp breach) OR marginUsd <= 0
+      - direction not in [LONG, SHORT]
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 6 AND no malformed fields
+      - 7-8:  score 4.5-5.9
+      - 7:    score 4-4.4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 5 xyz:GOLD SHORT 5x, RSI 78, +1.8% stretch, 4h NEUTRAL — fade a macro over-extension')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "ELEPHANT_MACRO_FADE ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — tight fast-capture mean-reversion) ──────────────────
+#
+# A reversion resolves fast or the thesis failed: tight phase1, lock the
+# snapback quickly, stall-cuts ON, 2d hard_timeout.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880           # 2d
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 240            # 4h
+      min_value: 1.5
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h
+    phase1:
+      enabled: true
+      max_loss_pct: 8.0
+      retrace_threshold: 5
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 4, lock_hw_pct: 35 }
+        - { trigger_pct: 8, lock_hw_pct: 55 }
+        - { trigger_pct: 15, lock_hw_pct: 70 }
+        - { trigger_pct: 28, lock_hw_pct: 85 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/elephant/runtime-trend.yaml
+++ b/elephant/runtime-trend.yaml
@@ -1,0 +1,188 @@
+name: elephant-trend-tracker
+# Top-level `version` is the SCHEMA version the senpi-trading-runtime
+# plugin expects (major=1). Skill version is "Elephant v1.0" — lives in
+# description + SKILL.md + _elephant_producer_version.
+version: 1.0.0
+description: >
+  ELEPHANT v1.0 (TREND book) — global-macro trend.
+
+  One of two macro books. This book scores the cross-asset macro complex
+  (XYZ equity indices / metals / energy / FX + BTC) on its medium-term
+  multi-timeframe trend — LONG clean uptrends, SHORT clean downtrends. The 4h
+  structure is the macro backbone; 1h + 24h momentum + RSI confirm. BOTH
+  directions. Pairs with the FADE book (runtime-fade.yaml) on a separate
+  wallet. The edge is GLOBAL MACRO: the cross-asset complex moves on macro
+  regime, and macro trends (oil on geopolitics, indices on the AI-equity bid,
+  metals on risk-off) are slow and clean.
+
+  Scoring (producer-side): 4h trend backbone, 1h confirmation, 24h momentum,
+  RSI room. LONG or SHORT per the macro trend.
+
+  Execution envelope:
+    - slots 3, margin_pct 18
+    - strict 5x leverage clamp, then each asset's HL venue max
+    - WIDE let-it-run DSL: macro trends are slow + persistent, so all time-cuts
+      OFF and only a 7d hard_timeout staleness backstop
+
+  Producer scores its universe and pushes signals via
+  SenpiClient.push_signal(); runtime LLM gate is pass-through; runtime owns
+  execution + DSL.
+
+strategy:
+  wallet: "${ELEPHANT_TREND_WALLET}"
+  # ── FUNDING SPLIT DEFAULT: TREND 60% / FADE 40% of the combined pool ──
+  # The trend book is the fee-efficient, let-it-run engine and carries the
+  # larger share; the fade book is higher-turnover and funded smaller. This is
+  # a FUNDING guideline for the operator, NOT a runtime-enforced field.
+  slots: 3
+  margin_pct: 18
+  trading_risk: moderate
+  enabled: true
+
+risk:
+  data_retention_hours: 168
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 4        # macro trends are slow → few new entries/day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_minutes: 90
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_minutes: 360
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval: 10s
+
+  - name: elephant_trend_signals
+    type: external_scanner
+    outputs:
+      signals: true
+      context: false
+    config:
+      fields:
+        score: { type: number, required: true }
+        leverage: { type: number, required: true }
+        marginUsd: { type: number, required: true }
+        direction: { type: string, required: true }
+        reasons: { type: array, required: false }
+        trend4h: { type: string, required: false }
+        own24h: { type: number, required: false }
+        heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: elephant_trend_entry
+    action_type: OPEN_POSITION
+    decision_mode: llm
+    decision_model: "${ELEPHANT_DECISION_MODEL}"   # REQUIRED. Bare model name only — NO provider prefix.
+    scanners: [elephant_trend_signals]
+    min_confidence: 7
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: elephant_trend_signals
+    decision_prompt: |
+      You are Elephant's TREND-book pass-through gate. The producer scores the
+      cross-asset macro complex (indices / metals / energy / FX + BTC) and emits
+      the macro trend DIRECTION (LONG a clean uptrend, SHORT a clean downtrend).
+      It already applied the 4h/1h trend scoring, the 5x leverage clamp, and
+      held-asset dedup. Honor the signal unless it is malformed.
+
+      SIGNAL:
+      {{signal_elephant_trend_signals}}
+
+      ## STRICT OUTPUT RULES — DO NOT VIOLATE
+
+      1. asset MUST be copied from signal.asset EXACTLY (preserve any xyz: prefix).
+      2. direction MUST be copied from signal.direction (LONG or SHORT — this book trades both).
+      3. leverage MUST be copied from signal.data.leverage.
+      4. marginUsd MUST be copied from signal.data.marginUsd.
+      5. Every claim in reasoning MUST cite signal values.
+
+      ## HARD SKIP CONDITIONS (output execute: false)
+
+      - score < 5 (producer floor; defensive)
+      - leverage <= 0 OR leverage > 5 (clamp breach) OR marginUsd <= 0
+      - direction not in [LONG, SHORT]
+      - signal.asset already in signal.data.heldAssets (duplicate)
+      - reasons array empty
+
+      ## CONFIDENCE SCORING
+
+      - 9-10: score >= 7 AND no malformed fields
+      - 7-8:  score 5.5-6.9
+      - 7:    score 5-5.4 (producer floor) — the signal IS the validation
+      - <7:   producer floor not cleared (should never reach you)
+
+      ## OUTPUT FORMAT
+
+      {
+        "execute": true OR false,
+        "actionType": "OPEN_POSITION",
+        "confidence": integer 1-10,
+        "reasoning": "concrete sentence citing signal values (e.g. 'score 7 xyz:BRENTOIL LONG 5x, 4h BULLISH, 1h confirm, +3.1% 24h — macro energy uptrend')",
+        "payload": {
+          "signals": [
+            {
+              "asset": "copy signal.asset EXACTLY",
+              "direction": "copy signal.direction EXACTLY",
+              "leverage": "copy signal.data.leverage EXACTLY",
+              "marginUsd": "copy signal.data.marginUsd EXACTLY",
+              "reason": "ELEPHANT_MACRO_TREND ${direction} — top reason"
+            }
+          ]
+        }
+      }
+
+# ── EXIT (DSL — wide let-macro-trends-run) ──────────────────────────
+#
+# Macro trends are slow and persistent, so ride them: wide phase1, ALL time
+# cuts OFF, and only a 7d hard_timeout staleness backstop.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10080          # 7d staleness cap
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 720
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 1440
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 12, lock_hw_pct: 0 }
+        - { trigger_pct: 25, lock_hw_pct: 45 }
+        - { trigger_pct: 45, lock_hw_pct: 65 }
+        - { trigger_pct: 75, lock_hw_pct: 80 }
+        - { trigger_pct: 120, lock_hw_pct: 90 }
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/elephant/scripts/elephant-producer.py
+++ b/elephant/scripts/elephant-producer.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+# Senpi ELEPHANT Producer v1.0.0
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under Apache-2.0
+# Source: https://github.com/Senpi-ai/senpi-skills
+"""ELEPHANT v1.0.0 Producer — global macro, two books, one script.
+
+Elephant trades the CROSS-ASSET MACRO COMPLEX — equity indices, precious
+metals, energy, FX (all on XYZ) plus BTC as the macro risk asset — which moves
+on macro regime, not crypto noise. ONE producer script serves both books; the
+ELEPHANT_LEG env var selects which:
+
+  ELEPHANT_LEG=trend  Macro trend book (BOTH directions).
+    Rides the medium-term multi-timeframe trend on the macro whitelist —
+    LONG clean uptrends, SHORT clean downtrends. Macro trends (oil on
+    geopolitics, indices on the AI-equity bid, metals on risk-off) are slow
+    and clean. Wide let-it-run DSL.
+
+  ELEPHANT_LEG=fade   Macro mean-reversion book (BOTH directions).
+    Fades short-TF stretch + RSI extremes on the same macro whitelist back
+    toward the mean, with a higher-TF regime filter so it never fades a
+    strong macro trend. Tight fast-capture DSL.
+
+The edge is GLOBAL MACRO: trade the durable macro direction (trend book) and
+the macro over-extensions (fade book). Aware of the themes (oil/Iran,
+AI-equity strength) and trading them AS macro, not as momentum chases. NOT a
+copy-trader. Each book scores its own universe and pushes signals via
+SenpiClient.push_signal(); runtime owns the LLM gate (pass-through), DSL
+exits, and all risk.guard_rails.
+
+Environment / config resolution:
+  ELEPHANT_LEG          — REQUIRED. "trend" or "fade".
+  SENPI_AUTH_TOKEN      — REQUIRED. Bearer token for MCP + signal POST.
+  ELEPHANT_TREND_WALLET — trend-book strategy wallet (or config.wallet)
+  ELEPHANT_FADE_WALLET  — fade-book strategy wallet (or config.wallet)
+  ELEPHANT_DECISION_MODEL — bare LLM model name; resolved into runtime.yaml
+  SENPI_MCP_URL         — optional, default https://mcp.prod.senpi.ai/mcp
+"""
+
+import hashlib
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import elephant_config as cfg
+
+from senpi_runtime_helpers import SenpiClientError, producer_daemon  # type: ignore  # noqa: E402
+
+
+VERSION = "1.0.0"
+LEG = cfg.LEG  # "trend" | "fade"
+SCANNER_NAME = f"elephant_{LEG}_signals"
+SIGNAL_TYPE = "ELEPHANT_MACRO_TREND" if LEG == "trend" else "ELEPHANT_MACRO_FADE"
+
+# Max raw score ~ 8 (trend) / 7 (fade).
+NORM_DIV = 9.0
+
+# Cross-asset macro whitelist (config.allowedAssets overrides). XYZ indices /
+# metals / energy / FX + BTC as the macro risk asset. Names not live on the
+# instrument board are filtered out at universe-build time.
+_MACRO_WHITELIST = [
+    "BTC",
+    "xyz:SP500", "xyz:XYZ100", "xyz:JP225", "xyz:KR200", "xyz:NIFTY", "xyz:IBOV",
+    "xyz:GOLD", "xyz:SILVER", "xyz:PLATINUM", "xyz:COPPER",
+    "xyz:BRENTOIL", "xyz:CL", "xyz:NATGAS",
+    "xyz:EUR", "xyz:JPY", "xyz:GBP", "xyz:DXY",
+]
+
+_DEFAULTS = {
+    "trend": {
+        "allowedAssets": _MACRO_WHITELIST,
+        "minScore": 5,
+        "marginPct": 0.18,
+        "maxLeverage": 5,
+        "maxSlots": 3,
+        "minNotionalUsd": 200,
+        "tickSeconds": 300,
+        "momThresholdPct": 1.5,   # 24h move for momentum confirmation (macro is slow)
+        "rsiOverbought": 75,
+        "rsiOversold": 25,
+    },
+    "fade": {
+        "allowedAssets": _MACRO_WHITELIST,
+        "minScore": 4,
+        "marginPct": 0.15,
+        "maxLeverage": 5,
+        "maxSlots": 3,
+        "minNotionalUsd": 200,
+        "tickSeconds": 300,
+        "rsiOversold": 30,
+        "rsiOverbought": 70,
+        "stretchThresholdPct": 1.0,   # macro stretch from the 20-bar MA
+    },
+}[LEG]
+
+
+def _resolve_wallet():
+    wallet, _ = cfg.get_wallet_and_strategy()
+    return wallet
+
+
+STRATEGY_ADDRESS = _resolve_wallet()
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical helpers
+# ═══════════════════════════════════════════════════════════════
+
+def _close(c):
+    return float(c.get("close", c.get("c", 0)) or 0)
+
+
+def _high(c):
+    return float(c.get("high", c.get("h", 0)) or 0)
+
+
+def _low(c):
+    return float(c.get("low", c.get("l", 0)) or 0)
+
+
+def trend_structure(candles, lookback=6):
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def simple_ma(closes, period):
+    if not closes:
+        return 0
+    window = closes[-period:] if len(closes) >= period else closes
+    return sum(window) / len(window)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers
+# ═══════════════════════════════════════════════════════════════
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def get_universe_meta():
+    data = cfg.mcp_call("market_list_instruments")
+    out, canonical = {}, []
+    if not data:
+        return out, canonical
+    insts = data.get("data", data)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict):
+            continue
+        if inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or inst.get("context", {}).get("coin")
+        if not name:
+            continue
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ctx": inst.get("context", {}) if isinstance(inst.get("context"), dict) else {},
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+        canonical.append(name)
+    return out, canonical
+
+
+def fetch_candles(asset, intervals):
+    data = cfg.mcp_call(
+        "market_get_asset_data",
+        asset=asset,
+        candle_intervals=intervals,
+        dex=_dex_for(asset),
+        include_funding=False,
+        include_order_book=False,
+    )
+    if not data or not data.get("success", True):
+        return None
+    d = data.get("data", data)
+    return {"candles": d.get("candles", {}) or {}, "ctx": d.get("asset_context", {}) or {}}
+
+
+def ret_24h(meta):
+    ctx = meta.get("ctx", {}) if meta else {}
+    try:
+        mark = float(ctx.get("markPx", 0) or 0)
+        prev = float(ctx.get("prevDayPx", 0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+    if prev <= 0 or mark <= 0:
+        return 0.0
+    return (mark - prev) / prev * 100.0
+
+
+# ═══════════════════════════════════════════════════════════════
+# TREND scoring — ride the macro multi-TF trend, both directions
+# ═══════════════════════════════════════════════════════════════
+
+def score_trend(asset, meta, config):
+    md = fetch_candles(asset, ["1h", "4h"])
+    if not md:
+        return None
+    c1 = md["candles"].get("1h", [])
+    c4 = md["candles"].get("4h", [])
+    if len(c1) < 8 or len(c4) < 6:
+        return None
+    closes1 = [_close(c) for c in c1]
+    price = closes1[-1]
+    trend4, s4 = trend_structure(c4)
+    trend1, s1 = trend_structure(c1)
+    rsi = calc_rsi(closes1)
+    own = ret_24h(meta)
+    mom = float(config.get("momThresholdPct", _DEFAULTS["momThresholdPct"]))
+    rsi_ob = float(config.get("rsiOverbought", _DEFAULTS["rsiOverbought"]))
+    rsi_os = float(config.get("rsiOversold", _DEFAULTS["rsiOversold"]))
+
+    # The 4h structure IS the macro trend; a NEUTRAL macro = no clean trend.
+    if trend4 == "BULLISH":
+        direction = "LONG"
+    elif trend4 == "BEARISH":
+        direction = "SHORT"
+    else:
+        return None
+
+    score = 3
+    reasons = [f"4h_{trend4.lower()}_{s4:.0%}"]
+
+    if (direction == "LONG" and trend1 == "BULLISH") or (direction == "SHORT" and trend1 == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirm_{s1:.0%}")
+    elif (direction == "LONG" and trend1 == "BEARISH") or (direction == "SHORT" and trend1 == "BULLISH"):
+        score -= 1
+        reasons.append("1h_against")
+
+    if direction == "LONG":
+        if own >= mom:
+            score += 2
+            reasons.append(f"mom_{own:+.1f}%")
+        elif own >= 0:
+            score += 1
+            reasons.append(f"mom_{own:+.1f}%")
+        if rsi < rsi_ob:
+            score += 1
+            reasons.append(f"rsi_room_{rsi:.0f}")
+    else:
+        if own <= -mom:
+            score += 2
+            reasons.append(f"mom_{own:+.1f}%")
+        elif own <= 0:
+            score += 1
+            reasons.append(f"mom_{own:+.1f}%")
+        if rsi > rsi_os:
+            score += 1
+            reasons.append(f"rsi_room_{rsi:.0f}")
+
+    return {
+        "coin": asset, "direction": direction, "score": score,
+        "reasons": reasons, "price": price, "rsi": rsi,
+        "trend4h": trend4, "own24h": own,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# FADE scoring — fade macro over-extensions, both directions
+# ═══════════════════════════════════════════════════════════════
+
+def score_fade(asset, meta, config):
+    md = fetch_candles(asset, ["1h", "4h"])
+    if not md:
+        return None
+    c1 = md["candles"].get("1h", [])
+    c4 = md["candles"].get("4h", [])
+    if len(c1) < 22 or len(c4) < 6:
+        return None
+    closes1 = [_close(c) for c in c1]
+    price = closes1[-1]
+    ma = simple_ma(closes1, 20)
+    stretch = ((price - ma) / ma * 100) if ma > 0 else 0
+    rsi = calc_rsi(closes1)
+    trend4, _ = trend_structure(c4)
+    rsi_os = float(config.get("rsiOversold", _DEFAULTS["rsiOversold"]))
+    rsi_ob = float(config.get("rsiOverbought", _DEFAULTS["rsiOverbought"]))
+    st = float(config.get("stretchThresholdPct", _DEFAULTS["stretchThresholdPct"]))
+
+    oversold_mag = max(rsi_os - rsi, 0) / max(rsi_os, 1) + max(-stretch, 0) / st
+    overbought_mag = max(rsi - rsi_ob, 0) / max(100 - rsi_ob, 1) + max(stretch, 0) / st
+    if oversold_mag <= 0 and overbought_mag <= 0:
+        return None
+    direction = "LONG" if oversold_mag >= overbought_mag else "SHORT"
+
+    score = 0
+    reasons = []
+    if direction == "LONG":
+        if rsi <= 20:
+            score += 3
+            reasons.append(f"rsi_{rsi:.0f}_deep_os")
+        elif rsi <= 25:
+            score += 2
+            reasons.append(f"rsi_{rsi:.0f}_os")
+        elif rsi <= rsi_os:
+            score += 1
+            reasons.append(f"rsi_{rsi:.0f}_os")
+        if -stretch >= 2 * st:
+            score += 2
+            reasons.append(f"stretch_{stretch:+.2f}%")
+        elif -stretch >= st:
+            score += 1
+            reasons.append(f"stretch_{stretch:+.2f}%")
+        # Regime filter: never fade a strong macro downtrend (knife guard).
+        if trend4 == "BULLISH":
+            score += 1
+            reasons.append("macro_uptrend_dip")
+        elif trend4 == "BEARISH":
+            score -= 2
+            reasons.append("macro_downtrend_knife")
+    else:
+        if rsi >= 80:
+            score += 3
+            reasons.append(f"rsi_{rsi:.0f}_deep_ob")
+        elif rsi >= 75:
+            score += 2
+            reasons.append(f"rsi_{rsi:.0f}_ob")
+        elif rsi >= rsi_ob:
+            score += 1
+            reasons.append(f"rsi_{rsi:.0f}_ob")
+        if stretch >= 2 * st:
+            score += 2
+            reasons.append(f"stretch_{stretch:+.2f}%")
+        elif stretch >= st:
+            score += 1
+            reasons.append(f"stretch_{stretch:+.2f}%")
+        if trend4 == "BEARISH":
+            score += 1
+            reasons.append("macro_downtrend_rip")
+        elif trend4 == "BULLISH":
+            score -= 2
+            reasons.append("macro_uptrend_knife")
+
+    return {
+        "coin": asset, "direction": direction, "score": score,
+        "reasons": reasons, "price": price, "rsi": rsi,
+        "trend4h": trend4, "stretchPct": stretch,
+    }
+
+
+# ═══════════════════════════════════════════════════════════════
+# Leverage clamp + emit
+# ═══════════════════════════════════════════════════════════════
+
+def clamp_leverage(desired, meta):
+    venue = (meta or {}).get("max_leverage")
+    try:
+        venue = int(venue)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))
+
+
+def push_signal(thesis, margin_usd, leverage, held_assets):
+    if not STRATEGY_ADDRESS:
+        cfg.log("ERROR: strategy wallet not resolved")
+        return False
+    if thesis["coin"].upper() in {h.upper() for h in held_assets}:
+        return False
+
+    data_block = {
+        "score": thesis["score"],
+        "leverage": leverage,
+        "marginUsd": margin_usd,
+        "direction": thesis["direction"],
+        "reasons": thesis["reasons"],
+        "heldAssets": held_assets,
+        "trend4h": thesis.get("trend4h"),
+    }
+    if LEG == "trend":
+        data_block["own24h"] = round(thesis.get("own24h", 0), 2)
+    else:
+        data_block["stretchPct"] = round(thesis.get("stretchPct", 0), 3)
+        data_block["rsi"] = round(thesis.get("rsi", 0), 1)
+
+    try:
+        cfg._wrapper_client.push_signal(
+            address=STRATEGY_ADDRESS,
+            scanner=SCANNER_NAME,
+            asset=thesis["coin"],
+            direction=thesis["direction"],
+            score=min(thesis["score"] / NORM_DIV, 1.0),
+            signal_type=SIGNAL_TYPE,
+            data=data_block,
+        )
+        return True
+    except SenpiClientError as e:
+        cfg.log(f"INGEST_REJECTED {thesis['coin']}: {e}")
+        return False
+    except Exception as e:  # noqa: BLE001
+        cfg.log(f"INGEST_EXCEPTION {thesis['coin']}: {type(e).__name__}: {e}")
+        return False
+
+
+# ═══════════════════════════════════════════════════════════════
+# Universe — static macro whitelist, intersected with the live board
+# ═══════════════════════════════════════════════════════════════
+
+def build_universe(config, meta_map):
+    """Macro whitelist (config.allowedAssets) intersected with the live
+    instrument board so dead/unavailable names are skipped."""
+    wl = config.get("allowedAssets", _DEFAULTS["allowedAssets"])
+    out = []
+    for name in wl:
+        if not isinstance(name, str):
+            continue
+        if meta_map.get(name) or meta_map.get(name.upper()):
+            out.append(name)
+    return out
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN — single tick. NO inner scanner_lock; daemon owns it.
+# ═══════════════════════════════════════════════════════════════
+
+def main():
+    run_start = time.time()
+    config = cfg.load_config()
+
+    if not STRATEGY_ADDRESS:
+        cfg.output({"status": "error", "reason": "no_wallet", "leg": LEG,
+                    "_elephant_producer_version": VERSION})
+        return
+
+    account_value, positions = cfg.get_positions(STRATEGY_ADDRESS)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+    if account_value <= 0:
+        cfg.output({"status": "ok", "leg": LEG, "note": "no account value",
+                    "_elephant_producer_version": VERSION})
+        return
+
+    min_score = config.get("minScore", _DEFAULTS["minScore"])
+    margin_pct = config.get("marginPct", _DEFAULTS["marginPct"])
+    max_lev = config.get("maxLeverage", _DEFAULTS["maxLeverage"])
+    max_slots = config.get("maxSlots", _DEFAULTS["maxSlots"])
+    min_notional = config.get("minNotionalUsd", _DEFAULTS["minNotionalUsd"])
+
+    open_slots = max_slots - len(held_assets)
+    if open_slots <= 0:
+        cfg.output({"status": "ok", "leg": LEG, "note": "slots full",
+                    "held_assets": held_assets, "max_slots": max_slots,
+                    "_elephant_producer_version": VERSION})
+        return
+
+    meta_map, _canonical = get_universe_meta()
+    universe = build_universe(config, meta_map)
+
+    candidates = []
+    recently_skipped = []
+    for name in universe:
+        if name.upper() in held_set:
+            continue
+        if cfg.was_recently_signaled(name):
+            recently_skipped.append(name)
+            continue
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue
+        thesis = score_trend(name, meta, config) if LEG == "trend" else score_fade(name, meta, config)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        cfg.output({
+            "status": "ok", "leg": LEG,
+            "scanned": len(universe), "candidates": 0, "signals_pushed": 0,
+            "min_score": min_score, "held_assets": held_assets,
+            "recently_signaled_skipped": recently_skipped,
+            "note": f"WAITING — no macro name cleared min score {min_score}",
+            "elapsed_sec": round(time.time() - run_start, 2),
+            "_elephant_producer_version": VERSION,
+        })
+        return
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    to_emit = candidates[:open_slots]
+    margin_usd = round(account_value * margin_pct, 2)
+
+    pushed = 0
+    emitted = []
+    for th in to_emit:
+        leverage = clamp_leverage(max_lev, th["_meta"])
+        notional = margin_usd * leverage
+        if leverage <= 0 or notional < min_notional:
+            continue
+        if push_signal(th, margin_usd, leverage, held_assets):
+            pushed += 1
+            cfg.record_signal(th["coin"])
+            emitted.append({
+                "coin": th["coin"], "direction": th["direction"],
+                "score": th["score"], "leverage": leverage,
+                "margin_usd": margin_usd, "reasons": th["reasons"][:6],
+            })
+
+    cfg.output({
+        "status": "ok", "leg": LEG,
+        "scanned": len(universe), "candidates": len(candidates),
+        "open_slots": open_slots, "signals_pushed": pushed, "emitted": emitted,
+        "held_assets": held_assets, "recently_signaled_skipped": recently_skipped,
+        "account_value": round(account_value, 2),
+        "elapsed_sec": round(time.time() - run_start, 2),
+        "_elephant_producer_version": VERSION,
+    })
+
+
+if __name__ == "__main__":
+    _lock_id = hashlib.sha256(
+        (STRATEGY_ADDRESS or LEG).lower().encode()
+    ).hexdigest()[:12]
+    _tick = int(cfg.load_config().get("tickSeconds", _DEFAULTS["tickSeconds"]))
+    producer_daemon(
+        fn=main,
+        interval_seconds=_tick,
+        name=f"elephant-{LEG}-producer-{_lock_id}",
+        tick_timeout=min(180, max(30, _tick - 10)),
+    )

--- a/elephant/scripts/elephant_config.py
+++ b/elephant/scripts/elephant_config.py
@@ -1,0 +1,336 @@
+"""ELEPHANT v1.0 — Shared config + MCP shim + helpers wrapper (LEG-AWARE).
+
+ELEPHANT — Global-Macro Hedge Fund. ONE producer script driven by the
+ELEPHANT_LEG env var into one of two macro books (BOTH directions) over the
+cross-asset macro complex — equity indices, precious metals, energy, FX (all
+on XYZ) plus BTC as the macro risk asset — each bound to its own wallet +
+runtime + DSL:
+
+  ELEPHANT_LEG=trend -> Macro trend book. Rides the medium-term multi-TF
+                       trend on the macro whitelist — LONG clean uptrends,
+                       SHORT clean downtrends. Macro trends (oil on
+                       geopolitics, indices on the AI-equity bid, metals on
+                       risk-off) are slow and clean. Wide let-it-run DSL.
+                       config/elephant-trend-config.json -> elephant_trend_signals
+  ELEPHANT_LEG=fade  -> Macro mean-reversion book. Fades short-TF stretch +
+                       RSI extremes on the same macro whitelist back toward
+                       the mean, with a higher-TF regime filter (never fades a
+                       strong macro trend). Tight fast-capture DSL.
+                       config/elephant-fade-config.json -> elephant_fade_signals
+
+The edge is GLOBAL MACRO: the cross-asset complex (indices / metals / energy /
+FX / BTC) moves on macro regime, not crypto noise. The trend book rides the
+durable macro direction; the fade book catches macro over-extensions. It is
+AWARE of the themes (oil/Iran, AI-equity strength) and trades them as macro,
+not as momentum chases. Each book is a single macro scorer, BOTH directions.
+
+This module owns: leg resolution, config load, the senpi_runtime_helpers
+client, the MCP call shim, account/position pulls, and the per-leg
+recent-signals race-dedup cache. The producer (elephant-producer.py) owns
+scoring + emit. The runtime owns the LLM gate, DSL exits, and all
+risk.guard_rails. NOT a copy-trader — each book scores its own universe.
+
+Plumbing: MCP calls + signal POSTs route through
+senpi_runtime_helpers.SenpiClient (in-process, direct HTTPS). No
+mcporter / openclaw subprocesses.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under Apache-2.0 — attribution required for derivative works
+# Source: https://github.com/Senpi-ai/senpi-skills
+
+import functools
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ─── Leg resolution ──────────────────────────────────────────
+# One script, two legs. ELEPHANT_LEG selects the config file, the
+# scanner name, the wallet env var, and the recent-signals cache.
+LEG = (os.environ.get("ELEPHANT_LEG") or "trend").strip().lower()
+if LEG not in ("trend", "fade"):
+    raise RuntimeError(
+        f"ELEPHANT_LEG must be 'trend' or 'fade' (got {LEG!r}). "
+        "Set it on the runtime host before starting the producer daemon."
+    )
+
+WORKSPACE = os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")
+SKILL_DIR = Path(WORKSPACE) / "skills" / "elephant-strategy"
+CONFIG_PATH = SKILL_DIR / "config" / f"elephant-{LEG}-config.json"
+STATE_DIR = SKILL_DIR / "state"
+RECENT_SIGNALS_PATH = STATE_DIR / f"recent-signals-{LEG}.json"
+# Generic per-leg state ledger (retained from the shared scaffold for
+# forward-compat; Elephant scans the live instrument board each tick, so it
+# does not use fresh-listing detection — these helpers are unused).
+XYZ_FIRST_SEEN_PATH = STATE_DIR / f"first-seen-{LEG}.json"
+
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Per-leg wallet / strategy env var names. The runtime YAMLs bind
+# ${ELEPHANT_TREND_WALLET} / ${ELEPHANT_FADE_WALLET}; the producer reads
+# the same names so producer and runtime always agree on the wallet.
+_WALLET_ENV = "ELEPHANT_TREND_WALLET" if LEG == "trend" else "ELEPHANT_FADE_WALLET"
+_STRATEGY_ENV = "ELEPHANT_TREND_STRATEGY_ID" if LEG == "trend" else "ELEPHANT_FADE_STRATEGY_ID"
+
+# How long after a push_signal() we treat the asset as "in-flight" and
+# refuse to re-emit. 180s = 3x the typical ALO open fill window. Covers
+# the race between push_signal() returning OK and the resulting position
+# appearing in the next-tick clearinghouse pull. On-chain held-asset
+# check is the safety floor underneath this.
+RECENT_SIGNAL_TTL_SEC = 180
+
+
+# ─── senpi_runtime_helpers (lazy + auth-validated) ───
+# senpi_runtime_helpers ships inside the senpi-trading-runtime skill.
+# Global skills install under ~/.openclaw/skills/ on standard hosts
+# (e.g. /data/.openclaw/skills/ on Railway). Some setups install user
+# skills under ${OPENCLAW_WORKSPACE}/skills/. Probe both in order.
+_sdk_candidates = [
+    str(Path.home() / ".openclaw" / "skills" / "senpi-trading-runtime"),
+    str(Path(os.environ.get("OPENCLAW_WORKSPACE", "/data/workspace")) / "skills" / "senpi-trading-runtime"),
+]
+_sdk_path = next(
+    (p for p in _sdk_candidates if (Path(p) / "senpi_runtime_helpers").is_dir()),
+    _sdk_candidates[0],
+)
+if _sdk_path not in sys.path:
+    sys.path.insert(0, _sdk_path)
+from senpi_runtime_helpers import SenpiClient, log_event  # type: ignore  # noqa: E402
+
+
+@functools.lru_cache(maxsize=1)
+def _get_wrapper_client() -> SenpiClient:
+    if not os.environ.get("SENPI_AUTH_TOKEN", "").strip():
+        raise RuntimeError(
+            "SENPI_AUTH_TOKEN is not set. Elephant's MCP calls and signal "
+            "POST both require it. Set it on the runtime host before "
+            "starting the producer daemon."
+        )
+    client = SenpiClient()
+    log_event("elephant_wrapper_enabled", leg=LEG, sdk_path=_sdk_path)
+    return client
+
+
+class _WrapperClientProxy:
+    def __getattr__(self, name: str):
+        return getattr(_get_wrapper_client(), name)
+
+
+_wrapper_client = _WrapperClientProxy()
+
+
+# ─── Atomic Write ────────────────────────────────────────────
+
+def atomic_write(path, data):
+    """Write JSON atomically via tmp file + os.replace."""
+    path = str(path)
+    dir_name = os.path.dirname(path) or "."
+    os.makedirs(dir_name, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, default=str)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+def load_config():
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {}
+
+
+def get_wallet_and_strategy():
+    """Resolve (wallet, strategyId) — leg env var first, config.json second."""
+    wallet = os.environ.get(_WALLET_ENV, "").strip()
+    strategy_id = os.environ.get(_STRATEGY_ENV, "").strip()
+    if not wallet or not strategy_id:
+        config = load_config()
+        wallet = wallet or (config.get("wallet") or "").strip()
+        strategy_id = strategy_id or (config.get("strategyId") or "").strip()
+    return wallet, strategy_id
+
+
+# ─── MCP Helper ──────────────────────────────────────────────
+
+def mcp_call(tool, **params):
+    """Direct MCP call via SenpiClient (in-process HTTPS). Returns the
+    unwrapped JSON document on success, or None if the wrapper raised."""
+    try:
+        return _wrapper_client.mcp_call(tool, **params)
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(
+            f"[elephant-v1:{LEG}] mcp_call_failed tool={tool} "
+            f"err={type(e).__name__}: {e}\n"
+        )
+        return None
+
+
+# Backward-compat alias — keeps legacy `cfg.mcporter_call(...)` call
+# sites working even though the transport is in-process now.
+mcporter_call = mcp_call
+
+
+def get_clearinghouse(wallet):
+    if not wallet:
+        return None
+    return mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet)
+
+
+def get_positions(wallet):
+    """Returns (account_value, [position_dicts]).
+
+    The 'main' and 'xyz' clearinghouse sections are TWO VIEWS of ONE
+    cross-margined Senpi wallet, NOT two separate collateral silos. Both
+    views report the SAME marginSummary.accountValue (the whole wallet's
+    equity). So account_value is taken ONCE via max() across the two
+    sections — never summed. Summing double-counts the balance and makes
+    every position size 2x too large (margin_usd = account_value *
+    margin_pct downstream). max() is exact whether the views mirror
+    (equal → max is the shared value), one view is empty/0 (the populated
+    view wins), or positions are open on both sub-DEXs (still one shared
+    cross-margin balance). assetPositions ARE per-sub-DEX, so those are
+    still enumerated across both sections.
+    """
+    ch = get_clearinghouse(wallet)
+    if not ch:
+        return 0, []
+    data = ch.get("data", ch)
+    positions, account_value = [], 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "upnl": float(pos.get("unrealizedPnl", 0) or 0),
+                "margin": float(pos.get("marginUsed", 0) or 0),
+                "entryPrice": float(pos.get("entryPx", 0) or 0),
+                "size": abs(szi),
+            })
+    return account_value, positions
+
+
+# ─── recent-signals cache (held-asset dedup race-fix) ─────────
+#
+# Each successful push_signal(coin) writes {coin: epoch_seconds} to
+# recent-signals-<leg>.json. The producer checks this BEFORE scoring and
+# skips coins seen within RECENT_SIGNAL_TTL_SEC. This covers the gap
+# between push_signal returning OK and the resulting position appearing
+# in the next-tick clearinghouse pull. The on-chain held-asset check
+# (get_positions) is the safety floor underneath.
+
+def _read_recent_signals():
+    if not RECENT_SIGNALS_PATH.exists():
+        return {}
+    try:
+        with open(RECENT_SIGNALS_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def _prune_recent_signals(signals, now):
+    """Drop entries older than 4x TTL to keep the file bounded."""
+    cutoff = now - (RECENT_SIGNAL_TTL_SEC * 4)
+    return {k: v for k, v in signals.items() if v >= cutoff}
+
+
+def record_signal(coin):
+    """Mark `coin` as recently signaled. Writes atomically."""
+    if not coin:
+        return
+    now = time.time()
+    signals = _prune_recent_signals(_read_recent_signals(), now)
+    signals[coin.upper()] = now
+    try:
+        atomic_write(RECENT_SIGNALS_PATH, signals)
+    except OSError:
+        pass
+
+
+def was_recently_signaled(coin, ttl_sec=RECENT_SIGNAL_TTL_SEC):
+    """True if `coin` was pushed within `ttl_sec`."""
+    if not coin:
+        return False
+    signals = _read_recent_signals()
+    last = signals.get(coin.upper())
+    if last is None:
+        return False
+    return (time.time() - last) < ttl_sec
+
+
+# ─── first-seen cache (generic; retained from the shared scaffold) ─────
+#
+# UNUSED by Elephant — kept for forward-compat with the shared producer
+# scaffold. Elephant scores a static macro whitelist each tick, so it
+# needs no fresh-listing detection. A derivative
+# that wants new-listing auto-catch can record when each instrument first
+# appeared. A name younger than a freshness window is auto-eligible even if it
+# isn't in the curated include-set. On the very first run (no state file)
+# every current name is treated as already-old so the auto-catch doesn't
+# fire across the whole board at once — only names that appear AFTER
+# deploy are "fresh".
+
+def read_first_seen():
+    """Return {name: epoch_seconds} of when each instrument was first seen."""
+    if not XYZ_FIRST_SEEN_PATH.exists():
+        return {}
+    try:
+        with open(XYZ_FIRST_SEEN_PATH) as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return {k: float(v) for k, v in data.items() if isinstance(v, (int, float))}
+    except (json.JSONDecodeError, OSError, ValueError):
+        return {}
+
+
+def write_first_seen(data):
+    """Persist the first-seen map atomically. Best-effort."""
+    try:
+        atomic_write(XYZ_FIRST_SEEN_PATH, data)
+    except OSError:
+        pass
+
+
+def output(data):
+    print(json.dumps(data, default=str))
+    sys.stdout.flush()
+
+
+def log(msg):
+    print(f"[elephant-v1:{LEG}] {msg}", file=sys.stderr, flush=True)
+
+
+def now_ts():
+    return time.time()
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -879,6 +879,29 @@ surge   = true_range(c[-1]) / atr(c[-31:], 30)          # >= 1.3-2.0x = real exp
 
 ---
 
+### 18. Global macro / cross-asset
+
+Trades the **macro asset complex** — equity indices, precious metals, energy, FX (all on XYZ) plus BTC as the macro risk asset — which moves on macro *regime* rather than crypto noise. A curated whitelist, intersected with the live board so unavailable names are skipped. Distinct from the crypto-native funds: the only archetype focused on the cross-asset macro classes, deliberately excluding single AI/Tech stocks (Spider's domain).
+
+```python
+# trend book: the 4h structure IS the macro trend; confirm + ride.
+trend4 = trend_structure(c4)            # BULLISH->LONG, BEARISH->SHORT, NEUTRAL->skip
+score  = 3 + confirm(1h) + momentum(24h) + rsi_room
+# fade book: fade short-TF over-extension with a 4h regime knife guard.
+side   = "LONG" if oversold(rsi,stretch) else "SHORT"
+score  = rsi_extreme + stretch - knife_guard(against a strong macro trend)
+```
+
+**When to use this pattern:** you want a low-correlation, regime-driven return stream over indices / metals / energy / FX — the global-macro / managed-futures lane — rather than a single-asset or crypto-only book. Two complementary sub-books (trend rides, fade reverts) keep it engaged across regimes.
+
+**Agents in this family:**
+
+| Agent | Version | Asset / Universe | Description | Tags |
+|---|---|---|---|---|
+| **Elephant** | v1.0 | XYZ indices/metals/energy/FX + BTC (trend + fade books) | **Global-Macro Hedge Fund.** Two books on two wallets, one leg-parameterized producer (`ELEPHANT_LEG`): **trend** rides the medium-term multi-TF macro trend (4h backbone + 1h + 24h momentum), **fade** fades short-TF macro over-extensions back to regime (1h RSI/stretch with a 4h knife guard). Both directions. Curated macro whitelist intersected with the live board. Theme-aware (oil/Iran energy trend, AI-equity index bid) but trades them AS macro, not chases. Trend = wide let-it-run DSL (18% phase1, time-cuts OFF, 7d timeout); fade = tight fast-capture (8% phase1, stall-cuts ON, 2d timeout). Strict 5x; 24/7 (XYZ). | Global-macro, Cross-asset, Trend+fade, Both-direction, Two-wallet, 24/7 |
+
+---
+
 ## Decision tree — help a user pick their first strategy
 
 This is the guided path an **onboarding agent** walks a new user through. Start broad ("what kind of trader do you want your agent to be?"), narrow **one layer at a time**, and land on a single deployable strategy. Ask one question, show 2–6 options, let them pick, then go deeper. Each leaf names a **real, installable agent** — beginners are routed to the **onboarding tier** (simpler scoring, conservative sizing); the *level up* line is the full-fleet version for once they're comfortable.


### PR DESCRIPTION
The **Global-Macro** pillar — fund 4 of 4, completing the hedge-fund family. New `global-macro` archetype.

**Thesis:** trades the cross-asset macro complex — XYZ equity indices / metals / energy / FX + BTC — the asset classes none of the other funds focus on (deliberately excludes AI/Tech single stocks = Spider's domain). The **trend** book rides the medium-term multi-TF macro trend; the **fade** book fades short-TF macro over-extensions back to regime (with a 4h knife guard). Both directions. Theme-aware (oil/Iran, the AI-equity index bid) but trades them AS macro, not chases.

**Asymmetric DSL by book:** trend = wide let-it-run (18% phase1, time-cuts off, 7d); fade = tight fast-capture (8% phase1, stall-cuts on, 2d). Strict 5x; 24/7 (XYZ). py_compile + JSON valid; 18-name macro whitelist; no stale caracal paths; leverage ≤5. Registered in catalog (new group) + README §18 + producer-patterns §18.

**Completes the 4-fund family:** Octopus (Relative-Value) · Camel (Carry) · Caracal (Volatility) · Elephant (Global Macro) — four classic hedge-fund pillars complementing Spider's directional book.

🤖 Generated with [Claude Code](https://claude.com/claude-code)