### PR TITLE
New skill: senpi-smart-money — "where is smart money moving?"

### DIFF
--- a/senpi-smart-money/README.md
+++ b/senpi-smart-money/README.md
@@ -1,0 +1,85 @@
+# senpi-smart-money
+
+A Senpi skill that answers **"where is smart money moving?"** — it shows where the proven,
+most-profitable Hyperliquid wallets are positioned, where they diverge from the crowd, and what the
+near-term flow looks like. The conversational, read-only counterpart to the **whalehunter** strategy.
+
+Modeled on `senpi-strategy-discover` / `senpi-market-pulse`: a **hidden deterministic engine** does
+the heavy data work; the **LLM (SKILL.md)** does the analysis, narration, and the closing CTAs.
+
+## What it reads
+
+Two cohorts, defined by **lifetime realized PnL** (the only honest "who's actually good" measure):
+
+- **Smart money** — wallets with **≥ $1M realized gains** (the proven cohort).
+- **The crowd** — wallets with **$10k–$100k realized** (good, but the followers).
+
+It aggregates each cohort's **net positioning** per coin (`bias = net/gross ∈ [−1,+1]`), finds the
+**divergences** (where the two are on opposite sides — the core signal), and overlays the near-term
+**Leaderboard/Hyperfeed 4h flow** (is the move building or fading).
+
+This mirrors the whalehunter strategy's cohort engine exactly — same definitions, same bias math —
+but as a one-shot *read* instead of a running trader.
+
+## Architecture
+
+```
+scripts/smartmoney.py   hidden engine — cohort build (paged discovery_get_top_traders) +
+                        bias aggregation (discovery_get_trader_state) + divergence detection +
+                        health-gated Leaderboard/Hyperfeed near-term layer → JSON
+scripts/_mcp.py         self-contained streamable-HTTP MCP client (stdlib only; read-only)
+SKILL.md                the analyst — lead-with-divergence output contract + the two CTAs
+references/analysis-framework.md   bias×members, divergence, all-time vs near-term, early-not-wrong
+tests/                  offline fixture test (no network)
+```
+
+## How it works
+
+1. **Build cohorts.** Page the ALL_TIME realized-PnL ranking (`discovery_get_top_traders`) until both
+   the ≥$1M smart band and the $10–100k crowd band are sampled. The crowd sits thousands of ranks
+   below the smart top, so a single top-N pull misses it — hence the paging (mirrors whalehunter).
+2. **Aggregate bias.** `discovery_get_trader_state` per cohort (batched) → net/gross/long/short per
+   coin → `bias ∈ [−1,+1]` with member counts.
+3. **Find divergences.** Coins where smart and crowd are on opposite sides (or far apart in
+   conviction), ranked opposite-sides-first.
+4. **Overlay near-term flow.** Health-gated `leaderboard_*` — concentration, hot traders, momentum
+   events (scale-ins = building, exits = fading). Degrades to `null` cleanly if Hyperfeed is down.
+
+Fails open end-to-end: partial data still returns valid JSON with `meta.warnings`.
+
+## Output
+
+`{cohorts, smart_leaning, divergences, near_term, meta}` →  the LLM narrates: headline lean → smart
+vs crowd divergence → near-term confirm/contradict → bottom line + watch list → **two CTAs**:
+
+> 1. Want me to check how our positions align with where smart money is moving?
+> 2. Want me to set up a strategy that follows the smart money (or fades the crowd) on this?
+
+CTA 2 routes to **senpi-strategy-author** (or names the **whalehunter** template, which trades this
+exact divergence) with a brief built from the strongest divergence — proposes, never auto-builds.
+
+## Run
+
+```sh
+python3 scripts/smartmoney.py            # full pull (cohorts + divergence + near-term)
+python3 scripts/smartmoney.py --no-near  # skip the Leaderboard/Hyperfeed layer
+python3 scripts/smartmoney.py --dry      # dump raw MCP responses for schema debugging
+python3 scripts/smartmoney.py --fixture tests/fixtures/smartmoney_fixture.json   # offline (tests)
+```
+
+## ⚠ Token scope
+
+`discovery_*` needs a **USER-scoped** `SENPI_AUTH_TOKEN` (it resolves a user id). An app-scoped token
+returns empty cohorts and the engine sets `meta.cohorts_unavailable` — the SKILL narrates that
+honestly rather than reporting an empty smart cohort as "flat." Same requirement as the whalehunter
+producer.
+
+## Status / review notes
+
+- **Cohort + bias logic is ported from `whalehunter/scripts/whalehunter-producer.py`** (realized-PnL
+  bands, paged sampling, `bias = net/gross`). Field-name fallbacks (`realizedProfitAndLoss`,
+  `openPositions`, `szi`/`positionValue`) match the producer's live usage — `--dry` dumps raw
+  responses if the schema drifts.
+- Cohort thresholds (`SMART_MIN_REALIZED`, crowd band, paging caps) are constants at the top of
+  `smartmoney.py`, team-editable.
+- Offline fixture test included; no network required.

--- a/senpi-smart-money/SKILL.md
+++ b/senpi-smart-money/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: senpi-smart-money
+description: >-
+  Answer "where is smart money moving?" — show where the most-profitable Hyperliquid wallets are
+  positioned, where they diverge from the crowd, and the near-term flow. Use for "where's smart
+  money", "what are the whales doing", "smart money vs the crowd", "follow the smart money". A
+  hidden engine (scripts/smartmoney.py) builds the cohorts and finds the divergences; you analyze.
+  Requires a USER-scoped Senpi token.
+license: Apache-2.0
+compatibility: OpenClaw, Hyperclaw, Claude Code
+metadata:
+  author: Senpi
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+---
+
+# Senpi Smart Money — where the proven money is moving
+
+You are a sharp flow analyst answering "where is smart money moving?" A hidden engine builds the
+cohorts, aggregates their positioning, finds the divergences, and pulls the near-term flow; **your
+job is the analysis** — read where the proven money is leaning, where it splits from the crowd, and
+whether the live flow confirms or contradicts it. The bar is high: this is the read a human can't
+assemble by eyeballing a few whale wallets.
+
+## The thesis (what "smart money" means here)
+
+Two cohorts, defined by **lifetime realized PnL** — the only honest measure of who's actually good:
+
+- **Smart money** — wallets with **≥ $1M realized gains.** The proven cohort.
+- **The crowd** — wallets with **$10k–$100k realized.** Good enough to have made money, but the
+  followers, not the leaders.
+
+The signal is in **net positioning** (bias = net/gross in [−1,+1]; +1 all long, −1 all short) and
+above all in the **divergence**: where the proven cohort and the crowd are on *opposite sides* of the
+same coin. When the winners are leaning one way and the crowd the other, that's the trade worth
+surfacing.
+
+## Golden rules
+
+- **Run the engine; never hand-build cohorts.** `python3 scripts/smartmoney.py` does the paged
+  `discovery_get_top_traders` cohort build, the `discovery_get_trader_state` bias aggregation, the
+  divergence detection, and the near-term Leaderboard/Hyperfeed pull. Read its JSON.
+- **Only name what the engine returned.** Cite assets/biases/cohort sizes from the JSON verbatim.
+  Don't invent positioning the engine didn't measure.
+- **Lead with the divergence.** Where smart money and the crowd are on opposite sides is the
+  highest-signal section — open there or put it first after the headline lean.
+- **Read the conviction, not just the direction.** A −0.9 bias across 40 wallets is a very different
+  statement than −0.3 across 6. Always cite `members` and `bias` together.
+- **Distinguish all-time positioning from near-term flow.** Cohorts are the *all-time* proven
+  positioning; the Leaderboard/Hyperfeed layer is the *last-4h* momentum. Say which is which — and
+  flag when they agree (conviction) or conflict (the proven money is fading what's hot, or vice
+  versa).
+- **Be honest about the smart cohort being early.** "Smart money is short" ≠ "it reverses tomorrow."
+  Surface it as positioning, not a timing call.
+- **Always end with the two CTAs** (below), verbatim.
+
+## How to run the engine
+
+Invoke via the `exec` tool:
+
+```
+python3 scripts/smartmoney.py [--no-near]
+```
+
+- Returns one JSON doc: `{cohorts, smart_leaning, divergences, near_term, meta}`.
+- `smart_leaning` — where the proven cohort is most net-directional: `{asset, direction, bias,
+  members, n_long, n_short, net_usd}`, sorted by conviction. **The headline.**
+- `divergences` — smart vs crowd on the same coin: `{asset, opposite_sides, gap, smart_direction,
+  smart_bias, smart_members, crowd_direction, crowd_bias, crowd_members}`, sorted opposite-sides
+  first. **The core signal.**
+- `near_term` — the Leaderboard/Hyperfeed 4h layer (`concentration`, `hot_traders`,
+  `momentum_events`) **or `null`** if Hyperfeed is down. Use it to confirm/contradict the cohort read.
+- `cohorts` — the sample sizes (how many proven / crowd wallets were measured). Cite these so the
+  user knows the sample behind the bias.
+- `meta` — `warnings`, `near_term_available`, and **`cohorts_unavailable`** (see token note below).
+- The engine **fails open** — partial data still returns valid JSON. Work with what you got.
+
+## ⚠ Token scope
+
+`discovery_*` needs a **USER-scoped** `SENPI_AUTH_TOKEN` (it resolves a user id). With an app-scoped
+token the cohort pulls come back empty and `meta.cohorts_unavailable` is set. If you see that, say so
+plainly ("I can't read the proven-cohort positioning with this token") — don't report an empty smart
+cohort as "smart money is flat." The near-term layer may still work.
+
+## Output contract
+
+1. **The headline** — where smart money is leaning *right now*, with conviction. Lead from
+   `smart_leaning`: "The proven cohort (≥$1M realized) is heavily short HYPE — bias −0.8 across 30
+   wallets." Cite bias + members.
+2. **Smart money vs the crowd** — the divergences. This is the payoff. For each: who's on which side,
+   how lopsided, how many wallets. Lead with `opposite_sides` cases. "The winners are short HYPE
+   (−0.8/30) while the $10–100k crowd is long it (+0.6/120) — they're on opposite sides."
+3. **Near-term flow** — the Leaderboard/Hyperfeed 4h read. Is the hot money *adding* (scale-ins in
+   `momentum_events`) or *unwinding*? Does it confirm the all-time cohort or fight it? If
+   `near_term` is null, note it and move on.
+4. **Bottom line** — one paragraph: where the proven money is positioned, where it diverges from the
+   crowd, whether the near-term flow backs it — plus a **"what to watch"** (e.g. "if the crowd
+   capitulates and flips short, the divergence is resolving").
+5. **The two CTAs** (next section).
+
+Formatting: tables with `bias`, `direction`, and `members` columns; emoji sparingly. Always pair a
+bias with its member count — conviction is the whole point.
+
+## Mandatory closing (verbatim)
+
+> **1. Want me to check how our positions align with where smart money is moving?**
+> **2. Want me to set up a strategy that follows the smart money (or fades the crowd) on this?**
+
+- **CTA 1 → positions read.** Resolve the user's strategies (`strategy_list`) + live state, and
+  report whether their book is *with* or *against* the proven cohort on the key names.
+- **CTA 2 → strategy.** Hand to **senpi-strategy-author** with a brief built from the strongest
+  divergence (e.g. *"proven cohort short HYPE −0.8/30 vs crowd long +0.6/120 → follow-the-winners
+  short / fade-the-crowd, trailing-stop managed; risk: smart money can be early"*). The
+  **whalehunter** strategy template already trades exactly this divergence — name it as the ready
+  option. **Propose; never auto-build or trade.**
+
+## Resilience (engine handles; narrate honestly)
+
+- **Hyperfeed down** → `near_term: null`. Note it; deliver the cohort read in full.
+- **Discovery token app-scoped** → `meta.cohorts_unavailable`. Say you can't read the cohort with
+  this token; offer the near-term layer if it came through.
+- **Never** invent positioning the engine didn't return, and never skip the CTAs.
+
+## Skill Attribution
+
+Guide/analysis skill — it *reads* positioning and *recommends*; it does not create a wallet or place
+a trade. Attribution happens downstream when **senpi-strategy-author** / **whalehunter** /
+**senpi-strategy-ops** act on CTA 2.

--- a/senpi-smart-money/references/analysis-framework.md
+++ b/senpi-smart-money/references/analysis-framework.md
@@ -1,0 +1,80 @@
+# Analysis framework — reading where smart money is moving
+
+The engine hands you two cohorts' net positioning + the divergences + the near-term flow. This is how
+you turn that into the read a human couldn't assemble by eyeballing a few whale wallets. **The signal
+is in positioning *relative to the crowd*, and in conviction — never in a single wallet.**
+
+## 1. Cohorts are defined by realized PnL — and that's the point
+
+- **Smart money = ≥ $1M lifetime realized gains.** Realized, not total (total includes unrealized,
+  which isn't proof of anything — a paper gain isn't a closed win). This is the only honest "who's
+  actually good" filter.
+- **The crowd = $10k–$100k realized.** Good enough to have made money, but the followers.
+
+When you cite the smart cohort, you're citing wallets that have *extracted* millions from this exact
+market. That's why their positioning is information.
+
+## 2. Bias + members, always together
+
+`bias = net_notional / gross_notional`, in [−1, +1]:
+- **+1** = every dollar the cohort holds in that coin is long. **−1** = every dollar short. **0** =
+  evenly split / no conviction.
+
+But bias alone lies. **Always pair it with `members`:**
+- −0.9 across **40** wallets = a strong, broad conviction. Lead with it.
+- −0.3 across **6** wallets = weak and thin. Mention it, don't headline it.
+
+A high bias on few members is noise; a moderate bias on many members is a real lean. The engine only
+surfaces coins with ≥ `MIN_MEMBERS` for exactly this reason.
+
+## 3. Divergence is the core signal
+
+The highest-value read is **where the proven cohort and the crowd are on opposite sides of the same
+coin.** The engine flags two cases:
+
+- **`opposite_sides: true`** — smart is net long, crowd net short (or vice versa). The cleanest
+  signal. The winners and the followers literally disagree.
+- **Large `gap`** — same side but very different conviction (smart −0.9, crowd −0.2 → the winners are
+  far more committed).
+
+Read it as: *"the wallets that have been right are positioned against the wallets that chase."* That's
+the whalehunter thesis, and it's the line the user remembers. Lead with the opposite-sides cases,
+ranked by how lopsided they are.
+
+## 4. All-time positioning vs. near-term flow — say which is which
+
+Two different clocks, and conflating them is the most common mistake:
+
+- **Cohorts (`smart_leaning`, `divergences`)** = *all-time* proven positioning. Slow-moving, high
+  conviction, the structural read.
+- **Near-term (`near_term`)** = the *last-4h* Leaderboard/Hyperfeed momentum. Fast, noisy, the live
+  flow.
+
+The interesting reads are at the seam:
+- **They agree** → the proven money and the hot money are both leaning the same way = high conviction.
+- **They conflict** → the proven cohort is positioned *against* what's hot right now. Either the
+  winners are early/contrarian (often the better read), or the near-term move is running away from
+  them. Name the tension; don't average it away.
+
+In `near_term.momentum_events`, **scale-in** events in the smart cohort's direction = the move is
+*building*; **exits** = it's *fading*. "Smart is short HYPE and the 4h flow shows fresh short
+scale-ins" is a much stronger statement than the static bias alone.
+
+## 5. Smart money is often early — frame it as positioning, not timing
+
+"The winners are short" and "it reverses tomorrow" are different claims. Proven wallets are
+frequently right on *direction* and wrong on *timing* — and some of a big short is hedging long spot,
+not a directional call. Surface the positioning honestly and let the user (and the risk engine, if
+they act on it) handle timing. Never present a cohort lean as a guaranteed reversal.
+
+## 6. Compose the read
+
+Lead with where smart money is leaning, make the divergence the centerpiece, check whether the
+near-term flow confirms it, and give the trigger that would resolve the divergence. Example:
+
+> "The proven cohort (≥$1M realized, 30 wallets) is heavily short HYPE — bias −0.8. The $10–100k
+> crowd (120 wallets) is long it, +0.6. They're on opposite sides, and the 4h flow shows the smart
+> cohort still adding shorts (fresh scale-ins), not covering. **What to watch:** if the crowd
+> capitulates and flips short, the divergence is resolving — that's often where the move accelerates."
+
+That's the difference between "whales are short" and a read worth acting on.

--- a/senpi-smart-money/scripts/_mcp.py
+++ b/senpi-smart-money/scripts/_mcp.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Self-contained streamable-HTTP MCP client (stdlib only).
+
+Ported from senpi_runtime_helpers.SenpiClient so the discovery skill has ZERO cross-skill
+dependency — it ships its own market-data transport. Read-only tool calls only.
+
+  client = MCPClient()                       # reads SENPI_AUTH_TOKEN / SENPI_MCP_URL from env
+  data = client.mcp_call("market_get_asset_data", asset="BTC")   # -> unwrapped {success,data,...}
+
+Returns the same unwrapped JSON `mcporter`/SenpiClient returns; None on an MCP-protocol error.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import http.client
+import itertools
+import json
+import os
+from urllib.parse import urlsplit
+
+MCP_URL = os.environ.get("SENPI_MCP_URL", "https://mcp.prod.senpi.ai/mcp")
+AUTH = os.environ.get("SENPI_AUTH_TOKEN", "")
+_PROTOCOL = "2025-03-26"
+
+
+class MCPError(Exception):
+    pass
+
+
+def _post(url, body, headers, timeout):
+    """POST a JSON body on a fresh connection; return (status, raw_bytes, content_type, session_id)."""
+    parts = urlsplit(url)
+    scheme = parts.scheme
+    host = parts.hostname or ""
+    port = parts.port or (443 if scheme == "https" else 80)
+    path = (parts.path or "/") + (("?" + parts.query) if parts.query else "")
+    data = json.dumps(body).encode("utf-8")
+    hdrs = {
+        "Host": parts.netloc,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "Content-Length": str(len(data)),
+    }
+    hdrs.update(headers)
+    cls = http.client.HTTPSConnection if scheme == "https" else http.client.HTTPConnection
+    conn = cls(host, port, timeout=timeout)
+    try:
+        conn.request("POST", path, body=data, headers=hdrs)
+        resp = conn.getresponse()
+        raw = resp.read()
+        return resp.status, raw, (resp.getheader("Content-Type") or ""), resp.getheader("Mcp-Session-Id")
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa
+            pass
+
+
+def _parse(raw, content_type):
+    """Streamable-HTTP returns a single JSON doc OR an SSE stream; return the first JSON-RPC payload."""
+    text = raw.decode("utf-8", errors="replace")
+    if "text/event-stream" in (content_type or "").lower():
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[5:].strip()
+                if payload and payload != "[DONE]":
+                    try:
+                        obj = json.loads(payload)
+                        if isinstance(obj, dict):
+                            return obj
+                    except json.JSONDecodeError:
+                        continue
+        return {}
+    if not text:
+        return {}
+    try:
+        obj = json.loads(text)
+        return obj if isinstance(obj, dict) else {"result": obj}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _unwrap(rpc):
+    """tools/call JSON-RPC -> the inner JSON document (content[0].text), like mcporter."""
+    if not isinstance(rpc, dict) or rpc.get("error"):
+        return None
+    result = rpc.get("result")
+    if not isinstance(result, dict):
+        return result
+    content = result.get("content")
+    if isinstance(content, list) and content:
+        first = content[0]
+        if isinstance(first, dict) and "text" in first:
+            try:
+                return json.loads(first["text"])
+            except (json.JSONDecodeError, TypeError):
+                return result
+    return result
+
+
+class MCPClient:
+    """Lazy `initialize` handshake (streamable-http), then `tools/call`. One per process."""
+
+    def __init__(self, url=None, token=None):
+        self.url = url or MCP_URL
+        self.token = token if token is not None else AUTH
+        self._sid = None
+        self._initialized = False
+        self._id = itertools.count(1)
+
+    def _headers(self, sid=None):
+        h = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        sid = sid or self._sid
+        if sid:
+            h["Mcp-Session-Id"] = sid
+        return h
+
+    def _initialize(self, timeout):
+        if self._initialized:
+            return
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "initialize",
+                "params": {"protocolVersion": _PROTOCOL, "capabilities": {},
+                           "clientInfo": {"name": "senpi-smart-money", "version": "2.0.0"}}}
+        status, _raw, _ct, sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"initialize HTTP {status}")
+        self._sid = sid
+        # streamable-http requires notifications/initialized after init
+        note = {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+        _post(self.url, note, self._headers(sid), timeout)
+        self._initialized = True
+
+    def mcp_call(self, tool, timeout=12, **arguments):
+        self._initialize(timeout)
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments}}
+        status, raw, ct, _sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"{tool} HTTP {status}")
+        return _unwrap(_parse(raw, ct))

--- a/senpi-smart-money/scripts/smartmoney.py
+++ b/senpi-smart-money/scripts/smartmoney.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""senpi-smart-money engine — cohort + divergence + near-term flow (hidden, deterministic).
+
+The agent (LLM) runs this via the OpenClaw `exec` tool, reads the JSON on stdout, and NARRATES
+"where smart money is moving" (see SKILL.md). The script does the heavy, deterministic data work —
+build the proven cohort vs the crowd, aggregate net positioning, find the divergences, pull the
+near-term Leaderboard/Hyperfeed flow — and the LLM does all the prose, the "why", and the CTAs.
+
+  python3 smartmoney.py               # full pull (cohorts + divergence + near-term)
+  python3 smartmoney.py --no-near     # skip the leaderboard / Hyperfeed near-term layer
+  python3 smartmoney.py --fixture f.json   # offline: recorded MCP-response map (tests)
+  python3 smartmoney.py --dry         # dump raw MCP responses for schema debugging
+
+Modeled on the whalehunter strategy's cohort engine (same definitions + bias math), and on
+senpi-strategy-discover's hidden-engine pattern: guarded I/O, fails open, always valid JSON.
+
+⚠ discovery_* requires a USER-scoped SENPI_AUTH_TOKEN (it resolves a user id). With an app-scoped
+token the cohort pulls return empty and the engine reports `meta.cohorts_unavailable` — narrate that
+honestly rather than pretending the smart cohort is flat.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# ──────────────────────────────────────────────────────────────── cohort definitions (mirror whalehunter)
+SMART_MIN_REALIZED = 1_000_000      # "smartest money": lifetime realized gains >= $1M
+CROWD_MIN_REALIZED = 10_000         # "crowd": $10k ..
+CROWD_MAX_REALIZED = 100_000        #        .. $100k realized
+PAGE_SIZE = 1000                    # discovery_get_top_traders page size (ALL_TIME realized ranking)
+MAX_PAGES = 6                       # page this deep to REACH the crowd band (it sits far below the smart top)
+SAMPLE_CAP = 150                    # cap each cohort's membership sample (bounds trader_state load)
+STATE_BATCH = 50                    # discovery_get_trader_state batch size
+MIN_MEMBERS = 5                     # need this many in a cohort on a coin to trust its net bias
+LEAN_THRESHOLD = 0.40               # |net/gross| past this = the cohort is meaningfully directional
+DIVERGENCE_MIN_GAP = 0.50           # smart-vs-crowd bias gap to flag a divergence (opposite signs always flag)
+
+
+# ──────────────────────────────────────────────────────────────── guarded I/O helpers
+def _ok(resp):
+    if isinstance(resp, dict):
+        if resp.get("success") is False:
+            return None
+        return resp.get("data", resp)
+    return resp
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _f(d, *keys, default=0.0):
+    if isinstance(d, dict):
+        for k in keys:
+            if k in d and d[k] is not None:
+                n = _num(d[k])
+                if n is not None:
+                    return n
+    return default
+
+
+def _field(d, *names, default=None):
+    if isinstance(d, dict):
+        for n in names:
+            if n in d and d[n] is not None:
+                return d[n]
+    return default
+
+
+def _traders_of(data):
+    """Normalize a discovery response into a list of trader dicts."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for k in ("traders", "data", "results"):
+            v = data.get(k)
+            if isinstance(v, list):
+                return v
+    return []
+
+
+# ──────────────────────────────────────────────────────────────── client
+def _get_client():
+    if HERE not in sys.path:
+        sys.path.insert(0, HERE)
+    from _mcp import MCPClient
+    return MCPClient()
+
+
+class _FixtureClient:
+    """Offline stand-in. Keys a call by (tool, dex) or (tool, first trader_address) so a fixture can
+    return DIFFERENT trader-state for the smart vs crowd cohort. Falls back to the bare tool name."""
+    def __init__(self, recorded):
+        self._r = recorded
+
+    def mcp_call(self, tool, timeout=12, **kw):
+        if "dex" in kw:
+            k = f"{tool}::{kw['dex']}"
+            if k in self._r:
+                return self._r[k]
+        addrs = kw.get("trader_addresses")
+        if addrs:
+            k = f"{tool}::{str(addrs[0]).lower()}"
+            if k in self._r:
+                return self._r[k]
+        return self._r.get(tool)
+
+
+# ──────────────────────────────────────────────────────────────── cohort building (mirror whalehunter)
+def _realized(t):
+    # LIFETIME realized PnL — never fall back to total profitAndLoss (not monotonic with the realized sort)
+    return _f(t, "realizedProfitAndLoss", "realized_profit_and_loss", "profit_and_loss_realized",
+              "realizedPnl", "realized_pnl", default=0.0)
+
+
+def build_cohorts(client, meta):
+    """Smart cohort (realized >= $1M) + crowd cohort ($10k..$100k) from the ALL_TIME realized-PnL
+    ranking. The ranking is DESC by realized, so the smart cohort is at the top and the crowd lives
+    thousands of ranks deeper — page by offset until both are sampled or the page drops below the
+    crowd floor."""
+    smart, crowd, seen = [], [], set()
+    pages = 0
+    for page in range(MAX_PAGES):
+        try:
+            resp = client.mcp_call("discovery_get_top_traders", time_frame="ALL_TIME",
+                                   sort_by="PROFIT_AND_LOSS_REALIZED", open_position_filter=False,
+                                   limit=PAGE_SIZE, offset=page * PAGE_SIZE, timeout=20)
+        except Exception as e:  # noqa
+            meta.setdefault("warnings", []).append(f"top_traders page {page} failed: {e}")
+            break
+        rows = _traders_of(_ok(resp))
+        if not rows:
+            break
+        pages += 1
+        page_top = None
+        for t in rows:
+            if not isinstance(t, dict):
+                continue
+            addr = str(_field(t, "address", "trader_address", "wallet", default="")).lower()
+            if not addr or addr in seen:
+                continue
+            rp = _realized(t)
+            page_top = rp if page_top is None else max(page_top, rp)
+            if rp >= SMART_MIN_REALIZED:
+                if len(smart) < SAMPLE_CAP:
+                    smart.append(addr); seen.add(addr)
+            elif CROWD_MIN_REALIZED <= rp <= CROWD_MAX_REALIZED:
+                if len(crowd) < SAMPLE_CAP:
+                    crowd.append(addr); seen.add(addr)
+        if len(smart) >= SAMPLE_CAP and len(crowd) >= SAMPLE_CAP:
+            break
+        if page_top is not None and page_top < CROWD_MIN_REALIZED:
+            break   # whole page below the crowd floor — we've paged past both cohorts
+    meta["cohort_pages"] = pages
+    return smart, crowd
+
+
+def _signed_notional(p):
+    szi = _f(p, "szi", "size")
+    val = _f(p, "positionValue", "notional", "position_value")
+    if val <= 0:
+        val = abs(szi) * _f(p, "entryPx", "markPx", "entry_price")
+    return (1.0 if szi > 0 else (-1.0 if szi < 0 else 0.0)) * abs(val)
+
+
+def cohort_bias(client, addrs, meta, label):
+    """Aggregate a cohort's NET positioning per coin: bias = net/gross in [-1,+1]
+    (+1 = all long, -1 = all short), plus long/short member counts. Batched."""
+    per = {}
+    for i in range(0, len(addrs), STATE_BATCH):
+        batch = addrs[i:i + STATE_BATCH]
+        try:
+            resp = client.mcp_call("discovery_get_trader_state", trader_addresses=batch, timeout=20)
+        except Exception as e:  # noqa
+            meta.setdefault("warnings", []).append(f"{label} trader_state batch failed: {e}")
+            continue
+        for t in _traders_of(_ok(resp)):
+            for p in (t.get("openPositions") or t.get("open_positions") or []):
+                if not isinstance(p, dict):
+                    continue
+                coin = p.get("coin") or p.get("asset")
+                sn = _signed_notional(p) if coin else 0.0
+                if not coin or sn == 0:
+                    continue
+                d = per.setdefault(coin, {"net": 0.0, "gross": 0.0, "n_long": 0, "n_short": 0})
+                d["net"] += sn
+                d["gross"] += abs(sn)
+                d["n_long" if sn > 0 else "n_short"] += 1
+    for d in per.values():
+        d["bias"] = round(d["net"] / d["gross"], 3) if d["gross"] > 0 else 0.0
+        d["members"] = d["n_long"] + d["n_short"]
+        d["net"] = round(d["net"], 2)
+    return per
+
+
+# ──────────────────────────────────────────────────────────────── signal computation
+def _dir(bias):
+    return "long" if bias > 0 else ("short" if bias < 0 else "flat")
+
+
+def smart_conviction(smart_per):
+    """Where the proven cohort is most net-directional (the 'where smart money is leaning' headline)."""
+    out = []
+    for coin, d in smart_per.items():
+        if d["members"] >= MIN_MEMBERS and abs(d["bias"]) >= LEAN_THRESHOLD:
+            out.append({"asset": coin, "bias": d["bias"], "direction": _dir(d["bias"]),
+                        "members": d["members"], "n_long": d["n_long"], "n_short": d["n_short"],
+                        "net_usd": d["net"]})
+    out.sort(key=lambda x: abs(x["bias"]) * x["members"], reverse=True)
+    return out
+
+
+def divergences(smart_per, crowd_per):
+    """Where the proven cohort and the crowd are on OPPOSITE sides (or far apart) — the core signal."""
+    out = []
+    for coin, sd in smart_per.items():
+        if sd["members"] < MIN_MEMBERS:
+            continue
+        cd = crowd_per.get(coin)
+        if not cd or cd["members"] < MIN_MEMBERS:
+            continue
+        gap = round(sd["bias"] - cd["bias"], 3)
+        opposite = (sd["bias"] > 0) != (cd["bias"] > 0) and sd["bias"] != 0 and cd["bias"] != 0
+        if opposite or abs(gap) >= DIVERGENCE_MIN_GAP:
+            out.append({
+                "asset": coin, "gap": gap, "opposite_sides": opposite,
+                "smart_bias": sd["bias"], "smart_direction": _dir(sd["bias"]),
+                "smart_members": sd["members"], "smart_net_usd": sd["net"],
+                "crowd_bias": cd["bias"], "crowd_direction": _dir(cd["bias"]),
+                "crowd_members": cd["members"],
+            })
+    out.sort(key=lambda x: (x["opposite_sides"], abs(x["gap"])), reverse=True)
+    return out
+
+
+# ──────────────────────────────────────────────────────────────── near-term layer (Leaderboard / Hyperfeed)
+def fetch_near_term(client, meta):
+    """The 4h-window momentum layer — health-gated. Returns None cleanly if Hyperfeed is down.
+    leaderboard_get_markets = where the hot cohort's gains concentrate; momentum_events = the live
+    entry/scale/exit flow (is the move building or fading)."""
+    try:
+        status = client.mcp_call("leaderboard_get_status", timeout=8)
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"near-term layer unavailable (status: {e})")
+        return None
+    if _ok(status) is None:
+        meta.setdefault("warnings", []).append("near-term layer unavailable (Hyperfeed unreachable)")
+        return None
+    near = {"status": _ok(status)}
+    for label, tool in (("concentration", "leaderboard_get_markets"),
+                        ("hot_traders", "leaderboard_get_top"),
+                        ("momentum_events", "leaderboard_get_momentum_events")):
+        try:
+            near[label] = _ok(client.mcp_call(tool, timeout=10))
+        except Exception as e:  # noqa
+            meta.setdefault("warnings", []).append(f"{tool} failed: {e}")
+            near[label] = None
+    return near
+
+
+# ──────────────────────────────────────────────────────────────── orchestration
+def run(client, want_near=True):
+    meta = {"warnings": []}
+    smart_addrs, crowd_addrs = build_cohorts(client, meta)
+    meta["smart_cohort_size"] = len(smart_addrs)
+    meta["crowd_cohort_size"] = len(crowd_addrs)
+
+    if not smart_addrs and not crowd_addrs:
+        meta["cohorts_unavailable"] = (
+            "no cohort data — discovery_get_top_traders returned empty. discovery_* needs a "
+            "USER-scoped SENPI_AUTH_TOKEN; an app-scoped token returns nothing here.")
+
+    smart_per = cohort_bias(client, smart_addrs, meta, "smart") if smart_addrs else {}
+    crowd_per = cohort_bias(client, crowd_addrs, meta, "crowd") if crowd_addrs else {}
+
+    leaning = smart_conviction(smart_per)
+    diverge = divergences(smart_per, crowd_per)
+    near = fetch_near_term(client, meta) if want_near else None
+    meta["near_term_available"] = near is not None
+
+    return {
+        "as_of": "live",
+        "cohorts": {
+            "smart": {"min_realized_usd": SMART_MIN_REALIZED, "members_sampled": len(smart_addrs),
+                      "coins": len(smart_per)},
+            "crowd": {"realized_band_usd": [CROWD_MIN_REALIZED, CROWD_MAX_REALIZED],
+                      "members_sampled": len(crowd_addrs), "coins": len(crowd_per)},
+        },
+        "smart_leaning": leaning,        # where the proven cohort is concentrated (headline)
+        "divergences": diverge,          # smart vs crowd, opposite sides (the core signal)
+        "near_term": near,               # Leaderboard / Hyperfeed 4h flow (confirm or contradict)
+        "meta": meta,
+    }
+
+
+# ──────────────────────────────────────────────────────────────── CLI
+def _dry(client):
+    out = {}
+    try:
+        out["discovery_get_top_traders(page0)"] = client.mcp_call(
+            "discovery_get_top_traders", time_frame="ALL_TIME", sort_by="PROFIT_AND_LOSS_REALIZED",
+            open_position_filter=False, limit=5, offset=0, timeout=20)
+    except Exception as e:  # noqa
+        out["discovery_get_top_traders(page0)"] = {"error": str(e)}
+    for tool, kw in (("leaderboard_get_status", {}), ("leaderboard_get_markets", {})):
+        try:
+            out[tool] = client.mcp_call(tool, timeout=8, **kw)
+        except Exception as e:  # noqa
+            out[tool] = {"error": str(e)}
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="senpi smart-money engine (cohort + divergence + near-term)")
+    ap.add_argument("--no-near", action="store_true", help="skip the leaderboard / Hyperfeed near-term layer")
+    ap.add_argument("--fixture", help="offline: path to a recorded MCP-response map (tests only)")
+    ap.add_argument("--dry", action="store_true", help="dump raw MCP responses for schema debugging")
+    args = ap.parse_args(argv)
+
+    if args.fixture:
+        try:
+            with open(args.fixture) as f:
+                client = _FixtureClient(json.load(f))
+        except Exception as e:  # noqa
+            print(json.dumps({"smart_leaning": [], "meta": {"error": f"fixture load failed: {e}"}}))
+            return 1
+    else:
+        try:
+            client = _get_client()
+        except Exception as e:  # noqa
+            print(json.dumps({"smart_leaning": [], "meta": {"error": f"mcp client init failed: {e}"}}))
+            return 1
+
+    if args.dry:
+        print(json.dumps(_dry(client), ensure_ascii=False, indent=2, default=str))
+        return 0
+
+    try:
+        result = run(client, want_near=not args.no_near)
+    except Exception as e:  # noqa  — last-resort guard; layer functions already fail open
+        print(json.dumps({"smart_leaning": [], "meta": {"error": f"engine failure: {e}"}}))
+        return 1
+
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/senpi-smart-money/tests/fixtures/smartmoney_fixture.json
+++ b/senpi-smart-money/tests/fixtures/smartmoney_fixture.json
@@ -1,0 +1,34 @@
+{
+  "discovery_get_top_traders": {
+    "traders": [
+      {"address": "0xsmart1", "realizedProfitAndLoss": 1500000},
+      {"address": "0xsmart2", "realizedProfitAndLoss": 1200000},
+      {"address": "0xcrowd1", "realizedProfitAndLoss": 50000},
+      {"address": "0xcrowd2", "realizedProfitAndLoss": 35000}
+    ]
+  },
+  "discovery_get_trader_state::0xsmart1": {
+    "traders": [
+      {"openPositions": [{"coin": "HYPE", "szi": -120, "positionValue": 9000, "entryPx": 62}, {"coin": "BTC", "szi": 1.0, "positionValue": 60000, "entryPx": 62000}]},
+      {"openPositions": [{"coin": "HYPE", "szi": -90, "positionValue": 7000, "entryPx": 63}, {"coin": "BTC", "szi": 0.8, "positionValue": 48000, "entryPx": 62500}]},
+      {"openPositions": [{"coin": "HYPE", "szi": -150, "positionValue": 11000, "entryPx": 61}, {"coin": "BTC", "szi": 1.2, "positionValue": 72000, "entryPx": 61500}]},
+      {"openPositions": [{"coin": "HYPE", "szi": -60, "positionValue": 5000, "entryPx": 62}, {"coin": "BTC", "szi": 0.5, "positionValue": 31000, "entryPx": 62000}]},
+      {"openPositions": [{"coin": "HYPE", "szi": -110, "positionValue": 8500, "entryPx": 62}, {"coin": "BTC", "szi": 0.9, "positionValue": 54000, "entryPx": 62000}]},
+      {"openPositions": [{"coin": "HYPE", "szi": -80, "positionValue": 6200, "entryPx": 62}, {"coin": "BTC", "szi": 0.7, "positionValue": 42000, "entryPx": 62000}]}
+    ]
+  },
+  "discovery_get_trader_state::0xcrowd1": {
+    "traders": [
+      {"openPositions": [{"coin": "HYPE", "szi": 100, "positionValue": 5000, "entryPx": 62}]},
+      {"openPositions": [{"coin": "HYPE", "szi": 80, "positionValue": 4000, "entryPx": 63}]},
+      {"openPositions": [{"coin": "HYPE", "szi": 120, "positionValue": 6000, "entryPx": 61}]},
+      {"openPositions": [{"coin": "HYPE", "szi": 60, "positionValue": 3000, "entryPx": 62}]},
+      {"openPositions": [{"coin": "HYPE", "szi": 90, "positionValue": 4500, "entryPx": 62}]},
+      {"openPositions": [{"coin": "HYPE", "szi": 70, "positionValue": 3500, "entryPx": 62}]}
+    ]
+  },
+  "leaderboard_get_status": {"window": "4h", "updated_at": "2026-06-23T15:00:00Z"},
+  "leaderboard_get_markets": {"concentration": [{"asset": "HYPE", "direction": "short", "pct_of_gains": 19}]},
+  "leaderboard_get_top": {"traders": [{"wallet": "0xhot", "delta_pnl": 80000}]},
+  "leaderboard_get_momentum_events": {"events": [{"asset": "HYPE", "type": "scale_in", "direction": "short"}]}
+}

--- a/senpi-smart-money/tests/test_smartmoney.py
+++ b/senpi-smart-money/tests/test_smartmoney.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Offline engine test — runs smartmoney.run() against a recorded MCP fixture (no network).
+
+    python3 -m pytest senpi-smart-money/tests/   # or: python3 tests/test_smartmoney.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+
+import smartmoney  # noqa: E402
+
+FIXTURE = os.path.join(HERE, "fixtures", "smartmoney_fixture.json")
+
+
+def _result():
+    with open(FIXTURE) as f:
+        client = smartmoney._FixtureClient(json.load(f))
+    return smartmoney.run(client, want_near=True)
+
+
+def test_cohorts_built():
+    c = _result()["cohorts"]
+    assert c["smart"]["members_sampled"] >= 2   # 0xsmart1/2 land in the >=$1M band
+    assert c["crowd"]["members_sampled"] >= 2   # 0xcrowd1/2 land in the $10-100k band
+
+
+def test_smart_leaning_headline():
+    """The proven cohort: short HYPE, long BTC — both above the lean threshold with enough members."""
+    leaning = {x["asset"]: x for x in _result()["smart_leaning"]}
+    assert leaning["HYPE"]["direction"] == "short" and leaning["HYPE"]["members"] >= 5
+    assert leaning["BTC"]["direction"] == "long" and leaning["BTC"]["members"] >= 5
+
+
+def test_divergence_opposite_sides():
+    """The core signal: smart short HYPE while the crowd is long it — flagged opposite_sides."""
+    div = {x["asset"]: x for x in _result()["divergences"]}
+    assert "HYPE" in div, "HYPE divergence not detected"
+    h = div["HYPE"]
+    assert h["opposite_sides"] is True
+    assert h["smart_direction"] == "short" and h["crowd_direction"] == "long"
+    assert h["smart_members"] >= 5 and h["crowd_members"] >= 5
+
+
+def test_near_term_present_when_healthy():
+    res = _result()
+    assert res["meta"]["near_term_available"] is True
+    assert res["near_term"]["concentration"]["concentration"][0]["asset"] == "HYPE"
+
+
+def test_cohorts_unavailable_flag_on_empty():
+    """No discovery data (e.g. app-scoped token) → flagged honestly, no exception."""
+    res = smartmoney.run(smartmoney._FixtureClient({}), want_near=True)
+    assert res["meta"].get("cohorts_unavailable")
+    assert res["smart_leaning"] == [] and res["divergences"] == []
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"  ✓ {fn.__name__}")
+    print(f"\n{len(fns)}/{len(fns)} passed")


### PR DESCRIPTION
## What

A new guide/analysis skill, **`senpi-smart-money`**, that answers *"show me where smart money is moving."* It's the conversational, **read-only counterpart to the `whalehunter` strategy** — same cohort engine, but a one-shot read instead of a running trader.

Built on the same hidden-engine pattern as **Sarvesh's `senpi-strategy-discover`** (and the `senpi-market-pulse` skill): deterministic Python engine does the heavy data work, the LLM (SKILL.md) does the analysis + CTAs.

## What it reads

Two cohorts by **lifetime realized PnL** (the honest "who's actually good" filter):
- **Smart money** — wallets with **≥ $1M realized** (the proven cohort)
- **The crowd** — wallets with **$10k–$100k realized** (good, but followers)

It aggregates each cohort's **net positioning** per coin (`bias = net/gross ∈ [−1,+1]`), finds the **divergences** (where they're on opposite sides — the core signal), and overlays the near-term **Leaderboard/Hyperfeed 4h flow** (building vs fading).

## How it works

1. **Build cohorts** — page the ALL_TIME realized-PnL ranking (`discovery_get_top_traders`) until both bands are sampled (the crowd sits thousands of ranks below the smart top, so a single top-N pull misses it — hence the paging).
2. **Aggregate bias** — `discovery_get_trader_state` per cohort (batched) → net/gross/long/short per coin.
3. **Find divergences** — opposite-sides (or large-gap) coins, ranked opposite-sides-first.
4. **Overlay near-term** — health-gated `leaderboard_*` (concentration / hot traders / momentum events; scale-ins = building, exits = fading). Degrades to `null` if Hyperfeed is down.

Cohort + bias math is **ported directly from `whalehunter/scripts/whalehunter-producer.py`** (same realized-PnL bands, same `bias = net/gross`), so the read matches what the strategy trades on.

## Output / CTAs

`{cohorts, smart_leaning, divergences, near_term, meta}` → headline lean → smart-vs-crowd divergence → near-term confirm/contradict → bottom line + watch list → two CTAs:
> 1. Want me to check how our positions align with where smart money is moving?
> 2. Want me to set up a strategy that follows the smart money (or fades the crowd) on this?

CTA 2 names the **whalehunter** template (trades this exact divergence) — proposes, never auto-builds.

## Review notes

- **Token scope:** `discovery_*` needs a **USER-scoped** `SENPI_AUTH_TOKEN`. App-scoped → empty cohorts → engine sets `meta.cohorts_unavailable` and the SKILL narrates that honestly. Same requirement as the whalehunter producer.
- Field-name fallbacks (`realizedProfitAndLoss`, `openPositions`, `szi`/`positionValue`) match the producer's live usage; `--dry` dumps raw responses if the schema drifts.
- Cohort thresholds are constants at the top of `smartmoney.py`, team-editable.
- Offline fixture test: **5/5 passing**, no network. Sample output: smart cohort short HYPE / long BTC, crowd long HYPE, divergence flagged opposite_sides (gap −2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Rebuilt cleanly on `strategy-v2` — supersedes #374. The original branch was cut from `main`, which shares no history with `strategy-v2` (orphan); since `strategy-v2` replaces `main`, this re-applies the additive skill on top of it._
