### PR TITLE
docs(cli): document senpi agent read surface (risk/scanner/audit/events/status)

### DIFF
--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -72,8 +72,9 @@ openclaw senpi runtime list                     # id, source, status (running/st
 Beyond `runtime create/list/delete`, the CLI exposes the runtime's live state — `senpi dsl
 positions|inspect|closes` (the exit engine), `senpi action list|inspect|history|decisions` (the
 decision layer), `senpi risk` (am I allowed to trade, and why not), `senpi audit` (backend trade
-trail with AI reasoning), `senpi status`/`senpi state` (health), and `senpi guide …` (in-shell
-reference). Full surface with every option → `references/runtime-cli.md`.
+trail with AI reasoning), `senpi scanner` (per-scanner health, liveness, and barren detection),
+`senpi status`/`senpi state` (health), and `senpi guide …` (in-shell reference). Full surface with
+every option → `references/runtime-cli.md`.
 
 ## The reference set
 

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -73,8 +73,9 @@ Beyond `runtime create/list/delete`, the CLI exposes the runtime's live state �
 positions|inspect|closes` (the exit engine), `senpi action list|inspect|history|decisions` (the
 decision layer), `senpi risk` (am I allowed to trade, and why not), `senpi audit` (backend trade
 trail with AI reasoning), `senpi scanner` (per-scanner health, liveness, and barren detection),
-`senpi status`/`senpi state` (health), and `senpi guide …` (in-shell reference). Full surface with
-every option → `references/runtime-cli.md`.
+`senpi events`/`senpi explain <asset>` (the local domain-event log — the trade narrative, and one
+asset's stitched lifecycle), `senpi status`/`senpi state` (health), and `senpi guide …` (in-shell
+reference). Full surface with every option → `references/runtime-cli.md`.
 
 ## The reference set
 

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -71,8 +71,9 @@ openclaw senpi runtime list                     # id, source, status (running/st
 
 Beyond `runtime create/list/delete`, the CLI exposes the runtime's live state — `senpi dsl
 positions|inspect|closes` (the exit engine), `senpi action list|inspect|history|decisions` (the
-decision layer), `senpi status`/`senpi state` (health), and `senpi guide …` (in-shell reference).
-Full surface with every option → `references/runtime-cli.md`.
+decision layer), `senpi risk` (am I allowed to trade, and why not), `senpi audit` (backend trade
+trail with AI reasoning), `senpi status`/`senpi state` (health), and `senpi guide …` (in-shell
+reference). Full surface with every option → `references/runtime-cli.md`.
 
 ## The reference set
 

--- a/senpi-trading-runtime/references/runtime-cli.md
+++ b/senpi-trading-runtime/references/runtime-cli.md
@@ -62,6 +62,12 @@ openclaw senpi runtime delete --id iguana-tracker  # tear down
 |---|---|---|
 | `risk` | Whether the runtime is allowed to trade (eligibility OPEN/COOLDOWN/CLOSED), gate totals, and per-gate status/reason — plus the evaluation faults (`failureKind`, fallback applied) the `status` summary hides. | `-r, --runtime <id>` · `--json` |
 
+## `senpi scanner` — per-scanner supervisor health
+
+| Command | What it does | Options |
+|---|---|---|
+| `scanner` | Per-scanner health: schedule mode, run/error/consecutive-error counts, next-run time, in-flight, cumulative `signals` produced, and external-scanner `alive` (heartbeat from the intake liveness clock; `n/a` for interval scanners). Flags a `BARREN` scanner — alive and has run but produced no signals. Reuses the `state` RPC. | `-r, --runtime <id>` · `--json` |
+
 ## `senpi audit` — backend trade-audit trail
 
 | Command | What it does | Options |

--- a/senpi-trading-runtime/references/runtime-cli.md
+++ b/senpi-trading-runtime/references/runtime-cli.md
@@ -1,6 +1,6 @@
 # Runtime CLI — `openclaw senpi …`
 
-The complete command surface for interacting with the Senpi trading runtime (`@senpi-ai/runtime` 2.x).
+The complete command surface for interacting with the Senpi trading runtime (`@senpi-ai/runtime`).
 The plugin registers a `senpi` command group on the OpenClaw gateway, so every command is invoked as
 **`openclaw senpi <group> <subcommand>`**. Most read commands accept `--json` to print the raw
 gateway payload, and `-r/--runtime <id>` / `-a/--address <wallet>` to filter to one runtime.
@@ -55,6 +55,18 @@ openclaw senpi runtime delete --id iguana-tracker  # tear down
 | `action inspect <actionName>` | Show the persisted latest state for one action (name from the runtime.yaml). | `-r` (required when multiple runtimes run) · `-a` (defaults to the runtime wallet) · `--json` |
 | `action history [actionName]` | Rolling execution history with decision audit fields. Omit the name to merge all actions for the runtime. | `-r` · `-a` · `-l, --limit <n>` (default 50) · `--json` |
 | `action decisions [actionName]` | History rows where the decision engine ran (reasoning in JSON). | `-r` · `-a` · `-l` (default 50) · `--json` |
+
+## `senpi risk` — risk eligibility
+
+| Command | What it does | Options |
+|---|---|---|
+| `risk` | Whether the runtime is allowed to trade (eligibility OPEN/COOLDOWN/CLOSED), gate totals, and per-gate status/reason — plus the evaluation faults (`failureKind`, fallback applied) the `status` summary hides. | `-r, --runtime <id>` · `--json` |
+
+## `senpi audit` — backend trade-audit trail
+
+| Command | What it does | Options |
+|---|---|---|
+| `audit` | Backend trade trail: MCP tool calls with success, duration, and AI reasoning. Compact table by default. | `-r, --runtime <id>` (required) · `--tool <name>` · `--action-type <read\|create\|update\|delete>` · `--success <bool>` · `--since <iso>` · `--until <iso>` · `-l, --limit <n>` (default 50) · `--json` |
 
 ## `senpi status` / `senpi state` — runtime health
 

--- a/senpi-trading-runtime/references/runtime-cli.md
+++ b/senpi-trading-runtime/references/runtime-cli.md
@@ -88,8 +88,8 @@ The trade narrative (position/dsl/order/signal/runtime events) is persisted to a
 
 | Command | What it does | Options |
 |---|---|---|
-| `status` | Lightweight runtime health for running runtimes. | `-r, --runtime <id>` · `--json` |
-| `state` | Full runtime state for running runtimes. | `-r` · `--json` |
+| `status` | Lightweight runtime health digest for running runtimes: overall health, scanner summary (with a degraded-scanner count), DSL monitor liveness (running/stopped, tick-in-flight, next tick, last tick error), and — when risk is enabled — trade eligibility (OPEN/COOLDOWN/CLOSED) and the per-gate table. | `-r, --runtime <id>` · `--json` |
+| `state` | Full runtime state for running runtimes — the escape hatch when the `status` digest isn't enough. | `-r` · `--json` |
 
 ## `senpi skills` — manage Senpi skills
 

--- a/senpi-trading-runtime/references/runtime-cli.md
+++ b/senpi-trading-runtime/references/runtime-cli.md
@@ -75,6 +75,15 @@ openclaw senpi runtime delete --id iguana-tracker  # tear down
 |---|---|---|
 | `audit` | Backend trade trail: MCP tool calls with success, duration, and AI reasoning. Compact table by default. | `-r, --runtime <id>` (required) · `--tool <name>` · `--action-type <read\|create\|update\|delete>` · `--success <bool>` · `--since <iso>` · `--until <iso>` · `-l, --limit <n>` (default 50) · `--json` |
 
+## `senpi events` / `senpi explain` — local domain-event log
+
+The trade narrative (position/dsl/order/signal/runtime events) is persisted to a per-strategy on-disk ring, queryable locally without the collector. Every event is stored as its body + capped scalars; only the redacted free-text slot (LLM reasoning, venue errors) stays collector-only. Because signal processing is strictly serial, the time-ordered window already reflects causal order.
+
+| Command | What it does | Options |
+|---|---|---|
+| `events` | The domain-event log as a table (time, level, event, asset, narrative). | `-r, --runtime <id>` (required) · `-a, --address <addr>` · `--name <event>` · `--asset <symbol>` · `--level <debug\|info\|warn\|error>` · `--since <iso>` · `--until <iso>` · `-l, --limit <n>` (default 200) · `--json` |
+| `explain <asset>` | Stitch one asset's position lifecycle (opened → dsl transitions → close+reason) into a chronological narrative tagged by position id. | `-r, --runtime <id>` (required) · `-a, --address <addr>` · `-l, --limit <n>` (events to scan, default 500) · `--json` |
+
 ## `senpi status` / `senpi state` — runtime health
 
 | Command | What it does | Options |

--- a/senpi-trading-runtime/references/runtime-cli.md
+++ b/senpi-trading-runtime/references/runtime-cli.md
@@ -61,6 +61,7 @@ openclaw senpi runtime delete --id iguana-tracker  # tear down
 | Command | What it does | Options |
 |---|---|---|
 | `risk` | Whether the runtime is allowed to trade (eligibility OPEN/COOLDOWN/CLOSED), gate totals, and per-gate status/reason — plus the evaluation faults (`failureKind`, fallback applied) the `status` summary hides. | `-r, --runtime <id>` · `--json` |
+| `risk audit` | Per-wallet gate-check audit log — the decision *history* behind the live `risk` view, as a digest (time, source, `guardrail=result` with reasons). Renders "No risk audit." until the first gate check runs. | `-r, --runtime <id>` (required) · `-a, --address <addr>` · `--since <iso>` · `-l, --limit <n>` (default 100) · `--json` |
 
 ## `senpi scanner` — per-scanner supervisor health
 


### PR DESCRIPTION
## Intent

Document the new agent-facing read/observability CLI surface in the **canonical `senpi-trading-runtime` skill** (the runtime-contract skill the other lifecycle skills reference), so an operating agent loading the skill knows the commands exist and how to use them. Pairs with the `@senpi-ai/runtime` PR that ships the commands themselves.

## Features added

New command rows in `references/runtime-cli.md` (and the matching SKILL.md pointer), covering the read surface:
- `senpi risk` / `senpi risk audit` — eligibility + per-gate state, and the gate-check audit log.
- `senpi scanner` — per-scanner health, liveness, barren detection.
- `senpi audit` — backend trade-audit trail.
- `senpi events` / `senpi explain` — the local domain-event log.
- `senpi status` (enriched) — eligibility + scanner degraded-count + DSL monitor liveness folded into the digest; `senpi state` documented as the escape hatch.

## Scope / LOC / considerations

- **2 files, +36 / −5** — pure documentation, no behavioral content. Linear on top of `strategy-v2` (0 commits behind).
- The suite refactor (the four-skill split) already lives in the `strategy-v2` base; this PR adds **only** the CLI documentation deltas on top.
- Command descriptions mirror the runtime's `senpi guide` output and the actual flag surface, so the skill and the in-shell reference stay consistent.

## Focus review here

- `references/runtime-cli.md` — that the command/flag descriptions match the shipped CLI (especially the enriched `senpi status` entry).

## Questions for confirmation

1. The in-repo copy of this skill (in the `@senpi-ai/runtime` repo) is the older **monolith** and was deliberately left untouched — the monolith-vs-suite reconciliation is a separate, parked decision. Confirm that's the intended split (canonical skill here is source of truth; the runtime repo's unshipped copy is not kept in lockstep).
