### PR TITLE
Rachin/curator fixes

### DIFF
--- a/strategies/asia-ai/hedge/runtime.yaml
+++ b/strategies/asia-ai/hedge/runtime.yaml
@@ -36,7 +36,7 @@ scanners:
       direction: "SHORT"
       wantTrend: "DOWN"
       minScore: 5
-      marginPct: 0.10
+      marginPct: 10          # percent of withdrawable (runtime sizes (marginPct/100)*withdrawable)
       rsiMin: 25
       recentSignalTtlSeconds: 1800
     signal_data_schema:

--- a/strategies/asia-ai/hedge/scanners/scan.py
+++ b/strategies/asia-ai/hedge/scanners/scan.py
@@ -18,7 +18,7 @@ def scan(inputs, ctx):
     direction = (inputs.get("direction", "LONG") or "LONG").upper()
     want = (inputs.get("wantTrend", "UP") or "UP").upper()
     min_score = int(inputs.get("minScore", 5))
-    margin_pct = float(inputs.get("marginPct", 0.12))
+    margin_pct = float(inputs.get("marginPct", 12))   # percent of withdrawable, not a fraction
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
     now = time.time()
 

--- a/strategies/asia-ai/main/runtime.yaml
+++ b/strategies/asia-ai/main/runtime.yaml
@@ -32,7 +32,7 @@ scanners:
       direction: "LONG"
       wantTrend: "UP"
       minScore: 5
-      marginPct: 0.12
+      marginPct: 12          # percent of withdrawable (runtime sizes (marginPct/100)*withdrawable)
       rsiMax: 75
       recentSignalTtlSeconds: 1800
     signal_data_schema:

--- a/strategies/asia-ai/main/scanners/scan.py
+++ b/strategies/asia-ai/main/scanners/scan.py
@@ -18,7 +18,7 @@ def scan(inputs, ctx):
     direction = (inputs.get("direction", "LONG") or "LONG").upper()
     want = (inputs.get("wantTrend", "UP") or "UP").upper()
     min_score = int(inputs.get("minScore", 5))
-    margin_pct = float(inputs.get("marginPct", 0.12))
+    margin_pct = float(inputs.get("marginPct", 12))   # percent of withdrawable, not a fraction
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
     now = time.time()
 

--- a/strategies/asia-ai/tests/test_margin_pct.py
+++ b/strategies/asia-ai/tests/test_margin_pct.py
@@ -1,0 +1,103 @@
+"""asia-ai margin-units regression.
+
+v3.0.4 runtime sizes (marginPct/100)*withdrawable, so per-signal `marginPct` MUST be
+a PERCENT in (0,100], never a fraction. asia-ai previously emitted 0.12 (main) / 0.10
+(hedge) -> ~100x undersize, silent (no 400). These tests drive the SHARED scan.py with
+each sleeve's real runtime.yaml inputs and assert the emitted wire marginPct lands in
+[1,100], plus cover the in-code default fallback.
+"""
+
+import importlib.util
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SLEEVES = {
+    "main": {"path": ROOT / "main", "expect": 12},
+    "hedge": {"path": ROOT / "hedge", "expect": 10},
+}
+
+
+def _load_scan(sleeve_dir):
+    """Import the sleeve's own scan.py (with its sibling scoring.py importable)."""
+    scanners = sleeve_dir / "scanners"
+    import sys
+
+    sys.path.insert(0, str(scanners))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"scan_{sleeve_dir.name}", scanners / "scan.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        sys.path.remove(str(scanners))
+
+
+def _inputs(sleeve_dir):
+    rt = yaml.safe_load((sleeve_dir / "runtime.yaml").read_text())
+    for s in rt["scanners"]:
+        if s.get("type") == "external_scanner":
+            return s["inputs"]
+    raise AssertionError("no external_scanner inputs")
+
+
+class _FakeMcp:
+    """Returns candles that guarantee confirm_trend fires for the given want trend."""
+
+    def __init__(self, want):
+        self.want = want
+
+    def call_tool(self, name, args):
+        # 8 monotone candles -> strong trend on both 4h and 1d in the wanted direction.
+        if self.want == "UP":
+            closes = [100, 102, 104, 106, 108, 110, 112, 114]
+        else:
+            closes = [114, 112, 110, 108, 106, 104, 102, 100]
+        candles = [[i, c, c, c, c, 1] for i, c in enumerate(closes)]
+        return {"data": {"candles": {"4h": candles, "1d": candles}}}
+
+
+class _FakeCtx:
+    def __init__(self, want):
+        self.senpi_mcp = _FakeMcp(want)
+        self.state = None
+
+
+def _emit(mod, inputs):
+    """Run scan with one asset forced through; return its emitted marginPct."""
+    ins = dict(inputs)
+    ins["universe"] = ["xyz:TEST"]
+    ins["minScore"] = 0  # ensure the candidate isn't filtered on score
+    want = (ins.get("wantTrend", "UP") or "UP").upper()
+    out = mod.scan(ins, _FakeCtx(want))
+    assert out, "scan emitted no candidates (trend stub failed)"
+    return out[0]["marginPct"]
+
+
+def test_each_sleeve_emits_percent_in_range():
+    for name, cfg in SLEEVES.items():
+        mod = _load_scan(cfg["path"])
+        mpct = _emit(mod, _inputs(cfg["path"]))
+        assert 1 <= mpct <= 100, f"{name}: emitted marginPct {mpct} not in [1,100]"
+        assert mpct == cfg["expect"], f"{name}: expected {cfg['expect']}, got {mpct}"
+
+
+def test_default_fallback_is_percent():
+    """Empty inputs -> in-code default must also be a percent in [1,100], not a fraction."""
+    for name, cfg in SLEEVES.items():
+        mod = _load_scan(cfg["path"])
+        ins = _inputs(cfg["path"])
+        ins = {k: v for k, v in ins.items() if k != "marginPct"}  # drop config knob
+        mpct = _emit(mod, ins)
+        assert 1 <= mpct <= 100, f"{name}: default marginPct {mpct} not in [1,100]"
+
+
+def test_runtime_yaml_margin_is_percent():
+    """Config-level guard: both runtime.yamls must declare marginPct >= 1."""
+    for name, cfg in SLEEVES.items():
+        mpct = _inputs(cfg["path"])["marginPct"]
+        assert mpct >= 1, f"{name}: runtime.yaml marginPct {mpct} < 1 (fraction, not percent)"
+        assert mpct <= 100, f"{name}: runtime.yaml marginPct {mpct} > 100"

--- a/strategies/kodiak/main/runtime.yaml
+++ b/strategies/kodiak/main/runtime.yaml
@@ -33,7 +33,7 @@ scanners:
       dex: ""
       macroAsset: "BTC"                    # "" disables the BTC-correlation factor (xyz ports)
       minScore: 10
-      marginPct: 0.20
+      marginPct: 20                        # PERCENT of withdrawable (0,100] — runtime sizes (marginPct/100)*withdrawable
       minTrendStrength4h: 0.75
       minMom15mPct: 0.1
       rsiMaxLong: 72

--- a/strategies/kodiak/main/scanners/scan.py
+++ b/strategies/kodiak/main/scanners/scan.py
@@ -86,7 +86,7 @@ def scan(inputs, ctx):
     dex = _dex_for(asset, inputs)
     macro_asset = inputs.get("macroAsset", "BTC")     # "" disables the BTC factor (e.g. xyz ports)
     min_score = float(inputs.get("minScore", 10))
-    margin_pct = float(inputs.get("marginPct", 0.20))
+    margin_pct = float(inputs.get("marginPct", 20))   # PERCENT of withdrawable (0,100], not a fraction
     tiers = inputs.get("leverageTiers", _DEFAULT_TIERS)
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
     now = time.time()

--- a/strategies/kodiak/main/scanners/test_margin_pct.py
+++ b/strategies/kodiak/main/scanners/test_margin_pct.py
@@ -1,0 +1,45 @@
+"""Guard: kodiak's marginPct must be a PERCENT in (0,100], never a v2 fraction.
+
+v3.x runtime sizes `(marginPct/100)*withdrawable` (resolve-margin.ts), so a
+fraction like 0.20 sizes 0.20% of withdrawable — ~100x undersize, silent (no 400,
+since 0.20 still satisfies the (0,100] bound). marginPct is a pure pass-through
+config value here: read at scan.py (inputs.marginPct, default 20) and emitted
+verbatim at the candidate top level; `scoring.build_thesis` never reads it. So
+this is a config-level invariant, asserted directly against the wire-bound value.
+"""
+
+import os
+import re
+
+import yaml
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_RUNTIME_YAML = os.path.join(_HERE, "..", "runtime.yaml")
+_SCAN_PY = os.path.join(_HERE, "scan.py")
+
+
+def _runtime_margin_pct():
+    with open(_RUNTIME_YAML) as f:
+        spec = yaml.safe_load(f)
+    for s in spec["scanners"]:
+        if s.get("type") == "external_scanner":
+            return float(s["inputs"]["marginPct"])
+    raise AssertionError("no external_scanner inputs.marginPct in runtime.yaml")
+
+
+def _scan_default_margin_pct():
+    src = open(_SCAN_PY).read()
+    m = re.search(r'inputs\.get\(\s*"marginPct"\s*,\s*([0-9.]+)\s*\)', src)
+    assert m, "scan.py marginPct default not found"
+    return float(m.group(1))
+
+
+def test_runtime_margin_pct_is_percent_in_range():
+    pct = _runtime_margin_pct()
+    # >=1 catches the fraction bug (0.20); <=100 is the wire upper bound.
+    assert 1 <= pct <= 100, f"runtime.yaml marginPct={pct} not a PERCENT in [1,100]"
+
+
+def test_scan_default_margin_pct_is_percent_in_range():
+    pct = _scan_default_margin_pct()
+    assert 1 <= pct <= 100, f"scan.py marginPct default={pct} not a PERCENT in [1,100]"

--- a/strategies/spider/scalp/runtime.yaml
+++ b/strategies/spider/scalp/runtime.yaml
@@ -19,7 +19,7 @@ description: >
 strategy:
   wallet: "${SPIDER_SCALP_WALLET}"
   slots: 4                          # source maxSlots 4
-  margin_pct: 15                    # source marginPct 0.15 → margin_usd = account_value * 0.15
+  margin_pct: 15                    # percent of withdrawable per signal (source marginPct 0.15)
   default_leverage: 5               # source scalpMaxLeverage cap (clamped per-asset to HL venue max in scan.py)
   trading_risk: moderate
   enabled: true
@@ -40,7 +40,7 @@ scanners:
     inputs:
       allowedAssets: ["BTC", "ETH", "SOL", "HYPE", "xyz:BRENTOIL", "xyz:CL"]
       minScore: 4
-      marginPct: 0.15
+      marginPct: 15
       maxLeverage: 5
       maxSlots: 4
       rsiOversold: 30

--- a/strategies/spider/scalp/scanners/scan.py
+++ b/strategies/spider/scalp/scanners/scan.py
@@ -136,7 +136,8 @@ def _prune_signaled(signaled, ttl, now):
 def scan(inputs, ctx):
     now = time.time()
     min_score = inputs.get("minScore", 4)
-    margin_pct = float(inputs.get("marginPct", 0.15))
+    # Per-signal size as a PERCENT of withdrawable, domain (0,100].
+    margin_pct = float(inputs.get("marginPct", 15))
     leg_max_lev = inputs.get("maxLeverage", 5)
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
     venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
@@ -149,7 +150,9 @@ def scan(inputs, ctx):
         return []
 
     min_notional = max(account_value * min_notional_pct, venue_min_notional)
-    margin_usd = round(account_value * margin_pct, 2)
+    # Margin the runtime will allocate per signal (marginPct of withdrawable),
+    # used only to apply the venue-min-notional gate below.
+    margin_usd = round(account_value * (margin_pct / 100), 2)
 
     signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
 
@@ -187,7 +190,7 @@ def scan(inputs, ctx):
         out.append({
             "asset": th["coin"],
             "direction": th["direction"],
-            "marginUsd": margin_usd,
+            "marginPct": margin_pct,
             "leverage": leverage,
             "data": {
                 "score": th["score"],

--- a/strategies/spider/swing/runtime.yaml
+++ b/strategies/spider/swing/runtime.yaml
@@ -19,7 +19,7 @@ description: >
 strategy:
   wallet: "${SPIDER_SWING_WALLET}"
   slots: 3                          # source maxSlots 3
-  margin_pct: 28                    # source marginPct 0.28 → margin_usd = account_value * 0.28
+  margin_pct: 28                    # percent of withdrawable per signal (source marginPct 0.28)
   default_leverage: 10              # source swingMaxLeverage cap (clamped per-asset to HL venue max in scan.py)
   trading_risk: moderate
   enabled: true
@@ -48,7 +48,7 @@ scanners:
       allowedAssets: ["xyz:NVDA", "xyz:AMD", "xyz:INTC", "xyz:MRVL", "xyz:MU", "xyz:TSM", "SUI", "ONDO", "HYPE", "NIL", "GRASS", "ZEC"]
       # ── scoring knobs ──
       minScore: 5
-      marginPct: 0.28
+      marginPct: 28
       maxLeverage: 10
       maxSlots: 3
       rsiMaxLong: 78

--- a/strategies/spider/swing/scanners/scan.py
+++ b/strategies/spider/swing/scanners/scan.py
@@ -24,8 +24,8 @@ What was simplified vs the source (FLAGGED):
     qualifying candidates above minScore (held + recently-signaled filtered).
     The signal-GATING thresholds (minScore, held-set, recent-dedup, venue min
     notional) are preserved exactly; only the per-tick emission CAP moves to the
-    runtime. marginUsd is still computed (account_value * marginPct) and carried
-    on data{} so the action sizes identically to the source.
+    runtime. Per-signal sizing is emitted as `marginPct` (a percent of
+    withdrawable); the runtime sizes (marginPct/100)*withdrawable*leverage.
 """
 
 import sys
@@ -246,7 +246,8 @@ def _build_universe(inputs, meta_map, first_seen, now):
 def scan(inputs, ctx):
     now = time.time()
     min_score = inputs.get("minScore", 5)
-    margin_pct = float(inputs.get("marginPct", 0.28))
+    # Per-signal size as a PERCENT of withdrawable, domain (0,100].
+    margin_pct = float(inputs.get("marginPct", 28))
     leg_max_lev = inputs.get("maxLeverage", 10)
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
     venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
@@ -259,7 +260,9 @@ def scan(inputs, ctx):
         return []
 
     min_notional = max(account_value * min_notional_pct, venue_min_notional)
-    margin_usd = round(account_value * margin_pct, 2)
+    # Margin the runtime will allocate per signal (marginPct of withdrawable),
+    # used only to apply the venue-min-notional gate below.
+    margin_usd = round(account_value * (margin_pct / 100), 2)
 
     signaled, first_seen = _load_state_maps(ctx)
     signaled = _prune_signaled(signaled, ttl, now)
@@ -301,7 +304,7 @@ def scan(inputs, ctx):
         out.append({
             "asset": th["coin"],
             "direction": th["direction"],
-            "marginUsd": margin_usd,
+            "marginPct": margin_pct,
             "leverage": leverage,
             "data": {
                 "score": th["score"],

--- a/strategies/spider/test_margin_wire_shape.py
+++ b/strategies/spider/test_margin_wire_shape.py
@@ -1,0 +1,157 @@
+"""Wire-shape guard for both spider sleeves' emitted candidates.
+
+The v3.0.4 supervised scaffold strips any top-level candidate key it does not
+recognize, then validates marginPct against (0, 100]. These tests drive the real
+scan() emit/sizing path for each sleeve through a fake ctx and assert:
+  (a) NO `marginUsd` key is emitted (it would be silently dropped on the wire);
+  (b) emitted `marginPct` is a percent in [1, 100], never a fraction.
+
+Each sleeve's scan.py imports a sibling `scoring` module, so we load each from
+its own scanners/ dir under a distinct module name and inject the dir on
+sys.path for the duration of the import.
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_scan(sleeve):
+    scanners_dir = os.path.join(_HERE, sleeve, "scanners")
+    sys.path.insert(0, scanners_dir)
+    try:
+        # Fresh `scoring` per sleeve (the two dirs hold different scoring.py).
+        for name in ("scoring", f"spider_{sleeve}_scan"):
+            sys.modules.pop(name, None)
+        spec = importlib.util.spec_from_file_location(
+            f"spider_{sleeve}_scan", os.path.join(scanners_dir, "scan.py")
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        sys.path.remove(scanners_dir)
+
+
+class _FakeState:
+    def __init__(self):
+        self._records = []
+
+    def __len__(self):
+        return len(self._records)
+
+    def last(self):
+        return self._records[-1] if self._records else {}
+
+    def append(self, rec):
+        self._records.append(rec)
+
+
+class _FakeMcp:
+    """Returns canned tool payloads driving exactly one qualifying candidate."""
+
+    def __init__(self, sleeve):
+        self._sleeve = sleeve
+
+    def call_tool(self, tool, args):
+        if tool == "strategy_get_clearinghouse_state":
+            return {"main": {"marginSummary": {"accountValue": 10000.0},
+                             "assetPositions": []}}
+        if tool == "market_list_instruments":
+            return {"instruments": [
+                {"name": "BTC", "max_leverage": 50,
+                 "context": {"coin": "BTC", "dayNtlVlm": 1e9}},
+                {"name": "xyz:NVDA", "max_leverage": 20,
+                 "context": {"coin": "xyz:NVDA", "dayNtlVlm": 1e9}},
+            ]}
+        if tool == "leaderboard_get_markets":
+            return {"markets": [
+                {"token": "BTC", "direction": "long", "longPct": 80},
+                {"token": "NVDA", "direction": "long", "longPct": 80},
+            ]}
+        if tool == "market_get_asset_data":
+            return {"data": {"candles": self._candles(), "asset_context": {}}}
+        return None
+
+    def _candles(self):
+        if self._sleeve == "scalp":
+            # 15m: deep-oversold RSI + large negative stretch (fade long); 1h bullish.
+            c15 = [{"close": 100.0, "high": 100, "low": 100} for _ in range(20)]
+            c15 += [{"close": 100 - i, "high": 101 - i, "low": 99 - i}
+                    for i in range(1, 11)]  # straight downtrend → low RSI, neg stretch
+            c1 = [{"close": 90 + i, "high": 90 + i, "low": 89 + i} for i in range(8)]
+            return {"15m": c15, "1h": c1}
+        # swing: 1h + 4h strong uptrend → bullish structure, positive RS.
+        c1 = [{"close": 100 + i, "high": 100 + i, "low": 99 + i} for i in range(30)]
+        c4 = [{"close": 100 + 2 * i, "high": 100 + 2 * i, "low": 99 + 2 * i}
+              for i in range(30)]
+        return {"1h": c1, "4h": c4}
+
+
+class _FakeCtx:
+    def __init__(self, sleeve):
+        self.senpi_mcp = _FakeMcp(sleeve)
+        self.state = _FakeState()
+        self.wallet = "0xtest"
+
+
+_SLEEVE_INPUTS = {
+    "scalp": {
+        "allowedAssets": ["BTC"],
+        "minScore": 1,
+        "marginPct": 15,
+        "maxLeverage": 5,
+        "rsiOversold": 30,
+        "rsiOverbought": 70,
+        "stretchThresholdPct": 0.8,
+        "venueMinNotionalUsd": 10,
+        "minNotionalPctOfEquity": 0.01,
+        "recentSignalTtlSeconds": 180,
+    },
+    "swing": {
+        "cryptoAlts": [],
+        "xyzIncludeSet": ["NVDA"],
+        "xyzExcludeSet": [],
+        "allowedAssets": ["xyz:NVDA"],
+        "minScore": 1,
+        "marginPct": 28,
+        "maxLeverage": 10,
+        "rsiMaxLong": 78,
+        "useSmBonus": True,
+        "venueMinNotionalUsd": 10,
+        "minNotionalPctOfEquity": 0.01,
+        "recentSignalTtlSeconds": 180,
+        "xyzVolFloorUsd": 1000,
+        "xyzMaxNames": 20,
+        "xyzFreshDays": 21,
+    },
+}
+
+_EXPECTED_PCT = {"scalp": 15.0, "swing": 28.0}
+
+
+@pytest.mark.parametrize("sleeve", ["scalp", "swing"])
+def test_emits_no_marginUsd_and_valid_marginPct(sleeve):
+    mod = _load_scan(sleeve)
+    out = mod.scan(_SLEEVE_INPUTS[sleeve], _FakeCtx(sleeve))
+
+    assert out, f"{sleeve}: expected at least one emitted candidate"
+    for sig in out:
+        assert "marginUsd" not in sig, (
+            f"{sleeve}: candidate must not emit top-level 'marginUsd' "
+            f"(scaffold drops it; sizing intent lost)"
+        )
+        assert "marginPct" in sig, f"{sleeve}: candidate must emit 'marginPct'"
+        mp = sig["marginPct"]
+        assert isinstance(mp, (int, float)) and not isinstance(mp, bool)
+        assert 1 <= mp <= 100, (
+            f"{sleeve}: marginPct={mp} out of [1,100] — likely a fraction, "
+            f"not a percent"
+        )
+        assert mp == pytest.approx(_EXPECTED_PCT[sleeve]), (
+            f"{sleeve}: marginPct={mp}, expected {_EXPECTED_PCT[sleeve]}"
+        )

--- a/strategies/whalehunter/long/runtime.yaml
+++ b/strategies/whalehunter/long/runtime.yaml
@@ -45,8 +45,8 @@ scanners:
       crowdDivergenceMin: 0.2
       requireGrowing: true
       cohortMinScore: 4
-      marginPct: 0.12
-      maxMarginPct: 0.25
+      marginPct: 12                        # PERCENT of withdrawable (0,100], not a fraction
+      maxMarginPct: 25                      # conviction-scale cap, percent of withdrawable
       maxConvictionScale: 2.0
       stdLeverage: 3
       maxLeverage: 5

--- a/strategies/whalehunter/long/scanners/scoring.py
+++ b/strategies/whalehunter/long/scanners/scoring.py
@@ -128,10 +128,11 @@ def cohort_signals(smart_per, crowd_per, growth, direction, config):
 
 
 def margin_pct_for(score, config):
-    """Conviction-scaled marginPct INTENT (not dollars — the runtime sizes). Scales
-    +25% per point above the floor, capped at maxMarginPct."""
-    base = float(config.get("marginPct", 0.12))
-    cap = float(config.get("maxMarginPct", 0.25))
+    """Conviction-scaled marginPct INTENT as a PERCENT of withdrawable in (0,100]
+    (the runtime sizes (marginPct/100)*withdrawable). Scales +25% per point above
+    the floor, capped at maxMarginPct."""
+    base = float(config.get("marginPct", 12))
+    cap = float(config.get("maxMarginPct", 25))
     smax = float(config.get("maxConvictionScale", 2.0))
     floor = int(config.get("cohortMinScore", 4))
     scale = min(smax, 1.0 + 0.25 * max(0, score - floor))

--- a/strategies/whalehunter/long/scanners/test_scoring_margin.py
+++ b/strategies/whalehunter/long/scanners/test_scoring_margin.py
@@ -1,0 +1,79 @@
+"""WHALEHUNTER — margin-unit regression for scoring.margin_pct_for.
+
+v3.0.4 treats per-signal `marginPct` as a PERCENT in (0,100] of withdrawable
+(resolve-margin.ts sizes (marginPct/100)*withdrawable). The producer must therefore
+emit a PERCENT, not a fraction. These tests pin the emitted value into [1,100]
+across the full conviction range, at the base and at the max-clamp boundary.
+
+scoring.py imports clean (no I/O), and scan.py does `import scoring`, so we add the
+scanner dir to sys.path and import the module directly.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import scoring  # noqa: E402
+
+# Two configs that BOTH must emit a percent:
+#  - DEFAULTS: empty dict -> exercises margin_pct_for's OWN built-in .get() fallbacks
+#    (the shipped fraction defaults are the bug; post-fix they must be percent).
+#  - YAML: the values actually wired in long/short runtime.yaml inputs (identical knobs).
+# We parametrize over both so a fix to only one place still leaves a red test.
+DEFAULTS = {}
+YAML = {
+    "marginPct": 12,
+    "maxMarginPct": 25,
+    "maxConvictionScale": 2.0,
+    "cohortMinScore": 4,
+}
+CONFIGS = [DEFAULTS, YAML]
+
+FLOOR = 4  # cohortMinScore default and YAML value
+
+
+def _floor(cfg):
+    return int(cfg.get("cohortMinScore", FLOOR))
+
+
+import pytest  # noqa: E402
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_base_conviction_is_percent(cfg):
+    # score == floor -> scale 1.0 -> emits the base, which must be a percent in [1,100].
+    mp = scoring.margin_pct_for(_floor(cfg), cfg)
+    assert 1 <= mp <= 100, f"base conviction emitted {mp}, expected a percent in [1,100]"
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_mid_conviction_is_percent(cfg):
+    mp = scoring.margin_pct_for(_floor(cfg) + 2, cfg)  # score 6
+    assert 1 <= mp <= 100, f"mid conviction emitted {mp}, expected a percent in [1,100]"
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_max_clamp_conviction_is_percent(cfg):
+    # Very high score saturates scale at maxConvictionScale -> max-clamp boundary.
+    mp = scoring.margin_pct_for(_floor(cfg) + 50, cfg)
+    assert 1 <= mp <= 100, f"max-clamp conviction emitted {mp}, expected a percent in [1,100]"
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_full_conviction_range_in_percent_band(cfg):
+    # Every score from floor through a large clamp value must land in [1,100], never <1.
+    fl = _floor(cfg)
+    for score in range(fl, fl + 51):
+        mp = scoring.margin_pct_for(score, cfg)
+        assert 1 <= mp <= 100, f"score {score} emitted {mp}, outside [1,100]"
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_monotonic_nondecreasing_with_conviction(cfg):
+    fl = _floor(cfg)
+    prev = 0.0
+    for score in range(fl, fl + 10):
+        mp = scoring.margin_pct_for(score, cfg)
+        assert mp >= prev, f"score {score} emitted {mp} < previous {prev}"
+        prev = mp

--- a/strategies/whalehunter/short/runtime.yaml
+++ b/strategies/whalehunter/short/runtime.yaml
@@ -45,8 +45,8 @@ scanners:
       crowdDivergenceMin: 0.2
       requireGrowing: true
       cohortMinScore: 4
-      marginPct: 0.12
-      maxMarginPct: 0.25
+      marginPct: 12                        # PERCENT of withdrawable (0,100], not a fraction
+      maxMarginPct: 25                      # conviction-scale cap, percent of withdrawable
       maxConvictionScale: 2.0
       stdLeverage: 3
       maxLeverage: 5

--- a/strategies/whalehunter/short/scanners/scoring.py
+++ b/strategies/whalehunter/short/scanners/scoring.py
@@ -128,10 +128,11 @@ def cohort_signals(smart_per, crowd_per, growth, direction, config):
 
 
 def margin_pct_for(score, config):
-    """Conviction-scaled marginPct INTENT (not dollars — the runtime sizes). Scales
-    +25% per point above the floor, capped at maxMarginPct."""
-    base = float(config.get("marginPct", 0.12))
-    cap = float(config.get("maxMarginPct", 0.25))
+    """Conviction-scaled marginPct INTENT as a PERCENT of withdrawable in (0,100]
+    (the runtime sizes (marginPct/100)*withdrawable). Scales +25% per point above
+    the floor, capped at maxMarginPct."""
+    base = float(config.get("marginPct", 12))
+    cap = float(config.get("maxMarginPct", 25))
     smax = float(config.get("maxConvictionScale", 2.0))
     floor = int(config.get("cohortMinScore", 4))
     scale = min(smax, 1.0 + 0.25 * max(0, score - floor))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes live entry sizing across multiple strategies (~100× larger margin than before where fractions were wrong); incorrect values would still pass validation but mis-size silently.
> 
> **Overview**
> Fixes a **silent ~100× undersize** bug: v3 runtime treats per-signal `marginPct` as a **percent** of withdrawable (`(marginPct/100) * withdrawable`), but several strategies still passed **v2 fractions** (e.g. `0.12` instead of `12`).
> 
> **asia-ai** (main/hedge), **kodiak**, and **whalehunter** (long/short) update `runtime.yaml` inputs, scanner defaults, and whalehunter `margin_pct_for` base/cap values to percent units. **Spider** scalp/swing do the same and **stop emitting top-level `marginUsd`** (dropped by the scaffold); candidates now emit **`marginPct`**, with local notional gates using `account_value * (marginPct / 100)`.
> 
> Adds regression tests (asia-ai, kodiak, spider wire shape, whalehunter scoring) so emitted/config `marginPct` stays in **[1, 100]** and spider never puts sizing on a stripped `marginUsd` key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e8d2d6417828be2c05e1f30f693b0c56b009cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->