### PR TITLE
docs: "AI Hedge Funds" first-class category

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,9 +330,23 @@ Each tool's full schema (params, types, response shape) is in the MCP server its
 
 # Trading Strategy Skills
 
-The fleet — **44 skills across 16 producer archetypes**. Every skill targets runtime **1.1.0**. Bucketing matches [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md), the canonical archetype catalog.
+The fleet — Senpi's flagship **AI Hedge Funds** plus a deep bench of single-strategy archetypes. Every skill targets runtime **1.1.0**. Archetype bucketing matches [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md), the canonical archetype catalog.
 
 Each row links to the skill's directory.
+
+## 🏦 AI Hedge Funds — flagship multi-strategy
+
+Senpi's flagship line. Each fund runs **two complementary strategy books on two wallets** under one producer — a real multi-strategy fund, not a single scanner — with its own built-in risk controls. Pick the style that fits your market view.
+
+| Fund | Style | Books | Description |
+|---|---|---|---|
+| [spider](spider/) | AI/Tech | AI/Tech momentum (long) + macro/majors mean-reversion (both ways) | Buys the strongest AI & tech names — including brand-new listings the day they appear — and rides winners for days; a faster book trades majors + oil both ways for quick profits. |
+| [octopus](octopus/) | Market-Neutral | Long leaders + short laggards | Longs the strongest and shorts the weakest of the liquid crypto cross-section at once — profits from the **gap** (dispersion), ~beta-neutral, in any market. |
+| [camel](camel/) | Carry | +funding shorts + −funding longs | Gets **paid to hold** — systematically collects the funding the crowd pays, on positions where the crowd is exhausting. Steady income, both directions. |
+| [caracal](caracal/) | Volatility | Crypto breakouts + XYZ catalyst breakouts | Waits for a market to coil, then rides the breakout **either way** — across crypto and stocks/oil/gold, 24/7. Episodic: most ticks empty by design. |
+| [elephant](elephant/) | Global Macro | Macro trend + macro fade | Trades the cross-asset macro complex — equity indices, metals, energy, FX + BTC — riding macro trends and fading the overreactions. Both directions, 24/7. |
+
+Each fund's individual books are also catalogued under their trading-edge archetype below.
 
 ## 🎯 Onboarding tier — new to Senpi? Start here.
 
@@ -437,8 +451,6 @@ Strict whitelist of 3–6 majors, best-of-N selection per tick.
 | [iguana](iguana/) | v1.0 | xyz:SP500 · xyz:XYZ100 | **Onboarding — XYZ index basket.** The simplest XYZ exposure — just the broad indices. Picks whichever has the stronger 4-day move past 1.5% and trades its direction. Balanced DSL + 48h hard_timeout. |
 | [sailfish](sailfish/) | v1.0 | BTC · ETH · SOL · HYPE | **Relative-strength rotator.** Ranks the universe by ~2.7d RS each tick; longs the leader iff leader RS ≥ 1% AND beats runner-up by ≥ 1.5pp (no whipsaw). Rotation via DSL exit + re-entry. Balanced DSL + 96h hard_timeout. |
 | [stag](stag/) | v1.0 | BTC · ETH · SOL · HYPE (often single-asset) | **Parabolic-run hunter.** Entry-side pair for the new `parabolic_runner` DSL preset (widest in the catalog: max_loss 25%, retrace 18, 2 breaches required, 14d outer bound). Strict 5-gate filter (200-SMA + 7d ≥25% + vol surge + acceleration + SM ≥60% LONG). LONG only. Operator-driven — most ticks return empty by design. Reference: HYPE 2026-05 (+60% in 16 days). |
-| [spider](spider/) | v5.1.1 | AI/Tech XYZ equities + crypto alts (swing) · BTC · ETH · SOL · HYPE + xyz:BRENTOIL/CL (scalp) | **AI/Tech hedge fund.** Two style legs on two wallets, one producer: a LONG-only AI/Tech momentum book (dynamic XYZ-equity universe, auto-catches fresh IPO/pre-IPO listings, 10x, wide let-winners-run DSL) **plus** a both-directions macro/majors mean-reversion counter-trading book (strict 5x, tight fast-capture DSL). Each leg scores its own universe; runtime owns LLM gate, DSL exits, and risk. |
-
 ## 5. Trader-follower / hot-streak
 
 Top-trader pool + conviction-gated coat-tail entries.
@@ -470,8 +482,6 @@ Persistent funding extremity → fade the crowd at exhaustion.
 | [pangolin](pangolin/) | v1.4 | Multi (OI > $3M) | Funding extremity + persistence + SM positioning + cooldowns. Quiet-hours gating (00–04 UTC). |
 | [dog](dog/) | v2.0 | 4-coin whitelist | Funding fade on 4-coin watchlist with regime hard-gate. |
 | [vulture](vulture/) | v2.3 | HYPE | HYPE funding-regime contrarian. Funding-history + held-position enrichment. |
-| [camel](camel/) | v1.0 | Liquid crypto cross-section (harvest + payout books) | **Carry Hedge Fund.** Two equally-funded single-direction books, one producer: the **harvest** book shorts the most-positive-funding names (short collects), the **payout** book longs the most-negative-funding names (paid to hold) — each gated to an *exhausting* crowd so price doesn't fight the carry. The edge is funding **carry** (recurring income), not direction. Funding read from the instrument board (no ClickHouse dependency). Strict 5x, tighter carry DSL. |
-
 ## 8. Contrarian crowding-unwind hunter
 
 Wait for crowd to overcommit AND exhaustion signals; enter opposite.
@@ -524,8 +534,6 @@ Trade the spread between two correlated assets, not a single asset's direction.
 | Skill | Version | Asset / Universe | Description |
 |---|---|---|---|
 | [chameleon](chameleon/) | v1.0 | ETH/BTC · SOL/ETH · SOL/BTC | Ratio mean-reversion — trades the high-beta leg when a pair's ratio z-score extends past ~2σ and starts reverting. Single-position directional bet (not a two-leg spread). Mean-reversion DSL (tight ladder, 48h). |
-| [octopus](octopus/) | v1.0 | Liquid crypto cross-section (long + short books) | **Market-Neutral Hedge Fund.** Two equally-funded single-direction books on two wallets, one producer: longs the relative leaders (top relative-strength, trend-confirmed) and shorts the relative laggards (bottom RS, trend-confirmed) of the liquid main-DEX cross-section. Net ~beta-neutral — harvests **dispersion** (leaders minus laggards), not market direction. Strict 5x, moderate DSL with stall-cuts ON. |
-
 ## 14. Meta-strategy follower / copy-the-copiers
 
 Follow not individual traders but the top-performing **strategies** — and trade their performance-weighted consensus.
@@ -550,21 +558,7 @@ Watches macro conditions and **classifies the market** into TREND_UP / TREND_DOW
 |---|---|---|---|
 | [coyote](coyote/) | v1.0 | BTC (positional) + universe (dispersion) | 3-regime classifier (TREND_UP / TREND_DOWN / CHOP) with vol-confirmation on the down side (crash = drop + vol spike, not slow grind). LONG BTC in TREND_UP, SHORT BTC in TREND_DOWN, no trade in CHOP. Regime + all 3 input metrics published on every tick. Balanced DSL. |
 
-## 17. Volatility / breakout-expansion
-
-Trades **movement, not direction** — fires when a coiled (low-volatility) name breaks its range with an expansion surge, and rides the break either way. Compression precedes expansion; a breakout from a coil follows through more than one in already-volatile tape.
-
-| Skill | Version | Asset / Universe | Description |
-|---|---|---|---|
-| [caracal](caracal/) | v1.0 | Crypto (breakout book) + XYZ (catalyst book) | **Volatility Hedge Fund.** Two books, one producer: the **breakout** book rides coiled-spring breakouts in liquid crypto; the **catalyst** book runs the same compression→expansion engine on XYZ (oil / AI-infra / metals / indices), capturing macro vol events 24/7. Requires an ATR squeeze (recent/baseline ≤ 0.7–0.9) **and** a range break **and** an expansion surge (≥1.3–2.0×). Both directions. Strict 5x, tight early-locking DSL. Episodic by design — most ticks empty. |
-
-## 18. Global macro / cross-asset
-
-Trades the macro asset complex — equity indices, precious metals, energy, FX — plus BTC as the macro risk asset. These move on macro **regime**, not crypto noise.
-
-| Skill | Version | Asset / Universe | Description |
-|---|---|---|---|
-| [elephant](elephant/) | v1.0 | XYZ indices/metals/energy/FX + BTC (trend + fade books) | **Global-Macro Hedge Fund.** Two books, one producer, over a curated macro whitelist: the **trend** book rides the medium-term multi-TF macro trend (4h backbone + 1h + momentum), the **fade** book fades short-TF macro over-extensions back to regime (RSI/stretch with a 4h knife guard). Both directions. Aware of oil/Iran + the AI-equity bid as *macro* (not chases). Trend = wide let-it-run DSL (7d); fade = tight fast-capture (2d). Strict 5x, 24/7 (XYZ). |
+> The **volatility** (Caracal) and **global-macro** (Elephant) archetypes live in the 🏦 AI Hedge Funds section at the top — each is a two-book fund rather than a single-strategy agent. Their per-edge architecture is documented in [`producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md) §17–§18.
 
 For full archetype theses, distinguishing MCP signatures, and code snippets, see [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md).
 

--- a/catalog.json
+++ b/catalog.json
@@ -1,7 +1,7 @@
 {
   "_version": "1.2",
-  "_updated": "2026-06-02",
-  "_instructions": "Agent reads this file to build the onboarding skill catalog. Group by each skill's 'group' field (the archetype slug \u2014 e.g. 'single-asset-alpha-hunter', 'contrarian-unwind', 'trader-follower'), sort within group by 'sort_order'. When displaying, humanize the archetype slug (e.g. 'single-asset-alpha-hunter' -> 'Single-Asset Alpha Hunters'). DO NOT INVENT quality tiers like 'Proven Performers', 'Top Picks', 'Best-in-Class' \u2014 there is no curated quality ranking in this catalog. Every live skill ships with the same standard runtime / DSL / risk-gate scaffolding; differentiation is by archetype and thesis only. Infrastructure skills (DSL, fee optimizer, scanners) are never displayed. NOTE on 'min_budget': it is the realistic platform floor (~$100 is the minimum to trade at all on Hyperliquid) and a SUGGESTED comfortable starting size \u2014 it is NOT a hard gate. Never refuse to deploy a willing user who is at or above the platform floor: position size scales with budget via margin_pct, so any amount works (smaller budget = smaller positions). Offer to start small or watch first; never dead-end a user over budget.",
+  "_updated": "2026-06-04",
+  "_instructions": "Agent reads this file to build the onboarding skill catalog. Each skill has a 'group' (its display category) and most also have an 'archetype' (the underlying trading edge). FEATURE the 'hedge-fund' group FIRST: these are Senpi's flagship multi-strategy AI Hedge Funds \u2014 each runs two complementary strategy books on two wallets under one producer. Show each fund's 'archetype' (e.g. 'AI/Tech', 'Market-Neutral', 'Carry', 'Volatility', 'Global-Macro') as its sub-label, sorted within the group by 'sort_order'. Group all OTHER skills by their 'group' archetype slug, humanized (e.g. 'single-asset-alpha-hunter' -> 'Single-Asset Alpha Hunters'), sorted within group by 'sort_order'. DO NOT INVENT quality tiers like 'Proven Performers', 'Top Picks', 'Best-in-Class' \u2014 there is no curated quality ranking in this catalog; differentiation is by category/archetype and thesis only. Infrastructure skills (DSL, fee optimizer, scanners) are never displayed. NOTE on 'min_budget': it is the realistic platform floor (~$100 is the minimum to trade at all on Hyperliquid) and a SUGGESTED comfortable starting size \u2014 it is NOT a hard gate: position size scales with budget via margin_pct, so any amount at or above the floor works (smaller budget = smaller positions). Never refuse to deploy a willing user who is at or above the platform floor; offer to start small or watch first, never dead-end a user over budget.",
   "skills": [
     {
       "id": "albatross",
@@ -216,17 +216,18 @@
     {
       "id": "octopus",
       "tracker_slug": "octopus",
-      "name": "Octopus — Market-Neutral Hedge Fund",
-      "emoji": "🐙",
-      "tagline": "Longs the relative leaders and shorts the relative laggards of the liquid crypto cross-section on two equally-funded wallets — net ~beta-neutral, harvesting dispersion (leaders minus laggards), not market direction.",
-      "group": "relative-value-pairs",
-      "sort_order": 49,
+      "name": "Octopus \u2014 Market-Neutral Hedge Fund",
+      "emoji": "\ud83d\udc19",
+      "tagline": "Longs the relative leaders and shorts the relative laggards of the liquid crypto cross-section on two equally-funded wallets \u2014 net ~beta-neutral, harvesting dispersion (leaders minus laggards), not market direction.",
+      "group": "hedge-fund",
+      "sort_order": 2,
       "min_budget": 100,
       "risk_level": "moderate",
       "base_skill": null,
       "branch": "main",
       "predators_url": "https://strategies.senpi.ai/bot/octopus",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "archetype": "relative-value"
     },
     {
       "id": "cheetah",
@@ -591,47 +592,50 @@
     {
       "id": "camel",
       "tracker_slug": "camel",
-      "name": "Camel — Carry Hedge Fund",
-      "emoji": "🐫",
-      "tagline": "Harvests funding carry on two wallets: shorts the most-positive-funding names (short collects) and longs the most-negative-funding names (paid to hold), each gated to an exhausting crowd. The edge is carry — recurring funding income — not market direction.",
-      "group": "funding-fade",
-      "sort_order": 50,
+      "name": "Camel \u2014 Carry Hedge Fund",
+      "emoji": "\ud83d\udc2b",
+      "tagline": "Harvests funding carry on two wallets: shorts the most-positive-funding names (short collects) and longs the most-negative-funding names (paid to hold), each gated to an exhausting crowd. The edge is carry \u2014 recurring funding income \u2014 not market direction.",
+      "group": "hedge-fund",
+      "sort_order": 3,
       "min_budget": 100,
       "risk_level": "moderate",
       "base_skill": null,
       "branch": "main",
       "predators_url": "https://strategies.senpi.ai/bot/camel",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "archetype": "carry"
     },
     {
       "id": "caracal",
       "tracker_slug": "caracal",
-      "name": "Caracal — Volatility Hedge Fund",
-      "emoji": "🐱",
-      "tagline": "Trades volatility expansion, not direction: rides coiled-spring breakouts (low-vol squeeze -> range break -> surge) on two wallets — crypto and XYZ (oil / AI-infra / metals / indices), both long and short, 24/7.",
-      "group": "volatility-breakout",
-      "sort_order": 51,
+      "name": "Caracal \u2014 Volatility Hedge Fund",
+      "emoji": "\ud83d\udc31",
+      "tagline": "Trades volatility expansion, not direction: rides coiled-spring breakouts (low-vol squeeze -> range break -> surge) on two wallets \u2014 crypto and XYZ (oil / AI-infra / metals / indices), both long and short, 24/7.",
+      "group": "hedge-fund",
+      "sort_order": 4,
       "min_budget": 100,
       "risk_level": "aggressive",
       "base_skill": null,
       "branch": "main",
       "predators_url": "https://strategies.senpi.ai/bot/caracal",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "archetype": "volatility"
     },
     {
       "id": "elephant",
       "tracker_slug": "elephant",
-      "name": "Elephant — Global-Macro Hedge Fund",
-      "emoji": "🐘",
-      "tagline": "Trades the cross-asset macro complex — equity indices, metals, energy, FX (all on XYZ) + BTC — on two wallets: a trend book rides the durable macro direction, a fade book catches macro over-extensions reverting to regime. Both directions, 24/7.",
-      "group": "global-macro",
-      "sort_order": 52,
+      "name": "Elephant \u2014 Global-Macro Hedge Fund",
+      "emoji": "\ud83d\udc18",
+      "tagline": "Trades the cross-asset macro complex \u2014 equity indices, metals, energy, FX (all on XYZ) + BTC \u2014 on two wallets: a trend book rides the durable macro direction, a fade book catches macro over-extensions reverting to regime. Both directions, 24/7.",
+      "group": "hedge-fund",
+      "sort_order": 5,
       "min_budget": 100,
       "risk_level": "moderate",
       "base_skill": null,
       "branch": "main",
       "predators_url": "https://strategies.senpi.ai/bot/elephant",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "archetype": "global-macro"
     },
     {
       "id": "piranha",
@@ -774,14 +778,15 @@
       "name": "Spider \u2014 AI/Tech Hedge Fund",
       "emoji": "\ud83d\udd77\ufe0f",
       "tagline": "AI/Tech-focused long book + a macro/majors long-short counter-trading book \u2014 two style legs, two wallets, one producer.",
-      "group": "multi-asset-whitelist",
-      "sort_order": 46,
+      "group": "hedge-fund",
+      "sort_order": 1,
       "min_budget": 100,
       "risk_level": "moderate",
       "base_skill": null,
       "branch": "main",
       "predators_url": "https://strategies.senpi.ai/bot/spider",
-      "version": "5.1.1"
+      "version": "5.1.1",
+      "archetype": "ai-tech"
     },
     {
       "id": "remora",

--- a/senpi-trading-runtime/references/producer-patterns.md
+++ b/senpi-trading-runtime/references/producer-patterns.md
@@ -86,6 +86,18 @@ Your producer only has to score the signal and call `push_signal(...)`. The runt
 
 ## The archetypes
 
+> **Cross-cutting: 🏦 AI Hedge Funds (multi-book architecture).** Five skills are
+> *funds* rather than single-strategy agents — each runs **two complementary
+> books on two wallets under one leg-parameterized producer** (the Spider
+> pattern: `<AGENT>_LEG` selects the book; each book has its own wallet, runtime
+> YAML, DSL, and risk envelope). They are catalogued below under their
+> trading-edge archetype (a builder studying an edge should find them there),
+> but as a product line they are: **Spider** (AI/Tech, §4) · **Octopus**
+> (relative-value, §13) · **Camel** (carry, §7) · **Caracal** (volatility, §17)
+> · **Elephant** (global-macro, §18). To build a sixth, clone any of them: same
+> `producer_daemon` + fcntl-lock + `push_signal` spine, swap the per-book scorer
+> + universe, fund the two wallets, launch two daemons with `setsid`+cron.
+
 ### 1. Universe trend-follower
 
 **Thesis:** Scan top-N HL assets each tick, score on SM consensus + multi-timeframe alignment, fire entries when conviction tier is hit. Hunts coordinated risk-on / risk-off moves across crypto majors.


### PR DESCRIPTION
Makes the 5 multi-book funds (Spider + Octopus/Camel/Caracal/Elephant) a first-class **AI Hedge Funds** category instead of scattering them across 5 edge buckets.

- **catalog.json** — `group: hedge-fund` for all 5 + new lossless `archetype` field + reorder (Spider first) + rewritten `_instructions` to feature the hedge-fund group first with archetype sub-labels.
- **README** — pinned 'AI Hedge Funds' section at the top; removed the 5 from their scattered sections; deleted now-redundant §17/§18.
- **producer-patterns** — kept per-edge families (builder doc) + added a cross-cutting Hedge Funds index.

**Split by audience:** users buy on structure/brand (group as Hedge Funds in catalog+README); builders learn on edge (keep by archetype in producer-patterns). The `archetype` field bridges both views. Per Jason, catalog rules can be broken to improve it — 'hedge-fund' is a real structural class, not an invented quality tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)