### PR TITLE
fix(strategy-discover): belief-first entry-point flow, fund routing, de-bias, stack-by-default

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -28,8 +28,14 @@ and recommend in a natural voice. It must never feel like a form or a filter.
   catalog or filter strategies yourself.
 - **Only ever name strategies the engine returned** (in `MatchResult.candidates`). Copy the `id`/`name`
   verbatim from its JSON. If it's not in the JSON, don't say it. This is the anti-hallucination rule.
-- **Lead with the live market read** — the `market_facts` (price move, funding, trend) are what make
-  you sound like an analyst, not a search box.
+- **Lead with the live market read _when you present picks_** — the `market_facts` (price move, funding,
+  trend) are what make you sound like an analyst. But **never pre-fetch on entry**: the opener is a
+  question, not a scan (see Conversation flow).
+- **Not just crypto.** Senpi trades **stocks, commodities, indices, and pre-IPO names 24/7** — about half
+  the volume here isn't crypto. Keep every question, example, and default **asset-agnostic**; never
+  assume "a coin."
+- **Stack, don't isolate.** One strategy is one bet. On any pick that isn't already a multi-wallet fund,
+  offer a complementary hedge (Conversation flow → *Stack, don't isolate*).
 - **Echo your understanding in one line** before showing picks ("got it — cautious, BTC/ETH, ~$300").
 - **Don't re-ask what they've already told you** — if "I'm new" → set `--experience new` and move on;
   if they named an asset/risk, use it. Only ask for genuine gaps.
@@ -45,11 +51,16 @@ Invoke via the `exec` tool with discrete flags (all optional; pass what you've l
 python3 scripts/discover.py [--risk conservative|moderate|aggressive]
   [--assets <csv of class-tags btc_eth,major_alts,universe_crypto,xyz_equities,commodities,indices,pre_ipo
              and/or named tickers BTC,SOL,NVDA>]
-  [--belief trend|contrarian|copy|breakout|structural|single_market]
+  [--belief trend|contrarian|copy|breakout|structural|single_market|thesis_fund|hedge_fund]
   [--horizon scalp|swing|position|hodl] [--direction long_only|short_only|any]
   [--budget <number>] [--exclude <csv>] [--experience new|experienced]
+  [--hedge-for <strategy id>]   # return complements to an already-chosen pick
   [--limit 8] [--offset 0]
 ```
+
+> `thesis_fund` / `hedge_fund` beliefs and `--hedge-for` require the companion engine
+> changes in this PR's checklist; until those land, route fund-intent via `--assets`
+> and surface a hedge by re-running for the opposite belief.
 
 - Values can be loose ("pretty cautious", "btc and eth") — the engine canonicalizes; unknown → ignored.
 - **You hold the flags across turns** and re-run with the FULL set each time (the script is stateless).
@@ -60,23 +71,87 @@ python3 scripts/discover.py [--risk conservative|moderate|aggressive]
 
 ## Conversation flow
 
-1. **Read the user.** If they stated risk/assets/budget/belief, infer the flags. If they're vague,
-   **ask plain-English questions, one at a time** — the chips in the UI are just a rendering of these:
-   - "When a coin's running hard — ride it, or wait for a pullback?" → `--belief`
-   - "Any markets you lean toward — BTC/ETH, wider alts, or stocks & commodities?" → `--assets`
-   - "Steady and slow, balanced, or swinging for bigger moves?" → `--risk`
-   - "A few big wins held for days, or lots of small quick ones?" → `--horizon`
-   - "Roughly how much are you starting with?" → `--budget`
-   - **Cold start** ("I don't know"): open with the belief question.
-2. **Personalize (optional).** To reference their holdings/budget, run `discover.py --context-only` →
-   `user_context`. Confirm before acting on it ("you hold ETH — lean that way?"); never silently infer.
-3. **Run the engine**, then **narrate 2–3 cards** + a build-custom option, leading with the top pick
-   and its `market_facts` "why now". Surface `caveats` verbatim.
-4. **On their choice → hand off.**
+Users arrive in different modes — meet them where they are. **There is NO fixed funnel.** "Read the
+market," "show me what's possible," and "build custom" are first-class moves available at ANY point, and
+the user moves between paths freely (browse → check the market → pick → stack a hedge → deploy; or
+market-first → build custom; etc.). The one constant: whenever you ask them to choose a *style*, ask
+**belief first → a belief-dependent follow-up → size & lock in.**
+
+### Entry points — start wherever the user starts
+
+| Opens with… | Go to |
+|---|---|
+| "Help me pick" / a vague goal | **Belief spine** ↓ |
+| "What can I even run?" / "how does this work?" | **Orient** ↓ — sketch the menu, then they pick a belief, check the market, or build custom |
+| "What's the market doing?" / "what's winning?" | **Read the market** ↓, then map the read to a fit |
+| Already stated belief/asset/risk ("aggressive NVDA", "something for gold") | skip ahead — run the engine on what they gave |
+| "Build my own" | hand to **senpi-strategy-author** (first-class, not a fallback) |
+| "I don't know" | **Layer 0 fallback** ↓ |
+
+These interconnect — after any path the user can jump to another (browse→deploy, browse→build,
+browse→market→fit, market-first→pick, …). Follow their lead; don't force the order.
+
+### Belief spine — the "help me pick" path
+
+1. **Belief first (Layer 1)** — ask which sounds most like them (asset-agnostic; ordered by demand —
+   managed → gut-feel → specific → copy → hot → advanced):
+   1. 🏦🎯 "A ready-made **fund** — a *view* on the world (a war, the economy, AI, one coin beating the rest), or a *return style* (AI/tech, market-neutral, income, macro)?" → `thesis_fund` / `hedge_fund`
+   2. "Ride what's moving, or fade the crowd?" → `trend` / `contrarian`
+   3. "A **specific market** — a stock (NVDA), pre-IPO (SpaceX), a commodity (gold/oil), an index, or a coin?" → `single_market`
+   4. "Copy traders already winning?" → `copy`
+   5. 🏆 "Just run what's performing best right now?" → top performer (live ROE)
+   6. "Catch breakouts early / earn from market structure?" → `breakout` / `structural`
+2. **Belief-dependent follow-up (Layer 2)** — the *next* question depends on step 1:
+   | Belief | Ask next |
+   |---|---|
+   | thesis_fund | "Which view — and **which side wins**?" (the direction is fixed by the preset; never guess it) |
+   | hedge_fund | "Which style — AI/tech, market-neutral, income, or macro?" |
+   | trend / contrarian | "On one name, a basket, or the whole board?" |
+   | single_market | "Which — **a stock, pre-IPO name, commodity, index, or coin**?" |
+   | copy | "Multi-week proven winners, live hot streaks, or specific whales?" |
+   | breakout / structural | the one drill-down that matters for that branch |
+3. **Size & lock in (Layer 3)** — ask budget (and risk if not implied) only to size & pick the DSL
+   preset. Optionally `discover.py --context-only` to reference holdings (confirm first; never silently
+   infer). Then run the engine with the FULL flag set → narrate 2–3 cards, leading with the top pick's
+   `market_facts` "why now"; surface `caveats` verbatim.
+
+### Always-available moves (any point, on demand)
+
+- **Read the market** — *opt-in only* ("help me choose" / "what's winning"). Several MCP calls; say
+  "give me a sec to read the market." **Never pre-fetch on entry.** Then map the read to a fit and recommend.
+- **Orient / browse** — a short plain-English menu of what's possible (the style families + the funds +
+  the non-crypto markets); never force a pick. From here they pick a belief, check the market, or build custom.
+- **Build custom** — hand to **senpi-strategy-author** at any time; a real choice, not a dead-end.
+
+### Layer 0 fallback — only if they can't answer belief
+
+They lack the vocabulary; recommend *without* making them self-classify:
+- **A. Express lane** — "just pick something simple" → the conservative default, deploy. Instant.
+- **B. Plain-language quiz** — map feelings to an archetype (no jargon), then route.
+- **C. Show, don't ask** — 2–3 one-liners across the whole board (a BTC trend-follower, a big-tech-stock
+  agent, an AI fund, a pre-IPO agent), let them point at one.
+- **D. Contextual suggestion** — opt-in; reads the live market, proposes one fit with reasons.
+
+### Stack, don't isolate (on every pick that isn't already a fund)
+
+- **Single-wallet pick** (no `funding_split` in its card): *"One strategy is one bet — want a hedge
+  alongside it to cut drawdown?"* Run `discover.py --hedge-for <id>` and offer the top complement (e.g. a
+  momentum pick → a contrarian/defensive one, à la Spider + Dog). Sizing ~70/30 toward the primary — it's
+  a cushion, not a co-bet.
+- **Fund pick** (`funding_split` present → already a multi-wallet long/short book): **don't push
+  stacking — it's internally hedged.** Just show the funding split when you present it.
+
+### Hand off
+
+Deploy → **senpi-strategy-ops** · build → **senpi-strategy-author**. Always offer build-custom; never dead-end.
 
 ### Few-shot: utterance → flags
 - "something safe for BTC, ~$300" → `--risk conservative --assets btc_eth --budget 300`
-- "aggressive SOL play" → `--risk aggressive --assets SOL`
+- "aggressive NVDA play" → `--risk aggressive --assets NVDA`
+- "trade SpaceX / pre-IPO names" → `--assets pre_ipo`
+- "an AI fund" → `--belief hedge_fund --assets xyz_equities`
+- "bet against the economy" → `--belief thesis_fund` (then ask which side wins before deploying)
+- "gold vs bitcoin" → `--belief thesis_fund` (theme without a side → ask which wins)
 - "copy good traders, nothing crazy" → `--belief copy --risk moderate`
 - "trade stocks not crypto" → `--assets xyz_equities --exclude crypto`  (the "not crypto" is an exclusion)
 - "I don't want to short" → `--direction long_only`


### PR DESCRIPTION
## What this fixes

The new `senpi-strategy-discover` skill is the right move (decision tree as code), but the **conversation flow** didn't match the producer-patterns decision-tree intent, and it was biased toward crypto. This PR rewrites the flow (SKILL.md only).

### Problems with the current flow
1. **Wrong ordering.** It was a flat list of five peer questions (belief/assets/risk/horizon/budget). The tree is **belief-FIRST → a follow-up that *depends on the belief* (Layer 2A–2H) → budget/risk only to size & lock in (Layer 3).** The second question must branch on the belief, not be a fixed "assets."
2. **Layer 0 backwards.** Intent: **always start with belief; drop to Layer 0 only if the user can't answer it.** The current version made "I don't know" reopen the belief question and omitted the Layer-0 fallback paths (express lane / plain-language quiz / show-by-vibe / opt-in contextual suggestion) entirely.
3. **Funds unreachable.** `--belief` is `trend|contrarian|copy|breakout|structural|single_market` — no thesis-fund or hedge-fund route, so the funds (the products most users want) can't be surfaced by belief.
4. **No "stack a hedge" step** — it lands on one pick and hands off; never encourages pairing.
5. **Crypto bias** — "when a coin's running," BTC/ETH-first examples — even though ~half of HL volume is now non-crypto (stocks, commodities, pre-IPO).

## What changed (SKILL.md)
- **Belief-first → branch-dependent drill-down → size** (Layer 1 → 2 → 3), with **Layer 0 as the explicit fallback** (express / quiz / vibe / opt-in contextual suggestion) only when the user can't answer belief.
- **Restructured into an entry-point map** — help-me-pick, browse/orient, read-the-market, already-decided, build-custom, and "I don't know" all interconnect; *read the market*, *browse*, and *build custom* are first-class moves available at any point. Covers every start permutation (browse→deploy, browse→build, browse→market→fit, market-first→pick, …).
- **Funds are first-class Layer-1 branches** and lead the reordered question (managed → gut-feel → specific → copy → hot → advanced): `thesis_fund` (a view) / `hedge_fund` (a return style).
- **De-biased from crypto** — asset-agnostic phrasing; stock/pre-IPO/commodity-forward examples (NVDA, SpaceX, gold); a golden rule that ~half the volume isn't crypto.
- **"Stack, don't isolate"** — offer a complementary hedge on any single-wallet pick (`funding_split` absent), à la Spider + Dog; skip it for funds (already internally hedged).
- **Market read** moved to the present-picks step; **never pre-fetch on entry**.

## ⛔ Companion engine changes required before this merges (`scripts/discover.py`)
This PR is the playbook; three small engine additions make it real. Left to @sarvesh to avoid conflicting with active WIP:

- [ ] **Add fund beliefs** — `thesis_fund` + `hedge_fund` to `BELIEF_TO_ARCHETYPE` / `BELIEF_SYN` (syns: "view"/"opinion"/"macro" → thesis_fund; "hedge fund"/"market-neutral"/"income" → hedge_fund), routing to catalog `group == "hedge-fund"` (+ thesis-fund presets). Without this the flow can route to funds but the engine returns none.
- [ ] **Tag funds so they're matchable** — fund packages' `strategy.yaml` `catalog:` block needs the corresponding declared `archetype` (`hedge_fund` / `thesis_fund`) so the generated catalog carries it.
- [ ] **`--hedge-for <id>`** mode → return complements. Cheap: **`ARCH_OPPOSITE` already exists** in the engine (trend↔contrarian, etc.) — reuse it to surface the opposite-archetype top pick, excluding funds.
- [ ] `funding_split` is **already** returned per candidate — that's the stack-vs-don't signal the agent uses. No change; just confirming.

Until those land, the SKILL notes the works-today fallback (route fund-intent via `--assets`; surface a hedge by re-running for the opposite belief).

## Scope
SKILL.md only — I deliberately did **not** touch `discover.py` (it's actively being written). Targets `feat/strategy-discover-engine`, not `main`.
