### PR TITLE
fix(spider): lift swing entry cap + tighten scalp to lose less

### DIFF
--- a/spider/SKILL.md
+++ b/spider/SKILL.md
@@ -110,7 +110,7 @@ alignment to clear the floor.
 - slots **3**, `margin_pct` **28%** (3 × 28 = 84% max committed), tick **300s**
 - conviction leverage clamped **10x**, then to each asset's venue max
 - DSL **wide let-winners-run**: phase1 max_loss **22%** / retrace 12 / 1 breach; **all time-cuts OFF**; `hard_timeout` **7d** staleness backstop; phase2 ladder `15%→lock0 / 30%→45 / 60%→68 / 100%→80 / 150%→90`
-- low turnover: `max_entries_per_day` **4**, `per_asset_cooldown` **4h**
+- low turnover: `max_entries_per_day` **12** (raised from 4 — don't throttle the winning style by trade count; the loss-based gates own risk), `per_asset_cooldown` **4h**, `bypass_max_entries_per_day_on_profit` **true**
 
 ---
 
@@ -141,8 +141,8 @@ a ripping uptrend — it only fires on genuine intraday extremes.
 
 - slots **4**, `margin_pct` **15%** (small scalp size), tick **60s**
 - **strict 5x** leverage clamp (the style's defining discipline), then venue max
-- DSL **tight fast-capture**: phase1 max_loss **7%** / retrace 4 / 1 breach; `weak_peak_cut` **ON** (30m @ 1.5), `dead_weight_cut` **ON** (25m), `hard_timeout` **2h**; phase2 ladder `3%→lock35 / 6%→55 / 12%→70 / 25%→85`
-- **HIGH turnover**: `max_entries_per_day` **30** — *fee-sensitive*; lower it if net-of-fees underperforms
+- DSL **tight fast-capture**: phase1 max_loss **5%** (tightened from 7% to lose less) / retrace 3 / 1 breach; `weak_peak_cut` **ON** (30m @ 1.5), `dead_weight_cut` **ON** (25m), `hard_timeout` **2h**; phase2 ladder `3%→lock35 / 6%→55 / 12%→70 / 25%→85`
+- **turnover**: `max_entries_per_day` **18** (trimmed from 30) — *fee-sensitive*; lower further if net-of-fees underperforms
 
 ---
 
@@ -182,7 +182,7 @@ filtering (`get_positions`) is the safety floor underneath.
 | Gate | swing | scalp |
 |---|---|---|
 | daily_loss_limit_pct | 15 | 10 |
-| max_entries_per_day | 4 | 30 (fee-sensitive) |
+| max_entries_per_day | 12 (bypass-on-profit) | 18 (fee-sensitive) |
 | max_consecutive_losses | 4 | 5 |
 | cooldown_minutes | 90 | 30 |
 | drawdown_halt_pct | 25 | 20 |

--- a/spider/runtime-scalp.yaml
+++ b/spider/runtime-scalp.yaml
@@ -56,7 +56,7 @@ risk:
   data_retention_hours: 72
   guard_rails:
     daily_loss_limit_pct: 10      # high frequency → cap a bad streak sooner
-    max_entries_per_day: 30       # FEE-SENSITIVE — see description note
+    max_entries_per_day: 18       # FEE-SENSITIVE + net-negative — trimmed from 30 to lose less: fewer trades = less fee drag + fewer marginal fades.
     bypass_max_entries_per_day_on_profit: false
     max_consecutive_losses: 5     # scalpers run loss streaks (small losses)
     cooldown_minutes: 30
@@ -184,8 +184,8 @@ exit:
       interval_in_minutes: 25             # at/below break-even after 25m → cut
     phase1:
       enabled: true
-      max_loss_pct: 7.0                    # scalper cuts losers fast
-      retrace_threshold: 4
+      max_loss_pct: 5.0                    # tightened 7->5 to LOSE LESS: losers were running to ~2x winner size (winners bank fast at +3%, losers ran to -$14). Cap the downside tighter so per-trade R/R is closer to symmetric.
+      retrace_threshold: 3
       consecutive_breaches_required: 1
     phase2:
       enabled: true

--- a/spider/runtime-swing.yaml
+++ b/spider/runtime-swing.yaml
@@ -47,8 +47,8 @@ risk:
   data_retention_hours: 168       # 7d — match the max hold horizon
   guard_rails:
     daily_loss_limit_pct: 15      # source tolerates drawdowns on conviction
-    max_entries_per_day: 4        # multi-day holds → few new entries/day
-    bypass_max_entries_per_day_on_profit: false
+    max_entries_per_day: 12       # don't throttle the winning style by trade COUNT — the loss-based gates (daily_loss_limit + drawdown_halt) are the real circuit breakers. A let-winners-run leg needs many shots at the next big winner; a 4/day cap blocked MRVL/CBRS after 3 quick DSL-cut losers used the budget.
+    bypass_max_entries_per_day_on_profit: true   # when the leg is green, never block a new qualifying entry
     max_consecutive_losses: 4
     cooldown_minutes: 90
     drawdown_halt_pct: 25


### PR DESCRIPTION
Two live-data tunes (2026-06-04).

**SWING — don't throttle the winner:** `max_entries_per_day` 4→12, `bypass_max_entries_per_day_on_profit`→true. The 4/day *count* cap was consumed by 3 quick DSL-cut losers + META, then hard-blocked MRVL/CBRS. Risk should be governed by the **loss-based** gates (daily_loss_limit 15% + drawdown_halt 25%, unchanged), not a trade count — a let-winners-run leg needs many shots at the next big winner.

**SCALP — lose less:** phase1 max_loss 7→5, retrace 4→3, max_entries 30→18. 20 trades netted −$16 with upside-down R/R (winners ~+$6, losers ran to ~−$14). Tighter stop caps the downside; fewer entries cut fee drag on a net-negative fee-sensitive leg.

Config-only; operator re-pulls + re-registers both runtimes. n=1 day → measured tune; revisit scalp size/leverage if bleeding persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)