### PR TITLE
docs(scan-contract): guard optional MCP reads so a read error can't kill the tick

### DIFF
--- a/senpi-trading-runtime/references/scan-contract.md
+++ b/senpi-trading-runtime/references/scan-contract.md
@@ -130,6 +130,29 @@ raises `PermissionError` (loud, fail-fast — never a silent `None`).
 The allowlist is scaffold-owned in source and **empty by default** — there is no env/operator/author
 knob. As an author: **assume you cannot mutate anything.** Produce signals; the runtime executes.
 
+### Reads can fail — guard the optional ones
+
+`call_tool` **propagates** read errors (auth, rate-limit, network, a 5xx). With the clean-tick rule
+above, an unguarded read that raises **kills the whole tick** — state rolls back and you emit nothing,
+*every* time it errors. So decide per read:
+
+- **Required reads** (no candles ⇒ no thesis): let a failure return `[]` for the tick — there's
+  nothing to score. Still wrap it so the failure is *logged*, not a bare traceback.
+- **Optional reads** (a secondary signal that only *adds* to the score — smart-money, cross-asset
+  flow, a discovery lookup): **wrap in `try/except` and degrade to neutral**. One flaky or
+  permissioned read must never silently zero the agent out — a capped score is recoverable; a dead
+  tick every cycle is not.
+
+```python
+def _smart_money(ctx, asset):
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {"limit": 100})
+    except Exception as exc:  # optional signal — never crash the whole tick on it
+        print(f"[scan] leaderboard read failed (smart-money -> neutral): {exc!r}", file=sys.stderr)
+        return None
+    # ... parse; on any shape problem also return None (degrade), don't raise
+```
+
 ---
 
 ## The signal dict (return value)


### PR DESCRIPTION
## What
Adds a **"Reads can fail — guard the optional ones"** subsection to `scan-contract.md` (the canonical `scan(inputs, ctx)` author contract), right after the read-only MCP boundary.

## Why
`ctx.senpi_mcp.call_tool` **propagates** read errors, and per the contract any exception in a tick rolls the whole tick back to `[]`. So an unguarded **optional** read (smart-money / discovery / cross-asset flow that only *adds* to the score) erroring makes a scanner **silently never emit** — not crash visibly, just quietly stop trading.

Generalized authoring guidance surfaced by the first live Runtime-3.0 scan deploy (Kodiak): an unguarded `leaderboard_get_markets` read would have zeroed the scanner on any auth/rate-limit gap. Documents the **required-vs-optional** split and the **try/except-and-degrade** pattern so every future scan author (and the curator skill) inherits it.

## Scope
Docs only. The Kodiak-specific debug instrumentation (per-cycle stderr log, per-tick history) is deliberately **not** generalized here — that's debug-only, per prior scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)