### PR TITLE
feat(strategy-ops): one-command run.sh for tester one-liners

### DIFF
--- a/senpi-strategy-ops/README.md
+++ b/senpi-strategy-ops/README.md
@@ -1,0 +1,42 @@
+# Running a Senpi strategy
+
+Strategies live under [`strategies/<id>/`](../strategies) on the **`strategy-v2`** branch. To deploy
+one, a tester gives an agent a one-line request:
+
+> **Run `asia-ai` on https://github.com/Senpi-ai/senpi-skills/tree/strategy-v2 using $500 budget**
+
+The agent maps that to a single command:
+
+```bash
+senpi-strategy-ops/scripts/run.sh asia-ai https://github.com/Senpi-ai/senpi-skills/tree/strategy-v2 500
+# equivalently, with a bare branch name:
+senpi-strategy-ops/scripts/run.sh asia-ai strategy-v2 500
+```
+
+`run.sh` parses the branch from the URL, checks it out, and runs the three deploy steps —
+`create` (fund the wallet(s)) → `runtime` (start) → `verify` (confirm scanning).
+
+## Host prerequisites
+- `@senpi/runtime` **≥ 3.0.6** installed.
+- `SENPI_AUTH_TOKEN` set (the deploying account's token).
+- A funding source holding at least the strategy's `min_budget` (see its `strategy.yaml`).
+
+## Manual / step-by-step
+```bash
+git checkout strategy-v2 && git pull
+cd senpi-strategy-ops/scripts
+python3 deploy.py create  <id> --budget <usd>   # create + fund wallet(s)
+python3 deploy.py runtime <id>                  # start the runtime
+python3 deploy.py verify  <id>                  # confirm scanners ticking
+```
+
+## What to expect
+Strategies are **selective** — they emit only when their setup appears, so a freshly deployed
+strategy often sits flat. **Flat is not broken.** `verify` confirms the scanners are *ticking*;
+positions follow when a qualifying signal fires. Multi-wallet strategies (e.g. `asia-ai`) split the
+budget across instances per each instance's `funding_share` in `strategy.yaml` (asia-ai: 65% main /
+35% hedge).
+
+## What's available
+[`strategies/catalog.json`](../strategies/catalog.json) is the index of deployable strategies and
+their metadata.

--- a/senpi-strategy-ops/scripts/run.sh
+++ b/senpi-strategy-ops/scripts/run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# run.sh — deploy a Senpi Runtime-3.0 strategy end-to-end from a one-line request.
+#
+#   ./run.sh <strategy-id> <branch-or-github-tree-url> <budget-usd>
+#
+# examples:
+#   ./run.sh asia-ai https://github.com/Senpi-ai/senpi-skills/tree/strategy-v2 500
+#   ./run.sh asia-ai strategy-v2 '$500'
+#
+# Maps the tester request  "Run <strategy> on <url> using $<budget>"  to:
+#   checkout the branch -> deploy.py create (fund) -> runtime (start) -> verify (ticking).
+#
+# Host prerequisites: @senpi/runtime >= 3.0.6, SENPI_AUTH_TOKEN set, and a funding
+# source holding at least the strategy's min_budget (see its strategy.yaml).
+set -euo pipefail
+
+usage() { echo "usage: run.sh <strategy-id> <branch-or-github-tree-url> <budget-usd>" >&2; exit 2; }
+ID="${1:-}"; SRC="${2:-}"; BUDGET="${3:-}"
+[ -n "$ID" ] && [ -n "$SRC" ] && [ -n "$BUDGET" ] || usage
+BUDGET="${BUDGET#\$}"                                  # tolerate a leading '$'
+
+# branch := the /tree/<branch> segment of a GitHub url; otherwise SRC is already a branch name
+BRANCH="$SRC"
+case "$SRC" in *"/tree/"*) BRANCH="${SRC#*/tree/}"; BRANCH="${BRANCH%%/*}";; esac
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"            # repo root (script: senpi-strategy-ops/scripts/run.sh)
+echo ">> strategy=$ID  branch=$BRANCH  budget=\$$BUDGET  repo=$ROOT"
+
+cd "$ROOT"
+git fetch origin "$BRANCH"
+git checkout "$BRANCH"
+git pull --ff-only origin "$BRANCH"
+
+[ -d "strategies/$ID" ] || { echo "error: strategies/$ID does not exist on branch '$BRANCH'" >&2; exit 1; }
+
+cd senpi-strategy-ops/scripts
+python3 deploy.py create  "$ID" --budget "$BUDGET"
+python3 deploy.py runtime "$ID"
+python3 deploy.py verify  "$ID" || true                # optional; first tick is gated by interval_seconds
+echo ">> done — $ID deployed from '$BRANCH' with \$$BUDGET. It scans on its own cadence; flat != broken."


### PR DESCRIPTION
Lets a tester say *"Run asia-ai on <strategy-v2 url> using $500 budget"* and have an agent execute it as one command: `run.sh <id> <branch-or-tree-url> <budget>` → checkout branch → deploy.py create/runtime/verify. Adds `senpi-strategy-ops/README.md` with the flow + host prereqs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)