### PR TITLE
Revert "Rachin/curator fixes"

### DIFF
--- a/strategies/asia-ai/hedge/runtime.yaml
+++ b/strategies/asia-ai/hedge/runtime.yaml
@@ -15,7 +15,6 @@ description: >
 strategy:
   wallet: "${ASIA_AI_HEDGE_WALLET}"
   slots: 2
-  margin_pct: 10                       # % of account per slot (runtime sizes the dollars)
   default_leverage: 3
   trading_risk: moderate
   enabled: true
@@ -37,6 +36,7 @@ scanners:
       direction: "SHORT"
       wantTrend: "DOWN"
       minScore: 5
+      marginPct: 0.10
       rsiMin: 25
       recentSignalTtlSeconds: 1800
     signal_data_schema:

--- a/strategies/asia-ai/hedge/scanners/scan.py
+++ b/strategies/asia-ai/hedge/scanners/scan.py
@@ -3,7 +3,7 @@
 Direction-parametrized: the `main` instance passes direction=LONG / wantTrend=UP
 (long the Asian AI semis); the `hedge` instance passes direction=SHORT /
 wantTrend=DOWN (short the broad/US-AI complex when it rolls over, to strip market
-beta). Read-only, pure, single-pass — emits asset+direction signals only."""
+beta). Read-only, pure, single-pass — emits a `marginPct` intent; the runtime sizes."""
 
 import sys
 import time
@@ -18,6 +18,7 @@ def scan(inputs, ctx):
     direction = (inputs.get("direction", "LONG") or "LONG").upper()
     want = (inputs.get("wantTrend", "UP") or "UP").upper()
     min_score = int(inputs.get("minScore", 5))
+    margin_pct = float(inputs.get("marginPct", 0.12))
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
     now = time.time()
 
@@ -43,6 +44,7 @@ def scan(inputs, ctx):
         out.append({
             "asset": asset,
             "direction": direction,
+            "marginPct": margin_pct,          # SIZING INTENT — the runtime sizes the dollars
             "data": {"score": th["score"], "direction": direction, "reasons": th["reasons"]},
         })
         recent[au] = now

--- a/strategies/asia-ai/main/runtime.yaml
+++ b/strategies/asia-ai/main/runtime.yaml
@@ -11,7 +11,6 @@ description: >
 strategy:
   wallet: "${ASIA_AI_MAIN_WALLET}"
   slots: 5
-  margin_pct: 12                       # % of account per slot (runtime sizes the dollars)
   default_leverage: 3
   trading_risk: moderate
   enabled: true
@@ -33,6 +32,7 @@ scanners:
       direction: "LONG"
       wantTrend: "UP"
       minScore: 5
+      marginPct: 0.12
       rsiMax: 75
       recentSignalTtlSeconds: 1800
     signal_data_schema:

--- a/strategies/asia-ai/main/scanners/scan.py
+++ b/strategies/asia-ai/main/scanners/scan.py
@@ -3,7 +3,7 @@
 Direction-parametrized: the `main` instance passes direction=LONG / wantTrend=UP
 (long the Asian AI semis); the `hedge` instance passes direction=SHORT /
 wantTrend=DOWN (short the broad/US-AI complex when it rolls over, to strip market
-beta). Read-only, pure, single-pass — emits asset+direction signals only."""
+beta). Read-only, pure, single-pass — emits a `marginPct` intent; the runtime sizes."""
 
 import sys
 import time
@@ -18,6 +18,7 @@ def scan(inputs, ctx):
     direction = (inputs.get("direction", "LONG") or "LONG").upper()
     want = (inputs.get("wantTrend", "UP") or "UP").upper()
     min_score = int(inputs.get("minScore", 5))
+    margin_pct = float(inputs.get("marginPct", 0.12))
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
     now = time.time()
 
@@ -43,8 +44,9 @@ def scan(inputs, ctx):
         out.append({
             "asset": asset,
             "direction": direction,
+            "marginPct": margin_pct,          # SIZING INTENT — the runtime sizes the dollars
             "data": {"score": th["score"], "direction": direction, "reasons": th["reasons"]},
-        })        
+        })
         recent[au] = now
 
     if ctx.state is not None:

--- a/strategies/kodiak/main/runtime.yaml
+++ b/strategies/kodiak/main/runtime.yaml
@@ -12,7 +12,6 @@ description: >
 strategy:
   wallet: "${KODIAK_WALLET}"
   slots: 1                                # single asset, single position
-  margin_pct: 20                          # % of account per slot (runtime sizes the dollars)
   default_leverage: 5                     # fallback; scan emits per-signal 5/6/7 by score
   trading_risk: aggressive
   enabled: true
@@ -34,6 +33,7 @@ scanners:
       dex: ""
       macroAsset: "BTC"                    # "" disables the BTC-correlation factor (xyz ports)
       minScore: 10
+      marginPct: 0.20
       minTrendStrength4h: 0.75
       minMom15mPct: 0.1
       rsiMaxLong: 72

--- a/strategies/kodiak/main/scanners/scan.py
+++ b/strategies/kodiak/main/scanners/scan.py
@@ -3,9 +3,9 @@
 Single-asset. Reads SOL candles (5m/15m/1h/4h) + funding/OI, a macro driver
 (BTC 1h momentum), and smart-money positioning (leaderboard_get_markets); scores
 via the pure `scoring.build_thesis`; and emits ONE conviction-tiered signal when
-the composite clears `minScore`. Read-only + single-pass — emits a per-signal
-`leverage` (5/6/7 by score); the runtime sizes the dollars, owns the cooldowns/risk
-gates, and trails the DSL exit. No daemon, no push_signal."""
+the composite clears `minScore`. Read-only + single-pass — emits a `marginPct`
+intent plus a per-signal `leverage` (5/6/7 by score); the runtime sizes the dollars,
+owns the cooldowns/risk gates, and trails the DSL exit. No daemon, no push_signal."""
 
 import sys
 import time
@@ -86,6 +86,7 @@ def scan(inputs, ctx):
     dex = _dex_for(asset, inputs)
     macro_asset = inputs.get("macroAsset", "BTC")     # "" disables the BTC factor (e.g. xyz ports)
     min_score = float(inputs.get("minScore", 10))
+    margin_pct = float(inputs.get("marginPct", 0.20))
     tiers = inputs.get("leverageTiers", _DEFAULT_TIERS)
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
     now = time.time()
@@ -125,6 +126,7 @@ def scan(inputs, ctx):
     out = [{
         "asset": asset,
         "direction": th["direction"],
+        "marginPct": margin_pct,          # SIZING INTENT — runtime sizes the dollars
         "leverage": leverage,             # conviction-tiered (5/6/7); runtime applies it
         "data": {
             "score": th["score"], "leverage": leverage, "direction": th["direction"],

--- a/strategies/whalehunter/long/runtime.yaml
+++ b/strategies/whalehunter/long/runtime.yaml
@@ -45,12 +45,11 @@ scanners:
       crowdDivergenceMin: 0.2
       requireGrowing: true
       cohortMinScore: 4
-      customMarginPct: 0.12                 # per-signal sizing base (NOT strategy.margin_pct)
+      marginPct: 0.12
       maxMarginPct: 0.25
       maxConvictionScale: 2.0
       stdLeverage: 3
       maxLeverage: 5
-      venueMinNotionalUsd: 10
       recentSignalTtlSeconds: 3600
     signal_data_schema:
       score: { type: number }

--- a/strategies/whalehunter/long/scanners/scan.py
+++ b/strategies/whalehunter/long/scanners/scan.py
@@ -9,7 +9,7 @@ the cohort cache + daily ledger are per-sleeve (the v2 daemon shared them on dis
 Per tick: refresh the smart/crowd cohorts (cached daily in ctx.state), aggregate each
 cohort's net positioning (discovery_get_trader_state), update the daily ledger to get
 the 'adding daily' growth, score the divergences for THIS direction, and emit a
-conviction-scaled marginUsd (pct of max()-collapsed account equity; runtime owns slots/dedup, trails DSL).
+conviction-scaled marginPct INTENT (the runtime sizes, owns slots/dedup, trails DSL).
 Read-only, single-pass. Derived universe — the coins come from the cohort's positions,
 not a fixed list. NOTE: ~1 UTC-day warmup before requireGrowing can pass."""
 
@@ -88,35 +88,12 @@ def _fetch_states(ctx, addrs):
     return traders
 
 
-def _account_value(ctx):
-    """max()-collapsed account equity from strategy_get_clearinghouse_state. main/xyz
-    are TWO VIEWS of ONE cross-margin wallet — take max(), never sum (summing doubles
-    the equity and 2x every position size). The dex holding a position reports full
-    equity; the other reports free collateral, so max() yields the true equity."""
-    try:
-        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
-                                     {"strategy_wallet": ctx.wallet})
-    except Exception:
-        return 0.0
-    data = ch.get("data", ch) if isinstance(ch, dict) else ch
-    if not isinstance(data, dict):
-        return 0.0
-    av = 0.0
-    for section in ("main", "xyz"):
-        s = data.get(section, {})
-        if isinstance(s, dict):
-            ms = s.get("marginSummary", {})
-            av = max(av, float(ms.get("accountValue", 0) or 0))
-    return av
-
-
 def scan(inputs, ctx):
     direction = (inputs.get("direction", "LONG") or "LONG").upper()
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
     std_lev = int(inputs.get("stdLeverage", 3))
     max_lev = int(inputs.get("maxLeverage", 5))
     min_members = int(inputs.get("cohortMinMembers", 5))
-    venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
     now = time.time()
     today = time.strftime("%Y-%m-%d", time.gmtime(now))
 
@@ -145,29 +122,16 @@ def scan(inputs, ctx):
     strikes = scoring.cohort_signals(smart_per, crowd_per, growth, direction, inputs)
 
     leverage = min(std_lev, max_lev)
-    account_value = _account_value(ctx)
-    if account_value <= 0:                                   # can't size — emit nothing this tick
-        print("[whalehunter.scan] WARNING: account value unavailable; no signals emitted",
-              file=sys.stderr)
-        _persist()
-        return []
-
     out = []
     for s in strikes:
         cu = s["coin"].upper()
         if recent.get(cu) is not None and (now - recent[cu]) < ttl:   # signal-dedup
             continue
-        # marginUsd = equity x conviction-scaled fraction from the `customMarginPct` input.
-        # `customMarginPct` is a per-signal producer tunable — do NOT confuse it with the
-        # runtime's strategy.margin_pct config field (a different sizing mechanism).
-        margin_usd = round(account_value * scoring.margin_pct_for(s["score"], inputs), 2)
-        if margin_usd * leverage < venue_min_notional:        # below venue min notional — skip
-            continue
         out.append({
             "asset": s["coin"],
             "direction": direction,
-            "marginUsd": margin_usd,                          # conviction-scaled USD; runtime opens it
-            "leverage": leverage,                             # std, runtime clamps to venue max
+            "marginPct": scoring.margin_pct_for(s["score"], inputs),  # conviction-scaled INTENT
+            "leverage": leverage,                                     # std, runtime clamps to venue max
             "data": {
                 "score": s["score"], "direction": direction, "signalKind": "COHORT_DIVERGENCE",
                 "smartBias": s["smart_bias"], "crowdBias": s["crowd_bias"],

--- a/strategies/whalehunter/long/scanners/scoring.py
+++ b/strategies/whalehunter/long/scanners/scoring.py
@@ -128,11 +128,9 @@ def cohort_signals(smart_per, crowd_per, growth, direction, config):
 
 
 def margin_pct_for(score, config):
-    """Conviction-scaled margin fraction: base `customMarginPct` scaled +25% per point
-    above the floor, capped at maxMarginPct. scan.py multiplies this by account equity to
-    get marginUsd. `customMarginPct` is a per-signal producer input — NOT the runtime's
-    strategy.margin_pct config field."""
-    base = float(config.get("customMarginPct", 0.12))
+    """Conviction-scaled marginPct INTENT (not dollars — the runtime sizes). Scales
+    +25% per point above the floor, capped at maxMarginPct."""
+    base = float(config.get("marginPct", 0.12))
     cap = float(config.get("maxMarginPct", 0.25))
     smax = float(config.get("maxConvictionScale", 2.0))
     floor = int(config.get("cohortMinScore", 4))

--- a/strategies/whalehunter/short/runtime.yaml
+++ b/strategies/whalehunter/short/runtime.yaml
@@ -45,12 +45,11 @@ scanners:
       crowdDivergenceMin: 0.2
       requireGrowing: true
       cohortMinScore: 4
-      customMarginPct: 0.12                 # per-signal sizing base (NOT strategy.margin_pct)
+      marginPct: 0.12
       maxMarginPct: 0.25
       maxConvictionScale: 2.0
       stdLeverage: 3
       maxLeverage: 5
-      venueMinNotionalUsd: 10
       recentSignalTtlSeconds: 3600
     signal_data_schema:
       score: { type: number }

--- a/strategies/whalehunter/short/scanners/scan.py
+++ b/strategies/whalehunter/short/scanners/scan.py
@@ -9,7 +9,7 @@ the cohort cache + daily ledger are per-sleeve (the v2 daemon shared them on dis
 Per tick: refresh the smart/crowd cohorts (cached daily in ctx.state), aggregate each
 cohort's net positioning (discovery_get_trader_state), update the daily ledger to get
 the 'adding daily' growth, score the divergences for THIS direction, and emit a
-conviction-scaled marginUsd (pct of max()-collapsed account equity; runtime owns slots/dedup, trails DSL).
+conviction-scaled marginPct INTENT (the runtime sizes, owns slots/dedup, trails DSL).
 Read-only, single-pass. Derived universe — the coins come from the cohort's positions,
 not a fixed list. NOTE: ~1 UTC-day warmup before requireGrowing can pass."""
 
@@ -88,35 +88,12 @@ def _fetch_states(ctx, addrs):
     return traders
 
 
-def _account_value(ctx):
-    """max()-collapsed account equity from strategy_get_clearinghouse_state. main/xyz
-    are TWO VIEWS of ONE cross-margin wallet — take max(), never sum (summing doubles
-    the equity and 2x every position size). The dex holding a position reports full
-    equity; the other reports free collateral, so max() yields the true equity."""
-    try:
-        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
-                                     {"strategy_wallet": ctx.wallet})
-    except Exception:
-        return 0.0
-    data = ch.get("data", ch) if isinstance(ch, dict) else ch
-    if not isinstance(data, dict):
-        return 0.0
-    av = 0.0
-    for section in ("main", "xyz"):
-        s = data.get(section, {})
-        if isinstance(s, dict):
-            ms = s.get("marginSummary", {})
-            av = max(av, float(ms.get("accountValue", 0) or 0))
-    return av
-
-
 def scan(inputs, ctx):
     direction = (inputs.get("direction", "LONG") or "LONG").upper()
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
     std_lev = int(inputs.get("stdLeverage", 3))
     max_lev = int(inputs.get("maxLeverage", 5))
     min_members = int(inputs.get("cohortMinMembers", 5))
-    venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
     now = time.time()
     today = time.strftime("%Y-%m-%d", time.gmtime(now))
 
@@ -145,29 +122,16 @@ def scan(inputs, ctx):
     strikes = scoring.cohort_signals(smart_per, crowd_per, growth, direction, inputs)
 
     leverage = min(std_lev, max_lev)
-    account_value = _account_value(ctx)
-    if account_value <= 0:                                   # can't size — emit nothing this tick
-        print("[whalehunter.scan] WARNING: account value unavailable; no signals emitted",
-              file=sys.stderr)
-        _persist()
-        return []
-
     out = []
     for s in strikes:
         cu = s["coin"].upper()
         if recent.get(cu) is not None and (now - recent[cu]) < ttl:   # signal-dedup
             continue
-        # marginUsd = equity x conviction-scaled fraction from the `customMarginPct` input.
-        # `customMarginPct` is a per-signal producer tunable — do NOT confuse it with the
-        # runtime's strategy.margin_pct config field (a different sizing mechanism).
-        margin_usd = round(account_value * scoring.margin_pct_for(s["score"], inputs), 2)
-        if margin_usd * leverage < venue_min_notional:        # below venue min notional — skip
-            continue
         out.append({
             "asset": s["coin"],
             "direction": direction,
-            "marginUsd": margin_usd,                          # conviction-scaled USD; runtime opens it
-            "leverage": leverage,                             # std, runtime clamps to venue max
+            "marginPct": scoring.margin_pct_for(s["score"], inputs),  # conviction-scaled INTENT
+            "leverage": leverage,                                     # std, runtime clamps to venue max
             "data": {
                 "score": s["score"], "direction": direction, "signalKind": "COHORT_DIVERGENCE",
                 "smartBias": s["smart_bias"], "crowdBias": s["crowd_bias"],

--- a/strategies/whalehunter/short/scanners/scoring.py
+++ b/strategies/whalehunter/short/scanners/scoring.py
@@ -128,11 +128,9 @@ def cohort_signals(smart_per, crowd_per, growth, direction, config):
 
 
 def margin_pct_for(score, config):
-    """Conviction-scaled margin fraction: base `customMarginPct` scaled +25% per point
-    above the floor, capped at maxMarginPct. scan.py multiplies this by account equity to
-    get marginUsd. `customMarginPct` is a per-signal producer input — NOT the runtime's
-    strategy.margin_pct config field."""
-    base = float(config.get("customMarginPct", 0.12))
+    """Conviction-scaled marginPct INTENT (not dollars — the runtime sizes). Scales
+    +25% per point above the floor, capped at maxMarginPct."""
+    base = float(config.get("marginPct", 0.12))
     cap = float(config.get("maxMarginPct", 0.25))
     smax = float(config.get("maxConvictionScale", 2.0))
     floor = int(config.get("cohortMinScore", 4))


### PR DESCRIPTION
Reverts Senpi-ai/senpi-skills#387

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live trading position sizing across multiple strategies and removes whalehunter scanner-side USD sizing and min-notional filters, so live behavior depends on the runtime correctly honoring signal `marginPct`.
> 
> **Overview**
> **Moves position sizing off `strategy.margin_pct` in runtime YAML and onto per-signal `marginPct` from external scanners**, with the runtime responsible for turning that fraction into dollar margin.
> 
> For **asia-ai** (main/hedge), **kodiak**, and **whalehunter** (long/short), each `runtime.yaml` drops `strategy.margin_pct` and adds a matching `marginPct` under scanner `inputs` (e.g. 0.12 main, 0.10 hedge, 0.20 kodiak). Scanners now attach `marginPct` on every emitted signal instead of relying on strategy-level config alone.
> 
> **Whalehunter** is the larger behavioral shift: signals no longer emit **`marginUsd`** computed from `strategy_get_clearinghouse_state` and conviction scaling in the scanner. **`customMarginPct`** is renamed to **`marginPct`** in inputs/scoring; **`venueMinNotionalUsd`** and the **`_account_value`** helper are removed, along with skips when equity is missing or notional is too small. Conviction scaling still lives in `margin_pct_for()` but returns a **`marginPct` intent** for the runtime to size.
> 
> Docstrings/comments are updated to describe scanners as emitting sizing intent, not dollar amounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c0389119174b29d643f0a8a35800a33bd94dc59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->