### PR TITLE
chore(strategy-v2): strip all strategies.senpi.ai references

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The repo is two things stacked on top of each other:
 
 Skills are versioned and MIT-licensed. Anyone can fork a skill, modify it, or build a new one from scratch using the capabilities below.
 
-**Platform:** [senpi.ai](https://senpi.ai) · **Live fleet tracker:** [strategies.senpi.ai](https://strategies.senpi.ai) · **Arena competition:** [senpi.ai/arena](https://senpi.ai/arena)
+**Platform:** [senpi.ai](https://senpi.ai) · **Arena competition:** [senpi.ai/arena](https://senpi.ai/arena)
 
 ---
 
@@ -550,7 +550,7 @@ Watches macro conditions and **classifies the market** into TREND_UP / TREND_DOW
 
 For full archetype theses, distinguishing MCP signatures, and code snippets, see [`senpi-trading-runtime/references/producer-patterns.md`](senpi-trading-runtime/references/producer-patterns.md).
 
-> **Live fleet trackers:** [strategies.senpi.ai](https://strategies.senpi.ai) (all-time PnL) · [senpi.ai/arena](https://senpi.ai/arena) (weekly ROE). One agent — Sentinel — runs an in-house producer not published to this repo; it appears on the live trackers but has no source link here.
+> **Live performance:** [senpi.ai/arena](https://senpi.ai/arena) (weekly ROE). One agent — Sentinel — runs an in-house producer not published to this repo; it appears on the Arena but has no source link here.
 
 ---
 

--- a/catalog.json
+++ b/catalog.json
@@ -14,7 +14,6 @@
       "min_budget": 100,
       "version": "5.1.1",
       "branch": "strategy-v2",
-      "predators_url": "https://strategies.senpi.ai/bot/spider",
       "sort_order": 1
     },
     {
@@ -27,7 +26,6 @@
       "min_budget": 100,
       "version": "7.0.0",
       "branch": "strategy-v2",
-      "predators_url": "https://strategies.senpi.ai/bot/kodiak",
       "sort_order": 1
     },
     {
@@ -40,7 +38,6 @@
       "min_budget": 100,
       "version": "5.0.0",
       "branch": "strategy-v2",
-      "predators_url": "https://strategies.senpi.ai/bot/polar",
       "sort_order": 2
     }
   ]

--- a/senpi-entrypoint/references/post-onboarding.md
+++ b/senpi-entrypoint/references/post-onboarding.md
@@ -70,7 +70,7 @@ To get started:
    1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
    2️⃣ {TOP2_NAME} (+{TOP2_ROE}% ROE)
 
-All strategies are open source and tracked live at strategies.senpi.ai
+All strategies are open source. Live user performance is on the Arena (senpi.ai/arena).
 
 🏆 Agents Arena — Ask me about the Arena to learn about Senpi's weekly AI trading competition.
 ```
@@ -140,7 +140,7 @@ Senpi Predators — AI trading strategies, all open source, all tracked live.
 {emoji} {name} — {description} [+X% ROE · X trades]
 {end}
 
-All tracked live at strategies.senpi.ai
+Live user performance is on the Arena (senpi.ai/arena).
 
 Which sounds interesting? I can explain any in detail or deploy one right now.
 
@@ -362,7 +362,4 @@ Share these with the user after confirmation:
 
 3. **Senpi Points** — Mention that trading on Senpi earns rewards through Senpi Points. Do not describe the program in detail — instead, prompt the user to ask about Senpi Points. The agent should use Senpi MCP tools to provide up-to-date information when asked.
 
-4. **Senpi Predators** — Live public tracker showing all trading strategies running with real money.
-   - strategies.senpi.ai
-
-5. **Agents Arena** — Senpi's weekly AI trading competition with a $100,000 Genesis prize pool. Mention that the first competition week is starting soon and prompt the user to ask about the Arena for details. Do not describe prize splits, qualification rules, or entry steps — instead, when asked, use `read_senpi_guide` to provide up-to-date information.
+4. **Agents Arena** — Senpi's weekly AI trading competition with a $100,000 Genesis prize pool. Mention that the first competition week is starting soon and prompt the user to ask about the Arena for details. Do not describe prize splits, qualification rules, or entry steps — instead, when asked, use `read_senpi_guide` to provide up-to-date information.

--- a/senpi-onboard/references/post-onboarding.md
+++ b/senpi-onboard/references/post-onboarding.md
@@ -69,7 +69,7 @@ To get started:
    1️⃣ {TOP1_NAME} (+{TOP1_ROE}% ROE)
    2️⃣ {TOP2_NAME} (+{TOP2_ROE}% ROE)
 
-All strategies are open source and tracked live at strategies.senpi.ai
+All strategies are open source. Live user performance is on the Arena (senpi.ai/arena).
 
 🏆 Agents Arena — Ask me about the Arena to learn about Senpi's weekly AI trading competition.
 ```
@@ -139,7 +139,7 @@ Senpi Predators — AI trading strategies, all open source, all tracked live.
 {emoji} {name} — {description} [+X% ROE · X trades]
 {end}
 
-All tracked live at strategies.senpi.ai
+Live user performance is on the Arena (senpi.ai/arena).
 
 Which sounds interesting? I can explain any in detail or deploy one right now.
 
@@ -361,7 +361,4 @@ Share these with the user after confirmation:
 
 3. **Senpi Points** — Mention that trading on Senpi earns rewards through Senpi Points. Do not describe the program in detail — instead, prompt the user to ask about Senpi Points. The agent should use Senpi MCP tools to provide up-to-date information when asked.
 
-4. **Senpi Predators** — Live public tracker showing all trading strategies running with real money.
-   - strategies.senpi.ai
-
-5. **Agents Arena** — Senpi's weekly AI trading competition with a $100,000 Genesis prize pool. Mention that the first competition week is starting soon and prompt the user to ask about the Arena for details. Do not describe prize splits, qualification rules, or entry steps — instead, when asked, use `read_senpi_guide` to provide up-to-date information.
+4. **Agents Arena** — Senpi's weekly AI trading competition with a $100,000 Genesis prize pool. Mention that the first competition week is starting soon and prompt the user to ask about the Arena for details. Do not describe prize splits, qualification rules, or entry steps — instead, when asked, use `read_senpi_guide` to provide up-to-date information.

--- a/senpi-trading-runtime/scripts/gen_catalog.py
+++ b/senpi-trading-runtime/scripts/gen_catalog.py
@@ -38,7 +38,6 @@ def build(updated: str, branch: str) -> dict:
             "min_budget": c.get("min_budget", 100),
             "version": m["version"],
             "branch": branch,
-            "predators_url": f"https://strategies.senpi.ai/bot/{m['id']}",
         })
     groups = defaultdict(list)
     for s in skills:


### PR DESCRIPTION
## For Sarvesh — review + merge into `strategy-v2`

This is the **strategy-v2 mirror** of [#368](https://github.com/Senpi-ai/senpi-skills/pull/368) (the main-branch strip), adapted for v2's generated-catalog architecture. **Base is `strategy-v2`**, so you can review the diff and merge it straight into your branch — no rework needed on your side.

### Why
Positioning shift landing with the **Senpi 2.0 waitlist go-live**: we stop promoting **strategies.senpi.ai** (the Predator tracker). Senpi is the **technology to build and run your own** Hyperliquid strategy — not a catalog of ready-made strategies to deploy. Users get pointed to the build tools (this repo) + the **Arena** (senpi.ai/arena) for live user performance.

### The v2-specific bit (the reason this is a separate PR from #368)
`senpi-trading-runtime/scripts/gen_catalog.py` **generated** the link:
```python
"predators_url": f"https://strategies.senpi.ai/bot/{m['id']}",
```
So on v2 it isn't enough to edit `catalog.json` — the next regen would put the links right back. This PR **removes that line from the generator** and **regenerates `catalog.json`** so it's consistent. Future regens stay clean.

### Changes
| File | Change |
|---|---|
| `senpi-trading-runtime/scripts/gen_catalog.py` | Removed the `predators_url` generation line (root cause on v2). |
| `catalog.json` | Regenerated — `predators_url` gone from all 3 current packages (kodiak/polar/spider). `_updated` preserved for a minimal diff. |
| `README.md` | Dropped the strategies.senpi.ai tracker link (header + footer); kept the Arena as the live-performance link. |
| `senpi-entrypoint/references/post-onboarding.md` + `senpi-onboard` mirror | "tracked live at strategies.senpi.ai" → "live user performance is on the Arena"; removed the "Senpi Predators" resource-list item (list renumbered). |

**Zero `strategies.senpi.ai` references remain on this branch** (verified with `git grep`).

### Notes
- When you regenerate the catalog as you migrate more packages, the generator now omits `predators_url` automatically — nothing further to do.
- If you ever want a per-strategy link back (e.g. an Arena page or the GitHub package), that's a one-line add in `gen_catalog.py` pointing somewhere other than strategies.senpi.ai.
- Companion ops actions (outside the repo): strategies.senpi.ai → redirect (Ignas); "Strategies" removed from senpi.ai header (Vysakh).

Docs + generator only — no producer/runtime behavior change.