### PR TITLE
Runtime 3.0 strategies on strategy-v2 — asia-ai, kodiak, whalehunter (marginPct-final)

### DIFF
--- a/strategies/asia-ai/hedge/runtime.yaml
+++ b/strategies/asia-ai/hedge/runtime.yaml
@@ -1,0 +1,90 @@
+# ── ASIA-AI · HEDGE leg — SHORT broad/US-tech beta (strips market beta from the long) ──
+name: asia-ai-hedge
+group: asia-ai
+version: 3.0.0
+description: >
+  ASIA-AI HEDGE — shorts the broad US/tech index (XYZ100, SP500) when it confirms a
+  downtrend on BOTH 4h and 1d. A pure beta hedge: only broad indices, no single names —
+  shorting NVDA/AMD would be a pairs trade against MAIN's own supply chain (and rallies
+  in a Taiwan/export-control shock, the one tail that threatens the long book), not a
+  hedge. Its job is to offset the market beta in the MAIN long book so the fund
+  expresses "Asia AI OUTPERFORMS", not "tech goes up".
+  Smaller funding share than MAIN — a cushion, not a second directional bet. Runs on a
+  separate wallet so it can hold shorts while MAIN holds longs.
+
+strategy:
+  wallet: "${ASIA_AI_HEDGE_WALLET}"
+  slots: 2
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: asia_ai_hedge_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900
+    timeout_seconds: 180
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 100
+    inputs:
+      universe: ["xyz:XYZ100", "xyz:SP500"]
+      direction: "SHORT"
+      wantTrend: "DOWN"
+      minScore: 5
+      marginPct: 10          # percent of withdrawable (runtime sizes (marginPct/100)*withdrawable)
+      rsiMin: 25
+      recentSignalTtlSeconds: 1800
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: asia_ai_hedge_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [asia_ai_hedge_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: asia_ai_hedge_signals
+
+# EXIT — let_winners_run (let a market-beta short run when it works; copied from dsl-presets.yaml)
+exit:
+  engine: dsl
+  dsl_preset:
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+risk:
+  guard_rails:
+    drawdown_halt_pct: 22
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6
+    cooldown_seconds: 3600
+    drawdown_reset_on_day_rollover: true

--- a/strategies/asia-ai/hedge/scanners/scan.py
+++ b/strategies/asia-ai/hedge/scanners/scan.py
@@ -30,11 +30,15 @@ def scan(inputs, ctx):
         last = recent.get(au)
         if last is not None and (now - last) < ttl:        # signal-dedup
             continue
-        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
-            "asset": asset,
-            "candle_intervals": ["4h", "1d"],
-            "dex": "xyz" if asset.lower().startswith("xyz:") else "",
-        })
+        try:
+            md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+                "asset": asset,
+                "candle_intervals": ["4h", "1d"],
+                "dex": "xyz" if asset.lower().startswith("xyz:") else "",
+            })
+        except Exception as exc:  # noqa: BLE001 — one bad/illiquid name must not roll back the whole universe tick
+            print(f"[asia-ai.scan] {asset} read failed, skipping: {exc!r}", file=sys.stderr)
+            continue
         if not md:
             continue
         c = (md.get("data", md) or {}).get("candles", {}) if isinstance(md, dict) else {}

--- a/strategies/asia-ai/hedge/scanners/scan.py
+++ b/strategies/asia-ai/hedge/scanners/scan.py
@@ -1,0 +1,57 @@
+"""ASIA-AI — supervised scanner (shared verbatim by both instances).
+
+Direction-parametrized: the `main` instance passes direction=LONG / wantTrend=UP
+(long the Asian AI semis); the `hedge` instance passes direction=SHORT /
+wantTrend=DOWN (short the broad/US-AI complex when it rolls over, to strip market
+beta). Read-only, pure, single-pass — emits a `marginPct` intent; the runtime sizes."""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 1800   # 30m: don't re-fire the same name while a signal is in flight
+
+
+def scan(inputs, ctx):
+    universe = inputs.get("universe", [])
+    direction = (inputs.get("direction", "LONG") or "LONG").upper()
+    want = (inputs.get("wantTrend", "UP") or "UP").upper()
+    min_score = int(inputs.get("minScore", 5))
+    margin_pct = float(inputs.get("marginPct", 12))   # percent of withdrawable, not a fraction
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    recent = (ctx.state.last() or {}).get("recent", {}) if ctx.state else {}
+
+    out = []
+    for asset in universe:
+        au = asset.upper()
+        last = recent.get(au)
+        if last is not None and (now - last) < ttl:        # signal-dedup
+            continue
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": asset,
+            "candle_intervals": ["4h", "1d"],
+            "dex": "xyz" if asset.lower().startswith("xyz:") else "",
+        })
+        if not md:
+            continue
+        c = (md.get("data", md) or {}).get("candles", {}) if isinstance(md, dict) else {}
+        th = scoring.confirm_trend(c.get("4h", []), c.get("1d", []), want, inputs)
+        if not th or th["score"] < min_score:
+            continue
+        out.append({
+            "asset": asset,
+            "direction": direction,
+            "marginPct": margin_pct,          # SIZING INTENT — the runtime sizes the dollars
+            "data": {"score": th["score"], "direction": direction, "reasons": th["reasons"]},
+        })
+        recent[au] = now
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[asia-ai.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/asia-ai/hedge/scanners/scoring.py
+++ b/strategies/asia-ai/hedge/scanners/scoring.py
@@ -1,0 +1,65 @@
+"""ASIA-AI — pure thesis math (no I/O, no MCP, no clock). Shared verbatim by both
+instances; direction is passed in (`want` = "UP" for the long book, "DOWN" for the
+hedge). Unit-testable on plain candle lists."""
+
+
+def _closes(candles):
+    out = []
+    for x in candles:
+        if isinstance(x, (list, tuple)) and len(x) >= 5:
+            out.append(float(x[4]))                      # [t,o,h,l,c,v] -> close
+        elif isinstance(x, dict):
+            out.append(float(x.get("close", x.get("c", 0)) or 0))
+    return out
+
+
+def _ret(candles, n):
+    c = _closes(candles)
+    if len(c) < n + 1 or c[-(n + 1)] == 0:
+        return 0.0
+    return (c[-1] - c[-(n + 1)]) / c[-(n + 1)]
+
+
+def _trend(candles, look=6):
+    r = _ret(candles, min(look, max(1, len(_closes(candles)) - 1)))
+    if r > 0.01:
+        return "UP"
+    if r < -0.01:
+        return "DOWN"
+    return "FLAT"
+
+
+def _rsi(candles, period=14):
+    c = _closes(candles)
+    if len(c) < period + 1:
+        return 50.0
+    gains = losses = 0.0
+    for i in range(-period, 0):
+        d = c[i] - c[i - 1]
+        gains += max(d, 0.0)
+        losses += max(-d, 0.0)
+    if losses == 0:
+        return 100.0
+    rs = (gains / period) / (losses / period)
+    return 100.0 - 100.0 / (1.0 + rs)
+
+
+def confirm_trend(c4, c1d, want, inputs):
+    """Confirm a directional trend (want = UP for long / DOWN for short) on BOTH the
+    4h and 1d timeframes, with RSI room so we accumulate rather than chase. Returns a
+    thesis dict or None."""
+    if len(c4) < 6 or len(c1d) < 6:
+        return None
+    if _trend(c4) != want or _trend(c1d) != want:
+        return None                                       # both timeframes must agree
+    rsi = _rsi(c4)
+    if want == "UP" and rsi > float(inputs.get("rsiMax", 75)):
+        return None                                       # don't chase an overbought long
+    if want == "DOWN" and rsi < float(inputs.get("rsiMin", 25)):
+        return None                                       # don't chase an oversold short
+    strength = abs(_ret(c4, 6))
+    room = (rsi < 60) if want == "UP" else (rsi > 40)
+    score = 3 + (1 if strength > 0.06 else 0) + (1 if room else 0)
+    return {"score": score,
+            "direction": "LONG" if want == "UP" else "SHORT",
+            "reasons": [f"4h_{want.lower()}_{strength:.0%}", f"1d_{want.lower()}", f"rsi_{rsi:.0f}"]}

--- a/strategies/asia-ai/main/runtime.yaml
+++ b/strategies/asia-ai/main/runtime.yaml
@@ -1,0 +1,86 @@
+# ── ASIA-AI · MAIN leg — LONG the Asian AI/semiconductor complex ──
+name: asia-ai-main
+group: asia-ai
+version: 3.0.0
+description: >
+  ASIA-AI MAIN — long the Asian AI/semiconductor complex (TSMC, Samsung, SK Hynix,
+  ARM, ASML). Accumulates a name only when it confirms an uptrend on BOTH the 4h and
+  1d timeframes with RSI room (accumulate, don't chase). Rides wide (let_winners_run).
+  Paired with the HEDGE leg on a separate wallet that shorts broad/US-tech beta.
+
+strategy:
+  wallet: "${ASIA_AI_MAIN_WALLET}"
+  slots: 5
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: asia_ai_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900                # multi-day sector thesis — slow cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 100         # signal-dedup map
+    inputs:
+      universe: ["xyz:TSM", "xyz:SMSN", "xyz:SKHX", "xyz:ARM", "xyz:ASML"]
+      direction: "LONG"
+      wantTrend: "UP"
+      minScore: 5
+      marginPct: 12          # percent of withdrawable (runtime sizes (marginPct/100)*withdrawable)
+      rsiMax: 75
+      recentSignalTtlSeconds: 1800
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: asia_ai_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [asia_ai_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: asia_ai_main_signals
+
+# EXIT — let_winners_run (ride the sector thesis; copied from dsl-presets.yaml)
+exit:
+  engine: dsl
+  dsl_preset:
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+risk:
+  guard_rails:
+    drawdown_halt_pct: 22
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6
+    cooldown_seconds: 3600
+    drawdown_reset_on_day_rollover: true

--- a/strategies/asia-ai/main/scanners/scan.py
+++ b/strategies/asia-ai/main/scanners/scan.py
@@ -30,11 +30,15 @@ def scan(inputs, ctx):
         last = recent.get(au)
         if last is not None and (now - last) < ttl:        # signal-dedup
             continue
-        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
-            "asset": asset,
-            "candle_intervals": ["4h", "1d"],
-            "dex": "xyz" if asset.lower().startswith("xyz:") else "",
-        })
+        try:
+            md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+                "asset": asset,
+                "candle_intervals": ["4h", "1d"],
+                "dex": "xyz" if asset.lower().startswith("xyz:") else "",
+            })
+        except Exception as exc:  # noqa: BLE001 — one bad/illiquid name must not roll back the whole universe tick
+            print(f"[asia-ai.scan] {asset} read failed, skipping: {exc!r}", file=sys.stderr)
+            continue
         if not md:
             continue
         c = (md.get("data", md) or {}).get("candles", {}) if isinstance(md, dict) else {}

--- a/strategies/asia-ai/main/scanners/scan.py
+++ b/strategies/asia-ai/main/scanners/scan.py
@@ -1,0 +1,57 @@
+"""ASIA-AI — supervised scanner (shared verbatim by both instances).
+
+Direction-parametrized: the `main` instance passes direction=LONG / wantTrend=UP
+(long the Asian AI semis); the `hedge` instance passes direction=SHORT /
+wantTrend=DOWN (short the broad/US-AI complex when it rolls over, to strip market
+beta). Read-only, pure, single-pass — emits a `marginPct` intent; the runtime sizes."""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 1800   # 30m: don't re-fire the same name while a signal is in flight
+
+
+def scan(inputs, ctx):
+    universe = inputs.get("universe", [])
+    direction = (inputs.get("direction", "LONG") or "LONG").upper()
+    want = (inputs.get("wantTrend", "UP") or "UP").upper()
+    min_score = int(inputs.get("minScore", 5))
+    margin_pct = float(inputs.get("marginPct", 12))   # percent of withdrawable, not a fraction
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    recent = (ctx.state.last() or {}).get("recent", {}) if ctx.state else {}
+
+    out = []
+    for asset in universe:
+        au = asset.upper()
+        last = recent.get(au)
+        if last is not None and (now - last) < ttl:        # signal-dedup
+            continue
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": asset,
+            "candle_intervals": ["4h", "1d"],
+            "dex": "xyz" if asset.lower().startswith("xyz:") else "",
+        })
+        if not md:
+            continue
+        c = (md.get("data", md) or {}).get("candles", {}) if isinstance(md, dict) else {}
+        th = scoring.confirm_trend(c.get("4h", []), c.get("1d", []), want, inputs)
+        if not th or th["score"] < min_score:
+            continue
+        out.append({
+            "asset": asset,
+            "direction": direction,
+            "marginPct": margin_pct,          # SIZING INTENT — the runtime sizes the dollars
+            "data": {"score": th["score"], "direction": direction, "reasons": th["reasons"]},
+        })
+        recent[au] = now
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[asia-ai.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/asia-ai/main/scanners/scoring.py
+++ b/strategies/asia-ai/main/scanners/scoring.py
@@ -1,0 +1,65 @@
+"""ASIA-AI — pure thesis math (no I/O, no MCP, no clock). Shared verbatim by both
+instances; direction is passed in (`want` = "UP" for the long book, "DOWN" for the
+hedge). Unit-testable on plain candle lists."""
+
+
+def _closes(candles):
+    out = []
+    for x in candles:
+        if isinstance(x, (list, tuple)) and len(x) >= 5:
+            out.append(float(x[4]))                      # [t,o,h,l,c,v] -> close
+        elif isinstance(x, dict):
+            out.append(float(x.get("close", x.get("c", 0)) or 0))
+    return out
+
+
+def _ret(candles, n):
+    c = _closes(candles)
+    if len(c) < n + 1 or c[-(n + 1)] == 0:
+        return 0.0
+    return (c[-1] - c[-(n + 1)]) / c[-(n + 1)]
+
+
+def _trend(candles, look=6):
+    r = _ret(candles, min(look, max(1, len(_closes(candles)) - 1)))
+    if r > 0.01:
+        return "UP"
+    if r < -0.01:
+        return "DOWN"
+    return "FLAT"
+
+
+def _rsi(candles, period=14):
+    c = _closes(candles)
+    if len(c) < period + 1:
+        return 50.0
+    gains = losses = 0.0
+    for i in range(-period, 0):
+        d = c[i] - c[i - 1]
+        gains += max(d, 0.0)
+        losses += max(-d, 0.0)
+    if losses == 0:
+        return 100.0
+    rs = (gains / period) / (losses / period)
+    return 100.0 - 100.0 / (1.0 + rs)
+
+
+def confirm_trend(c4, c1d, want, inputs):
+    """Confirm a directional trend (want = UP for long / DOWN for short) on BOTH the
+    4h and 1d timeframes, with RSI room so we accumulate rather than chase. Returns a
+    thesis dict or None."""
+    if len(c4) < 6 or len(c1d) < 6:
+        return None
+    if _trend(c4) != want or _trend(c1d) != want:
+        return None                                       # both timeframes must agree
+    rsi = _rsi(c4)
+    if want == "UP" and rsi > float(inputs.get("rsiMax", 75)):
+        return None                                       # don't chase an overbought long
+    if want == "DOWN" and rsi < float(inputs.get("rsiMin", 25)):
+        return None                                       # don't chase an oversold short
+    strength = abs(_ret(c4, 6))
+    room = (rsi < 60) if want == "UP" else (rsi > 40)
+    score = 3 + (1 if strength > 0.06 else 0) + (1 if room else 0)
+    return {"score": score,
+            "direction": "LONG" if want == "UP" else "SHORT",
+            "reasons": [f"4h_{want.lower()}_{strength:.0%}", f"1d_{want.lower()}", f"rsi_{rsi:.0f}"]}

--- a/strategies/asia-ai/strategy.yaml
+++ b/strategies/asia-ai/strategy.yaml
@@ -1,0 +1,44 @@
+# Asia AI — hedged sector long. A PACKAGE: this manifest + two self-contained runtime.yaml
+# instances (main = long Asia-AI semis, hedge = short broad/US-AI beta) + scanners/.
+# Install/teardown via senpi-strategy-ops. Published to the catalog via senpi-strategy-author-curator.
+schema_version: 1
+
+id: asia-ai
+version: "1.0.0"
+
+catalog:
+  name: "Asia AI — Hedged Sector Long"
+  emoji: "🌏"
+  tagline: "Long the Asian AI/semiconductor complex (TSMC, Samsung, SK Hynix, ARM, ASML) with a broad/US-tech short hedge that strips out market beta."
+  belief_plain: "Buys the Asian AI chipmakers while they're trending up, and shorts the broad US/tech index when it rolls over — so the bet is on Asia AI outperforming, not just the market going up."
+  thesis: "You think the AI buildout is increasingly an Asia story — Taiwan and Korea fabs, the chip supply chain — and you want a long on that sector with market beta hedged out, not a naked tech long."
+  group: multi-asset-whitelist
+  archetype: trend_following
+  sub_style: basket
+  asset_classes: [xyz_equities, indices]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 3
+  max_slots: 7
+  min_budget: 200
+  assets: ["xyz:TSM", "xyz:SMSN", "xyz:SKHX", "xyz:ARM", "xyz:ASML", "xyz:XYZ100", "xyz:SP500"]
+  tags: [ai, semiconductors, asia, taiwan, korea, hedged, sector, long_short]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: ASIA_AI_MAIN_WALLET
+    funding_share: 0.65
+  - name: hedge
+    runtime: hedge/runtime.yaml
+    wallet_env: ASIA_AI_HEDGE_WALLET
+    funding_share: 0.35

--- a/strategies/asia-ai/tests/test_margin_pct.py
+++ b/strategies/asia-ai/tests/test_margin_pct.py
@@ -1,0 +1,103 @@
+"""asia-ai margin-units regression.
+
+v3.0.4 runtime sizes (marginPct/100)*withdrawable, so per-signal `marginPct` MUST be
+a PERCENT in (0,100], never a fraction. asia-ai previously emitted 0.12 (main) / 0.10
+(hedge) -> ~100x undersize, silent (no 400). These tests drive the SHARED scan.py with
+each sleeve's real runtime.yaml inputs and assert the emitted wire marginPct lands in
+[1,100], plus cover the in-code default fallback.
+"""
+
+import importlib.util
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SLEEVES = {
+    "main": {"path": ROOT / "main", "expect": 12},
+    "hedge": {"path": ROOT / "hedge", "expect": 10},
+}
+
+
+def _load_scan(sleeve_dir):
+    """Import the sleeve's own scan.py (with its sibling scoring.py importable)."""
+    scanners = sleeve_dir / "scanners"
+    import sys
+
+    sys.path.insert(0, str(scanners))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"scan_{sleeve_dir.name}", scanners / "scan.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        sys.path.remove(str(scanners))
+
+
+def _inputs(sleeve_dir):
+    rt = yaml.safe_load((sleeve_dir / "runtime.yaml").read_text())
+    for s in rt["scanners"]:
+        if s.get("type") == "external_scanner":
+            return s["inputs"]
+    raise AssertionError("no external_scanner inputs")
+
+
+class _FakeMcp:
+    """Returns candles that guarantee confirm_trend fires for the given want trend."""
+
+    def __init__(self, want):
+        self.want = want
+
+    def call_tool(self, name, args):
+        # 8 monotone candles -> strong trend on both 4h and 1d in the wanted direction.
+        if self.want == "UP":
+            closes = [100, 102, 104, 106, 108, 110, 112, 114]
+        else:
+            closes = [114, 112, 110, 108, 106, 104, 102, 100]
+        candles = [[i, c, c, c, c, 1] for i, c in enumerate(closes)]
+        return {"data": {"candles": {"4h": candles, "1d": candles}}}
+
+
+class _FakeCtx:
+    def __init__(self, want):
+        self.senpi_mcp = _FakeMcp(want)
+        self.state = None
+
+
+def _emit(mod, inputs):
+    """Run scan with one asset forced through; return its emitted marginPct."""
+    ins = dict(inputs)
+    ins["universe"] = ["xyz:TEST"]
+    ins["minScore"] = 0  # ensure the candidate isn't filtered on score
+    want = (ins.get("wantTrend", "UP") or "UP").upper()
+    out = mod.scan(ins, _FakeCtx(want))
+    assert out, "scan emitted no candidates (trend stub failed)"
+    return out[0]["marginPct"]
+
+
+def test_each_sleeve_emits_percent_in_range():
+    for name, cfg in SLEEVES.items():
+        mod = _load_scan(cfg["path"])
+        mpct = _emit(mod, _inputs(cfg["path"]))
+        assert 1 <= mpct <= 100, f"{name}: emitted marginPct {mpct} not in [1,100]"
+        assert mpct == cfg["expect"], f"{name}: expected {cfg['expect']}, got {mpct}"
+
+
+def test_default_fallback_is_percent():
+    """Empty inputs -> in-code default must also be a percent in [1,100], not a fraction."""
+    for name, cfg in SLEEVES.items():
+        mod = _load_scan(cfg["path"])
+        ins = _inputs(cfg["path"])
+        ins = {k: v for k, v in ins.items() if k != "marginPct"}  # drop config knob
+        mpct = _emit(mod, ins)
+        assert 1 <= mpct <= 100, f"{name}: default marginPct {mpct} not in [1,100]"
+
+
+def test_runtime_yaml_margin_is_percent():
+    """Config-level guard: both runtime.yamls must declare marginPct >= 1."""
+    for name, cfg in SLEEVES.items():
+        mpct = _inputs(cfg["path"])["marginPct"]
+        assert mpct >= 1, f"{name}: runtime.yaml marginPct {mpct} < 1 (fraction, not percent)"
+        assert mpct <= 100, f"{name}: runtime.yaml marginPct {mpct} > 100"

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,9 +1,62 @@
 {
   "_version": "2.1",
-  "_updated": "2026-06-17",
+  "_updated": "2026-06-26",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
+    {
+      "id": "asia-ai",
+      "name": "Asia AI — Hedged Sector Long",
+      "emoji": "🌏",
+      "tagline": "Long the Asian AI/semiconductor complex (TSMC, Samsung, SK Hynix, ARM, ASML) with a broad/US-tech short hedge that strips out market beta.",
+      "belief_plain": "Buys the Asian AI chipmakers while they're trending up, and shorts the broad US/tech index when it rolls over — so the bet is on Asia AI outperforming, not just the market going up.",
+      "version": "1.0.0",
+      "thesis": "You think the AI buildout is increasingly an Asia story — Taiwan and Korea fabs, the chip supply chain — and you want a long on that sector with market beta hedged out, not a naked tech long.",
+      "tags": [
+        "ai",
+        "semiconductors",
+        "asia",
+        "taiwan",
+        "korea",
+        "hedged",
+        "sector",
+        "long_short"
+      ],
+      "group": "multi-asset-whitelist",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "basket",
+      "sub_style_label": "Holds a whitelist basket of majors.",
+      "asset_classes": [
+        "xyz_equities",
+        "indices"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:TSM",
+        "xyz:SMSN",
+        "xyz:SKHX",
+        "xyz:ARM",
+        "xyz:ASML",
+        "xyz:XYZ100",
+        "xyz:SP500"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 3,
+      "time_horizon": "position",
+      "cadence_seconds": 900,
+      "min_budget": 200,
+      "instance_count": 2,
+      "funding_split": [
+        0.65,
+        0.35
+      ],
+      "max_slots": 7,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
     {
       "id": "spider",
       "name": "Spider — AI/Tech Hedge Fund",
@@ -64,6 +117,92 @@
         0.4
       ],
       "max_slots": 7,
+      "branch": "strategy-v2",
+      "sort_order": 2
+    },
+    {
+      "id": "kodiak",
+      "name": "Kodiak — SOL Alpha Hunter",
+      "emoji": "🐻",
+      "tagline": "A single-asset SOL specialist: enters only when 4h and 1h trend structure agree, 15m momentum confirms, and smart-money lean, funding, and BTC all line up — then sizes leverage to conviction (5/6/7x) and lets the DSL ride the winner.",
+      "belief_plain": "Trades only SOL. It waits for the 4-hour and 1-hour trend to agree, momentum to confirm, and the best traders to be leaning the same way — then goes in harder when more of those line up, and trails a stop instead of guessing the exit.",
+      "version": "1.0.0",
+      "thesis": "You want one coin done really well, not a scattergun across the market. SOL has the liquidity and the moves, and an agent that watches only SOL can read its structure, smart-money flow, and funding far more tightly than a broad universe scanner ever could.",
+      "tags": [
+        "sol",
+        "single-asset",
+        "momentum",
+        "smart-money",
+        "conviction-leverage",
+        "alpha-hunter"
+      ],
+      "group": "single-asset",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "alpha_hunter",
+      "sub_style_label": "Multi-factor conviction scoring on one asset, with tiered leverage.",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "SOL"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 7,
+      "time_horizon": "swing",
+      "cadence_seconds": 180,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
+      "id": "whalehunter",
+      "name": "WhaleHunter — Smart-Money Cohort Divergence",
+      "emoji": "🐋",
+      "tagline": "Buckets Hyperliquid traders by lifetime realized PnL into a smart-money cohort and a crowd, then positions WITH the smartest money — and against the crowd — wherever the smart cohort is heavily net-directional and adding to it daily.",
+      "belief_plain": "Looks at where the most profitable traders on Hyperliquid are putting their money as a group, and copies that lean — going long what they're loading up on and short what they're dumping, especially when the average crowd is on the other side.",
+      "version": "1.0.0",
+      "thesis": "You trust the aggregate of proven winners over any single guru or your own read. When the >$1M-realized crowd is piling into a coin day after day while the small accounts fade it, that divergence is the edge — so follow the smart cohort, not one whale, and hedge the book with a separate short sleeve.",
+      "tags": [
+        "smart-money",
+        "cohort",
+        "divergence",
+        "copy-trading",
+        "long-short",
+        "crowd-fade",
+        "hedged"
+      ],
+      "group": "smart-money",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "cohort_divergence",
+      "sub_style_label": "Cohort Divergence",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 400,
+      "instance_count": 2,
+      "funding_split": [
+        0.5,
+        0.5
+      ],
+      "max_slots": 6,
       "branch": "strategy-v2",
       "sort_order": 1
     }

--- a/strategies/kodiak/main/runtime.yaml
+++ b/strategies/kodiak/main/runtime.yaml
@@ -27,7 +27,7 @@ scanners:
     interval_seconds: 180                  # v2 producer cadence (3 min)
     timeout_seconds: 150                   # 3 MCP reads/tick; v2 WARN_OVER_180S budget
     default_signal_validity_seconds: 1800
-    state_history_max_count: 100           # signal-dedup map
+    state_history_max_count: 100           # dedup map + per-tick scan-results history (~5h @180s)
     inputs:
       asset: "SOL"
       dex: ""

--- a/strategies/kodiak/main/runtime.yaml
+++ b/strategies/kodiak/main/runtime.yaml
@@ -1,0 +1,114 @@
+# ── KODIAK · single instance — SOL alpha hunter (Runtime 3.0 port of v2 Kodiak v7.0.0) ──
+name: kodiak-main
+group: kodiak
+version: 3.0.0
+description: >
+  KODIAK — single-asset SOL alpha hunter. Enters only when 4h structure (>=0.75) and
+  1h agree, 15m momentum confirms, and a multi-factor composite (smart-money lean,
+  funding, BTC correlation, RSI room) clears score 10. Conviction-tiered leverage:
+  5x standard, 6x at >=11, 7x apex at >=13. DSL is the ONLY exit (asymmetry-optimized:
+  cut losers fast/cheap, ride winners hard). Faithful port of the v2 producer thesis.
+
+strategy:
+  wallet: "${KODIAK_WALLET}"
+  slots: 1                                # single asset, single position
+  default_leverage: 5                     # fallback; scan emits per-signal 5/6/7 by score
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: kodiak_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 180                  # v2 producer cadence (3 min)
+    timeout_seconds: 150                   # 3 MCP reads/tick; v2 WARN_OVER_180S budget
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 100           # signal-dedup map
+    inputs:
+      asset: "SOL"
+      dex: ""
+      macroAsset: "BTC"                    # "" disables the BTC-correlation factor (xyz ports)
+      minScore: 10
+      marginPct: 20                        # PERCENT of withdrawable (0,100] — runtime sizes (marginPct/100)*withdrawable
+      minTrendStrength4h: 0.75
+      minMom15mPct: 0.1
+      rsiMaxLong: 72
+      rsiMinShort: 28
+      leverageTiers: [[13, 7], [11, 6], [10, 5]]
+      recentSignalTtlSeconds: 14400        # 240m — mirror the per-asset cooldown
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      trend4h: { type: string, required: false }
+      trendStrength4h: { type: number, required: false }
+      trend1h: { type: string, required: false }
+      mom15mPct: { type: number, required: false }
+      mom1hPct: { type: number, required: false }
+      mom4hPct: { type: number, required: false }
+      fundingRate: { type: number, required: false }
+      oiTrend: { type: string, required: false }
+      btcMom1hPct: { type: number, required: false }
+      rsi: { type: number, required: false }
+      smPctOfTopTraders: { type: number, required: false }
+      smTraderCount: { type: number, required: false }
+      smCc15m: { type: number, required: false }
+      smAligned: { type: boolean, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: kodiak_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter
+    scanners: [kodiak_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # a conviction strike must fill — taker fallback at 60s
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: kodiak_main_signals
+
+# EXIT — DSL, asymmetry-optimized (ported verbatim from v2): cut losers fast/cheap,
+# ride winners hard. Time cuts OFF — single-asset patience.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 5
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 20 }
+        - { trigger_pct: 18, lock_hw_pct: 40 }
+        - { trigger_pct: 30, lock_hw_pct: 60 }
+        - { trigger_pct: 45, lock_hw_pct: 75 }
+        - { trigger_pct: 75, lock_hw_pct: 88 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 10
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: true
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600
+    per_asset_cooldown_seconds: 14400
+    max_entries_per_day: 8
+    bypass_max_entries_per_day_on_profit: false

--- a/strategies/kodiak/main/scanners/scan.py
+++ b/strategies/kodiak/main/scanners/scan.py
@@ -1,0 +1,149 @@
+"""KODIAK — supervised scanner (Runtime 3.0 port of the v2 Kodiak SOL alpha hunter).
+
+Single-asset. Reads SOL candles (5m/15m/1h/4h) + funding/OI, a macro driver
+(BTC 1h momentum), and smart-money positioning (leaderboard_get_markets); scores
+via the pure `scoring.build_thesis`; and emits ONE conviction-tiered signal when
+the composite clears `minScore`. Read-only + single-pass — emits a `marginPct`
+intent plus a per-signal `leverage` (5/6/7 by score); the runtime sizes the dollars,
+owns the cooldowns/risk gates, and trails the DSL exit. No daemon, no push_signal."""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 14400          # 240m — mirror the v2 per-asset cooldown (anti re-fire)
+_DEFAULT_TIERS = [[13, 7], [11, 6], [10, 5]]
+
+
+def _dex_for(asset, inputs):
+    dex = inputs.get("dex")
+    if dex is not None:
+        return dex
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _asset_data(ctx, asset, dex, intervals, funding):
+    md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": intervals,
+        "include_funding": funding,
+        "include_order_book": False,
+        "dex": dex,
+    })
+    if not md:
+        return None
+    return md.get("data", md) if isinstance(md, dict) else None
+
+
+def _sm_for_asset(ctx, asset):
+    """Port of v2 get_sol_sm_signal: net smart-money lean for `asset` from
+    leaderboard_get_markets. Returns {direction, pct, traders, cc_15m} or None."""
+    raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {"limit": 100})
+    if not raw:
+        return None
+    data = raw.get("data", raw) if isinstance(raw, dict) else raw
+    markets = data.get("markets", data) if isinstance(data, dict) else data
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None
+
+    want = asset.upper()
+    long_pct = short_pct = 0.0
+    traders = 0
+    cc_15m = 0.0
+    found = False
+    for m in markets:
+        if not isinstance(m, dict) or str(m.get("token", "")).upper() != want:
+            continue
+        found = True
+        d = str(m.get("direction", "")).lower()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        tc = int(m.get("trader_count", m.get("traderCount", 0)) or 0)
+        cc = scoring._f(m.get("contribution_pct_change_15m", 0))
+        if d == "long":
+            long_pct, cc_15m = pct, cc
+            traders += tc
+        elif d == "short":
+            short_pct, cc_15m = pct, cc
+            traders += tc
+    if not found:
+        return None
+    total = long_pct + short_pct
+    if total == 0:
+        return {"direction": "NEUTRAL", "pct": 50, "traders": traders, "cc_15m": cc_15m}
+    long_ratio = (long_pct / total) * 100
+    if long_ratio > 58:
+        return {"direction": "LONG", "pct": long_ratio, "traders": traders, "cc_15m": cc_15m}
+    if long_ratio < 42:
+        return {"direction": "SHORT", "pct": 100 - long_ratio, "traders": traders, "cc_15m": cc_15m}
+    return {"direction": "NEUTRAL", "pct": 50, "traders": traders, "cc_15m": cc_15m}
+
+
+def scan(inputs, ctx):
+    asset = (inputs.get("asset", "SOL") or "SOL")
+    dex = _dex_for(asset, inputs)
+    macro_asset = inputs.get("macroAsset", "BTC")     # "" disables the BTC factor (e.g. xyz ports)
+    min_score = float(inputs.get("minScore", 10))
+    margin_pct = float(inputs.get("marginPct", 20))   # PERCENT of withdrawable (0,100], not a fraction
+    tiers = inputs.get("leverageTiers", _DEFAULT_TIERS)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+    hour = time.gmtime(now).tm_hour
+
+    # signal-dedup (defence-in-depth alongside the runtime's per-asset cooldown gate)
+    recent = (ctx.state.last() or {}).get("recent", {}) if ctx.state else {}
+    au = asset.upper()
+    last = recent.get(au)
+    if last is not None and (now - last) < ttl:
+        return []
+
+    data = _asset_data(ctx, asset, dex, ["5m", "15m", "1h", "4h"], True)
+    if not data:
+        return []
+    candles = data.get("candles", {}) or {}
+    ctx_block = data.get("asset_context", {}) or {}
+    funding = scoring._f(ctx_block.get("funding", 0))
+    oi = scoring._f(ctx_block.get("openInterest", 0))
+
+    btc_mom_1h = 0.0
+    if macro_asset:
+        mdata = _asset_data(ctx, macro_asset, "", ["1h"], False)
+        if mdata:
+            btc_mom_1h = scoring.mom((mdata.get("candles", {}) or {}).get("1h", []), 1)
+
+    sm = _sm_for_asset(ctx, asset)
+
+    th = scoring.build_thesis(
+        candles.get("5m", []), candles.get("15m", []), candles.get("1h", []), candles.get("4h", []),
+        funding, oi, btc_mom_1h, sm, hour, inputs,
+    )
+    if not th or th["score"] < min_score:
+        return []
+
+    leverage = scoring.get_leverage(th["score"], tiers)
+    out = [{
+        "asset": asset,
+        "direction": th["direction"],
+        "marginPct": margin_pct,          # SIZING INTENT — runtime sizes the dollars
+        "leverage": leverage,             # conviction-tiered (5/6/7); runtime applies it
+        "data": {
+            "score": th["score"], "leverage": leverage, "direction": th["direction"],
+            "trend4h": th["trend_4h"], "trendStrength4h": th["trend_strength_4h"], "trend1h": th["trend_1h"],
+            "mom15mPct": th["mom_15m"], "mom1hPct": th["mom_1h"], "mom4hPct": th["mom_4h"],
+            "fundingRate": th["funding"], "oiTrend": "rising" if th["oi"] > 0 else "unknown",
+            "btcMom1hPct": th["btc_mom_1h"], "rsi": th["rsi"],
+            "smPctOfTopTraders": th["sm_pct"], "smTraderCount": th["sm_traders"],
+            "smCc15m": th["sm_cc15m"], "smAligned": th["sm_aligned"],
+            "reasons": th["reasons"],
+        },
+    }]
+
+    recent[au] = now
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[kodiak.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/kodiak/main/scanners/scan.py
+++ b/strategies/kodiak/main/scanners/scan.py
@@ -24,13 +24,17 @@ def _dex_for(asset, inputs):
 
 
 def _asset_data(ctx, asset, dex, intervals, funding):
-    md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
-        "asset": asset,
-        "candle_intervals": intervals,
-        "include_funding": funding,
-        "include_order_book": False,
-        "dex": dex,
-    })
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": asset,
+            "candle_intervals": intervals,
+            "include_funding": funding,
+            "include_order_book": False,
+            "dex": dex,
+        })
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[kodiak.scan] market_get_asset_data({asset}) read failed: {exc!r}", file=sys.stderr)
+        return None
     if not md:
         return None
     return md.get("data", md) if isinstance(md, dict) else None
@@ -39,7 +43,11 @@ def _asset_data(ctx, asset, dex, intervals, funding):
 def _sm_for_asset(ctx, asset):
     """Port of v2 get_sol_sm_signal: net smart-money lean for `asset` from
     leaderboard_get_markets. Returns {direction, pct, traders, cc_15m} or None."""
-    raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {"limit": 100})
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {"limit": 100})
+    except Exception as exc:  # noqa: BLE001 — smart-money is optional; never crash the tick on it
+        print(f"[kodiak.scan] leaderboard_get_markets read failed (smart-money -> neutral): {exc!r}", file=sys.stderr)
+        return None
     if not raw:
         return None
     data = raw.get("data", raw) if isinstance(raw, dict) else raw

--- a/strategies/kodiak/main/scanners/scan.py
+++ b/strategies/kodiak/main/scanners/scan.py
@@ -119,10 +119,22 @@ def scan(inputs, ctx):
         candles.get("5m", []), candles.get("15m", []), candles.get("1h", []), candles.get("4h", []),
         funding, oi, btc_mom_1h, sm, hour, inputs,
     )
-    if not th or th["score"] < min_score:
+    if not th:
+        t4, s4 = scoring.trend_structure(candles.get("4h", []))
+        t1, _ = scoring.trend_structure(candles.get("1h", []))
+        m15 = scoring.mom(candles.get("15m", []), 1)
+        print(f"[kodiak.scan] {asset} HOLD (gate): 4h={t4} {s4:.0%} (need>=75% & directional) | "
+              f"1h={t1} | 15m={m15:+.2f}%", file=sys.stderr)
+        return []
+    if th["score"] < min_score:
+        print(f"[kodiak.scan] {asset} HOLD: score={th['score']}/{min_score:.0f} {th['direction']} | "
+              f"4h={th['trend_4h']} {th['trend_strength_4h']:.0%} rsi={th['rsi']} | {th['reasons']}",
+              file=sys.stderr)
         return []
 
     leverage = scoring.get_leverage(th["score"], tiers)
+    print(f"[kodiak.scan] {asset} EMIT: score={th['score']} {th['direction']} {leverage}x | {th['reasons']}",
+          file=sys.stderr)
     out = [{
         "asset": asset,
         "direction": th["direction"],

--- a/strategies/kodiak/main/scanners/scan.py
+++ b/strategies/kodiak/main/scanners/scan.py
@@ -119,43 +119,57 @@ def scan(inputs, ctx):
         candles.get("5m", []), candles.get("15m", []), candles.get("1h", []), candles.get("4h", []),
         funding, oi, btc_mom_1h, sm, hour, inputs,
     )
+    # ── per-tick result record → scan-results history (ctx.state, bounded by
+    #    state_history_max_count). Read back with ctx.state.recent(n); persists to state.json. ──
+    out = []
     if not th:
         t4, s4 = scoring.trend_structure(candles.get("4h", []))
         t1, _ = scoring.trend_structure(candles.get("1h", []))
         m15 = scoring.mom(candles.get("15m", []), 1)
+        result = {"ts": now, "asset": asset, "emitted": False, "gate": "blocked", "score": None,
+                  "direction": None, "trend4h": t4, "ts4h": round(s4, 3), "trend1h": t1,
+                  "mom15m": round(m15, 3)}
         print(f"[kodiak.scan] {asset} HOLD (gate): 4h={t4} {s4:.0%} (need>=75% & directional) | "
               f"1h={t1} | 15m={m15:+.2f}%", file=sys.stderr)
-        return []
-    if th["score"] < min_score:
+    elif th["score"] < min_score:
+        result = {"ts": now, "asset": asset, "emitted": False, "gate": "pass", "score": th["score"],
+                  "direction": th["direction"], "trend4h": th["trend_4h"], "ts4h": th["trend_strength_4h"],
+                  "trend1h": th["trend_1h"], "mom15m": th["mom_15m"], "rsi": th["rsi"],
+                  "reasons": th["reasons"]}
         print(f"[kodiak.scan] {asset} HOLD: score={th['score']}/{min_score:.0f} {th['direction']} | "
               f"4h={th['trend_4h']} {th['trend_strength_4h']:.0%} rsi={th['rsi']} | {th['reasons']}",
               file=sys.stderr)
-        return []
+    else:
+        leverage = scoring.get_leverage(th["score"], tiers)
+        recent[au] = now
+        result = {"ts": now, "asset": asset, "emitted": True, "gate": "pass", "score": th["score"],
+                  "direction": th["direction"], "leverage": leverage, "trend4h": th["trend_4h"],
+                  "ts4h": th["trend_strength_4h"], "trend1h": th["trend_1h"], "mom15m": th["mom_15m"],
+                  "rsi": th["rsi"], "reasons": th["reasons"]}
+        print(f"[kodiak.scan] {asset} EMIT: score={th['score']} {th['direction']} {leverage}x | {th['reasons']}",
+              file=sys.stderr)
+        out = [{
+            "asset": asset,
+            "direction": th["direction"],
+            "marginPct": margin_pct,          # SIZING INTENT — runtime sizes the dollars
+            "leverage": leverage,             # conviction-tiered (5/6/7); runtime applies it
+            "data": {
+                "score": th["score"], "leverage": leverage, "direction": th["direction"],
+                "trend4h": th["trend_4h"], "trendStrength4h": th["trend_strength_4h"], "trend1h": th["trend_1h"],
+                "mom15mPct": th["mom_15m"], "mom1hPct": th["mom_1h"], "mom4hPct": th["mom_4h"],
+                "fundingRate": th["funding"], "oiTrend": "rising" if th["oi"] > 0 else "unknown",
+                "btcMom1hPct": th["btc_mom_1h"], "rsi": th["rsi"],
+                "smPctOfTopTraders": th["sm_pct"], "smTraderCount": th["sm_traders"],
+                "smCc15m": th["sm_cc15m"], "smAligned": th["sm_aligned"],
+                "reasons": th["reasons"],
+            },
+        }]
 
-    leverage = scoring.get_leverage(th["score"], tiers)
-    print(f"[kodiak.scan] {asset} EMIT: score={th['score']} {th['direction']} {leverage}x | {th['reasons']}",
-          file=sys.stderr)
-    out = [{
-        "asset": asset,
-        "direction": th["direction"],
-        "marginPct": margin_pct,          # SIZING INTENT — runtime sizes the dollars
-        "leverage": leverage,             # conviction-tiered (5/6/7); runtime applies it
-        "data": {
-            "score": th["score"], "leverage": leverage, "direction": th["direction"],
-            "trend4h": th["trend_4h"], "trendStrength4h": th["trend_strength_4h"], "trend1h": th["trend_1h"],
-            "mom15mPct": th["mom_15m"], "mom1hPct": th["mom_1h"], "mom4hPct": th["mom_4h"],
-            "fundingRate": th["funding"], "oiTrend": "rising" if th["oi"] > 0 else "unknown",
-            "btcMom1hPct": th["btc_mom_1h"], "rsi": th["rsi"],
-            "smPctOfTopTraders": th["sm_pct"], "smTraderCount": th["sm_traders"],
-            "smCc15m": th["sm_cc15m"], "smAligned": th["sm_aligned"],
-            "reasons": th["reasons"],
-        },
-    }]
-
-    recent[au] = now
+    # ── persist dedup map + this tick's result EVERY tick (was emit-only); self-trims
+    #    at state_history_max_count. Read the history via ctx.state.recent(n). ──
     if ctx.state is not None:
         try:
-            ctx.state.append({"recent": recent})
+            ctx.state.append({"recent": recent, "result": result})
         except Exception as exc:  # noqa: BLE001
             print(f"[kodiak.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
     return out

--- a/strategies/kodiak/main/scanners/scoring.py
+++ b/strategies/kodiak/main/scanners/scoring.py
@@ -1,0 +1,266 @@
+"""KODIAK — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Kodiak producer's `build_sol_thesis` +
+multi-factor scoring (SKILL.md v7.0.0). The math/indexing is reproduced VERBATIM
+so a fidelity harness can diff this against the v2 producer on the same market
+snapshot. Behaviour-preserving quirks from v2 are kept and flagged `# v2-quirk`;
+fix them only as a separate, labelled change AFTER the port is validated.
+
+Single-asset, single-pass, unit-testable on plain candle lists. `tod_modifier`
+takes the hour as an argument (the caller owns the clock) so this stays pure."""
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts only; the list branch is defensive and never fires on dict candles,
+# so it does not change v2 behaviour.
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+# ── indicators (ported verbatim from v2) ──
+
+def mom(candles, n_bars=1):
+    """% change over the last n_bars (price_momentum)."""
+    if len(candles) < n_bars + 1:
+        return 0.0
+    cur = _close(candles[-1])
+    prev = _close(candles[-1 - n_bars])
+    if prev <= 0:
+        return 0.0
+    return (cur - prev) / prev * 100
+
+
+def trend_structure(candles, lookback=6):
+    """(label, strength): fraction of higher-lows (BULLISH) / lower-highs (BEARISH)
+    over the last `lookback` bars. Entry requires strength >= 0.75."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    recent = candles[-lookback:]
+    highs = [_high(c) for c in recent]
+    lows = [_low(c) for c in recent]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] >= lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] <= highs[i - 1])
+    bullish = higher_lows / (lookback - 1)
+    bearish = lower_highs / (lookback - 1)
+    if bullish >= 0.6:
+        return "BULLISH", bullish
+    if bearish >= 0.6:
+        return "BEARISH", bearish
+    return "NEUTRAL", max(bullish, bearish)
+
+
+def rsi(closes, period=14):
+    # v2-quirk: uses the FIRST period+1 closes (closes[0..period]), not the most
+    # recent. Reproduced verbatim for fidelity — do not "fix" inside the port.
+    if len(closes) < period + 1:
+        return 50.0
+    gains = losses = 0.0
+    for i in range(1, period + 1):
+        d = closes[i] - closes[i - 1]
+        if d > 0:
+            gains += d
+        else:
+            losses -= d
+    avg_gain = gains / period
+    avg_loss = losses / period
+    if avg_loss == 0:
+        return 100.0
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
+def tod_modifier(hour):
+    """UTC hour -> (score_delta, reason|None). Caller passes the hour (keeps this pure)."""
+    if 4 <= hour < 14:
+        return 1, "tod_active_window"
+    if hour >= 18 or hour < 2:
+        return -2, "tod_chop_zone"
+    return 0, None
+
+
+def get_leverage(score, tiers):
+    """Conviction-tiered leverage. tiers = [[min_score, leverage], ...] desc by score."""
+    for t in tiers:
+        if score >= t[0]:
+            return int(t[1])
+    return int(tiers[-1][1]) if tiers else 5
+
+
+# ── the thesis (gates + multi-factor score), ported verbatim from build_sol_thesis ──
+
+def build_thesis(c5, c15, c1h, c4h, funding, oi, btc_mom_1h, sm, hour, inputs):
+    """Returns a thesis dict (with `score`) or None if any gate blocks. `sm` is the
+    smart-money dict {direction, pct, traders, cc_15m} or None (the caller fetches it)."""
+    min_ts_4h = float(inputs.get("minTrendStrength4h", 0.75))
+    min_mom_15m = float(inputs.get("minMom15mPct", 0.1))
+    rsi_long_max = float(inputs.get("rsiMaxLong", 72))
+    rsi_short_min = float(inputs.get("rsiMinShort", 28))
+
+    if len(c5) < 12 or len(c15) < 8 or len(c1h) < 8 or len(c4h) < 6:
+        return None
+
+    # ── 4h structure ──
+    trend_4h, ts_4h = trend_structure(c4h)
+    if trend_4h == "NEUTRAL" or ts_4h < min_ts_4h:
+        return None
+    direction = "LONG" if trend_4h == "BULLISH" else "SHORT"
+
+    # ── 1h confirmation ──
+    trend_1h, _ = trend_structure(c1h)
+    if trend_1h != trend_4h:
+        return None
+
+    # ── 15m momentum + base-tech floor ──
+    mom_5m = mom(c5, 1)
+    mom_15m = mom(c15, 1)
+    mom_1h = mom(c1h, 2)
+    mom_4h = mom(c4h, 1)
+    if direction == "LONG" and mom_15m < min_mom_15m:
+        return None
+    if direction == "SHORT" and mom_15m > -min_mom_15m:
+        return None
+    strong_15m = abs(mom_15m) > min_mom_15m * 2
+    aligned_5m = (direction == "LONG" and mom_5m > 0) or (direction == "SHORT" and mom_5m < 0)
+    if not (strong_15m or aligned_5m):
+        return None
+
+    # ── RSI gate ──
+    closes_1h = [_close(c) for c in c1h]
+    r = rsi(closes_1h)
+    if direction == "LONG" and r > rsi_long_max:
+        return None
+    if direction == "SHORT" and r < rsi_short_min:
+        return None
+
+    # ── ALL GATES PASSED — SCORE ──
+    score = 0
+    reasons = []
+    score += 3
+    reasons.append(f"4h_{trend_4h.lower()}_{ts_4h:.0%}")
+    score += 2
+    reasons.append(f"1h_confirms_{mom_1h:+.2f}%")
+    if strong_15m:
+        score += 1
+        reasons.append(f"15m_strong_{mom_15m:+.2f}%")
+    if aligned_5m and strong_15m:
+        score += 1
+        reasons.append("4TF_aligned")
+
+    # smart-money concentration
+    sm_aligned = False
+    sm_pct = sm_traders = sm_cc15m = 0
+    if sm and sm.get("direction") == direction:
+        sm_aligned = True
+        sm_pct = _f(sm.get("pct", 0))
+        sm_traders = int(sm.get("traders", 0))
+        sm_cc15m = _f(sm.get("cc_15m", 0))
+        if sm_pct >= 70 and sm_traders >= 50:
+            score += 3
+            reasons.append(f"SM_DOMINANT_{sm_pct:.1f}%_{sm_traders}t")
+        elif sm_pct >= 60 and sm_traders >= 30:
+            score += 2
+            reasons.append(f"SM_STRONG_{sm_pct:.1f}%_{sm_traders}t")
+        else:
+            score += 1
+            reasons.append(f"SM_aligned_{sm_pct:.1f}%_{sm_traders}t")
+        if sm_cc15m > 0.5:
+            score += 2
+            reasons.append(f"SM_15m_strong_+{sm_cc15m:.2f}")
+        elif sm_cc15m > 0.2:
+            score += 1
+            reasons.append(f"SM_15m_+{sm_cc15m:.2f}")
+        if sm_traders >= 80:
+            score += 1
+            reasons.append(f"SM_DEEP_{sm_traders}t")
+
+    # funding
+    if direction == "LONG" and funding < -0.0001:
+        score += 2
+        reasons.append(f"funding_pays_longs_{funding:+.4f}")
+    elif direction == "SHORT" and funding > 0.0001:
+        score += 2
+        reasons.append(f"funding_pays_shorts_{funding:+.4f}")
+    elif (direction == "LONG" and funding > 0.0005) or (direction == "SHORT" and funding < -0.0005):
+        score -= 1
+        reasons.append(f"funding_crowded_{funding:+.4f}")
+
+    # BTC correlation
+    if (direction == "LONG" and btc_mom_1h > 0.3) or (direction == "SHORT" and btc_mom_1h < -0.3):
+        score += 1
+        reasons.append(f"btc_confirms_{btc_mom_1h:+.2f}%")
+
+    # RSI room
+    if (direction == "LONG" and r < 55) or (direction == "SHORT" and r > 45):
+        score += 1
+        reasons.append(f"rsi_room_{r:.0f}")
+
+    # 4h momentum bonus / exhaustion penalty
+    if (direction == "LONG" and mom_4h > 1.0) or (direction == "SHORT" and mom_4h < -1.0):
+        score += 1
+        reasons.append(f"4h_momentum_{mom_4h:+.1f}%")
+    if direction == "LONG" and mom_4h > 5.0:
+        score -= 2
+        reasons.append(f"MOVE_EXHAUSTION_{mom_4h:+.1f}%")
+    elif direction == "SHORT" and mom_4h < -5.0:
+        score -= 2
+        reasons.append(f"MOVE_EXHAUSTION_{mom_4h:+.1f}%")
+    elif direction == "LONG" and mom_4h > 3.0:
+        score -= 1
+        reasons.append(f"MOVE_TIRING_{mom_4h:+.1f}%")
+    elif direction == "SHORT" and mom_4h < -3.0:
+        score -= 1
+        reasons.append(f"MOVE_TIRING_{mom_4h:+.1f}%")
+
+    # time-of-day
+    tod_mod, tod_reason = tod_modifier(hour)
+    score += tod_mod
+    if tod_reason:
+        reasons.append(tod_reason)
+
+    return {
+        "direction": direction,
+        "score": round(score, 2),
+        "trend_4h": trend_4h,
+        "trend_strength_4h": round(ts_4h, 3),
+        "trend_1h": trend_1h,
+        "mom_15m": round(mom_15m, 3),
+        "mom_1h": round(mom_1h, 3),
+        "mom_4h": round(mom_4h, 3),
+        "funding": funding,
+        "oi": oi,
+        "rsi": round(r, 1),
+        "btc_mom_1h": round(btc_mom_1h, 3),
+        "sm_aligned": sm_aligned,
+        "sm_pct": round(_f(sm_pct), 2),
+        "sm_traders": int(sm_traders),
+        "sm_cc15m": round(_f(sm_cc15m), 3),
+        "reasons": reasons,
+    }

--- a/strategies/kodiak/main/scanners/test_margin_pct.py
+++ b/strategies/kodiak/main/scanners/test_margin_pct.py
@@ -1,0 +1,45 @@
+"""Guard: kodiak's marginPct must be a PERCENT in (0,100], never a v2 fraction.
+
+v3.x runtime sizes `(marginPct/100)*withdrawable` (resolve-margin.ts), so a
+fraction like 0.20 sizes 0.20% of withdrawable — ~100x undersize, silent (no 400,
+since 0.20 still satisfies the (0,100] bound). marginPct is a pure pass-through
+config value here: read at scan.py (inputs.marginPct, default 20) and emitted
+verbatim at the candidate top level; `scoring.build_thesis` never reads it. So
+this is a config-level invariant, asserted directly against the wire-bound value.
+"""
+
+import os
+import re
+
+import yaml
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_RUNTIME_YAML = os.path.join(_HERE, "..", "runtime.yaml")
+_SCAN_PY = os.path.join(_HERE, "scan.py")
+
+
+def _runtime_margin_pct():
+    with open(_RUNTIME_YAML) as f:
+        spec = yaml.safe_load(f)
+    for s in spec["scanners"]:
+        if s.get("type") == "external_scanner":
+            return float(s["inputs"]["marginPct"])
+    raise AssertionError("no external_scanner inputs.marginPct in runtime.yaml")
+
+
+def _scan_default_margin_pct():
+    src = open(_SCAN_PY).read()
+    m = re.search(r'inputs\.get\(\s*"marginPct"\s*,\s*([0-9.]+)\s*\)', src)
+    assert m, "scan.py marginPct default not found"
+    return float(m.group(1))
+
+
+def test_runtime_margin_pct_is_percent_in_range():
+    pct = _runtime_margin_pct()
+    # >=1 catches the fraction bug (0.20); <=100 is the wire upper bound.
+    assert 1 <= pct <= 100, f"runtime.yaml marginPct={pct} not a PERCENT in [1,100]"
+
+
+def test_scan_default_margin_pct_is_percent_in_range():
+    pct = _scan_default_margin_pct()
+    assert 1 <= pct <= 100, f"scan.py marginPct default={pct} not a PERCENT in [1,100]"

--- a/strategies/kodiak/strategy.yaml
+++ b/strategies/kodiak/strategy.yaml
@@ -1,0 +1,40 @@
+# Kodiak — SOL alpha hunter. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2
+# Kodiak (SKILL.md v7.0.0): multi-factor conviction scoring on one asset (SOL),
+# conviction-tiered leverage, DSL-only exits. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: kodiak
+version: "1.0.0"
+
+catalog:
+  name: "Kodiak — SOL Alpha Hunter"
+  emoji: "🐻"
+  tagline: "A single-asset SOL specialist: enters only when 4h and 1h trend structure agree, 15m momentum confirms, and smart-money lean, funding, and BTC all line up — then sizes leverage to conviction (5/6/7x) and lets the DSL ride the winner."
+  belief_plain: "Trades only SOL. It waits for the 4-hour and 1-hour trend to agree, momentum to confirm, and the best traders to be leaning the same way — then goes in harder when more of those line up, and trails a stop instead of guessing the exit."
+  thesis: "You want one coin done really well, not a scattergun across the market. SOL has the liquidity and the moves, and an agent that watches only SOL can read its structure, smart-money flow, and funding far more tightly than a broad universe scanner ever could."
+  group: single-asset
+  archetype: single_market
+  sub_style: alpha_hunter
+  asset_classes: [major_alts]
+  asset_scope: single
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  leverage_max: 7
+  max_slots: 1
+  min_budget: 200
+  assets: ["SOL"]
+  tags: [sol, single-asset, momentum, smart-money, conviction-leverage, alpha-hunter]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: KODIAK_WALLET
+    funding_share: 1.0

--- a/strategies/whalehunter/long/runtime.yaml
+++ b/strategies/whalehunter/long/runtime.yaml
@@ -1,0 +1,113 @@
+# ── WHALEHUNTER · LONG sleeve — position WITH a net-long smart-money cohort ──
+name: whalehunter-long
+group: whalehunter
+version: 3.0.0
+description: >
+  WHALEHUNTER LONG — smart-money-vs-crowd cohort divergence (Runtime 3.0 port of v2.0).
+  Segments Hyperliquid traders into a SMART cohort (lifetime realized >= $1M) and a
+  CROWD cohort ($10k-$100k), aggregates each cohort's NET positioning per coin, and
+  emits a LONG when the smart cohort is heavily net-long a coin AND adding to it daily
+  while the crowd leans the other way. Derived universe (coins come from the cohort's
+  positions). Rides a WIDE conviction DSL. Pairs with the SHORT sleeve on a separate
+  wallet so conflicting same-coin positions can coexist. ~1-day warmup (needs a prior
+  daily ledger snapshot before requireGrowing can pass).
+
+strategy:
+  wallet: "${WHALEHUNTER_LONG_WALLET}"
+  slots: 6
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: whalehunter_long_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 cohort cadence (5 min); ~10 trader_state reads/tick
+    timeout_seconds: 180
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 12            # holds the cohort cache + daily ledger + dedup map
+    inputs:
+      direction: "LONG"
+      smartMinRealizedUsd: 1000000
+      crowdMinRealizedUsd: 10000
+      crowdMaxRealizedUsd: 100000
+      cohortFetchLimit: 1000
+      cohortMaxPages: 6
+      cohortSampleCap: 250
+      cohortRefreshHours: 24
+      cohortMinMembers: 5
+      biasThreshold: 0.5
+      crowdDivergenceMin: 0.2
+      requireGrowing: true
+      cohortMinScore: 4
+      marginPct: 12                        # PERCENT of withdrawable (0,100], not a fraction
+      maxMarginPct: 25                      # conviction-scale cap, percent of withdrawable
+      maxConvictionScale: 2.0
+      stdLeverage: 3
+      maxLeverage: 5
+      recentSignalTtlSeconds: 3600
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      signalKind: { type: string, required: false }
+      smartBias: { type: number, required: false }
+      crowdBias: { type: number, required: false }
+      smartGrowth: { type: number, required: false }
+      smartMembers: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: whalehunter_long_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter
+    scanners: [whalehunter_long_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # a confirmed divergence must fill — taker fallback
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: whalehunter_long_signals
+
+# EXIT — WIDE "ride the conviction" DSL (ported verbatim from v2): wide disaster stop,
+# do nothing until a real run, then bank only a fraction. Time cuts OFF.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    phase1:
+      enabled: true
+      max_loss_pct: 30.0
+      retrace_threshold: 18
+      consecutive_breaches_required: 2
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 60, lock_hw_pct: 0 }
+        - { trigger_pct: 120, lock_hw_pct: 45 }
+        - { trigger_pct: 220, lock_hw_pct: 65 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 15
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: true
+    max_consecutive_losses: 5
+    cooldown_seconds: 3600
+    per_asset_cooldown_seconds: 21600
+    max_entries_per_day: 6
+    bypass_max_entries_per_day_on_profit: false

--- a/strategies/whalehunter/long/scanners/scan.py
+++ b/strategies/whalehunter/long/scanners/scan.py
@@ -22,6 +22,17 @@ CACHE_VERSION = 1     # bump if the cohort-BUILDING logic changes (busts a stale
 _DEFAULT_TTL = 3600   # 60m signal-dedup: don't re-fire a coin while a signal is in flight
 
 
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll back the
+    whole tick. Returns None on failure so the existing degrade paths apply (cohort
+    falls back to its daily cache; a failed state batch is skipped)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[whalehunter.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
 def _build_cohorts(ctx, cached, inputs, now):
     """Smart cohort (lifetime realized >= smartMinRealizedUsd) + crowd cohort
     (crowdMin..crowdMax) from the ALL_TIME realized-PnL ranking, PAGED by offset to
@@ -38,7 +49,7 @@ def _build_cohorts(ctx, cached, inputs, now):
     max_pages = int(inputs.get("cohortMaxPages", 6))
     smart, crowd, seen = [], [], set()
     for page in range(max_pages):
-        resp = ctx.senpi_mcp.call_tool("discovery_get_top_traders", {
+        resp = _read(ctx, "discovery_get_top_traders", {
             "time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
             "open_position_filter": False, "limit": page_size, "offset": page * page_size})
         if not resp:
@@ -78,7 +89,7 @@ def _fetch_states(ctx, addrs):
     """discovery_get_trader_state in batches of 50 -> flat list of trader-state dicts."""
     traders = []
     for i in range(0, len(addrs), 50):
-        resp = ctx.senpi_mcp.call_tool("discovery_get_trader_state",
+        resp = _read(ctx, "discovery_get_trader_state",
                                        {"trader_addresses": addrs[i:i + 50]})
         if not resp:
             continue

--- a/strategies/whalehunter/long/scanners/scan.py
+++ b/strategies/whalehunter/long/scanners/scan.py
@@ -1,0 +1,144 @@
+"""WHALEHUNTER — supervised scanner (Runtime 3.0 port of the v2 cohort engine).
+
+Direction-parametrized and shared verbatim by both sleeves: the `long` instance
+passes direction=LONG (positions with a net-long smart cohort); the `short` instance
+passes direction=SHORT. Each sleeve runs on its OWN wallet and its OWN ctx.state, so
+the cohort cache + daily ledger are per-sleeve (the v2 daemon shared them on disk;
+3.0 instances are isolated — signals are identical, only the cache is duplicated).
+
+Per tick: refresh the smart/crowd cohorts (cached daily in ctx.state), aggregate each
+cohort's net positioning (discovery_get_trader_state), update the daily ledger to get
+the 'adding daily' growth, score the divergences for THIS direction, and emit a
+conviction-scaled marginPct INTENT (the runtime sizes, owns slots/dedup, trails DSL).
+Read-only, single-pass. Derived universe — the coins come from the cohort's positions,
+not a fixed list. NOTE: ~1 UTC-day warmup before requireGrowing can pass."""
+
+import sys
+import time
+
+import scoring
+
+CACHE_VERSION = 1     # bump if the cohort-BUILDING logic changes (busts a stale cache)
+_DEFAULT_TTL = 3600   # 60m signal-dedup: don't re-fire a coin while a signal is in flight
+
+
+def _build_cohorts(ctx, cached, inputs, now):
+    """Smart cohort (lifetime realized >= smartMinRealizedUsd) + crowd cohort
+    (crowdMin..crowdMax) from the ALL_TIME realized-PnL ranking, PAGED by offset to
+    reach the deep crowd band, each capped. Cached daily in ctx.state."""
+    refresh_h = float(inputs.get("cohortRefreshHours", 24))
+    if (cached.get("smart") and cached.get("cache_version") == CACHE_VERSION
+            and (now - cached.get("refreshed_at", 0)) / 3600 < refresh_h):
+        return cached                                       # fresh cache — no fetch
+    smin = float(inputs.get("smartMinRealizedUsd", 1_000_000))
+    cmin = float(inputs.get("crowdMinRealizedUsd", 10_000))
+    cmax = float(inputs.get("crowdMaxRealizedUsd", 100_000))
+    cap = int(inputs.get("cohortSampleCap", 250))
+    page_size = int(inputs.get("cohortFetchLimit", 1000))
+    max_pages = int(inputs.get("cohortMaxPages", 6))
+    smart, crowd, seen = [], [], set()
+    for page in range(max_pages):
+        resp = ctx.senpi_mcp.call_tool("discovery_get_top_traders", {
+            "time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
+            "open_position_filter": False, "limit": page_size, "offset": page * page_size})
+        if not resp:
+            break
+        raw = resp.get("data", resp) if isinstance(resp, dict) else resp
+        if isinstance(raw, dict):
+            raw = raw.get("traders", raw.get("data", []))
+        if not isinstance(raw, list) or not raw:
+            break
+        page_top = None
+        for t in raw:
+            if not isinstance(t, dict):
+                continue
+            addr = (t.get("address") or t.get("trader_address") or "").lower()
+            if not addr or addr in seen:
+                continue
+            rp = scoring.realized(t)
+            page_top = rp if page_top is None else max(page_top, rp)
+            if rp >= smin:
+                if len(smart) < cap:
+                    smart.append(addr)
+                    seen.add(addr)
+            elif cmin <= rp <= cmax:
+                if len(crowd) < cap:
+                    crowd.append(addr)
+                    seen.add(addr)
+        if len(smart) >= cap and len(crowd) >= cap:
+            break
+        if page_top is not None and page_top < cmin:        # whole page below the crowd floor
+            break
+    if not smart and not crowd:
+        return cached                                       # failed refresh — keep the old cache
+    return {"refreshed_at": now, "cache_version": CACHE_VERSION, "smart": smart, "crowd": crowd}
+
+
+def _fetch_states(ctx, addrs):
+    """discovery_get_trader_state in batches of 50 -> flat list of trader-state dicts."""
+    traders = []
+    for i in range(0, len(addrs), 50):
+        resp = ctx.senpi_mcp.call_tool("discovery_get_trader_state",
+                                       {"trader_addresses": addrs[i:i + 50]})
+        if not resp:
+            continue
+        data = resp.get("data", resp) if isinstance(resp, dict) else resp
+        if isinstance(data, dict):
+            traders.extend(data.get("traders", []) or [])
+    return traders
+
+
+def scan(inputs, ctx):
+    direction = (inputs.get("direction", "LONG") or "LONG").upper()
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    std_lev = int(inputs.get("stdLeverage", 3))
+    max_lev = int(inputs.get("maxLeverage", 5))
+    min_members = int(inputs.get("cohortMinMembers", 5))
+    now = time.time()
+    today = time.strftime("%Y-%m-%d", time.gmtime(now))
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    ledger_days = (last.get("ledger") or {}).get("days", {})
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    cohorts = _build_cohorts(ctx, last.get("cohorts", {}), inputs, now)
+    smart, crowd = cohorts.get("smart", []), cohorts.get("crowd", [])
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"cohorts": cohorts, "ledger": {"days": ledger_days}, "recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[whalehunter.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    if len(smart) < min_members:                            # cohort too small — cache & bail
+        _persist()
+        return []
+
+    smart_per = scoring.aggregate_bias(_fetch_states(ctx, smart))
+    crowd_per = scoring.aggregate_bias(_fetch_states(ctx, crowd))
+    ledger_days, growth = scoring.update_ledger(ledger_days, smart_per, today)
+    strikes = scoring.cohort_signals(smart_per, crowd_per, growth, direction, inputs)
+
+    leverage = min(std_lev, max_lev)
+    out = []
+    for s in strikes:
+        cu = s["coin"].upper()
+        if recent.get(cu) is not None and (now - recent[cu]) < ttl:   # signal-dedup
+            continue
+        out.append({
+            "asset": s["coin"],
+            "direction": direction,
+            "marginPct": scoring.margin_pct_for(s["score"], inputs),  # conviction-scaled INTENT
+            "leverage": leverage,                                     # std, runtime clamps to venue max
+            "data": {
+                "score": s["score"], "direction": direction, "signalKind": "COHORT_DIVERGENCE",
+                "smartBias": s["smart_bias"], "crowdBias": s["crowd_bias"],
+                "smartGrowth": s["growth"], "smartMembers": s["n_confirm"], "reasons": s["reasons"],
+            },
+        })
+        recent[cu] = now
+
+    _persist()
+    return out

--- a/strategies/whalehunter/long/scanners/scoring.py
+++ b/strategies/whalehunter/long/scanners/scoring.py
@@ -1,0 +1,139 @@
+"""WHALEHUNTER — pure cohort-divergence math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 WhaleHunter v2.0 cohort engine
+(whalehunter-producer.py). Given trader-state dicts already fetched by scan.py,
+this bucketing/scoring is reproduced VERBATIM so a fidelity harness can diff it
+against the v2 producer on the same snapshot. Shared verbatim by both sleeves;
+the sleeve's direction is passed in (LONG for the long wallet, SHORT for the short).
+
+The thesis: segment Hyperliquid traders into a SMART cohort (high lifetime realized
+PnL) and a CROWD cohort, aggregate each cohort's NET positioning per coin, and fire
+when the smart cohort is net-directional past a threshold AND adding to it daily,
+with the crowd ideally on the other side. Position WITH the smart money, not the crowd."""
+
+
+def _f(x, *keys, default=0.0):
+    """Float from x. If keys given, x is a dict and we try each key in order."""
+    if keys:
+        if not isinstance(x, dict):
+            return default
+        for k in keys:
+            if x.get(k) is not None:
+                try:
+                    return float(x[k])
+                except (TypeError, ValueError):
+                    continue
+        return default
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return default
+
+
+def realized(t):
+    # LIFETIME realized PnL only — never fall back to total PnL (realized+unrealized),
+    # which is not monotonic with the realized-PnL sort and mis-buckets the cohorts.
+    return _f(t, "realizedProfitAndLoss", "realized_profit_and_loss",
+              "profit_and_loss_realized", "realizedPnl", "realized_pnl", default=0.0)
+
+
+def _signed_notional(p):
+    szi = _f(p, "szi", "size")
+    val = _f(p, "positionValue", "notional", "position_value")
+    if val <= 0:
+        val = abs(szi) * _f(p, "entryPx", "markPx", "entry_price")
+    return (1.0 if szi > 0 else (-1.0 if szi < 0 else 0.0)) * abs(val)
+
+
+def aggregate_bias(traders):
+    """Aggregate a cohort's NET positioning per coin from a list of trader-state dicts.
+    bias = net/gross in [-1, +1] (+1 all long, -1 all short), plus member counts."""
+    per = {}
+    for t in traders:
+        if not isinstance(t, dict):
+            continue
+        for p in (t.get("openPositions") or t.get("open_positions") or []):
+            if not isinstance(p, dict):
+                continue
+            coin = p.get("coin") or p.get("asset")
+            if not coin:
+                continue
+            sn = _signed_notional(p)
+            if sn == 0:
+                continue
+            d = per.setdefault(coin, {"net": 0.0, "gross": 0.0, "n_long": 0, "n_short": 0})
+            d["net"] += sn
+            d["gross"] += abs(sn)
+            d["n_long" if sn > 0 else "n_short"] += 1
+    for d in per.values():
+        d["bias"] = round(d["net"] / d["gross"], 3) if d["gross"] > 0 else 0.0
+    return per
+
+
+def update_ledger(days, smart_per, today, keep=10):
+    """Append today's smart-cohort net-per-coin to the daily ledger; return
+    (new_days, growth) where growth[coin] = today's net − the earliest snapshot's net
+    (the 'adding daily' signal). growth is {} on day 1 — `requireGrowing` then blocks
+    until ~day 2. `today` is passed in so this stays clock-free."""
+    days = dict(days)
+    days[today] = {c: round(d["net"], 2) for c, d in smart_per.items()}
+    for stale in sorted(days)[:-keep]:           # keep ~`keep` days
+        days.pop(stale, None)
+    prior = [d for d in sorted(days) if d < today]
+    growth = {}
+    if prior:
+        base = days[prior[0]]                     # earliest snapshot we still hold
+        for coin, net in days[today].items():
+            growth[coin] = round(net - float(base.get(coin, 0.0)), 2)
+    return days, growth
+
+
+def cohort_signals(smart_per, crowd_per, growth, direction, config):
+    """For THIS sleeve's direction: smart cohort net-directional past biasThreshold,
+    growing (adding), crowd ideally diverging. Returns scored strikes, best first."""
+    bt = float(config.get("biasThreshold", 0.50))
+    cdiv = float(config.get("crowdDivergenceMin", 0.2))
+    req_grow = bool(config.get("requireGrowing", True))
+    min_members = int(config.get("cohortMinMembers", 5))
+    floor = int(config.get("cohortMinScore", 4))
+    want_long = (direction == "LONG")
+    out = []
+    for coin, sd in smart_per.items():
+        if sd["n_long"] + sd["n_short"] < min_members:
+            continue
+        bias = sd["bias"]
+        if (want_long and bias < bt) or (not want_long and bias > -bt):
+            continue                              # smart cohort not net in our direction
+        g = growth.get(coin)
+        growing = (g is not None) and ((g > 0) if want_long else (g < 0))
+        if req_grow and not growing:
+            continue                              # not "adding" — skip
+        crowd_bias = crowd_per.get(coin, {}).get("bias", 0.0)
+        crowd_div = (crowd_bias <= -cdiv) if want_long else (crowd_bias >= cdiv)
+        score = 3 + (1 if abs(bias) >= 0.7 else 0) + (1 if growing else 0) + (1 if crowd_div else 0)
+        if score < floor:
+            continue
+        n_confirm = sd["n_long"] if want_long else sd["n_short"]
+        out.append({
+            "coin": coin, "direction": direction, "score": score,
+            "smart_bias": bias, "crowd_bias": round(crowd_bias, 3),
+            "growth": g, "n_confirm": n_confirm,
+            "reasons": [f"smart cohort net {bias:+.2f} on {coin}",
+                        f"{'ADDING' if growing else 'flat'} (dnet {g})",
+                        f"crowd {crowd_bias:+.2f}{' DIVERGES' if crowd_div else ''}",
+                        f"{n_confirm} smart whales {direction}"],
+        })
+    out.sort(key=lambda s: (s["score"], abs(s["smart_bias"])), reverse=True)
+    return out
+
+
+def margin_pct_for(score, config):
+    """Conviction-scaled marginPct INTENT as a PERCENT of withdrawable in (0,100]
+    (the runtime sizes (marginPct/100)*withdrawable). Scales +25% per point above
+    the floor, capped at maxMarginPct."""
+    base = float(config.get("marginPct", 12))
+    cap = float(config.get("maxMarginPct", 25))
+    smax = float(config.get("maxConvictionScale", 2.0))
+    floor = int(config.get("cohortMinScore", 4))
+    scale = min(smax, 1.0 + 0.25 * max(0, score - floor))
+    return round(min(base * scale, cap), 4)

--- a/strategies/whalehunter/long/scanners/test_scoring_margin.py
+++ b/strategies/whalehunter/long/scanners/test_scoring_margin.py
@@ -1,0 +1,79 @@
+"""WHALEHUNTER — margin-unit regression for scoring.margin_pct_for.
+
+v3.0.4 treats per-signal `marginPct` as a PERCENT in (0,100] of withdrawable
+(resolve-margin.ts sizes (marginPct/100)*withdrawable). The producer must therefore
+emit a PERCENT, not a fraction. These tests pin the emitted value into [1,100]
+across the full conviction range, at the base and at the max-clamp boundary.
+
+scoring.py imports clean (no I/O), and scan.py does `import scoring`, so we add the
+scanner dir to sys.path and import the module directly.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+import scoring  # noqa: E402
+
+# Two configs that BOTH must emit a percent:
+#  - DEFAULTS: empty dict -> exercises margin_pct_for's OWN built-in .get() fallbacks
+#    (the shipped fraction defaults are the bug; post-fix they must be percent).
+#  - YAML: the values actually wired in long/short runtime.yaml inputs (identical knobs).
+# We parametrize over both so a fix to only one place still leaves a red test.
+DEFAULTS = {}
+YAML = {
+    "marginPct": 12,
+    "maxMarginPct": 25,
+    "maxConvictionScale": 2.0,
+    "cohortMinScore": 4,
+}
+CONFIGS = [DEFAULTS, YAML]
+
+FLOOR = 4  # cohortMinScore default and YAML value
+
+
+def _floor(cfg):
+    return int(cfg.get("cohortMinScore", FLOOR))
+
+
+import pytest  # noqa: E402
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_base_conviction_is_percent(cfg):
+    # score == floor -> scale 1.0 -> emits the base, which must be a percent in [1,100].
+    mp = scoring.margin_pct_for(_floor(cfg), cfg)
+    assert 1 <= mp <= 100, f"base conviction emitted {mp}, expected a percent in [1,100]"
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_mid_conviction_is_percent(cfg):
+    mp = scoring.margin_pct_for(_floor(cfg) + 2, cfg)  # score 6
+    assert 1 <= mp <= 100, f"mid conviction emitted {mp}, expected a percent in [1,100]"
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_max_clamp_conviction_is_percent(cfg):
+    # Very high score saturates scale at maxConvictionScale -> max-clamp boundary.
+    mp = scoring.margin_pct_for(_floor(cfg) + 50, cfg)
+    assert 1 <= mp <= 100, f"max-clamp conviction emitted {mp}, expected a percent in [1,100]"
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_full_conviction_range_in_percent_band(cfg):
+    # Every score from floor through a large clamp value must land in [1,100], never <1.
+    fl = _floor(cfg)
+    for score in range(fl, fl + 51):
+        mp = scoring.margin_pct_for(score, cfg)
+        assert 1 <= mp <= 100, f"score {score} emitted {mp}, outside [1,100]"
+
+
+@pytest.mark.parametrize("cfg", CONFIGS)
+def test_monotonic_nondecreasing_with_conviction(cfg):
+    fl = _floor(cfg)
+    prev = 0.0
+    for score in range(fl, fl + 10):
+        mp = scoring.margin_pct_for(score, cfg)
+        assert mp >= prev, f"score {score} emitted {mp} < previous {prev}"
+        prev = mp

--- a/strategies/whalehunter/short/runtime.yaml
+++ b/strategies/whalehunter/short/runtime.yaml
@@ -1,0 +1,112 @@
+# ── WHALEHUNTER · SHORT sleeve — position WITH a net-short smart-money cohort ──
+name: whalehunter-short
+group: whalehunter
+version: 3.0.0
+description: >
+  WHALEHUNTER SHORT — smart-money-vs-crowd cohort divergence (Runtime 3.0 port of v2.0).
+  Segments Hyperliquid traders into a SMART cohort (lifetime realized >= $1M) and a
+  CROWD cohort ($10k-$100k), aggregates each cohort's NET positioning per coin, and
+  emits a SHORT when the smart cohort is heavily net-short a coin AND adding to it daily
+  while the crowd is buying it (e.g. the crowd piling into a rally the winners are
+  selling). Derived universe (coins come from the cohort's positions). Rides a WIDE
+  conviction DSL. Pairs with the LONG sleeve on a separate wallet so conflicting
+  same-coin positions can coexist. ~1-day warmup before requireGrowing can pass.
+
+strategy:
+  wallet: "${WHALEHUNTER_SHORT_WALLET}"
+  slots: 6
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: whalehunter_short_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300
+    timeout_seconds: 180
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 12
+    inputs:
+      direction: "SHORT"
+      smartMinRealizedUsd: 1000000
+      crowdMinRealizedUsd: 10000
+      crowdMaxRealizedUsd: 100000
+      cohortFetchLimit: 1000
+      cohortMaxPages: 6
+      cohortSampleCap: 250
+      cohortRefreshHours: 24
+      cohortMinMembers: 5
+      biasThreshold: 0.5
+      crowdDivergenceMin: 0.2
+      requireGrowing: true
+      cohortMinScore: 4
+      marginPct: 12                        # PERCENT of withdrawable (0,100], not a fraction
+      maxMarginPct: 25                      # conviction-scale cap, percent of withdrawable
+      maxConvictionScale: 2.0
+      stdLeverage: 3
+      maxLeverage: 5
+      recentSignalTtlSeconds: 3600
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      signalKind: { type: string, required: false }
+      smartBias: { type: number, required: false }
+      crowdBias: { type: number, required: false }
+      smartGrowth: { type: number, required: false }
+      smartMembers: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: whalehunter_short_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [whalehunter_short_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: whalehunter_short_signals
+
+# EXIT — WIDE "ride the conviction" DSL (ported verbatim from v2). Time cuts OFF.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    phase1:
+      enabled: true
+      max_loss_pct: 30.0
+      retrace_threshold: 18
+      consecutive_breaches_required: 2
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 60, lock_hw_pct: 0 }
+        - { trigger_pct: 120, lock_hw_pct: 45 }
+        - { trigger_pct: 220, lock_hw_pct: 65 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 15
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: true
+    max_consecutive_losses: 5
+    cooldown_seconds: 3600
+    per_asset_cooldown_seconds: 21600
+    max_entries_per_day: 6
+    bypass_max_entries_per_day_on_profit: false

--- a/strategies/whalehunter/short/scanners/scan.py
+++ b/strategies/whalehunter/short/scanners/scan.py
@@ -22,6 +22,17 @@ CACHE_VERSION = 1     # bump if the cohort-BUILDING logic changes (busts a stale
 _DEFAULT_TTL = 3600   # 60m signal-dedup: don't re-fire a coin while a signal is in flight
 
 
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll back the
+    whole tick. Returns None on failure so the existing degrade paths apply (cohort
+    falls back to its daily cache; a failed state batch is skipped)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[whalehunter.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
 def _build_cohorts(ctx, cached, inputs, now):
     """Smart cohort (lifetime realized >= smartMinRealizedUsd) + crowd cohort
     (crowdMin..crowdMax) from the ALL_TIME realized-PnL ranking, PAGED by offset to
@@ -38,7 +49,7 @@ def _build_cohorts(ctx, cached, inputs, now):
     max_pages = int(inputs.get("cohortMaxPages", 6))
     smart, crowd, seen = [], [], set()
     for page in range(max_pages):
-        resp = ctx.senpi_mcp.call_tool("discovery_get_top_traders", {
+        resp = _read(ctx, "discovery_get_top_traders", {
             "time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
             "open_position_filter": False, "limit": page_size, "offset": page * page_size})
         if not resp:
@@ -78,7 +89,7 @@ def _fetch_states(ctx, addrs):
     """discovery_get_trader_state in batches of 50 -> flat list of trader-state dicts."""
     traders = []
     for i in range(0, len(addrs), 50):
-        resp = ctx.senpi_mcp.call_tool("discovery_get_trader_state",
+        resp = _read(ctx, "discovery_get_trader_state",
                                        {"trader_addresses": addrs[i:i + 50]})
         if not resp:
             continue

--- a/strategies/whalehunter/short/scanners/scan.py
+++ b/strategies/whalehunter/short/scanners/scan.py
@@ -1,0 +1,144 @@
+"""WHALEHUNTER — supervised scanner (Runtime 3.0 port of the v2 cohort engine).
+
+Direction-parametrized and shared verbatim by both sleeves: the `long` instance
+passes direction=LONG (positions with a net-long smart cohort); the `short` instance
+passes direction=SHORT. Each sleeve runs on its OWN wallet and its OWN ctx.state, so
+the cohort cache + daily ledger are per-sleeve (the v2 daemon shared them on disk;
+3.0 instances are isolated — signals are identical, only the cache is duplicated).
+
+Per tick: refresh the smart/crowd cohorts (cached daily in ctx.state), aggregate each
+cohort's net positioning (discovery_get_trader_state), update the daily ledger to get
+the 'adding daily' growth, score the divergences for THIS direction, and emit a
+conviction-scaled marginPct INTENT (the runtime sizes, owns slots/dedup, trails DSL).
+Read-only, single-pass. Derived universe — the coins come from the cohort's positions,
+not a fixed list. NOTE: ~1 UTC-day warmup before requireGrowing can pass."""
+
+import sys
+import time
+
+import scoring
+
+CACHE_VERSION = 1     # bump if the cohort-BUILDING logic changes (busts a stale cache)
+_DEFAULT_TTL = 3600   # 60m signal-dedup: don't re-fire a coin while a signal is in flight
+
+
+def _build_cohorts(ctx, cached, inputs, now):
+    """Smart cohort (lifetime realized >= smartMinRealizedUsd) + crowd cohort
+    (crowdMin..crowdMax) from the ALL_TIME realized-PnL ranking, PAGED by offset to
+    reach the deep crowd band, each capped. Cached daily in ctx.state."""
+    refresh_h = float(inputs.get("cohortRefreshHours", 24))
+    if (cached.get("smart") and cached.get("cache_version") == CACHE_VERSION
+            and (now - cached.get("refreshed_at", 0)) / 3600 < refresh_h):
+        return cached                                       # fresh cache — no fetch
+    smin = float(inputs.get("smartMinRealizedUsd", 1_000_000))
+    cmin = float(inputs.get("crowdMinRealizedUsd", 10_000))
+    cmax = float(inputs.get("crowdMaxRealizedUsd", 100_000))
+    cap = int(inputs.get("cohortSampleCap", 250))
+    page_size = int(inputs.get("cohortFetchLimit", 1000))
+    max_pages = int(inputs.get("cohortMaxPages", 6))
+    smart, crowd, seen = [], [], set()
+    for page in range(max_pages):
+        resp = ctx.senpi_mcp.call_tool("discovery_get_top_traders", {
+            "time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
+            "open_position_filter": False, "limit": page_size, "offset": page * page_size})
+        if not resp:
+            break
+        raw = resp.get("data", resp) if isinstance(resp, dict) else resp
+        if isinstance(raw, dict):
+            raw = raw.get("traders", raw.get("data", []))
+        if not isinstance(raw, list) or not raw:
+            break
+        page_top = None
+        for t in raw:
+            if not isinstance(t, dict):
+                continue
+            addr = (t.get("address") or t.get("trader_address") or "").lower()
+            if not addr or addr in seen:
+                continue
+            rp = scoring.realized(t)
+            page_top = rp if page_top is None else max(page_top, rp)
+            if rp >= smin:
+                if len(smart) < cap:
+                    smart.append(addr)
+                    seen.add(addr)
+            elif cmin <= rp <= cmax:
+                if len(crowd) < cap:
+                    crowd.append(addr)
+                    seen.add(addr)
+        if len(smart) >= cap and len(crowd) >= cap:
+            break
+        if page_top is not None and page_top < cmin:        # whole page below the crowd floor
+            break
+    if not smart and not crowd:
+        return cached                                       # failed refresh — keep the old cache
+    return {"refreshed_at": now, "cache_version": CACHE_VERSION, "smart": smart, "crowd": crowd}
+
+
+def _fetch_states(ctx, addrs):
+    """discovery_get_trader_state in batches of 50 -> flat list of trader-state dicts."""
+    traders = []
+    for i in range(0, len(addrs), 50):
+        resp = ctx.senpi_mcp.call_tool("discovery_get_trader_state",
+                                       {"trader_addresses": addrs[i:i + 50]})
+        if not resp:
+            continue
+        data = resp.get("data", resp) if isinstance(resp, dict) else resp
+        if isinstance(data, dict):
+            traders.extend(data.get("traders", []) or [])
+    return traders
+
+
+def scan(inputs, ctx):
+    direction = (inputs.get("direction", "LONG") or "LONG").upper()
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    std_lev = int(inputs.get("stdLeverage", 3))
+    max_lev = int(inputs.get("maxLeverage", 5))
+    min_members = int(inputs.get("cohortMinMembers", 5))
+    now = time.time()
+    today = time.strftime("%Y-%m-%d", time.gmtime(now))
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    ledger_days = (last.get("ledger") or {}).get("days", {})
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    cohorts = _build_cohorts(ctx, last.get("cohorts", {}), inputs, now)
+    smart, crowd = cohorts.get("smart", []), cohorts.get("crowd", [])
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"cohorts": cohorts, "ledger": {"days": ledger_days}, "recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[whalehunter.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    if len(smart) < min_members:                            # cohort too small — cache & bail
+        _persist()
+        return []
+
+    smart_per = scoring.aggregate_bias(_fetch_states(ctx, smart))
+    crowd_per = scoring.aggregate_bias(_fetch_states(ctx, crowd))
+    ledger_days, growth = scoring.update_ledger(ledger_days, smart_per, today)
+    strikes = scoring.cohort_signals(smart_per, crowd_per, growth, direction, inputs)
+
+    leverage = min(std_lev, max_lev)
+    out = []
+    for s in strikes:
+        cu = s["coin"].upper()
+        if recent.get(cu) is not None and (now - recent[cu]) < ttl:   # signal-dedup
+            continue
+        out.append({
+            "asset": s["coin"],
+            "direction": direction,
+            "marginPct": scoring.margin_pct_for(s["score"], inputs),  # conviction-scaled INTENT
+            "leverage": leverage,                                     # std, runtime clamps to venue max
+            "data": {
+                "score": s["score"], "direction": direction, "signalKind": "COHORT_DIVERGENCE",
+                "smartBias": s["smart_bias"], "crowdBias": s["crowd_bias"],
+                "smartGrowth": s["growth"], "smartMembers": s["n_confirm"], "reasons": s["reasons"],
+            },
+        })
+        recent[cu] = now
+
+    _persist()
+    return out

--- a/strategies/whalehunter/short/scanners/scoring.py
+++ b/strategies/whalehunter/short/scanners/scoring.py
@@ -1,0 +1,139 @@
+"""WHALEHUNTER — pure cohort-divergence math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 WhaleHunter v2.0 cohort engine
+(whalehunter-producer.py). Given trader-state dicts already fetched by scan.py,
+this bucketing/scoring is reproduced VERBATIM so a fidelity harness can diff it
+against the v2 producer on the same snapshot. Shared verbatim by both sleeves;
+the sleeve's direction is passed in (LONG for the long wallet, SHORT for the short).
+
+The thesis: segment Hyperliquid traders into a SMART cohort (high lifetime realized
+PnL) and a CROWD cohort, aggregate each cohort's NET positioning per coin, and fire
+when the smart cohort is net-directional past a threshold AND adding to it daily,
+with the crowd ideally on the other side. Position WITH the smart money, not the crowd."""
+
+
+def _f(x, *keys, default=0.0):
+    """Float from x. If keys given, x is a dict and we try each key in order."""
+    if keys:
+        if not isinstance(x, dict):
+            return default
+        for k in keys:
+            if x.get(k) is not None:
+                try:
+                    return float(x[k])
+                except (TypeError, ValueError):
+                    continue
+        return default
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return default
+
+
+def realized(t):
+    # LIFETIME realized PnL only — never fall back to total PnL (realized+unrealized),
+    # which is not monotonic with the realized-PnL sort and mis-buckets the cohorts.
+    return _f(t, "realizedProfitAndLoss", "realized_profit_and_loss",
+              "profit_and_loss_realized", "realizedPnl", "realized_pnl", default=0.0)
+
+
+def _signed_notional(p):
+    szi = _f(p, "szi", "size")
+    val = _f(p, "positionValue", "notional", "position_value")
+    if val <= 0:
+        val = abs(szi) * _f(p, "entryPx", "markPx", "entry_price")
+    return (1.0 if szi > 0 else (-1.0 if szi < 0 else 0.0)) * abs(val)
+
+
+def aggregate_bias(traders):
+    """Aggregate a cohort's NET positioning per coin from a list of trader-state dicts.
+    bias = net/gross in [-1, +1] (+1 all long, -1 all short), plus member counts."""
+    per = {}
+    for t in traders:
+        if not isinstance(t, dict):
+            continue
+        for p in (t.get("openPositions") or t.get("open_positions") or []):
+            if not isinstance(p, dict):
+                continue
+            coin = p.get("coin") or p.get("asset")
+            if not coin:
+                continue
+            sn = _signed_notional(p)
+            if sn == 0:
+                continue
+            d = per.setdefault(coin, {"net": 0.0, "gross": 0.0, "n_long": 0, "n_short": 0})
+            d["net"] += sn
+            d["gross"] += abs(sn)
+            d["n_long" if sn > 0 else "n_short"] += 1
+    for d in per.values():
+        d["bias"] = round(d["net"] / d["gross"], 3) if d["gross"] > 0 else 0.0
+    return per
+
+
+def update_ledger(days, smart_per, today, keep=10):
+    """Append today's smart-cohort net-per-coin to the daily ledger; return
+    (new_days, growth) where growth[coin] = today's net − the earliest snapshot's net
+    (the 'adding daily' signal). growth is {} on day 1 — `requireGrowing` then blocks
+    until ~day 2. `today` is passed in so this stays clock-free."""
+    days = dict(days)
+    days[today] = {c: round(d["net"], 2) for c, d in smart_per.items()}
+    for stale in sorted(days)[:-keep]:           # keep ~`keep` days
+        days.pop(stale, None)
+    prior = [d for d in sorted(days) if d < today]
+    growth = {}
+    if prior:
+        base = days[prior[0]]                     # earliest snapshot we still hold
+        for coin, net in days[today].items():
+            growth[coin] = round(net - float(base.get(coin, 0.0)), 2)
+    return days, growth
+
+
+def cohort_signals(smart_per, crowd_per, growth, direction, config):
+    """For THIS sleeve's direction: smart cohort net-directional past biasThreshold,
+    growing (adding), crowd ideally diverging. Returns scored strikes, best first."""
+    bt = float(config.get("biasThreshold", 0.50))
+    cdiv = float(config.get("crowdDivergenceMin", 0.2))
+    req_grow = bool(config.get("requireGrowing", True))
+    min_members = int(config.get("cohortMinMembers", 5))
+    floor = int(config.get("cohortMinScore", 4))
+    want_long = (direction == "LONG")
+    out = []
+    for coin, sd in smart_per.items():
+        if sd["n_long"] + sd["n_short"] < min_members:
+            continue
+        bias = sd["bias"]
+        if (want_long and bias < bt) or (not want_long and bias > -bt):
+            continue                              # smart cohort not net in our direction
+        g = growth.get(coin)
+        growing = (g is not None) and ((g > 0) if want_long else (g < 0))
+        if req_grow and not growing:
+            continue                              # not "adding" — skip
+        crowd_bias = crowd_per.get(coin, {}).get("bias", 0.0)
+        crowd_div = (crowd_bias <= -cdiv) if want_long else (crowd_bias >= cdiv)
+        score = 3 + (1 if abs(bias) >= 0.7 else 0) + (1 if growing else 0) + (1 if crowd_div else 0)
+        if score < floor:
+            continue
+        n_confirm = sd["n_long"] if want_long else sd["n_short"]
+        out.append({
+            "coin": coin, "direction": direction, "score": score,
+            "smart_bias": bias, "crowd_bias": round(crowd_bias, 3),
+            "growth": g, "n_confirm": n_confirm,
+            "reasons": [f"smart cohort net {bias:+.2f} on {coin}",
+                        f"{'ADDING' if growing else 'flat'} (dnet {g})",
+                        f"crowd {crowd_bias:+.2f}{' DIVERGES' if crowd_div else ''}",
+                        f"{n_confirm} smart whales {direction}"],
+        })
+    out.sort(key=lambda s: (s["score"], abs(s["smart_bias"])), reverse=True)
+    return out
+
+
+def margin_pct_for(score, config):
+    """Conviction-scaled marginPct INTENT as a PERCENT of withdrawable in (0,100]
+    (the runtime sizes (marginPct/100)*withdrawable). Scales +25% per point above
+    the floor, capped at maxMarginPct."""
+    base = float(config.get("marginPct", 12))
+    cap = float(config.get("maxMarginPct", 25))
+    smax = float(config.get("maxConvictionScale", 2.0))
+    floor = int(config.get("cohortMinScore", 4))
+    scale = min(smax, 1.0 + 0.25 * max(0, score - floor))
+    return round(min(base * scale, cap), 4)

--- a/strategies/whalehunter/strategy.yaml
+++ b/strategies/whalehunter/strategy.yaml
@@ -1,0 +1,44 @@
+# WhaleHunter — smart-money-vs-crowd cohort divergence. A two-instance PACKAGE: this
+# manifest + two self-contained runtime.yaml sleeves (long / short on SEPARATE wallets,
+# so conflicting same-coin positions can coexist) + shared scanners/. A faithful Runtime
+# 3.0 port of the v2 WhaleHunter v2.0 cohort engine. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: whalehunter
+version: "1.0.0"
+
+catalog:
+  name: "WhaleHunter — Smart-Money Cohort Divergence"
+  emoji: "🐋"
+  tagline: "Buckets Hyperliquid traders by lifetime realized PnL into a smart-money cohort and a crowd, then positions WITH the smartest money — and against the crowd — wherever the smart cohort is heavily net-directional and adding to it daily."
+  belief_plain: "Looks at where the most profitable traders on Hyperliquid are putting their money as a group, and copies that lean — going long what they're loading up on and short what they're dumping, especially when the average crowd is on the other side."
+  thesis: "You trust the aggregate of proven winners over any single guru or your own read. When the >$1M-realized crowd is piling into a coin day after day while the small accounts fade it, that divergence is the edge — so follow the smart cohort, not one whale, and hedge the book with a separate short sleeve."
+  group: smart-money
+  archetype: copy_trading
+  sub_style: cohort_divergence
+  asset_classes: [universe_crypto]
+  asset_scope: follows_traders
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 5
+  max_slots: 6
+  min_budget: 400
+  assets: []
+  tags: [smart-money, cohort, divergence, copy-trading, long-short, crowd-fade, hedged]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: long
+    runtime: long/runtime.yaml
+    wallet_env: WHALEHUNTER_LONG_WALLET
+    funding_share: 0.5
+  - name: short
+    runtime: short/runtime.yaml
+    wallet_env: WHALEHUNTER_SHORT_WALLET
+    funding_share: 0.5


### PR DESCRIPTION
Lands the three Runtime 3.0 strategy packages on strategy-v2 (the trunk) with the final marginPct contract (percent, per-signal for whalehunter conviction / uniform for asia-ai+kodiak; per-signal leverage for kodiak; no clearinghouse read). Built on #387's contract-correct versions; catalog regenerated for strategy-v2. Universe gate + deploy preflight come via #380; whalehunter's strategic fix (price-confirm / cohort-invalidation exit / DSL retune) is a separate follow-up.