### PR TITLE
Two new read skills: senpi-trader-research + senpi-account-status (context-reduction Phase 2)

### DIFF
--- a/senpi-account-status/README.md
+++ b/senpi-account-status/README.md
@@ -1,0 +1,41 @@
+# senpi-account-status
+
+A Senpi skill that shows the user's **standing across Senpi's programs** in one real-time call —
+Senpi points + rank, loyalty tier + fee, Agents Arena position + prize context, referral earnings,
+and shareable wins.
+
+Same hidden-engine pattern as the other read skills. Collapses these read tools off the eager tool
+list (per the context-reduction plan): `arena_leaderboard`, `arena_pool`, `arena_prizes`,
+`arena_roe_chart`, `user_get_senpi_points`, `user_get_senpi_points_leaderboard`, `get_loyalty_tiers`,
+`get_share_your_wins`, `user_get_referral_rewards`.
+
+## What it returns
+
+`{identity, points, loyalty, arena, referral, wins, meta}`:
+- **points** — total, base (Base copy-trading) / perp (Hyperliquid) split, multiplier, rank, change.
+- **loyalty** — tier, fee bps + discount, and `points_to_next` → `next_tier` (the milestone; derived
+  from `get_loyalty_tiers` if the points response doesn't carry it).
+- **arena** — `enrolled`; if so: rank, ROE %, qualified flag, week pool, and prize estimate if top-5.
+- **referral** — pending `balance_usdc` (25% of builder fee on referred trades).
+- **wins** — recent profitable closed trades for sharing.
+
+## Run
+
+```sh
+python3 scripts/status.py
+python3 scripts/status.py --dry      # raw schema dump
+python3 scripts/status.py --fixture tests/fixtures/status_fixture.json   # offline (tests)
+```
+
+## ⚠ Token scope
+
+All tools are **USER-scoped** (the user's own account): needs a USER-scoped `SENPI_AUTH_TOKEN`.
+App-scoped → no user resolves and `meta.degraded`.
+
+## Status / review notes
+
+- Input params verified against the live MCP tool schemas (`user_get_senpi_points` takes
+  `input.{walletAddress|userId}`; arena tools take `period_type`). Output field names use defensive
+  alias fallbacks — run `--dry` to confirm the live response shape and adjust if needed.
+- Read-only: never calls `user_claim_referral_rewards` (claiming is a separate explicit action).
+- Offline fixture test included; no network.

--- a/senpi-account-status/SKILL.md
+++ b/senpi-account-status/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: senpi-account-status
+description: >-
+  Show the user's standing across Senpi programs — points and rank, loyalty tier and fees, Agents
+  Arena position, referral earnings, and shareable wins. Use for "how many points do I have?",
+  "what's my rank/tier?", "what are my fees?", "how am I doing in the Arena?", "my referral
+  rewards", "show my wins". A hidden engine (scripts/status.py) pulls it all in one call. Requires
+  a USER-scoped Senpi token.
+license: Apache-2.0
+compatibility: OpenClaw, Hyperclaw, Claude Code
+metadata:
+  author: Senpi
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+---
+
+# Senpi Account Status — your standing across Senpi
+
+A hidden engine pulls the user's standing in one real-time call; **your job is to present it
+cleanly** and point at the next milestone (next loyalty tier, Arena prize, etc.).
+
+## Golden rules
+
+- **Run the engine; never hand-pull.** `python3 scripts/status.py` gathers points, loyalty, Arena,
+  referral, and wins together. Read its JSON.
+- **Real-time, not from memory.** Points/rank/Arena move — never quote a figure from earlier in the
+  conversation; re-run.
+- **Fees come from the data, never from memory.** Quote `loyalty.fee_bps` / `fee_discount_pct` as
+  returned — the tier table changes; stale numbers mislead. (For the *full* tier table, that's
+  `get_loyalty_tiers`; this skill returns the user's *own* tier.)
+- **Lead with what they asked, then the milestone.** If they asked about points, lead with points +
+  rank, then "X to the next tier." Don't dump every section if they asked one question — but the
+  engine returns all of it so you can.
+- **Arena scope.** `arena.enrolled: false` means they're not in the competition — say so plainly and
+  point to senpi.ai/arena; don't report a rank they don't have.
+- **Always end with the two CTAs** (below).
+
+## How to run the engine
+
+```
+python3 scripts/status.py
+```
+
+Returns `{identity, points, loyalty, arena, referral, wins, meta}`:
+- `points` — `total`, `base` (Base copy-trading), `perp` (Hyperliquid), `multiplier`, `rank`,
+  `rank_change`.
+- `loyalty` — `tier`, `fee_bps`, `fee_discount_pct`, `next_tier`, `points_to_next` (the milestone).
+- `arena` — `enrolled`; if enrolled: `rank`, `roe_pct`, `total_pnl_usd`, `qualified` (hit the volume
+  threshold), `week_pool_usd`, `prize_estimate_usd` (if top-5).
+- `referral` — `balance_usdc` (pending referral earnings, 25% of builder fee on referred trades).
+- `wins` — recent profitable closed trades (asset, realized PnL, return %) for sharing.
+- `meta.warnings` / `meta.degraded` — narrate honestly.
+- Fails open — partial data still returns valid JSON.
+
+## Output contract
+
+Lead with the section they asked about; otherwise a tight standing card:
+
+1. **Points & rank** — total, base/perp split, multiplier, rank (+ change).
+2. **Loyalty** — current tier + fee/discount, and **`points_to_next` → next_tier** (the actionable
+   milestone).
+3. **Arena** — if `enrolled`: rank, ROE %, qualified-or-not, and the prize context (week pool;
+   estimate if top-5). If not enrolled: one line + the arena link.
+4. **Referral** — pending `balance_usdc` (and that it's claimable if > 0).
+5. **Wins** — a couple of brag-worthy recent trades, if any.
+
+Formatting: clean, scannable, numbers from the data; emoji sparingly (🏆 Arena, 🎯 next tier).
+
+## Mandatory closing (verbatim)
+
+> **1. Want me to share one of these wins?**
+> **2. Want me to break down what it takes to reach the next tier (or climb the Arena)?**
+
+- **CTA 1 → share.** Format a `wins[]` entry into a shareable line (the user posts it); never post on
+  their behalf.
+- **CTA 2 → milestone.** Use `loyalty.points_to_next` + `get_loyalty_tiers` for the tier path, or the
+  Arena `qualified`/volume threshold + `week_pool`/prize split for the Arena path.
+
+## ⚠ Token scope
+
+Every tool here is **USER-scoped** (the user's own account): needs a USER-scoped `SENPI_AUTH_TOKEN`.
+App-scoped → no user resolves and `meta.degraded`; say so rather than reporting zeros.
+
+## Skill Attribution
+
+Guide/analysis skill — it *reads* the user's standing; it does not mutate anything (claiming referral
+rewards is a separate explicit action via `user_claim_referral_rewards`, which this skill never calls).

--- a/senpi-account-status/references/presentation-notes.md
+++ b/senpi-account-status/references/presentation-notes.md
@@ -1,0 +1,34 @@
+# Presentation notes — standing, not analysis
+
+This skill *presents* the user's standing; it doesn't analyze a market. A few rules so it reads well.
+
+## Lead with the question, carry the rest
+
+The engine returns everything (points, loyalty, arena, referral, wins) in one call, but the user
+usually asked one thing. Lead with that section, then offer the rest. "How many points do I have?" →
+lead with `points.total` + `rank`, then *"you're 5,000 from Gold"* — don't open with the Arena.
+
+## Always point at the next milestone
+
+Standing is more motivating with a target. Pair every section with its next step:
+- **Loyalty** → `points_to_next` to `next_tier` (and what the next tier's fee discount buys).
+- **Arena** → if not `qualified`, the volume threshold to become prize-eligible; if ranked, the
+  prize at their rank vs. the rank above.
+- **Referral** → if `balance_usdc > 0`, that it's claimable (a separate explicit action — this skill
+  doesn't claim it).
+
+## Honesty rules
+
+- **Fees from the data, never memory.** Quote `loyalty.fee_bps` / `fee_discount_pct` as returned —
+  the tier table changes.
+- **Arena scope.** `enrolled: false` means not in the competition — say so and link senpi.ai/arena;
+  never invent a rank.
+- **`found: false` on points** means no leaderboard entry yet (base-tier defaults) — present it as
+  "you haven't started earning yet," not "0 / error."
+- **Decimals arrive as strings** from several of these tools (roePct, prizeAmount, balance_usdc) — the
+  engine parses them; just present clean numbers.
+
+## Wins are for sharing, not bragging-by-default
+
+Surface `wins[]` when relevant or asked, formatted as a shareable line — but the user posts it. Never
+auto-post.

--- a/senpi-account-status/scripts/_mcp.py
+++ b/senpi-account-status/scripts/_mcp.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Self-contained streamable-HTTP MCP client (stdlib only).
+
+Ported from senpi_runtime_helpers.SenpiClient so the discovery skill has ZERO cross-skill
+dependency — it ships its own market-data transport. Read-only tool calls only.
+
+  client = MCPClient()                       # reads SENPI_AUTH_TOKEN / SENPI_MCP_URL from env
+  data = client.mcp_call("market_get_asset_data", asset="BTC")   # -> unwrapped {success,data,...}
+
+Returns the same unwrapped JSON `mcporter`/SenpiClient returns; None on an MCP-protocol error.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import http.client
+import itertools
+import json
+import os
+from urllib.parse import urlsplit
+
+MCP_URL = os.environ.get("SENPI_MCP_URL", "https://mcp.prod.senpi.ai/mcp")
+AUTH = os.environ.get("SENPI_AUTH_TOKEN", "")
+_PROTOCOL = "2025-03-26"
+
+
+class MCPError(Exception):
+    pass
+
+
+def _post(url, body, headers, timeout):
+    """POST a JSON body on a fresh connection; return (status, raw_bytes, content_type, session_id)."""
+    parts = urlsplit(url)
+    scheme = parts.scheme
+    host = parts.hostname or ""
+    port = parts.port or (443 if scheme == "https" else 80)
+    path = (parts.path or "/") + (("?" + parts.query) if parts.query else "")
+    data = json.dumps(body).encode("utf-8")
+    hdrs = {
+        "Host": parts.netloc,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "Content-Length": str(len(data)),
+    }
+    hdrs.update(headers)
+    cls = http.client.HTTPSConnection if scheme == "https" else http.client.HTTPConnection
+    conn = cls(host, port, timeout=timeout)
+    try:
+        conn.request("POST", path, body=data, headers=hdrs)
+        resp = conn.getresponse()
+        raw = resp.read()
+        return resp.status, raw, (resp.getheader("Content-Type") or ""), resp.getheader("Mcp-Session-Id")
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa
+            pass
+
+
+def _parse(raw, content_type):
+    """Streamable-HTTP returns a single JSON doc OR an SSE stream; return the first JSON-RPC payload."""
+    text = raw.decode("utf-8", errors="replace")
+    if "text/event-stream" in (content_type or "").lower():
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[5:].strip()
+                if payload and payload != "[DONE]":
+                    try:
+                        obj = json.loads(payload)
+                        if isinstance(obj, dict):
+                            return obj
+                    except json.JSONDecodeError:
+                        continue
+        return {}
+    if not text:
+        return {}
+    try:
+        obj = json.loads(text)
+        return obj if isinstance(obj, dict) else {"result": obj}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _unwrap(rpc):
+    """tools/call JSON-RPC -> the inner JSON document (content[0].text), like mcporter."""
+    if not isinstance(rpc, dict) or rpc.get("error"):
+        return None
+    result = rpc.get("result")
+    if not isinstance(result, dict):
+        return result
+    content = result.get("content")
+    if isinstance(content, list) and content:
+        first = content[0]
+        if isinstance(first, dict) and "text" in first:
+            try:
+                return json.loads(first["text"])
+            except (json.JSONDecodeError, TypeError):
+                return result
+    return result
+
+
+class MCPClient:
+    """Lazy `initialize` handshake (streamable-http), then `tools/call`. One per process."""
+
+    def __init__(self, url=None, token=None):
+        self.url = url or MCP_URL
+        self.token = token if token is not None else AUTH
+        self._sid = None
+        self._initialized = False
+        self._id = itertools.count(1)
+
+    def _headers(self, sid=None):
+        h = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        sid = sid or self._sid
+        if sid:
+            h["Mcp-Session-Id"] = sid
+        return h
+
+    def _initialize(self, timeout):
+        if self._initialized:
+            return
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "initialize",
+                "params": {"protocolVersion": _PROTOCOL, "capabilities": {},
+                           "clientInfo": {"name": "senpi-account-status", "version": "2.0.0"}}}
+        status, _raw, _ct, sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"initialize HTTP {status}")
+        self._sid = sid
+        # streamable-http requires notifications/initialized after init
+        note = {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+        _post(self.url, note, self._headers(sid), timeout)
+        self._initialized = True
+
+    def mcp_call(self, tool, timeout=12, **arguments):
+        self._initialize(timeout)
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments}}
+        status, raw, ct, _sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"{tool} HTTP {status}")
+        return _unwrap(_parse(raw, ct))

--- a/senpi-account-status/scripts/status.py
+++ b/senpi-account-status/scripts/status.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""senpi-account-status engine — the user's standing across Senpi programs (hidden, deterministic).
+
+The agent (LLM) runs this via the OpenClaw `exec` tool, reads the JSON on stdout, and NARRATES the
+user's standing (see SKILL.md): Senpi points + rank, loyalty tier + fee, Arena position, referral
+earnings, and shareable wins. One real-time pull across all the status tools.
+
+  python3 status.py                 # full standing
+  python3 status.py --fixture f.json   # offline (tests)   |   --dry  (raw dump)
+
+Modeled on the other read skills: guarded I/O, fails open, valid JSON.
+⚠ All tools are USER-scoped (the user's own account): needs a USER-scoped SENPI_AUTH_TOKEN.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+# ──────────────────────────────────────────────────────────────── guarded helpers
+def _ok(resp):
+    if isinstance(resp, dict):
+        if resp.get("success") is False:
+            return None
+        return resp.get("data", resp)
+    return resp
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _f(d, *keys, default=None):
+    if isinstance(d, dict):
+        for k in keys:
+            if k in d and d[k] is not None:
+                n = _num(d[k])
+                if n is not None:
+                    return n
+    return default
+
+
+def _field(d, *names, default=None):
+    if isinstance(d, dict):
+        for n in names:
+            if n in d and d[n] is not None:
+                return d[n]
+    return default
+
+
+def _rows(data, *keys):
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for k in keys + ("entries", "data", "tiers", "results"):
+            v = data.get(k)
+            if isinstance(v, list):
+                return v
+    return []
+
+
+# ──────────────────────────────────────────────────────────────── client
+def _get_client():
+    if HERE not in sys.path:
+        sys.path.insert(0, HERE)
+    from _mcp import MCPClient
+    return MCPClient()
+
+
+class _FixtureClient:
+    def __init__(self, recorded):
+        self._r = recorded
+
+    def mcp_call(self, tool, timeout=12, **kw):
+        inp = kw.get("input") or {}
+        disc = inp.get("walletAddress") or inp.get("userId") or kw.get("period_type")
+        if disc:
+            k = f"{tool}::{str(disc).lower()}"
+            if k in self._r:
+                return self._r[k]
+        return self._r.get(tool)
+
+
+# ──────────────────────────────────────────────────────────────── data layer
+def resolve_user(client, meta):
+    out = {"senpi_user_id": None, "wallet": None}
+    try:
+        me = _ok(client.mcp_call("user_get_me", timeout=12)) or {}
+        u = me.get("user", me) if isinstance(me, dict) else {}
+        out["senpi_user_id"] = _field(u, "senpiUserId", "userId", "id")
+        for w in (_field(u, "wallets", default=[]) or []):
+            if str(_field(w, "walletType", "type", default="")).lower() == "embedded":
+                out["wallet"] = _field(w, "walletAddress", "address")
+                break
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"user_get_me failed: {e}")
+    return out
+
+
+def fetch_points(client, meta, wallet, user_id):
+    try:
+        inp = {"walletAddress": wallet} if wallet else {"userId": user_id}
+        p = _ok(client.mcp_call("user_get_senpi_points", input=inp, timeout=15)) or {}
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"user_get_senpi_points failed: {e}")
+        return {}, {}
+    p = p.get("user", p) if isinstance(p, dict) and "user" in p else p
+    points = {
+        "total": _f(p, "totalPoints", "points", "total"),
+        "base": _f(p, "basePoints", "base"),
+        "perp": _f(p, "perpPoints", "perp"),
+        "multiplier": _f(p, "loyaltyMultiplier", "multiplier"),
+        "rank": _f(p, "rank"),
+        "rank_change": _f(p, "rankChange", "rank_change"),
+        "found": _field(p, "found", default=True),
+    }
+    loyalty = {
+        "tier": _field(p, "loyaltyTier", "tier", "tierName"),
+        "fee_bps": _f(p, "feeBps", "builderFeeBps", "fee_bps"),
+        "fee_discount_pct": _f(p, "feeDiscount", "feeDiscountPct", "discount"),
+        "maintenance": _field(p, "maintenanceStatus", "maintenance"),
+        "next_tier": _field(p, "nextTier", "next_tier"),
+        "points_to_next": _f(p, "pointsToNextTier", "points_to_next", "nextTierPoints"),
+    }
+    return points, loyalty
+
+
+def enrich_next_tier(client, meta, loyalty, points_total):
+    """If the points response didn't carry next-tier progress, derive it from the tier table."""
+    if loyalty.get("points_to_next") is not None or points_total is None:
+        return
+    try:
+        tiers = _rows(_ok(client.mcp_call("get_loyalty_tiers", timeout=12)), "tiers")
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"get_loyalty_tiers failed: {e}")
+        return
+    thresholds = sorted((_f(t, "threshold", "pointsThreshold", "minPoints", default=None), _field(t, "name", "tier"))
+                        for t in tiers if _f(t, "threshold", "pointsThreshold", "minPoints", default=None) is not None)
+    for thr, name in thresholds:
+        if thr > points_total:
+            loyalty["next_tier"] = loyalty.get("next_tier") or name
+            loyalty["points_to_next"] = round(thr - points_total, 0)
+            break
+
+
+def fetch_referral(client, meta):
+    try:
+        r = _ok(client.mcp_call("user_get_referral_rewards", timeout=12)) or {}
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"user_get_referral_rewards failed: {e}")
+        return {}
+    return {"balance_usdc": _f(r, "balance_usdc", "balanceUsdc", "balance"),
+            "wallet": _field(r, "wallet_address", "walletAddress")}
+
+
+def fetch_arena(client, meta, user_id):
+    arena = {"enrolled": False}
+    try:
+        lb = _rows(_ok(client.mcp_call("arena_leaderboard", period_type="WEEK", limit=500, timeout=20)), "entries")
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"arena_leaderboard failed: {e}")
+        lb = []
+    me = next((e for e in lb if str(_field(e, "senpiUserId", "userId", default="")) == str(user_id)), None) if user_id else None
+    if me:
+        arena.update({"enrolled": True, "rank": _f(me, "rank"),
+                      "roe_pct": _f(me, "roePct", "roe"),
+                      "total_pnl_usd": _f(me, "totalPnl", "total_pnl"),
+                      "trade_count": _f(me, "tradeCount", "trades"),
+                      "notional_volume_usd": _f(me, "notionalVolume", "notional_volume"),
+                      "qualified": _field(me, "qualified", default=None)})
+    try:
+        pool = _ok(client.mcp_call("arena_pool", timeout=12)) or {}
+        arena["week_pool_usd"] = _f(pool, "currentWeekPool", "current_week_pool")
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"arena_pool failed: {e}")
+    if arena.get("enrolled") and arena.get("rank"):
+        try:
+            prizes = _rows(_ok(client.mcp_call("arena_prizes", period_type="WEEK", timeout=12)), "entries")
+            pe = next((e for e in prizes if _f(e, "rank") == arena["rank"]), None)
+            if pe:
+                arena["prize_estimate_usd"] = _f(pe, "prizeAmount", "prize_amount")
+        except Exception as e:  # noqa
+            meta.setdefault("warnings", []).append(f"arena_prizes failed: {e}")
+    return arena
+
+
+def fetch_wins(client, meta, limit=5):
+    try:
+        w = _rows(_ok(client.mcp_call("get_share_your_wins", limit=limit, timeout=15)), "wins", "positions")
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"get_share_your_wins failed: {e}")
+        return []
+    out = []
+    for p in w[:limit]:
+        if isinstance(p, dict):
+            out.append({"asset": _field(p, "coin", "asset"),
+                        "realized_pnl_usd": _f(p, "realizedPnl", "realized_pnl"),
+                        "return_pct": _f(p, "returnPercentage", "roe", "return_pct")})
+    return out
+
+
+# ──────────────────────────────────────────────────────────────── orchestration
+def run(client):
+    meta = {"warnings": []}
+    user = resolve_user(client, meta)
+    points, loyalty = fetch_points(client, meta, user.get("wallet"), user.get("senpi_user_id"))
+    enrich_next_tier(client, meta, loyalty, points.get("total"))
+    referral = fetch_referral(client, meta)
+    arena = fetch_arena(client, meta, user.get("senpi_user_id"))
+    wins = fetch_wins(client, meta)
+    if not user.get("senpi_user_id") and not user.get("wallet"):
+        meta["degraded"] = "no user resolved — check the token is USER-scoped"
+    return {
+        "as_of": "live",
+        "identity": user,
+        "points": points,
+        "loyalty": loyalty,
+        "arena": arena,
+        "referral": referral,
+        "wins": wins,
+        "meta": meta,
+    }
+
+
+# ──────────────────────────────────────────────────────────────── CLI
+def _dry(client):
+    out = {}
+    for tool, kw in (("user_get_me", {}), ("user_get_referral_rewards", {}),
+                    ("arena_pool", {}), ("get_loyalty_tiers", {})):
+        try:
+            out[tool] = client.mcp_call(tool, timeout=12, **kw)
+        except Exception as e:  # noqa
+            out[tool] = {"error": str(e)}
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="senpi account-status engine (standing across programs)")
+    ap.add_argument("--fixture")
+    ap.add_argument("--dry", action="store_true")
+    a = ap.parse_args(argv)
+
+    if a.fixture:
+        try:
+            with open(a.fixture) as f:
+                client = _FixtureClient(json.load(f))
+        except Exception as e:  # noqa
+            print(json.dumps({"points": {}, "meta": {"error": f"fixture load failed: {e}"}}))
+            return 1
+    else:
+        try:
+            client = _get_client()
+        except Exception as e:  # noqa
+            print(json.dumps({"points": {}, "meta": {"error": f"mcp init failed: {e}"}}))
+            return 1
+
+    if a.dry:
+        print(json.dumps(_dry(client), ensure_ascii=False, indent=2, default=str))
+        return 0
+    try:
+        result = run(client)
+    except Exception as e:  # noqa
+        print(json.dumps({"points": {}, "meta": {"error": f"engine failure: {e}"}}))
+        return 1
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/senpi-account-status/tests/fixtures/status_fixture.json
+++ b/senpi-account-status/tests/fixtures/status_fixture.json
@@ -1,0 +1,21 @@
+{
+  "user_get_me": {"user": {"senpiUserId": "u123", "wallets": [
+    {"walletType": "embedded", "walletAddress": "0xme"},
+    {"walletType": "external", "walletAddress": "0xext"}
+  ]}},
+  "user_get_senpi_points": {"totalPoints": 15000, "basePoints": 5000, "perpPoints": 10000, "loyaltyMultiplier": 1.5, "rank": 42, "rankChange": 3, "loyaltyTier": "Silver", "feeBps": 4.5, "feeDiscount": 10, "nextTier": "Gold", "pointsToNextTier": 5000, "found": true},
+  "user_get_referral_rewards": {"wallet_address": "0xme", "balance_usdc": "12.50", "balance_raw": "12500000"},
+  "arena_leaderboard": {"entries": [
+    {"senpiUserId": "other", "rank": 1, "roePct": "44.2", "totalPnl": "910", "qualified": true},
+    {"senpiUserId": "u123", "rank": 5, "roePct": "18.5", "totalPnl": "320", "tradeCount": 40, "notionalVolume": "60000", "qualified": true}
+  ]},
+  "arena_pool": {"currentWeekPool": 5000, "nextWeekPool": 5500},
+  "arena_prizes": {"totalPool": "5000", "entries": [
+    {"rank": 1, "sharePct": 40, "prizeAmount": "2000"},
+    {"rank": 5, "sharePct": 8, "prizeAmount": "400"}
+  ]},
+  "get_share_your_wins": {"wins": [
+    {"coin": "ETH", "realizedPnl": 25.25, "returnPercentage": 11.5},
+    {"coin": "BTC", "realizedPnl": 40.0, "returnPercentage": 8.0}
+  ]}
+}

--- a/senpi-account-status/tests/test_status.py
+++ b/senpi-account-status/tests/test_status.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Offline engine test — runs status.run() against a recorded MCP fixture (no network)."""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+import status  # noqa: E402
+
+FIXTURE = os.path.join(HERE, "fixtures", "status_fixture.json")
+
+
+def _result():
+    with open(FIXTURE) as f:
+        return status.run(status._FixtureClient(json.load(f)))
+
+
+def test_identity_and_points():
+    r = _result()
+    assert r["identity"]["senpi_user_id"] == "u123"
+    assert r["identity"]["wallet"] == "0xme"          # embedded, not external
+    assert r["points"]["total"] == 15000 and r["points"]["rank"] == 42.0
+
+
+def test_loyalty_milestone():
+    loy = _result()["loyalty"]
+    assert loy["tier"] == "Silver" and loy["fee_bps"] == 4.5
+    assert loy["next_tier"] == "Gold" and loy["points_to_next"] == 5000.0
+
+
+def test_arena_standing():
+    a = _result()["arena"]
+    assert a["enrolled"] is True and a["rank"] == 5.0
+    assert a["roe_pct"] == 18.5 and a["qualified"] is True
+    assert a["week_pool_usd"] == 5000 and a["prize_estimate_usd"] == 400.0   # rank-5 prize
+
+
+def test_referral_and_wins():
+    r = _result()
+    assert r["referral"]["balance_usdc"] == 12.5
+    assert len(r["wins"]) == 2 and r["wins"][0]["asset"] == "ETH"
+
+
+def test_fails_open_on_empty():
+    r = status.run(status._FixtureClient({}))
+    assert "points" in r and r["meta"].get("degraded")
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn(); print(f"  ✓ {fn.__name__}")
+    print(f"\n{len(fns)}/{len(fns)} passed")

--- a/senpi-trader-research/README.md
+++ b/senpi-trader-research/README.md
@@ -1,0 +1,52 @@
+# senpi-trader-research
+
+A Senpi skill that answers **"who should I copy?"** and **"is this trader any good?"** — it ranks
+Hyperliquid traders by track record and builds a due-diligence dossier on a specific trader before you
+mirror them.
+
+Same hidden-engine pattern as `senpi-market-pulse` / `senpi-smart-money` / `senpi-portfolio`: a
+deterministic Python engine does the data work; the LLM (SKILL.md) does the judgment + CTAs.
+
+Collapses these read tools off the eager tool list (per the context-reduction plan):
+`discovery_get_top_traders`, `discovery_get_top_strategies`, `discovery_get_trader_history`,
+`discovery_get_trader_state`, `leaderboard_get_trader`, `leaderboard_get_trader_positions`.
+
+## Two modes
+
+- **Find** (`research.py`) — historical track-record ranking with behavior labels + a reliability
+  verdict per trader. Or `--strategies` for the top copy-trading (mirror) leaderboard.
+- **Vet** (`research.py --trader 0x…`) — a dossier: track record + labels + current positions (with
+  account risk) + 4h momentum + risk flags. Distinguishes *proven* from *a hot streak*.
+
+## Key reads
+
+- **Track record ≠ timing.** Discovery = historical (is the trader good); leaderboard = 4h (are they
+  hot now). A copy decision needs both.
+- **Reliability floor:** < 5 trades or < 7 active days → `thin_track_record` (Senpi Discovery's own
+  trust threshold). The engine flags it; the SKILL surfaces it loudly.
+- **Risk flags:** `choppy_consistency`, `high`/`critical_margin_usage` (>80 / >90), `currently_in_drawdown`,
+  `concentrated_book`.
+
+## Run
+
+```sh
+python3 scripts/research.py                                   # top traders this month
+python3 scripts/research.py --time-frame ALL_TIME --sort-by WIN_RATE --limit 15
+python3 scripts/research.py --trader 0xABC…                   # vet one trader
+python3 scripts/research.py --strategies                      # top copy strategies
+python3 scripts/research.py --dry                             # raw schema dump
+python3 scripts/research.py --fixture tests/fixtures/research_fixture.json   # offline (tests)
+```
+
+## ⚠ Token scope
+
+`discovery_*` needs a **USER-scoped** `SENPI_AUTH_TOKEN` (resolves a user id). App-scoped → empty
+rankings + `meta.degraded`.
+
+## Status / review notes
+
+- Input params/enums verified against the live MCP tool schemas (`time_frame`, `sort_by`, label enums,
+  `trader_addresses`). Output field names use defensive alias fallbacks — run `--dry` to confirm the
+  live response shape and adjust if needed.
+- CTA 1 routes to `strategy_create` (copy path); confirm budget + multiplier before creating.
+- Offline fixture test included; no network.

--- a/senpi-trader-research/SKILL.md
+++ b/senpi-trader-research/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: senpi-trader-research
+description: >-
+  Research Hyperliquid traders to copy — rank the best track records and vet a specific trader
+  before mirroring. Use for "who should I copy?", "find good traders", "is this trader any good?",
+  "should I copy 0x…?", "best traders this month", "top copy strategies". A hidden engine
+  (scripts/research.py) pulls track record, current positions, and 4h momentum; you make the call.
+  Requires a USER-scoped Senpi token.
+license: Apache-2.0
+compatibility: OpenClaw, Hyperclaw, Claude Code
+metadata:
+  author: Senpi
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+---
+
+# Senpi Trader Research — find & vet copy candidates
+
+You are a sharp due-diligence analyst. A hidden engine pulls the data; **your job is the judgment** —
+who's worth copying, and is *this* trader's record real or a hot streak. Two jobs:
+
+- **Find** — rank Hyperliquid traders by track record (or rank the top copy strategies).
+- **Vet** — build a dossier on one trader: track record + behavior labels + what they hold now + 4h
+  momentum, so the user copies a proven trader, not a lucky one.
+
+## Golden rules
+
+- **Run the engine; never hand-pull.** `python3 scripts/research.py` (find) or `--trader 0x…` (vet).
+  Read its JSON.
+- **Only name traders/values the engine returned.** Cite addresses in **short form** (`0x35d1…acb1`)
+  unless the user asks for the full address.
+- **Track record ≠ timing.** Discovery (historical) tells you if they're *good*; the 4h momentum tells
+  you if they're *hot right now*. Say which is which. "Should I copy?" needs both.
+- **Respect the reliability floor.** A record with **< 5 trades or < 7 active days** is not yet
+  trustworthy — the engine flags it `thin_track_record`. Surface that loudly; don't recommend a copy
+  off a tiny sample.
+- **Use leveraged return + labels honestly.** Cite the behavior labels (consistency
+  ELITE/RELIABLE/STREAKY/CHOPPY, risk CONSERVATIVE/BALANCED/AGGRESSIVE/SNIPER) and surface every flag
+  verbatim — `choppy_consistency`, `high/critical_margin_usage`, `currently_in_drawdown`,
+  `concentrated_book`.
+- **Never say "safe."** Copying inherits their risk. Be honest.
+- **Always end with the two CTAs** (below).
+
+## How to run the engine
+
+**Default (no flags) = FIND mode** — ranks the top traders; **no address needed.** Add `--trader
+<addr>` *only* to vet one specific wallet. ("best traders this month" / "who should I copy" → run with
+no `--trader`.)
+
+```
+python3 scripts/research.py                        # FIND mode (default): rank top traders — NO address
+python3 scripts/research.py --time-frame MONTHLY --sort-by RETURN_ON_INVESTMENT --limit 15   # FIND, tuned
+python3 scripts/research.py --trader 0xABC…        # VET mode: due-diligence dossier on ONE trader
+python3 scripts/research.py --strategies           # top copy-trading (mirror) strategies
+```
+
+- **Find** → `candidates[]`: `short`, `roi_pct`, `pnl_usd`, `win_rate_pct`, `max_drawdown_pct`,
+  `trades`, `active_days`, `consistency`/`risk`/`activity`, and a `reliability` verdict
+  (`solid`/`ok`/`choppy`/`thin`). Lead with the *reliable* ones.
+- **Vet** → `trader`: `track_record`, `labels`, `current_positions` (+ `net_exposure` with
+  `margin_pct`), `recent_momentum` (4h rank + delta PnL), and `flags[]`. This is the dossier.
+- **`--strategies`** → `strategies[]`: ranked mirror strategies (copied trader, total/realized PnL,
+  return %, followers).
+- `meta.warnings` / `meta.degraded` — what was unavailable; narrate honestly.
+- Fails open — partial data still returns valid JSON.
+
+## Output contract
+
+**Finding candidates:** a short ranked table — `short`, ROI/PnL, win rate, max drawdown, the labels,
+and a one-line reliability read per row. Lead with `solid`; call out `thin`/`choppy` rather than
+burying them.
+
+**Vetting one trader:** a dossier —
+1. **Verdict line** — is this a proven, copy-worthy record or not, in one sentence, with the single
+   biggest reason.
+2. **Track record** — ROI, win rate, max drawdown, trades, active days. Flag thin samples.
+3. **Behavior** — the consistency/risk/activity labels, in plain English.
+4. **What they hold now** — current positions, net bias, and **account risk** (`margin_pct` > 80 high,
+   > 90 critical).
+5. **Right now** — 4h momentum (hot/cold), so timing isn't blind.
+6. **Risks** — every `flags[]` entry, verbatim.
+
+Formatting: short addresses, `Δ%`, labels as given; emoji sparingly.
+
+## Mandatory closing (verbatim)
+
+> **1. Want me to set up a copy strategy that mirrors this trader?**
+> **2. Want me to vet another trader, or pull the top traders to compare?**
+
+- **CTA 1 → copy.** Route to **`strategy_create`** (the copy-trading path) with the trader's address —
+  confirm budget + multiplier first; never create without confirmation.
+- **CTA 2 → compare.** Re-run the engine (`--trader` for another, or default for the ranking).
+
+## ⚠ Token scope
+
+`discovery_*` needs a **USER-scoped** `SENPI_AUTH_TOKEN`. App-scoped → empty rankings and
+`meta.degraded`; say so rather than reporting "no traders found."
+
+## Skill Attribution
+
+Guide/analysis skill — it *researches* and *recommends*; it does not create a wallet or place a trade.
+Attribution happens downstream when **`strategy_create`** sets up the copy strategy on CTA 1.

--- a/senpi-trader-research/references/analysis-framework.md
+++ b/senpi-trader-research/references/analysis-framework.md
@@ -1,0 +1,55 @@
+# Analysis framework — vetting a trader before you copy
+
+The engine hands you a track record, labels, current positions, and 4h momentum. This is how you turn
+that into a copy decision a user can trust. **The job is separating a proven edge from a lucky streak.**
+
+## 1. Is the sample even trustworthy? (gate first)
+
+Before anything else, check the reliability gate. A glittering ROI on **< 5 trades or < 7 active days**
+is noise — the engine flags it `thin_track_record`. Senpi Discovery itself won't rank a trader as
+reliable below that floor. Lead with this when it applies: *"+340% sounds great, but it's 3 trades over
+4 days — that's not a track record yet."* Never recommend a copy off a thin sample.
+
+## 2. Track record vs. timing — two different clocks
+
+- **Discovery (historical)** answers *is this trader good* — ROI, win rate, max drawdown, consistency
+  over weeks/months. This is the due-diligence layer.
+- **Leaderboard (4h)** answers *are they hot right now* — current rank, recent delta PnL. This is the
+  timing layer.
+
+"Should I copy?" needs both. A trader with a great history who's stone cold in the 4h window is a
+different decision than one who's also surging — and a hot 4h with no history is the classic trap.
+Always say which clock each number is on.
+
+## 3. Read the behavior labels, don't just cite them
+
+- **Consistency** (ELITE / RELIABLE / STREAKY / CHOPPY) — the single most useful label for copy. ELITE/
+  RELIABLE = the returns are repeatable; STREAKY/CHOPPY = high variance, you might copy in at the wrong
+  point of the cycle. `choppy_consistency` is a real flag, not a nit.
+- **Risk** (CONSERVATIVE / BALANCED / AGGRESSIVE / SNIPER) — tells the user what *they're* signing up
+  for. Copying a SNIPER means inheriting SNIPER drawdowns. Match it to the user's stomach.
+- **Activity** (DEGEN / ACTIVE / TACTICAL / PATIENT) — sets expectations on turnover (and fees).
+
+## 4. What they hold *now* is part of the diligence
+
+A great history doesn't matter if they're currently over-extended. Read `current_positions` +
+`net_exposure`:
+- **`margin_pct`** is the risk tell — > 80 is high, > 90 is critical (near liquidation). Copying a
+  trader who's already at 90% margin usage means inheriting that liquidation risk on day one.
+- **Concentration** — `concentrated_book` means one position dominates; their result will swing on a
+  single name.
+- **Net bias + drawdown** — are they long or short, and are they currently green or bleeding
+  (`currently_in_drawdown`)? You're copying into their *current* book, not their historical average.
+
+## 5. Compose the verdict
+
+One honest sentence first, then the support. Examples:
+
+> "Proven copy candidate: RELIABLE/BALANCED, +62% over 90 days across 140 trades, 58% win rate, −18%
+> max drawdown — and currently hot (rank 12 in the 4h window). Risk to note: 84% margin usage right
+> now, so they're running hot into this — size the copy accordingly."
+
+> "I'd pass for now: the +210% is real but it's STREAKY over just 6 trades — that's a hot streak, not a
+> track record. Worth watching, not copying yet."
+
+That's the difference between "this trader is up a lot" and a copy call worth standing behind.

--- a/senpi-trader-research/scripts/_mcp.py
+++ b/senpi-trader-research/scripts/_mcp.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Self-contained streamable-HTTP MCP client (stdlib only).
+
+Ported from senpi_runtime_helpers.SenpiClient so the discovery skill has ZERO cross-skill
+dependency — it ships its own market-data transport. Read-only tool calls only.
+
+  client = MCPClient()                       # reads SENPI_AUTH_TOKEN / SENPI_MCP_URL from env
+  data = client.mcp_call("market_get_asset_data", asset="BTC")   # -> unwrapped {success,data,...}
+
+Returns the same unwrapped JSON `mcporter`/SenpiClient returns; None on an MCP-protocol error.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import http.client
+import itertools
+import json
+import os
+from urllib.parse import urlsplit
+
+MCP_URL = os.environ.get("SENPI_MCP_URL", "https://mcp.prod.senpi.ai/mcp")
+AUTH = os.environ.get("SENPI_AUTH_TOKEN", "")
+_PROTOCOL = "2025-03-26"
+
+
+class MCPError(Exception):
+    pass
+
+
+def _post(url, body, headers, timeout):
+    """POST a JSON body on a fresh connection; return (status, raw_bytes, content_type, session_id)."""
+    parts = urlsplit(url)
+    scheme = parts.scheme
+    host = parts.hostname or ""
+    port = parts.port or (443 if scheme == "https" else 80)
+    path = (parts.path or "/") + (("?" + parts.query) if parts.query else "")
+    data = json.dumps(body).encode("utf-8")
+    hdrs = {
+        "Host": parts.netloc,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "Content-Length": str(len(data)),
+    }
+    hdrs.update(headers)
+    cls = http.client.HTTPSConnection if scheme == "https" else http.client.HTTPConnection
+    conn = cls(host, port, timeout=timeout)
+    try:
+        conn.request("POST", path, body=data, headers=hdrs)
+        resp = conn.getresponse()
+        raw = resp.read()
+        return resp.status, raw, (resp.getheader("Content-Type") or ""), resp.getheader("Mcp-Session-Id")
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa
+            pass
+
+
+def _parse(raw, content_type):
+    """Streamable-HTTP returns a single JSON doc OR an SSE stream; return the first JSON-RPC payload."""
+    text = raw.decode("utf-8", errors="replace")
+    if "text/event-stream" in (content_type or "").lower():
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[5:].strip()
+                if payload and payload != "[DONE]":
+                    try:
+                        obj = json.loads(payload)
+                        if isinstance(obj, dict):
+                            return obj
+                    except json.JSONDecodeError:
+                        continue
+        return {}
+    if not text:
+        return {}
+    try:
+        obj = json.loads(text)
+        return obj if isinstance(obj, dict) else {"result": obj}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _unwrap(rpc):
+    """tools/call JSON-RPC -> the inner JSON document (content[0].text), like mcporter."""
+    if not isinstance(rpc, dict) or rpc.get("error"):
+        return None
+    result = rpc.get("result")
+    if not isinstance(result, dict):
+        return result
+    content = result.get("content")
+    if isinstance(content, list) and content:
+        first = content[0]
+        if isinstance(first, dict) and "text" in first:
+            try:
+                return json.loads(first["text"])
+            except (json.JSONDecodeError, TypeError):
+                return result
+    return result
+
+
+class MCPClient:
+    """Lazy `initialize` handshake (streamable-http), then `tools/call`. One per process."""
+
+    def __init__(self, url=None, token=None):
+        self.url = url or MCP_URL
+        self.token = token if token is not None else AUTH
+        self._sid = None
+        self._initialized = False
+        self._id = itertools.count(1)
+
+    def _headers(self, sid=None):
+        h = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        sid = sid or self._sid
+        if sid:
+            h["Mcp-Session-Id"] = sid
+        return h
+
+    def _initialize(self, timeout):
+        if self._initialized:
+            return
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "initialize",
+                "params": {"protocolVersion": _PROTOCOL, "capabilities": {},
+                           "clientInfo": {"name": "senpi-trader-research", "version": "2.0.0"}}}
+        status, _raw, _ct, sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"initialize HTTP {status}")
+        self._sid = sid
+        # streamable-http requires notifications/initialized after init
+        note = {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+        _post(self.url, note, self._headers(sid), timeout)
+        self._initialized = True
+
+    def mcp_call(self, tool, timeout=12, **arguments):
+        self._initialize(timeout)
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments}}
+        status, raw, ct, _sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"{tool} HTTP {status}")
+        return _unwrap(_parse(raw, ct))

--- a/senpi-trader-research/scripts/research.py
+++ b/senpi-trader-research/scripts/research.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""senpi-trader-research engine — find copy candidates + vet a single trader (hidden, deterministic).
+
+The agent (LLM) runs this via the OpenClaw `exec` tool, reads the JSON on stdout, and NARRATES a
+trader read (see SKILL.md). The script does the data work — pull the historical track-record ranking,
+or build a due-diligence dossier on one trader (track record + current positions + 4h momentum) — and
+the LLM does the analyst prose + the CTAs.
+
+  python3 research.py                          # top traders (find copy candidates)
+  python3 research.py --trader 0xabc…          # due-diligence dossier on one trader
+  python3 research.py --strategies             # top copy-trading strategies (mirror leaderboard)
+  python3 research.py --time-frame ALL_TIME --sort-by WIN_RATE --limit 15
+  python3 research.py --fixture f.json          # offline (tests)   |   --dry  (raw dump)
+
+Modeled on senpi-strategy-discover's hidden-engine pattern: guarded I/O, fails open, valid JSON.
+⚠ discovery_* needs a USER-scoped SENPI_AUTH_TOKEN.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# Senpi Discovery reliability floor (per the overview): a track record needs enough trades + days.
+MIN_TRADES_FOR_TRUST = 5
+MIN_ACTIVE_DAYS_FOR_TRUST = 7
+
+
+# ──────────────────────────────────────────────────────────────── guarded helpers
+def _ok(resp):
+    if isinstance(resp, dict):
+        if resp.get("success") is False:
+            return None
+        return resp.get("data", resp)
+    return resp
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _f(d, *keys, default=None):
+    if isinstance(d, dict):
+        for k in keys:
+            if k in d and d[k] is not None:
+                n = _num(d[k])
+                if n is not None:
+                    return n
+    return default
+
+
+def _field(d, *names, default=None):
+    if isinstance(d, dict):
+        for n in names:
+            if n in d and d[n] is not None:
+                return d[n]
+    return default
+
+
+def _short(addr):
+    a = str(addr or "")
+    return f"{a[:6]}…{a[-4:]}" if len(a) > 12 else a
+
+
+def _rows(data, *keys):
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for k in keys + ("traders", "data", "results", "strategies", "entries"):
+            v = data.get(k)
+            if isinstance(v, list):
+                return v
+    return []
+
+
+# ──────────────────────────────────────────────────────────────── client
+def _get_client():
+    if HERE not in sys.path:
+        sys.path.insert(0, HERE)
+    from _mcp import MCPClient
+    return MCPClient()
+
+
+class _FixtureClient:
+    """Offline stand-in. Keys a call by tool + the most specific discriminator present."""
+    def __init__(self, recorded):
+        self._r = recorded
+
+    def mcp_call(self, tool, timeout=12, **kw):
+        addr = (kw.get("trader_addresses") or [None])[0] or kw.get("trader_address") or kw.get("trader_id")
+        for disc in (addr, kw.get("dex")):
+            if disc:
+                k = f"{tool}::{str(disc).lower()}"
+                if k in self._r:
+                    return self._r[k]
+        return self._r.get(tool)
+
+
+# ──────────────────────────────────────────────────────────────── find candidates
+def _candidate(t):
+    return {
+        "address": _field(t, "address", "trader_address", "wallet", default=""),
+        "short": _field(t, "shortAddress", "short_address") or _short(_field(t, "address", "trader_address", "wallet")),
+        "roi_pct": _f(t, "returnOnInvestment", "roi", "roiPct", "return_on_investment"),
+        "pnl_usd": _f(t, "profitAndLoss", "pnl", "realizedProfitAndLoss"),
+        "win_rate_pct": _f(t, "winRate", "win_rate"),
+        "max_drawdown_pct": _f(t, "maxDrawdown", "max_drawdown"),
+        "trades": _f(t, "totalTrades", "tradeCount", "trades", "numTrades"),
+        "active_days": _f(t, "activeDays", "active_days", "traderAgeDays"),
+        "consistency": _field(t, "consistency", "consistencyLabel", "tcs"),
+        "risk": _field(t, "risk", "riskLabel"),
+        "activity": _field(t, "activity", "activityLabel", "tas"),
+    }
+
+
+def _reliability(c):
+    trades, days = c.get("trades"), c.get("active_days")
+    if (trades is not None and trades < MIN_TRADES_FOR_TRUST) or \
+       (days is not None and days < MIN_ACTIVE_DAYS_FOR_TRUST):
+        return "thin"            # too few trades/days to trust the record
+    if c.get("consistency") == "CHOPPY":
+        return "choppy"          # erratic — high variance
+    if c.get("consistency") in ("ELITE", "RELIABLE"):
+        return "solid"
+    return "ok"
+
+
+def find_top_traders(client, meta, time_frame, sort_by, limit):
+    try:
+        resp = client.mcp_call("discovery_get_top_traders", time_frame=time_frame, sort_by=sort_by,
+                               limit=limit, timeout=20)
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"top_traders failed: {e}")
+        return []
+    out = []
+    for t in _rows(_ok(resp)):
+        if not isinstance(t, dict):
+            continue
+        c = _candidate(t)
+        c["reliability"] = _reliability(c)
+        out.append(c)
+    return out
+
+
+def find_top_strategies(client, meta, limit):
+    try:
+        resp = client.mcp_call("discovery_get_top_strategies", limit=limit, timeout=20)
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"top_strategies failed: {e}")
+        return []
+    out = []
+    for s in _rows(_ok(resp)):
+        if not isinstance(s, dict):
+            continue
+        out.append({
+            "strategy_wallet": _field(s, "strategyWalletAddress", "strategy_wallet", "wallet"),
+            "copied_trader": _short(_field(s, "traderAddress", "copied_trader", "trader_address")),
+            "total_pnl_usd": _f(s, "totalPnl", "total_pnl"),
+            "realized_pnl_usd": _f(s, "realizedPnl", "realized_pnl"),
+            "return_pct": _f(s, "returnPercentage", "return_pct", "roi"),
+            "followers": _f(s, "followers", "followerCount"),
+            "age_days": _f(s, "ageDays", "strategyAgeDays", "age_days"),
+        })
+    return out
+
+
+# ──────────────────────────────────────────────────────────────── vet one trader
+def vet_trader(client, meta, addr):
+    dossier = {"address": addr, "short": _short(addr)}
+
+    # 1) track record + behavior labels — pull this trader's row from the ranking
+    try:
+        tr = client.mcp_call("discovery_get_top_traders", time_frame="ALL_TIME",
+                             addresses=[addr], limit=1, timeout=20)
+        row = next((r for r in _rows(_ok(tr)) if isinstance(r, dict)), {})
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"labels lookup failed: {e}")
+        row = {}
+    c = _candidate(row) if row else {}
+    dossier["track_record"] = {k: c.get(k) for k in
+                               ("roi_pct", "pnl_usd", "win_rate_pct", "max_drawdown_pct", "trades", "active_days")}
+    dossier["labels"] = {"consistency": c.get("consistency"), "risk": c.get("risk"), "activity": c.get("activity")}
+    dossier["reliability"] = _reliability(c) if c else "unknown"
+
+    # 2) current state — open positions + account risk
+    try:
+        st = _ok(client.mcp_call("discovery_get_trader_state", trader_addresses=[addr], timeout=20))
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"trader_state failed: {e}")
+        st = None
+    positions, net_notional, upnl, margin_pct = [], 0.0, 0.0, None
+    trec = next((t for t in _rows(st, "traders") if isinstance(t, dict)), st if isinstance(st, dict) else {})
+    if isinstance(trec, dict):
+        cms = _field(trec, "crossMarginSummary", "cross_margin_summary", default={}) or {}
+        margin_pct = _f(trec, "marginPercentage", "margin_percentage") or _f(cms, "marginPercentage")
+        for p in (_field(trec, "openPositions", "open_positions", "positions", default=[]) or []):
+            if not isinstance(p, dict):
+                continue
+            szi = _f(p, "szi", "size", default=0.0)
+            val = _f(p, "positionValue", "position_value", "notional", default=0.0) or 0.0
+            pu = _f(p, "unrealizedPnl", "unrealized_pnl", default=0.0) or 0.0
+            upnl += pu
+            net_notional += (val if szi > 0 else -val)
+            positions.append({"asset": _field(p, "coin", "asset"),
+                              "direction": "long" if szi > 0 else "short",
+                              "notional": round(abs(val), 2), "upnl": round(pu, 2),
+                              "roe_pct": round((_f(p, "returnOnEquity", "return_on_equity", default=0.0) or 0.0) * 100, 2)})
+    dossier["current_positions"] = positions
+    dossier["net_exposure"] = {"net_notional_usd": round(net_notional, 2),
+                               "bias": "long" if net_notional > 0 else "short" if net_notional < 0 else "flat",
+                               "unrealized_pnl_usd": round(upnl, 2),
+                               "margin_pct": round(margin_pct, 1) if margin_pct is not None else None}
+
+    # 3) recent 4h momentum
+    try:
+        lm = _ok(client.mcp_call("leaderboard_get_trader", trader_id=addr, timeout=15))
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"leaderboard_get_trader failed: {e}")
+        lm = None
+    if isinstance(lm, dict):
+        dossier["recent_momentum"] = {"rank": _f(lm, "rank"),
+                                      "delta_pnl_4h_usd": _f(lm, "deltaPnl", "delta_pnl"),
+                                      "active_positions": _f(lm, "activePositions", "active_positions")}
+    else:
+        dossier["recent_momentum"] = None
+
+    # 4) flags + caveats (analyst anchors; the LLM narrates)
+    flags = []
+    if dossier["reliability"] == "thin":
+        flags.append("thin_track_record")     # < 5 trades or < 7 active days — record not yet trustworthy
+    if dossier["labels"].get("consistency") == "CHOPPY":
+        flags.append("choppy_consistency")
+    if margin_pct is not None and margin_pct > 90:
+        flags.append("critical_margin_usage")
+    elif margin_pct is not None and margin_pct > 80:
+        flags.append("high_margin_usage")
+    if upnl < 0:
+        flags.append("currently_in_drawdown")
+    if positions and max(p["notional"] for p in positions) > 0.6 * (sum(p["notional"] for p in positions) or 1):
+        flags.append("concentrated_book")
+    dossier["flags"] = flags
+    return dossier
+
+
+# ──────────────────────────────────────────────────────────────── orchestration
+def run(client, mode, addr=None, time_frame="MONTHLY", sort_by="RETURN_ON_INVESTMENT", limit=20):
+    meta = {"warnings": []}
+    out = {"as_of": "live", "mode": mode, "meta": meta}
+    if mode == "vet":
+        out["trader"] = vet_trader(client, meta, addr)
+    elif mode == "strategies":
+        out["strategies"] = find_top_strategies(client, meta, limit)
+    else:
+        out["candidates"] = find_top_traders(client, meta, time_frame, sort_by, limit)
+        out["ranking"] = {"time_frame": time_frame, "sort_by": sort_by}
+    if mode != "vet" and not out.get("candidates") and not out.get("strategies"):
+        meta["degraded"] = "no ranking data — check the token is USER-scoped"
+    return out
+
+
+# ──────────────────────────────────────────────────────────────── CLI
+def _dry(client):
+    out = {}
+    try:
+        out["discovery_get_top_traders"] = client.mcp_call("discovery_get_top_traders",
+                                                           time_frame="MONTHLY", limit=3, timeout=20)
+    except Exception as e:  # noqa
+        out["discovery_get_top_traders"] = {"error": str(e)}
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="senpi trader-research engine (find candidates + vet one)")
+    ap.add_argument("--trader", help="vet this trader address (due-diligence dossier)")
+    ap.add_argument("--strategies", action="store_true", help="rank top copy-trading strategies instead")
+    ap.add_argument("--time-frame", default="MONTHLY", choices=["DAILY", "WEEKLY", "MONTHLY", "ALL_TIME"])
+    ap.add_argument("--sort-by", default="RETURN_ON_INVESTMENT")
+    ap.add_argument("--limit", type=int, default=20)
+    ap.add_argument("--fixture")
+    ap.add_argument("--dry", action="store_true")
+    a = ap.parse_args(argv)
+
+    if a.fixture:
+        try:
+            with open(a.fixture) as f:
+                client = _FixtureClient(json.load(f))
+        except Exception as e:  # noqa
+            print(json.dumps({"candidates": [], "meta": {"error": f"fixture load failed: {e}"}}))
+            return 1
+    else:
+        try:
+            client = _get_client()
+        except Exception as e:  # noqa
+            print(json.dumps({"candidates": [], "meta": {"error": f"mcp init failed: {e}"}}))
+            return 1
+
+    if a.dry:
+        print(json.dumps(_dry(client), ensure_ascii=False, indent=2, default=str))
+        return 0
+
+    mode = "vet" if a.trader else ("strategies" if a.strategies else "top")
+    try:
+        result = run(client, mode, addr=a.trader, time_frame=a.time_frame, sort_by=a.sort_by, limit=a.limit)
+    except Exception as e:  # noqa
+        print(json.dumps({"candidates": [], "meta": {"error": f"engine failure: {e}"}}))
+        return 1
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/senpi-trader-research/tests/fixtures/research_fixture.json
+++ b/senpi-trader-research/tests/fixtures/research_fixture.json
@@ -1,0 +1,17 @@
+{
+  "discovery_get_top_traders": {"traders": [
+    {"address": "0xpro", "shortAddress": "0xpro…aaaa", "returnOnInvestment": 62.0, "profitAndLoss": 12000, "winRate": 58.0, "maxDrawdown": -18.0, "totalTrades": 140, "activeDays": 90, "consistency": "ELITE", "risk": "BALANCED", "activity": "TACTICAL"},
+    {"address": "0xstreak", "shortAddress": "0xstr…bbbb", "returnOnInvestment": 210.0, "profitAndLoss": 8000, "winRate": 66.0, "maxDrawdown": -40.0, "totalTrades": 6, "activeDays": 4, "consistency": "STREAKY", "risk": "SNIPER", "activity": "DEGEN"},
+    {"address": "0xsolid", "shortAddress": "0xsol…cccc", "returnOnInvestment": 31.0, "profitAndLoss": 4000, "winRate": 54.0, "maxDrawdown": -12.0, "totalTrades": 80, "activeDays": 45, "consistency": "RELIABLE", "risk": "CONSERVATIVE", "activity": "PATIENT"}
+  ]},
+  "discovery_get_trader_state::0xpro": {"traders": [
+    {"marginPercentage": 84, "crossMarginSummary": {"accountValue": "20000"}, "openPositions": [
+      {"coin": "BTC", "szi": 0.8, "positionValue": 50000, "unrealizedPnl": 1200, "returnOnEquity": 0.10},
+      {"coin": "ETH", "szi": -2, "positionValue": 3000, "unrealizedPnl": -100, "returnOnEquity": -0.03}
+    ]}
+  ]},
+  "leaderboard_get_trader::0xpro": {"rank": 12, "deltaPnl": 850, "activePositions": 2},
+  "discovery_get_top_strategies": {"strategies": [
+    {"strategyWalletAddress": "0xstrat", "traderAddress": "0xogtrader", "totalPnl": 5000, "realizedPnl": 3000, "returnPercentage": 25.0, "followers": 40, "ageDays": 60}
+  ]}
+}

--- a/senpi-trader-research/tests/test_research.py
+++ b/senpi-trader-research/tests/test_research.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Offline engine test — runs research.run() against a recorded MCP fixture (no network)."""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+import research  # noqa: E402
+
+FIXTURE = os.path.join(HERE, "fixtures", "research_fixture.json")
+
+
+def _client():
+    with open(FIXTURE) as f:
+        return research._FixtureClient(json.load(f))
+
+
+def test_top_candidates_and_reliability():
+    res = research.run(_client(), "top")
+    by = {c["short"]: c for c in res["candidates"]}
+    assert len(res["candidates"]) == 3
+    # ELITE, 140 trades / 90 days → solid; STREAKY, 6 trades / 4 days → thin (don't recommend)
+    assert next(c for c in res["candidates"] if c["address"] == "0xpro")["reliability"] == "solid"
+    assert next(c for c in res["candidates"] if c["address"] == "0xstreak")["reliability"] == "thin"
+
+
+def test_vet_dossier():
+    res = research.run(_client(), "vet", addr="0xpro")
+    t = res["trader"]
+    assert t["track_record"]["roi_pct"] == 62.0
+    assert t["labels"]["consistency"] == "ELITE"
+    assert t["net_exposure"]["margin_pct"] == 84.0
+    assert "high_margin_usage" in t["flags"]          # 84 > 80
+    assert "concentrated_book" in t["flags"]          # BTC notional dominates
+    assert t["recent_momentum"]["rank"] == 12.0       # 4h momentum present
+
+
+def test_strategies_mode():
+    res = research.run(_client(), "strategies")
+    assert res["strategies"][0]["total_pnl_usd"] == 5000
+    assert res["strategies"][0]["return_pct"] == 25.0
+
+
+def test_fails_open_on_empty():
+    res = research.run(research._FixtureClient({}), "top")
+    assert res["candidates"] == [] and res["meta"].get("degraded")
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn(); print(f"  ✓ {fn.__name__}")
+    print(f"\n{len(fns)}/{len(fns)} passed")


### PR DESCRIPTION
## What

The **two new read/analysis skills** from the context-reduction plan — same hidden-engine pattern as the shipped `senpi-portfolio` / `-market-pulse` / `-smart-money`. Together they collapse **15 read tools off the eager tool list** (the model sees two skill lines instead of 15 schemas).

### `senpi-trader-research` — "who should I copy / is this trader any good?"
Absorbs: `discovery_get_top_traders`, `discovery_get_top_strategies`, `discovery_get_trader_history`, `discovery_get_trader_state`, `leaderboard_get_trader`, `leaderboard_get_trader_positions` (6).

Two modes:
- **Find** — historical track-record ranking with behavior labels + a **reliability verdict** per trader (`solid`/`ok`/`choppy`/`thin`). Or `--strategies` for the mirror leaderboard.
- **Vet** (`--trader 0x…`) — a due-diligence **dossier**: track record + labels + current positions (with `margin_pct` risk) + 4h momentum + risk flags. Separates *proven* from *a hot streak*.

Enforces Senpi Discovery's reliability floor (**< 5 trades or < 7 active days → `thin_track_record`**) and surfaces `choppy_consistency` / `high`/`critical_margin_usage` / `currently_in_drawdown` / `concentrated_book`. CTA 1 → `strategy_create` (copy). **Tests 4/4.**

### `senpi-account-status` — "my points / tier / Arena / referrals / wins"
Absorbs: `arena_leaderboard`, `arena_pool`, `arena_prizes`, `arena_roe_chart`, `user_get_senpi_points`, `user_get_senpi_points_leaderboard`, `get_loyalty_tiers`, `get_share_your_wins`, `user_get_referral_rewards` (9).

One real-time pull of the user's standing: points + rank, loyalty tier + fee + **next-tier milestone**, Arena position + prize context, referral balance, shareable wins. Read-only — never calls `user_claim_referral_rewards`. **Tests 5/5.**

## Notes

- Input params/enums **verified against the live MCP tool schemas** (`time_frame`/`sort_by`/label enums; `user_get_senpi_points` `input.{walletAddress|userId}`; arena `period_type`). Output field names use defensive alias fallbacks + a `--dry` raw-dump flag for live-shape confirmation before merge.
- Both require a **USER-scoped** `SENPI_AUTH_TOKEN` (set `meta.degraded` otherwise).
- Offline fixture tests, no network.

## Context-reduction impact

With the 3 shipped skills (19 tools) + these 2 (15 tools), **34 read tools** can leave the eager tool list → that's the bulk of Phase 1+2 in the [context-reduction plan]. Remaining eager Senpi tools drop toward the ~12 hot core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Rebuilt cleanly on `strategy-v2` — supersedes #377. The original branch was cut from `main`, which shares no history with `strategy-v2` (orphan); since `strategy-v2` replaces `main`, this re-applies the additive skill on top of it._
