### PR TITLE
New skill: senpi-portfolio — real-time all-wallet portfolio analysis

### DIFF
--- a/senpi-portfolio/README.md
+++ b/senpi-portfolio/README.md
@@ -1,0 +1,83 @@
+# senpi-portfolio
+
+A Senpi skill that answers **"analyze my portfolio across all wallets"** with a precise, real-time
+wallet/balance breakdown and genuine analysis — not a flat data dump.
+
+Modeled on `senpi-strategy-discover` / `senpi-market-pulse` / `senpi-smart-money`: a **hidden
+deterministic engine** does the multi-wallet real-time pull + the balance taxonomy; the **LLM
+(SKILL.md)** does the analysis and the CTAs.
+
+## The problems it solves
+
+1. **Wallet clarity.** Main embedded wallet vs. per-strategy sub-wallets vs. funds deployed in
+   positions vs. sitting idle — computed explicitly and labeled by location.
+2. **The idle-cash trap.** Agents conflate `total_withdrawable` (free margin *inside strategy
+   wallets*) with "idle cash in the embedded wallet." The engine splits these into two structurally
+   separate fields so the agent can never mix them. (This is the exact bug that mislabeled $1,157 of
+   strategy margin as embedded idle when the embedded wallet held $0.)
+3. **No cached data.** `account_get_portfolio` caches HL data for 12h — the engine **always** passes
+   `forceFetch: true`, and reads each strategy's live `strategy_get_clearinghouse_state`.
+4. **Analysis, not a dump.** Every position is compared to the market (24h move, with/against the
+   tape, leveraged return); the portfolio gets net-exposure, concentration, and idle-drag reads.
+5. **Funding-ledger correctness.** Surfaces `total_funded` / `total_withdrawn` so a small balance
+   from withdrawn profits isn't misread as a loss.
+
+## The three buckets
+
+```
+grand_total = idle_in_embedded      (HL USDC + EVM USDC in the main wallet — truly free)
+            + idle_in_strategies     (free margin inside strategy wallets — == total_withdrawable)
+            + deployed_in_positions  (margin backing open trades)
+```
+
+`total_withdrawable` is **bucket 2, not bucket 1.** That distinction is the whole point of the skill.
+
+## Architecture
+
+```
+scripts/portfolio.py   hidden engine — user_get_me (embedded addr) + account_get_portfolio
+                       (forceFetch) + strategy_list + per-wallet strategy_get_clearinghouse_state +
+                       per-asset market_get_asset_data → three-bucket taxonomy + exposure + signals
+scripts/_mcp.py        self-contained streamable-HTTP MCP client (stdlib only; read-only)
+SKILL.md               the analyst — wallet model + bucket contract + position-vs-market + 2 CTAs
+references/analysis-framework.md   the money map, position-vs-market, exposure/concentration/idle-drag
+tests/                 offline fixture test (no network) — guards the conflation bug
+```
+
+## How it works
+
+1. **Embedded wallet** — `user_get_me` for the embedded address; `account_get_portfolio(forceFetch)`
+   for `total_usdc_in_hyperliquid` + EVM `token_balances` = idle-in-embedded (the only truly free
+   cash). Also grabs the portfolio aggregate for a reconciliation cross-check.
+2. **Strategy wallets** — `strategy_list` → per-wallet `strategy_get_clearinghouse_state` (live, both
+   DEXes). Each wallet's `withdrawable` = its idle margin (bucket 2); its positions = deployed.
+3. **Market context** — capped per-asset `market_get_asset_data` for each holding's 24h move →
+   `vs_market` (with/against the tape) on every position.
+4. **Compute** — the three buckets, net exposure (long/short, by asset), concentration, idle drag,
+   and a `reconciles` flag that flags drift between the per-wallet sum and the portfolio aggregate.
+
+Fails open end-to-end; partial data still returns valid JSON with `meta.warnings`.
+
+## Run
+
+```sh
+python3 scripts/portfolio.py             # full real-time pull (all wallets + market context)
+python3 scripts/portfolio.py --no-market # skip the per-asset market enrichment
+python3 scripts/portfolio.py --dry       # dump raw MCP responses for schema debugging
+python3 scripts/portfolio.py --fixture tests/fixtures/portfolio_fixture.json   # offline (tests)
+```
+
+## ⚠ Token scope
+
+Every tool here is **USER-scoped** (the user's own account): needs a USER-scoped `SENPI_AUTH_TOKEN`.
+An app-scoped token returns no wallet data and the engine sets `meta.degraded` — the SKILL says so
+rather than reporting "$0."
+
+## Status / review notes
+
+- **Field names verified against the Senpi MCP tool schemas + overview guide** (`total_withdrawable`,
+  `total_usdc_in_hyperliquid`, `total_allocated_in_strategy`, `token_balances`; clearinghouse
+  `marginSummary.accountValue` / `withdrawable` / `assetPositions[].position`). The engine reads
+  defensively with alias fallbacks — run `--dry` to confirm the live shape and adjust if needed.
+- Offline fixture test: guards that idle-in-embedded ≠ `total_withdrawable`, plus position/exposure
+  computation. No network required.

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: senpi-portfolio
+description: >-
+  Analyze the user's portfolio across all wallets — main embedded wallet, strategy sub-wallets,
+  deployed vs idle — with real-time balances and real analysis, not a flat dump. Use for "analyze
+  my portfolio", "how am I doing", "show my positions", "balance across all wallets", "how much is
+  idle". A hidden engine (scripts/portfolio.py) does the multi-wallet pull and taxonomy; you
+  narrate. Requires a USER-scoped Senpi token.
+license: Apache-2.0
+compatibility: OpenClaw, Hyperclaw, Claude Code
+metadata:
+  author: Senpi
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+---
+
+# Senpi Portfolio — real-time, all-wallet analysis
+
+You are a sharp portfolio analyst. A hidden engine pulls every wallet in real time and classifies
+every dollar into the right bucket; **your job is the analysis** — where the money sits, how the
+positions are doing *relative to the market*, and what the risks are. The bar is high: a flat list of
+balances is a failure. The user wants a read.
+
+## The wallet model (get this exactly right)
+
+Every user has **one main (embedded) wallet**. Funds flow: **embedded wallet → strategy sub-wallet →
+positions.** Each strategy is an isolated sub-wallet; **no strategy trades from the embedded wallet.**
+
+Every dollar is in exactly one of **three buckets** — and the #1 mistake is conflating them:
+
+| Bucket | What it is | Engine field |
+|---|---|---|
+| **Idle in embedded** | Truly free cash in the main wallet — HL USDC + EVM USDC. Deploy it into a strategy or withdraw it to your bank. | `totals.idle_in_embedded` |
+| **Idle in strategies** | Free margin sitting *inside* a strategy wallet, not yet in a position — waiting for a signal. | `totals.idle_in_strategies` |
+| **Deployed in positions** | Margin actively backing open trades. | `totals.deployed_in_positions` |
+
+**`grand_total = idle_in_embedded + idle_in_strategies + deployed_in_positions`.**
+
+### Cross-DEX: main and xyz are ONE wallet, not two
+
+A strategy wallet's clearinghouse state has a `main` (crypto) view and an `xyz` (equities/metals)
+view. **These are two views of one wallet, not two separate pools.** The `withdrawable` (idle cash) is
+**shared** and reported *identically* in both views — so it is counted **once**, never summed. Each
+view's `accountValue` = that shared idle + only *that* DEX's position equity, so
+`wallet_value = main.av + xyz.av − shared_idle`. The engine already de-duplicates this; you just read
+`account_value` / `idle_withdrawable` / `deployed` per strategy. **Never add the two views' account
+values or withdrawables yourself** — that double-counts the shared collateral (the bug that inflated a
+$3.1K account to $5.6K).
+
+### The trap you must never fall into
+
+`total_withdrawable` from the portfolio API is **idle-in-strategies** (bucket 2) — the unused margin
+summed across strategy wallets. **It is NOT idle cash in the embedded wallet.** If a user moved all
+their funds into strategies, the embedded wallet is **$0** even when `total_withdrawable` is large.
+The engine computes these as two separate fields precisely so you don't mix them. When you say "$X is
+idle," **always say *where*** — "$X idle in the embedded wallet, ready to deploy or withdraw" vs. "$Y
+sitting in strategy wallets waiting for signals." They are not the same money and not the same thing.
+
+## Golden rules
+
+- **Run the engine; never hand-pull balances.** `python3 scripts/portfolio.py` enumerates the
+  embedded wallet + every strategy sub-wallet, pulls live clearinghouse state per wallet, and
+  classifies the buckets. Read its JSON.
+- **Real-time, always.** The engine forces a fresh fetch (no 12h cache) and reads each strategy's
+  live clearinghouse state. Never report balances from earlier in the conversation — re-run.
+- **Always say which wallet / which bucket.** Every dollar figure gets a location. "Idle" is
+  meaningless without "idle *where*."
+- **Analyze, don't dump.** For every position, compare it to the market (`market_24h_pct`,
+  `vs_market`): is this short *working* because the asset is falling, or *fighting* a rally? Read net
+  exposure, concentration, idle drag. See `references/analysis-framework.md`.
+- **Use leveraged return, not raw price %.** Cite `return_on_equity_pct` (uPnL / margin), the number
+  that actually reflects the position — a 1% price move at 10x is a 10% return on margin.
+- **Don't infer "wiped out" from a low balance.** Check `total_funded` / `total_withdrawn` — a
+  strategy can show a small balance because profits were withdrawn (`netFunded` can be negative). That
+  is not a loss.
+- **"Current / my strategies" = ACTIVE only — never CLOSED.** The engine already filters
+  `strategy_list(status=["ACTIVE"])`, so closed strategies are excluded by construction. If you ever
+  reach for `strategy_list` directly, pass `status: ["ACTIVE"]` — a bare call returns CLOSED/PAUSED too
+  and they must not be presented as current. Mention PAUSED strategies only if relevant, clearly
+  labeled "paused," never as active.
+- **Present active strategies as known state, not a fresh discovery.** Pull the data quietly and state
+  what's running as established fact ("Your two active strategies are…"). Don't narrate the lookup
+  ("let me check… oh, I see you have…") — that reads like you didn't already know your own book.
+- **Always end with the two CTAs** (below), verbatim.
+
+## How to run the engine
+
+```
+python3 scripts/portfolio.py [--no-market]
+```
+
+Returns `{totals, embedded_wallet, strategies, exposure, signals, meta}`:
+- `totals` — the three buckets + `grand_total_usd`, `unrealized_pnl`, and a `reconciles` flag (cross-
+  checks the per-wallet sum against the portfolio aggregate; if `false`, say the numbers don't tie out
+  and lead with the per-wallet figures).
+- `embedded_wallet` — `address`, `idle_hl_usdc`, `evm_usdc[]` (per chain), `spot_usd`, `idle_total`.
+- `strategies[]` — per strategy: `name`, `wallet`, `account_value`, `idle_withdrawable` (bucket 2 for
+  *this* strategy), `deployed` (equity tied up in positions = account_value − withdrawable),
+  `position_margin` (initial margin detail), `total_funded`/`total_withdrawn`, and `positions[]` (asset,
+  dex, direction, leverage, notional, margin, `upnl`, `return_on_equity_pct`, `liq_px`,
+  `market_24h_pct`, `vs_market`).
+- `exposure` — `net_notional_usd` + `net_bias`, gross long/short, `by_asset_net_usd`,
+  `largest_position`.
+- `signals` — `idle_drag_pct` (how much capital isn't working), `deployed_pct`,
+  `largest_position_pct_of_deployed` (concentration).
+- The engine **fails open** — partial data still returns valid JSON with `meta.warnings`.
+
+## Output contract
+
+1. **Total + the three buckets.** Open with `grand_total_usd`, then break it into idle-in-embedded /
+   idle-in-strategies / deployed — each labeled by *where*. This is the part that's usually wrong;
+   get it right and explicit.
+2. **Per-strategy breakdown.** For each strategy sub-wallet: its account value, how much is deployed
+   vs idle *in that wallet*, and its positions. Use the strategy's own name (`tradingStrategyName`).
+3. **Position analysis (the real value).** For each open position: direction, leveraged return, and
+   **how it's doing vs the market** — "short ETH, +11% on margin, *with* the move as ETH falls 4%
+   today." Flag positions fighting the tape, near liquidation (`liq_px` vs mark), or oversized.
+4. **Portfolio-level read.** Net exposure (net long/short and by sector), concentration (largest
+   position), idle drag (capital sitting in cash), and the overall posture — is this book hedged,
+   directional, mostly in cash? Compare the net tilt to where the broader market is.
+5. **The two CTAs** (next section).
+
+Formatting: group by wallet; show `Δ%` and leveraged return; emoji sparingly (🟢/🔴 for green/red
+books). Show strategy wallet addresses in short form (`0x35d1...acb1`) unless asked for full.
+
+## Mandatory closing (verbatim)
+
+> **1. Want me to rebalance or adjust any of these positions?**
+> **2. Want me to put the idle capital to work in a new strategy?**
+
+- **CTA 1 → position management.** Route to the execution tools (`edit_position` / `close_position` /
+  `strategy_update`) for the specific position — confirm before any change; never trade unprompted.
+- **CTA 2 → deploy idle.** If there's meaningful idle capital (lead from `signals.idle_drag_pct`),
+  offer to hand it to **senpi-strategy-discover** / **senpi-strategy-author** — fund a new strategy
+  from the embedded idle, or top up an existing one from `strategy_top_up`. Propose; never deploy
+  without confirmation.
+
+## Resilience (engine handles; narrate honestly)
+
+- **Token app-scoped / no wallet data** → `meta.degraded`. Say you can't read the account with this
+  token (it needs a USER-scoped token); don't report an empty portfolio as "$0."
+- **A strategy's clearinghouse read failed** → it's in `meta.warnings`; that wallet's positions may be
+  incomplete. Say so rather than implying it's flat.
+- **`totals.reconciles == false`** → the per-wallet sum and the portfolio aggregate disagree; surface
+  it and trust the per-wallet (live) figures.
+- **Never** report `total_withdrawable` as embedded idle, never skip a wallet, never skip the CTAs.
+
+## Skill Attribution
+
+Guide/analysis skill — it *reads* the account and *recommends*; it does not place a trade or move
+funds. Attribution happens downstream when the execution tools / strategy skills act on a CTA.

--- a/senpi-portfolio/references/analysis-framework.md
+++ b/senpi-portfolio/references/analysis-framework.md
@@ -1,0 +1,79 @@
+# Analysis framework — reading a portfolio, not dumping balances
+
+The engine hands you a precise, real-time breakdown. This is how you turn it into analysis. Two
+jobs: (1) get the **money map** exactly right, and (2) read the **positions against the market.**
+
+## 1. The money map — three buckets, never conflated
+
+Every dollar is in exactly one place. The single most common failure is mislabeling where idle cash
+sits, so anchor on this:
+
+```
+grand_total
+├── idle_in_embedded      ← truly free. HL USDC + EVM USDC in the MAIN wallet.
+│                            Deploy into a strategy, or withdraw to your bank.
+├── idle_in_strategies     ← free margin sitting INSIDE strategy wallets, between trades.
+│                            Withdrawable back to main, but currently committed to a strategy.
+└── deployed_in_positions  ← margin actively backing open trades.
+```
+
+**The `total_withdrawable` trap.** The portfolio API's `total_withdrawable` is **idle_in_strategies**
+(bucket 2) — the unused margin summed across strategy wallets. It is **not** cash in the embedded
+wallet. A user who has moved everything into strategies has a **$0 embedded wallet** even when
+`total_withdrawable` reads four figures. The engine splits these into two fields on purpose. When you
+report idle capital, **name the wallet**: *"$0 idle in your embedded wallet — it's all deployed to
+strategies; $2,300 of that is sitting as free margin inside the strategy wallets waiting for
+signals."* Never collapse those into one "idle" number.
+
+**Always re-fetch.** Balances move every second. The engine forces a fresh pull (no 12h cache) and
+reads each strategy's live clearinghouse state — so re-run it every time, even if the user asked a
+minute ago. Never quote a figure from earlier in the conversation.
+
+## 2. Read each position against the market
+
+A balance is data; *"this short is working because the asset is falling"* is analysis. For every
+open position, the engine gives you `return_on_equity_pct`, `market_24h_pct`, and `vs_market`:
+
+- **Leveraged return, always.** Cite `return_on_equity_pct` (uPnL / margin), not the raw price move.
+  A 1% price move at 10x is a 10% return on margin — the raw % understates everything.
+- **With or against the tape.** A short is *working* when the asset is down today; a long when it's
+  up. `vs_market` flags this. The interesting cases are the ones *fighting* the move — a long
+  bleeding into a falling market is a position to call out, not bury.
+- **Alignment to the thesis.** If the book is a hedge (long sleeve + short sleeve), say which sleeve
+  is carrying — *"the short sleeve is up 11% and cushioning the long sleeve's drawdown."* That's the
+  read the user actually wants.
+
+## 3. Portfolio-level signals
+
+Zoom out from individual positions to the posture of the whole book:
+
+- **Net exposure** (`exposure.net_notional_usd`, `net_bias`). Is the book net long, net short, or
+  market-neutral? Compare that tilt to where the broader market is — a net-long book into a
+  semiconductor-led selloff is exposed; a net-short book is positioned for it.
+- **By-asset / by-sector** (`by_asset_net_usd`). Where is the real concentration? Three "different"
+  longs that are all AI semis are one bet, not three.
+- **Concentration** (`signals.largest_position_pct_of_deployed`). One position that's 60% of deployed
+  margin is a risk to name, even if it's green.
+- **Idle drag** (`signals.idle_drag_pct`). Capital sitting in cash earns nothing. A book that's 70%
+  idle is either patient or asleep — say which, and tee up the "put it to work" CTA.
+- **Liquidation proximity.** `liq_px` vs the current mark — a position 5% from liquidation is a risk
+  headline regardless of current PnL.
+
+## 4. Don't misread the funding ledger
+
+A small strategy balance is **not** proof of a loss. `netFunded = total_funded − total_withdrawn`
+can be negative when profits (and then some) have been withdrawn — that's a *win* being harvested,
+not a blow-up. Before calling anything "down," check the funding ledger. True performance is PnL
+against `netFunded`, not the raw account value.
+
+## 5. Compose the read
+
+Lead with the money map (correctly bucketed and located), then per-strategy, then the position-vs-
+market analysis, then the portfolio posture. End on the one or two things that actually matter — the
+position fighting the tape, the concentration risk, the idle capital — not a recap of every row.
+
+> "Your $2,933 is fully deployed to strategies — $0 sits idle in your embedded wallet, and $2,300 is
+> free margin inside the strategy wallets. The only live book is cub-short: three shorts (ETH, SP500,
+> XRP), all green and all *with* today's selloff — the short sleeve is doing exactly its job. cub-long
+> and cub-preipo are 100% in cash, waiting. Net-short, well-hedged, but ~78% of your capital isn't
+> working yet."

--- a/senpi-portfolio/scripts/_mcp.py
+++ b/senpi-portfolio/scripts/_mcp.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Self-contained streamable-HTTP MCP client (stdlib only).
+
+Ported from senpi_runtime_helpers.SenpiClient so the discovery skill has ZERO cross-skill
+dependency — it ships its own market-data transport. Read-only tool calls only.
+
+  client = MCPClient()                       # reads SENPI_AUTH_TOKEN / SENPI_MCP_URL from env
+  data = client.mcp_call("market_get_asset_data", asset="BTC")   # -> unwrapped {success,data,...}
+
+Returns the same unwrapped JSON `mcporter`/SenpiClient returns; None on an MCP-protocol error.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import http.client
+import itertools
+import json
+import os
+from urllib.parse import urlsplit
+
+MCP_URL = os.environ.get("SENPI_MCP_URL", "https://mcp.prod.senpi.ai/mcp")
+AUTH = os.environ.get("SENPI_AUTH_TOKEN", "")
+_PROTOCOL = "2025-03-26"
+
+
+class MCPError(Exception):
+    pass
+
+
+def _post(url, body, headers, timeout):
+    """POST a JSON body on a fresh connection; return (status, raw_bytes, content_type, session_id)."""
+    parts = urlsplit(url)
+    scheme = parts.scheme
+    host = parts.hostname or ""
+    port = parts.port or (443 if scheme == "https" else 80)
+    path = (parts.path or "/") + (("?" + parts.query) if parts.query else "")
+    data = json.dumps(body).encode("utf-8")
+    hdrs = {
+        "Host": parts.netloc,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "Content-Length": str(len(data)),
+    }
+    hdrs.update(headers)
+    cls = http.client.HTTPSConnection if scheme == "https" else http.client.HTTPConnection
+    conn = cls(host, port, timeout=timeout)
+    try:
+        conn.request("POST", path, body=data, headers=hdrs)
+        resp = conn.getresponse()
+        raw = resp.read()
+        return resp.status, raw, (resp.getheader("Content-Type") or ""), resp.getheader("Mcp-Session-Id")
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa
+            pass
+
+
+def _parse(raw, content_type):
+    """Streamable-HTTP returns a single JSON doc OR an SSE stream; return the first JSON-RPC payload."""
+    text = raw.decode("utf-8", errors="replace")
+    if "text/event-stream" in (content_type or "").lower():
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[5:].strip()
+                if payload and payload != "[DONE]":
+                    try:
+                        obj = json.loads(payload)
+                        if isinstance(obj, dict):
+                            return obj
+                    except json.JSONDecodeError:
+                        continue
+        return {}
+    if not text:
+        return {}
+    try:
+        obj = json.loads(text)
+        return obj if isinstance(obj, dict) else {"result": obj}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _unwrap(rpc):
+    """tools/call JSON-RPC -> the inner JSON document (content[0].text), like mcporter."""
+    if not isinstance(rpc, dict) or rpc.get("error"):
+        return None
+    result = rpc.get("result")
+    if not isinstance(result, dict):
+        return result
+    content = result.get("content")
+    if isinstance(content, list) and content:
+        first = content[0]
+        if isinstance(first, dict) and "text" in first:
+            try:
+                return json.loads(first["text"])
+            except (json.JSONDecodeError, TypeError):
+                return result
+    return result
+
+
+class MCPClient:
+    """Lazy `initialize` handshake (streamable-http), then `tools/call`. One per process."""
+
+    def __init__(self, url=None, token=None):
+        self.url = url or MCP_URL
+        self.token = token if token is not None else AUTH
+        self._sid = None
+        self._initialized = False
+        self._id = itertools.count(1)
+
+    def _headers(self, sid=None):
+        h = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        sid = sid or self._sid
+        if sid:
+            h["Mcp-Session-Id"] = sid
+        return h
+
+    def _initialize(self, timeout):
+        if self._initialized:
+            return
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "initialize",
+                "params": {"protocolVersion": _PROTOCOL, "capabilities": {},
+                           "clientInfo": {"name": "senpi-portfolio", "version": "2.0.0"}}}
+        status, _raw, _ct, sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"initialize HTTP {status}")
+        self._sid = sid
+        # streamable-http requires notifications/initialized after init
+        note = {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+        _post(self.url, note, self._headers(sid), timeout)
+        self._initialized = True
+
+    def mcp_call(self, tool, timeout=12, **arguments):
+        self._initialize(timeout)
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments}}
+        status, raw, ct, _sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"{tool} HTTP {status}")
+        return _unwrap(_parse(raw, ct))

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""senpi-portfolio engine — real-time wallet/balance taxonomy + holdings analysis (hidden).
+
+The agent (LLM) runs this via the OpenClaw `exec` tool, reads the JSON on stdout, and NARRATES a
+portfolio analysis (see SKILL.md). The script does the precise, real-time data work — enumerate every
+wallet, classify every dollar into the right bucket, attribute positions, and pull market context for
+analysis — and the LLM does the prose, the comparison, and the CTAs.
+
+  python3 portfolio.py              # full real-time pull (all wallets + market context)
+  python3 portfolio.py --no-market  # skip the per-asset market enrichment
+  python3 portfolio.py --fixture f.json   # offline: recorded MCP-response map (tests)
+  python3 portfolio.py --dry        # dump raw MCP responses for schema debugging
+
+WHY THIS EXISTS — the balance-bucket trap:
+Agents conflate `total_withdrawable` (free margin sitting INSIDE strategy wallets) with "idle cash in
+the main embedded wallet." They are different buckets. This engine computes three structurally
+separate pools so the agent never mixes them:
+  1. idle_in_embedded   = total_usdc_in_hyperliquid + EVM token_balances   (truly free; deploy or withdraw)
+  2. idle_in_strategies = sum of each strategy wallet's `withdrawable`      (in a strategy, not a position)
+  3. deployed           = margin backing open positions
+Grand total = idle_in_embedded + idle_in_strategies + deployed.
+
+REAL-TIME, NEVER CACHED: account_get_portfolio caches HL data 12h unless forceFetch=true — this
+engine always passes forceFetch. Per-strategy truth comes from live strategy_get_clearinghouse_state.
+
+⚠ All tools here are USER-scoped (your own account): needs a USER-scoped SENPI_AUTH_TOKEN.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+MARKET_ENRICH_CAP = 24      # cap the per-asset market pull
+
+
+# ──────────────────────────────────────────────────────────────── guarded I/O helpers
+def _ok(resp):
+    if isinstance(resp, dict):
+        if resp.get("success") is False:
+            return None
+        return resp.get("data", resp)
+    return resp
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _f(d, *keys, default=0.0):
+    if isinstance(d, dict):
+        for k in keys:
+            if k in d and d[k] is not None:
+                n = _num(d[k])
+                if n is not None:
+                    return n
+    return default
+
+
+def _field(d, *names, default=None):
+    if isinstance(d, dict):
+        for n in names:
+            if n in d and d[n] is not None:
+                return d[n]
+    return default
+
+
+def _pct(mark, prev):
+    m, p = _num(mark), _num(prev)
+    if m is None or p is None or p == 0:
+        return None
+    return round((m - p) / p * 100, 2)
+
+
+# ──────────────────────────────────────────────────────────────── client
+def _get_client():
+    if HERE not in sys.path:
+        sys.path.insert(0, HERE)
+    from _mcp import MCPClient
+    return MCPClient()
+
+
+class _FixtureClient:
+    """Offline stand-in. Keys a call by (tool, strategy_wallet) or (tool, asset/dex) so a fixture can
+    return per-wallet clearinghouse state. Falls back to the bare tool name."""
+    def __init__(self, recorded):
+        self._r = recorded
+
+    def mcp_call(self, tool, timeout=12, **kw):
+        for keyer in ("strategy_wallet", "asset"):
+            if kw.get(keyer):
+                k = f"{tool}::{str(kw[keyer]).lower()}"
+                if k in self._r:
+                    return self._r[k]
+        if "dex" in kw:
+            k = f"{tool}::{kw['dex']}"
+            if k in self._r:
+                return self._r[k]
+        return self._r.get(tool)
+
+
+# ──────────────────────────────────────────────────────────────── wallet discovery
+def fetch_embedded(client, meta):
+    """Main/embedded wallet idle cash — the ONLY truly-free pool. Real-time (forceFetch)."""
+    out = {"address": None, "idle_hl_usdc": None, "evm_usdc": [], "spot_usd": None,
+           "idle_total": None}
+    try:
+        me = _ok(client.mcp_call("user_get_me", timeout=12)) or {}
+        wallets = _field(me, "wallets", default=[]) or (me.get("user", {}) or {}).get("wallets", [])
+        for w in wallets if isinstance(wallets, list) else []:
+            if str(_field(w, "walletType", "type", default="")).lower() == "embedded":
+                out["address"] = _field(w, "walletAddress", "address")
+                break
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"user_get_me failed: {e}")
+
+    try:
+        # forceFetch=True → bypass the 12h HL cache. This is the cache-freshness guarantee.
+        p = _ok(client.mcp_call("account_get_portfolio", forceFetch=True, strategyStatus="ALL", timeout=25)) or {}
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"account_get_portfolio failed: {e}")
+        return out, {}
+
+    out["idle_hl_usdc"] = _f(p, "total_usdc_in_hyperliquid", default=0.0)
+    out["spot_usd"] = _f(p, "total_spot_usd_in_hyperliquid", default=0.0)
+    evm = 0.0
+    for tb in (_field(p, "token_balances", default=[]) or []):
+        sym = str(_field(tb, "symbol", "tokenSymbol", default="")).upper()
+        if sym in ("USDC", "USDC.E", "USDT"):
+            amt = _f(tb, "usdValue", "usd_value", "amountUsd", "balanceUsd", "amount", default=0.0)
+            chain = _field(tb, "chain", "network", "chainName", default="EVM")
+            if amt:
+                out["evm_usdc"].append({"chain": chain, "usd": round(amt, 2)})
+                evm += amt
+    out["idle_total"] = round((out["idle_hl_usdc"] or 0.0) + evm, 2)
+    portfolio_totals = {
+        "total_balance_usd": _f(p, "total_balance_usd", default=None),
+        "total_allocated_in_strategy": _f(p, "total_allocated_in_strategy", default=None),
+        "total_withdrawable": _f(p, "total_withdrawable", default=None),
+    }
+    return out, portfolio_totals
+
+
+def fetch_strategies(client, meta):
+    """Live per-strategy state: enumerate strategies, then clearinghouse state per wallet (real-time,
+    both DEXes). withdrawable = free margin idle IN that strategy; positions = deployed."""
+    try:
+        sl = _ok(client.mcp_call("strategy_list", status=["ACTIVE"], timeout=20))
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"strategy_list failed: {e}")
+        return []
+    rows = sl if isinstance(sl, list) else _field(sl, "strategies", "data", default=[])
+    strategies = []
+    for s in (rows or []):
+        wallet = _field(s, "strategyWalletAddress", "strategy_wallet_address", "walletAddress")
+        if not wallet:
+            continue
+        strategies.append({
+            "name": _field(s, "tradingStrategyName", "name", default="strategy"),
+            "wallet": wallet,
+            "status": _field(s, "status", default="ACTIVE"),
+            "total_funded": _f(s, "totalFunded", "total_funded", default=None),
+            "total_withdrawn": _f(s, "totalWithdrawn", "total_withdrawn", default=None),
+        })
+
+    def hydrate(strat):
+        try:
+            ch = _ok(client.mcp_call("strategy_get_clearinghouse_state", strategy_wallet=strat["wallet"], timeout=20))
+        except Exception as e:  # noqa
+            meta.setdefault("warnings", []).append(f"clearinghouse {strat['wallet'][:8]} failed: {e}")
+            return strat
+        dex_av, dex_wd, positions = {}, {}, []
+        for dex in ("main", "xyz"):
+            d = _field(ch, dex, default={}) if isinstance(ch, dict) else {}
+            ms = _field(d, "marginSummary", "margin_summary", default={}) or {}
+            dex_av[dex] = _f(ms, "accountValue", "account_value", default=0.0)
+            dex_wd[dex] = _f(d, "withdrawable", default=0.0)
+            for ap in (_field(d, "assetPositions", "asset_positions", default=[]) or []):
+                pos = _field(ap, "position", default=ap) or {}
+                szi = _f(pos, "szi", "size", default=0.0)
+                if szi == 0:
+                    continue
+                lev = pos.get("leverage") or {}
+                positions.append({
+                    "asset": _field(pos, "coin", "asset"),
+                    "dex": dex,
+                    "direction": "long" if szi > 0 else "short",
+                    "leverage": _f(lev, "value", default=None) if isinstance(lev, dict) else _num(lev),
+                    "notional": round(abs(_f(pos, "positionValue", "position_value", default=0.0)), 2),
+                    "margin": round(_f(pos, "marginUsed", "margin_used", default=0.0), 2),
+                    "entry_px": _f(pos, "entryPx", "entry_px", default=None),
+                    "upnl": round(_f(pos, "unrealizedPnl", "unrealized_pnl", default=0.0), 2),
+                    "return_on_equity_pct": round(_f(pos, "returnOnEquity", "return_on_equity", default=0.0) * 100, 2),
+                    "liq_px": _f(pos, "liquidationPx", "liquidation_px", default=None),
+                })
+        # CRITICAL — main and xyz are two VIEWS of ONE wallet, not separate pools. `withdrawable` is
+        # the SHARED idle collateral, mirrored identically in both views — count it ONCE (max == either).
+        # Each view's accountValue = shared idle + that DEX's own position equity (margin + uPnL), so:
+        #   wallet_value = main.av + xyz.av − shared_idle   (subtract the duplicated base exactly once)
+        # Summing av (or summing withdrawable) double-counts the shared collateral — the bug this fixes.
+        shared_idle = max(dex_wd.get("main", 0.0), dex_wd.get("xyz", 0.0))
+        deployed = sum(max(0.0, dex_av.get(dex, 0.0) - shared_idle) for dex in ("main", "xyz"))
+        strat["idle_withdrawable"] = round(shared_idle, 2)         # shared free margin (counted once)
+        strat["deployed"] = round(deployed, 2)                     # position equity across BOTH dexes
+        strat["account_value"] = round(shared_idle + deployed, 2)  # = main.av + xyz.av − shared_idle
+        strat["position_margin"] = round(sum(p["margin"] for p in positions), 2)   # initial margin detail
+        strat["positions"] = positions
+        return strat
+
+    try:
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(max_workers=6) as ex:
+            strategies = list(ex.map(hydrate, strategies))
+    except Exception:  # noqa
+        strategies = [hydrate(s) for s in strategies]
+    return strategies
+
+
+# ──────────────────────────────────────────────────────────────── market context (for analysis)
+def enrich_market(client, strategies, meta):
+    """Per-held-asset 24h move so the LLM can compare each position to the broader market."""
+    assets = []
+    for s in strategies:
+        for p in s.get("positions", []):
+            tag = (p["asset"], p["dex"])
+            if p["asset"] and tag not in assets:
+                assets.append(tag)
+    assets = assets[:MARKET_ENRICH_CAP]
+
+    def one(item):
+        asset, dex = item
+        kw = dict(asset=asset, candle_intervals=["1h"], include_order_book=False, timeout=12)
+        if dex == "xyz" or str(asset).startswith("xyz:"):
+            kw["dex"] = "xyz"
+        try:
+            data = _ok(client.mcp_call("market_get_asset_data", **kw))
+            ctx = _field(data, "asset_context", "context", default={}) or {}
+            # live schema nests the quote under `context`; handle both
+            inner = ctx if ("markPx" in ctx) else (_field(data, "context", default={}) or {})
+            mark = _field(ctx, "markPx", default=None) or _field(inner, "markPx", default=None)
+            prev = _field(ctx, "prevDayPx", default=None) or _field(inner, "prevDayPx", default=None)
+            return (asset, _pct(mark, prev))
+        except Exception:  # noqa
+            return (asset, None)
+
+    facts = {}
+    try:
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(max_workers=6) as ex:
+            for a, chg in ex.map(one, assets):
+                facts[a] = chg
+    except Exception:  # noqa
+        for item in assets:
+            a, chg = one(item)
+            facts[a] = chg
+    # fold onto positions + tag alignment
+    for s in strategies:
+        for p in s.get("positions", []):
+            chg = facts.get(p["asset"])
+            if chg is None:
+                continue
+            p["market_24h_pct"] = chg
+            # a short is "working" when the asset is down; a long when it's up
+            working = (p["direction"] == "short" and chg < 0) or (p["direction"] == "long" and chg > 0)
+            p["vs_market"] = "with the move" if working else "against the move"
+    return facts
+
+
+# ──────────────────────────────────────────────────────────────── taxonomy + signals
+def compute(embedded, strategies, portfolio_totals):
+    idle_strat = round(sum(_num(s.get("idle_withdrawable")) or 0.0 for s in strategies), 2)
+    deployed = round(sum(_num(s.get("deployed")) or 0.0 for s in strategies), 2)
+    idle_emb = embedded.get("idle_total") or 0.0
+    strat_acct = round(sum(_num(s.get("account_value")) or 0.0 for s in strategies), 2)
+    grand_total = round(idle_emb + strat_acct, 2)
+
+    # exposure
+    gross_long = gross_short = 0.0
+    by_asset = {}
+    upnl_total = 0.0
+    largest = None
+    for s in strategies:
+        for p in s.get("positions", []):
+            n = p["notional"]
+            upnl_total += p["upnl"]
+            if p["direction"] == "long":
+                gross_long += n
+            else:
+                gross_short += n
+            sign = n if p["direction"] == "long" else -n
+            by_asset[p["asset"]] = round(by_asset.get(p["asset"], 0.0) + sign, 2)
+            if largest is None or n > largest["notional"]:
+                largest = {"asset": p["asset"], "notional": n, "strategy": s["name"]}
+
+    totals = {
+        "grand_total_usd": grand_total,
+        "idle_in_embedded": round(idle_emb, 2),
+        "idle_in_strategies": idle_strat,
+        "deployed_in_positions": deployed,
+        "strategy_account_value": strat_acct,
+        "unrealized_pnl": round(upnl_total, 2),
+        # cross-check against the (cached-bypassed) portfolio aggregate, if present
+        "portfolio_total_balance_usd": portfolio_totals.get("total_balance_usd"),
+        "portfolio_total_withdrawable": portfolio_totals.get("total_withdrawable"),
+    }
+    # reconciliation flag — surfaces silent drift between the two sources
+    pbal = portfolio_totals.get("total_balance_usd")
+    totals["reconciles"] = (pbal is None) or (abs(pbal - grand_total) <= max(2.0, 0.01 * grand_total))
+
+    net = round(gross_long - gross_short, 2)
+    exposure = {
+        "net_notional_usd": net, "net_bias": ("long" if net > 0 else "short" if net < 0 else "flat"),
+        "gross_long_usd": round(gross_long, 2), "gross_short_usd": round(gross_short, 2),
+        "by_asset_net_usd": by_asset, "largest_position": largest,
+    }
+    working_cap = idle_emb + strat_acct
+    signals = {
+        "idle_drag_pct": round((idle_emb + idle_strat) / working_cap * 100, 1) if working_cap else None,
+        "deployed_pct": round(deployed / working_cap * 100, 1) if working_cap else None,
+        "largest_position_pct_of_deployed": round(largest["notional"] / (gross_long + gross_short) * 100, 1)
+            if largest and (gross_long + gross_short) else None,
+    }
+    return totals, exposure, signals
+
+
+# ──────────────────────────────────────────────────────────────── orchestration
+def run(client, want_market=True):
+    meta = {"warnings": [], "real_time": True, "force_fetch": True}
+    embedded, portfolio_totals = fetch_embedded(client, meta)
+    strategies = fetch_strategies(client, meta)
+    if want_market and strategies:
+        enrich_market(client, strategies, meta)
+    totals, exposure, signals = compute(embedded, strategies, portfolio_totals)
+    meta["strategy_count"] = len(strategies)
+    if not strategies and not embedded.get("address"):
+        meta["degraded"] = "no wallet data — check the token is USER-scoped"
+    return {
+        "as_of": "live",
+        "totals": totals,           # the three buckets — NEVER conflate them
+        "embedded_wallet": embedded,
+        "strategies": strategies,
+        "exposure": exposure,
+        "signals": signals,
+        "meta": meta,
+    }
+
+
+# ──────────────────────────────────────────────────────────────── CLI
+def _dry(client):
+    out = {}
+    for label, tool, kw in (("user_get_me", "user_get_me", {}),
+                            ("account_get_portfolio", "account_get_portfolio", {"forceFetch": True}),
+                            ("strategy_list", "strategy_list", {})):
+        try:
+            out[label] = client.mcp_call(tool, timeout=20, **kw)
+        except Exception as e:  # noqa
+            out[label] = {"error": str(e)}
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="senpi portfolio engine (real-time wallet taxonomy + analysis)")
+    ap.add_argument("--no-market", action="store_true", help="skip per-asset market enrichment")
+    ap.add_argument("--fixture", help="offline: path to a recorded MCP-response map (tests only)")
+    ap.add_argument("--dry", action="store_true", help="dump raw MCP responses for schema debugging")
+    args = ap.parse_args(argv)
+
+    if args.fixture:
+        try:
+            with open(args.fixture) as f:
+                client = _FixtureClient(json.load(f))
+        except Exception as e:  # noqa
+            print(json.dumps({"strategies": [], "meta": {"error": f"fixture load failed: {e}"}}))
+            return 1
+    else:
+        try:
+            client = _get_client()
+        except Exception as e:  # noqa
+            print(json.dumps({"strategies": [], "meta": {"error": f"mcp client init failed: {e}"}}))
+            return 1
+
+    if args.dry:
+        print(json.dumps(_dry(client), ensure_ascii=False, indent=2, default=str))
+        return 0
+
+    try:
+        result = run(client, want_market=not args.no_market)
+    except Exception as e:  # noqa
+        print(json.dumps({"strategies": [], "meta": {"error": f"engine failure: {e}"}}))
+        return 1
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/senpi-portfolio/tests/fixtures/portfolio_fixture.json
+++ b/senpi-portfolio/tests/fixtures/portfolio_fixture.json
@@ -1,0 +1,39 @@
+{
+  "user_get_me": {"wallets": [
+    {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"},
+    {"walletType": "external", "walletAddress": "0xext0000000000000000000000000000000000ext"}
+  ]},
+  "account_get_portfolio": {
+    "total_balance_usd": 3102.94,
+    "total_allocated_in_strategy": 3101.43,
+    "total_withdrawable": 2461.98,
+    "total_usdc_in_hyperliquid": 0,
+    "total_spot_usd_in_hyperliquid": 0,
+    "token_balances": [{"symbol": "USDC", "chain": "Base", "usdValue": 1.51}]
+  },
+  "strategy_list": {"strategies": [
+    {"tradingStrategyName": "cub-long", "strategyWalletAddress": "0xlong0000000000000000000000000000000long", "status": "ACTIVE", "totalFunded": 1739, "totalWithdrawn": 0},
+    {"tradingStrategyName": "cub-short", "strategyWalletAddress": "0xshort000000000000000000000000000000shrt", "status": "ACTIVE", "totalFunded": 1378, "totalWithdrawn": 0},
+    {"tradingStrategyName": "cub-preipo", "strategyWalletAddress": "0xpreipo00000000000000000000000000000prei", "status": "ACTIVE", "totalFunded": 202, "totalWithdrawn": 0}
+  ]},
+  "strategy_get_clearinghouse_state::0xlong0000000000000000000000000000000long": {
+    "main": {"marginSummary": {"accountValue": "1520.90"}, "withdrawable": "1520.90", "assetPositions": []},
+    "xyz": {"marginSummary": {"accountValue": "1520.90"}, "withdrawable": "1520.90", "assetPositions": []}
+  },
+  "strategy_get_clearinghouse_state::0xshort000000000000000000000000000000shrt": {
+    "main": {"marginSummary": {"accountValue": "1149.42"}, "withdrawable": "740.32", "assetPositions": [
+      {"position": {"coin": "ETH", "szi": -0.5, "positionValue": 840, "marginUsed": 210, "entryPx": 1719.7, "unrealizedPnl": 25.25, "returnOnEquity": 0.119, "leverage": {"value": 4}, "liquidationPx": 2100}},
+      {"position": {"coin": "XRP", "szi": -700, "positionValue": 770, "marginUsed": 192, "entryPx": 1.1177, "unrealizedPnl": 7.18, "returnOnEquity": 0.033, "leverage": {"value": 4}, "liquidationPx": 1.45}}
+    ]},
+    "xyz": {"marginSummary": {"accountValue": "970.67"}, "withdrawable": "740.32", "assetPositions": [
+      {"position": {"coin": "SP500", "szi": -0.11, "positionValue": 815, "marginUsed": 210, "entryPx": 7471.9, "unrealizedPnl": 10.14, "returnOnEquity": 0.046, "leverage": {"value": 4}, "liquidationPx": 9000}}
+    ]}
+  },
+  "strategy_get_clearinghouse_state::0xpreipo00000000000000000000000000000prei": {
+    "main": {"marginSummary": {"accountValue": "200.76"}, "withdrawable": "200.76", "assetPositions": []},
+    "xyz": {"marginSummary": {"accountValue": "200.76"}, "withdrawable": "200.76", "assetPositions": []}
+  },
+  "market_get_asset_data::eth": {"asset_context": {"markPx": "1660", "prevDayPx": "1744"}},
+  "market_get_asset_data::xrp": {"asset_context": {"markPx": "1.10", "prevDayPx": "1.135"}},
+  "market_get_asset_data::sp500": {"asset_context": {"markPx": "7396", "prevDayPx": "7475"}}
+}

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Offline engine test — runs portfolio.run() against a recorded MCP fixture (no network).
+
+The fixture reproduces the canonical bug scenario: embedded wallet holds ~$0 idle, all funds are in
+strategies, and `total_withdrawable` is large. The test guards that the engine reports those as
+SEPARATE buckets and never collapses strategy-margin into "embedded idle."
+
+    python3 -m pytest senpi-portfolio/tests/   # or: python3 tests/test_portfolio.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+
+import portfolio  # noqa: E402
+
+FIXTURE = os.path.join(HERE, "fixtures", "portfolio_fixture.json")
+
+
+def _result():
+    with open(FIXTURE) as f:
+        client = portfolio._FixtureClient(json.load(f))
+    return portfolio.run(client, want_market=True)
+
+
+def test_embedded_idle_is_not_total_withdrawable():
+    """THE bug guard: embedded idle is the $1.51 EVM USDC, NOT the $2,301 total_withdrawable."""
+    t = _result()["totals"]
+    assert t["idle_in_embedded"] == 1.51                 # only the EVM USDC; HL embedded is $0
+    assert t["idle_in_strategies"] > 2000                # this is where total_withdrawable lives
+    assert t["idle_in_embedded"] != t["idle_in_strategies"]
+
+
+def test_three_buckets_sum_to_total():
+    t = _result()["totals"]
+    s = t["idle_in_embedded"] + t["idle_in_strategies"] + t["deployed_in_positions"]
+    assert abs(s - t["grand_total_usd"]) <= 2.0          # the three buckets reconcile to the total
+
+
+def test_shared_dex_collateral_not_double_counted():
+    """REGRESSION: `withdrawable` is shared/mirrored across the main+xyz views — count it ONCE.
+    cub-short raw: main.av 1149.42 / xyz.av 970.67 / shared withdrawable 740.32.
+    Correct wallet value = 1149.42 + 970.67 − 740.32 = 1379.77 (NOT 2120.09 summed, NOT 1149.42 max)."""
+    strat = {s["name"]: s for s in _result()["strategies"]}
+    short = strat["cub-short"]
+    assert short["idle_withdrawable"] == 740.32          # shared idle, counted once (not 1480.64)
+    assert short["account_value"] == 1379.77             # main.av + xyz.av − shared idle
+    assert short["deployed"] == 639.45                   # position equity across BOTH dexes (409.10 + 230.35)
+    # and the grand total reflects it — ~$3,103, not the double-counted ~$5,560
+    t = _result()["totals"]
+    assert 3050 <= t["grand_total_usd"] <= 3150
+
+
+def test_embedded_address_resolved():
+    e = _result()["embedded_wallet"]
+    assert e["address"] == "0xembed00000000000000000000000000000000ed"
+    assert e["idle_hl_usdc"] == 0                         # all funds moved into strategies
+
+
+def test_short_book_positions_and_market_alignment():
+    """cub-short holds 3 shorts, all working WITH today's selloff."""
+    strat = {s["name"]: s for s in _result()["strategies"]}
+    short = strat["cub-short"]
+    assert len(short["positions"]) == 3
+    assert all(p["direction"] == "short" for p in short["positions"])
+    eth = next(p for p in short["positions"] if p["asset"] == "ETH")
+    assert eth["market_24h_pct"] < 0 and eth["vs_market"] == "with the move"
+    assert eth["return_on_equity_pct"] == 11.9           # leveraged return, not raw price %
+
+
+def test_flat_strategies_are_all_idle():
+    strat = {s["name"]: s for s in _result()["strategies"]}
+    lng = strat["cub-long"]
+    assert lng["positions"] == [] and lng["deployed"] == 0
+    assert lng["idle_withdrawable"] > 1500               # 100% free margin
+
+
+def test_exposure_net_short():
+    exp = _result()["exposure"]
+    assert exp["net_bias"] == "short"                    # every open position is a short
+    assert exp["gross_long_usd"] == 0
+
+
+def test_fails_open_on_empty():
+    res = portfolio.run(portfolio._FixtureClient({}), want_market=True)
+    assert "totals" in res and res["meta"].get("degraded")
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"  ✓ {fn.__name__}")
+    print(f"\n{len(fns)}/{len(fns)} passed")


### PR DESCRIPTION
## What

A new guide/analysis skill, **`senpi-portfolio`**, that answers *"analyze my portfolio across all wallets"* with a precise, real-time wallet/balance taxonomy and genuine analysis — not a flat data dump. Same hidden-engine pattern as `senpi-strategy-discover` / `senpi-market-pulse` / `senpi-smart-money`.

## The problems it solves (all from real agent failures)

1. **Wallet clarity** — main embedded wallet vs. per-strategy sub-wallets vs. deployed-in-positions vs. idle, computed explicitly and labeled by *location*.
2. **The idle-cash trap** — `account_get_portfolio.total_withdrawable` is free margin sitting **inside strategy wallets** (bucket 2), **not** idle cash in the embedded wallet (bucket 1). A user who moved everything into strategies has a **$0 embedded wallet** even when `total_withdrawable` is four figures. The engine computes these as two structurally separate fields so the agent can't conflate them. *(This is the exact bug where an agent reported $1,157 of strategy margin as "idle in the embedded wallet" when it held $0.)* A test guards it.
3. **No cached data** — `account_get_portfolio` caches HL data **12h** unless `forceFetch: true`; the engine always forces a fresh fetch and reads each strategy's live `strategy_get_clearinghouse_state`.
4. **Analysis, not a dump** — every position is compared to the market (24h move, with/against the tape, leveraged return); the portfolio gets net-exposure, concentration, and idle-drag reads.
5. **Funding-ledger correctness** — surfaces `totalFunded`/`totalWithdrawn` so a small balance from withdrawn profits isn't misread as a loss (`netFunded` can be negative — normal).

## The three buckets (reconcile by construction)

```
grand_total = idle_in_embedded      (HL USDC + EVM USDC in the main wallet — truly free)
            + idle_in_strategies     (free margin inside strategy wallets — == total_withdrawable)
            + deployed_in_positions  (equity tied up in positions = account_value − withdrawable)
```

`total_withdrawable` is **bucket 2, not bucket 1** — the whole point of the skill.

## How it works

- `user_get_me` → embedded address; `account_get_portfolio(forceFetch)` → embedded idle (HL USDC + EVM `token_balances`) + aggregate for a reconciliation cross-check.
- `strategy_list` → per-wallet `strategy_get_clearinghouse_state` (live, both DEXes). Each wallet's `withdrawable` = idle-in-strategy; `account_value − withdrawable` = deployed.
- Capped per-asset `market_get_asset_data` → `vs_market` (with/against the tape) on every position.
- Computes exposure (net long/short, by asset), concentration, idle drag, and a `reconciles` flag.

Fails open end-to-end. **Offline fixture test: 7/7**, no network — guards `idle_in_embedded ≠ total_withdrawable` and that the three buckets sum to the total.

## CTAs

> 1. Want me to rebalance or adjust any of these positions?
> 2. Want me to put the idle capital to work in a new strategy?

CTA 1 → execution tools; CTA 2 → strategy-discover / strategy-author / `strategy_top_up`. Propose, never act.

## Review notes

- Field names verified against the Senpi MCP tool schemas + the `senpi-overview` guide. Defensive alias fallbacks; `--dry` dumps raw responses if the live shape differs.
- **USER-scoped `SENPI_AUTH_TOKEN` required** — app-scoped returns no wallet data and the engine sets `meta.degraded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Rebuilt cleanly on `strategy-v2` — supersedes #376. The original branch was cut from `main`, which shares no history with `strategy-v2` (orphan); since `strategy-v2` replaces `main`, this re-applies the additive skill on top of it._
