### PR TITLE
New skill: senpi-market-pulse — "what's happening in the markets today?"

### DIFF
--- a/senpi-market-pulse/README.md
+++ b/senpi-market-pulse/README.md
@@ -1,0 +1,74 @@
+# senpi-market-pulse
+
+A Senpi skill that answers **"what's happening in the markets today?"** with thoughtful, structured,
+cross-asset analysis — the read a human couldn't assemble alone, not just "BTC is up."
+
+Modeled on `senpi-strategy-discover`: a **hidden deterministic engine** does the streamlined,
+resilient data-gathering and computes the concrete cross-asset signals; the **LLM (SKILL.md)** does
+the analysis, the narration, the catalyst (web-search) layer, and the closing CTAs.
+
+## Why a skill
+
+"What's moving today?" has dozens of valid tool calls and a hundred orderings. Left freeform, the
+agent wanders, leaves out asset classes, leads with the wrong thing, and stalls on infra hiccups —
+and stops at "BTC is down 3%." This skill fixes the **call plan**, the **output contract**, the
+**resilience rules**, and the **analysis framework** so the gold-standard answer is the *first*
+answer, every time.
+
+## Architecture
+
+```
+scripts/pulse.py     hidden engine — parallel multi-class pull, prevDayPx resilience,
+                     smart-money (leaderboard) layer (health-gated), deterministic signals → JSON
+scripts/_mcp.py      self-contained streamable-HTTP MCP client (stdlib only; read-only)
+SKILL.md             the analyst — golden rules, top-down output contract, the two CTAs
+references/analysis-framework.md   the cross-asset reasoning (dispersion, confirmation checklist, K-shape)
+tests/               offline fixture test for the engine (no network)
+```
+
+## How it works
+
+1. **One health-check + parallel bulk pull.** `market_list_instruments` on both dexes gives
+   price + `prevDayPx` for the whole universe — so daily moves never depend on candles, and a
+   candle 500 or a Hyperfeed outage can't drop an asset class.
+2. **Capped parallel deep-pull** of the biggest movers for volume/funding conviction.
+3. **Health-gated smart-money layer** (`leaderboard_*`) — cohort concentration, top traders,
+   momentum events; degrades to `null` cleanly if Hyperfeed is down.
+4. **Deterministic signals** — dispersion (index vs. components), the gold/DXY/VIX confirmation
+   checklist, a coarse day classification. The LLM turns these into the thesis.
+
+The engine **fails open** end-to-end: partial data still returns valid JSON with `meta.warnings`.
+
+## Output
+
+Top-down, fixed shape: macro picture → indices → epicenter sector (with gradient) → the divergence →
+commodities/macro → crypto → notables → bottom line + "what to watch" → **the two CTAs**:
+
+> 1. Want me to check how our strategies and positions are positioned in this?
+> 2. Want me to create a new strategy catered to this market?
+
+CTA 1 routes to a positions read; CTA 2 hands **senpi-strategy-author** a brief pre-built from the
+market thesis (proposes, never auto-builds).
+
+## Run
+
+```sh
+python3 scripts/pulse.py            # full live pull
+python3 scripts/pulse.py --no-smart # skip the leaderboard layer
+python3 scripts/pulse.py --fixture tests/fixtures/pulse_fixture.json   # offline (tests)
+```
+
+Env: `SENPI_AUTH_TOKEN`, `SENPI_MCP_URL` (defaults to prod).
+
+## Status / review notes
+
+- **v1** per the scope: Senpi MCP + the deterministic framework. The catalyst web-search and the
+  CTA-2 brief live in the SKILL (LLM) layer. Primary macro/FX feeds and holdings-personalization are
+  v1.1 / v2 (see scope doc).
+- **Schema verified against live MCP (2026-06-23).** `market_list_instruments` nests the quote under
+  a `context` sub-object and XYZ symbols are `xyz:`-prefixed — both handled in `fetch_instruments`,
+  and the test fixture now uses the real nested shape so the regression is guarded. Run
+  `python3 scripts/pulse.py --dry` to dump raw responses if the schema ever drifts again.
+- The smart-money health gate treats any non-None `leaderboard_get_status` as healthy (the response
+  is window metadata, not a boolean flag).
+- The asset universe in `pulse.py` (`CRYPTO`, `XYZ_GROUPS`) is meant to be edited by the team.

--- a/senpi-market-pulse/SKILL.md
+++ b/senpi-market-pulse/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: senpi-market-pulse
+description: >-
+  Answer "what's happening in the markets today?" with structured cross-asset analysis, not just
+  "BTC is up." Use for "what's moving", "market overview", "market update", "give me a read on
+  today", or any open-ended market read. A hidden engine (scripts/pulse.py) pulls all asset
+  classes (crypto, equities, indices, commodities, macro) and computes the signals; you narrate.
+  Requires Senpi MCP.
+license: Apache-2.0
+compatibility: OpenClaw, Hyperclaw, Claude Code
+metadata:
+  author: Senpi
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+---
+
+# Senpi Market Pulse — the daily cross-asset read
+
+You are a sharp markets analyst answering "what's happening today?" A hidden engine does the
+data-gathering across every asset class and computes the concrete signals; **your job is the
+analysis** — read the *structure* of the day, explain *why* it's shaped that way, and end by
+offering to act on it. The bar is high: **"BTC is up 3%" is a failure.** The user wants the read
+they couldn't get from a price screen on their own.
+
+## Golden rules
+
+- **Run the engine; never hand-pull the market.** `python3 scripts/pulse.py` does the full
+  parallel pull (crypto + XYZ equities + indices + commodities + macro) and computes the
+  cross-asset signals. Read its JSON — don't fire `market_*` calls yourself.
+- **Always cover every asset class.** Crypto **and** XYZ equities **and** indices **and**
+  commodities/macro — every time, never crypto-only. The engine always returns all of them; your
+  answer must too.
+- **Lead top-down.** Open with the macro character of the day, then drill down. **Never open on a
+  single coin.** Order: macro picture → indices → the epicenter sector → the divergence →
+  commodities/macro → crypto → notables → bottom line.
+- **Analyze the structure, don't list prices.** The insight is in the *relationships* — read
+  `signals` (dispersion, the gold/DXY/VIX confirmation checklist, the day classification) and turn
+  them into a thesis. See `references/analysis-framework.md` — this is what makes the answer
+  non-obvious. Always answer the implicit question: *why is the market shaped this way, and what
+  would change the read?*
+- **Attach the "why" (catalyst).** The engine gives prices and structure, not news. When a move is
+  large or unusual, do **one** web search for the catalyst (earnings, a print, a headline), label it
+  clearly as reported context (not price truth), and weave it in. This is the single biggest lever
+  for "a human couldn't find this."
+- **Always end with the two CTAs** (below) — verbatim.
+- **Freshness:** the engine pulls live every run. Don't serve session-cached prices as "current."
+
+## How to run the engine
+
+Invoke via the `exec` tool:
+
+```
+python3 scripts/pulse.py [--no-smart]
+```
+
+- Returns one JSON doc: `{day_classification, signals, groups, smart_money, meta}`.
+- `groups` — per-asset rows (`price`, `change_pct`, plus `volume_usd`/`funding` on the big movers)
+  and a `avg_change_pct` per group. Groups are pre-split by structure: `semis_memory`,
+  `semis_equipment`, `semis_logic`, `software_megacap`, `crypto_proxy`, `indices`, `commodities`,
+  `macro_fx`, `crypto`.
+- `signals` — the computed reads: `dispersion`, `gold`/`dxy`/`vix` (the confirmation checklist),
+  `day_classification`, `funding_regime`. Each carries a plain `read` string you can cite.
+- `smart_money` — the leaderboard layer (cohort concentration, top traders, momentum events) **or
+  `null`** if Hyperfeed is down. If null, note it once and move on — never stall.
+- `meta.warnings` / `meta.degraded` — what was unavailable. Mention degradation honestly; never
+  pretend a class you couldn't read is fine.
+- The engine **fails open** — partial data still returns valid JSON. Work with what you got; flag
+  what's missing.
+
+## Output contract
+
+Top-down, always this shape:
+
+1. **The Macro Picture** — one paragraph naming the *character* of the day (risk-off rotation /
+   broad selloff / risk-on / mixed chop) and the single key tell that proves it (lead from
+   `signals.dispersion` and `signals.day_classification`).
+2. **Global Indices** — SP500, XYZ100, JP225, KR200, NIFTY, VIX. A one-line *read* per row, not just
+   a number.
+3. **The epicenter** — wherever the action is. Drill the gradient (e.g. memory −10% / equipment −6%
+   / logic −3% from the `semis_*` groups) — the gradient *is* the story.
+4. **The divergence** — what's NOT moving with the crowd (e.g. `software_megacap` green while semis
+   bleed). Usually the most insightful section. Name it (K-shaped, asset-light vs asset-heavy).
+5. **Commodities & macro** — gold, silver, copper, oil, DXY, FX. Use them as *confirmation signals*
+   (cite the `signals.gold/dxy/vix` reads), not just quotes.
+6. **Crypto** — BTC/ETH/majors + funding regime + volume character (flush vs drift). Use
+   `funding_regime` and the movers' `funding`/`volume_usd`.
+7. **Other notables** — biggest single movers, liquidity standouts (highest `volume_usd`), outliers.
+8. **Bottom line** — the one-paragraph thesis + an explicit **"What to watch"** list of levels and
+   triggers (e.g. "BTC $62k holds → flush done; VIX > 25 → selloff broadening").
+9. **The two CTAs** (next section).
+
+Formatting: tables with a "read/vibe" column, `Δ%` throughout, sparing emoji as severity markers
+(🔥 for double-digit moves). Always show the daily move, not just the price. If `smart_money` is
+present, add a short "Smart money" note (e.g. "the >$1M cohort is X% concentrated short HYPE and
+adding") — it's high-signal.
+
+## Mandatory closing (verbatim)
+
+Always end every market read with exactly these two offers:
+
+> **1. Want me to check how our strategies and positions are positioned in this?**
+> **2. Want me to create a new strategy catered to this market?**
+
+- **CTA 1 → positions read.** Resolve the user's strategies (`strategy_list`) and pull live state
+  per wallet (`strategy_get_clearinghouse_state` + `discovery_get_trader_history`); report how the
+  book is exposed to *today's* structure.
+- **CTA 2 → new strategy.** Hand to **senpi-strategy-author** with a structured brief built from the
+  thesis you just produced (e.g. *"semi-led risk-off, memory −10%/logic −3%, software green, gold &
+  DXY calm = orderly rotation → candidate: long asset-light software / short memory, or fade if
+  washout; risk: timing"*). **Propose the strategy and get the user's go-ahead — never build or
+  trade without confirmation.**
+
+## Resilience (the engine handles these — narrate them honestly)
+
+- **Hyperfeed / smart-money down** → `smart_money: null`. Note "smart-money layer unavailable",
+  deliver the rest in full.
+- **A class came back thin** → it's in `meta.warnings`. Say so; don't drop the section silently.
+- **Never** answer crypto-only, never lead with a single coin, never skip the CTAs — even on
+  degraded data.
+
+## Skill Attribution
+
+This is a guide/analysis skill (it *reads* the market and *recommends*; it does not create a
+strategy wallet or place a trade), so it has no `references/skill-attribution.md` wallet flow.
+Attribution happens downstream when **senpi-strategy-author** / **senpi-strategy-ops** act on CTA 2.

--- a/senpi-market-pulse/references/analysis-framework.md
+++ b/senpi-market-pulse/references/analysis-framework.md
@@ -1,0 +1,75 @@
+# Analysis framework — turning prices into a non-obvious read
+
+The engine hands you prices, per-group averages, and a few computed `signals`. This is how you turn
+that into the analysis a human couldn't assemble alone. **The insight is always in the
+*relationships between* assets, never in any single price.** Read these in order.
+
+## 1. Dispersion vs. capitulation (the first question)
+
+Is the headline index calm while its components break, or is everything moving together?
+
+- **Index calm, components broken** (e.g. SP500 −1% but individual semis −10%) → **dispersion / sector
+  rotation.** Money is moving *between* sectors, not *out* of the market. This is the common,
+  high-signal case — name it explicitly.
+- **Everything down together, index and components alike** → **broad / macro move.** A liquidity or
+  macro-regime event, not a rotation.
+
+The engine pre-computes this in `signals.dispersion` (SP500 move vs. the worst group's average).
+Cite the gap: "SP500 −1.1% while memory names are −10% — that's dispersion, not capitulation."
+
+## 2. The gradient within the epicenter (the texture)
+
+Once you've found the sector taking the damage, read the *gradient* across its sub-groups — it tells
+you the *kind* of move:
+
+- A **steep gradient** (`semis_memory` −10%, `semis_equipment` −6%, `semis_logic` −3%) → a
+  fundamental, supply/demand-specific story (here: a memory glut, not an AI-capex scare). The
+  further from the epicenter, the less damage.
+- A **flat gradient** (everything in the sector down ~5% uniformly) → a liquidity/de-risking move,
+  not a fundamental one.
+
+The `semis_memory` / `semis_equipment` / `semis_logic` split exists precisely so you can read this.
+The same logic generalizes to any sector that's leading.
+
+## 3. The confirmation checklist (does the structure hold up?)
+
+These cross-asset tells separate an orderly rotation from a genuine stress event. The engine computes
+each with a plain `read` string — cite them:
+
+| Signal | Holding | Breaking |
+|---|---|---|
+| **Gold** (`signals.gold`) | Flat/down-small while equities dump → **no forced-liquidation cascade** (orderly) | Gold dumping too → margin-call / liquidity event |
+| **DXY** (`signals.dxy`) | Flat → no flight-to-USD, **no funding stress** | Spiking → macro funding crisis |
+| **VIX** (`signals.vix`) | ≤ ~22 and not spiking → **fear contained, rotation** | 25+ / spiking → selloff **broadening** |
+
+The classic orderly-rotation signature: *semis −10%, gold only −1%, DXY flat, VIX elevated but not
+spiking.* If gold and DXY were both moving hard too, you'd be looking at something much more
+dangerous — say so.
+
+## 4. K-shaped / divergence (the most insightful section)
+
+Look for what's moving *opposite* the crowd on the same tape. The textbook case: **asset-light
+winners green while asset-heavy losers bleed** — software mega-caps (`software_megacap`) holding up
+while the physical-chip complex gets repriced. That divergence tells you the move is *specific*
+(hardware/memory), not a broad tech liquidation. This is usually the line the user remembers.
+
+## 5. Volume as conviction; funding as exhaustion
+
+- **Volume** (`volume_usd` on the movers) — flag institutional-scale notional ("MU $417M daily") so
+  the user knows what's real repositioning vs. noise. The biggest-volume name is often the real story.
+- **Crypto funding** (`funding` on movers + `signals.funding_regime`) — funding flipping negative
+  into a flush (shorts paying) on huge volume = a **leverage washout**, often near-term exhaustion
+  rather than the start of a deeper leg. An orderly drift with funding unchanged is different — don't
+  call a washout that isn't there.
+
+## 6. Compose the thesis
+
+Put it together into one sentence the rest of the read defends, then give the user the triggers that
+would change it. Example:
+
+> "Semiconductor-led risk repricing, not a macro crisis — memory −10%, logic −3%, software green,
+> gold −1%, DXY flat, no VIX spike; crypto selling in sympathy with washout characteristics.
+> **What to watch:** BTC $62k (holds → flush done), memory names finding a floor, VIX 25+ (→
+> broadening)."
+
+That's the difference between "the market is down" and a read worth paying for.

--- a/senpi-market-pulse/references/scope.md
+++ b/senpi-market-pulse/references/scope.md
@@ -1,0 +1,162 @@
+# Scope: `market-pulse` skill — "What's happening in the markets today?"
+
+**Owner:** Jason · **Audience:** Senpi skills/runtime team · **Status:** Draft for review · **Date:** 2026-06-23
+
+---
+
+## 1. The problem
+
+"What's happening in the markets today?" is one of the most common things a user asks their agent — and today the agent answers it badly. Without a skill, it:
+
+- **Wanders.** It fires tool calls ad hoc, in no fixed order, and the answer depends on which call it happened to reach for first.
+- **Leaves out whole markets.** It answered crypto-only and skipped XYZ equities entirely until the user pushed back — twice.
+- **Leads with the wrong thing.** It opened on BTC instead of an overall market read, so the user had to say "start with the entire market, then drill down."
+- **Breaks on infra hiccups** (Hyperfeed down, XYZ candles 500ing, needing `dex="xyz"` explicitly) and gives up on data instead of routing around it.
+- **Stops at "BTC is down 3%."** It states *what* moved, not *why it's structured the way it is* — which is the only part a human couldn't get themselves from a price screen.
+
+It eventually produced an excellent answer (see Appendix A) — but only after ~5 user prompts, a memory correction, and several dead-ended tool calls. **The job of this skill is to make that gold-standard answer the first answer, every time, in one shot.**
+
+## 2. Goal & non-goals
+
+**Goal:** A single skill that turns "what's happening in the markets today?" into thoughtful, structured, *non-obvious* cross-asset analysis — the kind of read a human can't assemble on their own — with a deterministic data-gathering plan and graceful degradation when data sources fail.
+
+**The bar:** "BTC is up" is a failure. The answer must explain the **structure** of the move (what's dispersing from what, and what that implies), not just enumerate prices.
+
+**Non-goals:**
+- Not a trade recommender (it *offers* to build/check strategies at the end — it doesn't place trades).
+- Not a backtester or historical research tool.
+- Not real-time streaming — it's a point-in-time snapshot on demand.
+
+## 3. Why a skill (not freeform tool use)
+
+There are dozens of valid tool calls and a hundred ways to order them. Left freeform, the agent gets lost navigating them and the output is non-deterministic. A skill lets us:
+
+- **Fix the call plan** (what to pull, in what order, what to parallelize).
+- **Fix the output contract** (overview → drill-down → bottom line → CTAs).
+- **Encode the resilience rules** (the fallbacks below) once, so every agent inherits them.
+- **Encode the analysis framework** — the dispersion/cross-asset reasoning that makes the answer non-obvious — instead of hoping the model rediscovers it each time.
+
+## 4. Output contract (what the user sees)
+
+Fixed structure, **top-down**. Never lead with a single asset.
+
+1. **The Macro Picture** — one paragraph naming the *character* of the day (risk-off rotation vs. broad panic vs. melt-up vs. chop) and the single key tell that proves it.
+2. **Global Indices** — SP500, XYZ100, Nikkei/JP225, KR200, NIFTY, VIX. With a one-line "read" per row, not just a number.
+3. **Sector epicenter** — wherever the action actually is (today: semis/memory). The drill-down with the gradient (e.g. memory −10%, logic −3%).
+4. **The divergence** — what's NOT moving with the crowd (today: software mega-caps green). This is usually the most insightful section.
+5. **Commodities & macro** — gold, silver, copper, oil, DXY, key FX. Used as *confirmation signals*, not just quotes (see framework).
+6. **Crypto** — BTC/ETH/majors + funding + volume character (flush vs. drift).
+7. **Other notables** — outliers, biggest single movers, liquidity standouts.
+8. **Bottom line** — the one-paragraph thesis + an explicit **"What to watch"** list of levels/triggers.
+9. **Mandatory closing CTAs** (Section 8).
+
+Formatting: tables with a "read/vibe" column, Δ% throughout, sparing emoji as severity markers. Always show the daily move, not just the price.
+
+## 5. The analysis framework (this is the differentiator)
+
+The skill must instruct the agent to reason cross-asset, not list prices. The non-obvious read comes from *relationships*:
+
+- **Dispersion vs. capitulation.** Is the index calm while components break (rotation), or is everything down together (liquidity event)? The tell: SP500 −1% while individual names −10% = dispersion.
+- **The gradient within a sector.** "Memory −10%, equipment −6%, logic −3%" tells a supply/demand story; a flat −5% across all of them tells a liquidity story. Name the gradient.
+- **The cross-asset confirmation checklist** (these turn data into insight):
+  - **Gold** holding while equities dump → no forced-liquidation cascade (orderly). Gold dumping too → liquidity event.
+  - **DXY** flat → no flight-to-USD / funding stress. DXY spiking → macro funding crisis.
+  - **VIX** level as the broadening gauge — elevated-but-not-spiking = contained rotation; 25+ = selloff broadening.
+  - **Crypto funding flip negative + volume spike** → leverage washout (often near-term exhaustion), vs. orderly drift.
+- **K-shaped framing** where it applies — asset-light winners vs. asset-heavy losers, on the same tape.
+- **Volume as conviction** — flag notional that's institutional-scale ("MU $417M daily notional") so the user knows what's real repositioning vs. noise.
+
+The output should always answer the implicit question: **"why is the market shaped this way, and what would change the read?"**
+
+## 6. Data sources & call plan
+
+### 6.1 Senpi MCP — primary
+
+| Tool | Role in the skill |
+|------|-------------------|
+| `market_get_prices` | Live prices across the full asset set (crypto + XYZ + indices + commodities + FX). Backbone call. |
+| `market_list_instruments` | **`prevDayPx` for daily-move math** — and the resilience fallback when candles are down (compute Δ% from `prevDayPx` vs. live). |
+| `market_get_asset_data` | Per-asset depth (candles/volume/momentum) for the headline movers. **Must pass `dex="xyz"` explicitly for XYZ names.** |
+| `market_get_funding_regime` | Funding context for the crypto leverage-washout read. |
+| `market_get_cross_asset_flows` | BTC-move → laggard-alt detection when BTC moves >2% (only fire when warmed up; filter follow_rate). |
+| `leaderboard_get_top` | "Who's hot" — positioning context (smart-money tilt). |
+| `leaderboard_get_markets` | **Cohort concentration by asset** — "X% of top-trader gains are on HYPE shorts." High-signal when available. |
+| `leaderboard_get_momentum_events` | Live entry/scale/exit flow — is the smart money *adding* or *unwinding*. |
+| `leaderboard_get_status` | Health-check the Hyperfeed layer **before** relying on the leaderboard calls. |
+
+### 6.2 External data (gaps the MCP doesn't cover well)
+
+Decisions (see §10 build plan for phasing):
+- **Headline/catalyst context [v1]** — *why* today (an earnings miss, a CPI print, a memory-glut headline). **This is the single highest-leverage element for the "humans couldn't find this" bar** — without the cause, the skill is a pretty price table. One web-search call, timestamped, clearly walled off from price data, framed as "reported catalyst" (context, not truth).
+- **Economic calendar [v1]** — is today a scheduled-event day (FOMC/CPI/NFP)? Cheap, high-value context; fold into the same catalyst step.
+- **Traditional index/VIX/FX/commodity prints [v2]** — authoritative SP500, VIX, DXY, JP225/KR200/NIFTY, gold/oil. XYZ proxies are close enough for the *structural* read (dispersion/K-shape/confirmation all work on proxies), so primary feeds are a v2 accuracy upgrade, not a v1 blocker. **Do not gate v1 on this integration.**
+
+### 6.3 Streamlined orchestration
+
+The skill should **batch and parallelize**, not serialize:
+
+1. **Health check + bulk pull (parallel):** `leaderboard_get_status`, `market_get_prices` (full set), `market_list_instruments` (for prevDayPx). One round.
+2. **Branch on health:** if Hyperfeed is up → add `leaderboard_get_markets` + `_momentum_events` + `_top` for the smart-money layer. If down → skip cleanly, note it, proceed on market data alone.
+3. **Drill the movers (parallel):** `market_get_asset_data` on the top N movers only (cap it — don't pull all 100 XYZ names), `market_get_funding_regime`, `market_get_cross_asset_flows` if BTC move qualifies.
+4. **(Optional) external:** one web-search for catalyst + economic-calendar check.
+5. **Synthesize** into the Section 4 contract.
+
+Goal: **two data rounds, fully parallel within each**, instead of the ~15 sequential calls the agent made unguided.
+
+## 7. Resilience rules (encode these — they're the observed failure modes)
+
+- **Hyperfeed / leaderboard down** → don't stall. Fall back to `market_*` calls, note "smart-money layer unavailable," deliver the rest.
+- **XYZ candles 500ing** → fall back to `prevDayPx` from `market_list_instruments` to compute daily moves. Never drop XYZ because candles failed.
+- **`dex="xyz"` required** → always pass it explicitly for XYZ equities on `market_get_asset_data`; don't let a default-dex miss return empty.
+- **Always refresh** at the start of an answer — never serve session-cached prices as "current." (Pairs with the verify-positions-first discipline.)
+- **Coverage is mandatory, not optional** (next section).
+
+## 8. Mandatory rules
+
+- **Always include all asset classes:** crypto **and** XYZ equities **and** indices **and** commodities/macro. Never crypto-only. (This was a memory correction the agent had to be given twice — bake it into the skill so it's structural, not learned.)
+- **Always lead top-down:** macro overview first, then drill down. Never open on a single coin.
+- **Always end with the two CTAs**, verbatim, as the closing block:
+
+  > **1. Want me to check how our strategies and positions are positioned in this?**
+  > **2. Want me to create a new strategy catered to this market?**
+
+  CTA 1 → hand to the positions/strategy read (`strategy_list` → `strategy_get_clearinghouse_state` + `discovery_get_trader_history` per wallet). CTA 2 → hand to the strategy-author/discover flow, pre-seeded with the market thesis just generated (e.g. "semi-led risk-off, software resilient" → a long-software / short-memory or a divergence-fade brief).
+
+## 9. Success criteria
+
+- **One-shot:** produces the Appendix-A-quality answer on the first prompt, with zero follow-up corrections for coverage or ordering.
+- **Complete:** every answer spans all asset classes + the two CTAs.
+- **Non-obvious:** every answer contains at least one cross-asset structural insight (a dispersion call, a confirmation-signal read, a divergence) — not just a price list.
+- **Resilient:** degrades gracefully on Hyperfeed-down and XYZ-candle-500 without losing asset classes.
+- **Fast:** ≤ 2 parallel data rounds in the common path.
+
+## 10. Build plan (v1 / v1.1 / v2)
+
+**The connective idea across all phases: the skill's thesis is the asset.** Use it to explain *why* (catalyst), to make it *theirs* (personalization), and to seed the *next action* (CTA-2 brief).
+
+### v1 — the core, shippable on Senpi MCP + one external call
+
+- Full top-down output contract (§4) + analysis framework (§5) + resilience rules (§7) + mandatory coverage & both CTAs (§8).
+- 2-round parallel orchestration (§6.3).
+- **Catalyst web-search + economic-calendar check** — one call, timestamped, walled off from price data. *This is in v1, not deferred* — it's what clears the "non-obvious" bar today.
+- **CTA 2 auto-generates a proposed strategy brief from the thesis** — never opens the author skill cold. Pass a structured intent brief (e.g. *"semi-led risk-off, memory −10%/logic −3%, software green, gold/DXY calm = orderly rotation → candidate: long asset-light software / short memory, or fade if washout; risk: timing"*). **It proposes; the user approves before anything is built** — keep the human in the loop on money-moving actions.
+
+### v1.1 — personalization overlay (ship here if it adds cost to v1; pull into v1 if cheap)
+
+- **Weight the read to the user's live book — as a final-pass lens, not a data filter.** Always pull the full market (the whole-board scan is the point); then overlay "here's how this hits your positions" and surface held assets first. Gated on "user has live positions" via a light `strategy_list` + open-positions read; if flat, skip silently (no empty portfolio section). This makes CTA 1 feel earned rather than bolted on.
+
+### v2 — primary data + depth
+
+- Authoritative macro/VIX/FX/foreign-index feeds replacing/augmenting XYZ proxies.
+- Richer catalyst sourcing; per-sector narrative memory across days ("yesterday's rotation continued / reversed").
+
+### Resolved implementation params (were open questions)
+
+- **Mover cap:** deep-pull the **top ~8–10 movers by |Δ%| × notional** with `market_get_asset_data`; don't pull all 100 XYZ names.
+- **Caching window:** **always re-pull prices** on every ask (never serve session-cached quotes as "current"); **reuse the catalyst/calendar context** within the session.
+
+---
+
+## Appendix A — gold-standard reference output
+
+The target quality bar is the "Market Overview — Tuesday June 23, 2026" answer the agent eventually produced: top-down (macro → indices → semi epicenter → software divergence → commodities → crypto → notables → bottom line + what-to-watch), with the semiconductor-rotation thesis, the gold/DXY/VIX confirmation reads, and the K-shaped framing. That output — reached after 5 prompts and a memory fix — is what this skill must produce in **one**. (Full text on file with Jason.)

--- a/senpi-market-pulse/scripts/_mcp.py
+++ b/senpi-market-pulse/scripts/_mcp.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Self-contained streamable-HTTP MCP client (stdlib only).
+
+Ported from senpi_runtime_helpers.SenpiClient so the discovery skill has ZERO cross-skill
+dependency — it ships its own market-data transport. Read-only tool calls only.
+
+  client = MCPClient()                       # reads SENPI_AUTH_TOKEN / SENPI_MCP_URL from env
+  data = client.mcp_call("market_get_asset_data", asset="BTC")   # -> unwrapped {success,data,...}
+
+Returns the same unwrapped JSON `mcporter`/SenpiClient returns; None on an MCP-protocol error.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import http.client
+import itertools
+import json
+import os
+from urllib.parse import urlsplit
+
+MCP_URL = os.environ.get("SENPI_MCP_URL", "https://mcp.prod.senpi.ai/mcp")
+AUTH = os.environ.get("SENPI_AUTH_TOKEN", "")
+_PROTOCOL = "2025-03-26"
+
+
+class MCPError(Exception):
+    pass
+
+
+def _post(url, body, headers, timeout):
+    """POST a JSON body on a fresh connection; return (status, raw_bytes, content_type, session_id)."""
+    parts = urlsplit(url)
+    scheme = parts.scheme
+    host = parts.hostname or ""
+    port = parts.port or (443 if scheme == "https" else 80)
+    path = (parts.path or "/") + (("?" + parts.query) if parts.query else "")
+    data = json.dumps(body).encode("utf-8")
+    hdrs = {
+        "Host": parts.netloc,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "Content-Length": str(len(data)),
+    }
+    hdrs.update(headers)
+    cls = http.client.HTTPSConnection if scheme == "https" else http.client.HTTPConnection
+    conn = cls(host, port, timeout=timeout)
+    try:
+        conn.request("POST", path, body=data, headers=hdrs)
+        resp = conn.getresponse()
+        raw = resp.read()
+        return resp.status, raw, (resp.getheader("Content-Type") or ""), resp.getheader("Mcp-Session-Id")
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa
+            pass
+
+
+def _parse(raw, content_type):
+    """Streamable-HTTP returns a single JSON doc OR an SSE stream; return the first JSON-RPC payload."""
+    text = raw.decode("utf-8", errors="replace")
+    if "text/event-stream" in (content_type or "").lower():
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[5:].strip()
+                if payload and payload != "[DONE]":
+                    try:
+                        obj = json.loads(payload)
+                        if isinstance(obj, dict):
+                            return obj
+                    except json.JSONDecodeError:
+                        continue
+        return {}
+    if not text:
+        return {}
+    try:
+        obj = json.loads(text)
+        return obj if isinstance(obj, dict) else {"result": obj}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _unwrap(rpc):
+    """tools/call JSON-RPC -> the inner JSON document (content[0].text), like mcporter."""
+    if not isinstance(rpc, dict) or rpc.get("error"):
+        return None
+    result = rpc.get("result")
+    if not isinstance(result, dict):
+        return result
+    content = result.get("content")
+    if isinstance(content, list) and content:
+        first = content[0]
+        if isinstance(first, dict) and "text" in first:
+            try:
+                return json.loads(first["text"])
+            except (json.JSONDecodeError, TypeError):
+                return result
+    return result
+
+
+class MCPClient:
+    """Lazy `initialize` handshake (streamable-http), then `tools/call`. One per process."""
+
+    def __init__(self, url=None, token=None):
+        self.url = url or MCP_URL
+        self.token = token if token is not None else AUTH
+        self._sid = None
+        self._initialized = False
+        self._id = itertools.count(1)
+
+    def _headers(self, sid=None):
+        h = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        sid = sid or self._sid
+        if sid:
+            h["Mcp-Session-Id"] = sid
+        return h
+
+    def _initialize(self, timeout):
+        if self._initialized:
+            return
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "initialize",
+                "params": {"protocolVersion": _PROTOCOL, "capabilities": {},
+                           "clientInfo": {"name": "senpi-market-pulse", "version": "2.0.0"}}}
+        status, _raw, _ct, sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"initialize HTTP {status}")
+        self._sid = sid
+        # streamable-http requires notifications/initialized after init
+        note = {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+        _post(self.url, note, self._headers(sid), timeout)
+        self._initialized = True
+
+    def mcp_call(self, tool, timeout=12, **arguments):
+        self._initialize(timeout)
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments}}
+        status, raw, ct, _sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"{tool} HTTP {status}")
+        return _unwrap(_parse(raw, ct))

--- a/senpi-market-pulse/scripts/pulse.py
+++ b/senpi-market-pulse/scripts/pulse.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""senpi-market-pulse engine — Data Layer + deterministic cross-asset signals (hidden).
+
+The agent (LLM) runs this via the OpenClaw `exec` tool, reads the JSON on stdout, and NARRATES the
+top-down market read (see SKILL.md output contract). The script does the streamlined, resilient
+data-gathering + the *concrete* signal computation; the LLM does ALL of the narrative analysis,
+the catalyst (web-search) layer, and the closing CTAs.
+
+  python3 pulse.py                 # full live pull (crypto + XYZ equities + indices + commodities/macro)
+  python3 pulse.py --no-smart      # skip the leaderboard (smart-money) layer
+  python3 pulse.py --fixture f.json  # offline: read a recorded MCP-response map (for tests)
+
+Design contract (mirrors senpi-strategy-discover):
+- ONE health-check + parallel bulk pull, then a capped parallel deep-pull of the biggest movers.
+- Resilient by construction: daily moves come from `prevDayPx` on the instruments list, so a candle
+  500 or a Hyperfeed outage never drops an asset or an asset class. Every class is always attempted.
+- Fails open: any call that errors degrades to a flag in `meta`, never an exception; always valid
+  JSON; exit 0 for handled cases.
+- The script computes only CONCRETE signals (per-group averages, dispersion, the confirmation
+  checklist, a coarse day-classification). The LLM owns the prose, the "why", and the CTAs.
+
+SCHEMA NOTE (verified against live MCP 2026-06-23): `market_list_instruments` nests the quote under a
+`context` sub-object — `{"name": "BTC", "context": {"markPx": "...", "prevDayPx": "...", ...}}` — not
+at the row top level. `fetch_instruments` folds `context` in before extraction. XYZ symbols come back
+`xyz:`-prefixed. Use `--dry` to dump the raw response for any future schema drift.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# ──────────────────────────────────────────────────────────────── asset universe (edit me)
+# Grouped so the engine can compute per-group dispersion. `main` dex = crypto perps;
+# everything else is an XYZ (HIP-3) instrument and needs dex="xyz" on per-asset pulls.
+CRYPTO = ["BTC", "ETH", "SOL", "HYPE", "XRP", "SUI", "DOGE", "AVAX", "LINK", "AAVE", "BNB", "LTC", "NEAR"]
+
+XYZ_GROUPS = {
+    # the usual epicenter — split by distance from the memory/hardware core so the LLM can read the gradient
+    "semis_memory":   ["MU", "SNDK", "SKHX", "DRAM", "WDC"],
+    "semis_equipment": ["ASML", "TSM", "QCOM", "ARM", "MRVL"],
+    "semis_logic":    ["NVDA", "AMD", "AVGO", "SMH"],
+    "software_megacap": ["AMZN", "MSFT", "META", "GOOGL", "AAPL", "ORCL", "PLTR"],
+    "crypto_proxy":   ["MSTR", "COIN", "HOOD", "CRWV"],
+    "other_equity":   ["TSLA", "SPCX", "ZHIPU"],
+    "indices":        ["SP500", "XYZ100", "JP225", "KR200", "NIFTY", "VIX"],
+    "commodities":    ["GOLD", "SILVER", "COPPER", "BRENTOIL", "NATGAS", "PLATINUM"],
+    "macro_fx":       ["DXY", "JPY", "EUR", "GBP"],
+}
+XYZ_ALL = [a for g in XYZ_GROUPS.values() for a in g]
+
+# how many of the biggest movers get a deep (candle/volume/funding) pull
+MOVER_DEEP_PULL = 12
+
+
+# ──────────────────────────────────────────────────────────────── guarded I/O helpers
+def _ok(resp):
+    """Unwrap an MCP response; None if it failed (mcp_call returns success:False, not an exception)."""
+    if isinstance(resp, dict):
+        if resp.get("success") is False:
+            return None
+        return resp.get("data", resp)
+    return resp
+
+
+def _field(d, *names, default=None):
+    """First present key among aliases — defends against minor schema drift across market_* tools."""
+    if not isinstance(d, dict):
+        return default
+    for n in names:
+        if n in d and d[n] is not None:
+            return d[n]
+    return default
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pct(mark, prev):
+    m, p = _num(mark), _num(prev)
+    if m is None or p is None or p == 0:
+        return None
+    return round((m - p) / p * 100, 2)
+
+
+def _funding_sign(funding):
+    f = _num(funding)
+    if f is None:
+        return None
+    return "positive" if f > 1e-6 else ("negative" if f < -1e-6 else "flat")
+
+
+# ──────────────────────────────────────────────────────────────── data layer (MCP, fails open)
+def _get_client():
+    if HERE not in sys.path:
+        sys.path.insert(0, HERE)
+    from _mcp import MCPClient
+    return MCPClient()
+
+
+class _FixtureClient:
+    """Offline stand-in: maps an mcp_call to a recorded response by `(tool, dex)`. Used by tests."""
+    def __init__(self, recorded):
+        self._r = recorded
+
+    def mcp_call(self, tool, timeout=12, **kw):
+        key = tool + ("::" + kw["dex"] if "dex" in kw else "")
+        return self._r.get(key, self._r.get(tool))
+
+
+def fetch_instruments(client, meta):
+    """Bulk price+prevDayPx for EVERY asset, both dexes, in two calls. This is the resilient backbone:
+    daily moves never depend on candles, so a candle 500 can't drop an asset class.
+
+    Returns {ASSET: {"price": float, "change_pct": float}}.
+    """
+    out = {}
+
+    def pull(dex):
+        kw = {"timeout": 12}
+        if dex:
+            kw["dex"] = dex
+        try:
+            data = _ok(client.mcp_call("market_list_instruments", **kw))
+        except Exception as e:  # noqa
+            meta.setdefault("warnings", []).append(f"instruments({dex or 'main'}) failed: {e}")
+            return
+        # accept {instruments:[...]} | {universe:[...]} | [...] | {data:[...]}
+        rows = data if isinstance(data, list) else _field(data, "instruments", "universe", "data", default=[])
+        if not isinstance(rows, list):
+            return
+        for r in rows:
+            sym = _field(r, "name", "coin", "symbol", "asset")
+            if not sym:
+                continue
+            sym = str(sym).upper().replace("XYZ:", "")
+            # live schema nests the quote under `context`; fall through to it if not at top level
+            ctx = r.get("context") if isinstance(r.get("context"), dict) else {}
+            price = _num(_field(r, "markPx", "mark", "price", "midPx")) or _num(_field(ctx, "markPx", "mark", "price", "midPx"))
+            prev = _num(_field(r, "prevDayPx", "prevDay", "prev")) or _num(_field(ctx, "prevDayPx", "prevDay", "prev"))
+            out[sym] = {"price": price, "change_pct": _pct(price, prev)}
+
+    pull(None)      # main (crypto)
+    pull("xyz")     # HIP-3 equities / indices / commodities / fx
+    if not out:
+        meta.setdefault("warnings", []).append("instruments empty on both dexes — prices unavailable")
+    return out
+
+
+def deep_pull_movers(client, movers, meta):
+    """Capped parallel candle/volume/funding pull on the biggest movers — adds conviction + funding read.
+
+    `movers` is a list of (asset, is_xyz). Returns {ASSET: {volume_usd, funding, ...}}.
+    """
+    regime = None
+    try:
+        resp = _ok(client.mcp_call("market_get_funding_regime", timeout=8))
+        if isinstance(resp, str):
+            regime = resp
+        else:
+            regime = _field(resp or {}, "regime", "funding_regime", "label", "state")
+    except Exception:  # noqa
+        pass
+
+    def one(item):
+        asset, is_xyz = item
+        kw = dict(asset=asset, candle_intervals=["1h"], include_order_book=False,
+                  include_funding=True, timeout=12)
+        if is_xyz:
+            kw["dex"] = "xyz"   # HIP-3 requires dex, else INVALID_ARGUMENT
+        try:
+            data = _ok(client.mcp_call("market_get_asset_data", **kw))
+            if not data:
+                return (asset, None)
+            ctx = _field(data, "asset_context", "context", default={}) or {}
+            return (asset, {
+                "volume_usd": _num(_field(ctx, "dayNtlVlm", "dayNotionalVolume", "volume_usd")),
+                "funding": _funding_sign(_field(ctx, "funding")),
+                "oi_trend": _field(data.get("oi_velocity") or {}, "oi_trend"),
+            })
+        except Exception:  # noqa
+            return (asset, None)
+
+    pairs = []
+    try:
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(max_workers=6) as ex:
+            pairs = list(ex.map(one, movers))
+    except Exception:  # noqa
+        pairs = [one(m) for m in movers]
+    return {a: v for a, v in pairs if v}, regime
+
+
+def fetch_smart_money(client, meta):
+    """The leaderboard / Hyperfeed layer — health-gated. Returns None (cleanly) if the feed is down."""
+    try:
+        status = _ok(client.mcp_call("leaderboard_get_status", timeout=8))
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"smart-money layer unavailable (status check: {e})")
+        return None
+    # status is window metadata (timestamps, etc.), not a boolean flag — a non-None response IS health
+    if status is None:
+        meta.setdefault("warnings", []).append("smart-money layer unavailable (Hyperfeed unreachable)")
+        return None
+
+    sm = {"status": status}
+    for label, tool in (("concentration", "leaderboard_get_markets"),
+                        ("top_traders", "leaderboard_get_top"),
+                        ("momentum_events", "leaderboard_get_momentum_events")):
+        try:
+            sm[label] = _ok(client.mcp_call(tool, timeout=10))
+        except Exception as e:  # noqa
+            meta.setdefault("warnings", []).append(f"{tool} failed: {e}")
+            sm[label] = None
+    return sm
+
+
+# ──────────────────────────────────────────────────────────────── deterministic signals
+def _avg(vals):
+    xs = [v for v in vals if v is not None]
+    return round(sum(xs) / len(xs), 2) if xs else None
+
+
+def build_groups(prices):
+    """Per-asset rows + per-group average move, for crypto and every XYZ group."""
+    def rows(assets):
+        out = []
+        for a in assets:
+            p = prices.get(a)
+            if p:
+                out.append({"asset": a, "price": p.get("price"), "change_pct": p.get("change_pct")})
+            else:
+                out.append({"asset": a, "price": None, "change_pct": None, "missing": True})
+        return out
+
+    groups = {"crypto": {"rows": rows(CRYPTO)}}
+    groups["crypto"]["avg_change_pct"] = _avg(r["change_pct"] for r in groups["crypto"]["rows"])
+    for name, assets in XYZ_GROUPS.items():
+        groups[name] = {"rows": rows(assets)}
+        groups[name]["avg_change_pct"] = _avg(r["change_pct"] for r in groups[name]["rows"])
+    return groups
+
+
+def compute_signals(prices, groups):
+    """The concrete cross-asset reads the framework leans on (see references/analysis-framework.md).
+    Booleans/labels only — the LLM turns these into prose."""
+    def chg(a):
+        return (prices.get(a) or {}).get("change_pct")
+
+    sig = {}
+    # the confirmation checklist (each: value + a plain label the LLM can cite)
+    gold, dxy, vix = chg("GOLD"), chg("DXY"), chg("VIX")
+    sp500 = chg("SP500")
+    sig["gold"] = {"change_pct": gold,
+                   "read": "haven bid intact (no forced-liquidation cascade)" if (gold is not None and gold > -2)
+                   else "haven also selling — possible liquidity event" if gold is not None else None}
+    sig["dxy"] = {"change_pct": dxy,
+                  "read": "dollar calm — no funding stress" if (dxy is not None and abs(dxy) < 0.6)
+                  else "dollar bid — flight-to-USD / funding stress" if (dxy is not None and dxy > 0.6) else None}
+    sig["vix"] = {"value": (prices.get("VIX") or {}).get("price"), "change_pct": vix,
+                  "read": "fear contained" if (vix is not None and (prices.get('VIX') or {}).get('price') or 0) and ((prices.get('VIX') or {}).get('price') or 0) < 22
+                  else "fear elevated — watch for broadening" if vix is not None else None}
+
+    # dispersion: is the headline index calm while components break?
+    worst_group, worst_avg = None, 0.0
+    for name, g in groups.items():
+        a = g.get("avg_change_pct")
+        if a is not None and a < worst_avg:
+            worst_group, worst_avg = name, a
+    sig["dispersion"] = {
+        "sp500_change_pct": sp500,
+        "worst_group": worst_group, "worst_group_avg_pct": round(worst_avg, 2) if worst_group else None,
+        "read": ("dispersion — index calm while a sector breaks (rotation, not capitulation)"
+                 if (sp500 is not None and worst_group and (sp500 - worst_avg) > 2.5)
+                 else "broad — index moving with its components (macro, not rotation)"
+                 if sp500 is not None and worst_group else None),
+    }
+
+    # coarse day classification (the LLM refines; this just seeds the headline)
+    crypto_avg = groups.get("crypto", {}).get("avg_change_pct")
+    breadth = [g.get("avg_change_pct") for g in groups.values() if g.get("avg_change_pct") is not None]
+    down = sum(1 for x in breadth if x is not None and x < -0.5)
+    up = sum(1 for x in breadth if x is not None and x > 0.5)
+    if breadth:
+        if down >= up * 2 and down >= 3:
+            day = "risk_off"
+        elif up >= down * 2 and up >= 3:
+            day = "risk_on"
+        else:
+            day = "mixed"
+    else:
+        day = None
+    sig["day_classification"] = {"label": day, "groups_down": down, "groups_up": up,
+                                 "crypto_avg_pct": crypto_avg}
+    return sig
+
+
+# ──────────────────────────────────────────────────────────────── orchestration
+def run(client, want_smart=True):
+    meta = {"warnings": []}
+    prices = fetch_instruments(client, meta)
+    groups = build_groups(prices)
+    signals = compute_signals(prices, groups)
+
+    # deep-pull the biggest movers for volume/funding conviction (capped)
+    ranked = sorted(
+        ((a, p.get("change_pct")) for a, p in prices.items() if p.get("change_pct") is not None),
+        key=lambda x: abs(x[1]), reverse=True,
+    )
+    xyz_set = set(XYZ_ALL)
+    movers = [(a, a in xyz_set) for a, _ in ranked[:MOVER_DEEP_PULL]]
+    deep, regime = ({}, None)
+    if movers:
+        deep, regime = deep_pull_movers(client, movers, meta)
+    # fold conviction back onto the rows
+    for g in groups.values():
+        for row in g["rows"]:
+            if row["asset"] in deep:
+                row.update({k: v for k, v in deep[row["asset"]].items() if v is not None})
+    signals["funding_regime"] = regime
+
+    smart = fetch_smart_money(client, meta) if want_smart else None
+    meta["smart_money_available"] = smart is not None
+    if not prices:
+        meta["degraded"] = "no price data — all instrument pulls failed"
+
+    return {
+        "as_of": "live",                       # the agent stamps the human date; script stays deterministic
+        "day_classification": signals.get("day_classification"),
+        "signals": signals,
+        "groups": groups,
+        "smart_money": smart,
+        "meta": meta,
+    }
+
+
+# ──────────────────────────────────────────────────────────────── CLI
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="senpi market-pulse engine (cross-asset snapshot + signals)")
+    ap.add_argument("--no-smart", action="store_true", help="skip the leaderboard / smart-money layer")
+    ap.add_argument("--fixture", help="offline: path to a recorded MCP-response map (tests only)")
+    ap.add_argument("--dry", action="store_true",
+                    help="dump raw MCP responses (instruments both dexes + one asset) for schema debugging")
+    args = ap.parse_args(argv)
+
+    if args.dry:
+        try:
+            client = _get_client()
+            dump = {
+                "market_list_instruments": client.mcp_call("market_list_instruments", timeout=12),
+                "market_list_instruments::xyz": client.mcp_call("market_list_instruments", dex="xyz", timeout=12),
+                "market_get_asset_data(BTC)": client.mcp_call("market_get_asset_data", asset="BTC",
+                                                              candle_intervals=["1h"], timeout=12),
+                "market_get_funding_regime": client.mcp_call("market_get_funding_regime", timeout=8),
+                "leaderboard_get_status": client.mcp_call("leaderboard_get_status", timeout=8),
+            }
+            print(json.dumps(dump, ensure_ascii=False, indent=2, default=str))
+            return 0
+        except Exception as e:  # noqa
+            print(json.dumps({"error": f"dry dump failed: {e}"}))
+            return 1
+
+    if args.fixture:
+        try:
+            with open(args.fixture) as f:
+                client = _FixtureClient(json.load(f))
+        except Exception as e:  # noqa
+            print(json.dumps({"groups": {}, "meta": {"error": f"fixture load failed: {e}"}}))
+            return 1
+    else:
+        try:
+            client = _get_client()
+        except Exception as e:  # noqa
+            print(json.dumps({"groups": {}, "meta": {"error": f"mcp client init failed: {e}"}}))
+            return 1
+
+    try:
+        result = run(client, want_smart=not args.no_smart)
+    except Exception as e:  # noqa  — last-resort guard; the layer functions already fail open
+        print(json.dumps({"groups": {}, "meta": {"error": f"engine failure: {e}"}}))
+        return 1
+
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/senpi-market-pulse/tests/fixtures/pulse_fixture.json
+++ b/senpi-market-pulse/tests/fixtures/pulse_fixture.json
@@ -1,0 +1,53 @@
+{
+  "market_list_instruments": {
+    "instruments": [
+      {"name": "BTC", "context": {"markPx": "62515", "prevDayPx": "64802"}},
+      {"name": "ETH", "context": {"markPx": "1660", "prevDayPx": "1744"}},
+      {"name": "SOL", "context": {"markPx": "68.88", "prevDayPx": "71.7"}},
+      {"name": "HYPE", "context": {"markPx": "62.37", "prevDayPx": "64.3"}},
+      {"name": "XRP", "context": {"markPx": "1.10", "prevDayPx": "1.135"}},
+      {"name": "AVAX", "context": {"markPx": "6.37", "prevDayPx": "6.70"}},
+      {"name": "DOGE", "context": {"markPx": "0.079", "prevDayPx": "0.084"}}
+    ]
+  },
+  "market_list_instruments::xyz": {
+    "instruments": [
+      {"name": "xyz:MU", "context": {"markPx": "1092", "prevDayPx": "1180"}},
+      {"name": "xyz:SNDK", "context": {"markPx": "2009", "prevDayPx": "2301"}},
+      {"name": "xyz:SKHX", "context": {"markPx": "1718", "prevDayPx": "1924"}},
+      {"name": "xyz:DRAM", "context": {"markPx": "71.35", "prevDayPx": "79.73"}},
+      {"name": "xyz:WDC", "context": {"markPx": "675", "prevDayPx": "750"}},
+      {"name": "xyz:ASML", "context": {"markPx": "1787", "prevDayPx": "1902"}},
+      {"name": "xyz:TSM", "context": {"markPx": "443", "prevDayPx": "470"}},
+      {"name": "xyz:ARM", "context": {"markPx": "371", "prevDayPx": "408"}},
+      {"name": "xyz:NVDA", "context": {"markPx": "203", "prevDayPx": "210"}},
+      {"name": "xyz:AMD", "context": {"markPx": "525", "prevDayPx": "538"}},
+      {"name": "xyz:AMZN", "context": {"markPx": "235", "prevDayPx": "234"}},
+      {"name": "xyz:MSFT", "context": {"markPx": "373", "prevDayPx": "371"}},
+      {"name": "xyz:META", "context": {"markPx": "565", "prevDayPx": "563"}},
+      {"name": "xyz:GOOGL", "context": {"markPx": "347", "prevDayPx": "347"}},
+      {"name": "xyz:AAPL", "context": {"markPx": "298", "prevDayPx": "301"}},
+      {"name": "xyz:MSTR", "context": {"markPx": "106", "prevDayPx": "112"}},
+      {"name": "xyz:COIN", "context": {"markPx": "160", "prevDayPx": "166"}},
+      {"name": "xyz:TSLA", "context": {"markPx": "384", "prevDayPx": "408"}},
+      {"name": "xyz:SP500", "context": {"markPx": "7396", "prevDayPx": "7475"}},
+      {"name": "xyz:XYZ100", "context": {"markPx": "29571", "prevDayPx": "30262"}},
+      {"name": "xyz:JP225", "context": {"markPx": "69241", "prevDayPx": "72743"}},
+      {"name": "xyz:KR200", "context": {"markPx": "1346", "prevDayPx": "1505"}},
+      {"name": "xyz:VIX", "context": {"markPx": "20.0", "prevDayPx": "18.5"}},
+      {"name": "xyz:GOLD", "context": {"markPx": "4136", "prevDayPx": "4186"}},
+      {"name": "xyz:SILVER", "context": {"markPx": "62.27", "prevDayPx": "65.51"}},
+      {"name": "xyz:COPPER", "context": {"markPx": "6.22", "prevDayPx": "6.42"}},
+      {"name": "xyz:BRENTOIL", "context": {"markPx": "76.81", "prevDayPx": "77.19"}},
+      {"name": "xyz:NATGAS", "context": {"markPx": "3.23", "prevDayPx": "3.30"}},
+      {"name": "xyz:DXY", "context": {"markPx": "97.15", "prevDayPx": "97.20"}}
+    ]
+  },
+  "market_get_funding_regime": {"regime": "neutral"},
+  "market_get_asset_data": {"context": {"dayNtlVlm": "500000000", "funding": "-0.0000051"}},
+  "market_get_asset_data::xyz": {"context": {"dayNtlVlm": "417000000", "funding": "0.0"}},
+  "leaderboard_get_status": {"window": "4h", "updated_at": "2026-06-23T15:00:00Z"},
+  "leaderboard_get_markets": {"concentration": [{"asset": "HYPE", "direction": "short", "pct_of_gains": 19}]},
+  "leaderboard_get_top": {"traders": [{"wallet": "0xabc", "delta_pnl": 120000}]},
+  "leaderboard_get_momentum_events": {"events": [{"asset": "HYPE", "type": "scale_in", "direction": "short"}]}
+}

--- a/senpi-market-pulse/tests/test_pulse.py
+++ b/senpi-market-pulse/tests/test_pulse.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Offline engine test — runs pulse.run() against a recorded MCP fixture (no network).
+
+    python3 -m pytest senpi-market-pulse/tests/        # or: python3 tests/test_pulse.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS = os.path.join(HERE, "..", "scripts")
+sys.path.insert(0, SCRIPTS)
+
+import pulse  # noqa: E402
+
+FIXTURE = os.path.join(HERE, "fixtures", "pulse_fixture.json")
+
+
+def _result():
+    with open(FIXTURE) as f:
+        client = pulse._FixtureClient(json.load(f))
+    return pulse.run(client, want_smart=True)
+
+
+def test_all_classes_present():
+    """Every asset class is always returned — never crypto-only."""
+    g = _result()["groups"]
+    for required in ("crypto", "semis_memory", "software_megacap", "indices", "commodities", "macro_fx"):
+        assert required in g, f"missing group {required}"
+    assert g["crypto"]["avg_change_pct"] is not None
+    assert g["crypto"]["avg_change_pct"] < 0  # the fixture is a down day for crypto
+
+
+def test_context_nested_quotes_extracted():
+    """Regression: live market_list_instruments nests markPx/prevDayPx under `context`.
+    The fixture uses that real shape; prices must still come through (not all-null)."""
+    g = _result()["groups"]
+    btc = next(r for r in g["crypto"]["rows"] if r["asset"] == "BTC")
+    assert btc["price"] == 62515 and btc["change_pct"] is not None
+    # xyz rows arrive `xyz:`-prefixed — the symbol must be normalized and matched
+    sp500 = next(r for r in g["indices"]["rows"] if r["asset"] == "SP500")
+    assert sp500["price"] == 7396
+
+
+def test_day_classified_risk_off():
+    sig = _result()["signals"]
+    assert sig["day_classification"]["label"] == "risk_off"
+    assert sig["day_classification"]["groups_down"] >= 3
+
+
+def test_dispersion_read():
+    """SP500 calm while memory names break → the engine should flag dispersion, not capitulation."""
+    sig = _result()["signals"]
+    disp = sig["dispersion"]
+    assert disp["worst_group"] in ("semis_memory", "semis_equipment")
+    assert "dispersion" in (disp["read"] or "")
+
+
+def test_confirmation_checklist():
+    sig = _result()["signals"]
+    assert "haven bid intact" in (sig["gold"]["read"] or "")     # gold only -1.2%
+    assert "no funding stress" in (sig["dxy"]["read"] or "")     # DXY flat
+    assert "contained" in (sig["vix"]["read"] or "")             # VIX 20 < 22
+
+
+def test_movers_get_volume():
+    """The biggest movers should be deep-pulled and carry volume conviction."""
+    groups = _result()["groups"]
+    rows = [r for g in groups.values() for r in g["rows"]]
+    assert any(r.get("volume_usd") for r in rows), "no mover got a volume read"
+
+
+def test_smart_money_present_when_healthy():
+    res = _result()
+    assert res["meta"]["smart_money_available"] is True
+    assert res["smart_money"]["concentration"]["concentration"][0]["asset"] == "HYPE"
+
+
+def test_fails_open_on_empty():
+    """No data anywhere → still valid structure, flagged degraded, no exception."""
+    res = pulse.run(pulse._FixtureClient({}), want_smart=True)
+    assert "groups" in res and "meta" in res
+    assert res["meta"].get("degraded")
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    passed = 0
+    for fn in fns:
+        fn()
+        print(f"  ✓ {fn.__name__}")
+        passed += 1
+    print(f"\n{passed}/{len(fns)} passed")


### PR DESCRIPTION
## What

A new guide/analysis skill, **`senpi-market-pulse`**, that answers *"what's happening in the markets today?"* with thoughtful, structured, cross-asset analysis — the read a human couldn't assemble alone, not just "BTC is up."

Built on **Sarvesh's `senpi-strategy-discover` pattern** (`feat/strategy-discover-engine`): a hidden deterministic engine does the streamlined, resilient data-gathering + computes the cross-asset signals; the LLM (SKILL.md) does the analysis, narration, catalyst layer, and the closing CTAs.

## Why

Today, unguided, the agent answers this badly — it wanders across dozens of tool calls, leaves out whole asset classes (answered crypto-only until pushed, twice), leads with a single coin, stalls on infra hiccups (Hyperfeed down, XYZ candles 500ing, needs `dex="xyz"`), and stops at "BTC is down 3%." This skill makes the gold-standard answer the **first** answer.

## How it works

- **Engine (`scripts/pulse.py`)** — one health-check + parallel multi-class pull (crypto + XYZ equities + indices + commodities + macro). Daily moves come from `prevDayPx` on the instruments list, so a candle 500 / Hyperfeed outage **never drops an asset class**. Capped parallel deep-pull of the biggest movers for volume/funding conviction. Health-gated `leaderboard_*` smart-money layer (degrades to `null` cleanly). Deterministic signals: **dispersion** (index vs. components), the **gold/DXY/VIX confirmation checklist**, day classification. Fails open end-to-end.
- **`scripts/_mcp.py`** — self-contained MCP transport, reused from `senpi-strategy-discover`.
- **`SKILL.md`** — top-down output contract, the analysis framework, mandatory all-class coverage, and the two mandatory CTAs.
- **`references/analysis-framework.md`** — the cross-asset reasoning (dispersion vs capitulation, the gradient, confirmation checklist, K-shape, volume/funding).
- **`references/scope.md`** — v1 / v1.1 / v2 build plan.
- **`tests/`** — offline fixture test, **7/7 passing**, no network.

## Mandatory CTAs (per Jason)

Every market read ends with, verbatim:
> 1. Want me to check how our strategies and positions are positioned in this?
> 2. Want me to create a new strategy catered to this market?

CTA 1 → positions read. CTA 2 → hands **senpi-strategy-author** a brief pre-built from the thesis (proposes, never auto-builds).

## Review notes

- **Verify before merge:** the `market_*` field names in `pulse.py` (`markPx`/`prevDayPx`/`funding`/`dayNtlVlm` + the `market_list_instruments` shape) are taken from `senpi-strategy-discover`'s live usage + observed responses. Confirm against one live call and adjust the `_field()` fallbacks if the schema differs (engine is written defensively).
- **Scope:** v1 = Senpi MCP + the deterministic framework; catalyst web-search + CTA-2 brief live in the SKILL layer. Primary macro/FX feeds + holdings-personalization are v1.1 / v2 (see `references/scope.md`).
- The asset universe in `pulse.py` (`CRYPTO`, `XYZ_GROUPS`) is team-editable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Rebuilt cleanly on `strategy-v2` — supersedes #373. The original branch was cut from `main`, which shares no history with `strategy-v2` (orphan); since `strategy-v2` replaces `main`, this re-applies the additive skill on top of it._
