### PR TITLE
Runtime 3.0 Wave 1 (iguana/koala/sailfish/tortoise) + data_retention_seconds fix

### DIFF
--- a/senpi-strategy-author/references/momentum-guarded-strategy.md
+++ b/senpi-strategy-author/references/momentum-guarded-strategy.md
@@ -46,7 +46,7 @@ strategy:
   enabled: true
 
 risk:
-  data_retention_hours: 72
+  data_retention_seconds: 259200    # 72h
   guard_rails:
     daily_loss_limit_pct: 4
     max_entries_per_day: 6

--- a/senpi-strategy-author/references/risk-gates.md
+++ b/senpi-strategy-author/references/risk-gates.md
@@ -32,7 +32,7 @@ Every signal that reaches `open-position` triggers a real-time gate check via MC
 
 ```yaml
 risk:
-  data_retention_hours: 72
+  data_retention_seconds: 259200    # 72h
   guard_rails:
     daily_loss_limit_pct: 15          # halt new entries after a -15% day
     drawdown_halt_pct: 25             # circuit breaker on a -25% PnL drawdown from peak

--- a/senpi-strategy-author/references/yaml-schema.md
+++ b/senpi-strategy-author/references/yaml-schema.md
@@ -72,7 +72,7 @@ Risk gates are checked before every trade entry. If any gate is not "OPEN", the 
 
 ```yaml
 risk:
-  data_retention_hours: 72    # How long to keep PnL history (max 168 = 7 days)
+  data_retention_seconds: 259200    # PnL history retention; integer 3600-604800 (1h-7d)
   guard_rails:
     daily_loss_limit_pct: 4           # Stop if daily loss exceeds 4%
     max_entries_per_day: 6            # Max 6 entries per UTC day

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -47,6 +47,56 @@
       "sort_order": 1
     },
     {
+      "id": "tortoise",
+      "name": "Tortoise — DCA Scheduler",
+      "emoji": "🐢",
+      "tagline": "A time-triggered dollar-cost-averaging scheduler on a small basket (BTC/ETH/SOL): no price prediction, no scoring, no timing — each tick it buys a fixed % of budget on whichever asset is most overdue past its DCA interval, always LONG, and lets a wide DSL ratchet ride the accumulation for days.",
+      "belief_plain": "Buys a fixed slice of your budget on a strict schedule — by default every 24 hours, one of BTC, ETH or SOL at a time. It predicts nothing; it just keeps accumulating on cadence and trails a wide stop so the position can run instead of getting churned. The most-overdue coin goes first.",
+      "version": "1.0.0",
+      "thesis": "Dollar-cost averaging is the single most accessible trade in crypto and needs zero prediction skill. Every other agent makes a directional call; Tortoise makes none — it buys on a clock. Cadence IS the signal: when an asset has gone longer than the interval since its last buy it is due, never-bought assets are always due, and the most-overdue wins. A very wide let-winners-run DSL (30d hard_timeout) lets the accumulated longs compound while Phase-2 locks bank gains gradually.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "multi-asset",
+        "dca",
+        "dollar-cost-averaging",
+        "time-trigger",
+        "always-long",
+        "onboarding",
+        "let-winners-run"
+      ],
+      "group": "dca",
+      "archetype": "structural_neutral",
+      "archetype_label": "Structural / Neutral",
+      "sub_style": "dca",
+      "sub_style_label": "Dollar-cost-averages on a schedule; predicts nothing.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "whitelist",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL"
+      ],
+      "direction": "long",
+      "risk_level": "conservative",
+      "tier": "onboarding",
+      "leverage_max": 3,
+      "time_horizon": "position",
+      "cadence_seconds": 1800,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
       "id": "magpie",
       "name": "Magpie — IPO / New-Listing Event Fund",
       "emoji": "🐦",
@@ -182,6 +232,56 @@
       "max_slots": 1,
       "branch": "strategy-v2",
       "sort_order": 2
+    },
+    {
+      "id": "sailfish",
+      "name": "Sailfish — Relative-Strength Rotator",
+      "emoji": "🐠",
+      "tagline": "Always hold the strongest major: ranks BTC/ETH/SOL/HYPE by ~2.7-day relative strength each tick and longs the leader, with a leader-RS floor and a margin-vs-runner-up gate to avoid whipsaw on tight races. Single-position; when the held leader exits via the DSL trail, the next tick re-evaluates and enters the new leader — that's the rotation.",
+      "belief_plain": "Trades only the big, liquid coins (BTC, ETH, SOL, HYPE). Each cycle it measures which one has been strongest over the last few days and buys that one — but only if it is clearly ahead of the next-best, not in a photo finish. It never sells on its own; a trailing stop manages the exit, and when one leader is done, the next-strongest takes its place.",
+      "version": "1.0.0",
+      "thesis": "Among the majors, leadership tends to persist — when one decisively outperforms the others it usually keeps doing so for days. Rotating into the strongest captures that persistence, while the margin-vs-runner-up gate keeps the agent out of tight, whipsaw-prone races where 'the leader' flips every tick. Rotation is realized through the DSL exit (not a mid-position close), so leadership changes only cost a fill when the old leader is genuinely finished — never on noise.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "hype",
+        "multi-asset",
+        "momentum",
+        "relative-strength",
+        "rotation",
+        "single-position",
+        "let-winners-run"
+      ],
+      "group": "momentum",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "relative_strength_rotation",
+      "sub_style_label": "Relative Strength Rotation",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "whitelist",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE"
+      ],
+      "direction": "long_only",
+      "risk_level": "balanced",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 3
     },
     {
       "id": "jaguar",
@@ -1064,6 +1164,99 @@
       "sort_order": 5
     },
     {
+      "id": "iguana",
+      "name": "Iguana — XYZ Macro Index Trend",
+      "emoji": "🦎",
+      "tagline": "A broad-index trend-follower on the XYZ equity indices (xyz:SP500 + xyz:XYZ100): each tick measures the 4-day move of each index, picks the stronger one past the trend floor, and rides it in that direction — no stock-picking, no commodities. The closest thing to an index fund, but 24/7 on Hyperliquid.",
+      "belief_plain": "Trades only the two broad stock-market indices (S&P 500 and the XYZ 100). Every few minutes it checks which index has the bigger 4-day move; if that move is large enough it goes that way (up = long, down = short), bets bigger when the move is strong and volume is rising, and then trails a stop. The simplest stock-market exposure on Hyperliquid — no individual stocks.",
+      "version": "1.0.0",
+      "thesis": "You want broad stock-market exposure on Hyperliquid without picking individual stocks, commodities, or pre-IPO names. Two liquid index instruments, one decision per tick: trend-follow whichever index has the clearer 4-day direction. The edge is in the slow index drift, so a wide DSL rides it for days and a 48h hard-timeout caps the XYZ weekend pricing-gap risk.",
+      "tags": [
+        "sp500",
+        "xyz100",
+        "xyz",
+        "indices",
+        "index-fund",
+        "trend-following",
+        "macro",
+        "onboarding",
+        "24-7",
+        "two-asset"
+      ],
+      "group": "single-asset",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "index_trend",
+      "sub_style_label": "Index Trend",
+      "asset_classes": [
+        "xyz_indices"
+      ],
+      "asset_scope": "whitelist",
+      "assets": [
+        "xyz:SP500",
+        "xyz:XYZ100"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "onboarding",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 6
+    },
+    {
+      "id": "koala",
+      "name": "Koala — Set-and-Forget Trail HODL",
+      "emoji": "🐨",
+      "tagline": "The simplest agent in the catalog: pick one asset (default BTC), fire LONG once on deploy, then hold with an ultra-wide DSL trail (max_loss 30%, retrace, 90-day timeout). No scoring, no scheduling — the choice to deploy Koala IS the bet.",
+      "belief_plain": "Trades only the one coin you pick (BTC by default). It buys once when you turn it on, then just holds — never adding, never trading around it — with a very wide safety stop that only releases on a catastrophic reversal or after three months. The whole idea is to own the coin and have a net under it.",
+      "version": "1.0.0",
+      "thesis": "Some users do not want a market-reading agent at all — they just want to own one asset and have a safety net. Koala is that answer in code: one asset, one entry, one stop. Fire-once by default (a true buy-and-forget), with an optional re-entry cycle for operators who want 'buy / DSL-exits / buy again' on a long cooldown.",
+      "tags": [
+        "btc",
+        "single-asset",
+        "hodl",
+        "buy-and-hold",
+        "set-and-forget",
+        "wide-dsl",
+        "onboarding",
+        "long-only"
+      ],
+      "group": "single-asset",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "buy_and_hold",
+      "sub_style_label": "Buy And Hold",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "BTC"
+      ],
+      "direction": "long_only",
+      "risk_level": "conservative",
+      "tier": "onboarding",
+      "leverage_max": 3,
+      "time_horizon": "position",
+      "cadence_seconds": 1800,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 7
+    },
+    {
       "id": "kodiak",
       "name": "Kodiak — SOL Alpha Hunter",
       "emoji": "🐻",
@@ -1104,7 +1297,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 6
+      "sort_order": 8
     },
     {
       "id": "polar",
@@ -1148,7 +1341,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 7
+      "sort_order": 9
     },
     {
       "id": "stag",
@@ -1196,7 +1389,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 8
+      "sort_order": 10
     },
     {
       "id": "wolverine",
@@ -1241,7 +1434,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 9
+      "sort_order": 11
     },
     {
       "id": "hydra",

--- a/strategies/cougar/long/runtime.yaml
+++ b/strategies/cougar/long/runtime.yaml
@@ -107,7 +107,7 @@ exit:
         - { trigger_pct: 100, lock_hw_pct: 88 }
 
 risk:
-  data_retention_hours: 168
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
   guard_rails:
     daily_loss_limit_pct: 12
     max_entries_per_day: 6                # basket rotation as equity leadership shifts

--- a/strategies/cougar/short/runtime.yaml
+++ b/strategies/cougar/short/runtime.yaml
@@ -107,7 +107,7 @@ exit:
         - { trigger_pct: 100, lock_hw_pct: 88 }
 
 risk:
-  data_retention_hours: 168
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
   guard_rails:
     daily_loss_limit_pct: 12
     max_entries_per_day: 6

--- a/strategies/iguana/main/runtime.yaml
+++ b/strategies/iguana/main/runtime.yaml
@@ -1,0 +1,131 @@
+# ── IGUANA · single instance — XYZ macro index trend (Runtime 3.0 port of v2 IGUANA producer v1.0.1) ──
+# Two-asset broad-index trend-follower on the Hyperliquid XYZ (HIP-3) DEX: xyz:SP500 +
+# xyz:XYZ100. One decision per tick — compute each index's 4-day move (% change over
+# trendLookbackBars 4h candles, default 24 = 4 days), pick the stronger past minTrendPct
+# (1.5%), and emit in that direction. Score = 3 (base) +2 strong-trend (>= strongTrendPct
+# 4%) +1 rising-volume (>15%); floor minScore 4. Flat margin (20%) + leverage clamp (<=5x).
+# DSL ported VERBATIM from v2 (balanced preset + 48h hard_timeout for XYZ weekend pricing-gap
+# risk + 8h weak_peak_cut). ONBOARDING TIER. xyz indices trade 24/7 incl weekends.
+name: iguana-main
+group: iguana
+version: 3.0.0
+description: >
+  IGUANA — two-asset XYZ macro index trend-follower (xyz:SP500 + xyz:XYZ100, HIP-3 DEX).
+  Each tick computes the 4-day trend strength (% change over the last trendLookbackBars
+  4h candles) for each index, picks the stronger move past minTrendPct, and emits in its
+  direction. Score 3 base + 2 if |trend| >= strongTrendPct + 1 if 4h volume rising > 15%;
+  floor minScore 4. Held-asset and recent-signal dedup. Flat sizing: marginPct 20% of
+  withdrawable, leverage clamped to maxLeverage (5x). DSL is the ONLY exit (balanced
+  Phase 1 + Phase 2 ratchet; first lock tier REACHABLE at +5% ROE; 48h hard_timeout for
+  XYZ weekend pricing-gap risk; 8h weak_peak_cut bails flat-but-tired positions before the
+  weekend gap). The simplest possible XYZ equity exposure — closest thing to an index fund,
+  but 24/7. Faithful port of the v2 thesis. ONBOARDING TIER.
+
+strategy:
+  wallet: "${IGUANA_WALLET}"
+  slots: 1                                # two assets, ONE decision/position per tick (emit-one)
+  default_leverage: 3                     # v2 DEFAULT_LEVERAGE; scan emits per-signal leverage (clamped <=5)
+  trading_risk: conservative
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: iguana_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 180                   # v2 tick_timeout; up to 3 MCP reads/tick (clearinghouse + 2 index candles)
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 100           # dedup map + per-tick scan-results history (~8h @300s)
+    inputs:
+      whitelist: ["xyz:SP500", "xyz:XYZ100"]   # v2 DEFAULT_WHITELIST — broad XYZ indices only
+      dex: "xyz"                           # HIP-3 DEX — prefix mandatory on xyz: tickers
+      trendLookbackBars: 24                # 24 x 4h bars = 4 days (v2 DEFAULT_TREND_LOOKBACK)
+      minTrendPct: 1.5                     # minimum |4-day move| to call it a trend (v2 DEFAULT_MIN_TREND_PCT)
+      strongTrendPct: 4.0                  # |move| >= this -> score +2 (v2 DEFAULT_STRONG_TREND_PCT)
+      minScore: 4                          # producer floor (v2 DEFAULT_MIN_SCORE)
+      marginPct: 20                        # PERCENT of withdrawable (0,100] — runtime sizes (marginPct/100)*withdrawable
+                                           #   v2 stored marginPct 0.20 as a FRACTION; ported to 20 PERCENT
+      leverage: 3                          # v2 DEFAULT_LEVERAGE (config leverage)
+      maxLeverage: 5                       # v2 MAX_LEVERAGE clamp
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      marginPct: { type: number, required: false }
+      direction: { type: string }
+      trendPct: { type: number, required: false }
+      volumeTrendPct: { type: number, required: false }
+      reasons: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: iguana_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every gate (v2 LLM gate was pass-through)
+    scanners: [iguana_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # ride the trend NOW — a resting maker order misses extension (v2)
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: iguana_main_signals
+
+# EXIT — DSL, ported VERBATIM from v2 iguana runtime.yaml (balanced + XYZ-tuned).
+# Index trends extend over days/weeks; the 48h hard_timeout accommodates the weekend
+# pricing-gap risk on XYZ, and weak_peak_cut bails from flat-but-tired positions before
+# the weekend gap. First Phase-2 lock tier fires at +5% ROE — REACHABLE (not >+40%), so
+# no flag. NOTE: unlike the single-asset Kodiak family (time cuts disabled), iguana KEEPS
+# its time cuts per the v2 thesis (XYZ weekend gap) — preserved verbatim, not redesigned.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880           # 48h — XYZ weekend pricing-gap risk
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,  lock_hw_pct: 0 }    # REACHABLE first lock (+5% ROE)
+        - { trigger_pct: 10, lock_hw_pct: 40 }
+        - { trigger_pct: 18, lock_hw_pct: 60 }
+        - { trigger_pct: 30, lock_hw_pct: 75 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
+
+risk:
+  data_retention_seconds: 345600       # 96h (was data_retention_hours: 96)
+  guard_rails:
+    daily_loss_limit_pct: 12               # v2 daily_loss_limit_pct
+    max_entries_per_day: 2                 # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 5400                 # v2 cooldown_minutes: 90
+    drawdown_halt_pct: 20                  # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false  # v2 drawdown_reset_on_day_rollover
+    per_asset_cooldown_seconds: 21600      # v2 per_asset_cooldown_minutes: 360

--- a/strategies/iguana/main/scanners/scan.py
+++ b/strategies/iguana/main/scanners/scan.py
@@ -1,0 +1,282 @@
+"""IGUANA — supervised scanner (Runtime 3.0 port of the v2 IGUANA index trend producer).
+
+Two-asset broad-index trend-follower on the Hyperliquid XYZ (HIP-3) DEX: xyz:SP500 +
+xyz:XYZ100. Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum();
+    read-sanity guard for the funding/$0 corrupt-clearinghouse glitch),
+  - skips held + recently-signaled assets BEFORE fetching their candles (v2 main()),
+  - computes each remaining index's 4-day trend strength (pure scoring.trend_strength),
+  - picks the single strongest move past minTrendPct (scoring.pick_strongest_trend),
+  - scores it via the pure scoring.build_thesis and emits ONE signal at/above minScore.
+
+Read-only + single-pass. Emits a flat `marginPct` intent (PERCENT) plus a clamped
+`leverage`; the runtime sizes the dollars, owns cooldowns / daily caps / drawdown halt,
+and trails the DSL exit. No daemon, no push_signal, no create_position. The v2 LLM gate
+was pass-through, so the entry action runs in rule mode — the scan already applied every
+filter.
+
+FIDELITY NOTES vs the v2 producer (iguana-producer.py v1.0.1):
+  - v2 sized via `marginUsd = account_value * marginPct(0.20)` and emitted a top-level
+    `marginUsd`. Runtime 3.0 sizes off a top-level `marginPct` PERCENT, so this port
+    converts the v2 marginPct FRACTION (0.20) to a PERCENT (20) and emits `marginPct`;
+    the runtime computes (marginPct/100)*withdrawable. The fraction was the only
+    sizing input, so behaviour is preserved.
+  - v2 used config marginPct directly (0.20). The runtime.yaml `marginPct` input is the
+    PERCENT (20). If an operator passes a value <= 1.0 (i.e. a fraction was left in by
+    mistake) this scan *100-normalizes it* so a 0.20 still becomes 20% — defensive,
+    matches dire/polar fraction->percent handling.
+  - v2 read positions via cfg.get_positions (clearinghouse, dual-DEX equity via max(),
+    read-sanity guard). Ported VERBATIM into _get_account here.
+  - v2 recent-signals JSON cache + 240s TTL (pruned at 4x TTL) -> ctx.state dedup map
+    with identical TTL semantics.
+  - v2 emitted exactly one signal (the strongest trend `best`). Preserved: scan() emits
+    <= 1 signal/tick (slots: 1).
+  - v2 LLM gate was pass-through (decision_mode llm, min_confidence 7 but honor-signal
+    prompt). Ported to decision_mode: rule — the scan owns the full gate stack.
+  - DSL time cuts (48h hard_timeout + 8h weak_peak_cut) are KEPT from v2 (XYZ weekend
+    pricing-gap thesis), NOT disabled. This DIFFERS from the single-asset Kodiak family
+    (time cuts off) — preserved verbatim per the port directive; FLAG for review if the
+    fleet decides index ports should also drop time cuts.
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 defaults (iguana-producer.py — preferred over config.json per the port directive)
+_DEFAULT_WHITELIST = ["xyz:SP500", "xyz:XYZ100"]   # v2 DEFAULT_WHITELIST
+_DEFAULT_TREND_LOOKBACK = 24          # 24 x 4h bars = 4 days (v2 DEFAULT_TREND_LOOKBACK)
+_DEFAULT_MIN_TREND_PCT = 1.5          # v2 DEFAULT_MIN_TREND_PCT
+_DEFAULT_MIN_SCORE = 4                # v2 DEFAULT_MIN_SCORE
+_DEFAULT_LEVERAGE = 3                 # v2 DEFAULT_LEVERAGE
+_DEFAULT_MAX_LEVERAGE = 5            # v2 MAX_LEVERAGE
+_DEFAULT_MARGIN_PCT = 20             # PERCENT (v2 config marginPct 0.20 fraction -> 20 percent)
+_DEFAULT_TTL = 240                   # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+
+
+def _dex_for(asset, inputs):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''. Honor an
+    explicit inputs.dex if set, else derive from the xyz: prefix."""
+    dex = inputs.get("dex")
+    if dex is not None:
+        return dex
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [coin,...]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED — a read error must never roll back the whole tick. Dual-DEX equity
+    collapse: account_value via max() across main/xyz (two views of ONE cross-margined
+    wallet — summing double-counts the shared free balance -> 2x sizing). assetPositions
+    are per-sub-DEX, enumerated across both sections. Ported VERBATIM from v2
+    cfg.get_positions, including the read-sanity guard (margin in use + empty positions
+    -> skip tick, returns (0.0, []))."""
+    if not ctx.wallet:
+        return 0.0, []
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — read error must not roll back the whole tick
+        print(f"[iguana.scan] clearinghouse read failed (degrade): {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else {}
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    held = []
+    account_value = 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) or {}
+        try:
+            # one wallet, two sub-DEX views -> count equity ONCE (max, not sum;
+            # summing double-counts the shared free balance -> 2x sizing).
+            account_value = max(account_value, float(ms.get("accountValue", 0)))
+        except (TypeError, ValueError):
+            pass
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            try:
+                szi = float(pos.get("szi", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+            if szi == 0:
+                continue
+            coin = pos.get("coin", "")
+            if coin:
+                held.append(coin)
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported VERBATIM from v2): a corrupt
+    # clearinghouse read can report margin/notional IN USE while returning an EMPTY
+    # positions list; sizing or the held-asset dedup off that re-enters held names
+    # (pyramiding) and mis-sizes. Skip the tick (return 0.0 account -> caller WAITs).
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        try:
+            _use = max(_use,
+                       float(_ms.get("totalMarginUsed", 0) or 0),
+                       abs(float(_ms.get("totalNtlPos", 0) or 0)))
+        except (TypeError, ValueError):
+            pass
+    if _use > 1.0 and not held:
+        return 0.0, []
+    return account_value, held
+
+
+def _fetch_4h_candles(ctx, asset, dex):
+    """READ-GUARD: fetch the asset's 4h candles. A read error must never roll back
+    the whole tick — returns [] (degrade — skip this asset rather than crash)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": asset,
+            "candle_intervals": ["4h"],
+            "include_funding": False,        # XYZ DEX — no funding needed
+            "include_order_book": False,
+            "dex": dex,
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[iguana.scan] market_get_asset_data({asset}) read failed: {exc!r}", file=sys.stderr)
+        return []
+    if not md:
+        return []
+    data = md.get("data", md) if isinstance(md, dict) else {}
+    if not isinstance(data, dict):
+        return []
+    candles = data.get("candles", {}) or {}
+    return candles.get("4h", []) or []
+
+
+def _load_recent(ctx):
+    """Read the dedup map from the last clean tick's state record."""
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = last.get("recent", {})
+    return dict(recent) if isinstance(recent, dict) else {}
+
+
+def _prune_recent(recent, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in recent.items() if v >= cutoff}
+
+
+def _was_recently_signaled(recent, coin, ttl, now):
+    last = recent.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    whitelist = inputs.get("whitelist", _DEFAULT_WHITELIST)
+    lookback = int(inputs.get("trendLookbackBars", _DEFAULT_TREND_LOOKBACK))
+    min_pct = float(inputs.get("minTrendPct", _DEFAULT_MIN_TREND_PCT))
+    min_score = int(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    leverage_cfg = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    max_leverage = int(inputs.get("maxLeverage", _DEFAULT_MAX_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+
+    # marginPct: PERCENT in (0,100]. Defensive fraction->percent (a stray 0.20 -> 20).
+    raw_margin = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    margin_pct = round(raw_margin * 100, 2) if 0 < raw_margin <= 1.0 else round(raw_margin, 2)
+
+    account_value, held_assets = _get_account(ctx)
+    held_set = {h.upper() for h in held_assets}
+
+    recent = _prune_recent(_load_recent(ctx), ttl, now)
+
+    out = []
+    result = None
+
+    if account_value <= 0:
+        result = {"ts": now, "emitted": False, "gate": "no_account_value",
+                  "held": held_assets, "note": "WAITING — no account value (or read-sanity skip)"}
+        print("[iguana.scan] WAITING — no account value (or clearinghouse read-sanity skip)",
+              file=sys.stderr)
+    else:
+        # ── per-asset 4-day trend strength; skip held + recently-signaled BEFORE the
+        #    per-asset MCP fetch (exactly as v2 main()) ──
+        candles_by_asset = {}
+        strength_by_asset = {}
+        for asset in whitelist:
+            if asset.upper() in held_set or _was_recently_signaled(recent, asset, ttl, now):
+                continue
+            dex = _dex_for(asset, inputs)
+            candles = _fetch_4h_candles(ctx, asset, dex)
+            if len(candles) <= lookback:
+                continue
+            closes = [scoring._f(c, "close", "c") for c in candles]
+            candles_by_asset[asset] = candles
+            strength_by_asset[asset] = scoring.trend_strength(closes, lookback)
+
+        picked = scoring.pick_strongest_trend(strength_by_asset, min_pct)
+        if picked is None:
+            strengths = {k: round(v, 2) if v is not None else None
+                         for k, v in strength_by_asset.items()}
+            result = {"ts": now, "emitted": False, "gate": "no_trend",
+                      "strength": strengths, "held": held_assets,
+                      "note": f"WAITING — neither index has a 4d move past {min_pct}%"}
+            print(f"[iguana.scan] WAITING — no index past {min_pct}% 4d move; "
+                  f"strength={strengths} held={held_assets}", file=sys.stderr)
+        else:
+            asset, strength = picked
+            th = scoring.build_thesis(asset, strength, candles_by_asset[asset], inputs)
+            if th is None or th["score"] < min_score:
+                sc = th["score"] if th else None
+                result = {"ts": now, "emitted": False, "gate": "score_low",
+                          "coin": asset, "score": sc, "held": held_assets,
+                          "note": f"WAITING — pick cleared trend gate but missed minScore {min_score}"}
+                print(f"[iguana.scan] WAITING — {asset} score={sc}/{min_score} "
+                      f"(cleared trend, missed minScore)", file=sys.stderr)
+            else:
+                leverage = min(leverage_cfg, max_leverage)
+                if leverage <= 0 or margin_pct <= 0:
+                    result = {"ts": now, "emitted": False, "gate": "sizing_unresolved",
+                              "coin": asset, "score": th["score"], "held": held_assets,
+                              "note": f"sizing unresolved lev={leverage} marginPct={margin_pct}"}
+                    print(f"[iguana.scan] HOLD — {asset} sizing unresolved "
+                          f"lev={leverage} marginPct={margin_pct}", file=sys.stderr)
+                else:
+                    recent[asset.upper()] = now
+                    result = {"ts": now, "emitted": True, "gate": "pass",
+                              "coin": asset, "direction": th["direction"],
+                              "score": th["score"], "leverage": leverage,
+                              "marginPct": margin_pct, "trendPct": th["trend_pct"],
+                              "held": held_assets, "reasons": th["reasons"]}
+                    print(f"[iguana.scan] EMIT {asset} {th['direction']} score={th['score']} "
+                          f"{leverage}x marginPct={margin_pct}% 4d={th['trend_pct']:+.1f}% "
+                          f"| {th['reasons']}", file=sys.stderr)
+                    out = [{
+                        "asset": asset,
+                        "direction": th["direction"],
+                        "marginPct": margin_pct,      # PERCENT in (0,100] — runtime sizes (marginPct/100)*withdrawable
+                        "leverage": leverage,         # v2 leverage clamped to maxLeverage
+                        "data": {
+                            "score": float(th["score"]),
+                            "leverage": float(leverage),
+                            "marginPct": margin_pct,
+                            "direction": th["direction"],
+                            "trendPct": th.get("trend_pct") or 0.0,
+                            "volumeTrendPct": th.get("volume_trend_pct") or 0.0,
+                            "reasons": th["reasons"],
+                            "heldAssets": held_assets,
+                        },
+                    }]
+
+    # ── persist dedup map + this tick's result EVERY tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"recent": recent, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[iguana.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/iguana/main/scanners/scoring.py
+++ b/strategies/iguana/main/scanners/scoring.py
@@ -1,0 +1,134 @@
+"""IGUANA — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 IGUANA producer's pure index-trend logic
+(iguana-producer.py v1.0.1 / SKILL.md v1.0.0). IGUANA is the two-asset broad-index
+trend-follower on the Hyperliquid XYZ (HIP-3) DEX: xyz:SP500 + xyz:XYZ100. One
+decision per tick — compute each index's 4-day trend strength, pick the stronger
+move past the floor, and trade in its direction.
+
+The math/indexing is reproduced VERBATIM from iguana-producer.py so a fidelity
+harness can diff this against the v2 producer on the same market snapshot. The four
+pure functions (trend_strength, trend_direction, pick_strongest_trend, volume_trend)
+were already unit-tested in the v2 tests/test_signal.py.
+
+Single-asset-flavoured but two-instrument: stays pure, unit-testable on plain candle
+lists. No clock, no MCP — the caller (scan.py) owns all I/O.
+
+INDEX / 24-7-XYZ TUNING PRESERVED (do NOT redesign):
+  - Trend strength = % change of the latest close vs the close `lookback` bars ago
+    (NOT a structure / higher-low count). Deliberately a slow, broad index-drift read.
+  - Volume trend = recent-half vs earlier-half mean over the last 6 4h candles.
+  - xyz:SP500 / xyz:XYZ100 trade 24/7 incl weekends — no weekday/session gating.
+"""
+
+
+# ── value coercion (v2: _f, with primary/alt key fallback) ──
+
+def _f(c, primary, alt=None, default=0.0):
+    """Coerce c[primary] (or c[alt]) to float, default on missing/bad.
+
+    Ported VERBATIM from iguana-producer._f. `c` is a candle dict; supports the
+    dual-shape {close|c} / {volume|v} keys the v2 producer read."""
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ── pure index-trend logic (ported VERBATIM from iguana-producer.py) ──
+
+def trend_strength(closes, lookback):
+    """% change of the latest close vs the close `lookback` bars ago.
+    None if insufficient data or the reference price is non-positive."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def trend_direction(strength, min_pct):
+    """Direction implied by trend strength. None if magnitude below threshold."""
+    if strength is None or abs(strength) < min_pct:
+        return None
+    return "LONG" if strength > 0 else "SHORT"
+
+
+def pick_strongest_trend(per_asset_strength, min_pct):
+    """Among {asset: strength}, return the asset with the highest |strength|
+    above min_pct. Returns (asset, strength) or None."""
+    best, best_mag = None, -1.0
+    for asset, strength in per_asset_strength.items():
+        if strength is None:
+            continue
+        mag = abs(strength)
+        if mag < min_pct:
+            continue
+        if mag > best_mag:
+            best_mag, best = mag, (asset, strength)
+    return best
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-half vs earlier-half mean 4h volume over the last `lookback` candles,
+    as a % change. 0.0 on insufficient data or non-positive earlier mean.
+
+    Ported VERBATIM from iguana-producer.volume_trend."""
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ── thesis builder (ported VERBATIM from iguana-producer.build_thesis) ──
+
+def build_thesis(asset, strength, candles, config):
+    """Build the per-asset trend thesis. Returns a thesis dict or None if the
+    move does not clear the trend floor.
+
+    Score: 3 (base — trend strength above min) + 2 if |strength| >= strongTrendPct
+    + 1 if 4h volume_trend > 15%. Max attainable score = 6.
+
+    Args (all already fetched by the caller — this stays pure):
+      asset    : ticker string (e.g. "xyz:SP500")
+      strength : float | None — the 4-day trend strength (from trend_strength)
+      candles  : the asset's 4h candle list (for the volume factor)
+      config   : the inputs dict (thresholds)"""
+    min_pct = float(config.get("minTrendPct", 1.5))
+    strong_pct = float(config.get("strongTrendPct", 4.0))
+
+    direction = trend_direction(strength, min_pct)
+    if direction is None:
+        return None
+
+    vol = volume_trend(candles)
+
+    score = 3   # base — trend strength above min
+    reasons = [f"{asset}_4d_trend_{strength:+.1f}%"]
+    if abs(strength) >= strong_pct:
+        score += 2
+        reasons.append(f"trend_strong_{strength:+.1f}%")
+    if vol > 15:
+        score += 1
+        reasons.append(f"vol_rising_{vol:+.0f}%")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_pct": round(strength, 2),
+        "volume_trend_pct": round(vol, 2),
+    }

--- a/strategies/iguana/strategy.yaml
+++ b/strategies/iguana/strategy.yaml
@@ -1,0 +1,43 @@
+# Iguana — XYZ macro index trend. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2 Iguana
+# (producer v1.0.1 / SKILL.md v1.0.0): a two-asset broad-index trend-follower on the
+# XYZ indices (xyz:SP500 + xyz:XYZ100, Hyperliquid HIP-3 DEX), one decision per tick —
+# picks the stronger 4-day move past the trend floor and rides it. ONBOARDING TIER.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: iguana
+
+version: "1.0.0"
+
+catalog:
+  name: "Iguana — XYZ Macro Index Trend"
+  emoji: "🦎"
+  tagline: "A broad-index trend-follower on the XYZ equity indices (xyz:SP500 + xyz:XYZ100): each tick measures the 4-day move of each index, picks the stronger one past the trend floor, and rides it in that direction — no stock-picking, no commodities. The closest thing to an index fund, but 24/7 on Hyperliquid."
+  belief_plain: "Trades only the two broad stock-market indices (S&P 500 and the XYZ 100). Every few minutes it checks which index has the bigger 4-day move; if that move is large enough it goes that way (up = long, down = short), bets bigger when the move is strong and volume is rising, and then trails a stop. The simplest stock-market exposure on Hyperliquid — no individual stocks."
+  thesis: "You want broad stock-market exposure on Hyperliquid without picking individual stocks, commodities, or pre-IPO names. Two liquid index instruments, one decision per tick: trend-follow whichever index has the clearer 4-day direction. The edge is in the slow index drift, so a wide DSL rides it for days and a 48h hard-timeout caps the XYZ weekend pricing-gap risk."
+  group: single-asset
+  archetype: trend_following
+  sub_style: index_trend
+  asset_classes: [xyz_indices]
+  asset_scope: whitelist
+  direction: long_short
+  risk_level: moderate
+  tier: onboarding
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 100
+  assets: ["xyz:SP500", "xyz:XYZ100"]
+  tags: [sp500, xyz100, xyz, indices, index-fund, trend-following, macro, onboarding, 24-7, two-asset]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: IGUANA_WALLET
+    funding_share: 1.0

--- a/strategies/jaguar/main/runtime.yaml
+++ b/strategies/jaguar/main/runtime.yaml
@@ -113,7 +113,7 @@ exit:
 
 # RISK — guard_rails ported verbatim from v2 v3.7 (cap losers, ride winners).
 risk:
-  data_retention_hours: 72
+  data_retention_seconds: 259200       # 72h (was data_retention_hours: 72)
   guard_rails:
     daily_loss_limit_pct: 10
     max_entries_per_day: 3                   # hard cap when day is RED

--- a/strategies/koala/main/runtime.yaml
+++ b/strategies/koala/main/runtime.yaml
@@ -1,0 +1,140 @@
+# ── KOALA · single instance — Set-and-Forget Trail HODL (Runtime 3.0 port of v2 KOALA) ──
+# The simplest agent in the catalog. ONE asset (default BTC). Fire LONG ONCE on deploy,
+# then hold with an ultra-wide DSL trail. No scoring, no multi-timeframe analysis, no SM
+# gates — the only decision the operator makes is "which asset?". Fire-once mode by default
+# (lifetime one-shot); operators who want a cycling deploy set fireOnceMode=false with a
+# reEntryCooldownHours. Producer NEVER closes — the wide DSL is the entire exit logic.
+# Faithful port of the v2 Koala (SKILL.md v1.0.0 / producer VERSION 1.0.1). The state-machine
+# entry logic (should_enter / record_entry / record_exit) is reproduced VERBATIM in
+# scanners/scoring.py; scan.py does the MCP reads + ctx.state. DSL preserved verbatim from
+# the v2 runtime.yaml.
+name: koala-main
+group: koala
+version: 3.0.0
+description: >
+  KOALA — single-asset Set-and-Forget Trail HODL. Pick one asset (default BTC), fire
+  LONG ONCE on deploy, then hold with an ultra-wide DSL trail. No scoring, no
+  multi-timeframe analysis, no smart-money gates — the choice to deploy Koala IS the bet.
+  Fire-once mode by default (lifetime one-shot): even after the DSL eventually exits, the
+  scanner stays silent forever. Operators wanting a cycle set fireOnceMode=false with a
+  reEntryCooldownHours (default 168h / 7d) — Koala then re-enters once the cooldown has
+  elapsed since the last detected exit. Fixed sizing: marginPct 50% of withdrawable,
+  leverage 2x (clamped to MAX_LEVERAGE 3x — Koala is HODL, not gambling). The widest DSL
+  in the catalog is the ONLY exit (max_loss 30%, 90d hard_timeout) — it deliberately does
+  NOT cut on ordinary corrections. Faithful port of the v2 Koala thesis (state machine +
+  DSL verbatim).
+
+strategy:
+  wallet: "${KOALA_WALLET}"
+  slots: 1                                # single asset, single position
+  margin_pct: 50                          # baseline %; scan emits the per-signal marginPct (50% default)
+  default_leverage: 2                     # fallback; scan emits 2x (clamped to MAX_LEVERAGE 3x)
+  trading_risk: conservative
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: koala_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 1800                 # v2 producer cadence (30 min — Koala has no urgency)
+    timeout_seconds: 120                   # v2 tick_timeout=120; 1 MCP read/tick (clearinghouse)
+    default_signal_validity_seconds: 3600  # 2x tick; one-shot entry, state owns re-fire suppression
+    state_history_max_count: 100           # koala state machine + dedup map + per-tick scan-results history
+    inputs:
+      asset: "BTC"                         # v2 config default (validated live on HL main DEX 2026-06-29)
+      dex: ""                              # main DEX; an xyz:NAME asset would set dex="xyz"
+      fireOnceMode: true                   # v2 DEFAULT_FIRE_ONCE — lifetime one-shot (recommended posture)
+      reEntryCooldownHours: 168            # v2 DEFAULT_RE_ENTRY_COOLDOWN_HOURS (7d) — only used if fireOnceMode=false
+      marginPct: 50                        # PERCENT of withdrawable (0,100] — v2 DEFAULT_MARGIN_PCT 0.50 (fraction) -> 50
+      leverage: 2                          # v2 DEFAULT_LEVERAGE; clamped to maxLeverage in scan.py
+      maxLeverage: 3                       # v2 MAX_LEVERAGE (hardcoded — Koala is HODL, not gambling)
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+      firstEntryAt: { type: number, required: false }
+      totalEntries: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: koala_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied the state-machine decision (v2 LLM gate was pass-through)
+    scanners: [koala_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false   # v2: Koala is patient — let it rest as maker, save fees
+        execution_timeout_seconds: 60      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: koala_main_signals
+
+# ── EXIT (DSL — preserved VERBATIM from the v2 Koala runtime.yaml) ─────────────
+# The widest DSL in any Senpi agent. max_loss 30% (accepts a 30% margin drawdown
+# before the catastrophic stop), retrace_threshold 10 on Phase 1 (trail into profit),
+# 90d hard_timeout (3 months — set-and-forget means a long horizon), NO weak_peak_cut,
+# NO dead_weight_cut, super-late Phase 2 ladder. Phase 1 needs 3 consecutive breaches
+# before the catastrophic stop trips. Built to NOT cut on ordinary corrections — only
+# releases on catastrophic reversal or 3-month timeout. The Phase 2 FIRST lock is
+# REACHABLE (+12% ROE / lock 35% — the v2 runtime.yaml inline comment notes this was
+# corrected from an unreachable +20/0). interval_seconds 60 (v2).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: false       # v2: patient maker exit, save fees
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 129600          # 90d — set-and-forget
+    weak_peak_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 30.0                    # 30% margin loss tolerated
+      retrace_threshold: 10                 # v2: trail into profit (was 25)
+      consecutive_breaches_required: 3      # 3 confirmations before the catastrophic stop trips
+    phase2:
+      enabled: true
+      tiers:                                # v2 ladder — first lock REACHABLE (+12% ROE)
+        - { trigger_pct: 12,  lock_hw_pct: 35 }
+        - { trigger_pct: 25,  lock_hw_pct: 55 }
+        - { trigger_pct: 50,  lock_hw_pct: 68 }
+        - { trigger_pct: 120, lock_hw_pct: 80 }
+        - { trigger_pct: 300, lock_hw_pct: 88 }   # still rides a big runner
+
+# ── RISK guard rails (from the v2 Koala runtime.yaml; minutes -> seconds) ──
+risk:
+  data_retention_seconds: 604800       # clamped to 3.0 max (7d); v2 intent 90d exceeds cap
+  guard_rails:
+    daily_loss_limit_pct: 20               # v2 — very permissive (Koala is meant to ride drawdowns)
+    max_entries_per_day: 1                  # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 2              # v2 max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 cooldown_minutes: 60
+    drawdown_halt_pct: 35                  # v2 drawdown_halt_pct (tolerates a 35% margin drawdown)
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 3600       # v2 per_asset_cooldown_minutes: 60
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/koala/main/scanners/scan.py
+++ b/strategies/koala/main/scanners/scan.py
@@ -1,0 +1,246 @@
+"""KOALA — supervised scanner (Runtime 3.0 port of the v2 KOALA Set-and-Forget HODL).
+
+The simplest scanner in the catalog. Single asset (default BTC). There is NO
+scoring, NO multi-timeframe analysis, NO smart-money gate — the entire decision
+is a tiny state machine over a persisted entry-history record (the pure
+`scoring.should_enter` / `record_entry` / `record_exit`). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - detects a closed position (had a first_entry but the asset is no longer held
+    and no exit was recorded -> record the exit),
+  - if the asset is held -> HOLD (the DSL owns exits),
+  - else asks the state machine `should_enter` (fire-once vs re-entry-cooldown),
+  - emits ONE LONG signal at fixed margin/leverage when eligible, then records
+    the entry into ctx.state so the next tick stays silent.
+
+Read-only + single-pass. Emits a `marginPct` intent (PERCENT, fixed) plus a
+fixed `leverage` (clamped to MAX_LEVERAGE); the runtime sizes the dollars, owns
+cooldowns/risk gates, and trails the DSL exit. No daemon, no push_signal, no
+create_position.
+
+FIDELITY NOTES vs the v2 producer (koala-producer.py producer VERSION 1.0.1,
+file-header label "v1.0.0"; the header and the VERSION constant disagree — the
+VERSION constant 1.0.1 is cited as authoritative):
+  - The v2 producer persisted TWO files: koala-state.json (first_entry_at /
+    last_entry_at / last_exit_at / total_entries) AND recent-signals.json
+    (race-window dedup). Both collapse into ctx.state here: each tick appends
+    {"signaled":..., "result":..., "koala":<state>}; the next tick reads the
+    latest record back. Semantics are identical (TTL, 4x-TTL prune, fire-once
+    one-shot, re-entry cooldown, exit detection).
+  - v2 DEFAULT_MARGIN_PCT was 0.50 (a FRACTION) * account_value -> marginUsd.
+    This port carries marginPct=50 (a PERCENT) in runtime.yaml and emits a
+    top-level `marginPct`; the runtime sizes (marginPct/100)*withdrawable. A
+    defensive guard converts a value <= 1 (an operator who pasted the v2
+    fraction) to a PERCENT (*100) and logs it. FLAGGED below.
+  - v2 leverage default 2, hard-capped at MAX_LEVERAGE=3 (Koala is HODL, not
+    gambling). Preserved verbatim (min(leverage, maxLeverage)).
+  - v2 emitted exactly one signal (or none). Preserved: scan() emits <= 1.
+  - v2 `push_signal` skipped if the asset was already in held_assets; here the
+    held check happens earlier (held -> HOLD branch) AND the signal carries
+    heldAssets for the rule action's belt-and-braces.
+  - The v2 LLM entry gate was an explicit pass-through ("honor the signal",
+    always confidence 7). The Runtime 3.0 action is decision_mode: rule — the
+    scan IS the decision, so the pass-through LLM step is correctly dropped.
+  - v2 score in data{} was a fixed 5 to satisfy the schema (Koala has no
+    scoring). Preserved verbatim (data.score = 5).
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 defaults (koala-producer.py / koala-config.json / koala_config.py)
+_DEFAULT_ASSET = "BTC"
+_DEFAULT_FIRE_ONCE = True
+_DEFAULT_RE_ENTRY_COOLDOWN_HOURS = 168.0   # v2 DEFAULT_RE_ENTRY_COOLDOWN_HOURS (7d)
+_DEFAULT_MARGIN_PCT = 50.0                 # PERCENT (v2 fraction 0.50 -> 50)
+_DEFAULT_LEVERAGE = 2                      # v2 DEFAULT_LEVERAGE
+_DEFAULT_MAX_LEVERAGE = 3                  # v2 MAX_LEVERAGE (hardcoded)
+_DEFAULT_TTL = 240                         # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+_FIXED_SCORE = 5                           # v2 data.score — fixed (Koala has no scoring)
+
+
+def _dex_for(asset, inputs):
+    dex = inputs.get("dex")
+    if dex is not None:
+        return dex
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [held_coin_strings]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED — a read error must never roll back the whole tick (degrade to
+    (0.0, []) so the runtime's own slot/cooldown gates stay the backstop).
+    Dual-DEX equity collapse: account_value via max() across main/xyz (two views
+    of ONE cross-margined wallet — summing double-counts the shared free balance
+    -> 2x sizing). Ported verbatim from v2 cfg.get_positions, including the
+    read-sanity guard (margin in use + empty positions -> skip tick)."""
+    if not ctx.wallet:
+        return 0.0, []
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — read error must not roll back the tick
+        print(f"[koala.scan] clearinghouse read failed (degrade): {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    held, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) or {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            coin = pos.get("coin", "")
+            if coin:
+                held.append(coin)
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)), abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not held:
+        print("[koala.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, held
+
+
+# ── ctx.state: koala state machine + recent-signal dedup ──
+
+def _load_state(ctx):
+    """Latest persisted record -> (koala_state, signaled_map)."""
+    if ctx.state is None or len(ctx.state) == 0:
+        return scoring.empty_state(), {}
+    last = ctx.state.last() or {}
+    koala = last.get("koala")
+    koala = dict(koala) if isinstance(koala, dict) else scoring.empty_state()
+    sig = last.get("signaled", {})
+    signaled = dict(sig) if isinstance(sig, dict) else {}
+    return koala, signaled
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    asset = str(inputs.get("asset", _DEFAULT_ASSET) or _DEFAULT_ASSET).upper()
+    fire_once = bool(inputs.get("fireOnceMode", _DEFAULT_FIRE_ONCE))
+    cooldown_hours = float(inputs.get("reEntryCooldownHours", _DEFAULT_RE_ENTRY_COOLDOWN_HOURS))
+    leverage = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    max_leverage = int(inputs.get("maxLeverage", _DEFAULT_MAX_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+
+    # marginPct is a PERCENT in (0,100]. FLAGGED: defensively convert a value <= 1
+    # (an operator who pasted the v2 FRACTION 0.50) into a PERCENT so it never
+    # silently sizes ~100x small (resolve-margin sizes (marginPct/100)*withdrawable).
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        print(f"[koala.scan] marginPct={margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
+
+    # leverage clamp: min(leverage, maxLeverage) — v2 MAX_LEVERAGE cap (HODL, not gambling)
+    leverage = min(leverage, max_leverage)
+
+    koala, signaled = _load_state(ctx)
+    signaled = scoring.prune_signaled(signaled, ttl, now)
+
+    account_value, held = _get_account(ctx)
+    held_set = {h.upper() for h in held}
+
+    out = []
+    result = None
+
+    if account_value <= 0:
+        # No account value (or read degraded / read-sanity guard tripped) -> hold.
+        result = {"ts": now, "asset": asset, "emitted": False, "note": "no_account_value"}
+        print(f"[koala.scan] {asset} WAITING — no account value (read degraded or zero equity)",
+              file=sys.stderr)
+    else:
+        # Detect a closed position: had a first_entry but the asset is no longer
+        # held and no exit was recorded -> log the exit (verbatim v2 main()).
+        if koala.get("first_entry_at") and asset not in held_set and koala.get("last_exit_at") is None:
+            koala = scoring.record_exit(koala, now)
+
+        if asset in held_set:
+            # Currently held -> do nothing (DSL is in charge).
+            result = {"ts": now, "asset": asset, "emitted": False, "gate": "holding",
+                      "first_entry_at": koala.get("first_entry_at"),
+                      "total_entries": koala.get("total_entries", 0)}
+            print(f"[koala.scan] {asset} HOLDING — DSL owns exits "
+                  f"(entries={koala.get('total_entries', 0)})", file=sys.stderr)
+        elif not scoring.should_enter(koala, fire_once, cooldown_hours, now):
+            # Not eligible — surface the reason for ops visibility (verbatim v2 reasons).
+            if fire_once:
+                reason = f"fire-once AND already entered (first_entry_at={koala.get('first_entry_at')})"
+            else:
+                last_exit = koala.get("last_exit_at")
+                if last_exit is None:
+                    reason = "re-entry mode but no exit recorded yet (position state ambiguous)"
+                else:
+                    wait_left_h = max(0.0, (cooldown_hours * 3600 - (now - float(last_exit))) / 3600.0)
+                    reason = f"re-entry cooldown active ({wait_left_h:.1f}h remaining)"
+            result = {"ts": now, "asset": asset, "emitted": False, "gate": "not_eligible",
+                      "note": reason, "fire_once": fire_once}
+            print(f"[koala.scan] {asset} WAITING — {reason}", file=sys.stderr)
+        elif scoring.was_recently_signaled(signaled, asset, ttl, now):
+            # Race-window dedup (defence-in-depth alongside the runtime cooldown gate).
+            result = {"ts": now, "asset": asset, "emitted": False, "gate": "recently_signaled"}
+            print(f"[koala.scan] {asset} WAITING — recently signaled (race-window dedup)",
+                  file=sys.stderr)
+        elif leverage <= 0 or margin_pct <= 0:
+            result = {"ts": now, "asset": asset, "emitted": False, "gate": "sizing_unresolved",
+                      "leverage": leverage, "marginPct": margin_pct}
+            print(f"[koala.scan] {asset} WAITING — sizing unresolved lev={leverage} marginPct={margin_pct}",
+                  file=sys.stderr)
+        else:
+            # ── EMIT: one LONG, fixed sizing. Record the entry into state. ──
+            signaled[asset] = now
+            koala = scoring.record_entry(koala, now)
+            koala["last_exit_at"] = None     # new lifecycle started (verbatim v2)
+            result = {"ts": now, "asset": asset, "emitted": True, "gate": "pass",
+                      "direction": "LONG", "leverage": leverage, "marginPct": round(margin_pct, 4),
+                      "first_entry_at": koala.get("first_entry_at"),
+                      "total_entries": koala.get("total_entries")}
+            print(f"[koala.scan] {asset} EMIT: LONG {leverage}x marginPct={margin_pct:.2f}% "
+                  f"(entry #{koala.get('total_entries')}, hodl_first_entry)", file=sys.stderr)
+            out = [{
+                "asset": asset,
+                "direction": "LONG",
+                "marginPct": margin_pct,        # PERCENT in (0,100] — runtime sizes (marginPct/100)*withdrawable
+                "leverage": leverage,           # 2x (clamped to maxLeverage 3); runtime applies it
+                "data": {
+                    "score": _FIXED_SCORE,      # fixed — Koala has no scoring (verbatim v2)
+                    "leverage": float(leverage),
+                    "direction": "LONG",
+                    "reasons": ["hodl_first_entry"],
+                    "heldAssets": held,
+                    "firstEntryAt": scoring._f(koala.get("first_entry_at")),
+                    "totalEntries": float(koala.get("total_entries", 0)),
+                },
+            }]
+
+    # ── persist koala state + dedup map + this tick's result EVERY tick; bounded
+    #    by state_history_max_count. Read back via ctx.state.last(). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"koala": koala, "signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[koala.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/koala/main/scanners/scoring.py
+++ b/strategies/koala/main/scanners/scoring.py
@@ -1,0 +1,114 @@
+"""KOALA — pure entry-decision logic (no I/O, no MCP, no clock-owning).
+
+A faithful Runtime 3.0 port of the v2 KOALA producer's pure functions
+(koala-producer.py producer VERSION 1.0.1 / SKILL.md v1.0.0). Koala is the
+simplest agent in the catalog: ONE asset, fire LONG ONCE on deploy, hold with
+an ultra-wide DSL trail. There is NO scoring, NO multi-timeframe analysis, NO
+smart-money gate — the "thesis" is a tiny state machine over a persisted
+entry-history record. Those pure functions live here so a fidelity harness can
+diff them against the v2 producer on the same state snapshot.
+
+`should_enter` / `record_entry` / `record_exit` are reproduced VERBATIM from
+koala-producer.py. The dedup helpers (`prune_signaled`, `was_recently_signaled`)
+mirror the v2 koala_config recent-signals cache semantics (4x-TTL prune, TTL
+membership check) — the only change is that the store is now an in-memory dict
+handed in by scan.py (ctx.state) instead of a JSON file.
+
+Single-pass, unit-testable on plain dicts. The caller (scan.py) owns the clock
+and passes `now_ts`, so this module stays pure.
+"""
+
+
+# ── value coercion ──
+
+def _f(v, d=0.0):
+    if v is None:
+        return d
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure entry-decision logic (VERBATIM from koala-producer.py v1.0.1)
+# ═══════════════════════════════════════════════════════════════
+
+def should_enter(state, fire_once, re_entry_cooldown_hours, now_ts):
+    """Decide whether Koala should emit an entry signal RIGHT NOW.
+
+    - state: koala state record (first_entry_at / last_entry_at / last_exit_at / total_entries)
+    - fire_once: True -> only one entry ever (lifetime one-shot)
+    - re_entry_cooldown_hours: minimum hours between exit and next entry
+                              (only relevant if fire_once is False)
+    - now_ts: epoch seconds (current time)
+
+    Returns True if Koala should emit; False otherwise.
+    """
+    first_entry_at = state.get("first_entry_at") if state else None
+
+    if fire_once:
+        # Lifetime one-shot — fire if and only if we've never entered.
+        return first_entry_at is None
+
+    # Re-entry allowed. Two conditions for "should fire":
+    #   1. Never entered -> fire immediately.
+    #   2. Last exit happened >= cooldown ago.
+    if first_entry_at is None:
+        return True
+
+    last_exit_at = state.get("last_exit_at") if state else None
+    if last_exit_at is None:
+        # We've entered before but never recorded an exit -> position must
+        # still be held (or the close went undetected). Don't fire again.
+        return False
+
+    try:
+        last_exit = float(last_exit_at)
+    except (TypeError, ValueError):
+        return False
+
+    cooldown_sec = float(re_entry_cooldown_hours) * 3600.0
+    return (now_ts - last_exit) >= cooldown_sec
+
+
+def record_entry(state, now_ts):
+    """Pure: return a new state dict with the entry recorded."""
+    new_state = dict(state or {})
+    if not new_state.get("first_entry_at"):
+        new_state["first_entry_at"] = float(now_ts)
+    new_state["last_entry_at"] = float(now_ts)
+    new_state["total_entries"] = int(new_state.get("total_entries", 0)) + 1
+    return new_state
+
+
+def record_exit(state, now_ts):
+    """Pure: return a new state dict with the exit recorded."""
+    new_state = dict(state or {})
+    new_state["last_exit_at"] = float(now_ts)
+    return new_state
+
+
+def empty_state():
+    """The v2 koala_config.read_koala_state() default shape."""
+    return {"first_entry_at": None, "last_entry_at": None, "last_exit_at": None, "total_entries": 0}
+
+
+# ═══════════════════════════════════════════════════════════════
+# Race-window dedup (mirrors v2 koala_config recent-signals cache)
+# ═══════════════════════════════════════════════════════════════
+
+def prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in (signaled or {}).items() if v >= cutoff}
+
+
+def was_recently_signaled(signaled, coin, ttl, now):
+    """TTL membership check (verbatim from v2 was_recently_signaled)."""
+    if not coin:
+        return False
+    last = (signaled or {}).get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl

--- a/strategies/koala/main/scanners/test_margin_pct.py
+++ b/strategies/koala/main/scanners/test_margin_pct.py
@@ -1,0 +1,51 @@
+"""Guard: koala's marginPct must be a PERCENT in (0,100], never a v2 fraction.
+
+The v3.x runtime sizes `(marginPct/100)*withdrawable` (resolve-margin.ts), so a
+fraction like 0.50 would size 0.50% of withdrawable — ~100x undersize, silent
+(no 400, since 0.50 still satisfies the (0,100] bound).
+
+Koala is a trap case: the v2 DEFAULT_MARGIN_PCT was a FRACTION (0.50). This port
+carries marginPct=50 (a PERCENT) in runtime.yaml; scan.py emits it top-level and
+additionally converts any value <= 1 (a pasted v2 fraction) to a PERCENT. This
+test asserts the runtime input is a PERCENT in [1,100] and that scan.py keeps the
+defensive fraction->percent conversion.
+"""
+
+import os
+import re
+
+import yaml
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_RUNTIME_YAML = os.path.join(_HERE, "..", "runtime.yaml")
+_SCAN_PY = os.path.join(_HERE, "scan.py")
+
+
+def _external_scanner_inputs():
+    with open(_RUNTIME_YAML) as f:
+        spec = yaml.safe_load(f)
+    for s in spec["scanners"]:
+        if s.get("type") == "external_scanner":
+            return s["inputs"]
+    raise AssertionError("no external_scanner inputs in runtime.yaml")
+
+
+def test_runtime_top_level_margin_pct_is_percent_in_range():
+    pct = float(_external_scanner_inputs()["marginPct"])
+    # >=1 catches the fraction bug (0.50); <=100 is the wire upper bound.
+    assert 1 <= pct <= 100, f"runtime.yaml marginPct={pct} not a PERCENT in [1,100]"
+
+
+def test_leverage_clamped_to_max_leverage():
+    inputs = _external_scanner_inputs()
+    lev = int(inputs["leverage"])
+    max_lev = int(inputs["maxLeverage"])
+    assert 0 < lev <= max_lev, f"leverage={lev} not in (0, maxLeverage={max_lev}]"
+
+
+def test_scan_keeps_fraction_to_percent_guard():
+    src = open(_SCAN_PY).read()
+    # the defensive *100 conversion (value <= 1 -> percent) must be present.
+    assert "* 100" in src and "<= 1.0" in src, (
+        "scan.py must keep the defensive fraction->percent guard for marginPct"
+    )

--- a/strategies/koala/strategy.yaml
+++ b/strategies/koala/strategy.yaml
@@ -1,0 +1,42 @@
+# Koala — Set-and-Forget Trail HODL. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2 Koala
+# (SKILL.md v1.0.0 / producer VERSION 1.0.1): the simplest agent in the catalog — pick
+# one asset (default BTC), fire LONG once on deploy, hold with an ultra-wide DSL trail.
+# No scoring, no multi-timeframe analysis, no SM gates. Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: koala
+version: "1.0.0"
+
+catalog:
+  name: "Koala — Set-and-Forget Trail HODL"
+  emoji: "🐨"
+  tagline: "The simplest agent in the catalog: pick one asset (default BTC), fire LONG once on deploy, then hold with an ultra-wide DSL trail (max_loss 30%, retrace, 90-day timeout). No scoring, no scheduling — the choice to deploy Koala IS the bet."
+  belief_plain: "Trades only the one coin you pick (BTC by default). It buys once when you turn it on, then just holds — never adding, never trading around it — with a very wide safety stop that only releases on a catastrophic reversal or after three months. The whole idea is to own the coin and have a net under it."
+  thesis: "Some users do not want a market-reading agent at all — they just want to own one asset and have a safety net. Koala is that answer in code: one asset, one entry, one stop. Fire-once by default (a true buy-and-forget), with an optional re-entry cycle for operators who want 'buy / DSL-exits / buy again' on a long cooldown."
+  group: single-asset
+  archetype: single_market
+  sub_style: buy_and_hold
+  asset_classes: [major_alts]
+  asset_scope: single
+  direction: long_only
+  risk_level: conservative
+  tier: onboarding
+  leverage_max: 3
+  max_slots: 1
+  min_budget: 100
+  assets: ["BTC"]
+  tags: [btc, single-asset, hodl, buy-and-hold, set-and-forget, wide-dsl, onboarding, long-only]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: KOALA_WALLET
+    funding_share: 1.0

--- a/strategies/rhino/escalation/runtime.yaml
+++ b/strategies/rhino/escalation/runtime.yaml
@@ -116,7 +116,7 @@ exit:
         - { trigger_pct: 60, lock_hw_pct: 88 }
 
 risk:
-  data_retention_hours: 96
+  data_retention_seconds: 345600       # 96h (was data_retention_hours: 96)
   guard_rails:
     daily_loss_limit_pct: 14
     max_entries_per_day: 8                # stress arrives in bursts -> deploy fast when it does

--- a/strategies/rhino/hedge/runtime.yaml
+++ b/strategies/rhino/hedge/runtime.yaml
@@ -116,7 +116,7 @@ exit:
         - { trigger_pct: 140, lock_hw_pct: 90 }
 
 risk:
-  data_retention_hours: 168
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
   guard_rails:
     daily_loss_limit_pct: 8
     max_entries_per_day: 3                # the hedge turns over slowly

--- a/strategies/sailfish/main/runtime.yaml
+++ b/strategies/sailfish/main/runtime.yaml
@@ -1,0 +1,134 @@
+# ── SAILFISH · single instance — relative-strength rotator (crypto majors) ─────
+# Runtime 3.0 port of the v2 Sailfish (SKILL.md v1.0.0 / producer v1.0.1). Ranks
+# BTC/ETH/SOL/HYPE by ~2.7d 4h relative strength each tick and longs the leader,
+# gated by a leader-RS floor + margin-vs-runner-up (no whipsaw). Single-position;
+# producer never closes — rotation is realized by the DSL trail exiting a stalled
+# leader and scan() re-entering the new leader next tick. Faithful port of the v2
+# thesis — see scanners/scoring.py (RS math reproduced verbatim).
+name: sailfish-main
+group: sailfish
+version: 1.0.0
+description: >
+  SAILFISH — relative-strength rotator on crypto majors (BTC/ETH/SOL/HYPE).
+  Each tick ranks the universe by ~2.7d (16 x 4h) relative strength and longs
+  the leader iff (a) the leader's own RS >= minLeaderRsPct (1.0%) AND (b) the
+  leader beats the runner-up by >= leaderMarginPct (1.5pp) — no whipsaw on
+  tight races. Single-position, LONG-only, 20% margin, 3x (max 5x). The
+  producer never closes: when the held leader exits via the DSL trail, the next
+  tick re-evaluates and enters the new leader (that's the "rotation"). DSL is
+  balanced + a 96h hard_timeout so leadership can play out. Faithful port of the
+  v2 Sailfish v1.0.x thesis (all RS math/gates/cutoffs verbatim).
+
+strategy:
+  wallet: "${SAILFISH_WALLET}"
+  slots: 1                                # v2 slots 1 — single-position rotator
+  margin_pct: 20                          # baseline %; scan emits marginPct per signal (= this value)
+  default_leverage: 3                     # fallback; scan emits 3x (clamped to 5x max) per signal
+  trading_risk: balanced
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: sailfish_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 180                   # v2 tick_timeout=180; ~1 read/asset + account
+    default_signal_validity_seconds: 600   # 2x tick; rule action, a fresh re-rank arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      whitelist: ["BTC", "ETH", "SOL", "HYPE"]   # v1.0.x universe (validated live on HL main DEX 2026-06-29)
+      rsLookbackBars: 16                   # v2 DEFAULT_RS_LOOKBACK (16 x 4h = ~2.7d)
+      minLeaderRsPct: 1.0                  # v2 DEFAULT_MIN_LEADER_RS_PCT — leader must actually be up
+      leaderMarginPct: 1.5                 # v2 DEFAULT_LEADER_MARGIN_PCT — beat runner-up by this (no whipsaw)
+      minScore: 4                          # v2 DEFAULT_MIN_SCORE
+      marginPct: 20                        # PERCENT of withdrawable (0,100]; v2 fraction 0.20 x100
+      leverage: 3                          # v2 DEFAULT_LEVERAGE; clamped to 5x (MAX_LEVERAGE) in scan.py
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      leaderRsPct: { type: number, required: false }
+      leaderMarginPct: { type: number, required: false }
+      rankSnapshot: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: sailfish_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [sailfish_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # ride the leader NOW — a maker order that rests (CREATE_ORDER_RESTING)
+                                           # misses the extension; taker fallback guarantees fill + DSL attach.
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: sailfish_main_signals
+
+# ── EXIT (DSL — balanced, leadership-tuned; preserved VERBATIM from v2) ─────────
+# Leadership can extend for days: balanced ladder + 96h hard_timeout so a leader
+# can finish its run before staleness cuts it. weak_peak_cut (8h / 3.0) bails from
+# a stalled leader. The natural DSL exit on a stalled leader is what triggers
+# Sailfish's "rotation" — the next tick re-evaluates and enters the new leader.
+# All time intervals/tiers preserved verbatim (interval_in_minutes from v2).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760            # 96h — leadership can extend
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480             # 8h
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # first lock at +8% ROE (well under +40% — no flag)
+        - { trigger_pct: 8,  lock_hw_pct: 0 }
+        - { trigger_pct: 15, lock_hw_pct: 40 }
+        - { trigger_pct: 25, lock_hw_pct: 60 }
+        - { trigger_pct: 40, lock_hw_pct: 75 }
+        - { trigger_pct: 70, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes -> seconds) ──
+risk:
+  data_retention_seconds: 345600           # 96h (v2 data_retention_hours 96)
+  guard_rails:
+    daily_loss_limit_pct: 12               # v2 daily_loss_limit_pct
+    max_entries_per_day: 2                  # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 7200                 # v2 cooldown_minutes 120 -> 7200s
+    drawdown_halt_pct: 20                  # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 21600      # v2 per_asset_cooldown_minutes 360 -> 21600s (6h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/sailfish/main/scanners/scan.py
+++ b/strategies/sailfish/main/scanners/scan.py
@@ -1,0 +1,264 @@
+"""SAILFISH — supervised scanner (Runtime 3.0 port of the v2 Sailfish RS rotator).
+
+Relative-Strength Rotator on crypto majors (BTC/ETH/SOL/HYPE by default). Per tick:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - fetches 4h candles per whitelist asset and computes RS = % change over
+    rsLookbackBars bars (pure `scoring.relative_strength`),
+  - ranks the universe and picks the leader iff it clears BOTH gates
+    (leader RS >= minLeaderRsPct AND margin-vs-runner-up >= leaderMarginPct),
+  - skips if the leader is already held (single-position; producer never closes),
+    or recently signaled (race-window dedup),
+  - emits the SINGLE leader at/above `minScore`, sized by a fixed margin PERCENT.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit.
+No daemon, no push_signal, no create_position. "Rotation" is realized by the DSL
+trail exiting a stalled leader and this scan re-entering the new leader next tick.
+
+FIDELITY NOTES vs the v2 producer (sailfish-producer.py v1.0.1):
+  - v2 sized `marginUsd = account_value * config.marginPct` where marginPct was a
+    FRACTION (0.20). This port emits a top-level `marginPct` PERCENT (20) and lets
+    the runtime size `(marginPct/100)*withdrawable` (resolve-margin.ts). The
+    FRACTION->PERCENT conversion (0.20 -> 20) is the only sizing change; the
+    economic intent (20% of equity per slot) is identical.
+  - v2 wire `score` was normalized to `min(score/6.0, 1.0)` for push_signal. In
+    Runtime 3.0 the scaffold owns the wire envelope; we emit the RAW integer score
+    on data{} (per scan-contract.md) and gate on it in scan.py.
+  - v2's LLM gate (runtime.yaml decision_prompt) was pass-through (honor the
+    signal; hard-skip on direction!=LONG / score<4 / lev<=0 / held / leaderRs<=0).
+    Those hard-skips are ALREADY enforced here (LONG-only, score>=minScore floor,
+    held-asset filter, leader_rs>=minLeaderRsPct gate), so the entry action is a
+    RULE action (no LLM). Behaviour is identical to the pass-through gate.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=240, prune at 4xTTL) ->
+    ctx.state dedup map with the SAME TTL semantics.
+  - v2 ranked the WHOLE whitelist (including held), then skipped if the leader was
+    held. Preserved: ranking includes held assets so the margin-vs-runner-up
+    comparison uses the true runner-up; the held check is applied to the LEADER
+    only, exactly as in v2 main().
+  - v2 main() emitted exactly one signal (the leader). Preserved: scan() emits <=1.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v1.0.x defaults (sailfish-producer.py / sailfish-config.json)
+_DEFAULT_WHITELIST = ["BTC", "ETH", "SOL", "HYPE"]
+_DEFAULT_RS_LOOKBACK = 16          # 16 x 4h bars = ~2.7 days
+_DEFAULT_MIN_LEADER_RS_PCT = 1.0   # leader's own RS must be >= this %
+_DEFAULT_LEADER_MARGIN_PCT = 1.5   # leader must beat the runner-up by this much
+_DEFAULT_MIN_SCORE = 4             # v2 DEFAULT_MIN_SCORE
+_DEFAULT_MARGIN_PCT = 20.0         # PERCENT in (0,100] — v2 fraction 0.20 x100
+_DEFAULT_LEVERAGE = 3              # v2 DEFAULT_LEVERAGE
+_MAX_LEVERAGE = 5                  # v2 MAX_LEVERAGE (hardcoded clamp)
+_DEFAULT_RECENT_TTL = 240          # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    Sailfish's default universe is all main-DEX majors, so this returns '' in
+    practice — kept for parity if an operator adds an XYZ asset to the whitelist."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[sailfish.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)), abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[sailfish.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _fetch_closes(ctx, asset):
+    """4h close list for `asset` or [] on any read failure. READ-GUARDED.
+    Ported from v2 fetch_candles -> closes (market_get_asset_data, 4h only)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": asset,
+            "candle_intervals": ["4h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": _dex_for(asset),
+        })
+    except Exception as exc:  # noqa: BLE001 — one asset failing must not crash the tick
+        print(f"[sailfish.scan] market_get_asset_data({asset}) read failed: {exc!r}", file=sys.stderr)
+        return []
+    if not md:
+        return []
+    if isinstance(md, dict) and md.get("success") is False:
+        return []
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return []
+    candles = (d.get("candles", {}) or {}).get("4h", []) or []
+    if not isinstance(candles, list):
+        return []
+    return [scoring._close(c) for c in candles]
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    whitelist = inputs.get("whitelist", _DEFAULT_WHITELIST)
+    lookback = int(inputs.get("rsLookbackBars", _DEFAULT_RS_LOOKBACK))
+    min_leader_rs = float(inputs.get("minLeaderRsPct", _DEFAULT_MIN_LEADER_RS_PCT))
+    margin_pct_threshold = float(inputs.get("leaderMarginPct", _DEFAULT_LEADER_MARGIN_PCT))
+    min_score = int(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))   # PERCENT in (0,100]
+    leverage = min(int(inputs.get("leverage", _DEFAULT_LEVERAGE)), _MAX_LEVERAGE)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── compute RS per whitelist asset (held INCLUDED in ranking so the
+    #    margin-vs-runner-up comparison uses the true runner-up, as in v2) ──
+    strength_by_asset = {}
+    scanned = 0
+    for asset in whitelist:
+        if not asset:
+            continue
+        closes = _fetch_closes(ctx, asset)
+        if len(closes) <= lookback:
+            continue
+        scanned += 1
+        strength_by_asset[asset.upper()] = scoring.relative_strength(closes, lookback)
+
+    ranked = scoring.rank_assets(strength_by_asset)
+    picked = scoring.leader_above_runner_up(ranked, min_leader_rs, margin_pct_threshold)
+
+    out = []
+    note = None
+    leader_asset = None
+    score = None
+    if picked is None:
+        note = "WAITING — no clear leader (insufficient RS or margin)"
+    else:
+        leader_asset, leader_rs, margin_vs_runner = picked
+        if leader_asset in held_set:
+            note = f"HOLDING — {leader_asset} is the leader and already held"
+        elif _was_recently_signaled(signaled, leader_asset, ttl, now):
+            note = f"WAITING — {leader_asset} leader but recently-signaled (race-window dedup)"
+        else:
+            score, reasons = scoring.build_score(
+                leader_asset, leader_rs, margin_vs_runner, bool(held_assets))
+            if score < min_score:
+                note = f"WAITING — {leader_asset} cleared gates but score {score} < min {min_score}"
+            else:
+                margin_finite = margin_vs_runner if margin_vs_runner != float('inf') else 0.0
+                signaled[leader_asset.upper()] = now
+                out = [{
+                    "asset": leader_asset,
+                    "direction": "LONG",                       # Sailfish is LONG-only
+                    "marginPct": margin_pct,                   # PERCENT in (0,100] — runtime sizes the dollars
+                    "leverage": leverage,                      # 1..5; runtime applies it
+                    "data": {
+                        "score": score,
+                        "leverage": leverage,
+                        "direction": "LONG",
+                        "reasons": reasons,
+                        "leaderRsPct": float(leader_rs),
+                        "leaderMarginPct": float(margin_finite),
+                        "rankSnapshot": [{"asset": a, "rs": round(s, 2)} for a, s in ranked[:6]],
+                        "heldAssets": held_assets,
+                    },
+                }]
+
+    # ── observability: one-line stderr + per-tick result append (guarded) ──
+    if out:
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": leader_asset, "direction": "LONG", "score": score,
+                  "leverage": leverage, "marginPct": round(margin_pct, 4),
+                  "ranked": [{"asset": a, "rs": round(s, 2)} for a, s in ranked],
+                  "held": held_assets}
+        print(f"[sailfish.scan] EMIT {leader_asset} LONG score={score} {leverage}x "
+              f"marginPct={margin_pct:.2f}% | ranked={[(a, round(s, 2)) for a, s in ranked[:4]]} "
+              f"held={held_assets}", file=sys.stderr)
+    else:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "note": note,
+                  "ranked": [{"asset": a, "rs": round(s, 2)} for a, s in ranked],
+                  "held": held_assets}
+        print(f"[sailfish.scan] {note}; scanned={scanned} "
+              f"ranked={[(a, round(s, 2)) for a, s in ranked[:4]]} held={held_assets}",
+              file=sys.stderr)
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[sailfish.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/sailfish/main/scanners/scoring.py
+++ b/strategies/sailfish/main/scanners/scoring.py
@@ -1,0 +1,110 @@
+"""SAILFISH — pure relative-strength thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Sailfish producer's pure logic
+(`relative_strength`, `rank_assets`, `leader_above_runner_up`) plus the inline
+score builder from v2 `main()`. The math/indexing is reproduced VERBATIM so a
+fidelity harness can diff this against the v2 producer on the same market
+snapshot.
+
+Sailfish ranks the whitelist (BTC/ETH/SOL/HYPE) by 4h relative strength each
+tick and longs the leader iff (a) the leader's own RS >= minLeaderRsPct AND
+(b) the leader beats the runner-up by >= leaderMarginPct (no whipsaw on tight
+races). Single-position; the producer never closes — rotation is realized via
+the DSL trail's natural exit + the next tick's re-evaluation.
+
+`scan.py` does the MCP reads + state; this module stays pure and unit-testable
+on plain close lists.
+"""
+
+
+# ── candle close accessor (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts via _f(c, "close", "c"); the list branch is defensive and never
+# fires on dict candles, so it does not change v2 behaviour.
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        val = c.get("close")
+        if val is None:
+            val = c.get("c")
+        return _f(val if val is not None else 0.0)
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+# ── pure relative-strength logic (ported VERBATIM from v2 sailfish-producer.py) ──
+
+def relative_strength(closes, lookback):
+    """% change of the latest close vs the close `lookback` bars ago.
+    Used as a single-asset RS proxy; ranking sorts these across the universe.
+    None if insufficient data or ref price is non-positive. Verbatim from v2."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def rank_assets(strength_by_asset):
+    """Sort {asset: strength} by strength descending. Assets with None
+    strength are dropped. Returns list of (asset, strength). Verbatim from v2."""
+    pairs = [(a, s) for a, s in strength_by_asset.items() if s is not None]
+    pairs.sort(key=lambda t: t[1], reverse=True)
+    return pairs
+
+
+def leader_above_runner_up(ranked, min_leader_rs_pct, margin_pct):
+    """Given a ranked list of (asset, strength), return the leader iff:
+      1. leader's own RS >= min_leader_rs_pct (leader must actually be up), AND
+      2. leader - runner_up >= margin_pct (clean separation, no whipsaw).
+    If there's only one ranked asset, the margin requirement defaults to met.
+    Returns (asset, strength, margin_vs_runner_up) or None. Verbatim from v2."""
+    if not ranked:
+        return None
+    leader_asset, leader_rs = ranked[0]
+    if leader_rs < min_leader_rs_pct:
+        return None
+    if len(ranked) == 1:
+        return (leader_asset, leader_rs, float('inf'))
+    runner_rs = ranked[1][1]
+    margin = leader_rs - runner_rs
+    if margin < margin_pct:
+        return None
+    return (leader_asset, leader_rs, margin)
+
+
+# ── score builder (ported VERBATIM from v2 main()) ──
+
+def build_score(leader_asset, leader_rs, margin_vs_runner, has_held):
+    """Port of v2 main()'s inline scoring. Returns (score, reasons).
+
+    Base 3 (leader cleared both gates) + 1 if leader_rs >= 4.0 (leader_strong)
+    + 1 if margin_vs_runner >= 3.0 (dominant_margin). A `post_dsl_re_entry`
+    reason flag is appended when there is an existing/held position (re-entering
+    after a prior DSL exit) — informational only, no score effect. Max ~5.
+    Verbatim from v2 (margin gates/cutoffs preserved)."""
+    score = 3   # base — leader cleared both RS and margin gates
+    reasons = [
+        f"{leader_asset}_rs_{leader_rs:+.2f}%",
+        f"margin_vs_runner_up_{margin_vs_runner:+.2f}pp",
+    ]
+    if leader_rs >= 4.0:
+        score += 1
+        reasons.append("leader_strong")
+    if margin_vs_runner >= 3.0:
+        score += 1
+        reasons.append("dominant_margin")
+    if has_held:
+        # Re-entering after a prior position exited — leadership has either
+        # confirmed the holdover OR rotated. Either way it's a fresh decision.
+        reasons.append("post_dsl_re_entry")
+    return score, reasons

--- a/strategies/sailfish/strategy.yaml
+++ b/strategies/sailfish/strategy.yaml
@@ -1,0 +1,43 @@
+# Sailfish — relative-strength rotator (crypto majors). A single-instance PACKAGE:
+# this manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0
+# port of the v2 Sailfish (SKILL.md v1.0.0 / producer v1.0.1): ranks BTC/ETH/SOL/HYPE
+# by ~2.7d 4h relative strength each tick and longs the leader, gated by a
+# leader-RS floor + margin-vs-runner-up to avoid whipsaw. Single-position; producer
+# never closes — DSL-mediated rotation (held leader exits via the DSL trail, next
+# tick re-enters the new leader). Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: sailfish
+version: "1.0.0"
+
+catalog:
+  name: "Sailfish — Relative-Strength Rotator"
+  emoji: "🐠"
+  tagline: "Always hold the strongest major: ranks BTC/ETH/SOL/HYPE by ~2.7-day relative strength each tick and longs the leader, with a leader-RS floor and a margin-vs-runner-up gate to avoid whipsaw on tight races. Single-position; when the held leader exits via the DSL trail, the next tick re-evaluates and enters the new leader — that's the rotation."
+  belief_plain: "Trades only the big, liquid coins (BTC, ETH, SOL, HYPE). Each cycle it measures which one has been strongest over the last few days and buys that one — but only if it is clearly ahead of the next-best, not in a photo finish. It never sells on its own; a trailing stop manages the exit, and when one leader is done, the next-strongest takes its place."
+  thesis: "Among the majors, leadership tends to persist — when one decisively outperforms the others it usually keeps doing so for days. Rotating into the strongest captures that persistence, while the margin-vs-runner-up gate keeps the agent out of tight, whipsaw-prone races where 'the leader' flips every tick. Rotation is realized through the DSL exit (not a mid-position close), so leadership changes only cost a fill when the old leader is genuinely finished — never on noise."
+  group: momentum
+  archetype: trend_following
+  sub_style: relative_strength_rotation
+  asset_classes: [major_alts]
+  asset_scope: whitelist
+  direction: long_only
+  risk_level: balanced
+  tier: advanced
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL", "HYPE"]
+  tags: [btc, eth, sol, hype, multi-asset, momentum, relative-strength, rotation, single-position, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: SAILFISH_WALLET
+    funding_share: 1.0

--- a/strategies/thesis-fund/main/runtime.yaml
+++ b/strategies/thesis-fund/main/runtime.yaml
@@ -118,7 +118,7 @@ exit:
 
 # ── RISK (per instance) — ported from v2 risk.guard_rails ──
 risk:
-  data_retention_hours: 168
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
   guard_rails:
     daily_loss_limit_pct: 12
     max_entries_per_day: 8

--- a/strategies/tortoise/main/runtime.yaml
+++ b/strategies/tortoise/main/runtime.yaml
@@ -1,0 +1,133 @@
+# ── TORTOISE · single instance — DCA scheduler (Runtime 3.0 port of v2 TORTOISE v1.0.0) ──
+# Time-triggered dollar-cost averaging on a small basket (BTC/ETH/SOL). NO price
+# prediction, NO scoring, NO market data read — the "scanner" is purely a clock.
+# Each tick: read account + held positions, read the per-asset DCA-history cache
+# (ctx.state), pick the most-overdue eligible asset past the interval, emit ONE
+# LONG signal sized at marginPct of withdrawable. Never-DCA'd assets always win.
+# DSL is the ONLY exit — let-winners-run preset, 30d hard_timeout so accumulation
+# compounds. Faithful port of the v2 producer thesis — see scanners/scoring.py
+# (cadence math reproduced verbatim, v2-quirks flagged).
+name: tortoise-main
+group: tortoise
+version: 3.0.0
+description: >
+  TORTOISE — DCA scheduler. "Slow and steady wins the race." Buys a fixed % of
+  budget on a strict time cadence (every intervalHours) on a small basket — BTC
+  alone or BTC/ETH/SOL. No price prediction, no scoring, no timing; the
+  oldest-overdue asset past the interval wins each tick, everything else is
+  silent. A never-DCA'd asset is always due (fresh setup starts buying
+  immediately, then cadence takes over). Always LONG (DCA = accumulate).
+  Sizing is fixed: marginPct of withdrawable per buy (default 8%), leverage 2x
+  (clamped to 3x max). DSL is the ONLY exit — let-winners-run preset with a 30d
+  hard_timeout so accumulation compounds; Phase-2 ladder locks gains gradually.
+  THE most beginner-accessible trade in crypto. Onboarding tier. Faithful port of
+  the v2 Tortoise v1.0.0 thesis (cadence/selection/sizing verbatim).
+
+strategy:
+  wallet: "${TORTOISE_WALLET}"
+  slots: 3                                # v2 slots: 3 — accumulates across 3 assets over time
+  margin_pct: 8                           # baseline %; scan emits the per-signal marginPct (fixed, no tiers)
+  default_leverage: 2                     # v2 DEFAULT_LEVERAGE; scan clamps to [1,3] (MAX_LEVERAGE=3)
+  trading_risk: conservative
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: tortoise_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 1800                 # v2 producer cadence (30min) — DCA is slow by design; cadence is the signal
+    timeout_seconds: 120                   # v2 tick_timeout=120; one clearinghouse read per tick (no market data)
+    default_signal_validity_seconds: 3600  # 2x tick; rule action, a fresh cadence re-check arrives next tick
+    state_history_max_count: 100           # DCA-history cache + race-window dedup + per-tick scan-results history
+    inputs:
+      assets: ["BTC", "ETH", "SOL"]        # v2 DEFAULT_ASSETS (validated live on HL main DEX 2026-06-29)
+      intervalHours: 24                    # v2 DEFAULT_INTERVAL_HOURS — one DCA per asset per day
+      marginPct: 8                         # PERCENT of withdrawable (0,100] — v2 marginPct 0.08 (FRACTION) x100
+      leverage: 2                          # v2 DEFAULT_LEVERAGE; clamped to MAX_LEVERAGE=3 in scan.py
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup; ALO fill window + next-tick refresh)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      intervalSec: { type: number, required: false }
+      elapsedSec: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: tortoise_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # v2 LLM gate was pure pass-through (always confidence 7, no price scoring)
+    scanners: [tortoise_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false   # v2: DCA isn't urgent — rest as maker to save fees
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: tortoise_main_signals
+
+# ── EXIT (DSL — let-winners-run preset, preserved VERBATIM from v2 v1.0.0) ──
+# DCA accumulates over time. Wide ladder + VERY long hard_timeout (30d) so
+# accumulation can compound; Phase-2 lock tiers bank gains gradually so a deep
+# drawdown doesn't wipe accumulated entries, but a winner is never cut just for
+# being old. No weak_peak_cut — flat-but-not-failing accumulation should not be
+# churned. FIRST Phase-2 lock is at +10% ROE (reachable; NOT +40-80%) — no flag.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: false
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 43200           # 30d — DCA is meant to compound
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 25, lock_hw_pct: 50 }
+        - { trigger_pct: 50, lock_hw_pct: 70 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+        - { trigger_pct: 200, lock_hw_pct: 92 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes -> seconds) ──
+risk:
+  data_retention_seconds: 604800       # clamped to 3.0 max (7d); v2 intent 30d exceeds cap
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 6                  # v2: 3 assets x ~2 DCA cycles allowed/day at default cadence
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 5
+    cooldown_seconds: 1800                  # v2 cooldown_minutes: 30
+    drawdown_halt_pct: 18                   # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 3600        # v2 per_asset_cooldown_minutes: 60
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/tortoise/main/scanners/scan.py
+++ b/strategies/tortoise/main/scanners/scan.py
@@ -1,0 +1,238 @@
+"""TORTOISE — supervised scanner (Runtime 3.0 port of the v2 Tortoise DCA scheduler).
+
+Multi-asset whitelist (BTC/ETH/SOL by default), but NO price prediction and NO
+market-data read — the "scanner" is purely a clock. Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - reads the per-asset DCA-history cache + recent-signal dedup map from ctx.state,
+  - filters out held assets and recently-signaled assets (no duplicate stacking),
+  - picks the SINGLE most-overdue eligible asset past its DCA interval
+    (never-DCA'd assets always win), via the pure scoring.pick_next_dca_asset,
+  - emits ONE LONG signal sized at a FIXED marginPct of withdrawable (no tiers),
+  - records the chosen asset's DCA timestamp + dedup timestamp back into ctx.state.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus a `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit.
+No daemon, no push_signal, no create_position. The DSL owns ALL exits.
+
+FIDELITY NOTES vs the v2 producer (tortoise-producer.py v1.0.1):
+  - v2 persisted the DCA-history cache to dca-history.json (read_dca_history /
+    record_dca). This port stores it in ctx.state (the runtime's transactional
+    history store) under "dca_history". Same {ASSET: epoch_seconds} semantics,
+    same upper-case keys. ctx.state advances ONLY on a clean tick, so a failed
+    tick never records a phantom DCA (strictly safer than the v2 file write).
+  - v2 emitted exactly one signal (the most-overdue `best`). Preserved: scan()
+    emits <= 1 signal/tick. Selection (pick_next_dca_asset) is verbatim.
+  - v2 sizing: marginUsd = round(account_value * marginPct, 2) where marginPct
+    was a FRACTION (0.08). This port emits `marginPct` as a PERCENT (8) and lets
+    the runtime size (marginPct/100)*withdrawable. Fixed, no conviction tiers
+    (DCA has no scoring — every fire is "valid by cadence"). leverage = min(
+    config leverage, MAX_LEVERAGE=3) — verbatim clamp.
+  - v2 filtered candidates: NOT held (no duplicate stacking) AND NOT recently
+    signaled (race-window dedup). Both preserved; the held-asset filter runs off
+    the read-sanity-guarded clearinghouse read (ported verbatim).
+  - v2 data block: score=5 (producer-fixed), wire score=0.7 (static — DCA
+    conviction comes from cadence, not scoring), leverage, direction LONG,
+    reasons [dca_cadence, elapsed_Ns, interval_Ns], intervalSec, elapsedSec,
+    heldAssets. Preserved (the `data.score` slot carries the v2 producer-fixed 5).
+  - v2 push_signal hard-skipped if the chosen asset was already held; here that
+    asset is already excluded from the candidate set, so the guard is redundant
+    but kept as defence-in-depth.
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 defaults (tortoise-producer.py / tortoise-config.json)
+_DEFAULT_ASSETS = ["BTC", "ETH", "SOL"]      # v2 DEFAULT_ASSETS
+_DEFAULT_INTERVAL_HOURS = 24.0               # v2 DEFAULT_INTERVAL_HOURS
+_DEFAULT_MARGIN_PCT = 8.0                     # PERCENT; v2 marginPct 0.08 (FRACTION) x100
+_DEFAULT_LEVERAGE = 2                         # v2 DEFAULT_LEVERAGE
+_MAX_LEVERAGE = 3                             # v2 MAX_LEVERAGE — DCA is accumulation, not leverage
+_DEFAULT_RECENT_TTL = 240                     # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+_DIRECTION = "LONG"                           # v2 DEFAULT_DIRECTION — DCA = accumulate longs
+_PRODUCER_FIXED_SCORE = 5                     # v2 data.score (producer-fixed; DCA has no scoring)
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[tortoise.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", "")})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)), abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[tortoise.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+# ── ctx.state: DCA-history cache + recent-signal dedup map ──
+# v2 persisted these to dca-history.json + recent-signals.json. Here both ride in
+# the latest ctx.state record; we read the last record, mutate, and append a fresh
+# one every tick (bounded by state_history_max_count).
+
+def _load_state(ctx):
+    """Returns (dca_history{ASSET:ts}, signaled{ASSET:ts}) from the latest record."""
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}, {}
+    last = ctx.state.last() or {}
+    hist = last.get("dca_history", {})
+    sig = last.get("signaled", {})
+    hist = {str(k).upper(): scoring._f(v) for k, v in hist.items()} if isinstance(hist, dict) else {}
+    sig = {str(k).upper(): scoring._f(v) for k, v in sig.items()} if isinstance(sig, dict) else {}
+    return hist, sig
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    """Verbatim from v2 was_recently_signaled (TTL window check)."""
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    assets = inputs.get("assets", _DEFAULT_ASSETS)
+    interval_hours = float(inputs.get("intervalHours", _DEFAULT_INTERVAL_HOURS))
+    interval_sec = interval_hours * 3600.0
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))   # PERCENT in (0,100]
+    leverage = min(int(inputs.get("leverage", _DEFAULT_LEVERAGE)), _MAX_LEVERAGE)   # v2 clamp
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    account_value, positions = _get_account(ctx)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    history, signaled = _load_state(ctx)
+    signaled = _prune_signaled(signaled, ttl, now)
+
+    out = []
+    if account_value <= 0:
+        # v2: no account value -> silent ok (no signal). Still persist state so the
+        # cache/dedup map survive the tick.
+        result = {"ts": now, "emitted": False, "note": "no account value",
+                  "held": held_assets}
+        print("[tortoise.scan] WAITING — no account value", file=sys.stderr)
+        _persist(ctx, history, signaled, result)
+        return out
+
+    # Filter: an asset already held is not a candidate (no duplicate stacking);
+    # an asset recently signaled is in the race-window cooldown. Both verbatim v2.
+    eligible = [a for a in assets
+                if str(a).upper() not in held_set
+                and not _was_recently_signaled(signaled, str(a), ttl, now)]
+
+    chosen = scoring.pick_next_dca_asset(eligible, history, interval_sec, now)
+
+    if chosen is None:
+        next_due = scoring.next_due_seconds(eligible, history, interval_sec, now)
+        next_due_min = round(next_due / 60.0, 1) if next_due is not None else None
+        result = {"ts": now, "emitted": False, "assets": list(assets), "held": held_assets,
+                  "next_due_in_min": next_due_min,
+                  "note": "WAITING — no asset past its DCA interval (or all in cooldown/held)"}
+        print(f"[tortoise.scan] WAITING — no asset due (next in {next_due_min}min); "
+              f"assets={list(assets)} held={held_assets}", file=sys.stderr)
+        _persist(ctx, history, signaled, result)
+        return out
+
+    # Defence-in-depth (redundant — chosen is already excluded from held_set).
+    if chosen in held_set:
+        result = {"ts": now, "emitted": False, "note": f"chosen {chosen} held — skip",
+                  "held": held_assets}
+        print(f"[tortoise.scan] SKIP — chosen {chosen} already held", file=sys.stderr)
+        _persist(ctx, history, signaled, result)
+        return out
+
+    elapsed = scoring.seconds_since(history.get(chosen), now)
+    elapsed_sec = float(elapsed or 0.0)
+
+    # record the DCA + dedup timestamps (mirrors v2 record_dca + record_signal)
+    history[chosen] = now
+    signaled[chosen] = now
+
+    reasons = ["dca_cadence", f"elapsed_{int(elapsed_sec)}s", f"interval_{int(interval_sec)}s"]
+    result = {"ts": now, "emitted": True, "coin": chosen, "direction": _DIRECTION,
+              "leverage": leverage, "marginPct": round(margin_pct, 4),
+              "elapsed_hours": round(elapsed_sec / 3600.0, 2), "interval_hours": interval_hours,
+              "held": held_assets, "reasons": reasons}
+    print(f"[tortoise.scan] EMIT {chosen} {_DIRECTION} {leverage}x marginPct={margin_pct:.2f}% | "
+          f"elapsed={elapsed_sec / 3600.0:.1f}h interval={interval_hours}h held={held_assets}",
+          file=sys.stderr)
+
+    out = [{
+        "asset": chosen,
+        "direction": _DIRECTION,
+        "marginPct": margin_pct,              # PERCENT in (0,100] — runtime sizes the dollars
+        "leverage": leverage,                 # 1..3; runtime applies it
+        "data": {
+            "score": _PRODUCER_FIXED_SCORE,   # v2 producer-fixed 5 (DCA has no scoring)
+            "leverage": leverage,
+            "direction": _DIRECTION,
+            "reasons": reasons,
+            "intervalSec": float(interval_sec),
+            "elapsedSec": elapsed_sec,
+            "heldAssets": held_assets,
+        },
+    }]
+
+    _persist(ctx, history, signaled, result)
+    return out
+
+
+def _persist(ctx, history, signaled, result):
+    """Persist the DCA-history cache + dedup map + this tick's result every tick;
+    bounded by state_history_max_count. ctx.state advances ONLY on a clean tick,
+    so a failed tick never records a phantom DCA timestamp."""
+    if ctx.state is None:
+        return
+    try:
+        ctx.state.append({"dca_history": history, "signaled": signaled, "result": result})
+    except Exception as exc:  # noqa: BLE001
+        print(f"[tortoise.scan] WARNING: state append failed; next tick may re-DCA "
+              f"or re-emit a suppressed signal: {exc!r}", file=sys.stderr)

--- a/strategies/tortoise/main/scanners/scoring.py
+++ b/strategies/tortoise/main/scanners/scoring.py
@@ -1,0 +1,88 @@
+"""TORTOISE — pure cadence/selection math (no I/O, no MCP, no clock side-effects).
+
+A faithful Runtime 3.0 port of the v2 Tortoise producer's DCA-scheduler logic
+(tortoise-producer.py v1.0.1). The cadence math is reproduced VERBATIM so a
+fidelity harness can diff this against the v2 producer on the same history map +
+`now`. Behaviour-preserving quirks from v2 are kept and flagged `# v2-quirk`.
+
+There is NO price scoring in Tortoise — "scoring" here means the DCA clock:
+which whitelisted asset is most overdue past its interval. `now` and the
+per-asset last-DCA history are passed IN by the caller (scan.py reads them from
+ctx.state), keeping this module pure and unit-testable on plain dicts.
+
+FIDELITY NOTES vs tortoise-producer.py v1.0.1:
+  - seconds_since / is_dca_due / pick_next_dca_asset / next_due_seconds are
+    ported VERBATIM (same >=, same never-DCA'd-wins sentinel, same case
+    normalization, same future-timestamp clamp-to-0 clock-skew guard).
+  - The v2 producer also clamped a future timestamp to 0.0 in seconds_since
+    (max(0.0, now - last)); preserved.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def seconds_since(last_dca_ts, now_ts):
+    """Seconds elapsed since the last DCA event. None for unknown (never-DCA'd)
+    assets — they should be treated as MAXIMALLY overdue. Verbatim from v2.
+
+    v2-quirk: a future timestamp clamps to 0.0 (clock-skew safety)."""
+    if last_dca_ts is None:
+        return None
+    try:
+        return max(0.0, float(now_ts) - float(last_dca_ts))
+    except (TypeError, ValueError):
+        return None
+
+
+def is_dca_due(elapsed_sec, interval_sec):
+    """True if the DCA interval has elapsed OR this asset has never been DCA'd
+    (elapsed_sec=None). Never-DCA'd assets are always due. Verbatim from v2.
+
+    v2-quirk: threshold is `>=`, not `>` (an asset exactly at the interval is
+    due)."""
+    if elapsed_sec is None:
+        return True
+    return elapsed_sec >= interval_sec
+
+
+def pick_next_dca_asset(assets, last_dca_by_asset, interval_sec, now_ts):
+    """Among `assets`, pick the one most overdue (longest since last DCA, past
+    the interval). Never-DCA'd assets win over any DCA'd asset (infinite-overdue
+    sentinel). Returns the upper-cased asset symbol or None if nothing is due.
+    Verbatim from v2 pick_next_dca_asset (case normalized to upper)."""
+    best_asset, best_elapsed = None, -1.0
+    for asset in assets:
+        key = str(asset).upper()
+        last = last_dca_by_asset.get(key)
+        elapsed = seconds_since(last, now_ts)
+        if not is_dca_due(elapsed, interval_sec):
+            continue
+        # Never-DCA'd asset (elapsed is None) -> treat as infinitely overdue so
+        # it wins over any DCA'd asset. Sentinel sortable above any real elapsed.
+        rank = float('inf') if elapsed is None else elapsed
+        if rank > best_elapsed:
+            best_elapsed = rank
+            best_asset = key
+    return best_asset
+
+
+def next_due_seconds(assets, history, interval_sec, now_ts):
+    """Seconds until the next eligible asset comes due (for the WAITING
+    diagnostic). 0 if any asset is already past-due; None only if `assets` is
+    empty. Verbatim from v2 next_due_seconds."""
+    soonest = None
+    for asset in assets:
+        last = history.get(str(asset).upper())
+        if last is None:
+            return 0
+        wait = (interval_sec - (now_ts - last))
+        if wait <= 0:
+            return 0
+        if soonest is None or wait < soonest:
+            soonest = wait
+    return soonest

--- a/strategies/tortoise/main/scanners/test_margin_pct.py
+++ b/strategies/tortoise/main/scanners/test_margin_pct.py
@@ -1,0 +1,64 @@
+"""Guard: tortoise's marginPct must be a PERCENT in (0,100], never a v2 fraction.
+
+v3.x runtime sizes `(marginPct/100)*withdrawable` (resolve-margin.ts), so a
+fraction like 0.08 sizes 0.08% of withdrawable — ~100x undersize, silent (no 400,
+since 0.08 still satisfies the (0,100] bound). The v2 producer used marginPct=0.08
+(a FRACTION) and multiplied by account_value; this port emits a PERCENT (8) and
+the runtime sizes. Tortoise has NO conviction tiers — the emitted marginPct is the
+fixed input value. Also assert the leverage clamp matches v2 (MAX_LEVERAGE=3).
+"""
+
+import os
+import re
+import sys
+
+import yaml
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_RUNTIME_YAML = os.path.join(_HERE, "..", "runtime.yaml")
+_SCAN_PY = os.path.join(_HERE, "scan.py")
+
+sys.path.insert(0, _HERE)
+
+
+def _runtime_margin_pct():
+    with open(_RUNTIME_YAML) as f:
+        spec = yaml.safe_load(f)
+    for s in spec["scanners"]:
+        if s.get("type") == "external_scanner":
+            return float(s["inputs"]["marginPct"])
+    raise AssertionError("no external_scanner inputs.marginPct in runtime.yaml")
+
+
+def _scan_default_margin_pct():
+    src = open(_SCAN_PY).read()
+    m = re.search(r"_DEFAULT_MARGIN_PCT\s*=\s*([0-9.]+)", src)
+    assert m, "scan.py _DEFAULT_MARGIN_PCT not found"
+    return float(m.group(1))
+
+
+def _scan_max_leverage():
+    src = open(_SCAN_PY).read()
+    m = re.search(r"_MAX_LEVERAGE\s*=\s*([0-9]+)", src)
+    assert m, "scan.py _MAX_LEVERAGE not found"
+    return int(m.group(1))
+
+
+def test_runtime_margin_pct_is_percent_in_range():
+    pct = _runtime_margin_pct()
+    assert 1 <= pct <= 100, f"runtime.yaml marginPct={pct} not a PERCENT in [1,100]"
+
+
+def test_scan_default_margin_pct_is_percent_in_range():
+    pct = _scan_default_margin_pct()
+    assert 1 <= pct <= 100, f"scan.py _DEFAULT_MARGIN_PCT={pct} not a PERCENT in [1,100]"
+
+
+def test_runtime_and_scan_margin_pct_agree():
+    assert _runtime_margin_pct() == _scan_default_margin_pct(), \
+        "runtime.yaml marginPct must match scan.py _DEFAULT_MARGIN_PCT"
+
+
+def test_max_leverage_matches_v2():
+    """v2 MAX_LEVERAGE = 3 (DCA is accumulation, not leverage)."""
+    assert _scan_max_leverage() == 3, "scan.py _MAX_LEVERAGE must be 3 (v2 cap)"

--- a/strategies/tortoise/strategy.yaml
+++ b/strategies/tortoise/strategy.yaml
@@ -1,0 +1,42 @@
+# Tortoise — DCA scheduler. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2
+# Tortoise (SKILL.md v1.0.0): time-triggered dollar-cost averaging on a small
+# basket (BTC/ETH/SOL), no price prediction — the oldest-overdue asset wins each
+# tick, sized at a fixed margin %, always LONG, let-winners-run DSL with a 30d
+# hard_timeout so accumulation compounds. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: tortoise
+version: "1.0.0"
+
+catalog:
+  name: "Tortoise — DCA Scheduler"
+  emoji: "🐢"
+  tagline: "A time-triggered dollar-cost-averaging scheduler on a small basket (BTC/ETH/SOL): no price prediction, no scoring, no timing — each tick it buys a fixed % of budget on whichever asset is most overdue past its DCA interval, always LONG, and lets a wide DSL ratchet ride the accumulation for days."
+  belief_plain: "Buys a fixed slice of your budget on a strict schedule — by default every 24 hours, one of BTC, ETH or SOL at a time. It predicts nothing; it just keeps accumulating on cadence and trails a wide stop so the position can run instead of getting churned. The most-overdue coin goes first."
+  thesis: "Dollar-cost averaging is the single most accessible trade in crypto and needs zero prediction skill. Every other agent makes a directional call; Tortoise makes none — it buys on a clock. Cadence IS the signal: when an asset has gone longer than the interval since its last buy it is due, never-bought assets are always due, and the most-overdue wins. A very wide let-winners-run DSL (30d hard_timeout) lets the accumulated longs compound while Phase-2 locks bank gains gradually."
+  group: dca
+  archetype: structural_neutral
+  sub_style: dca
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: whitelist
+  direction: long
+  risk_level: conservative
+  tier: onboarding
+  leverage_max: 3
+  max_slots: 3
+  min_budget: 100
+  assets: ["BTC", "ETH", "SOL"]
+  tags: [btc, eth, sol, multi-asset, dca, dollar-cost-averaging, time-trigger, always-long, onboarding, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: TORTOISE_WALLET
+    funding_share: 1.0


### PR DESCRIPTION
## data_retention fix
Runtime 3.0 schema field is `data_retention_seconds` (integer 3600–604800). Converted the stale `data_retention_hours` on cougar(×2), jaguar, rhino(×2), thesis-fund + 3 author-reference docs. Wave-1 ports that exceeded the 7d cap (koala 90d, tortoise 30d) clamped to 604800.

## Wave 1 ports (28 → 32)
Faithful `scan()`/`scoring.py` ports of the v2 onboarding specialists:
- **iguana** — broad XYZ-index trend (xyz:SP500 + xyz:XYZ100)
- **koala** — single-asset HODL (fire-once, ultra-wide DSL)
- **sailfish** — relative-strength rotation (BTC/ETH/SOL/HYPE)
- **tortoise** — DCA scheduler (BTC/ETH/SOL, time-trigger)

Each: read-guarded MCP, marginPct percent (fraction×100), tickers HL-meta-verified, DSL verbatim, no `__init__.py`, per-tick `ctx.state` result + one-line stderr. py_compile + unit-test parity per port.

Note: catalog glossary warnings are pre-existing fleet-wide drift (64 across the 28), tracked separately.