### PR TITLE
fix(whalehunter): port the give-back DSL fix to the 3.0 package

### DIFF
--- a/strategies/whalehunter/long/runtime.yaml
+++ b/strategies/whalehunter/long/runtime.yaml
@@ -92,14 +92,16 @@ exit:
     phase1:
       enabled: true
       max_loss_pct: 30.0
-      retrace_threshold: 18
+      retrace_threshold: 10
       consecutive_breaches_required: 2
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 60, lock_hw_pct: 0 }
-        - { trigger_pct: 120, lock_hw_pct: 45 }
-        - { trigger_pct: 220, lock_hw_pct: 65 }
+        - { trigger_pct: 15, lock_hw_pct: 40 }   # first lock reachable (was 60/0 — never armed)
+        - { trigger_pct: 25, lock_hw_pct: 55 }
+        - { trigger_pct: 45, lock_hw_pct: 65 }
+        - { trigger_pct: 90, lock_hw_pct: 78 }
+        - { trigger_pct: 180, lock_hw_pct: 88 }
 
 risk:
   guard_rails:

--- a/strategies/whalehunter/short/runtime.yaml
+++ b/strategies/whalehunter/short/runtime.yaml
@@ -91,14 +91,16 @@ exit:
     phase1:
       enabled: true
       max_loss_pct: 30.0
-      retrace_threshold: 18
+      retrace_threshold: 10
       consecutive_breaches_required: 2
     phase2:
       enabled: true
       tiers:
-        - { trigger_pct: 60, lock_hw_pct: 0 }
-        - { trigger_pct: 120, lock_hw_pct: 45 }
-        - { trigger_pct: 220, lock_hw_pct: 65 }
+        - { trigger_pct: 15, lock_hw_pct: 40 }   # first lock reachable (was 60/0 — never armed)
+        - { trigger_pct: 25, lock_hw_pct: 55 }
+        - { trigger_pct: 45, lock_hw_pct: 65 }
+        - { trigger_pct: 90, lock_hw_pct: 78 }
+        - { trigger_pct: 180, lock_hw_pct: 88 }
 
 risk:
   guard_rails:


### PR DESCRIPTION
The 3.0 whalehunter port inherited the v2 *original* DSL — first protective lock at +120% ROE (never reached), retrace 18 — the give-back bug that wiped the live v2 whale's long sleeve. The v2 agent was fixed; the port wasn't. Lowers first lock to +15% with a reachable ladder and tightens retrace to 10 (both sleeves), matching the v2 fix. Last blocker to install whalehunter from strategy-v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)