### PR TITLE
Discovery-pilot prep: senpi-audit (read-bucket) + senpi-help (capabilities directory)

### DIFF
--- a/senpi-audit/README.md
+++ b/senpi-audit/README.md
@@ -1,0 +1,28 @@
+# senpi-audit
+
+A Senpi skill that answers **"what happened?"** — recent account activity, a single strategy's change
+history, or failure investigation. The clean read-bucket for the audit tools.
+
+Same hidden-engine pattern as the other read skills. Collapses: `audit_get_recent_actions`,
+`audit_get_strategy_history`, `audit_query`.
+
+## Modes
+
+```sh
+python3 scripts/audit.py                  # recent activity across the account
+python3 scripts/audit.py --strategy <id>  # one strategy's full mutation history
+python3 scripts/audit.py --failures       # only failed operations (debugging)
+python3 scripts/audit.py --tool <name>    # filter to one tool
+python3 scripts/audit.py --dry            # raw schema dump
+python3 scripts/audit.py --fixture tests/fixtures/audit_fixture.json   # offline (tests)
+```
+
+Returns `{entries, summary, meta}` — each entry carries `time`, `action_type`, `tool`, `success`,
+`resource`, and the agent's `reason` for the action. `summary` rolls up counts + surfaces failures.
+
+USER-scoped token required (defaults to the authenticated user's log). Offline test 4/4.
+
+> **Role in the context-reduction plan:** this is the **read** half of the DEFER bucket — a coherent,
+> findable skill so "what happened?" doesn't require the 3 raw `audit_*` tools in the eager list. The
+> *mutation* DEFER tools (cancel/pause/withdraw/transfer/stops-edit) stay first-class (they need the
+> confirmation UX), so they are not collapsed here.

--- a/senpi-audit/SKILL.md
+++ b/senpi-audit/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: senpi-audit
+description: >-
+  Answer "what happened?" — review the user's recent Senpi activity, a single
+  strategy's change history, or investigate failures. Use for "what did my
+  strategy do", "change history for my strategy", "what happened yesterday",
+  "show my activity", "why did that fail", "what trades were made". A
+  hidden engine (scripts/audit.py) pulls and normalizes the audit trail; you
+  summarize it. Requires a USER-scoped Senpi token. Not for live positions
+  (senpi-portfolio) or market data (senpi-market-pulse).
+license: Apache-2.0
+compatibility: OpenClaw, Hyperclaw, Claude Code
+metadata:
+  author: Senpi
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+---
+
+# Senpi Audit — what happened
+
+A hidden engine pulls the audit trail; **your job is to make it readable** — what the account (or a
+strategy) did, and why, with failures surfaced.
+
+## Golden rules
+
+- **Run the engine; never hand-pull.** `python3 scripts/audit.py` (recent), `--strategy <id>` (one
+  strategy's history), `--failures` (debugging), `--tool <name>` (one tool). Read its JSON.
+- **Lead with the answer to "what happened," then the detail.** Summarize the activity (counts by
+  action, the notable mutations), then list entries if asked.
+- **Surface failures loudly.** Any `success: false` entry is a flag — lead with it when debugging.
+- **Cite the reasoning.** Audit entries carry the agent's `reason` for each action — quote it; that's
+  the "why" the user actually wants.
+- **Times + tools in plain English.** Translate tool names to user language ("opened a position,"
+  "topped up," "closed the strategy"); don't dump raw tool names.
+
+## How to run
+
+```
+python3 scripts/audit.py                     # recent activity (default)
+python3 scripts/audit.py --strategy <id>     # one strategy's change/mutation history
+python3 scripts/audit.py --failures          # only failed operations (debugging)
+python3 scripts/audit.py --tool <name>       # filter to one tool
+```
+
+> **"Change history for my *named* strategy"** ("cub-short", "the long book") → `--strategy <id>`. The
+> user names it; **resolve the name to its `strategyId` first via `strategy_list`**, then pass that id
+> to `--strategy`. ("history of my strategy", "what did cub-short do", "audit my strategy" all → this.)
+
+Returns `{entries, summary, meta}`:
+- `entries[]` — `time`, `action_type` (read/create/update/delete), `tool`, `success`, `resource`,
+  `reason`.
+- `summary` — `total`, `by_action` (counts), `failures[]` (the failed ops).
+- `meta.warnings` / `meta.degraded` — narrate honestly.
+- Fails open — partial data still returns valid JSON.
+
+## Output contract
+
+1. **The headline** — what happened in the window, in one line ("3 positions opened, 1 strategy
+   closed, no failures").
+2. **Notable actions** — the mutations that matter (opens/closes/top-ups/updates), each with its
+   `reason`.
+3. **Failures** — any `success: false`, with the error, lead here if the user is debugging.
+4. **(On `--strategy`)** a clean timeline for that one strategy.
+
+## Mandatory closing (verbatim)
+
+> **1. Want me to dig into any of these actions or failures?**
+> **2. Want me to check the current state of your positions or strategies?**
+
+CTA 2 → hand to **senpi-portfolio** (live positions) — the audit log is *history*; the portfolio is
+*now*.
+
+## ⚠ Token scope
+
+USER-scoped `SENPI_AUTH_TOKEN` (defaults to the authenticated user). App-scoped → `meta.degraded`.
+
+## Skill Attribution
+
+Guide/analysis skill — read-only; it reviews history, it does not act.

--- a/senpi-audit/scripts/_mcp.py
+++ b/senpi-audit/scripts/_mcp.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Self-contained streamable-HTTP MCP client (stdlib only).
+
+Ported from senpi_runtime_helpers.SenpiClient so the discovery skill has ZERO cross-skill
+dependency — it ships its own market-data transport. Read-only tool calls only.
+
+  client = MCPClient()                       # reads SENPI_AUTH_TOKEN / SENPI_MCP_URL from env
+  data = client.mcp_call("market_get_asset_data", asset="BTC")   # -> unwrapped {success,data,...}
+
+Returns the same unwrapped JSON `mcporter`/SenpiClient returns; None on an MCP-protocol error.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import http.client
+import itertools
+import json
+import os
+from urllib.parse import urlsplit
+
+MCP_URL = os.environ.get("SENPI_MCP_URL", "https://mcp.prod.senpi.ai/mcp")
+AUTH = os.environ.get("SENPI_AUTH_TOKEN", "")
+_PROTOCOL = "2025-03-26"
+
+
+class MCPError(Exception):
+    pass
+
+
+def _post(url, body, headers, timeout):
+    """POST a JSON body on a fresh connection; return (status, raw_bytes, content_type, session_id)."""
+    parts = urlsplit(url)
+    scheme = parts.scheme
+    host = parts.hostname or ""
+    port = parts.port or (443 if scheme == "https" else 80)
+    path = (parts.path or "/") + (("?" + parts.query) if parts.query else "")
+    data = json.dumps(body).encode("utf-8")
+    hdrs = {
+        "Host": parts.netloc,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "Content-Length": str(len(data)),
+    }
+    hdrs.update(headers)
+    cls = http.client.HTTPSConnection if scheme == "https" else http.client.HTTPConnection
+    conn = cls(host, port, timeout=timeout)
+    try:
+        conn.request("POST", path, body=data, headers=hdrs)
+        resp = conn.getresponse()
+        raw = resp.read()
+        return resp.status, raw, (resp.getheader("Content-Type") or ""), resp.getheader("Mcp-Session-Id")
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa
+            pass
+
+
+def _parse(raw, content_type):
+    """Streamable-HTTP returns a single JSON doc OR an SSE stream; return the first JSON-RPC payload."""
+    text = raw.decode("utf-8", errors="replace")
+    if "text/event-stream" in (content_type or "").lower():
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[5:].strip()
+                if payload and payload != "[DONE]":
+                    try:
+                        obj = json.loads(payload)
+                        if isinstance(obj, dict):
+                            return obj
+                    except json.JSONDecodeError:
+                        continue
+        return {}
+    if not text:
+        return {}
+    try:
+        obj = json.loads(text)
+        return obj if isinstance(obj, dict) else {"result": obj}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _unwrap(rpc):
+    """tools/call JSON-RPC -> the inner JSON document (content[0].text), like mcporter."""
+    if not isinstance(rpc, dict) or rpc.get("error"):
+        return None
+    result = rpc.get("result")
+    if not isinstance(result, dict):
+        return result
+    content = result.get("content")
+    if isinstance(content, list) and content:
+        first = content[0]
+        if isinstance(first, dict) and "text" in first:
+            try:
+                return json.loads(first["text"])
+            except (json.JSONDecodeError, TypeError):
+                return result
+    return result
+
+
+class MCPClient:
+    """Lazy `initialize` handshake (streamable-http), then `tools/call`. One per process."""
+
+    def __init__(self, url=None, token=None):
+        self.url = url or MCP_URL
+        self.token = token if token is not None else AUTH
+        self._sid = None
+        self._initialized = False
+        self._id = itertools.count(1)
+
+    def _headers(self, sid=None):
+        h = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        sid = sid or self._sid
+        if sid:
+            h["Mcp-Session-Id"] = sid
+        return h
+
+    def _initialize(self, timeout):
+        if self._initialized:
+            return
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "initialize",
+                "params": {"protocolVersion": _PROTOCOL, "capabilities": {},
+                           "clientInfo": {"name": "senpi-audit", "version": "2.0.0"}}}
+        status, _raw, _ct, sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"initialize HTTP {status}")
+        self._sid = sid
+        # streamable-http requires notifications/initialized after init
+        note = {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
+        _post(self.url, note, self._headers(sid), timeout)
+        self._initialized = True
+
+    def mcp_call(self, tool, timeout=12, **arguments):
+        self._initialize(timeout)
+        body = {"jsonrpc": "2.0", "id": next(self._id), "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments}}
+        status, raw, ct, _sid = _post(self.url, body, self._headers(), timeout)
+        if status >= 400:
+            raise MCPError(f"{tool} HTTP {status}")
+        return _unwrap(_parse(raw, ct))

--- a/senpi-audit/scripts/audit.py
+++ b/senpi-audit/scripts/audit.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""senpi-audit engine — recent activity / strategy history / failure investigation (hidden).
+
+The agent (LLM) runs this via the OpenClaw `exec` tool, reads the JSON on stdout, and NARRATES a
+"what happened" answer (see SKILL.md). The script pulls the audit trail and normalizes it; the LLM
+turns it into a readable activity summary.
+
+  python3 audit.py                       # recent activity across the account
+  python3 audit.py --strategy <id>       # full mutation history for one strategy
+  python3 audit.py --failures            # only failed operations (debugging)
+  python3 audit.py --tool <name>         # filter to one tool
+  python3 audit.py --fixture f.json      # offline (tests)   |   --dry  (raw dump)
+
+⚠ USER-scoped SENPI_AUTH_TOKEN (defaults to the authenticated user's audit log).
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import argparse
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _ok(resp):
+    if isinstance(resp, dict):
+        if resp.get("success") is False and "data" not in resp:
+            return None
+        return resp.get("data", resp)
+    return resp
+
+
+def _field(d, *names, default=None):
+    if isinstance(d, dict):
+        for n in names:
+            if n in d and d[n] is not None:
+                return d[n]
+    return default
+
+
+def _rows(data, *keys):
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for k in keys + ("entries", "actions", "logs", "data", "results"):
+            v = data.get(k)
+            if isinstance(v, list):
+                return v
+    return []
+
+
+def _get_client():
+    if HERE not in sys.path:
+        sys.path.insert(0, HERE)
+    from _mcp import MCPClient
+    return MCPClient()
+
+
+class _FixtureClient:
+    def __init__(self, recorded):
+        self._r = recorded
+
+    def mcp_call(self, tool, timeout=12, **kw):
+        for disc in (kw.get("strategy_id"), kw.get("tool_name"),
+                     ("failures" if kw.get("success") is False else None)):
+            if disc:
+                k = f"{tool}::{str(disc).lower()}"
+                if k in self._r:
+                    return self._r[k]
+        return self._r.get(tool)
+
+
+def _entry(e):
+    return {
+        "time": _field(e, "timestamp", "createdAt", "created_at", "time"),
+        "action_type": _field(e, "actionType", "action_type", "action"),
+        "tool": _field(e, "toolName", "tool_name", "tool"),
+        "success": _field(e, "success", default=None),
+        "resource": _field(e, "resourceType", "resource_type") or _field(e, "resourceId", "resource_id"),
+        "reason": _field(e, "aiReasoning", "ai_reasoning", "reason", "reasoning"),
+    }
+
+
+def fetch(client, meta, mode, strategy_id=None, tool_name=None):
+    try:
+        if mode == "strategy":
+            resp = client.mcp_call("audit_get_strategy_history", strategy_id=strategy_id, limit=100, timeout=20)
+        elif mode == "failures":
+            resp = client.mcp_call("audit_query", success=False, limit=100, timeout=20)
+        elif mode == "tool":
+            resp = client.mcp_call("audit_query", tool_name=tool_name, limit=100, timeout=20)
+        else:
+            resp = client.mcp_call("audit_get_recent_actions", limit=100, timeout=20)
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"{mode} audit fetch failed: {e}")
+        return []
+    return [_entry(e) for e in _rows(_ok(resp)) if isinstance(e, dict)]
+
+
+def summarize(entries):
+    by_action, failures = {}, []
+    for e in entries:
+        a = e.get("action_type") or "unknown"
+        by_action[a] = by_action.get(a, 0) + 1
+        if e.get("success") is False:
+            failures.append(e)
+    return {"total": len(entries), "by_action": by_action, "failures": failures}
+
+
+def run(client, mode, strategy_id=None, tool_name=None):
+    meta = {"warnings": []}
+    entries = fetch(client, meta, mode, strategy_id, tool_name)
+    if not entries and mode == "default":
+        meta["degraded"] = "no audit entries — check the token is USER-scoped"
+    return {"as_of": "live", "mode": mode, "entries": entries,
+            "summary": summarize(entries), "meta": meta}
+
+
+def _dry(client):
+    try:
+        return {"audit_get_recent_actions": client.mcp_call("audit_get_recent_actions", limit=3, timeout=15)}
+    except Exception as e:  # noqa
+        return {"error": str(e)}
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="senpi audit engine (activity / history / failures)")
+    ap.add_argument("--strategy", help="strategy id — full mutation history for that strategy")
+    ap.add_argument("--failures", action="store_true", help="only failed operations")
+    ap.add_argument("--tool", help="filter to one tool name")
+    ap.add_argument("--fixture")
+    ap.add_argument("--dry", action="store_true")
+    a = ap.parse_args(argv)
+
+    if a.fixture:
+        try:
+            with open(a.fixture) as f:
+                client = _FixtureClient(json.load(f))
+        except Exception as e:  # noqa
+            print(json.dumps({"entries": [], "meta": {"error": f"fixture load failed: {e}"}}))
+            return 1
+    else:
+        try:
+            client = _get_client()
+        except Exception as e:  # noqa
+            print(json.dumps({"entries": [], "meta": {"error": f"mcp init failed: {e}"}}))
+            return 1
+
+    if a.dry:
+        print(json.dumps(_dry(client), ensure_ascii=False, indent=2, default=str))
+        return 0
+
+    mode = "strategy" if a.strategy else ("failures" if a.failures else ("tool" if a.tool else "default"))
+    try:
+        result = run(client, mode, strategy_id=a.strategy, tool_name=a.tool)
+    except Exception as e:  # noqa
+        print(json.dumps({"entries": [], "meta": {"error": f"engine failure: {e}"}}))
+        return 1
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/senpi-audit/tests/fixtures/audit_fixture.json
+++ b/senpi-audit/tests/fixtures/audit_fixture.json
@@ -1,0 +1,13 @@
+{
+  "audit_get_recent_actions": {"entries": [
+    {"timestamp": "2026-06-24T14:00:00Z", "actionType": "create", "toolName": "create_position", "success": true, "resourceType": "strategy", "aiReasoning": "Opened BTC long on 4h momentum breakout"},
+    {"timestamp": "2026-06-24T13:30:00Z", "actionType": "update", "toolName": "strategy_top_up", "success": true, "resourceType": "strategy", "aiReasoning": "Topped up cub-short by $300 per user request"},
+    {"timestamp": "2026-06-24T13:00:00Z", "actionType": "create", "toolName": "create_position", "success": false, "resourceType": "strategy", "aiReasoning": "Attempted SOL short", "error": "insufficient margin"}
+  ]},
+  "audit_get_strategy_history::strat1": {"entries": [
+    {"timestamp": "2026-06-24T12:00:00Z", "actionType": "create", "toolName": "strategy_create_custom_strategy", "success": true, "resourceId": "strat1", "aiReasoning": "Created cub-short with $1300"}
+  ]},
+  "audit_query::failures": {"entries": [
+    {"timestamp": "2026-06-24T13:00:00Z", "actionType": "create", "toolName": "create_position", "success": false, "resourceType": "strategy", "aiReasoning": "Attempted SOL short", "error": "insufficient margin"}
+  ]}
+}

--- a/senpi-audit/tests/test_audit.py
+++ b/senpi-audit/tests/test_audit.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Offline engine test — runs audit.run() against a recorded MCP fixture (no network)."""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+import audit  # noqa: E402
+
+FIXTURE = os.path.join(HERE, "fixtures", "audit_fixture.json")
+
+
+def _client():
+    with open(FIXTURE) as f:
+        return audit._FixtureClient(json.load(f))
+
+
+def test_recent_summary():
+    r = audit.run(_client(), "default")
+    assert r["summary"]["total"] == 3
+    assert r["summary"]["by_action"]["create"] == 2 and r["summary"]["by_action"]["update"] == 1
+    assert len(r["summary"]["failures"]) == 1            # the failed SOL short
+    e = r["entries"][0]
+    assert e["tool"] == "create_position" and e["reason"].startswith("Opened BTC")
+
+
+def test_strategy_history():
+    r = audit.run(_client(), "strategy", strategy_id="strat1")
+    assert r["entries"][0]["tool"] == "strategy_create_custom_strategy"
+
+
+def test_failures_only():
+    r = audit.run(_client(), "failures")
+    assert all(e["success"] is False for e in r["entries"]) and len(r["entries"]) == 1
+
+
+def test_fails_open_on_empty():
+    r = audit.run(audit._FixtureClient({}), "default")
+    assert r["entries"] == [] and r["meta"].get("degraded")
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn(); print(f"  ✓ {fn.__name__}")
+    print(f"\n{len(fns)}/{len(fns)} passed")

--- a/senpi-help/SKILL.md
+++ b/senpi-help/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: senpi-help
+description: >-
+  Directory of every Senpi capability and which skill or tool handles it. Read
+  this when a user asks for something Senpi-related and no other skill clearly
+  matches, when you are unsure how to do it, or when asked "what can you do?".
+  Maps intents (analyze portfolio, find traders, manage stops, withdraw funds,
+  audit history, build a strategy) to the right skill or tool — so no request
+  is ever a dead end. Always available; consult it before giving up on a task.
+license: Apache-2.0
+compatibility: OpenClaw, Hyperclaw, Claude Code
+metadata:
+  author: Senpi
+  version: "1.0.0"
+  platform: senpi
+  exchange: hyperliquid
+---
+
+# Senpi Help — the capabilities directory
+
+This is the **safety net.** If a user asks for something Senpi-related and no specific skill obviously
+matches, read this directory, find the row that fits the intent, and route there. **Never tell a user
+something isn't possible without checking here first** — most capabilities are reachable, just behind
+a skill or a tool you may not have in your current tool list.
+
+> Some Senpi tools are intentionally kept out of the model's tool list to save context. They are still
+> fully available — either through a **skill** (run its script) or as a **tool** that can be enabled.
+> If a row points to a tool you don't currently see, say so and proceed via the skill, or note that
+> the capability exists and can be enabled. A missing tool is never a missing capability.
+
+## Read & analysis — run the skill
+
+| The user wants… | Use |
+|---|---|
+| Analyze portfolio across all wallets; idle vs deployed; positions + PnL | **`senpi-portfolio`** |
+| A market read — what's moving, cross-asset, "what's happening today" | **`senpi-market-pulse`** |
+| Where smart money is positioned / diverging from the crowd | **`senpi-smart-money`** |
+| Find good traders to copy / vet a specific trader before mirroring | **`senpi-trader-research`** |
+| Points, rank, loyalty tier, fees, Arena standing, referrals, wins | **`senpi-account-status`** |
+| "What happened" — recent activity, strategy history, why something failed | **`senpi-audit`** |
+
+## Pick / build / deploy a strategy — run the lifecycle skill
+
+| The user wants… | Use |
+|---|---|
+| Help choosing a strategy / "what should I trade" / recommend one | **`senpi-strategy-discover`** |
+| Build or edit a custom strategy package | **`senpi-strategy-author`** |
+| Install / monitor / close a named strategy (spider, kodiak, …) | **`senpi-strategy-ops`** |
+
+## Act now — first-class tools (direct, with confirmation)
+
+| The user wants… | Tool |
+|---|---|
+| Their wallet address / identity | `user_get_me` |
+| A quick balance | `account_get_portfolio` |
+| A quick price | `market_get_prices` |
+| List their strategies | `strategy_list` |
+| Open / close / resize a position | `create_position` / `close_position` / `edit_position` |
+| Create a strategy (specific positions) | `strategy_create_custom_strategy` |
+| Copy a trader | `strategy_create` |
+| Add funds to a strategy | `strategy_top_up` |
+| Close a strategy | `strategy_close` |
+| Preview a trade before placing | `execution_estimate_position_opening` / `estimate_custom_strategy_positions_opening` |
+
+## Less common actions — available, may need enabling
+
+| The user wants… | Tool |
+|---|---|
+| Cancel an open order | `cancel_order` |
+| Pause / update a strategy; close just its positions | `strategy_pause` / `strategy_update` / `strategy_close_positions` |
+| Withdraw funds from a strategy | `strategy_withdraw_funds` |
+| Move funds to an EVM chain | `strategy_bridge_funds_from_hyperliquid_to_evm` |
+| Send USDC / move spot→perps | `send_usdc` / `transfer_spot_to_perps` |
+| Set / change / remove a trailing stop | `ratchet_stop_add` / `ratchet_stop_edit` / `ratchet_stop_delete` |
+| Claim referral rewards | `user_claim_referral_rewards` |
+| Browse Senpi guides | `read_senpi_guide` (+ `list_senpi_guides`) |
+
+## How to route
+
+1. Match the user's intent to a **row** above.
+2. **Skill row** → read that skill's `SKILL.md` and run it. **Tool row** → call the tool (if it's not
+   in your current tool list, say the capability exists and proceed via the nearest skill or note it
+   can be enabled).
+3. Still no match? It may genuinely be out of scope — say so honestly. But check here first.
+
+## Skill Attribution
+
+Guide/utility skill — pure navigation. It performs no reads or mutations itself; it points to the
+skill or tool that does.

--- a/senpi-help/references/agents-md-router.md
+++ b/senpi-help/references/agents-md-router.md
@@ -1,0 +1,34 @@
+# Always-loaded router — drop this into each agent's AGENTS.md
+
+This is the **compact, always-in-context** version of the `senpi-help` directory. Put it in the
+agent's `AGENTS.md` so the intent→skill map is present every turn — the agent never has to *decide to
+look it up*. (`senpi-help` remains the full directory, loaded on demand for edge cases.) Cost: ~150
+tokens/turn, against the ~24K saved by collapsing tools — a trivial trade that removes the "did the
+agent consult help?" risk.
+
+```markdown
+## Senpi capabilities — routing (check before saying "I can't")
+
+Match the request, then use the skill or tool. If unsure, read the `senpi-help` skill (full
+directory). **Never tell a user a Senpi request is impossible without checking first.**
+
+Reads → run the skill (it carries the data tools internally):
+- portfolio / balances / positions / idle-vs-deployed → **senpi-portfolio**
+- market read / what's moving / cross-asset / "the tape" → **senpi-market-pulse**
+- smart money / whales vs the crowd / divergence → **senpi-smart-money**
+- find or vet traders to copy → **senpi-trader-research** (default = FIND; `--trader <addr>` to vet one)
+- points / tier / fees / Arena / referrals / wins → **senpi-account-status**
+- what happened / history / why it failed → **senpi-audit** (`--strategy <id>` for one strategy)
+
+Act now → first-class tools:
+- wallet / quick balance / quick price / list strategies → user_get_me / account_get_portfolio /
+  market_get_prices / strategy_list — **"current / my strategies" = ACTIVE only: call
+  `strategy_list(status: ["ACTIVE"])`; never present CLOSED/PAUSED as current. Treat active strategies
+  as known state, not a fresh discovery.**
+- open / close / resize a position → create_position / close_position / edit_position
+- create / top-up / close a strategy → strategy_create_custom_strategy / strategy_top_up / strategy_close
+- withdraw / move funds / set a stop / cancel an order → the matching tool (may need enabling)
+
+Pick / build / deploy a strategy → senpi-strategy-discover / -author / -ops
+Anything else, or unsure which → read **senpi-help**.
+```

--- a/senpi-help/references/agents-md-router.md
+++ b/senpi-help/references/agents-md-router.md
@@ -16,6 +16,27 @@ because it keeps every tool reachable.)
 ```markdown
 ## Senpi capabilities — routing (check before saying "I can't")
 
+**Skill-first — the default reflex, before you touch any tool.** For ANY Senpi question that involves
+*reading or analyzing data* — markets, portfolio, positions, smart money, traders, points/fees,
+history — your FIRST move is to scan the "Reads → skill" map below. If your intent matches a skill,
+**that skill is mandatory**: read its SKILL.md and run it. This is not a suggestion or a fallback — it
+is the required first step.
+
+Three rules that close the gap that makes agents skip skills:
+- **A visible tool is NOT a reason to use it.** `market_get_prices`, `discovery_*`, `account_*`,
+  `audit_*`, `web_fetch`, `web_search` sitting in your tool list does not make them the right call. If
+  a skill covers the intent, the skill wins — every time. The tool feeling "more immediately
+  actionable" is the exact trap.
+- **The multi-tool tell.** If you're about to call **two or more** read tools — or **any** `web_fetch`
+  / `web_search` — to assemble an answer, STOP. That is the signal a skill already does it, in one
+  correct pass, better than you can hand-rolling it. Hand-pulling data a skill's engine would gather is
+  always inferior.
+- **Don't self-diagnose mid-answer.** Don't answer with raw tools and then offer to "re-run it through
+  the skill." Check the map first; run the skill the first time.
+
+A raw tool beats a skill ONLY for the **"Act now"** one-shots below — a single price, a single balance,
+or a mutation. Everything analytical → skill first.
+
 **Find the capability in this order — then stop, don't cycle:**
 1. **Senpi skill first.** Scan the skills index for one that matches the request; if it fits, read its
    SKILL.md and use it.
@@ -32,7 +53,7 @@ because it keeps every tool reachable.)
 
 **Never tell a user a Senpi request is impossible without going through steps 1–3 first.**
 
-Reads → run the skill (it carries the data tools internally):
+Reads → run the skill — MANDATORY, not the raw tools (the skill carries the data tools internally):
 - portfolio / balances / positions / idle-vs-deployed → **senpi-portfolio**
 - market read / what's moving / cross-asset / "the tape" → **senpi-market-pulse**
 - smart money / whales vs the crowd / divergence → **senpi-smart-money**
@@ -40,7 +61,7 @@ Reads → run the skill (it carries the data tools internally):
 - points / tier / fees / Arena / referrals / wins → **senpi-account-status**
 - what happened / history / why it failed → **senpi-audit** (`--strategy <id>` for one strategy)
 
-Act now → first-class tools:
+Act now → first-class tools (the ONLY place a raw tool leads — single lookups + mutations):
 - wallet / quick balance / quick price / list strategies → user_get_me / account_get_portfolio /
   market_get_prices / strategy_list — **"current / my strategies" = ACTIVE only: call
   `strategy_list(status: ["ACTIVE"])`; never present CLOSED/PAUSED as current. Treat active strategies

--- a/senpi-help/references/agents-md-router.md
+++ b/senpi-help/references/agents-md-router.md
@@ -6,8 +6,10 @@ look it up*. (`senpi-help` remains the full directory, loaded on demand for edge
 tokens/turn — cheap insurance that the agent routes to the right skill (or tool) first.
 
 **No tools are denied or removed.** Routing is about *order of preference*, not access: prefer a skill
-because it's faster and cheaper, but every underlying tool stays reachable via Tool Search (step 3).
-Whether we later collapse any tool schemas to save context is a separate decision — not assumed here.
+because it's cleaner and does the multi-step work for you, but every tool is already in your list and
+directly callable. Whether we later remove (deny) any tool schemas to save context is a separate
+decision — not assumed here. (This runtime loads all tool schemas every turn; there is no on-demand
+"tool search" — a tool is either in your list or it isn't.)
 
 ```markdown
 ## Senpi capabilities — routing (check before saying "I can't")
@@ -17,9 +19,9 @@ Whether we later collapse any tool schemas to save context is a separate decisio
    SKILL.md and use it.
 2. **Then `senpi-help`.** No clear skill? Read the `senpi-help` skill — its directory maps the intent to
    the right skill or tool.
-3. **Then Tool Search.** Still nothing? Use Tool Search to pull up the exact tool by name and call it
-   directly. Every tool stays reachable this way — nothing is hidden; a skill is just the preferred,
-   cheaper route when one fits.
+3. **Then the tool directly.** Still nothing? The matching tool is already in your list — find its
+   name in `senpi-help` (or scan your tools) and call it. A skill is just the preferred route when one
+   fits; nothing is hidden.
 4. **Cap it at ~5 attempts — do NOT keep cycling.** Don't grind for 10–20 minutes retrying the same
    thing. If you're still stuck after ~5 tries, **stop**: tell the user what you tried and suggest
    another path (an external source, a different framing, or one clarifying question). A clear "here's
@@ -42,8 +44,7 @@ Act now → first-class tools:
   as known state, not a fresh discovery.**
 - open / close / resize a position → create_position / close_position / edit_position
 - create / top-up / close a strategy → strategy_create_custom_strategy / strategy_top_up / strategy_close
-- withdraw / move funds / set a stop / cancel an order → the matching tool (Tool Search if it's not
-  already in your list)
+- withdraw / move funds / set a stop / cancel an order → the matching tool (already in your list)
 
 Pick / build / deploy a strategy → senpi-strategy-discover / -author / -ops
 Anything else, or unsure which → read **senpi-help**.

--- a/senpi-help/references/agents-md-router.md
+++ b/senpi-help/references/agents-md-router.md
@@ -9,8 +9,19 @@ agent consult help?" risk.
 ```markdown
 ## Senpi capabilities — routing (check before saying "I can't")
 
-Match the request, then use the skill or tool. If unsure, read the `senpi-help` skill (full
-directory). **Never tell a user a Senpi request is impossible without checking first.**
+**Find the capability in this order — then stop, don't cycle:**
+1. **Senpi skill first.** Scan the skills index for one that matches the request; if it fits, read its
+   SKILL.md and use it.
+2. **Then `senpi-help`.** No clear skill? Read the `senpi-help` skill — its directory maps the intent to
+   the right skill or tool.
+3. **Then tool search.** Still nothing? Search your available tools for a direct match (a tool may need
+   enabling).
+4. **Cap it at ~5 attempts — do NOT keep cycling.** Don't grind for 10–20 minutes retrying the same
+   thing. If you're still stuck after ~5 tries, **stop**: tell the user what you tried and suggest
+   another path (an external source, a different framing, or one clarifying question). A clear "here's
+   what I tried, here's another way" beats grinding silently.
+
+**Never tell a user a Senpi request is impossible without going through steps 1–3 first.**
 
 Reads → run the skill (it carries the data tools internally):
 - portfolio / balances / positions / idle-vs-deployed → **senpi-portfolio**

--- a/senpi-help/references/agents-md-router.md
+++ b/senpi-help/references/agents-md-router.md
@@ -6,10 +6,12 @@ look it up*. (`senpi-help` remains the full directory, loaded on demand for edge
 tokens/turn — cheap insurance that the agent routes to the right skill (or tool) first.
 
 **No tools are denied or removed.** Routing is about *order of preference*, not access: prefer a skill
-because it's cleaner and does the multi-step work for you, but every tool is already in your list and
-directly callable. Whether we later remove (deny) any tool schemas to save context is a separate
-decision — not assumed here. (This runtime loads all tool schemas every turn; there is no on-demand
-"tool search" — a tool is either in your list or it isn't.)
+because it's cleaner and does the multi-step work for you, but every tool stays reachable. If this
+runtime has **Tool Search** enabled (`tools.toolSearch` — `tool_search` / `tool_describe` /
+`tool_call`, or `tool_search_code`), you discover and call any catalog tool on demand; if it isn't,
+the tool is already in your list. Either way nothing is hidden. (How we reduce per-turn context —
+enabling Tool Search vs. denying tools — is a separate decision; Tool Search is the lower-risk lever
+because it keeps every tool reachable.)
 
 ```markdown
 ## Senpi capabilities — routing (check before saying "I can't")
@@ -19,9 +21,10 @@ decision — not assumed here. (This runtime loads all tool schemas every turn; 
    SKILL.md and use it.
 2. **Then `senpi-help`.** No clear skill? Read the `senpi-help` skill — its directory maps the intent to
    the right skill or tool.
-3. **Then the tool directly.** Still nothing? The matching tool is already in your list — find its
-   name in `senpi-help` (or scan your tools) and call it. A skill is just the preferred route when one
-   fits; nothing is hidden.
+3. **Then Tool Search (or the tool directly).** Still nothing? If Tool Search is enabled, use it —
+   `tool_search` to find the tool, `tool_describe` to load its schema, `tool_call` to run it (or the
+   `tool_search_code` bridge). If it isn't, the matching tool is already in your list — find its name
+   in `senpi-help` and call it. Nothing is hidden either way.
 4. **Cap it at ~5 attempts — do NOT keep cycling.** Don't grind for 10–20 minutes retrying the same
    thing. If you're still stuck after ~5 tries, **stop**: tell the user what you tried and suggest
    another path (an external source, a different framing, or one clarifying question). A clear "here's

--- a/senpi-help/references/agents-md-router.md
+++ b/senpi-help/references/agents-md-router.md
@@ -3,8 +3,11 @@
 This is the **compact, always-in-context** version of the `senpi-help` directory. Put it in the
 agent's `AGENTS.md` so the intent→skill map is present every turn — the agent never has to *decide to
 look it up*. (`senpi-help` remains the full directory, loaded on demand for edge cases.) Cost: ~150
-tokens/turn, against the ~24K saved by collapsing tools — a trivial trade that removes the "did the
-agent consult help?" risk.
+tokens/turn — cheap insurance that the agent routes to the right skill (or tool) first.
+
+**No tools are denied or removed.** Routing is about *order of preference*, not access: prefer a skill
+because it's faster and cheaper, but every underlying tool stays reachable via Tool Search (step 3).
+Whether we later collapse any tool schemas to save context is a separate decision — not assumed here.
 
 ```markdown
 ## Senpi capabilities — routing (check before saying "I can't")
@@ -14,8 +17,9 @@ agent consult help?" risk.
    SKILL.md and use it.
 2. **Then `senpi-help`.** No clear skill? Read the `senpi-help` skill — its directory maps the intent to
    the right skill or tool.
-3. **Then tool search.** Still nothing? Search your available tools for a direct match (a tool may need
-   enabling).
+3. **Then Tool Search.** Still nothing? Use Tool Search to pull up the exact tool by name and call it
+   directly. Every tool stays reachable this way — nothing is hidden; a skill is just the preferred,
+   cheaper route when one fits.
 4. **Cap it at ~5 attempts — do NOT keep cycling.** Don't grind for 10–20 minutes retrying the same
    thing. If you're still stuck after ~5 tries, **stop**: tell the user what you tried and suggest
    another path (an external source, a different framing, or one clarifying question). A clear "here's
@@ -38,7 +42,8 @@ Act now → first-class tools:
   as known state, not a fresh discovery.**
 - open / close / resize a position → create_position / close_position / edit_position
 - create / top-up / close a strategy → strategy_create_custom_strategy / strategy_top_up / strategy_close
-- withdraw / move funds / set a stop / cancel an order → the matching tool (may need enabling)
+- withdraw / move funds / set a stop / cancel an order → the matching tool (Tool Search if it's not
+  already in your list)
 
 Pick / build / deploy a strategy → senpi-strategy-discover / -author / -ops
 Anything else, or unsure which → read **senpi-help**.


### PR DESCRIPTION
> ## ⚠️ Assumption — DO NOT MERGE until @Sarvesh enables Tool Search
> This pilot is designed for the **Tool-Search-enabled** configuration. It assumes OpenClaw
> **`tools.toolSearch`** is turned on in **`directory` mode** so the catalog is *deferred, not denied*
> — the model sees compact descriptors + a hot set of likely schemas, and hydrates the rest on demand.
> **No tools are denied by this PR.** Two prerequisites are Sarvesh's / infra's call:
> 1. **Version** — the deployed OpenClaw build must include `tools.toolSearch`. Our last-checked build
>    (2026.5.7) showed no tool-search symbols in source, so this likely needs a **Railway-template
>    version bump**, not just a flag.
> 2. **Config** — `{ tools: { toolSearch: { mode: "directory" } } }` (per-host for a pilot, template for fleet).
>
> Until both are in place, these skills still work (tools load eagerly, no context savings yet) — so the
> PR is safe to hold, but the *context win* only lands once Sarvesh enables Tool Search. **Holding for Sarvesh.**

---

Prep for the **next set of pilots** — testing how agents discover the less-frequent capabilities once the catalog moves behind Tool Search, so nothing is lost when full schemas leave the eager prompt.

## `senpi-audit` — the clean READ bucket
Answers *"what happened?"* — recent activity / a strategy's history / failure investigation. Collapses `audit_get_recent_actions`, `audit_get_strategy_history`, `audit_query`. Hidden-engine pattern, fails open, `--dry`, **offline test 4/4**.

> Note: the *mutation* tools (cancel/pause/withdraw/transfer/stop-edits) stay first-class — they need the confirmation UX — so only the audit **reads** are skilled. The skillable long tail is the rare reads.

## `senpi-help` + always-loaded router — the discovery layer
An always-available **capabilities directory** (pure-markdown skill, no engine) mapping every Senpi intent → the skill or tool that handles it. Core line: **"a missing tool is never a missing capability."** Paired with the always-loaded `AGENTS.md` router block (intent→skill map, in context every turn) and the find-then-stop ladder:

1. Senpi skill first → 2. then `senpi-help` → 3. then **Tool Search** (`tool_search`/`tool_describe`/`tool_call`, or `tool_search_code`) → 4. cap at ~5 attempts, then stop and suggest another path (no 10–20-min grinds).

## Why these two (under Tool Search)
With Tool Search in `directory` mode, full schemas leave the prompt but tool **names + descriptions stay visible** in the bounded directory — and anything beyond it is one `tool_search` away. The skills act as the **hot set** (the common reads, pre-loaded), `senpi-help` + the router give **human-curated discovery** on top of the raw catalog, and the ladder guarantees the agent **routes before giving up**. Net: the context win of deferral, with discovery *better* than raw Tool Search alone — and **zero denials**, so nothing is ever unreachable.

Both descriptions are spec-clean (≤1024 chars); `senpi-help` has no engine (Level-2 directory only).

## Measuring it (once enabled)
Tool Search ships built-in telemetry — serialized prompt bytes, catalog size, search/describe/call counts — and a gateway E2E proving the payload shrinks. So we get a **real before/after number**, not an estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Rebuilt cleanly on `strategy-v2` — supersedes #378 (original was main-based; strategy-v2 replaces main)._