### PR TITLE
Runtime 3.0 Wave 2 (12 smart-money/momentum agents) + author validator captures data_retention

### DIFF
--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -8,6 +8,7 @@ relies on. Exit 0 = all packages valid; exit 1 = at least one error.
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import ast
+import re
 import sys
 from pathlib import Path
 
@@ -39,7 +40,6 @@ def validate(pkg: Path) -> list:
     for inst in man.get("instances", []):
         name = inst.get("name", "?")
         rt_rel = inst.get("runtime")
-        scn = (inst.get("scanner") or {})
         wenv = inst.get("wallet_env")
 
         rt = pkg / rt_rel if rt_rel else None
@@ -48,23 +48,39 @@ def validate(pkg: Path) -> list:
             continue
         rt_text = rt.read_text()
 
-        if scn.get("name") not in rt_text:
-            errs.append(f"instance {name}: scanner.name {scn.get('name')!r} not an external_scanner in {rt_rel}")
-        ep = pkg / "scripts" / scn.get("entrypoint", "scanner.py")
-        if not (pkg / scn.get("entrypoint", "scanner.py")).is_file() and not ep.is_file():
-            errs.append(f"instance {name}: scanner.entrypoint {scn.get('entrypoint')!r} not found")
+        # data_retention: Runtime 3.0 uses data_retention_seconds (integer 3600–604800);
+        # the v2 data_retention_hours field is deprecated. (See senpi-trading-runtime/references/runtime-yaml.md.)
+        if re.search(r"^\s*data_retention_hours\s*:", rt_text, re.M):
+            errs.append(f"instance {name}: {rt_rel} uses deprecated 'data_retention_hours' — "
+                        f"use 'data_retention_seconds' (integer 3600-604800; hours x 3600)")
+        m = re.search(r"^\s*data_retention_seconds\s*:\s*([0-9]+)", rt_text, re.M)
+        if m and not (3600 <= int(m.group(1)) <= 604800):
+            errs.append(f"instance {name}: {rt_rel} data_retention_seconds {m.group(1)} "
+                        f"out of range [3600, 604800] (1h-7d)")
+
+        # Runtime 3.0 scanner package: <runtime_dir>/scanners/scan.py exports scan(inputs, ctx);
+        # the thesis math is a sibling scanners/scoring.py imported as `import scoring` (NO __init__.py).
+        scn_dir = rt.parent / "scanners"
+        scan_py = scn_dir / "scan.py"
+        scoring_py = scn_dir / "scoring.py"
+        if not scan_py.is_file():
+            errs.append(f"instance {name}: missing {scan_py.relative_to(pkg)} (Runtime 3.0 scan() entrypoint)")
+        elif "def scan(" not in scan_py.read_text():
+            errs.append(f"instance {name}: {scan_py.relative_to(pkg)} does not define scan(inputs, ctx)")
+        if not scoring_py.is_file():
+            errs.append(f"instance {name}: missing sibling {scoring_py.relative_to(pkg)} ('import scoring' will fail)")
+        if (scn_dir / "__init__.py").is_file():
+            errs.append(f"instance {name}: {(scn_dir / '__init__.py').relative_to(pkg)} present — remove it (sibling-import model)")
         if not wenv or ("${%s}" % wenv) not in rt_text:
             errs.append(f"instance {name}: wallet_env {wenv!r} not bound as ${{{wenv}}} in {rt_rel}")
         seen_wallet_envs.add(wenv)
-        if inst.get("params") is None:
-            errs.append(f"instance {name}: missing params block")
 
     # multi-instance must use distinct wallets
     if len(man.get("instances", [])) > 1 and len(seen_wallet_envs) < len(man["instances"]):
         errs.append("multi-instance strategy must declare a distinct wallet_env per instance")
 
     # scanner present + parses; no '@senpi/runtime' without -ai anywhere
-    for py in (pkg / "scripts").glob("*.py"):
+    for py in pkg.rglob("*.py"):
         try:
             ast.parse(py.read_text())
         except SyntaxError as e:

--- a/strategies/badger/main/runtime.yaml
+++ b/strategies/badger/main/runtime.yaml
@@ -1,0 +1,142 @@
+# ── BADGER · single instance — OI-divergence breakout anticipator ─────────────
+# Runtime 3.0 port of the v2 Badger (SKILL.md v1.0.0 / badger-producer.py v1.0.1).
+# Liquid-majors whitelist (BTC/ETH/SOL/HYPE). Takes a prior-24h range break ONLY
+# when open interest is RISING (new money) AND smart money agrees with the break,
+# then sizes 20% / 5x and hands it to a wide DSL ladder so a confirmed breakout
+# can run. DSL-only exits, time-cuts disabled. Faithful port of the v2 producer
+# thesis — see scanners/scoring.py (math reproduced verbatim, v2-quirks flagged).
+name: badger-main
+group: badger
+version: 1.0.0
+description: >
+  BADGER — OI-Divergence Breakout Anticipator on liquid majors (BTC/ETH/SOL/HYPE).
+  Open interest is the fuel of a breakout: a price push beyond the prior 24h range
+  confirmed by RISING open interest = new money committing = real follow-through; a
+  breakout on flat/declining OI is a fakeout. Three hard gates — price breaks the
+  prior 24h range edge, OI rising >= 2% over 1h, smart-money direction agrees + tilt
+  >= 55% — then a max-~10 score (breakout magnitude, OI strength, SM strength, 4h
+  structure, volume) picks the single best candidate at score >= 5. Flat 20% margin /
+  5x leverage. DSL is the ONLY exit — time-cuts disabled, wide ratchet ladder (first
+  lock at +10% ROE) so a confirmed breakout runs. Faithful port of v2 Badger v1.0.0.
+
+strategy:
+  wallet: "${BADGER_WALLET}"
+  slots: 1                                # v2 emitted a single best candidate / 1 slot
+  margin_pct: 20                          # baseline %; scan emits a flat marginPct per signal (v2 config 0.20)
+  default_leverage: 5                     # fallback; scan emits 1-5x per signal (v2 MAX_LEVERAGE 5)
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: badger_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 180                   # v2 tick_timeout=180; up to ~1 read/asset + sm + account
+    default_signal_validity_seconds: 600   # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + OI baseline + per-tick scan-results history
+    inputs:
+      universe: ["BTC", "ETH", "SOL", "HYPE"]   # v2 config universe (validated live on HL main DEX 2026-06-29)
+      minScore: 5                          # v2 DEFAULT_MIN_SCORE / config minScore
+      breakoutLookbackHours: 24            # v2 breakoutLookbackHours (prior 24h, 1h bars)
+      oiRisingMinPct: 2.0                  # v2 oiRisingMinPct — the conviction gate (core edge)
+      oiStrongPct: 5.0                     # v2 oiStrongPct — strongly-building bonus
+      smTiltMinPct: 55                     # v2 smTiltMinPct
+      smStrongTiltPct: 70                  # v2 smStrongTiltPct
+      marginPct: 20                        # PERCENT of withdrawable (0,100]; v2 config 0.20 -> 20%
+      leverage: 5                          # clamped to MAX_LEVERAGE 5 in scan.py
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      breakoutDir: { type: string, required: false }
+      breakoutMagPct: { type: number, required: false }
+      oiChangePct: { type: number, required: false }
+      oiSource: { type: string, required: false }
+      trend4h: { type: string, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      volumeTrendPct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: badger_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [badger_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # momentum entries MUST fill — maker-only can rest unfilled
+                                           # (CREATE_ORDER_RESTING); a confirmed breakout won't wait.
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: badger_main_signals
+
+# ── EXIT (DSL — preserved VERBATIM from the v2 runtime.yaml) ───────────────────
+# A confirmed breakout can run far, so let it. Time-cuts DISABLED (single-asset/
+# conviction pattern: v1 DSL fires hard_timeout in Phase 2 incorrectly). Phase 1
+# max_loss 20% cuts a failed breakout. Phase 2 wide-by-design: T0 +10%/lock 0
+# through T5 +100%/lock 85 so a winner breathes. order_type FEE_OPTIMIZED_LIMIT,
+# taker fallback on (closes MUST happen).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: false                       # v2: DISABLED — confirmed breakout runs until DSL retrace
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0                    # v2: catastrophic floor (cuts a failed breakout)
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # wide-by-design; FIRST lock at +10% ROE (reachable)
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # 72h (was data_retention_hours 72) -> in [3600, 604800]
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 risk.guard_rails.daily_loss_limit_pct
+    max_entries_per_day: 3                  # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 cooldown_minutes 60 -> 3600s
+    drawdown_halt_pct: 20                  # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400      # v2 per_asset_cooldown_minutes 240 -> 14400s (4h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/badger/main/scanners/scan.py
+++ b/strategies/badger/main/scanners/scan.py
@@ -1,0 +1,376 @@
+"""BADGER — supervised scanner (Runtime 3.0 port of the v2 Badger OI-divergence
+breakout anticipator).
+
+Multi-asset, whitelist-gated (BTC/ETH/SOL/HYPE by default). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - for each non-held, non-recently-signaled whitelist coin applies the THREE hard
+    gates verbatim from v2 build_thesis:
+      GATE 1  price breaks the prior 24h range edge (breakout_signal),
+      GATE 2  open interest RISING >= oiRisingMinPct over 1h (conviction gate — the
+              core edge; uses market_get_asset_data's oi_velocity object, else a
+              self-computed delta from the per-asset OI baseline in ctx.state),
+      GATE 3  smart money (leaderboard_get_markets) agrees with the break + tilt >= floor,
+  - scores survivors via the pure `scoring.build_thesis`,
+  - emits the SINGLE highest-scoring candidate at/above `minScore` (v2 main()
+    emitted only `best`), sized by a flat margin PERCENT + leverage clamp.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit.
+No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs the v2 producer (badger-producer.py v1.0.1):
+  - v2 persisted the per-asset last-seen openInterest to state/oi-state.json and
+    self-computed the OI delta on the next tick when market_get_asset_data's
+    oi_velocity object was null. This port stores that OI baseline map in
+    ctx.state instead (same warm-up semantics: a freshly-started Badger has no
+    prior OI for an asset on its first tick, so the OI gate returns 'unavailable'
+    and the asset is skipped until the baseline is seeded). v2 refreshed the OI
+    baseline on EVERY tick an asset was fetched (even when it bailed early on
+    insufficient candles or no breakout); this port preserves that — the baseline
+    is updated for every asset whose market_get_asset_data read succeeds.
+  - v2 sizing used marginPct (a FRACTION, 0.20 in badger-config.json) * account_value
+    -> marginUsd. This port uses marginPct=20 (a PERCENT) and emits `marginPct`;
+    the runtime sizes (marginPct/100)*withdrawable. Value preserved (0.20 -> 20%).
+    Defensive koala-pattern guard: a value <= 1.0 is treated as a pasted v2
+    fraction and x100'd.
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1 signal/tick.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=240) -> ctx.state dedup map
+    (same TTL semantics, same 4x-TTL prune horizon).
+  - leverage clamp min(leverage, MAX_LEVERAGE=5) preserved verbatim.
+  - FLAG: the v2 runtime.yaml template said strategy.margin_pct: 25, which
+    CONTRADICTS the producer + config (marginPct 0.20 = 20%). Per the spec
+    source-of-truth order (producer + config + SKILL over a stale runtime template)
+    this port uses 20%.
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 defaults (badger-producer.py / badger-config.json)
+_DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL", "HYPE"]
+_DEFAULT_MIN_SCORE = 5                 # v2 DEFAULT_MIN_SCORE / config minScore
+_DEFAULT_BREAKOUT_LOOKBACK = 24       # v2 DEFAULT_BREAKOUT_LOOKBACK (prior 24h, 1h bars)
+_DEFAULT_OI_RISING_MIN_PCT = 2.0     # v2 DEFAULT_OI_RISING_MIN_PCT — the conviction gate
+_DEFAULT_OI_STRONG_PCT = 5.0         # v2 DEFAULT_OI_STRONG_PCT — strongly-building bonus
+_DEFAULT_SM_TILT_MIN = 55            # v2 DEFAULT_SM_TILT_MIN
+_DEFAULT_SM_STRONG = 70              # v2 DEFAULT_SM_STRONG
+_DEFAULT_MARGIN_PCT = 20.0           # v2 config marginPct 0.20 -> 20 PERCENT
+_DEFAULT_LEVERAGE = 5                # v2 DEFAULT_LEVERAGE
+_MAX_LEVERAGE = 5                    # v2 MAX_LEVERAGE (hardcoded clamp)
+_DEFAULT_RECENT_TTL = 240           # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    Badger's universe is all main-DEX majors, so this only ever returns ''."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[badger.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[badger.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _asset_data(ctx, coin):
+    """Raw market_get_asset_data doc for `coin` or None. READ-GUARDED.
+    Ported from v2 fetch_market_data (1h/4h candles, no funding, no order book)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["1h", "4h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[badger.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    return md
+
+
+def _oi_velocity_1h(asset_data, coin, oi_baseline):
+    """Return (oi_change_pct_1h, source, cur_oi). Prefers the runtime oi_velocity
+    object; falls back to a self-computed delta vs the per-asset OI baseline in
+    ctx.state. Returns (None, 'unavailable', cur_oi) when neither is usable yet.
+
+    Ported verbatim from v2 oi_velocity_1h (the JSON last-OI cache is replaced by
+    the oi_baseline dict passed in from ctx.state)."""
+    data = asset_data.get("data", {}) if isinstance(asset_data, dict) else {}
+    asset_ctx = data.get("asset_context", {}) or {}
+    cur_oi = scoring._f(asset_ctx.get("openInterest"))
+    oiv = data.get("oi_velocity")
+    if isinstance(oiv, dict):
+        ch = oiv.get("oi_change_pct")
+        if isinstance(ch, dict) and ch.get("1h") is not None:
+            try:
+                return float(ch["1h"]), "oi_velocity", cur_oi
+            except (TypeError, ValueError):
+                pass
+    if cur_oi > 0:
+        prev = oi_baseline.get(coin.upper())
+        if prev and scoring._f(prev.get("oi", 0)) > 0:
+            pct = ((cur_oi - scoring._f(prev["oi"])) / scoring._f(prev["oi"])) * 100
+            return pct, "computed", cur_oi
+    return None, "unavailable", cur_oi
+
+
+def _get_sm_direction(ctx, coin):
+    """Port of v2 fetch_sm_direction: net smart-money lean for `coin` from
+    leaderboard_get_markets. Returns (direction, tilt_pct) or (None, 0.0).
+    READ-GUARDED. Verbatim thresholds: long_ratio >= 50 -> LONG, else SHORT."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — smart-money is GATE 3; a read fail just fails the gate
+        print(f"[badger.scan] leaderboard_get_markets read failed (SM gate -> skip): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and not raw.get("success", True)):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != coin.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+# ── ctx.state: recent-signal dedup + OI baseline (port of v2 JSON caches) ──
+
+def _load_state(ctx):
+    """Returns (signaled_map, oi_baseline_map) from the last clean tick."""
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}, {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    oi = last.get("oi_baseline", {})
+    return (dict(sig) if isinstance(sig, dict) else {},
+            dict(oi) if isinstance(oi, dict) else {})
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    universe = [a.upper() for a in inputs.get("universe", _DEFAULT_UNIVERSE)]
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    lookback = int(inputs.get("breakoutLookbackHours", _DEFAULT_BREAKOUT_LOOKBACK))
+    oi_min = float(inputs.get("oiRisingMinPct", _DEFAULT_OI_RISING_MIN_PCT))
+    sm_min = float(inputs.get("smTiltMinPct", _DEFAULT_SM_TILT_MIN))
+    lev_default = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    # marginPct is a PERCENT in (0,100]. Defensive koala-pattern guard: a value
+    # <= 1.0 (operator pasted the v2 FRACTION 0.20) is treated as a fraction and
+    # x100'd so it never silently sizes ~100x small.
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        print(f"[badger.scan] marginPct={margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled, oi_baseline = _load_state(ctx)
+    signaled = _prune_signaled(signaled, ttl, now)
+
+    candidates = []
+    scanned = 0
+    for coin in universe:
+        if not coin:
+            continue
+        cu = coin.upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        d = md.get("data", {}) if isinstance(md, dict) else {}
+        candles_1h = d.get("candles", {}).get("1h", []) if isinstance(d, dict) else []
+        candles_4h = d.get("candles", {}).get("4h", []) if isinstance(d, dict) else []
+
+        # Always refresh the OI baseline for this asset (warms the fallback cache),
+        # exactly as v2 did on every successful market read.
+        oi_now = scoring._f((d.get("asset_context", {}) or {}).get("openInterest")) if isinstance(d, dict) else 0.0
+
+        if len(candles_1h) < lookback + 1 or len(candles_4h) < 6:
+            if oi_now > 0:
+                oi_baseline[cu] = {"oi": oi_now, "ts": now}
+            continue
+
+        # GATE 1 — price breakout
+        bo_dir, bo_mag = scoring.breakout_signal(candles_1h, lookback)
+        if bo_dir is None:
+            if oi_now > 0:
+                oi_baseline[cu] = {"oi": oi_now, "ts": now}
+            continue
+        direction = "LONG" if bo_dir == "UP" else "SHORT"
+
+        # GATE 2 — OI rising (the conviction gate, Badger's core edge)
+        oi_pct, oi_src, _cur = _oi_velocity_1h(md, coin, oi_baseline)
+        if oi_now > 0:                                       # refresh AFTER the read (v2 order)
+            oi_baseline[cu] = {"oi": oi_now, "ts": now}
+        if oi_pct is None:
+            continue                                         # OI unknown (cache warming) — skip
+        if oi_pct < oi_min:
+            continue                                         # breakout without rising OI = fakeout
+
+        # GATE 3 — Smart-Money agreement
+        sm_dir, sm_tilt = _get_sm_direction(ctx, coin)
+        if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+            continue
+        if sm_tilt < sm_min:
+            continue
+
+        th = scoring.build_thesis(coin, direction, bo_dir, bo_mag, oi_pct, oi_src,
+                                  candles_1h, candles_4h, sm_dir, sm_tilt, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets, "note": f"WAITING (min score {min_score:.0f})"}
+        print(f"[badger.scan] WAITING — no OI-confirmed breakout w/ SM agreement "
+              f"(min score {min_score:.0f}); scanned={scanned} held={held_assets}", file=sys.stderr)
+    else:
+        # v2 emitted exactly the single best (highest score).
+        candidates.sort(key=lambda c: c["score"], reverse=True)
+        best = candidates[0]
+
+        leverage = min(lev_default, _MAX_LEVERAGE)          # v2 clamp verbatim
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"],
+                  "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best["reasons"]}
+        print(f"[badger.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+              f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:6]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # 1..5; runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "breakoutDir": best["breakout_dir"],
+                "breakoutMagPct": best.get("breakout_mag_pct") or 0.0,
+                "oiChangePct": best.get("oi_change_pct") or 0.0,
+                "oiSource": best.get("oi_source") or "unavailable",
+                "trend4h": best["trend_4h"],
+                "smDirection": best["sm_direction"],
+                "smTiltPct": best.get("sm_tilt_pct") or 0.0,
+                "volumeTrendPct": best.get("volume_trend_pct") or 0.0,
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + OI baseline + this tick's result every tick; bounded
+    #    by state_history_max_count. Read back via ctx.state.last(). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "oi_baseline": oi_baseline, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[badger.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal or lose an OI baseline: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/badger/main/scanners/scoring.py
+++ b/strategies/badger/main/scanners/scoring.py
@@ -1,0 +1,204 @@
+"""BADGER — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Badger producer's technical helpers +
+OI-confirmed-breakout scoring (SKILL.md v1.0.0, badger-producer.py v1.0.1). The
+math/indexing is reproduced VERBATIM so a fidelity harness can diff this against
+the v2 producer on the same market snapshot. v2 quirks are kept and flagged
+`# v2-quirk`; fix them only as a separate, labelled change AFTER the port is
+validated.
+
+Multi-asset, single-pass, unit-testable on plain candle lists. The three HARD
+gates (price breakout, OI rising, smart-money agreement) and the OI-velocity
+read live in scan.py (they need MCP + cross-tick OI cache); this module is the
+pure scorer over already-fetched candles + already-resolved gate values.
+
+`build_thesis` here is called by scan.py ONLY after all three gates have passed,
+so it never returns None — it assembles the score + reasons. The caller gates on
+`thesis['score'] >= minScore`.
+"""
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts only (via the _f primary/alt helper); the list branch is
+# defensive and never fires on dict candles, so it does not change v2 behaviour.
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── indicators (ported verbatim from v2 badger-producer.py) ──
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim from v2.
+
+    v2-quirk: thresholds use strict (>) for higher-lows / lower-highs counting,
+    and the BULLISH/BEARISH gate is `>= total * 0.6` where total = lookback - 1.
+    Returns (label, strength)."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def breakout_signal(candles_1h, lookback):
+    """Returns (direction, magnitude_pct) where direction is 'UP' (latest close
+    above the prior `lookback`-bar high), 'DOWN' (below the prior low), or None.
+
+    Verbatim from v2 breakout_signal: takes the last lookback+1 closes, compares
+    the latest close against the max/min of the PRIOR `lookback` closes."""
+    if len(candles_1h) < lookback + 1:
+        return None, 0.0
+    closes = [_close(c) for c in candles_1h[-(lookback + 1):]]
+    latest = closes[-1]
+    prior = closes[:-1]
+    if not prior or latest <= 0:
+        return None, 0.0
+    hi, lo = max(prior), min(prior)
+    if hi > 0 and latest > hi:
+        return "UP", ((latest - hi) / hi) * 100
+    if lo > 0 and latest < lo:
+        return "DOWN", ((lo - latest) / lo) * 100
+    return None, 0.0
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-half vs earlier-half average volume, % change. Verbatim from v2.
+
+    v2-quirk: Badger's volume_trend guards on `len(candles) < lookback` (NOT
+    lookback+2 like Bison) and slices vols = last `lookback` bars, so recent/
+    earlier are the two halves of exactly `lookback` bars. Reproduced exactly."""
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_vol(c) for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ── the thesis (OI-confirmed breakout score), ported verbatim from v2 build_thesis ──
+
+def build_thesis(coin, direction, bo_dir, bo_mag, oi_pct, oi_src,
+                 candles_1h, candles_4h, sm_dir, sm_tilt, inputs):
+    """Port of v2 build_thesis's SCORING half (gates already passed in scan.py).
+
+    Inputs:
+      - direction: "LONG"/"SHORT" (= 'UP'->LONG / 'DOWN'->SHORT from breakout_signal)
+      - bo_dir: "UP"/"DOWN"; bo_mag: breakout magnitude % (>=0)
+      - oi_pct: OI 1h change % (gate already confirmed >= oiRisingMinPct); oi_src tag
+      - sm_dir: "LONG"/"SHORT" (gate already confirmed == direction); sm_tilt: %
+      - candles_4h: for 4h trend-structure confirmation bonus
+      - candles_1h: for the volume-rising bonus
+
+    Returns a thesis dict with `score` + `reasons`. minScore is applied by the
+    CALLER (scan.py). Scoring weights/cutoffs are VERBATIM from v2:
+      breakout magnitude: +3 (>=1.0%) / +2 (>=0.3%) / +1 (else)
+      OI rising (gate-confirmed): +2 ; OI strongly building (>= oiStrongPct): +1
+      SM aligned (gate-confirmed): +2 ; SM strongly tilted (>= smStrongTiltPct): +1
+      4h structure confirms direction: +1
+      volume rising (> 10%): +1
+    """
+    oi_strong = float(inputs.get("oiStrongPct", 5.0))
+    sm_strong = float(inputs.get("smStrongTiltPct", 70))
+
+    trend_4h, _str_4h = trend_structure(candles_4h)
+
+    score = 0
+    reasons = []
+
+    # Breakout magnitude
+    if bo_mag >= 1.0:
+        score += 3
+    elif bo_mag >= 0.3:
+        score += 2
+    else:
+        score += 1
+    reasons.append(f"breakout_{bo_dir.lower()}_{bo_mag:+.2f}%")
+
+    # OI rising (gate-confirmed) + strongly-building bonus
+    score += 2
+    reasons.append(f"oi_rising_{oi_pct:+.1f}%_{oi_src}")
+    if oi_pct >= oi_strong:
+        score += 1
+        reasons.append("oi_strongly_building")
+
+    # SM aligned (gate-confirmed) + strong bonus
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    # 4h structure confirms breakout direction
+    if (direction == "LONG" and trend_4h == "BULLISH") or \
+       (direction == "SHORT" and trend_4h == "BEARISH"):
+        score += 1
+        reasons.append(f"4h_confirms_{trend_4h.lower()}")
+
+    # Volume rising bonus
+    vol_pct = volume_trend(candles_1h)
+    if vol_pct > 10:
+        score += 1
+        reasons.append(f"vol_rising_{vol_pct:+.0f}%")
+
+    return {
+        "coin": coin,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "breakout_dir": bo_dir,
+        "breakout_mag_pct": round(bo_mag, 3),
+        "oi_change_pct": round(oi_pct, 3),
+        "oi_source": oi_src,
+        "trend_4h": trend_4h,
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": _f(sm_tilt),
+        "volume_trend_pct": round(vol_pct, 2),
+    }

--- a/strategies/badger/strategy.yaml
+++ b/strategies/badger/strategy.yaml
@@ -1,0 +1,43 @@
+# Badger — OI-divergence breakout anticipator. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port
+# of the v2 Badger (SKILL.md v1.0.0): a liquid-majors whitelist (BTC/ETH/SOL/HYPE)
+# breakout scorer gated on RISING open interest + smart-money agreement, single-best
+# emit, wide "let winners run" DSL ladder, DSL-only exits.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: badger
+version: "1.0.0"
+
+catalog:
+  name: "Badger — OI-Divergence Breakout Anticipator"
+  emoji: "🦡"
+  tagline: "Only takes the breakout the order flow confirms: enters a prior-24h range break on BTC/ETH/SOL/HYPE only when open interest is RISING (new money committing) AND smart money agrees with the break — then sizes 20% / 5x and lets a wide DSL ratchet ride the move for days."
+  belief_plain: "Most price breakouts fail. The single best filter for whether a breakout will follow through is open interest: if price breaks its prior 24-hour high (or low) while open interest is rising, new money is committing and the move has conviction. If open interest is flat or falling, it's just stops and short-covering — a fakeout — and Badger skips it. It also checks that the best traders are leaning the same way before it commits."
+  thesis: "Open interest is the fuel of a breakout. A price push beyond the recent range confirmed by rising OI = new positions opening in the breakout direction = real follow-through; a breakout on flat/declining OI is shorts covering or stops triggering, with no new money behind it. Gating breakouts on OI velocity (plus smart-money agreement) filters the fakeouts that kill a naive breakout buyer, and a wide let-winners-run exit ladder means the rare confirmed breakout that runs far pays for the ones that don't."
+  group: momentum
+  archetype: breakout_momentum
+  sub_style: oi_confirmed
+  asset_classes: [major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL", "HYPE"]
+  tags: [btc, eth, sol, hype, breakout, open-interest, oi-confirmed, smart-money, momentum, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: BADGER_WALLET
+    funding_share: 1.0

--- a/strategies/bald-eagle/main/runtime.yaml
+++ b/strategies/bald-eagle/main/runtime.yaml
@@ -1,0 +1,138 @@
+# ── BALD EAGLE · single instance — XYZ macro Contrarian Fader ────────────────
+# Runtime 3.0 port of the v2 Bald Eagle (SKILL.md v5.0.0 / eagle-producer.py v5.0.1).
+# Fades smart-money consensus on 6 high-liquidity XYZ macro assets (CL, BRENTOIL,
+# GOLD, SILVER, SP500, XYZ100) when SM is overcrowded + the 4h move is exhausting.
+# Conviction-scaled leverage (5x/7x; XYZ caps lower than crypto). Spread hard-gate
+# (<0.1%). Wide DSL gives macro reversals hours, not minutes, to develop. Faithful
+# port of the v2 thesis — see scanners/scoring.py (math reproduced verbatim).
+name: bald-eagle-main
+group: bald-eagle
+version: 3.0.0
+description: >
+  BALD EAGLE — XYZ macro Contrarian Fader. Counter-trades smart-money consensus on 6
+  high-liquidity XYZ macro assets (CL, BRENTOIL, GOLD, SILVER, SP500, XYZ100) when SM
+  concentration is high AND the 4h move is exhausting. Scores every contributor (SM
+  concentration, trader depth, contribution velocity 1h/4h, 4h price alignment, XYZ-
+  tuned move-exhaustion 1-2% bands, 4h trend structure, 1h momentum, volume trend,
+  funding alignment) at/above MIN_SCORE 8, hard-gates on book spread <0.1%, then emits
+  the OPPOSITE direction (fade). Conviction-scaled leverage (5x/7x). Wide XYZ-tuned DSL
+  (480min hard timeout, 12% retrace). Faithful port of the v2 Bald Eagle v5.0.0 thesis.
+
+strategy:
+  wallet: "${BALD_EAGLE_WALLET}"
+  slots: 2                                # v2 strategy.slots 2
+  margin_pct: 40                          # baseline %; scan emits the per-signal marginPct (40% of equity)
+  default_leverage: 5                     # fallback; scan emits 5-7x per signal
+  trading_risk: moderate                  # v2 strategy.trading_risk moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: eagle_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 240                   # leaderboard + up to 2 reads/asset (candles + spread) across 6 assets
+    default_signal_validity_seconds: 600   # 2x tick; a fresh re-score arrives next tick
+    state_history_max_count: 100           # recent-signal dedup map + per-tick scan-results history
+    inputs:
+      trackedAssets: ["CL", "BRENTOIL", "GOLD", "SILVER", "SP500", "XYZ100"]  # v2 TRACKED_XYZ (validated live on HL xyz DEX 2026-06-29)
+      minScore: 8                          # v2 MIN_SCORE (contrarian threshold, lowered v4.0)
+      marginPct: 40                        # PERCENT of withdrawable (0,100]; v2 MARGIN_PCT 0.40
+      maxSpreadPct: 0.001                  # v2 MAX_SPREAD_PCT (0.1% book spread hard gate)
+      maxLeverage: 7                       # v2 MAX_LEVERAGE (XYZ caps lower than crypto)
+      recentSignalTtlSeconds: 21600        # v2 is_asset_cooled_down(360min) -> 21600s anti re-fire
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      marginPct: { type: number }
+      smDirection: { type: string, required: false }
+      fadeDirection: { type: string, required: false }
+      smPct: { type: number, required: false }
+      smTraders: { type: number, required: false }
+      priceChg4hPct: { type: number, required: false }
+      priceChg1hPct: { type: number, required: false }
+      contribChg1hPct: { type: number, required: false }
+      contribChg4hPct: { type: number, required: false }
+      fundingAnnualizedPct: { type: number, required: false }
+      spreadPct: { type: number, required: false }
+      reasons: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: eagle_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [eagle_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT      # v2: contrarian fades can wait — MAKER entry
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false   # v2 entry: maker-only (contrarian fades wait)
+        execution_timeout_seconds: 60      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: eagle_signals
+
+# ── EXIT (DSL — XYZ-tuned wide timings, preserved VERBATIM from v2 runtime.yaml) ──
+# Oil/commodities move slowly (1-3% 4h vs crypto 3-5%) so timings are wide. Exits use
+# FEE_OPTIMIZED_LIMIT with taker fallback (60s) — exits MUST fill. interval 30s (v2).
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # exits need to fill — taker fallback safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    # Time-based exits — wide for macro assets (v2 verbatim)
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 480
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 240
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 120
+    # Phase 1: Loss protection — wider for macro volatility (v2 verbatim)
+    phase1:
+      enabled: true
+      max_loss_pct: 25.0
+      retrace_threshold: 12
+      consecutive_breaches_required: 1
+    # Phase 2: RatchetStop ladder — preserved verbatim from v2 (FIRST lock at +5% ROE — reachable)
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,  lock_hw_pct: 0  }
+        - { trigger_pct: 10, lock_hw_pct: 20 }
+        - { trigger_pct: 20, lock_hw_pct: 35 }
+        - { trigger_pct: 30, lock_hw_pct: 50 }
+        - { trigger_pct: 50, lock_hw_pct: 70 }
+        - { trigger_pct: 75, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # 72h (was data_retention_hours 72)
+  guard_rails:
+    daily_loss_limit_pct: 10               # v2 guard_rails.daily_loss_limit_pct
+    max_entries_per_day: 4                  # v2 guard_rails.max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 guard_rails.max_consecutive_losses
+    cooldown_seconds: 7200                 # v2 cooldown_minutes 120 -> 7200s (2h)
+    drawdown_halt_pct: 25                  # v2 guard_rails.drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 21600      # v2 per_asset_cooldown_minutes 360 -> 21600s (6h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/bald-eagle/main/scanners/scan.py
+++ b/strategies/bald-eagle/main/scanners/scan.py
@@ -1,0 +1,412 @@
+"""BALD EAGLE — supervised scanner (Runtime 3.0 port of the v2 XYZ Contrarian Fader).
+
+UNIVERSE scanner over a FIXED 6-asset XYZ macro basket (CL, BRENTOIL, GOLD, SILVER,
+SP500, XYZ100; all on the Hyperliquid HIP-3 `xyz` DEX). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - fetches the smart-money leaderboard (leaderboard_get_markets), filtered to the
+    `xyz` DEX + the 6-asset universe, picking the best SM row per token,
+  - for each non-held, non-recently-signaled candidate: fetches 1h/4h candles + funding,
+    scores it IN THE SM DIRECTION via the pure `scoring.score_candidate`,
+  - applies the v2 gate stack: minScore floor, then the spread HARD GATE (<0.1% book
+    spread — execution-quality, not thesis),
+  - FLIPS the direction (contrarian fade — emit OPPOSITE the SM consensus),
+  - emits the SINGLE highest-scoring candidate (v2 main() emitted only `best`),
+    sized by conviction-scaled leverage (5x/7x) + a fixed margin PERCENT.
+
+Read-only + single-pass. Emits a top-level `marginPct` (PERCENT) + `leverage`; the
+runtime sizes the dollars, owns cooldowns/daily caps/drawdown halt, and trails the DSL
+exit. No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs eagle-producer.py v5.0.1 (thesis verbatim from v4.1):
+  - SCORING (scoring.score_candidate): SM concentration, trader depth, contribution
+    velocity (1h/4h), 4h price alignment, move-exhaustion bonus (XYZ 1-2% bands), 4h
+    trend structure, 1h momentum, volume trend, funding alignment — ALL VERBATIM.
+    MIN_SCORE 8 verbatim. Leverage tiers (5x/7x; cap 7) verbatim.
+  - CONTRARIAN FLIP: scoring runs in the SM consensus direction; scan() emits the
+    OPPOSITE direction (scoring.fade_direction) — verbatim v2 main() behaviour.
+  - SPREAD HARD GATE (<0.1%, MAX_SPREAD_PCT 0.001): preserved as a producer-side
+    pre-filter via market_get_asset_data(..., include_order_book=True, dex="xyz").
+    SPREAD_UNREADABLE / SPREAD_WIDE both skip the candidate (verbatim).
+  - MARGIN: v2 MARGIN_PCT=0.40 (FRACTION) * account_value -> marginUsd. Runtime 3.0
+    sizes from a PERCENT in (0,100], so this emits marginPct=40 and the runtime sizes
+    (marginPct/100)*withdrawable. The 40% value is preserved verbatim. (See the
+    "<=1.0 -> pasted fraction, x100" guard in scan() for the input override.)
+  - DROPPED (now owned by the runtime/scaffold, NOT thesis):
+      * has_resting_orders()/cancel_order 600s stale-purge — that auto-CANCELS orders,
+        a MUTATION; scan() is read-only (mutations raise PermissionError). The runtime's
+        own order/slot reconciliation owns stale-order handling now. FLAGGED below.
+      * is_asset_cooled_down() 360m soft pre-filter -> ctx.state recent-signal dedup +
+        the runtime's per_asset_cooldown_seconds guard_rail (same intent).
+      * push_signal / create_position -> scan() returns the candidate; the runtime
+        executes (FEE_OPTIMIZED_LIMIT maker entry).
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1 signal/tick.
+  - fundingAnnualizedPct: v2 emitted funding*100*24*365 (a rough APR). Preserved.
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 constants (eagle-producer.py v5.0.1) — defaults; overridable via inputs
+_DEFAULT_TRACKED_XYZ = ["CL", "BRENTOIL", "GOLD", "SILVER", "SP500", "XYZ100"]
+_DEFAULT_MIN_SCORE = 8                 # v4.0 contrarian threshold (verbatim)
+_DEFAULT_MARGIN_PCT = 40.0            # v2 MARGIN_PCT=0.40 -> 40 PERCENT
+_DEFAULT_MAX_SPREAD_PCT = 0.001       # 0.1% max book spread (execution-quality hard gate)
+_DEFAULT_MAX_LEVERAGE = 7            # v2 MAX_LEVERAGE
+_DEFAULT_TTL = 21600                 # 360m — mirror v2 is_asset_cooled_down(360) anti re-fire
+_DEFAULT_MIN_SM_PCT = 3.0           # informational (concentration already scored 0 below 3%)
+_DEFAULT_MIN_SM_TRADERS = 5         # informational
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll back the
+    whole tick (the contract rolls ANY exception back to []). Returns None on failure
+    so the existing degrade paths apply (markets empty -> skip; candle read None ->
+    technicals just don't contribute; spread unreadable -> skip that candidate)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[bald-eagle.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+# ── ACCOUNT + HELD ASSETS (port of v2 cfg.get_positions, verbatim shape) ──
+
+def _get_account(ctx, wallet):
+    """(account_value, held_tokens_set) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across main/xyz
+    (two views of ONE cross-margined wallet — summing double-counts the shared free
+    balance -> 2x sizing). held_tokens are uppercase coins with the XYZ: prefix
+    stripped (v2 held_tokens normalization). Includes the v2 read-sanity guard
+    (margin in use + empty positions -> skip tick)."""
+    if not wallet:
+        return 0.0, set()
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": wallet})
+    if not ch:
+        return 0.0, set()
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, set()
+
+    account_value = 0.0
+    held = set()
+    any_position = False
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) or {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            any_position = True
+            coin = str(pos.get("coin", "")).upper().replace("XYZ:", "")
+            if coin:
+                held.add(coin)
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a corrupt
+    # clearinghouse read can report margin/notional IN USE while returning an EMPTY
+    # positions list; running the held-token dedup off that re-enters held names
+    # (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not any_position:
+        print("[bald-eagle.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, set()
+    return account_value, held
+
+
+# ── SM SCANNING (port of v2 scan_xyz_sm, verbatim parse) ──
+
+def _scan_xyz_sm(ctx, allowed):
+    """leaderboard_get_markets filtered to dex='xyz' + the allowed universe. Keeps the
+    best SM row per token (highest pct_of_top_traders_gain). Returns a list of
+    normalized candidate dicts sorted by pct desc. READ-GUARDED (None -> [])."""
+    raw = _read(ctx, "leaderboard_get_markets", {})
+    if not raw:
+        return []
+
+    markets = raw
+    if isinstance(markets, dict):
+        markets = markets.get("data", markets)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return []
+
+    allowed_set = {a.upper() for a in allowed}
+    token_best = {}
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", "")).upper()
+        dex = str(m.get("dex", "")).lower()
+        if dex != "xyz":
+            continue
+        if token not in allowed_set:
+            continue
+
+        pct = scoring._f(m.get("pct_of_top_traders_gain", 0))
+        traders = int(scoring._f(m.get("trader_count", 0)))
+        direction = str(m.get("direction", "")).upper()
+        if direction not in ("LONG", "SHORT"):
+            continue
+
+        entry = {
+            "token": token,
+            "direction": direction,
+            "pct": pct,
+            "traders": traders,
+            "price_chg_4h": scoring._f(m.get("token_price_change_pct_4h", 0)),
+            "price_chg_1h": scoring._f(m.get("token_price_change_pct_1h",
+                                       m.get("price_change_1h", 0))),
+            "contrib_chg_1h": scoring._f(m.get("contribution_pct_change_1h", 0)),
+            "contrib_chg_4h": scoring._f(m.get("contribution_pct_change_4h", 0)),
+        }
+
+        if token not in token_best or pct > token_best[token]["pct"]:
+            token_best[token] = entry
+
+    return sorted(token_best.values(), key=lambda x: x["pct"], reverse=True)
+
+
+# ── CANDLE DATA FOR SCORING (port of v2 fetch_candle_data) ──
+
+def _fetch_candle_data(ctx, token):
+    """1h + 4h candles + funding for technical scoring. Requires dex='xyz'. READ-GUARDED.
+    Returns the inner data dict ({candles{}, asset_context|funding}) or None (degrade —
+    the technicals block in scoring just doesn't contribute)."""
+    data = _read(ctx, "market_get_asset_data", {
+        "asset": f"xyz:{token}",
+        "candle_intervals": ["1h", "4h"],
+        "include_funding": True,
+        "include_order_book": False,
+        "dex": "xyz",
+    })
+    if not data:
+        return None
+    if isinstance(data, dict) and "success" in data and not data.get("success"):
+        return None
+    return data.get("data", data) if isinstance(data, dict) else None
+
+
+# ── SPREAD GATE (port of v2 check_spread) ──
+
+def _check_spread(ctx, token):
+    """Live order-book spread for an XYZ asset. Returns (spread_pct, bid, ask) or
+    (None, 0, 0). Requires dex='xyz' — XYZ orderbook is silent without it. READ-GUARDED."""
+    data = _read(ctx, "market_get_asset_data", {
+        "asset": f"xyz:{token}",
+        "candle_intervals": [],
+        "include_funding": False,
+        "include_order_book": True,
+        "dex": "xyz",
+    })
+    if not data:
+        return None, 0, 0
+
+    ad = data.get("data", data) if isinstance(data, dict) else None
+    if not isinstance(ad, dict):
+        return None, 0, 0
+
+    ob = ad.get("order_book", ad.get("orderBook", {}))
+    if not isinstance(ob, dict):
+        return None, 0, 0
+
+    # API returns order_book.levels = [bids_array, asks_array]; each level is a dict
+    # {px, sz, n}. Verified vs live xyz:BRENTOIL/GOLD/CL (v2 comment preserved).
+    levels = ob.get("levels", [])
+    if not isinstance(levels, list) or len(levels) < 2:
+        return None, 0, 0
+    bids, asks = levels[0], levels[1]
+    if not bids or not asks:
+        return None, 0, 0
+
+    def _lvl_px(lvl):
+        if isinstance(lvl, dict):
+            return scoring._f(lvl.get("px", lvl.get("price", 0)))
+        if isinstance(lvl, (list, tuple)) and lvl:
+            return scoring._f(lvl[0])
+        return 0
+
+    best_bid = _lvl_px(bids[0])
+    best_ask = _lvl_px(asks[0])
+    if best_bid <= 0 or best_ask <= 0:
+        return None, 0, 0
+
+    mid = (best_bid + best_ask) / 2
+    spread_pct = (best_ask - best_bid) / mid
+    return spread_pct, best_bid, best_ask
+
+
+# ── ctx.state: recent-signal dedup (port of v2 is_asset_cooled_down) ──
+
+def _load_recent(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    rec = last.get("recent", {})
+    return dict(rec) if isinstance(rec, dict) else {}
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    allowed = inputs.get("trackedAssets", _DEFAULT_TRACKED_XYZ)
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    max_spread_pct = float(inputs.get("maxSpreadPct", _DEFAULT_MAX_SPREAD_PCT))
+    max_leverage = int(inputs.get("maxLeverage", _DEFAULT_MAX_LEVERAGE))
+    tiers = inputs.get("leverageTiers", scoring.DEFAULT_LEVERAGE_TIERS)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+
+    # margin PERCENT in (0,100]; defensive guard: a <=1.0 input is a pasted FRACTION
+    # (v2 stored 0.40) -> x100 (-> 40). (dire/koala pattern.)
+    base_margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if base_margin_pct <= 1.0:
+        base_margin_pct *= 100
+
+    account_value, held_tokens = _get_account(ctx, ctx.wallet)
+    if account_value <= 0:
+        # state still advances so liveness (state.json mtime) is observable
+        if ctx.state is not None:
+            try:
+                ctx.state.append({"recent": _load_recent(ctx),
+                                  "result": {"ts": now, "emitted": False, "gate": "no_account"}})
+            except Exception as exc:  # noqa: BLE001
+                print(f"[bald-eagle.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+        print("[bald-eagle.scan] WAITING — no account value", file=sys.stderr)
+        return []
+
+    recent = _load_recent(ctx)
+
+    raw_candidates = _scan_xyz_sm(ctx, allowed)
+
+    out = []
+    result = None
+    if not raw_candidates:
+        result = {"ts": now, "emitted": False, "gate": "no_sm",
+                  "scanned": len(allowed), "held": sorted(held_tokens)}
+        print(f"[bald-eagle.scan] WAITING — no SM signals on {','.join(sorted(allowed))} "
+              f"(scanned={len(allowed)} held={sorted(held_tokens)})", file=sys.stderr)
+    else:
+        scored = []
+        for cand in raw_candidates:
+            token = cand["token"]
+            if token in held_tokens:                               # dedup layer 1 (held)
+                continue
+            last = recent.get(token)                               # dedup layer 2 (recent emit)
+            if last is not None and (now - last) < ttl:
+                continue
+
+            candle_data = _fetch_candle_data(ctx, token)
+            score, reasons = scoring.score_candidate(cand, candle_data)
+            if score < min_score:                                  # gate: minScore floor
+                continue
+
+            # gate: spread HARD GATE (execution-quality, <0.1%)
+            spread_pct, _bid, _ask = _check_spread(ctx, token)
+            if spread_pct is None:
+                reasons.append("SPREAD_UNREADABLE")
+                continue
+            if spread_pct > max_spread_pct:
+                reasons.append(f"SPREAD_WIDE {spread_pct*100:.3f}%")
+                continue
+            reasons.append(f"SPREAD_OK {spread_pct*100:.3f}%")
+
+            # CONTRARIAN FLIP — fade SM consensus (verbatim v2 main())
+            sm_direction = cand["direction"]
+            fade_dir = scoring.fade_direction(sm_direction)
+            reasons.insert(0, f"CONTRARIAN_FLIP xyz:{token} (SM is {sm_direction})")
+
+            funding = 0.0
+            if candle_data:
+                ac = candle_data.get("asset_context", candle_data)
+                if isinstance(ac, dict):
+                    funding = scoring._f(ac.get("funding", 0))
+
+            scored.append({
+                "asset": f"xyz:{token}",
+                "token": token,
+                "direction": fade_dir,
+                "score": score,
+                "reasons": reasons,
+                "smDirection": sm_direction,
+                "smPct": cand["pct"],
+                "smTraders": cand["traders"],
+                "priceChg4h": cand["price_chg_4h"],
+                "priceChg1h": cand["price_chg_1h"],
+                "contribChg1h": cand["contrib_chg_1h"],
+                "contribChg4h": cand["contrib_chg_4h"],
+                "fundingAnnualizedPct": funding * 100 * 24 * 365,   # rough APR (v2 verbatim)
+                "spreadPct": spread_pct * 100,
+            })
+
+        if not scored:
+            best_raw = raw_candidates[0]
+            note = (f"{len(raw_candidates)} XYZ candidates, best raw: {best_raw['token']} "
+                    f"{best_raw['direction']} {best_raw['pct']:.1f}% SM — "
+                    f"none passed score {min_score:.0f} + spread gate")
+            result = {"ts": now, "emitted": False, "gate": "no_candidate",
+                      "scanned": len(allowed), "candidates": 0, "held": sorted(held_tokens)}
+            print(f"[bald-eagle.scan] WAITING — {note}", file=sys.stderr)
+        else:
+            # v2 emitted exactly the single best (highest score).
+            scored.sort(key=lambda x: x["score"], reverse=True)
+            best = scored[0]
+            leverage = scoring.get_leverage_for_score(best["score"], tiers, max_leverage)
+            margin_pct = round(base_margin_pct, 4)
+
+            recent[best["token"]] = now
+            result = {"ts": now, "emitted": True, "gate": "pass",
+                      "asset": best["asset"], "direction": best["direction"],
+                      "score": best["score"], "leverage": leverage,
+                      "marginPct": margin_pct, "smDirection": best["smDirection"],
+                      "smPct": best["smPct"], "candidates": len(scored),
+                      "held": sorted(held_tokens), "reasons": best["reasons"][:6]}
+            print(f"[bald-eagle.scan] EMIT {best['asset']} {best['direction']} "
+                  f"(fade SM {best['smDirection']}) score={best['score']} {leverage}x "
+                  f"marginPct={margin_pct}% | {best['reasons'][:6]}", file=sys.stderr)
+            out = [{
+                "asset": best["asset"],                # "xyz:TOKEN" (HIP-3 DEX prefix)
+                "direction": best["direction"],        # FADE direction (opposite SM)
+                "marginPct": margin_pct,               # PERCENT of withdrawable — runtime sizes the dollars
+                "leverage": leverage,                  # conviction-tiered (5/7); runtime applies + clamps
+                "data": {
+                    "score": float(best["score"]),
+                    "leverage": float(leverage),
+                    "marginPct": margin_pct,
+                    "smDirection": best["smDirection"],
+                    "fadeDirection": best["direction"],
+                    "smPct": float(best["smPct"]),
+                    "smTraders": int(best["smTraders"]),
+                    "priceChg4hPct": float(best["priceChg4h"]),
+                    "priceChg1hPct": float(best["priceChg1h"]),
+                    "contribChg1hPct": float(best["contribChg1h"]),
+                    "contribChg4hPct": float(best["contribChg4h"]),
+                    "fundingAnnualizedPct": float(best["fundingAnnualizedPct"]),
+                    "spreadPct": float(best["spreadPct"]),
+                    "reasons": best["reasons"],
+                    "heldAssets": sorted(held_tokens),
+                },
+            }]
+
+    # ── persist dedup map + this tick's result EVERY tick; bounded by
+    #    state_history_max_count. Read the history via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"recent": recent, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[bald-eagle.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/bald-eagle/main/scanners/scoring.py
+++ b/strategies/bald-eagle/main/scanners/scoring.py
@@ -1,0 +1,271 @@
+"""BALD EAGLE — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Bald Eagle producer's candidate scorer
+(eagle-producer.py v5.0.1, thesis preserved verbatim from v4.1). All math/indexing
+is reproduced VERBATIM so a fidelity harness can diff this against the v2 producer on
+the same market snapshot. Behaviour-preserving quirks from v2 are kept and flagged
+`# v2-quirk`.
+
+THESIS: XYZ macro CONTRARIAN FADER. The producer scores a smart-money (SM) candidate
+in the SM CONSENSUS direction (all scoring is "does the SM move look strong/exhausting
+in the SM direction?"). The FADE flip (emit the OPPOSITE direction) happens in the
+CALLER (scan.py), NOT here — `score_candidate` returns the score in the SM direction
+exactly as v2 `score_candidate(cand, candle_data)` did.
+
+Single-pass, unit-testable on plain candle lists + a normalized SM candidate dict.
+`candle_data` (1h/4h candles + funding) is fetched by the caller and passed in, so this
+module stays pure.
+"""
+
+
+# ── safe numeric coercion (v2 safe_float) ──
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# back-compat alias for callers that prefer the v2 name
+safe_float = _f
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts only; the list branch is defensive and never fires on dict candles,
+# so it does not change v2 behaviour.
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── indicators (ported verbatim from v2 eagle-producer.py) ──
+
+def price_momentum(candles, n_bars=1):
+    """% change over the last n_bars. Verbatim from v2 price_momentum."""
+    if len(candles) < n_bars + 1:
+        return 0
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    if old == 0:
+        return 0
+    return ((new - old) / old) * 100
+
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim from v2.
+
+    v2-quirk: BULLISH/BEARISH gate is `>= total * 0.6` where total = lookback - 1,
+    with STRICT (>) higher-lows / lower-highs counting. Reproduced exactly."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-half vs earlier-half average volume, % change. Verbatim from v2."""
+    if len(candles) < lookback + 2:
+        return 0
+    vols = [_vol(c) for c in candles[-(lookback + 2):]]
+    half = lookback // 2
+    recent = sum(vols[-half:]) / half if half > 0 else 1
+    earlier = sum(vols[:half]) / half if half > 0 else 1
+    if earlier == 0:
+        return 0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ── conviction-scaled leverage (ported verbatim from v2 get_leverage_for_score) ──
+
+# Conviction-scaled leverage (XYZ macro caps lower than crypto agents)
+DEFAULT_LEVERAGE_TIERS = [
+    {"min_score": 10, "leverage": 7},
+    {"min_score": 8,  "leverage": 5},
+]
+DEFAULT_LEVERAGE = 5
+MAX_LEVERAGE = 7
+MIN_LEVERAGE = 3
+
+
+def get_leverage_for_score(score, tiers=None, max_leverage=MAX_LEVERAGE):
+    """Conviction-scaled leverage. Higher score = higher leverage. Verbatim from v2:
+      score >= 10 -> 7x ; score >= 8 -> 5x ; else -> DEFAULT_LEVERAGE (5x).
+    Each tier is clamped to MAX_LEVERAGE, exactly as v2."""
+    if tiers is None:
+        tiers = DEFAULT_LEVERAGE_TIERS
+    for tier in tiers:
+        if score >= tier["min_score"]:
+            return min(tier["leverage"], max_leverage)
+    return DEFAULT_LEVERAGE
+
+
+# ── candidate scoring (ported VERBATIM from v2 score_candidate) ──
+
+def score_candidate(cand, candle_data):
+    """Score an XYZ SM candidate in the SM CONSENSUS direction. Preserved verbatim
+    from v2 score_candidate(cand, candle_data) (v4.1 thesis).
+
+    `cand` is a normalized leaderboard_get_markets row:
+      {direction, pct, traders, price_chg_4h, price_chg_1h, contrib_chg_1h,
+       contrib_chg_4h}.  `direction` is the SM CONSENSUS direction (LONG/SHORT).
+    `candle_data` is {candles:{"1h":[],"4h":[]}, asset_context|funding} or None.
+
+    Returns (score:int, reasons:list[str]). The contrarian FADE flip is the
+    caller's job — this scores in the SM direction exactly as v2 did."""
+    score = 0
+    reasons = []
+    direction = cand["direction"]
+
+    # ── SM concentration (0-4 pts) ──
+    pct = cand["pct"]
+    if pct >= 20:
+        score += 4
+        reasons.append(f"DOMINANT_SM {pct:.1f}%")
+    elif pct >= 10:
+        score += 3
+        reasons.append(f"HIGH_SM {pct:.1f}%")
+    elif pct >= 5:
+        score += 2
+        reasons.append(f"SOLID_SM {pct:.1f}%")
+    elif pct >= 3:
+        score += 1
+        reasons.append(f"BASE_SM {pct:.1f}%")
+
+    # ── Trader depth (0-2 pts) ──
+    traders = cand["traders"]
+    if traders >= 100:
+        score += 2
+        reasons.append(f"DEEP_SM ({traders}t)")
+    elif traders >= 30:
+        score += 1
+        reasons.append(f"SM_ACTIVE ({traders}t)")
+
+    # ── SM contribution velocity (0-3 pts) ──
+    c1h = cand["contrib_chg_1h"]
+    c4h = cand["contrib_chg_4h"]
+    if c1h > 5:
+        score += 2
+        reasons.append(f"CONTRIB_SURGE_1H +{c1h:.1f}%")
+    elif c1h > 2:
+        score += 1
+        reasons.append(f"CONTRIB_RISING_1H +{c1h:.1f}%")
+    if c4h > 3 and c1h > 0:
+        score += 1
+        reasons.append(f"CONTRIB_SUSTAINED_4H +{c4h:.1f}%")
+
+    # ── 4H price alignment (±2 pts) ──
+    p4h = cand["price_chg_4h"]
+    if direction == "LONG" and p4h > 0.5:
+        score += 2
+        reasons.append(f"4H_ALIGNED +{p4h:.1f}%")
+    elif direction == "SHORT" and p4h < -0.5:
+        score += 2
+        reasons.append(f"4H_ALIGNED {p4h:.1f}%")
+    elif direction == "LONG" and p4h > 0:
+        score += 1
+        reasons.append(f"4H_POSITIVE +{p4h:.2f}%")
+    elif direction == "SHORT" and p4h < 0:
+        score += 1
+        reasons.append(f"4H_POSITIVE {p4h:.2f}%")
+    elif direction == "LONG" and p4h < -1:
+        score -= 1
+        reasons.append(f"4H_OPPOSING {p4h:.1f}%")
+    elif direction == "SHORT" and p4h > 1:
+        score -= 1
+        reasons.append(f"4H_OPPOSING +{p4h:.1f}%")
+
+    # ── MOVE EXHAUSTION BONUS (XYZ-tuned: 1-2% vs crypto 3-5%) ──
+    if abs(p4h) >= 2.0:
+        if (direction == "LONG" and p4h > 0) or (direction == "SHORT" and p4h < 0):
+            score += 2
+            reasons.append(f"DEEP_EXHAUSTION {p4h:+.1f}%")
+    elif abs(p4h) >= 1.0:
+        if (direction == "LONG" and p4h > 0) or (direction == "SHORT" and p4h < 0):
+            score += 1
+            reasons.append(f"EXHAUSTION {p4h:+.1f}%")
+
+    # ── Technical scoring from candles ──
+    if candle_data:
+        candles_1h = candle_data.get("candles", {}).get("1h", [])
+        candles_4h = candle_data.get("candles", {}).get("4h", [])
+
+        # 4H trend structure (0-2 pts)
+        if len(candles_4h) >= 6:
+            trend_4h, strength = trend_structure(candles_4h)
+            if (direction == "LONG" and trend_4h == "BULLISH") or \
+               (direction == "SHORT" and trend_4h == "BEARISH"):
+                score += 2
+                reasons.append(f"4H_TREND_{trend_4h} {strength:.0%}")
+            elif trend_4h != "NEUTRAL" and \
+                 ((direction == "LONG" and trend_4h == "BEARISH") or
+                  (direction == "SHORT" and trend_4h == "BULLISH")):
+                score -= 1
+                reasons.append("4H_TREND_OPPOSING")
+
+        # 1H momentum (0-1 pts)
+        if len(candles_1h) >= 4:
+            mom_1h = price_momentum(candles_1h, 2)
+            if (direction == "LONG" and mom_1h > 0.3) or \
+               (direction == "SHORT" and mom_1h < -0.3):
+                score += 1
+                reasons.append(f"1H_MOMENTUM {mom_1h:+.2f}%")
+
+        # Volume trend (0-1 pts)
+        if len(candles_1h) >= 8:
+            vol = volume_trend(candles_1h)
+            if vol > 15:
+                score += 1
+                reasons.append(f"VOL_RISING +{vol:.0f}%")
+
+        # Funding alignment (0-1 pts)
+        asset_ctx = candle_data.get("asset_context", candle_data)
+        funding = _f(asset_ctx.get("funding", 0)) if isinstance(asset_ctx, dict) else 0
+        if (direction == "LONG" and funding < -0.005) or \
+           (direction == "SHORT" and funding > 0.005):
+            score += 1
+            reasons.append(f"FUNDING_ALIGNED {funding:+.4f}")
+
+    return score, reasons
+
+
+def fade_direction(sm_direction):
+    """Contrarian flip — fade SM consensus. Verbatim from v2 main():
+      fade_direction = "SHORT" if sm_direction == "LONG" else "LONG"."""
+    return "SHORT" if sm_direction == "LONG" else "LONG"

--- a/strategies/bald-eagle/strategy.yaml
+++ b/strategies/bald-eagle/strategy.yaml
@@ -1,0 +1,43 @@
+# Bald Eagle — XYZ macro Contrarian Fader. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2
+# Bald Eagle (SKILL.md v5.0.0): contrarian fade of smart-money consensus on a fixed
+# 6-asset XYZ macro basket (CL, BRENTOIL, GOLD, SILVER, SP500, XYZ100; Hyperliquid
+# HIP-3 DEX), conviction-scaled leverage, spread hard-gate, wide DSL-only exits.
+# The only Senpi agent trading commodities + indices + equities macro. Install/teardown
+# via senpi-strategy-ops.
+schema_version: 1
+
+id: bald-eagle
+version: "1.0.0"
+
+catalog:
+  name: "Bald Eagle — XYZ Macro Fader"
+  emoji: "🦅"
+  tagline: "A contrarian fader on the 6 deepest XYZ macro markets (oil, brent, gold, silver, SP500, XYZ100): when smart money is piled into one side AND the 4h move is exhausting, it takes the OPPOSITE side and lets a wide DSL ride the mean-reversion for hours."
+  belief_plain: "Trades only macro markets — oil, gold, silver, and the big stock indices — that run around the clock. When the best traders have all crowded into one direction and the move over the last few hours is already stretched, it bets on the snap-back the other way, sizes up when more signals agree, and trails a wide stop so a slow reversal has hours to play out."
+  thesis: "Macro assets on Hyperliquid attract directional momentum traders who load up after a clean 1-3% intraday move. By the time smart-money concentration crosses 10-20% on a 4h-extended move, the trade is usually exhausted — mean reversion is the positive-edge play. Bald Eagle scores SM crowding + contribution velocity + move exhaustion, hard-gates on tight book spread, fades the crowd, and gives commodities the wide exit they need to revert."
+  group: contrarian
+  archetype: contrarian_fade
+  sub_style: xyz_overextended
+  asset_classes: [commodities, indices]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 7
+  max_slots: 2
+  min_budget: 200
+  assets: ["xyz:CL", "xyz:BRENTOIL", "xyz:GOLD", "xyz:SILVER", "xyz:SP500", "xyz:XYZ100"]
+  tags: [xyz, commodities, indices, oil, gold, silver, sp500, contrarian, fade, smart-money, mean-reversion, 24-7]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: BALD_EAGLE_WALLET
+    funding_share: 1.0

--- a/strategies/bobcat/main/runtime.yaml
+++ b/strategies/bobcat/main/runtime.yaml
@@ -1,0 +1,146 @@
+# ── BOBCAT · single instance — Big Tech equity-perp trend follower (Runtime 3.0 port) ──
+# Faithful port of v2 Bobcat (SKILL.md v1.0.0 + bobcat-producer.py v1.0.1 + bobcat-config.json).
+# 12-name big-tech whitelist on Hyperliquid XYZ (HIP-3 DEX): NVDA/TSLA/AAPL/META/MSFT/GOOGL/
+# AMZN/AMD/MU/INTC/TSM/ORCL. LONG OR SHORT on 4h-trend (gate) + Smart-Money direction (gate,
+# tilt >= 55%). Flat 20% margin / 5x. Emits the single strongest setup per tick (v2 main()
+# emitted only `best`). DSL exits — Phase 1 15% max_loss, Phase 2 standard ladder, hard_timeout
+# 48h (equities have weekend pricing gaps). xyz: prefix mandatory for the HIP-3 DEX.
+#
+# CAUTION: the v2 runtime.yaml prose described a STALE single-asset-BTC template that contradicts
+# the real strategy. The thesis/universe below is reconstructed from producer + config + SKILL
+# (all three agree on the 12-name big-tech basket). The DSL + risk guard-rails ARE ported from
+# the v2 runtime.yaml two-phase block, which is universe-agnostic and matches the SKILL big-tech
+# spec (48h hard_timeout, Phase1 15%, the exact T0..T5 ladder, 4h cooldown, 4 entries/day).
+name: bobcat-main
+group: bobcat
+version: 1.0.0
+description: >
+  BOBCAT — Big Tech equity-perp trend follower on Hyperliquid XYZ. A 12-name whitelist
+  (NVDA/TSLA/AAPL/META/MSFT/GOOGL/AMZN/AMD/MU/INTC/TSM/ORCL). Per tick it scores every
+  non-held, non-recently-signaled name and emits the single strongest setup whose 4h trend
+  is non-neutral AND whose Smart-Money direction agrees (tilt >= 55%). Score (max ~9):
+  +3 4h trend, +2 1h confirms, +2 SM aligned, +1 SM strongly tilted (>= 70%); floor minScore 5.
+  Flat sizing: 20% margin / 5x. DSL is the ONLY exit — Phase 1 15% max_loss, Phase 2
+  Bison-pattern wide ladder (T0 +10%/lock 0 through T5 +100%/lock 85), hard_timeout 48h
+  (equity perps have a weekend pricing gap — internal-oracle drift accumulates Fri-Sun).
+  Onboarding-tier. Faithful port of the v2 Bobcat v1.0.0 thesis.
+
+strategy:
+  wallet: "${BOBCAT_WALLET}"
+  slots: 3                                # v2 SKILL "Slots: 3"
+  margin_pct: 20                          # baseline %; scan emits the flat marginPct per signal (v2 0.20 FRACTION -> 20 PERCENT)
+  default_leverage: 5                     # fallback; scan emits 5x per signal (v2 DEFAULT_LEVERAGE/MAX_LEVERAGE)
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: bobcat_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 180                   # v2 tick_timeout=180; ~1 read/asset + SM (shared) + account
+    default_signal_validity_seconds: 600   # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      universe: ["xyz:NVDA", "xyz:TSLA", "xyz:AAPL", "xyz:META", "xyz:MSFT", "xyz:GOOGL", "xyz:AMZN", "xyz:AMD", "xyz:MU", "xyz:INTC", "xyz:TSM", "xyz:ORCL"]  # validated live vs HL xyz meta 2026-06-29
+      dex: "xyz"                           # HIP-3 DEX — xyz: prefix mandatory
+      minScore: 5                          # v2 DEFAULT_MIN_SCORE / config minScore
+      smTiltMinPct: 55                     # v2 DEFAULT_SM_TILT_MIN / config smTiltMinPct (gate)
+      smStrongTiltPct: 70                  # v2 DEFAULT_SM_STRONG / config smStrongTiltPct (+1 bonus)
+      marginPct: 20                        # PERCENT of withdrawable (0,100]; v2 config marginPct 0.20 (FRACTION) -> 20
+      leverage: 5                          # v2 DEFAULT_LEVERAGE; clamped to MAX_LEVERAGE 5 in scan.py
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      trend4hStrength: { type: number, required: false }
+      trend1h: { type: string, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: bobcat_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [bobcat_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # v2: momentum entries must fill — maker-only rests unfilled (CREATE_ORDER_RESTING)
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: bobcat_main_signals
+
+# ── EXIT (DSL — ported VERBATIM from the v2 runtime.yaml two-phase block) ──────
+# Standard preset per SKILL v1.0.0: Phase 1 max_loss 15% + retrace 8; Phase 2 Bison-pattern
+# wide ladder (T0 +10%/lock 0 through T5 +100%/lock 85) so winning trends ride multi-day moves;
+# weak_peak_cut + dead_weight_cut DISABLED. hard_timeout ENABLED at 48h (2880 min) — INTENTIONAL
+# for equities: the post-Friday-close -> pre-Sunday-reopen window is where internal-oracle drift
+# accumulates without external price discovery, so positions must not camp through the full gap.
+# (This differs from the crypto single-asset family pattern where hard_timeout is OFF; equities
+# justify it via the weekend pricing gap — see SKILL RULE 2. Ported verbatim, not changed.)
+# order_type FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST happen). interval_seconds 60
+# (v2: REDUCE_ONLY-spam mitigation when runtime position state lags HL).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # exit closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # 48h cap — equities have weekend pricing gaps (SKILL RULE 2)
+      interval_in_minutes: 2880
+    weak_peak_cut:
+      enabled: false                       # DISABLED (v2)
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                       # DISABLED (v2)
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0                    # v2 / SKILL Phase 1 max_loss_pct
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # wide-by-design; FIRST lock at +10% ROE (NOT +60-80%)
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # v2 data_retention_hours 72 -> 72*3600 (in [3600,604800])
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 risk.daily_loss_limit_pct
+    max_entries_per_day: 4                  # v2 / SKILL max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 risk.max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 cooldown_minutes 60 -> 3600s
+    drawdown_halt_pct: 20                  # v2 risk.drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400      # v2 per_asset_cooldown_minutes 240 -> 14400s (4h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/bobcat/main/scanners/scan.py
+++ b/strategies/bobcat/main/scanners/scan.py
@@ -1,0 +1,305 @@
+"""BOBCAT — supervised scanner (Runtime 3.0 port of the v2 Bobcat big-tech follower).
+
+Multi-asset, whitelist-gated big-tech equity perps on Hyperliquid XYZ (HIP-3 DEX):
+NVDA/TSLA/AAPL/META/MSFT/GOOGL/AMZN/AMD/MU/INTC/TSM/ORCL. Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - iterates the whitelist (held + recently-signaled filtered BEFORE the per-asset
+    MCP fetch, as in v2 main()),
+  - scores each candidate via the pure `scoring.build_thesis` (4h-trend gate +
+    Smart-Money-direction gate + tilt floor),
+  - emits the SINGLE highest-scoring candidate at/above `minScore` (v2 main() emitted
+    only `best`), sized at a flat marginPct / leverage.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`; the
+runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit. No
+daemon, no push_signal, no create_position.
+
+XYZ notes (preserved from v2 — do NOT redesign):
+  - every asset is xyz:NAME, dex = "xyz" — the prefix is mandatory for the HIP-3 DEX.
+  - 23/5 trading; the 48h hard_timeout (in runtime.yaml) caps holds across the
+    weekend pricing gap. There is NO scan-level market-hours gate (none in v2).
+
+FIDELITY NOTES vs the v2 producer (bobcat-producer.py v1.0.1):
+  - v2's get_positions / build_thesis / fetch_sm_direction / scoring are ported
+    VERBATIM (math + thresholds + gate order). The SM-direction thresholds are
+    Bobcat's own (long_ratio >= 50 -> LONG, else SHORT; NEUTRAL only when total<=0),
+    NOT Bison's 58/42 band — preserved exactly.
+  - v2 stored margin as a FRACTION (config marginPct 0.20) and computed
+    marginUsd = account_value * 0.20. In Runtime 3.0 the runtime sizes from a
+    PERCENT in (0,100], so this port emits `marginPct` (20). A defensive guard
+    converts any pasted FRACTION (<=1.0) to a PERCENT (*100), matching dire/koala.
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1 signal/tick.
+  - v2 recent-signals JSON cache -> ctx.state dedup map (same TTL semantics, TTL 240s).
+  - v2 leverage = min(config.leverage, MAX_LEVERAGE 5); preserved (clamped to 5).
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v2 defaults (bobcat-producer.py / bobcat-config.json)
+_DEFAULT_UNIVERSE = [
+    "xyz:NVDA", "xyz:TSLA", "xyz:AAPL", "xyz:META", "xyz:MSFT",
+    "xyz:GOOGL", "xyz:AMZN", "xyz:AMD", "xyz:MU", "xyz:INTC",
+    "xyz:TSM", "xyz:ORCL",
+]
+_DEFAULT_MIN_SCORE = 5            # v2 DEFAULT_MIN_SCORE
+_DEFAULT_SM_TILT_MIN = 55         # v2 DEFAULT_SM_TILT_MIN
+_DEFAULT_SM_STRONG = 70          # v2 DEFAULT_SM_STRONG
+_DEFAULT_MARGIN_PCT = 20          # v2 config 0.20 FRACTION -> 20 PERCENT
+_DEFAULT_LEVERAGE = 5             # v2 DEFAULT_LEVERAGE
+_MAX_LEVERAGE = 5                # v2 MAX_LEVERAGE (hardcoded clamp)
+_DEFAULT_RECENT_TTL = 240        # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+
+
+def _dex_for(asset, inputs):
+    dex = inputs.get("dex")
+    if dex is not None:
+        return dex
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[bobcat.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) or {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[bobcat.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _get_sm_direction(ctx, coin):
+    """Port of v2 fetch_sm_direction: net smart-money lean for `coin` from
+    leaderboard_get_markets. Returns (direction, tilt_pct) or (None, 0.0).
+    READ-GUARDED.
+
+    v2-quirk: token match is case-insensitive uppercase. Verbatim thresholds:
+    long_ratio >= 50 -> (LONG, long_ratio); else -> (SHORT, 100 - long_ratio).
+    total<=0 -> (NEUTRAL, 50.0). Not-found -> (None, 0.0)."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — SM is a hard gate; a read error degrades to (None,0) -> gate blocks
+        print(f"[bobcat.scan] leaderboard_get_markets read failed (smart-money -> none): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and raw.get("success") is False):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != coin.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def _asset_data(ctx, coin, dex):
+    """{candles_1h, candles_4h} for `coin` or None. READ-GUARDED.
+    Ported from v2 fetch_market_data (1h/4h candles, no funding/order book)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["1h", "4h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": dex,
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[bobcat.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    return {"candles_1h": candles.get("1h", []) or [], "candles_4h": candles.get("4h", []) or []}
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    universe = inputs.get("universe", _DEFAULT_UNIVERSE)
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    lev_cfg = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    # marginPct: PERCENT in (0,100]. Defensive fraction guard (dire/koala pattern):
+    # a value <= 1.0 is a pasted v2 FRACTION (e.g. 0.20) -> *100 -> 20.
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        margin_pct = margin_pct * 100
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── score every eligible whitelist candidate (held + recently signaled
+    #    filtered BEFORE the per-asset MCP fetch, exactly as v2 main()) ──
+    candidates = []
+    scanned = 0
+    for coin in universe:
+        if not coin:
+            continue
+        cu = coin.upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin, _dex_for(coin, inputs))
+        if not md:
+            continue
+        sm = _get_sm_direction(ctx, coin)
+        th = scoring.build_thesis(coin, md["candles_1h"], md["candles_4h"], sm, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets, "note": f"WAITING (min score {min_score:.0f})"}
+        print(f"[bobcat.scan] WAITING — no big-tech setup with 4h trend + SM agreement "
+              f"(min score {min_score:.0f}); scanned={scanned} held={held_assets}", file=sys.stderr)
+    else:
+        # v2 emitted exactly the single best (highest score).
+        candidates.sort(key=lambda x: x["score"], reverse=True)
+        best = candidates[0]
+
+        # leverage: clamp v2 config default to MAX_LEVERAGE (verbatim min(cfg, 5)).
+        leverage = min(lev_cfg, _MAX_LEVERAGE)
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"],
+                  "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best["reasons"]}
+        print(f"[bobcat.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+              f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:5]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes (marginPct/100)*withdrawable
+            "leverage": leverage,             # flat 5x; runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "trend4h": best["trend_4h"],
+                "trend4hStrength": best["trend_4h_strength"],
+                "trend1h": best["trend_1h"],
+                "smDirection": best["sm_direction"] or "NEUTRAL",
+                "smTiltPct": best["sm_tilt_pct"],
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + this tick's result EVERY tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[bobcat.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/bobcat/main/scanners/scoring.py
+++ b/strategies/bobcat/main/scanners/scoring.py
@@ -1,0 +1,122 @@
+"""BOBCAT — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Bobcat producer's `trend_structure` +
+`build_thesis` scoring (SKILL.md v1.0.0 / bobcat-producer.py v1.0.1). The
+math/indexing is reproduced VERBATIM so a fidelity harness can diff this against
+the v2 producer on the same market snapshot. Behaviour-preserving quirks from v2
+are kept and flagged `# v2-quirk`.
+
+Multi-asset (12-name big-tech whitelist), single-pass, unit-testable on plain
+candle lists. Smart-money lean (`sm`) is fetched by the caller (scan.py) and
+passed in, so this module stays pure.
+
+Bobcat is a GATED scorer (unlike Bison, where signals are score contributors):
+  - 4h trend must be non-neutral (else None),
+  - Smart-Money direction must be LONG/SHORT AND equal the 4h-derived direction,
+  - SM tilt must be >= smTiltMinPct.
+If any gate fails, build_thesis returns None. The minScore floor is applied by
+the CALLER (scan.py), exactly as v2 main() did.
+"""
+
+
+# ── candle accessors (dual-key: dict {low|l}/{high|h}/{close|c}) ──
+# v2 used `_f(c, "low", "l")` etc.; reproduced here as helpers over the same keys.
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _ck(c, primary, alt=None, default=0.0):
+    """Verbatim port of the v2 producer's `_f(c, primary, alt, default)` candle
+    field accessor: read `primary`, fall back to `alt`, coerce to float."""
+    if not isinstance(c, dict):
+        return default
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    return _f(val if val is not None else default, default)
+
+
+# ── indicators (ported verbatim from v2 bobcat-producer.py) ──
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim from v2.
+
+    v2-quirk: thresholds use strict (>) for higher-lows / lower-highs counting,
+    and the BULLISH/BEARISH gate is `>= total * 0.6` where total = lookback - 1.
+    Reproduced exactly. Strength returned is higher_lows/total (BULLISH) or
+    lower_highs/total (BEARISH); NEUTRAL returns 0.0."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_ck(c, "low", "l") for c in candles[-lookback:]]
+    highs = [_ck(c, "high", "h") for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+# ── the thesis (gated 4h-trend + SM-direction scorer), ported verbatim ──
+
+def build_thesis(coin, candles_1h, candles_4h, sm, inputs):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned (a GATE FAILED) when:
+      - insufficient candle history (len(c4h) < 6 or len(c1h) < 6), OR
+      - the 4h trend is NEUTRAL, OR
+      - Smart-Money direction is not LONG/SHORT, OR
+      - Smart-Money direction != the 4h-derived direction, OR
+      - Smart-Money tilt < smTiltMinPct.
+    The minScore floor is NOT applied here — the caller gates on thesis['score'].
+
+    `sm` is the smart-money tuple (direction, tilt_pct) or (None, 0.0) — the caller
+    fetches it (scan._get_sm_direction) and passes it in.
+
+    Score components (verbatim from v2; max ~9):
+      +3  4h trend (gate-confirmed)
+      +2  1h trend confirms the 4h direction
+      +2  SM aligned (gate-confirmed; always added post-gate)
+      +1  SM strongly tilted (tilt >= smStrongTiltPct)
+    """
+    sm_min = float(inputs.get("smTiltMinPct", 55))
+    sm_strong = float(inputs.get("smStrongTiltPct", 70))
+
+    if len(candles_4h) < 6 or len(candles_1h) < 6:
+        return None
+
+    t4, s4 = trend_structure(candles_4h)
+    t1, _ = trend_structure(candles_1h)
+    if t4 == "NEUTRAL":
+        return None
+
+    direction = "LONG" if t4 == "BULLISH" else "SHORT"
+
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    score = 3  # 4h trend (gate-confirmed)
+    reasons = [f"4h_{t4.lower()}_{s4:.0%}"]
+    if (direction == "LONG" and t1 == "BULLISH") or (direction == "SHORT" and t1 == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirms_{t1.lower()}")
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    return {
+        "coin": coin, "direction": direction, "score": score, "reasons": reasons,
+        "trend_4h": t4, "trend_4h_strength": round(s4, 4), "trend_1h": t1,
+        "sm_direction": sm_dir, "sm_tilt_pct": round(_f(sm_tilt), 2),
+    }

--- a/strategies/bobcat/strategy.yaml
+++ b/strategies/bobcat/strategy.yaml
@@ -1,0 +1,45 @@
+# Bobcat — Big Tech equity-perp trend follower. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port
+# of the v2 Bobcat (SKILL.md v1.0.0 + bobcat-producer.py v1.0.1 + bobcat-config.json):
+# a 12-name big-tech whitelist on Hyperliquid XYZ (NVDA/TSLA/AAPL/META/MSFT/GOOGL/
+# AMZN/AMD/MU/INTC/TSM/ORCL), 4h-trend + Smart-Money-direction confluence, flat 20%
+# margin / 5x, DSL exits with a 48h hard_timeout (equities have weekend pricing gaps).
+# NOTE: the v2 runtime.yaml prose is a STALE single-asset-BTC template — the REAL
+# strategy is the big-tech basket per producer + config + SKILL. Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: bobcat
+version: "1.0.0"
+
+catalog:
+  name: "Bobcat — Big Tech Trend Follower"
+  emoji: "🐈"
+  tagline: "A big-tech equity-perp trend follower on Hyperliquid XYZ (NVDA/TSLA/AAPL/META/MSFT/GOOGL/AMZN/AMD/MU/INTC/TSM/ORCL): enters the single strongest name when its 4h trend is non-neutral AND smart-money leans the same way (tilt >= 55%), sizes a flat 20% margin at 5x, and lets a wide DSL ratchet ride the move — with a 48h cap so positions don't camp through the weekend pricing gap."
+  belief_plain: "Trades the big tech stocks you already know — NVDA, TSLA, AAPL and nine more — as perps on Hyperliquid XYZ, 23/5. It only enters when a stock's 4-hour trend and the best traders are pointing the same way, holds the single strongest setup, and trails a stop so a real move can run — but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price."
+  thesis: "Big tech is the most-traded equity sector, and Hyperliquid XYZ surfaces these names as leveraged perps with 23/5 hours. A clean trend + smart-money confluence on the highest-liquidity XYZ equities catches directional moves without the small-cap noise of a broad scanner. The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap, where drift accumulates without external price discovery — so winners are let to run on the 4h timescale but never held through the full Fri-Sun window."
+  group: single-asset
+  archetype: single_market
+  sub_style: big_tech
+  asset_classes: [xyz_equities]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: starter
+  leverage_max: 5
+  max_slots: 3
+  min_budget: 200
+  assets: ["xyz:NVDA", "xyz:TSLA", "xyz:AAPL", "xyz:META", "xyz:MSFT", "xyz:GOOGL", "xyz:AMZN", "xyz:AMD", "xyz:MU", "xyz:INTC", "xyz:TSM", "xyz:ORCL"]
+  tags: [big-tech, equities, xyz, nvda, tsla, aapl, trend-following, smart-money, basket, onboarding, 23-5]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: BOBCAT_WALLET
+    funding_share: 1.0

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -5,6 +5,174 @@
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
     {
+      "id": "hawk",
+      "name": "Hawk — Breakout Buyer / Breakdown Seller",
+      "emoji": "🦅",
+      "tagline": "An onboarding-grade breakout trader on the liquid majors (BTC/ETH/SOL): goes LONG when price breaks above its 7-day high AND smart-money is net long, SHORT when it breaks below the 7-day low AND smart-money is net short, then cuts failed breakouts fast (tight 8% Phase 1) while letting a real one run on a wide Phase 2 ratchet.",
+      "belief_plain": "Watches BTC, ETH and SOL. When one of them breaks above its highest price of the last week and the best traders are also leaning long, it buys; when one breaks below its weekly low and the best traders are leaning short, it sells short. A fake breakout gets cut quickly, but a real one is given lots of room to run.",
+      "version": "1.0.0",
+      "thesis": "Most breakout strategies lose because they fight the trend, chase fake breakouts into stop-hunts, or hold failed breakouts too long. Hawk requires three things at once — a genuine break of the 7-day range, the 4h trend pointing the same way, and the smart-money leaderboard net in the breakout direction — so it only fires on confirmed breaks. Then the asymmetry does the work: an 8% Phase 1 floor cuts a breakout that fails immediately, while a wide Phase 2 ladder (first lock only at +10% ROE) keeps the rare breakout that runs, because that tail pays for the quiet weeks.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "multi-asset",
+        "breakout",
+        "breakdown",
+        "smart-money",
+        "range-break",
+        "onboarding",
+        "let-winners-run"
+      ],
+      "group": "breakout",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "range_break",
+      "sub_style_label": "Buys/sells the break of a multi-day range.",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
+      "id": "bald-eagle",
+      "name": "Bald Eagle — XYZ Macro Fader",
+      "emoji": "🦅",
+      "tagline": "A contrarian fader on the 6 deepest XYZ macro markets (oil, brent, gold, silver, SP500, XYZ100): when smart money is piled into one side AND the 4h move is exhausting, it takes the OPPOSITE side and lets a wide DSL ride the mean-reversion for hours.",
+      "belief_plain": "Trades only macro markets — oil, gold, silver, and the big stock indices — that run around the clock. When the best traders have all crowded into one direction and the move over the last few hours is already stretched, it bets on the snap-back the other way, sizes up when more signals agree, and trails a wide stop so a slow reversal has hours to play out.",
+      "version": "1.0.0",
+      "thesis": "Macro assets on Hyperliquid attract directional momentum traders who load up after a clean 1-3% intraday move. By the time smart-money concentration crosses 10-20% on a 4h-extended move, the trade is usually exhausted — mean reversion is the positive-edge play. Bald Eagle scores SM crowding + contribution velocity + move exhaustion, hard-gates on tight book spread, fades the crowd, and gives commodities the wide exit they need to revert.",
+      "tags": [
+        "xyz",
+        "commodities",
+        "indices",
+        "oil",
+        "gold",
+        "silver",
+        "sp500",
+        "contrarian",
+        "fade",
+        "smart-money",
+        "mean-reversion",
+        "24-7"
+      ],
+      "group": "contrarian",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "xyz_overextended",
+      "sub_style_label": "Fades overextended stocks/commodities.",
+      "asset_classes": [
+        "commodities",
+        "indices"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:CL",
+        "xyz:BRENTOIL",
+        "xyz:GOLD",
+        "xyz:SILVER",
+        "xyz:SP500",
+        "xyz:XYZ100"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 7,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
+      "id": "lemon",
+      "name": "Lemon — Degen Fader",
+      "emoji": "🍋",
+      "tagline": "Watches where the worst, most crowded traders are piling in across a fixed basket of 12 crypto majors and 4 commodity/index names — and once that one-sided crowd stops following through (its 15-minute momentum rolls over), takes the OTHER side at conviction-scaled leverage and lets a wide ratcheting stop ride the snap-back.",
+      "belief_plain": "When a lot of low-quality traders crowd hard onto one side of a coin and the move starts running out of steam, that crowd usually gets unwound. Lemon waits for the crowding to actually start fading on the 15-minute clock, blocks the trade if it's really a genuine trend (big BTC move or the asset itself ripping), then bets the OPPOSITE direction and trails a wide stop while the over-stretched move mean-reverts.",
+      "version": "1.0.0",
+      "thesis": "Hyperliquid is full of high-leverage retail that piles into exhausted moves. A crowded smart-money consensus is only a fade setup once it STOPS following through — so Lemon gates on 15m exhaustion, not just crowding, and refuses to fade a real run (crypto MACRO gate on |BTC 4h|>3%, per-asset gate on |4h|>5%) because fading genuine trend is how a contrarian dies. Concentration + velocity-fade + overextension + reversal compound into a score; it fires the single best fade at score >=9, sizes leverage to conviction, and lets a wide DSL ride the mean reversion since reversals take hours, not minutes.",
+      "tags": [
+        "degen-fader",
+        "contrarian",
+        "smart-money",
+        "crowd-exhaustion",
+        "mean-reversion",
+        "fade",
+        "basket",
+        "conviction-leverage",
+        "single-slot",
+        "xyz"
+      ],
+      "group": "contrarian",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "sm_crowding",
+      "sub_style_label": "Fades the crowded smart-money side once price stops following.",
+      "asset_classes": [
+        "major_alts",
+        "commodities",
+        "indices"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE",
+        "AVAX",
+        "DOGE",
+        "LINK",
+        "XRP",
+        "ADA",
+        "NEAR",
+        "UNI",
+        "AAVE",
+        "xyz:BRENTOIL",
+        "xyz:CL",
+        "xyz:GOLD",
+        "xyz:SP500"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 2
+    },
+    {
       "id": "pangolin",
       "name": "Pangolin — Funding-Rate Fader",
       "emoji": "🦔",
@@ -44,7 +212,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 1
+      "sort_order": 3
     },
     {
       "id": "tortoise",
@@ -144,6 +312,56 @@
       "sort_order": 1
     },
     {
+      "id": "badger",
+      "name": "Badger — OI-Divergence Breakout Anticipator",
+      "emoji": "🦡",
+      "tagline": "Only takes the breakout the order flow confirms: enters a prior-24h range break on BTC/ETH/SOL/HYPE only when open interest is RISING (new money committing) AND smart money agrees with the break — then sizes 20% / 5x and lets a wide DSL ratchet ride the move for days.",
+      "belief_plain": "Most price breakouts fail. The single best filter for whether a breakout will follow through is open interest: if price breaks its prior 24-hour high (or low) while open interest is rising, new money is committing and the move has conviction. If open interest is flat or falling, it's just stops and short-covering — a fakeout — and Badger skips it. It also checks that the best traders are leaning the same way before it commits.",
+      "version": "1.0.0",
+      "thesis": "Open interest is the fuel of a breakout. A price push beyond the recent range confirmed by rising OI = new positions opening in the breakout direction = real follow-through; a breakout on flat/declining OI is shorts covering or stops triggering, with no new money behind it. Gating breakouts on OI velocity (plus smart-money agreement) filters the fakeouts that kill a naive breakout buyer, and a wide let-winners-run exit ladder means the rare confirmed breakout that runs far pays for the ones that don't.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "hype",
+        "breakout",
+        "open-interest",
+        "oi-confirmed",
+        "smart-money",
+        "momentum",
+        "let-winners-run"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "oi_confirmed",
+      "sub_style_label": "Enters a breakout only when open interest confirms (new money).",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
       "id": "bison",
       "name": "Bison — Conviction Momentum Holder",
       "emoji": "🦬",
@@ -189,7 +407,7 @@
       ],
       "max_slots": 3,
       "branch": "strategy-v2",
-      "sort_order": 1
+      "sort_order": 2
     },
     {
       "id": "condor",
@@ -231,7 +449,107 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 2
+      "sort_order": 3
+    },
+    {
+      "id": "hedgehog",
+      "name": "Hedgehog — Major Crypto Basket",
+      "emoji": "🦔",
+      "tagline": "Equal-weight BTC + ETH + SOL, each leg independently directional: every asset gets its own Smart-Money-confirmed 4h-trend signal (long OR short), so it can hold BTC long and ETH short at the same time — three slots, three independent positions, each with its own per-position stop.",
+      "belief_plain": "Trades only the three biggest crypto majors (BTC, ETH, SOL), one position per coin. For each coin it waits until the 4-hour trend and the best traders agree on the same direction before entering — going long if they're bullish, short if they're bearish — and manages each position on its own, so one coin going wrong doesn't drag the others down.",
+      "version": "1.0.0",
+      "thesis": "Most basket strategies force the same direction across every asset; Hedgehog doesn't. Each of BTC/ETH/SOL gets its own independent Smart-Money-confirmed 4h-trend decision, so the diversification benefit is real — the per-asset directions are uncorrelated by construction. For a new user who wants 'exposure to crypto majors without picking one,' Hedgehog does the picking: it enters when the gates pass and lets a per-position DSL ratchet ride each leg on its own merits.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "multi-asset",
+        "basket",
+        "momentum",
+        "smart-money",
+        "directional",
+        "onboarding",
+        "per-position-dsl"
+      ],
+      "group": "momentum",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "basket",
+      "sub_style_label": "Holds a whitelist basket of majors.",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL"
+      ],
+      "direction": "long_short",
+      "risk_level": "conservative",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 4
+    },
+    {
+      "id": "lynx",
+      "name": "Lynx — Adaptive MIN_SCORE Self-Tuner",
+      "emoji": "🐯",
+      "tagline": "A multi-asset momentum holder on liquid majors (BTC/ETH/SOL/HYPE) that learns its own conviction floor: every 6 hours it audits its own closed trades, buckets them by entry score, and ratchets its MIN_SCORE up above any score band that has been losing money — then enters only candidates that clear the learned floor and lets a wide DSL ride the move.",
+      "belief_plain": "Trades the big, liquid coins (BTC, ETH, SOL, HYPE) on a simple momentum score. Every six hours it looks back at its own finished trades, figures out which score levels have actually been making money and which have been losing, and raises its own bar so it stops taking the kinds of trades that bled — it only ever raises the bar, never lowers it. When a coin clears the current bar it bets and trails a wide stop so a real move can run.",
+      "version": "1.0.0",
+      "thesis": "A fixed entry threshold is a guess that goes stale: the market regime that made score-6 trades profitable last month may make them losers this month. Instead of an operator hand-tuning MIN_SCORE off a 30-trade table, Lynx bakes that loop into a scheduled audit — it reads its own closed-trade history, buckets by the entry score it logged, and raises the floor above any band whose realized ROE has turned negative with enough samples to trust. It ratchets up only (a floor that worked is never relaxed), caps at a hard ceiling, and otherwise runs a plain momentum scorer so the audit always has clean data to learn from.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "hype",
+        "multi-asset",
+        "momentum",
+        "smart-money",
+        "self-tuning",
+        "adaptive-threshold",
+        "let-winners-run"
+      ],
+      "group": "momentum",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "adaptive",
+      "sub_style_label": "Self-tunes its thresholds from its own track record.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 5
     },
     {
       "id": "sailfish",
@@ -281,7 +599,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 3
+      "sort_order": 6
     },
     {
       "id": "jaguar",
@@ -945,6 +1263,101 @@
       "sort_order": 10
     },
     {
+      "id": "coyote",
+      "name": "Coyote — Regime Classifier (BTC)",
+      "emoji": "🐺",
+      "tagline": "A single-asset BTC bet driven by a macro-regime read: each tick it measures BTC's 7-day trend strength and annualized realized volatility (plus cross-asset dispersion for context) and classifies the market into TREND_UP, TREND_DOWN or CHOP — going long BTC in a calm uptrend, short BTC in a high-vol crash, and staying out otherwise, then letting a balanced DSL ride the regime.",
+      "belief_plain": "Coyote first asks 'what kind of market are we in?' It looks at how far Bitcoin has moved over the last week and how violent that move has been. A steady 5%+ climb with calm volatility means uptrend — it goes long BTC. A sharp 5%+ drop with a volatility spike means a panic crash — it goes short BTC. Anything in between is chop, so it stays out. Real regimes last days, so it trades rarely and lets the trend run.",
+      "version": "1.0.0",
+      "thesis": "Most agents re-implement their own 'should I be active right now?' check; Coyote makes the macro regime a first-class decision. BTC's 7-day move sets the direction and realized vol confirms the character — demanding HIGH vol for a short distinguishes a panic crash worth fading-with from an orderly grind-down that's really just chop. Because regimes are persistent, the right behavior is a slow cadence, a 6h cooldown and a max of 2 entries/day so it never churns on noise, then a wide DSL trail so a real regime move runs for days.",
+      "tags": [
+        "btc",
+        "single-asset",
+        "regime",
+        "macro",
+        "trend",
+        "realized-vol",
+        "dispersion",
+        "balanced-dsl",
+        "let-winners-run"
+      ],
+      "group": "regime",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "crypto_major",
+      "sub_style_label": "Specializes in one crypto major.",
+      "asset_classes": [
+        "btc_eth"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "BTC"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 900,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
+      "id": "chameleon",
+      "name": "Chameleon — Relative-Value / Pairs",
+      "emoji": "🦎",
+      "tagline": "A relative-value pairs trader on correlated crypto majors: for each pair (ETH/BTC, SOL/ETH, SOL/BTC) it z-scores the latest price ratio vs its 48-bar (1h) mean, and when the ratio stretches >=2 sigma AND starts reverting, it takes a directional bet on the high-beta leg in the snap-back direction — sizing one slot and letting a tight mean-reversion DSL bank the reversion.",
+      "belief_plain": "Trades the spread between two coins, not the market. When ETH gets expensive relative to BTC (or SOL vs ETH), the ratio stretches far from its usual level — and ratios snap back more reliably than outright prices. Chameleon measures how stretched a pair is, waits until the ratio starts turning back, then bets on the high-beta coin (ETH or SOL) in the direction that profits from the snap-back, and trails a tight stop to bank the reversion.",
+      "version": "1.0.0",
+      "thesis": "Correlated majors trade as a pack, but their ratios oscillate around a mean. A 3-sigma ETH/BTC extension is a cleaner edge than guessing ETH's absolute direction — the pair's correlation does the work. The Senpi runtime is single-position, so instead of a two-leg market-neutral spread Chameleon takes a directional bet on the high-beta leg; it captures most of the reversion edge without spread-level position management, and the move is bounded, so a tight ladder banks the snap-back rather than holding for a trend.",
+      "tags": [
+        "eth",
+        "sol",
+        "btc",
+        "pairs",
+        "relative-value",
+        "ratio",
+        "z-score",
+        "mean-reversion",
+        "market-neutral-leg",
+        "structural"
+      ],
+      "group": "relative-value",
+      "archetype": "structural_neutral",
+      "archetype_label": "Structural / Neutral",
+      "sub_style": "pairs_rv",
+      "sub_style_label": "Trades a pair's ratio back to its mean (relative value).",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "ETH",
+        "SOL"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
       "id": "beaver",
       "name": "Beaver — BTC Trend Follower",
       "emoji": "🦫",
@@ -986,6 +1399,65 @@
       "max_slots": 1,
       "branch": "strategy-v2",
       "sort_order": 1
+    },
+    {
+      "id": "bobcat",
+      "name": "Bobcat — Big Tech Trend Follower",
+      "emoji": "🐈",
+      "tagline": "A big-tech equity-perp trend follower on Hyperliquid XYZ (NVDA/TSLA/AAPL/META/MSFT/GOOGL/AMZN/AMD/MU/INTC/TSM/ORCL): enters the single strongest name when its 4h trend is non-neutral AND smart-money leans the same way (tilt >= 55%), sizes a flat 20% margin at 5x, and lets a wide DSL ratchet ride the move — with a 48h cap so positions don't camp through the weekend pricing gap.",
+      "belief_plain": "Trades the big tech stocks you already know — NVDA, TSLA, AAPL and nine more — as perps on Hyperliquid XYZ, 23/5. It only enters when a stock's 4-hour trend and the best traders are pointing the same way, holds the single strongest setup, and trails a stop so a real move can run — but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
+      "version": "1.0.0",
+      "thesis": "Big tech is the most-traded equity sector, and Hyperliquid XYZ surfaces these names as leveraged perps with 23/5 hours. A clean trend + smart-money confluence on the highest-liquidity XYZ equities catches directional moves without the small-cap noise of a broad scanner. The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap, where drift accumulates without external price discovery — so winners are let to run on the 4h timescale but never held through the full Fri-Sun window.",
+      "tags": [
+        "big-tech",
+        "equities",
+        "xyz",
+        "nvda",
+        "tsla",
+        "aapl",
+        "trend-following",
+        "smart-money",
+        "basket",
+        "onboarding",
+        "23-5"
+      ],
+      "group": "single-asset",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "big_tech",
+      "sub_style_label": "Trades big-tech equities (NVDA/TSLA/AAPL/…) 24/7.",
+      "asset_classes": [
+        "xyz_equities"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:NVDA",
+        "xyz:TSLA",
+        "xyz:AAPL",
+        "xyz:META",
+        "xyz:MSFT",
+        "xyz:GOOGL",
+        "xyz:AMZN",
+        "xyz:AMD",
+        "xyz:MU",
+        "xyz:INTC",
+        "xyz:TSM",
+        "xyz:ORCL"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 2
     },
     {
       "id": "dire",
@@ -1031,7 +1503,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 2
+      "sort_order": 3
     },
     {
       "id": "grizzly",
@@ -1075,7 +1547,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 3
+      "sort_order": 4
     },
     {
       "id": "heron",
@@ -1118,7 +1590,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "hummingbird",
@@ -1161,7 +1633,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "iguana",
@@ -1209,7 +1681,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 6
+      "sort_order": 7
     },
     {
       "id": "koala",
@@ -1254,7 +1726,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 7
+      "sort_order": 8
     },
     {
       "id": "kodiak",
@@ -1297,7 +1769,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 8
+      "sort_order": 9
     },
     {
       "id": "polar",
@@ -1341,7 +1813,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "stag",
@@ -1389,7 +1861,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "wolverine",
@@ -1434,7 +1906,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "hydra",
@@ -1536,6 +2008,163 @@
       "sort_order": 1
     },
     {
+      "id": "dog",
+      "name": "Dog — Contrarian Pup (SM Exhaustion Fader)",
+      "emoji": "🐕",
+      "tagline": "A patient contrarian on BTC/ETH/SOL/HYPE: waits for a major to move 3%+ in 4h while smart money piles in heavily, then fades the crowded, exhausted side — but only when the funding regime confirms the unwind and the move is still fresh. Conservative 7-10x leverage, wide DSL to let the reversal develop.",
+      "belief_plain": "When a big coin runs hard and the best traders are all crowded onto the same side, the crowd is maximum exposed and the unwind is the trade. Dog bets against that exhausted consensus on BTC, ETH, SOL and HYPE — but only when the move has genuinely overextended, the crowding is still building, and market-wide funding shows the crowd really is one-sided. Most of the time it waits.",
+      "version": "1.0.0",
+      "thesis": "Hyperliquid is dominated by leverage traders chasing momentum. When a major moves 3%+ in four hours and smart-money consensus piles in 15%+, the late entrants are maximally exposed and funding pressure plus mean reversion force the unwind. Dog's edge is being on the unwind side before capitulation accelerates — so it scores the smart-money direction, hard-gates on exhaustion (>=3% 4h move), freshness (15m contribution still rising), trader depth (>=30), and a funding regime that confirms the crowd is one-sided, then emits the OPPOSITE direction at conservative leverage and lets a wide ratcheting stop ride the reversal rather than banking too early.",
+      "tags": [
+        "smart-money",
+        "contrarian",
+        "fade",
+        "exhaustion",
+        "funding-regime",
+        "multi-asset",
+        "btc",
+        "eth",
+        "sol",
+        "hype",
+        "conservative",
+        "let-winners-run"
+      ],
+      "group": "smart-money",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "sm_crowding",
+      "sub_style_label": "Fades the crowded smart-money side once price stops following.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE"
+      ],
+      "direction": "long_short",
+      "risk_level": "conservative",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 180,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 2
+    },
+    {
+      "id": "egret",
+      "name": "Egret — Smart-Money Divergence Fader",
+      "emoji": "🐦",
+      "tagline": "Fades an exhausted crowd: when 70%+ of top traders are piled onto one side of BTC/ETH/SOL/HYPE but price refuses to follow (it stalls or rolls over against the crowd), the crowded side is out of fuel — Egret takes the other side, sized flat at 15% / <=5x, and banks the bounded snapback with a tight ratchet.",
+      "belief_plain": "When almost everyone good is leaning the same way on a coin but the price won't move with them, the trade is crowded and out of buyers (or sellers). Egret bets on the snap-back the other way, and because that bounce is small and quick, it locks in profit fast instead of holding for a big trend.",
+      "version": "1.0.0",
+      "thesis": "Smart-money concentration is usually a confirmation signal — but at an extreme, with price refusing to confirm, it flips contrarian: a maximally-crowded side with no one left to push has only one way to resolve, the unwind. The edge is the bounded snapback, so the right design is the inverse of a momentum holder: maker-only non-urgent entry, a tight ratchet that banks the bounce, and time-cuts that exit a fade that didn't resolve quickly.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "hype",
+        "smart-money",
+        "contrarian",
+        "fade",
+        "mean-reversion",
+        "divergence",
+        "rsi",
+        "maker-only",
+        "tight-ratchet"
+      ],
+      "group": "smart-money",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "sm_crowding",
+      "sub_style_label": "Fades the crowded smart-money side once price stops following.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": null,
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 3
+    },
+    {
+      "id": "marlin",
+      "name": "Marlin — Order-Book Imbalance Momentum",
+      "emoji": "🐟",
+      "tagline": "Reads the L2 order book on BTC/ETH/SOL/HYPE — when resting depth is lopsided (bids far heavier than asks, or the reverse) that's directional pressure, but it only fires when 15m momentum and smart money agree, then hands the position to a wide DSL and lets the move run (it does not scalp).",
+      "belief_plain": "Looks at how much resting buy vs sell interest is stacked in the order book of the big, liquid coins. A heavily one-sided book signals pressure in that direction — but a lopsided book alone is noise, so it only acts when short-term price momentum and the best traders are pointing the same way. Then it holds the trade with a wide trailing stop instead of flipping in and out.",
+      "version": "1.0.0",
+      "thesis": "Order-book imbalance is a genuine microstructure edge, but trading it as a per-tick scalp just bleeds fees. Marlin uses the imbalance differently — as the entry-timing signal on a momentum thesis: the book says which side has pressure right now, momentum and smart money confirm the move is real, and then you hold it with a wide ratchet and let it work. Restricting the universe to four liquid majors keeps the imbalance reading reliable (thin books give garbage ratios), and a 24h hard timeout caps the short-horizon thesis without choking a real run.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "hype",
+        "order-book",
+        "imbalance",
+        "microstructure",
+        "momentum",
+        "smart-money",
+        "let-winners-run",
+        "single-slot"
+      ],
+      "group": "smart-money",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "orderbook_pressure",
+      "sub_style_label": "Trades order-book depth skew.",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 180,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 4
+    },
+    {
       "id": "raptor",
       "name": "Raptor — Hot-Streak Follower",
       "emoji": "🦅",
@@ -1574,7 +2203,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 2
+      "sort_order": 5
     },
     {
       "id": "whalehunter",
@@ -1617,7 +2246,7 @@
       ],
       "max_slots": 6,
       "branch": "strategy-v2",
-      "sort_order": 3
+      "sort_order": 6
     }
   ]
 }

--- a/strategies/chameleon/main/runtime.yaml
+++ b/strategies/chameleon/main/runtime.yaml
@@ -1,0 +1,151 @@
+# ── CHAMELEON · single instance — relative-value / pairs (ratio mean-reversion) ──
+# Runtime 3.0 port of the v2 Chameleon (SKILL.md v1.0.0 / producer v1.0.1).
+# Correlated-pair basket (ETH/BTC, SOL/ETH, SOL/BTC) -> trades the high-beta leg
+# (ETH or SOL). Per tick: z-score the latest price RATIO vs its mean/std over
+# lookbackBars 1h candles; when |z| >= zEntryMin AND the reversion is starting,
+# take a directional bet on the leg in the snap-back direction. Single slot,
+# 4x (cap 5x), mean-reversion DSL (tight "bank the snapback" ladder, 48h
+# hard_timeout + weak_peak_cut). Faithful port of the v2 producer thesis — see
+# scanners/scoring.py (ratio math reproduced verbatim, v2-quirks flagged).
+name: chameleon-main
+group: chameleon
+version: 1.0.0
+description: >
+  CHAMELEON — relative-value / pairs (ratio mean-reversion). For each correlated
+  pair (ETH/BTC, SOL/ETH, SOL/BTC) it computes the latest price RATIO's z-score
+  vs its mean/std over lookbackBars (48) 1h candles. When |z| >= zEntryMin (2.0)
+  and the reversion is starting, it trades the high-beta leg (ETH or SOL) in the
+  direction that profits as the ratio reverts: z high (numerator rich) -> SHORT
+  the leg if leg==numerator, LONG if leg==denominator; mirror for z low. The
+  runtime is single-position, so this is a directional relative-value bet, not a
+  two-leg market-neutral spread. Score (max ~7): +2 |z|>=zEntryMin, +2 |z|>=zStrong,
+  +1 ratio turning, +1 smart-money confirms the leg, +1 leg volume rising. Floor
+  minScore 4. Emits the single most-extended reversion candidate per tick at 4x
+  (cap 5x), 15% margin. DSL is the ONLY exit — mean-reversion preset (tight ladder,
+  first lock 30% at +5% ROE, 48h hard_timeout + weak_peak_cut). Faithful port of
+  the v2 Chameleon v1.0.0 thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${CHAMELEON_WALLET}"
+  slots: 1                                # v2 single-position
+  margin_pct: 15                          # baseline %; scan emits marginPct per signal (v2 config marginPct 0.15 -> 15%)
+  default_leverage: 4                     # v2 DEFAULT_LEVERAGE; scan emits 4x clamped to <=5x per signal
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: chameleon_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 180                   # v2 tick_timeout=180; candles per unique asset + sm + account
+    default_signal_validity_seconds: 600   # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      pairs:                               # v2 DEFAULT_PAIRS / config.pairs (numerator/denominator + high-beta leg)
+        - { numerator: "ETH", denominator: "BTC", leg: "ETH" }
+        - { numerator: "SOL", denominator: "ETH", leg: "SOL" }
+        - { numerator: "SOL", denominator: "BTC", leg: "SOL" }
+      minScore: 4                          # v2 DEFAULT_MIN_SCORE / config.minScore
+      lookbackBars: 48                     # v2 DEFAULT_LOOKBACK_BARS — 1h bars (~2 days) for ratio mean/std
+      zEntryMin: 2.0                       # v2 DEFAULT_Z_ENTRY_MIN — |z| to consider the ratio extended
+      zStrong: 3.0                         # v2 DEFAULT_Z_STRONG — |z| for the extreme bonus
+      smTiltMinPct: 55                     # v2 DEFAULT_SM_TILT_MIN — smart-money tilt floor for the +1
+      marginPct: 15                        # PERCENT of withdrawable (0,100] (v2 config marginPct 0.15 -> 15%)
+      leverage: 4                          # v2 DEFAULT_LEVERAGE; clamped to <=5 (MAX_LEVERAGE) in scan.py
+      maxLeverage: 5                       # v2 MAX_LEVERAGE
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      pair: { type: string, required: false }
+      zscore: { type: number, required: false }
+      ratio: { type: number, required: false }
+      ratioMean: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      legVolumeTrendPct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: chameleon_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [chameleon_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # enter at the extreme — a maker order that rests
+                                           # (CREATE_ORDER_RESTING) misses the reversion window.
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: chameleon_signals
+
+# ── EXIT (DSL — preserved VERBATIM from v2 runtime.yaml, mean-reversion preset) ──
+# A ratio reversion is a BOUNDED move — bank it. Tight ladder (first lock 30% at
+# +5% ROE), 48h hard_timeout + weak_peak_cut (a reversion resolves quickly or the
+# thesis failed). dead_weight_cut disabled. Phase 1 max_loss 15%. NOTE: time-cuts
+# are KEPT ON here (mean-reversion class), unlike the single-asset/conviction
+# pattern which disables them — verbatim from v2, which is a multi-pair RV agent,
+# not a single-asset conviction hold. interval_seconds 60 (REDUCE_ONLY-spam
+# mitigation when runtime position state lags HL).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30          # v2 exit execution_timeout_seconds
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # v2: ON — reversion resolves or the thesis failed
+      interval_in_minutes: 2880            # 48h
+    weak_peak_cut:
+      enabled: true                        # v2: ON
+      interval_in_minutes: 120
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0                    # v2 Phase 1 max_loss
+      retrace_threshold: 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # v2 mean-reversion ladder; FIRST lock at +5% ROE (reachable)
+        - { trigger_pct: 5,  lock_hw_pct: 30 }
+        - { trigger_pct: 10, lock_hw_pct: 50 }
+        - { trigger_pct: 15, lock_hw_pct: 65 }
+        - { trigger_pct: 25, lock_hw_pct: 80 }
+        - { trigger_pct: 40, lock_hw_pct: 90 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # 72h (was data_retention_hours 72)
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 daily_loss_limit_pct
+    max_entries_per_day: 3                  # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 cooldown_minutes 60 -> 3600s
+    drawdown_halt_pct: 20                  # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 21600      # v2 per_asset_cooldown_minutes 360 -> 21600s (6h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/chameleon/main/scanners/scan.py
+++ b/strategies/chameleon/main/scanners/scan.py
@@ -1,0 +1,302 @@
+"""CHAMELEON — supervised scanner (Runtime 3.0 port of the v2 Chameleon RV/pairs).
+
+Relative-value / pairs (ratio mean-reversion). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - fetches 1h candles ONCE per unique asset across all configured pairs,
+  - for each pair computes the latest ratio z-score, and if |z| >= zEntryMin AND
+    the reversion is starting, scores the high-beta leg via pure
+    `scoring.build_pair_thesis` (smart-money lean on the leg passed in),
+  - emits the SINGLE most-extended candidate at/above `minScore` (v2 main()
+    emitted only `best`), sized by marginPct (PERCENT) and clamped leverage.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit.
+No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs the v2 producer (chameleon-producer.py v1.0.1):
+  - v2 sized via marginPct * account_value -> marginUsd, with marginPct stored as
+    a FRACTION (config marginPct=0.15). This port emits `marginPct` as a PERCENT
+    in (0,100] (15) and the runtime sizes (marginPct/100)*withdrawable. The
+    defensive "<=1.0 means a pasted v2 fraction, x100" guard is added (dire/koala
+    pattern) so an operator who pastes 0.15 doesn't silently size ~100x small.
+  - v2's runtime.yaml template said `margin_pct: 20`, but the PRODUCER + config.json
+    are the source of truth and use marginPct 0.15 (=15%). This port uses 15% and
+    FLAGS the v2 runtime-vs-producer mismatch (15% trusted, per spec source order).
+  - v2 fetched candles for every unique asset across all pairs once per tick
+    (numerator + denominator + leg). Preserved verbatim.
+  - v2 emitted exactly one signal (the highest-scoring candidate). Preserved:
+    scan() emits <= 1 signal/tick.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=240) -> ctx.state dedup map
+    (same TTL semantics; prune at 4x TTL).
+  - v2 held-asset + recently-signaled filter ran on the LEG before scoring; both
+    are reproduced (held checked on the leg; was_recently_signaled on the leg).
+  - leverage: v2 clamped min(config.leverage, MAX_LEVERAGE=5). Preserved.
+  - LLM gate in v2 was an explicit pass-through (honor the producer's signal); this
+    port uses decision_mode: rule in runtime.yaml, equivalent and cheaper.
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 defaults (chameleon-producer.py / chameleon-config.json)
+_DEFAULT_PAIRS = [
+    {"numerator": "ETH", "denominator": "BTC", "leg": "ETH"},
+    {"numerator": "SOL", "denominator": "ETH", "leg": "SOL"},
+    {"numerator": "SOL", "denominator": "BTC", "leg": "SOL"},
+]
+_DEFAULT_MIN_SCORE = 4               # v2 DEFAULT_MIN_SCORE / config.minScore
+_DEFAULT_MARGIN_PCT = 15.0           # PERCENT (v2 config marginPct 0.15 -> 15%)
+_DEFAULT_LEVERAGE = 4                # v2 DEFAULT_LEVERAGE
+_MAX_LEVERAGE = 5                    # v2 MAX_LEVERAGE (hardcoded cap)
+_DEFAULT_TTL = 240                   # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    Chameleon's universe is crypto majors, so this only ever returns '' here."""
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[chameleon.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        if isinstance(ms, dict):
+            account_value = max(account_value, scoring._f(ms, "accountValue", default=0.0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos, "szi", default=0.0)
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", "")})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        if not isinstance(_ms, dict):
+            continue
+        _use = max(_use,
+                   scoring._f(_ms, "totalMarginUsed", default=0.0),
+                   abs(scoring._f(_ms, "totalNtlPos", default=0.0)))
+    if _use > 1.0 and not positions:
+        print("[chameleon.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _fetch_candles(ctx, asset):
+    """1h candle list for `asset` or []. READ-GUARDED. Ported from v2
+    fetch_candles (market_get_asset_data, 1h only, no funding/order-book)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": asset,
+            "candle_intervals": ["1h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": _dex_for(asset),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[chameleon.scan] market_get_asset_data({asset}) read failed: {exc!r}", file=sys.stderr)
+        return []
+    if not md:
+        return []
+    if isinstance(md, dict) and md.get("success") is False:
+        return []
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return []
+    candles = d.get("candles", {}) or {}
+    if not isinstance(candles, dict):
+        return []
+    return candles.get("1h", []) or []
+
+
+def _fetch_sm_direction(ctx, asset):
+    """Port of v2 fetch_sm_direction: net smart-money lean for `asset` from
+    leaderboard_get_markets. Returns (direction, tilt_pct) or (None, 0.0).
+    READ-GUARDED. Verbatim: long_ratio >= 50 -> ('LONG', long_ratio) else
+    ('SHORT', 100 - long_ratio); total==0 -> ('NEUTRAL', 50.0)."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — smart-money is a +1 contributor; never crash the tick
+        print(f"[chameleon.scan] leaderboard_get_markets read failed (smart-money -> none): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw:
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m, "pct_of_top_traders_gain", "longPct", default=0.0)
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    pairs = inputs.get("pairs", _DEFAULT_PAIRS)
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    lev_default = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    max_leverage = int(inputs.get("maxLeverage", _MAX_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+
+    # marginPct is a PERCENT in (0,100]. FLAGGED: defensively convert a value <= 1
+    # (an operator who pasted the v2 FRACTION 0.15) into a PERCENT so it never
+    # silently sizes ~100x small (the runtime sizes (marginPct/100)*withdrawable).
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        print(f"[chameleon.scan] marginPct={margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
+
+    # leverage: clamp v2 default into <= MAX_LEVERAGE (verbatim min(leverage, MAX))
+    leverage = min(lev_default, max_leverage)
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[chameleon.scan] WAITING — no account value (read degraded or zero equity)",
+              file=sys.stderr)
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = scoring.prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # Fetch 1h candles ONCE per unique asset across all pairs (verbatim v2 main()).
+    assets = sorted({a for p in pairs for a in (p["numerator"], p["denominator"], p["leg"])})
+    candles_by_asset = {a: _fetch_candles(ctx, a) for a in assets}
+    closes_by_asset = {
+        a: [scoring._f(c, "close", "c") for c in candles_by_asset.get(a, [])]
+        for a in assets
+    }
+
+    # Score each pair whose LEG is not held / not recently signaled (v2 order:
+    # held + recently-signaled filter on the leg BEFORE thesis build).
+    candidates = []
+    scanned = 0
+    for pair in pairs:
+        leg = str(pair["leg"]).upper()
+        if leg in held_set or scoring.was_recently_signaled(signaled, leg, ttl, now):
+            continue
+        scanned += 1
+        sm = _fetch_sm_direction(ctx, pair["leg"])
+        th = scoring.build_pair_thesis(pair, closes_by_asset, candles_by_asset, sm, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets,
+                  "pairs": [f"{p['numerator']}/{p['denominator']}" for p in pairs],
+                  "note": f"WAITING (min score {min_score:.0f})"}
+        print(f"[chameleon.scan] WAITING — no ratio extended past z-threshold with reversion "
+              f"starting (min score {min_score:.0f}); scanned={scanned} held={held_assets}",
+              file=sys.stderr)
+    else:
+        # v2 emitted exactly the single best (highest score; most-extended reversion).
+        candidates.sort(key=lambda c: c["score"], reverse=True)
+        best = candidates[0]
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"],
+                  "pair": best["pair"], "zscore": best["zscore"],
+                  "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best["reasons"]}
+        print(f"[chameleon.scan] EMIT {best['coin']} {best['direction']} "
+              f"{best['pair']} z={best['zscore']} score={best['score']} {leverage}x "
+              f"marginPct={margin_pct:.2f}% | {best['reasons'][:5]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # <=5; runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "pair": best["pair"],
+                "zscore": best.get("zscore") or 0.0,
+                "ratio": best.get("ratio") or 0.0,
+                "ratioMean": best.get("ratio_mean") or 0.0,
+                "smDirection": best.get("sm_direction") or "NONE",
+                "smTiltPct": best.get("sm_tilt_pct") or 0.0,
+                "legVolumeTrendPct": best.get("leg_volume_trend_pct") or 0.0,
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + this tick's result every tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[chameleon.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/chameleon/main/scanners/scoring.py
+++ b/strategies/chameleon/main/scanners/scoring.py
@@ -1,0 +1,181 @@
+"""CHAMELEON — pure relative-value / pairs math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Chameleon producer's ratio mean-reversion
+math (SKILL.md v1.0.0 / chameleon-producer.py v1.0.1). The math/indexing is
+reproduced VERBATIM so a fidelity harness can diff this against the v2 producer on
+the same market snapshot. Behaviour-preserving quirks from v2 are kept and flagged
+`# v2-quirk`; fix them only as a separate, labelled change AFTER the port validates.
+
+Thesis: for a correlated pair (numerator/denominator) compute the latest A/B price
+RATIO's z-score vs its mean/std over `lookback` 1h bars. When |z| >= zEntryMin and
+the reversion is starting, trade the high-beta LEG in the direction that profits as
+the ratio reverts to its mean (single-position runtime -> directional RV bet, not a
+two-leg spread). `sm` (smart-money lean on the leg) is fetched by the caller and
+passed in, so this module stays pure and unit-testable on plain candle lists.
+
+Score (max ~7):  +2 |z|>=zEntryMin (gate-confirmed) · +2 |z|>=zStrong ·
+                 +1 ratio turning · +1 SM on the leg confirms direction · +1 leg vol rising.
+"""
+
+import statistics
+
+# v2 defaults (chameleon-producer.py / chameleon-config.json)
+DEFAULT_LOOKBACK_BARS = 48          # 1h bars (~2 days) for the ratio mean/std
+DEFAULT_Z_ENTRY_MIN = 2.0           # |z| to consider the ratio extended
+DEFAULT_Z_STRONG = 3.0
+DEFAULT_SM_TILT_MIN = 55
+
+
+def _f(c, primary, alt=None, default=0.0):
+    """Numeric accessor over a candle dict. Verbatim from v2 _f (primary key,
+    optional alt key, default). v2 read dicts only; this matches that shape."""
+    if isinstance(c, dict):
+        val = c.get(primary)
+        if val is None and alt:
+            val = c.get(alt)
+    else:
+        val = c
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ── ratio mean-reversion (ported verbatim from v2 chameleon-producer.py) ──
+
+def ratio_zscore(closes_a, closes_b, lookback):
+    """z-score of the latest A/B ratio vs the mean/stdev of the ratio over the
+    last `lookback` bars. Returns (z, ratio, mean, std) or None if data is
+    insufficient or the ratio has ~no variance. Verbatim from v2 ratio_zscore."""
+    n = min(len(closes_a), len(closes_b))
+    if n < lookback:
+        return None
+    a = closes_a[-lookback:]
+    b = closes_b[-lookback:]
+    ratios = [x / y for x, y in zip(a, b) if y > 0]
+    if len(ratios) < lookback:
+        return None
+    mean = statistics.fmean(ratios)
+    std = statistics.pstdev(ratios)
+    if std <= 0:
+        return None
+    latest = ratios[-1]
+    return (latest - mean) / std, latest, mean, std
+
+
+def reversion_direction(z, leg, numerator, z_entry_min):
+    """Direction to trade `leg` so the position profits from the ratio
+    (numerator/denominator) reverting toward its mean. None if |z| too small.
+    Verbatim from v2 reversion_direction.
+
+      z high (ratio above mean -> numerator rich vs denominator):
+        leg == numerator   -> SHORT   ;   leg == denominator -> LONG
+      z low (numerator cheap):
+        leg == numerator   -> LONG    ;   leg == denominator -> SHORT
+    """
+    if z is None or abs(z) < z_entry_min:
+        return None
+    rich = z > 0   # ratio above mean -> numerator expensive vs denominator
+    if leg == numerator:
+        return "SHORT" if rich else "LONG"
+    return "LONG" if rich else "SHORT"   # leg == denominator
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-half vs earlier-half average volume, % change. Verbatim from v2."""
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ── the thesis (one pair), ported verbatim from v2 build_pair_thesis ──
+
+def build_pair_thesis(pair, closes_by_asset, candles_by_asset, sm, entry_cfg):
+    """Port of v2 build_pair_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned when:
+      - either leg's closes are missing, OR
+      - ratio_zscore is None (insufficient history / ~zero ratio variance), OR
+      - reversion_direction is None (|z| < zEntryMin).
+    minScore is NOT applied here — the caller gates on thesis['score'].
+
+    `sm` is the smart-money tuple (direction, tilt_pct) for the LEG, or (None, 0)
+    — the caller fetches it (fetch_sm_direction) so this stays pure."""
+    num, den, leg = pair["numerator"], pair["denominator"], pair["leg"]
+    ca, cb = closes_by_asset.get(num), closes_by_asset.get(den)
+    if not ca or not cb:
+        return None
+    lookback = int(entry_cfg.get("lookbackBars", DEFAULT_LOOKBACK_BARS))
+    z_min = float(entry_cfg.get("zEntryMin", DEFAULT_Z_ENTRY_MIN))
+    z_strong = float(entry_cfg.get("zStrong", DEFAULT_Z_STRONG))
+
+    zr = ratio_zscore(ca, cb, lookback)
+    if zr is None:
+        return None
+    z, ratio, mean, std = zr
+    direction = reversion_direction(z, leg, num, z_min)
+    if direction is None:
+        return None
+
+    # Reversion must be starting, not still extending: |z| one bar ago > |z| now.
+    zr_prev = ratio_zscore(ca[:-1], cb[:-1], lookback)
+    turning = bool(zr_prev and abs(z) < abs(zr_prev[0]))
+
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    sm_min = float(entry_cfg.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    leg_vol = volume_trend(candles_by_asset.get(leg, []))
+
+    score = 0
+    reasons = [f"{num}/{den}_z_{z:+.2f}"]
+    score += 2  # |z| >= z_min gate-confirmed
+    if abs(z) >= z_strong:
+        score += 2
+        reasons.append(f"z_extreme_{z:+.2f}")
+    if turning:
+        score += 1
+        reasons.append("ratio_turning")
+    if sm_dir == direction and sm_tilt >= sm_min:
+        score += 1
+        reasons.append(f"sm_confirms_{sm_tilt:.0f}%")
+    if leg_vol > 10:
+        score += 1
+        reasons.append(f"vol_rising_{leg_vol:+.0f}%")
+
+    return {
+        "coin": leg,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "pair": f"{num}/{den}",
+        "zscore": round(z, 3),
+        "ratio": round(ratio, 6),
+        "ratio_mean": round(mean, 6),
+        "turning": turning,
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": float(sm_tilt) if isinstance(sm_tilt, (int, float)) else 0.0,
+        "leg_volume_trend_pct": round(leg_vol, 2),
+    }
+
+
+# ── recent-signal dedup helpers (port of v2 _prune_recent_signals semantics) ──
+
+def prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def was_recently_signaled(signaled, coin, ttl, now):
+    """True if `coin` was signaled within `ttl` seconds (verbatim semantics)."""
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl

--- a/strategies/chameleon/strategy.yaml
+++ b/strategies/chameleon/strategy.yaml
@@ -1,0 +1,44 @@
+# Chameleon — relative-value / pairs (ratio mean-reversion). A single-instance PACKAGE:
+# this manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port
+# of the v2 Chameleon (SKILL.md v1.0.0): for each correlated pair (ETH/BTC, SOL/ETH,
+# SOL/BTC) it z-scores the latest price RATIO vs its mean/std over lookbackBars 1h candles,
+# then takes a DIRECTIONAL bet on the high-beta leg in the direction that profits as the
+# ratio reverts to its mean (single-position runtime -> not a two-leg market-neutral spread).
+# Mean-reversion DSL (tight "bank the snapback" ladder, 48h hard_timeout + weak_peak_cut).
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: chameleon
+version: "1.0.0"
+
+catalog:
+  name: "Chameleon — Relative-Value / Pairs"
+  emoji: "🦎"
+  tagline: "A relative-value pairs trader on correlated crypto majors: for each pair (ETH/BTC, SOL/ETH, SOL/BTC) it z-scores the latest price ratio vs its 48-bar (1h) mean, and when the ratio stretches >=2 sigma AND starts reverting, it takes a directional bet on the high-beta leg in the snap-back direction — sizing one slot and letting a tight mean-reversion DSL bank the reversion."
+  belief_plain: "Trades the spread between two coins, not the market. When ETH gets expensive relative to BTC (or SOL vs ETH), the ratio stretches far from its usual level — and ratios snap back more reliably than outright prices. Chameleon measures how stretched a pair is, waits until the ratio starts turning back, then bets on the high-beta coin (ETH or SOL) in the direction that profits from the snap-back, and trails a tight stop to bank the reversion."
+  thesis: "Correlated majors trade as a pack, but their ratios oscillate around a mean. A 3-sigma ETH/BTC extension is a cleaner edge than guessing ETH's absolute direction — the pair's correlation does the work. The Senpi runtime is single-position, so instead of a two-leg market-neutral spread Chameleon takes a directional bet on the high-beta leg; it captures most of the reversion edge without spread-level position management, and the move is bounded, so a tight ladder banks the snap-back rather than holding for a trend."
+  group: relative-value
+  archetype: structural_neutral
+  sub_style: pairs_rv
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 200
+  assets: ["ETH", "SOL"]
+  tags: [eth, sol, btc, pairs, relative-value, ratio, z-score, mean-reversion, market-neutral-leg, structural]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: CHAMELEON_WALLET
+    funding_share: 1.0

--- a/strategies/coyote/main/runtime.yaml
+++ b/strategies/coyote/main/runtime.yaml
@@ -1,0 +1,138 @@
+# ── COYOTE · single instance — regime classifier / single-asset BTC bet ──────
+# Runtime 3.0 port of the v2 Coyote (coyote-producer.py v1.0.1 / SKILL.md v1.0.0).
+# Coyote classifies the macro regime from BTC 7d trend + annualized realized vol
+# (+ informational cross-asset dispersion) into TREND_UP / TREND_DOWN / CHOP and
+# takes a single positional BTC bet: LONG in TREND_UP, SHORT in TREND_DOWN, out in
+# CHOP. The regime view is published to scanner state on EVERY tick (incl no-trade)
+# for operator visibility. DSL-only exits (balanced preset). Faithful port — see
+# scanners/scoring.py (regime math reproduced verbatim).
+name: coyote-main
+group: coyote
+version: 3.0.0
+description: >
+  COYOTE — regime classifier / single-asset BTC bet. Each tick computes BTC 7d
+  move + annualized realized vol over 4h candles (+ cross-asset dispersion across
+  BTC/ETH/SOL/HYPE, informational only) and classifies the market: TREND_UP
+  (BTC 7d >= +5% AND vol <= 80%) -> LONG BTC; TREND_DOWN (BTC 7d <= -5% AND
+  vol >= 60%) -> SHORT BTC; CHOP otherwise -> no trade. Regimes are persistent —
+  15min cadence, 6h per-asset cooldown, max 2 entries/day, so it doesn't churn on
+  noise. DSL is the ONLY exit (balanced ladder: first lock at +10% ROE, weak-peak
+  cut at 8h). Faithful port of the v2 Coyote v1.0.1 thesis (regime math verbatim).
+
+strategy:
+  wallet: "${COYOTE_WALLET}"
+  slots: 1                                # single regime bet on BTC
+  margin_pct: 25                          # baseline %; scan emits marginPct per signal
+  default_leverage: 3                     # fallback; scan emits 1-5x per signal (clamped to 5)
+  trading_risk: balanced
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: coyote_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900                  # v2 producer cadence (15min — regimes don't flip in 5min)
+    timeout_seconds: 180                   # v2 tick_timeout=180; account + 1 read/universe asset (4)
+    default_signal_validity_seconds: 1800  # 2x tick; rule action re-scores next tick
+    state_history_max_count: 100           # dedup map + per-tick regime-view history (~25h @900s)
+    inputs:
+      btcAsset: "BTC"                      # validated live on HL main DEX 2026-06-29
+      dispersionUniverse: ["BTC", "ETH", "SOL", "HYPE"]  # dispersion only (informational; SKILL RULE 3)
+      trendLookbackBars: 42                # 7d on 4h bars
+      volLookbackBars: 42                  # 7d realized vol
+      dispersionLookbackBars: 24           # 4d dispersion
+      trendUpThresholdPct: 5.0             # TREND_UP: BTC 7d >= this
+      trendDownThresholdPct: 5.0           # TREND_DOWN: BTC 7d <= -this
+      maxVolForTrendPct: 80.0              # annualized vol cap for TREND_UP
+      minVolForCrashPct: 60.0              # vol floor for TREND_DOWN (panic-crash, not slow grind)
+      marginPct: 25                        # PERCENT of withdrawable (0,100] (v2 fraction 0.25 * 100)
+      leverage: 3                          # clamped to MAX 5 in scan.py
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      marginPct: { type: number, required: false }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      regime: { type: string, required: false }
+      btc7dMovePct: { type: number, required: false }
+      realizedVolPct: { type: number, required: false }
+      dispersionPct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: coyote_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # scan already classified + filtered (v2 LLM gate was pass-through)
+    scanners: [coyote_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # regime is established; enter NOW (v2 entry param)
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: coyote_main_signals
+
+# ── EXIT (DSL — preserved VERBATIM from v2 runtime.yaml, balanced preset) ──────
+# Regime trades hold for the duration of the regime. Balanced ladder + weak_peak_cut
+# so a stalled regime trade gets cut. hard_timeout 5d (regimes can run days/weeks);
+# weak_peak_cut 8h/min 3.0; phase1 max_loss 15%; phase2 first lock at +10% ROE
+# (REACHABLE — not +60-80%). interval_seconds 60 + taker fallback (closes MUST happen).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 7200            # 5d
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480             # 8h
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 30 }
+        - { trigger_pct: 35,  lock_hw_pct: 50 }
+        - { trigger_pct: 60,  lock_hw_pct: 70 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; hours/minutes -> seconds) ──
+risk:
+  data_retention_seconds: 604800           # v2 data_retention_hours 168 -> 604800 (7d, clamp ceiling)
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 risk.daily_loss_limit_pct
+    max_entries_per_day: 2                  # v2: regimes are persistent — don't churn
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 risk.max_consecutive_losses
+    cooldown_seconds: 21600                # v2 cooldown_minutes 360 -> 21600 (6h)
+    drawdown_halt_pct: 22                  # v2 risk.drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 21600      # v2 per_asset_cooldown_minutes 360 -> 21600 (6h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/coyote/main/scanners/scan.py
+++ b/strategies/coyote/main/scanners/scan.py
@@ -1,0 +1,283 @@
+"""COYOTE — supervised scanner (Runtime 3.0 port of the v2 Coyote regime classifier).
+
+Single-asset BTC positional bet whose DIRECTION is set by a macro-regime
+classification. Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - reads BTC 4h candles -> 7d move + annualized realized vol,
+  - reads each dispersion-universe asset's 4h candles -> cross-asset dispersion
+    (INFORMATIONAL ONLY; published, never gating — SKILL RULE 3),
+  - classifies TREND_UP / TREND_DOWN / CHOP / UNKNOWN via pure `scoring`,
+  - emits ONE BTC signal (LONG in TREND_UP, SHORT in TREND_DOWN), else nothing.
+
+The regime view is appended to ctx.state EVERY tick (even on CHOP / UNKNOWN /
+no-trade), reproducing the v2 producer's "always publish the regime" behaviour
+for operator visibility.
+
+Read-only + single-pass — emits `marginPct` (PERCENT in (0,100]) + `leverage`
+at the TOP level; the runtime sizes the dollars, owns cooldowns/risk gates, and
+trails the DSL exit. No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs the v2 producer (coyote-producer.py v1.0.1):
+  - v2 stored margin as a FRACTION (config marginPct=0.25) and computed
+    marginUsd = account_value * 0.25. Runtime 3.0 sizes from a PERCENT in
+    (0,100], so this port emits `marginPct` = 25 (0.25 * 100). The defensive
+    "<=1.0 means a pasted fraction, *100" guard is applied so an operator who
+    leaves the v2-style 0.25 in inputs still gets 25%.
+  - v2 leverage: min(int(config.leverage=3), MAX_LEVERAGE=5) -> clamped to 5.
+    Preserved verbatim (DEFAULT_LEVERAGE=3, MAX_LEVERAGE=5).
+  - v2 published the regime in EVERY tick output (incl. no-trade). Preserved:
+    the regime view is written to ctx.state every tick + a one-line stderr.
+  - v2 emitted exactly one signal (BTC). Preserved: scan() emits <= 1/tick.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=240) -> ctx.state dedup
+    map (same TTL + 4x-TTL prune semantics).
+  - v2 score in the data block was a constant 5 / wire score 0.7. Score is not a
+    gate in Coyote (regime IS the gate); preserved as a constant 5 in data.
+  - dispersion is computed + published but NEVER enters the gate (SKILL RULE 3,
+    verbatim). It only refines an operator's read of "mixed vs synchronized".
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 defaults (coyote-producer.py / coyote-config.json)
+_DEFAULT_BTC = "BTC"
+_DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL", "HYPE"]   # dispersion only (informational)
+_DEFAULT_TREND_LOOKBACK = 42            # 7d on 4h bars
+_DEFAULT_VOL_LOOKBACK = 42              # 7d realized vol
+_DEFAULT_DISPERSION_LOOKBACK = 24       # 4d dispersion
+_DEFAULT_TREND_UP_THRESHOLD_PCT = 5.0
+_DEFAULT_TREND_DOWN_THRESHOLD_PCT = 5.0
+_DEFAULT_MAX_VOL_FOR_TREND_PCT = 80.0
+_DEFAULT_MIN_VOL_FOR_CRASH_PCT = 60.0
+_DEFAULT_MARGIN_PCT = 25                # PERCENT (v2 fraction 0.25 * 100)
+_DEFAULT_LEVERAGE = 3
+_MAX_LEVERAGE = 5                       # v2 MAX_LEVERAGE (hardcoded)
+_DEFAULT_RECENT_TTL = 240              # v2 RECENT_SIGNAL_TTL_SEC
+
+
+def _to_percent(v, default):
+    """Defensive fraction->percent guard (dire/koala pattern). A v2 config that
+    still carries marginPct as a FRACTION (0.25) would otherwise size at 0.25%.
+    Any value <= 1.0 is treated as a pasted fraction and scaled *100."""
+    try:
+        p = float(v)
+    except (TypeError, ValueError):
+        return float(default)
+    if p <= 0:
+        return float(default)
+    if p <= 1.0:
+        p *= 100.0
+    return p
+
+
+def _get_account(ctx):
+    """(account_value, [held_coin_upper]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    if not ctx.wallet:
+        return 0.0, []
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[coyote.scan] clearinghouse read failed (degrade): {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    held, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) or {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0), default=0.0))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring._f(pos.get("szi", 0), default=0.0)
+            if szi == 0:
+                continue
+            coin = str(pos.get("coin", "")).upper()
+            if coin:
+                held.append(coin)
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing / held-asset dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use,
+                   scoring._f(_ms.get("totalMarginUsed", 0), default=0.0),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0), default=0.0)))
+    if _use > 1.0 and not held:
+        print("[coyote.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, held
+
+
+def _fetch_closes(ctx, asset):
+    """4h close-price series for `asset` or [] on any error. READ-GUARDED.
+    Ported from v2 producer `fetch_candles` (market_get_asset_data, 4h only)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": asset,
+            "candle_intervals": ["4h"],
+            "include_funding": False,
+            "include_order_book": False,
+        })
+    except Exception as exc:  # noqa: BLE001 — degrade to empty series, never crash the tick
+        print(f"[coyote.scan] market_get_asset_data({asset}) read failed (degrade): {exc!r}",
+              file=sys.stderr)
+        return []
+    if not md:
+        return []
+    if isinstance(md, dict) and md.get("success") is False:
+        return []
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return []
+    candles = (d.get("candles", {}) or {}).get("4h", []) or []
+    return scoring.closes_from_candles(candles)
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    btc_asset = inputs.get("btcAsset", _DEFAULT_BTC)
+    universe = inputs.get("dispersionUniverse", _DEFAULT_UNIVERSE)
+    trend_lb = int(inputs.get("trendLookbackBars", _DEFAULT_TREND_LOOKBACK))
+    vol_lb = int(inputs.get("volLookbackBars", _DEFAULT_VOL_LOOKBACK))
+    disp_lb = int(inputs.get("dispersionLookbackBars", _DEFAULT_DISPERSION_LOOKBACK))
+    trend_up_th = float(inputs.get("trendUpThresholdPct", _DEFAULT_TREND_UP_THRESHOLD_PCT))
+    trend_dn_th = float(inputs.get("trendDownThresholdPct", _DEFAULT_TREND_DOWN_THRESHOLD_PCT))
+    max_vol_trend = float(inputs.get("maxVolForTrendPct", _DEFAULT_MAX_VOL_FOR_TREND_PCT))
+    min_vol_crash = float(inputs.get("minVolForCrashPct", _DEFAULT_MIN_VOL_FOR_CRASH_PCT))
+    margin_pct = _to_percent(inputs.get("marginPct", _DEFAULT_MARGIN_PCT), _DEFAULT_MARGIN_PCT)
+    leverage = min(int(inputs.get("leverage", _DEFAULT_LEVERAGE)), _MAX_LEVERAGE)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    account_value, held = _get_account(ctx)
+    held_set = {h.upper() for h in held}
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # v2 produced no signal (and skipped scoring) when account value was 0.
+    if account_value <= 0:
+        result = {"ts": now, "emitted": False, "regime": None,
+                  "note": "no account value", "held": held}
+        print("[coyote.scan] WAITING — no account value", file=sys.stderr)
+        _persist(ctx, signaled, result)
+        return []
+
+    # ── BTC trend + realized vol ──
+    btc_closes = _fetch_closes(ctx, btc_asset)
+    btc_move = scoring.pct_move(btc_closes, trend_lb)
+    btc_vol = scoring.realized_vol_pct(btc_closes, vol_lb)
+
+    # ── cross-asset dispersion (INFORMATIONAL ONLY — never gates; SKILL RULE 3) ──
+    returns_by_asset = {}
+    for a in universe:
+        closes = btc_closes if a == btc_asset else _fetch_closes(ctx, a)
+        returns_by_asset[a] = scoring.pct_move(closes, disp_lb)
+    disp = scoring.dispersion_pct(returns_by_asset)
+
+    regime = scoring.classify_regime(btc_move, btc_vol, trend_up_th, trend_dn_th,
+                                     max_vol_trend, min_vol_crash)
+    direction = scoring.regime_to_direction(regime)
+
+    out = []
+    btc_u = btc_asset.upper()
+
+    if direction is None:
+        # CHOP / UNKNOWN — publish the regime view, no trade (verbatim v2 behaviour).
+        result = {"ts": now, "emitted": False, "regime": regime,
+                  "btc7dMovePct": round(btc_move, 2) if btc_move is not None else None,
+                  "realizedVolPct": round(btc_vol, 1) if btc_vol is not None else None,
+                  "dispersionPct": round(disp, 2) if disp is not None else None,
+                  "held": held}
+        print(f"[coyote.scan] WAITING — REGIME={regime} (no positional expression); "
+              f"btc7d={result['btc7dMovePct']}% vol={result['realizedVolPct']}% "
+              f"disp={result['dispersionPct']} held={held}", file=sys.stderr)
+    elif btc_u in held_set or _was_recently_signaled(signaled, btc_asset, ttl, now):
+        result = {"ts": now, "emitted": False, "regime": regime, "direction": direction,
+                  "btc7dMovePct": round(btc_move, 2), "realizedVolPct": round(btc_vol, 1),
+                  "dispersionPct": round(disp, 2) if disp is not None else None,
+                  "note": "BTC already held or recently signaled", "held": held}
+        print(f"[coyote.scan] WAITING — REGIME={regime} {direction} but BTC held/recently-signaled; "
+              f"held={held}", file=sys.stderr)
+    else:
+        signaled[btc_u] = now
+        result = {"ts": now, "emitted": True, "regime": regime, "direction": direction,
+                  "btc7dMovePct": round(btc_move, 2), "realizedVolPct": round(btc_vol, 1),
+                  "dispersionPct": round(disp, 2) if disp is not None else None,
+                  "leverage": leverage, "marginPct": round(margin_pct, 4), "held": held}
+        print(f"[coyote.scan] EMIT {btc_asset} {direction} REGIME={regime} "
+              f"btc7d={btc_move:+.1f}% vol={btc_vol:.0f}% disp="
+              f"{round(disp, 2) if disp is not None else None} {leverage}x "
+              f"marginPct={margin_pct:.2f}%", file=sys.stderr)
+        out = [{
+            "asset": btc_asset,
+            "direction": direction,
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # 1..5; runtime applies it
+            "data": {
+                "score": 5,                   # constant (v2 data score=5; regime IS the gate)
+                "leverage": float(leverage),
+                "marginPct": round(margin_pct, 4),
+                "direction": direction,
+                "reasons": [f"regime_{regime}", f"btc_7d_{btc_move:+.1f}%", f"vol_{btc_vol:.0f}%"],
+                "regime": regime,
+                "btc7dMovePct": float(btc_move),
+                "realizedVolPct": float(btc_vol),
+                "dispersionPct": float(disp) if disp is not None else 0.0,
+                "heldAssets": held,
+            },
+        }]
+
+    _persist(ctx, signaled, result)
+    return out
+
+
+def _persist(ctx, signaled, result):
+    """Append the dedup map + this tick's regime view EVERY tick; bounded by
+    state_history_max_count. Read back via ctx.state.recent(n)."""
+    if ctx.state is None:
+        return
+    try:
+        ctx.state.append({"signaled": signaled, "result": result})
+    except Exception as exc:  # noqa: BLE001
+        print(f"[coyote.scan] WARNING: state append failed; next tick may re-emit "
+              f"a suppressed signal: {exc!r}", file=sys.stderr)

--- a/strategies/coyote/main/scanners/scoring.py
+++ b/strategies/coyote/main/scanners/scoring.py
@@ -1,0 +1,122 @@
+"""COYOTE — pure regime-classification math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Coyote producer's regime classifier
+(coyote-producer.py v1.0.1 / SKILL.md v1.0.0). Every metric and threshold is
+reproduced VERBATIM so a fidelity harness can diff this against the v2 producer
+on the same candle snapshot.
+
+Coyote classifies the market into TREND_UP / TREND_DOWN / CHOP from three pure
+metrics over BTC (plus a cross-asset dispersion metric that is INFORMATIONAL
+ONLY — published, never gating, per SKILL RULE 3):
+
+  - btc_7d_pct        : % change of BTC close vs 42 4h-bars ago (7 days)
+  - realized_vol_pct  : annualized realized vol = stdev(log returns) * sqrt(2190) * 100
+  - dispersion_pct    : cross-sectional stdev of recent returns across the universe
+                        (BTC/ETH/SOL/HYPE) — operator visibility only
+
+Regime rules (verbatim, evaluated in order):
+  TREND_UP   : btc_7d >=  trendUpThresholdPct  AND vol <= maxVolForTrendPct
+  TREND_DOWN : btc_7d <= -trendDownThresholdPct AND vol >= minVolForCrashPct
+  CHOP       : otherwise
+  UNKNOWN    : required inputs missing
+
+Direction: TREND_UP -> LONG BTC, TREND_DOWN -> SHORT BTC, else no trade.
+
+All functions are single-pass and unit-testable on plain close-price lists.
+`scan.py` does the MCP reads + state; this module does the numbers.
+"""
+
+import math
+
+
+def _f(c, primary="close", alt="c", default=0.0):
+    """Pull a float close from a candle dict (dual-shape: {close} OR {c}).
+    Mirrors the v2 producer's `_f(c, "close", "c")` accessor used to build the
+    close-price series. Returns `default` on any non-numeric value."""
+    if isinstance(c, dict):
+        val = c.get(primary)
+        if val is None and alt:
+            val = c.get(alt)
+    else:
+        val = c
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def closes_from_candles(candles):
+    """List of close prices from a list of 4h candle dicts. Verbatim shape of
+    the v2 producer's `[_f(c, "close", "c") for c in candles]`."""
+    return [_f(c) for c in (candles or [])]
+
+
+def pct_move(closes, lookback):
+    """% change of the latest close vs the close `lookback` bars ago.
+    Verbatim from v2 producer `pct_move`. None if insufficient data or a
+    non-positive reference price."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def realized_vol_pct(closes, lookback, bars_per_year=2190):
+    """Annualized realized volatility (stdev of log returns * sqrt(N)) as a
+    percent. `bars_per_year` defaults to 2190 (4h bars, 24/7 trading). Verbatim
+    from v2 producer `realized_vol_pct`. None if insufficient data."""
+    if not closes or len(closes) < lookback + 1:
+        return None
+    series = closes[-(lookback + 1):]
+    log_returns = []
+    for prev, curr in zip(series[:-1], series[1:]):
+        if prev is None or prev <= 0 or curr is None or curr <= 0:
+            continue
+        log_returns.append(math.log(curr / prev))
+    if len(log_returns) < 2:
+        return None
+    mean = sum(log_returns) / len(log_returns)
+    var = sum((r - mean) ** 2 for r in log_returns) / (len(log_returns) - 1)
+    stdev = math.sqrt(var)
+    return stdev * math.sqrt(bars_per_year) * 100.0
+
+
+def dispersion_pct(returns_by_asset):
+    """Cross-sectional dispersion: stdev of returns across assets.
+    `returns_by_asset` is {asset: recent_return_pct}. High = mixed market,
+    low = synchronized. Verbatim from v2 producer `dispersion_pct`. None if
+    fewer than 2 assets have data. INFORMATIONAL ONLY — never gates."""
+    values = [r for r in returns_by_asset.values() if r is not None]
+    if len(values) < 2:
+        return None
+    mean = sum(values) / len(values)
+    var = sum((v - mean) ** 2 for v in values) / (len(values) - 1)
+    return math.sqrt(var)
+
+
+def classify_regime(btc_7d_pct, realized_vol_pct_value,
+                    trend_up_threshold, trend_down_threshold,
+                    max_vol_for_trend, min_vol_for_crash):
+    """Classify the market regime from BTC trend strength + realized vol.
+    Returns "TREND_UP" | "TREND_DOWN" | "CHOP" | "UNKNOWN". Verbatim from v2
+    producer `classify_regime` (rule order preserved exactly)."""
+    if btc_7d_pct is None or realized_vol_pct_value is None:
+        return "UNKNOWN"
+    if btc_7d_pct >= trend_up_threshold and realized_vol_pct_value <= max_vol_for_trend:
+        return "TREND_UP"
+    if btc_7d_pct <= -trend_down_threshold and realized_vol_pct_value >= min_vol_for_crash:
+        return "TREND_DOWN"
+    return "CHOP"
+
+
+def regime_to_direction(regime):
+    """Map a regime classification to an entry direction. None if no trade.
+    Verbatim from v2 producer `regime_to_direction`."""
+    if regime == "TREND_UP":
+        return "LONG"
+    if regime == "TREND_DOWN":
+        return "SHORT"
+    return None

--- a/strategies/coyote/strategy.yaml
+++ b/strategies/coyote/strategy.yaml
@@ -1,0 +1,43 @@
+# Coyote — regime classifier / single-asset BTC bet. A single-instance PACKAGE:
+# this manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0
+# port of the v2 Coyote (coyote-producer.py v1.0.1 / SKILL.md v1.0.0): classifies the
+# macro regime from BTC 7d trend + annualized realized vol (+ informational cross-asset
+# dispersion) into TREND_UP / TREND_DOWN / CHOP and takes a single positional BTC bet —
+# LONG in TREND_UP, SHORT in TREND_DOWN, out in CHOP. DSL-only exits.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: coyote
+version: "1.0.0"
+
+catalog:
+  name: "Coyote — Regime Classifier (BTC)"
+  emoji: "🐺"
+  tagline: "A single-asset BTC bet driven by a macro-regime read: each tick it measures BTC's 7-day trend strength and annualized realized volatility (plus cross-asset dispersion for context) and classifies the market into TREND_UP, TREND_DOWN or CHOP — going long BTC in a calm uptrend, short BTC in a high-vol crash, and staying out otherwise, then letting a balanced DSL ride the regime."
+  belief_plain: "Coyote first asks 'what kind of market are we in?' It looks at how far Bitcoin has moved over the last week and how violent that move has been. A steady 5%+ climb with calm volatility means uptrend — it goes long BTC. A sharp 5%+ drop with a volatility spike means a panic crash — it goes short BTC. Anything in between is chop, so it stays out. Real regimes last days, so it trades rarely and lets the trend run."
+  thesis: "Most agents re-implement their own 'should I be active right now?' check; Coyote makes the macro regime a first-class decision. BTC's 7-day move sets the direction and realized vol confirms the character — demanding HIGH vol for a short distinguishes a panic crash worth fading-with from an orderly grind-down that's really just chop. Because regimes are persistent, the right behavior is a slow cadence, a 6h cooldown and a max of 2 entries/day so it never churns on noise, then a wide DSL trail so a real regime move runs for days."
+  group: regime
+  archetype: single_market
+  sub_style: crypto_major
+  asset_classes: [btc_eth]
+  asset_scope: single
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 200
+  assets: ["BTC"]
+  tags: [btc, single-asset, regime, macro, trend, realized-vol, dispersion, balanced-dsl, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: COYOTE_WALLET
+    funding_share: 1.0

--- a/strategies/dog/main/runtime.yaml
+++ b/strategies/dog/main/runtime.yaml
@@ -1,0 +1,140 @@
+# ── DOG · single instance — multi-asset contrarian SM-exhaustion fader ────────
+# Runtime 3.0 port of the v2 Dog (dog-producer.py v3.0.0, thesis frozen at v2.5).
+# Basket of liquid majors (BTC/ETH/SOL/HYPE), scored off the top-100 smart-money
+# leaderboard each tick. CONTRARIAN FLIP: scores the SM direction, emits the
+# OPPOSITE. 3.0% exhaustion gate, 15m freshness gate, regime hard-gate,
+# MIN_SCORE 8, conservative leverage (7x base, 10x at score >=10). FLAT 30%
+# margin. Wide DSL so reversals develop. Faithful port of the v2 thesis — see
+# scanners/scoring.py (math reproduced verbatim).
+name: dog-main
+group: dog
+version: 3.0.0
+description: >
+  DOG — multi-asset contrarian fader on liquid majors (BTC/ETH/SOL/HYPE).
+  Scores the top-100 smart-money leaderboard each tick, then FADES the crowded,
+  exhausted side: hard gates require 4H price moved >=3.0% in the SM direction,
+  15m SM contribution still building (>0), >=30 traders, and the market-wide
+  funding regime must not contradict the fade. Composite score (SM concentration
+  + trader depth + 4H alignment + INVERTED move-exhaustion bonus + 15m freshness
+  + 1h acceleration + funding-pays + regime confirmation + persistence + US
+  session) must clear 8. CONTRARIAN FLIP emits the opposite of SM. Conservative
+  leverage 7x base, 10x at score >=10 (clamped to the per-asset venue cap). Flat
+  30% margin. Wide DSL (hard_timeout 6h, first lock +5%/20%) so reversals develop.
+  Faithful port of the v2 Dog v3.0.0 thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${DOG_WALLET}"
+  slots: 1                                # v2 strategy.slots 1
+  margin_pct: 30                          # FLAT %; scan emits the same marginPct per signal (v2 30, a PERCENT)
+  default_leverage: 7                     # fallback; scan emits 7-10x per signal
+  trading_risk: conservative              # v2 strategy.trading_risk
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: dog_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 180                  # v2 producer cadence (3 min)
+    timeout_seconds: 120                   # v2 tick_timeout=120; account + leaderboard + regime + per-asset funding/history
+    default_signal_validity_seconds: 360   # 2x tick; a fresh re-score arrives next tick
+    state_history_max_count: 100           # per-tick scan-result history (observability)
+    inputs:
+      assets: ["BTC", "ETH", "SOL", "HYPE"]  # v2.5 ASSETS (validated live on HL main DEX 2026-06-29)
+      minScore: 8                          # v2.5 MIN_SCORE (contrarian floor)
+      marginPct: 30                        # PERCENT of withdrawable (0,100]; flat (v2 did not tier margin)
+      leaderboardLimit: 100                # v2 leaderboard_get_markets limit
+    signal_data_schema:
+      score: { type: number }
+      smDirection: { type: string }
+      leverage: { type: number }
+      reasons: { type: array, required: false }
+      smPct: { type: number, required: false }
+      smTraders: { type: number, required: false }
+      priceChange4hPct: { type: number, required: false }
+      priceChange1hPct: { type: number, required: false }
+      contribChange15m: { type: number, required: false }
+      contribChange1h: { type: number, required: false }
+      contribChange4h: { type: number, required: false }
+      fundingRegime: { type: string, required: false }
+      persistenceHours: { type: number, required: false }
+      crowdingTrend: { type: string, required: false }
+      assetFunding: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: dog_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [dog_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # taker fallback — a fade entry that rests and never fills misses the unwind
+        execution_timeout_seconds: 60      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: dog_signals
+
+# ── EXIT (DSL — preserved VERBATIM from v2.5 runtime.yaml) ─────────────────────
+# Wide for contrarian fades — reversals take time to develop, let winners run.
+# hard_timeout 6h, weak_peak_cut 90m/2.0, dead_weight_cut 60m (v2.4: 30->60).
+# Phase 1 max_loss 15% (tighter than fleet 25% — contrarian losses small).
+# Phase 2 first lock +5%/20% (well within realistic range — no unreachable trigger).
+# order_type FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST happen).
+exit:
+  engine: dsl
+  interval_seconds: 30                     # v2 exit.interval_seconds
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # v2.5: ON — reversals take time but 6h is the ceiling
+      interval_in_minutes: 360
+    weak_peak_cut:
+      enabled: true                        # v2.5: ON — cut if peak ROE < 2.0 in 90m
+      interval_in_minutes: 90
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true                        # v2.5: ON — v2.4 loosened 30 -> 60 (let fades develop)
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0                    # v2.5: tighter than fleet 25% — contrarian losses small
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # verbatim from v2.5
+        - { trigger_pct: 5,  lock_hw_pct: 20 }
+        - { trigger_pct: 10, lock_hw_pct: 40 }
+        - { trigger_pct: 15, lock_hw_pct: 60 }
+        - { trigger_pct: 20, lock_hw_pct: 75 }
+        - { trigger_pct: 30, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # 72h (was data_retention_hours 72); within [3600, 604800]
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 risk.daily_loss_limit_pct
+    max_entries_per_day: 3                  # v2 risk.max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 risk.max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 risk.cooldown_minutes 60 -> 3600s
+    drawdown_halt_pct: 25                  # v2 risk.drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false  # v2 risk.drawdown_reset_on_day_rollover
+    per_asset_cooldown_seconds: 7200       # v2 risk.per_asset_cooldown_minutes 120 -> 7200s (2h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false             # v2 notifications.dsl_notify_sl_updates
+  action_lifecycle: true

--- a/strategies/dog/main/scanners/scan.py
+++ b/strategies/dog/main/scanners/scan.py
@@ -1,0 +1,315 @@
+"""DOG — supervised scanner (Runtime 3.0 port of the v2 Dog contrarian fader).
+
+Multi-asset BASKET scanner over the four liquid majors (BTC/ETH/SOL/HYPE). Per tick:
+  - read the account + held set (clearinghouse, dual-DEX equity via max(), XYZ enumerated),
+  - fetch the top-100 smart-money leaderboard markets,
+  - build the per-asset map keeping the highest-conviction SM direction per asset
+    (v2 pre-pass: max pct_of_top_traders_gain),
+  - enrich ONCE per tick (market-wide funding regime + per-asset funding_history +
+    per-asset funding rate),
+  - score each tracked asset via the pure `scoring.score_market` (CONTRARIAN FLIP +
+    every v2.5 gate),
+  - filter by MIN_SCORE, drop held assets (defense-in-depth dedup), and emit ALL
+    qualifying candidates (v2 main() pushed every qualified candidate; the runtime's
+    slots + risk.guard_rails own the ceiling).
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT, flat) plus a conviction-
+tiered `leverage` (7x base, 10x at score >=10, clamped to the per-asset venue cap). The
+runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit. No daemon,
+no push_signal, no create_position.
+
+FIDELITY NOTES vs dog-producer.py v3.0.0 (thesis frozen at v2.5):
+  - v2's wallet/held dedup, regime/funding enrichment, and CONTRARIAN FLIP scoring are
+    reproduced verbatim. The per-asset funding rate (v2 fetched inline via
+    market_get_asset_data inside score_market) is fetched here in scan.py and passed
+    into the pure scoring.score_market(asset_funding=...), keeping scoring.py I/O-free.
+    The thresholds (>0.0002 / <-0.0002) and the "funding pays the fade" logic are
+    verbatim.
+  - v2 read datetime.now(timezone.utc).hour inside score_market; here scan.py reads the
+    clock and passes utc_hour in (scoring.py is clock-free). The 13<=h<=21 US-session
+    window is verbatim.
+  - v2 EMITTED ALL qualifying candidates (qualified list, sorted by score desc), then
+    skipped any already-held asset at push time. Preserved: scan() emits every qualified,
+    non-held candidate. The runtime's slots:1 + per_asset_cooldown own the real ceiling
+    (v2 relied on runtime guard_rails for the same).
+  - v2 producer-side dedup was the runtime's per_asset_cooldown (no Python TTL cache in
+    v3.0); this port keeps a lightweight per-tick result record in ctx.state for
+    observability but does NOT add a producer-side dedup TTL (faithful — v3.0 dropped it).
+  - margin is FLAT 30% (v2 runtime.yaml strategy.margin_pct: 30 — already a PERCENT, NOT
+    a fraction; no x100 conversion needed). v2 did NOT conviction-tier the margin (only
+    the leverage). Defensive guard still applies: a value <=1.0 would be a pasted
+    fraction -> x100.
+"""
+
+import sys
+import time
+from datetime import datetime, timezone
+
+import scoring
+
+
+# v2.5 defaults (dog-producer.py constants; overridable via inputs)
+_ASSETS_DEFAULT = ["BTC", "ETH", "SOL", "HYPE"]
+_DEFAULT_MIN_SCORE = 8                 # v2.5 MIN_SCORE (contrarian floor)
+_DEFAULT_MARGIN_PCT = 30.0             # v2 runtime.yaml strategy.margin_pct (PERCENT)
+_DEFAULT_LEADERBOARD_LIMIT = 100       # v2 leaderboard_get_markets limit
+_MIN_TRADERS = 30                      # informational; gate lives in scoring.score_market
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll back the
+    whole tick (the contract rolls ANY exception back to []). Returns None on failure so
+    the existing degrade paths apply (markets empty -> skip tick; regime None -> neutral;
+    funding 0.0 -> the funding bonus just doesn't fire)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[dog.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+# ── ACCOUNT + HELD ASSETS (port of v2 fetch_held_assets, dual-DEX) ──
+
+def _get_account(ctx):
+    """(account_value, held_assets_list) from strategy_get_clearinghouse_state.
+    READ-GUARDED. Dual-DEX: account_value via max() across main/xyz (two views of
+    ONE cross-margined wallet — summing double-counts the shared free balance);
+    assetPositions enumerated across both sub-DEX sections (v2 fetch_held_assets)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+    account_value = 0.0
+    held = []
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring.safe_float(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            if scoring.safe_float(pos.get("szi", 0)) != 0:
+                coin = pos.get("coin", "")
+                if coin:
+                    held.append(str(coin))
+    return account_value, held
+
+
+# ── MARKET FETCH (port of v2 main() leaderboard parse) ──
+
+def _fetch_markets(ctx, limit):
+    raw = _read(ctx, "leaderboard_get_markets", {"limit": limit})
+    if not raw:
+        return []
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return []
+    return markets
+
+
+# ── REGIME (port of v2 fetch_funding_regime) ──
+
+def _fetch_regime(ctx):
+    r = _read(ctx, "market_get_funding_regime", {})
+    if not r:
+        return None
+    data = r.get("data", r) if isinstance(r, dict) else r
+    if isinstance(data, dict):
+        return data.get("regime")
+    return None
+
+
+# ── PER-ASSET FUNDING HISTORY (port of v2 fetch_funding_history, parser fix preserved) ──
+
+def _fetch_funding_history(ctx, asset):
+    """{persistence_hours, trend} for one asset or None. READ-GUARDED.
+
+    v2.4 parser fix preserved: MCP returns data.data=[{asset, ...}], not data.<field>.
+    Iterate the list, match by asset, normalize the funding_trend enum
+    (INTENSIFYING->INCREASING, DECAYING->DECREASING)."""
+    r = _read(ctx, "market_get_funding_history", {"asset": asset})
+    if not r:
+        return None
+    outer = r.get("data", r) if isinstance(r, dict) else r
+    rows = outer.get("data") if isinstance(outer, dict) else None
+    if not rows:
+        return None
+    row = next((x for x in rows if isinstance(x, dict) and x.get("asset") == asset), None)
+    if row is None:
+        return None
+    raw_trend = (row.get("funding_trend") or row.get("trend") or "").upper()
+    if raw_trend == "INTENSIFYING":
+        trend = "INCREASING"
+    elif raw_trend == "DECAYING":
+        trend = "DECREASING"
+    else:
+        trend = raw_trend
+    return {"persistence_hours": row.get("persistence_hours"), "trend": trend}
+
+
+# ── PER-ASSET FUNDING RATE (port of v2 score_market's inline market_get_asset_data) ──
+
+def _fetch_asset_funding(ctx, asset):
+    """Current 8h funding rate for one asset (float), 0.0 on any failure.
+    READ-GUARDED. v2 fetched this inline inside score_market; pulled out here to
+    keep scoring.py pure. The funding bonus simply doesn't fire on a 0.0 fallback."""
+    ad = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": [],
+        "include_funding": True,
+        "include_order_book": False,
+    })
+    if not ad:
+        return 0.0
+    d = ad.get("data", ad) if isinstance(ad, dict) else ad
+    if not isinstance(d, dict):
+        return 0.0
+    ac = d.get("asset_context", d.get("assetContext", {}))
+    if isinstance(ac, dict):
+        return scoring.safe_float(ac.get("funding", 0))
+    return 0.0
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    assets = inputs.get("assets", _ASSETS_DEFAULT)
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))   # PERCENT (0,100]
+    leaderboard_limit = int(inputs.get("leaderboardLimit", _DEFAULT_LEADERBOARD_LIMIT))
+
+    # Defensive: a value <=1.0 is a pasted FRACTION (v2 stored 0.30) -> x100 (dire/koala
+    # guard). Dog's v2 runtime stored 30 (a PERCENT) so this never fires in practice.
+    if 0 < margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    assets_upper = [str(a).upper() for a in assets]
+    asset_set = set(assets_upper)
+
+    # ── account + held assets ──
+    account_value, held_assets = _get_account(ctx)
+    if account_value <= 0:
+        print("[dog.scan] cannot read account value; skip tick", file=sys.stderr)
+        _persist(ctx, now, {"emitted": False, "gate": "no_account"})
+        return []
+    held_set = {h.upper() for h in held_assets}
+
+    # ── fetch SM markets ──
+    markets = _fetch_markets(ctx, leaderboard_limit)
+    if not markets:
+        print("[dog.scan] failed to fetch leaderboard_get_markets; skip tick", file=sys.stderr)
+        _persist(ctx, now, {"emitted": False, "gate": "no_markets"})
+        return []
+
+    # ── pre-pass: per-asset map keeping highest-conviction direction (v2 main) ──
+    asset_data = {}
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", "")).upper()
+        dex = m.get("dex", "")
+        if dex or token not in asset_set:
+            continue
+        pct = scoring.safe_float(m.get("pct_of_top_traders_gain", 0))
+        if token not in asset_data or pct > scoring.safe_float(
+                asset_data[token].get("pct_of_top_traders_gain", 0)):
+            asset_data[token] = m
+
+    # ── enrich ONCE per run — shared context across all candidates (v2 main) ──
+    regime = _fetch_regime(ctx)
+    fh_map = {tok: _fetch_funding_history(ctx, tok) for tok in asset_data}
+    funding_map = {tok: _fetch_asset_funding(ctx, tok) for tok in asset_data}
+    utc_hour = datetime.now(timezone.utc).hour
+
+    # ── score each tracked asset (v2 iterates ASSETS in fixed order) ──
+    candidates = []
+    for token in assets_upper:
+        m = asset_data.get(token)
+        if not m:
+            continue
+        c = scoring.score_market(m, regime, fh_map.get(token),
+                                 funding_map.get(token, 0.0), utc_hour)
+        if c is not None:
+            candidates.append(c)
+
+    # ── filter by MIN_SCORE, sort desc (v2 main) ──
+    qualified = [c for c in candidates if c["score"] >= min_score]
+    qualified.sort(key=lambda c: c["score"], reverse=True)
+
+    if not qualified:
+        best = max(candidates, key=lambda c: c["score"], default=None)
+        note = (f"SNIFFING: best {best['asset']} fade={best['direction']} "
+                f"score={best['score']}<{min_score:.0f}") if best else "no exhaustion setups"
+        print(f"[dog.scan] WAITING — {note}; regime={regime} "
+              f"scanned={len(markets)} held={sorted(held_set)}", file=sys.stderr)
+        _persist(ctx, now, {"emitted": False, "gate": "no_candidate",
+                            "candidates": len(candidates), "regime": regime,
+                            "note": note})
+        return []
+
+    # ── emit ALL qualifying, non-held candidates (v2 main pushed every qualified) ──
+    out = []
+    emitted = []
+    for c in qualified:
+        if c["asset"].upper() in held_set:        # defense-in-depth dedup (v2 push_signal)
+            continue
+        out.append({
+            "asset": c["asset"],
+            "direction": c["direction"],          # the FADE direction (post contrarian flip)
+            "marginPct": margin_pct,              # FLAT PERCENT (0,100] — runtime sizes the dollars
+            "leverage": c["leverage"],            # conviction-tiered 7/10x; runtime applies + clamps
+            "data": {
+                "score": c["score"],
+                "smDirection": c["sm_direction"],
+                "leverage": c["leverage"],
+                "reasons": c["reasons"],
+                "smPct": float(c["sm_pct"]),
+                "smTraders": int(c["sm_traders"]),
+                "priceChange4hPct": float(c["p4h"]),
+                "priceChange1hPct": float(c["p1h"]),
+                "contribChange15m": float(c["cc_15m"]),
+                "contribChange1h": float(c["cc_1h"]),
+                "contribChange4h": float(c["cc_4h"]),
+                "fundingRegime": c["regime"],
+                "persistenceHours": c["persistence_hours"],
+                "crowdingTrend": c["crowding_trend"],
+                "assetFunding": float(c["asset_funding"]),
+                "heldAssets": sorted(held_set),
+            },
+        })
+        emitted.append({"asset": c["asset"], "direction": c["direction"],
+                        "score": c["score"], "leverage": c["leverage"]})
+
+    if not out:
+        print(f"[dog.scan] WAITING — {len(qualified)} qualified but all held "
+              f"{sorted(held_set)}; regime={regime}", file=sys.stderr)
+        _persist(ctx, now, {"emitted": False, "gate": "all_held",
+                            "qualified": len(qualified), "regime": regime})
+        return out
+
+    top = emitted[0]
+    print(f"[dog.scan] EMIT {len(out)} fade(s); top {top['asset']} {top['direction']} "
+          f"score={top['score']} {top['leverage']}x regime={regime} | "
+          f"{qualified[0]['reasons'][:6]}", file=sys.stderr)
+    _persist(ctx, now, {"emitted": True, "count": len(out), "signals": emitted,
+                        "candidates": len(candidates), "qualified": len(qualified),
+                        "regime": regime, "held": sorted(held_set)})
+    return out
+
+
+def _persist(ctx, now, result):
+    """Append a concise per-tick result to ctx.state EVERY tick (observability).
+    Guarded — a disabled history store or append failure must not crash the tick."""
+    if ctx.state is None:
+        return
+    try:
+        ctx.state.append({"signaled": result.get("emitted", False),
+                          "result": dict(result, ts=now)})
+    except Exception as exc:  # noqa: BLE001
+        print(f"[dog.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)

--- a/strategies/dog/main/scanners/scoring.py
+++ b/strategies/dog/main/scanners/scoring.py
@@ -1,0 +1,261 @@
+"""DOG — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Dog producer's `score_market` +
+`regime_confirms_fade` (dog-producer.py v3.0.0, thesis frozen at v2.5). Every
+scoring component, weight, threshold, gate, and the CONTRARIAN FLIP are reproduced
+VERBATIM so a fidelity harness can diff this against the v2 producer on the same
+market snapshot.
+
+Dog is a CONTRARIAN FADER: it scores the smart-money (SM) direction, then emits the
+OPPOSITE direction (the fade). All hard gates that returned None in v2 return None
+here too. Per-asset side-data the v2 producer fetched via MCP (funding regime,
+per-asset funding rate, persistence/trend) is FETCHED BY THE CALLER (scan.py) and
+passed in, so this module stays pure and unit-testable on plain dicts.
+
+The only thing the caller owns that this module reproduces as an INPUT is the clock:
+v2 read datetime.utcnow().hour for the US-session bonus; here `utc_hour` is passed in.
+"""
+
+
+ASSETS = ["BTC", "ETH", "SOL", "HYPE"]
+
+# Scoring thresholds — verbatim from v2.5
+MIN_SCORE = 8                          # contrarian floor — applied by the caller
+MIN_EXHAUSTION_PCT = 3.0               # v2.5 sweet spot (2.5 too loose, 4.5 never fires)
+EXHAUSTION_BONUS_SEVERE_PCT = 4.0      # +2 points for deep exhaustion
+EXHAUSTION_BONUS_MODERATE_PCT = 2.5    # +1 point
+
+# Leverage tiers — conservative for contrarian (verbatim from v2.5)
+LEVERAGE_TIERS = [
+    {"min_score": 10, "leverage": 10},
+    {"min_score": 8,  "leverage": 7},
+]
+DEFAULT_LEVERAGE = 7
+
+# Max leverage caps per asset (from Hyperliquid meta; validated 2026-06-29:
+# BTC 40 / ETH 25 / SOL 20 / HYPE 10 all match live HL maxLeverage exactly).
+ASSET_MAX_LEVERAGE = {"BTC": 40, "ETH": 25, "SOL": 20, "HYPE": 10}
+
+
+def safe_float(v, d=0.0):
+    if v is None:
+        return d
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def regime_confirms_fade(fade_direction, regime):
+    """Fade is confirmed when regime shows crowding in the OPPOSITE direction of
+    the trade. Dog goes SHORT to fade LONG_CROWDED. Returns True/False/None
+    (None = neutral, doesn't confirm or deny). Verbatim from v2.5."""
+    if regime is None or regime == "NEUTRAL":
+        return None
+    if fade_direction == "SHORT" and regime == "LONG_CROWDED":
+        return True
+    if fade_direction == "LONG" and regime == "SHORT_CROWDED":
+        return True
+    return False
+
+
+def score_market(m, regime, fh, asset_funding, utc_hour):
+    """Score one market. Returns a candidate dict (post contrarian flip) or None
+    to skip. v2.5 `score_market` logic preserved VERBATIM.
+
+    Inputs the caller resolves (so this module stays pure):
+      regime        — market-wide funding regime string or None
+                      (LONG_CROWDED / SHORT_CROWDED / NEUTRAL).
+      fh            — per-asset funding_history dict {persistence_hours, trend}
+                      or None.
+      asset_funding — per-asset 8h funding rate (float), 0.0 if unavailable.
+      utc_hour      — current UTC hour (int) for the US-session bonus.
+    """
+    if not isinstance(m, dict):
+        return None
+    token = str(m.get("token", "")).upper()
+    dex = m.get("dex", "")
+    if dex or token not in ASSETS:
+        return None
+
+    sm_direction = str(m.get("direction", "")).upper()
+    if sm_direction not in ("LONG", "SHORT"):
+        return None
+
+    pct = safe_float(m.get("pct_of_top_traders_gain", 0))
+    traders = int(m.get("trader_count", 0))
+    p4h = safe_float(m.get("token_price_change_pct_4h", 0))
+    p1h = safe_float(m.get("token_price_change_pct_1h",
+                            m.get("price_change_1h", 0)))
+    cc_15m = safe_float(m.get("contribution_pct_change_15m", 0))
+    cc_1h = safe_float(m.get("contribution_pct_change_1h", 0))
+    cc_4h = safe_float(m.get("contribution_pct_change_4h", 0))
+
+    # Hard gate: minimum SM engagement
+    if traders < 30:
+        return None
+
+    # CONTRARIAN EXHAUSTION GATE
+    if abs(p4h) < MIN_EXHAUSTION_PCT:
+        return None  # Not exhausted yet — don't fight a fresh trend
+    if (sm_direction == "LONG" and p4h < 0) or (sm_direction == "SHORT" and p4h > 0):
+        return None  # SM direction opposes price — not an exhaustion pattern
+
+    score, reasons = 0, []
+
+    # ── SM concentration (0-3) ──
+    if pct >= 15:
+        score += 3
+        reasons.append(f"DOMINANT_SM {pct:.1f}% ({traders}t)")
+    elif pct >= 10:
+        score += 2
+        reasons.append(f"STRONG_SM {pct:.1f}% ({traders}t)")
+    elif pct >= 5:
+        score += 1
+        reasons.append(f"SM_ALIGNED {pct:.1f}% ({traders}t)")
+
+    # ── Trader depth (0-1) ──
+    if traders >= 100:
+        score += 1
+        reasons.append(f"DEEP_CONSENSUS ({traders}t)")
+
+    # ── 4H price alignment (+/-2) ──
+    if abs(p4h) >= 2.0:
+        if (sm_direction == "LONG" and p4h > 0) or (sm_direction == "SHORT" and p4h < 0):
+            score += 2
+            reasons.append(f"STRONG_4H {p4h:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"4H_OPPOSING {p4h:+.1f}%")
+    elif abs(p4h) >= 0.5:
+        if (sm_direction == "LONG" and p4h > 0) or (sm_direction == "SHORT" and p4h < 0):
+            score += 1
+            reasons.append(f"4H_CONFIRMS {p4h:+.1f}%")
+
+    # ── MOVE EXHAUSTION — INVERTED for contrarian ──
+    if abs(p4h) >= EXHAUSTION_BONUS_SEVERE_PCT:
+        if (sm_direction == "LONG" and p4h > 0) or (sm_direction == "SHORT" and p4h < 0):
+            score += 2
+            reasons.append(f"DEEP_EXHAUSTION {p4h:+.1f}% (great fade)")
+    elif abs(p4h) >= EXHAUSTION_BONUS_MODERATE_PCT:
+        if (sm_direction == "LONG" and p4h > 0) or (sm_direction == "SHORT" and p4h < 0):
+            score += 1
+            reasons.append(f"EXHAUSTION {p4h:+.1f}% (fadeable)")
+
+    # ── 1H momentum (0-1) ──
+    if (sm_direction == "LONG" and p1h > 0.2) or (sm_direction == "SHORT" and p1h < -0.2):
+        score += 1
+        reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
+
+    # ── 15m velocity freshness gate ──
+    # For contrarian: SM must be actively building the position we're about to fade.
+    # If SM is already unwinding (15m <= 0), the fade opportunity is passing — skip.
+    if cc_15m <= 0:
+        return None
+    if cc_15m > 2.0:
+        score += 3
+        reasons.append(f"15M_STRONG_SPIKE +{cc_15m:.2f}")
+    elif cc_15m > 0.5:
+        score += 2
+        reasons.append(f"15M_SPIKE +{cc_15m:.2f}")
+    elif cc_15m > 0.1:
+        score += 1
+        reasons.append(f"15M_BUILDING +{cc_15m:.2f}")
+
+    # ── 1h acceleration (0-1) ──
+    if cc_1h > 1.0:
+        score += 1
+        reasons.append(f"1H_ACCEL +{cc_1h:.2f}")
+
+    # ── Funding alignment (0-1) — Dog likes funded trades ──
+    # asset_funding is resolved by the caller (market_get_asset_data). SM direction
+    # is the to-be-faded direction; Dog will EMIT the opposite. Funding "pays the
+    # fade" means SM is short into positive funding (paying longs) OR long into
+    # negative funding (paying shorts) — same as v2.5 logic.
+    fade_direction = "SHORT" if sm_direction == "LONG" else "LONG"
+    asset_funding = safe_float(asset_funding)
+    if (fade_direction == "SHORT" and asset_funding > 0.0002) or \
+       (fade_direction == "LONG" and asset_funding < -0.0002):
+        score += 1
+        reasons.append(f"FUNDING_PAYS {asset_funding*100:.4f}%")
+
+    # ── Regime HARD GATE — fade direction must align with crowded regime ──
+    confirms = regime_confirms_fade(fade_direction, regime)
+    if confirms is False:
+        return None  # regime contradicts fade — skip
+    if confirms is True:
+        score += 2
+        reasons.append(f"REGIME_CONFIRMS_{regime}")
+    elif regime is not None:
+        reasons.append(f"REGIME_{regime}")
+
+    # ── Persistence + trend via funding_history ──
+    ph_val = None
+    crowding_trend = None
+    if fh:
+        ph = fh.get("persistence_hours")
+        crowding_trend = (fh.get("trend") or "").upper() or None
+        try:
+            ph_val = float(ph) if ph is not None else None
+        except (TypeError, ValueError):
+            ph_val = None
+        if ph_val is not None:
+            if ph_val >= 12:
+                score += 2
+                reasons.append(f"MATURE_CROWDING_{ph_val:.0f}h")
+            elif ph_val >= 6:
+                score += 1
+                reasons.append(f"STABLE_CROWDING_{ph_val:.0f}h")
+        if crowding_trend == "INCREASING":
+            score -= 1
+            reasons.append("CROWDING_STILL_BUILDING (early fade)")
+        elif crowding_trend == "DECREASING":
+            score += 1
+            reasons.append("CROWDING_UNWINDING (fade confirmed)")
+
+    # ── US session bonus (0-1) ──
+    if 13 <= utc_hour <= 21:
+        score += 1
+        reasons.append("US_SESSION")
+
+    # CONTRARIAN FLIP: emit OPPOSITE direction
+    reasons.insert(0, f"CONTRARIAN_FLIP {token} (SM is {sm_direction})")
+
+    # Leverage tier (verbatim from v2.5)
+    leverage = DEFAULT_LEVERAGE
+    for tier in LEVERAGE_TIERS:
+        if score >= tier["min_score"]:
+            leverage = tier["leverage"]
+            break
+    leverage = min(leverage, ASSET_MAX_LEVERAGE.get(token, 10))
+
+    return {
+        "asset": token,
+        "direction": fade_direction,
+        "sm_direction": sm_direction,
+        "score": score,
+        "leverage": leverage,
+        "reasons": reasons,
+        "sm_pct": pct,
+        "sm_traders": traders,
+        "p4h": p4h,
+        "p1h": p1h,
+        "cc_15m": cc_15m,
+        "cc_1h": cc_1h,
+        "cc_4h": cc_4h,
+        "regime": regime or "UNKNOWN",
+        "persistence_hours": ph_val,
+        "crowding_trend": crowding_trend,
+        "asset_funding": asset_funding,
+    }
+
+
+def leverage_for_score(score, token):
+    """Conviction-tiered leverage, clamped to the per-asset cap. Verbatim from
+    v2.5 (10x at score >=10, else 7x), then min() against ASSET_MAX_LEVERAGE."""
+    leverage = DEFAULT_LEVERAGE
+    for tier in LEVERAGE_TIERS:
+        if score >= tier["min_score"]:
+            leverage = tier["leverage"]
+            break
+    return min(leverage, ASSET_MAX_LEVERAGE.get(token, 10))

--- a/strategies/dog/strategy.yaml
+++ b/strategies/dog/strategy.yaml
@@ -1,0 +1,43 @@
+# Dog — multi-asset contrarian SM-exhaustion fader. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port
+# of the v2 Dog (dog-producer.py v3.0.0, thesis frozen at v2.5): a BASKET fader on the
+# four liquid majors (BTC/ETH/SOL/HYPE) that scores the top-100 smart-money leaderboard,
+# then trades AGAINST the crowded, exhausted side. Conservative leverage, wide DSL.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: dog
+version: "1.0.0"
+
+catalog:
+  name: "Dog — Contrarian Pup (SM Exhaustion Fader)"
+  emoji: "🐕"
+  tagline: "A patient contrarian on BTC/ETH/SOL/HYPE: waits for a major to move 3%+ in 4h while smart money piles in heavily, then fades the crowded, exhausted side — but only when the funding regime confirms the unwind and the move is still fresh. Conservative 7-10x leverage, wide DSL to let the reversal develop."
+  belief_plain: "When a big coin runs hard and the best traders are all crowded onto the same side, the crowd is maximum exposed and the unwind is the trade. Dog bets against that exhausted consensus on BTC, ETH, SOL and HYPE — but only when the move has genuinely overextended, the crowding is still building, and market-wide funding shows the crowd really is one-sided. Most of the time it waits."
+  thesis: "Hyperliquid is dominated by leverage traders chasing momentum. When a major moves 3%+ in four hours and smart-money consensus piles in 15%+, the late entrants are maximally exposed and funding pressure plus mean reversion force the unwind. Dog's edge is being on the unwind side before capitulation accelerates — so it scores the smart-money direction, hard-gates on exhaustion (>=3% 4h move), freshness (15m contribution still rising), trader depth (>=30), and a funding regime that confirms the crowd is one-sided, then emits the OPPOSITE direction at conservative leverage and lets a wide ratcheting stop ride the reversal rather than banking too early."
+  group: smart-money
+  archetype: contrarian_fade
+  sub_style: sm_crowding
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: conservative
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 10
+  max_slots: 1
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL", "HYPE"]
+  tags: [smart-money, contrarian, fade, exhaustion, funding-regime, multi-asset, btc, eth, sol, hype, conservative, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: DOG_WALLET
+    funding_share: 1.0

--- a/strategies/egret/main/runtime.yaml
+++ b/strategies/egret/main/runtime.yaml
@@ -1,0 +1,140 @@
+# ── EGRET · single instance — Smart-Money Divergence Fader ────────────────────
+# Runtime 3.0 port of the v2 Egret (SKILL.md v1.0.0 / producer v1.0.1). Multi-asset
+# whitelist (BTC/ETH/SOL/HYPE). Two hard gates: SM concentration >= 70% AND price
+# NOT confirming the crowd (divergence). Fades the exhausted crowd; RSI exhaustion
+# adds conviction. FLAT margin (15%), leverage clamped <=5. TIGHT fader DSL (T0
+# +5% / lock 30 — bank the bounded snapback) + ENABLED time-cuts + MAKER-ONLY entry.
+# Faithful port of the v2 producer thesis — see scanners/scoring.py (math verbatim).
+name: egret-main
+group: egret
+version: 3.0.0
+description: >
+  EGRET — multi-asset Smart-Money Divergence Fader (BTC/ETH/SOL/HYPE). When the
+  Smart-Money crowd is extremely concentrated one way (>= crowdingMinPct, default
+  70%) but price is NOT confirming over the recent window (it has stalled or rolled
+  over against the crowd), the crowded side is exhausted and the unwind is the edge —
+  Egret fades it. Crowded LONG + price stalled -> FADE SHORT; crowded SHORT + price
+  stalled -> FADE LONG. RSI exhaustion adds conviction (score max ~9, floor 5).
+  This is a mean-reversion / unwind play, tuned OPPOSITE the momentum agents:
+  TIGHT DSL ladder (first lock at +5% — bank the bounded snapback fast), MAKER-ONLY
+  entry (a fade is non-urgent and fee-sensitive), time-cuts ENABLED (a fade resolves
+  quickly or the thesis failed). Flat 15% margin, leverage <=5. DSL owns all exits.
+  Faithful port of the v2 Egret v1.0.1 thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${EGRET_WALLET}"
+  slots: 1                                # v2 slots 1
+  margin_pct: 15                          # flat baseline %; scan emits the same marginPct per signal
+  default_leverage: 4                     # fallback; scan emits 4x (clamped <=5) per signal
+  trading_risk: moderate                  # v2 trading_risk "balanced" -> moderate (canonical)
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10                   # v2 position_tracker interval 10s
+  - name: egret_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 180                   # v2 tick_timeout=180
+    default_signal_validity_seconds: 600   # 2x tick; a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      universe: ["BTC", "ETH", "SOL", "HYPE"]  # v2 universe (validated live on HL main DEX 2026-06-29)
+      minScore: 5                          # v2 DEFAULT_MIN_SCORE / config minScore
+      crowdingMinPct: 70                   # v2 DEFAULT_CROWDING_MIN_PCT — GATE 1
+      crowdingExtremePct: 80               # v2 DEFAULT_CROWDING_EXTREME_PCT — ultra-crowded bonus
+      confirmMaxPct: 0.5                   # v2 DEFAULT_CONFIRM_MAX_PCT — divergence threshold (GATE 2)
+      divergenceLookbackHours: 4           # v2 DEFAULT_DIVERGENCE_LOOKBACK — 1h bars
+      marginPct: 15                        # PERCENT of withdrawable (0,100]; flat (NOT tiered)
+      leverage: 4                          # clamped to <=5 in scan.py (MAX_LEVERAGE)
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      smCrowdDirection: { type: string, required: false }
+      smCrowdPct: { type: number, required: false }
+      priceMomentumPct: { type: number, required: false }
+      rsi: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: egret_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [egret_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false   # FADER: maker-only is correct. A fade is non-urgent and
+                                           # fee-sensitive — if the maker can't fill, the trade wasn't
+                                           # ripe. (Verbatim from v2; the taker-fallback rule is for
+                                           # MOMENTUM agents that must catch a move; a fader is the opposite.)
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: egret_main_signals
+
+# ── EXIT (DSL — TIGHT fader profile, preserved VERBATIM from v2) ──────────────
+# A fade is a BOUNDED unwind — bank the snapback fast, don't hold for a trend.
+# Tight Phase 2 ladder (first lock at +5% ROE) + ENABLED time-cuts (a fade resolves
+# quickly or the thesis failed). Intentionally the OPPOSITE of the momentum agents'
+# wide "let winners run" ladder. order_type FEE_OPTIMIZED_LIMIT, taker fallback on
+# (exit closes MUST happen).
+exit:
+  engine: dsl
+  interval_seconds: 60                     # v2 exit interval_seconds 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # exit closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # v2: ENABLED — a fade resolves quickly or the thesis failed
+      interval_in_minutes: 2880            # v2 48h outer bound
+    weak_peak_cut:
+      enabled: true                        # v2: ENABLED — cut a stale fade
+      interval_in_minutes: 120             # v2 weak_peak_cut interval 120min
+      min_value: 2.0                       # v2 weak_peak_cut min_value 2.0
+    dead_weight_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 90
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0                    # v2 phase1 max_loss_pct 15
+      retrace_threshold: 6                  # v2 phase1 retrace_threshold 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # TIGHT — bank the snapback; FIRST lock at +5% ROE
+        - { trigger_pct: 5,  lock_hw_pct: 30 }
+        - { trigger_pct: 10, lock_hw_pct: 50 }
+        - { trigger_pct: 15, lock_hw_pct: 65 }
+        - { trigger_pct: 25, lock_hw_pct: 80 }
+        - { trigger_pct: 40, lock_hw_pct: 90 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # v2 data_retention_hours 72 -> 259200s (within [3600,604800])
+  guard_rails:
+    daily_loss_limit_pct: 12               # v2 daily_loss_limit_pct 12
+    max_entries_per_day: 3                  # v2 max_entries_per_day 3
+    bypass_max_entries_per_day_on_profit: false   # v2 bypass_max_entries_per_day_on_profit false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses 3
+    cooldown_seconds: 5400                 # v2 cooldown_minutes 90 -> 5400s
+    drawdown_halt_pct: 18                  # v2 drawdown_halt_pct 18
+    drawdown_reset_on_day_rollover: false  # v2 drawdown_reset_on_day_rollover false
+    per_asset_cooldown_seconds: 21600      # v2 per_asset_cooldown_minutes 360 -> 21600s (6h)
+
+notifications:
+  dsl_lifecycle: true                      # v2 dsl_lifecycle true
+  dsl_notify_sl_updates: false             # v2 dsl_notify_sl_updates false
+  action_lifecycle: true                   # v2 action_lifecycle true

--- a/strategies/egret/main/scanners/scan.py
+++ b/strategies/egret/main/scanners/scan.py
@@ -1,0 +1,298 @@
+"""EGRET — supervised scanner (Runtime 3.0 port of the v2 Egret Smart-Money Divergence Fader).
+
+Multi-asset, whitelist-gated (BTC/ETH/SOL/HYPE). A CONTRARIAN FADER: when the
+Smart-Money crowd is extremely concentrated one way (>= crowdingMinPct) but price
+is NOT confirming over the recent window, the crowded side is exhausted and the
+unwind is the edge — Egret fades it (crowded LONG + price stalled -> SHORT;
+crowded SHORT + price stalled -> LONG). RSI exhaustion adds conviction. Per tick:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - iterates the whitelist universe (XYZ banned; held + recently-signaled filtered
+    BEFORE the per-asset MCP fetch, as in v2 main()),
+  - scores each candidate via the pure `scoring.build_thesis` (two hard gates:
+    SM crowding + price divergence),
+  - emits the SINGLE highest-scoring candidate at/above `minScore`
+    (v2 main() emitted only `best`), sized by a FLAT margin percent.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates, and trails the TIGHT DSL
+exit (fader profile — bank the bounded snapback). No daemon, no push_signal, no
+create_position.
+
+FIDELITY NOTES vs the v2 producer (egret-producer.py v1.0.1):
+  - v2 sized margin as a FLAT FRACTION: marginUsd = account_value * marginPct
+    (config marginPct=0.15). This port emits `marginPct` as a PERCENT (15) and the
+    runtime sizes (marginPct/100)*withdrawable. The defensive "<=1.0 means a pasted
+    fraction, x100" guard converts a config that still stores 0.15. NOT tiered by
+    score (unlike bison) — v2 used a single flat marginPct for every emit.
+  - v2 emitted exactly one signal (best, highest score). Preserved: scan() emits
+    <= 1 signal/tick.
+  - v2 leverage = min(config.leverage=4, MAX_LEVERAGE=5) = 4. Clamp preserved.
+  - v2 `fetch_sm_direction` returns the CROWDED SIDE + concentration (long_ratio if
+    >= 50 else SHORT/100-long_ratio) — DIFFERENT from bison's net-lean 58/42
+    thresholds. Ported verbatim from egret's own producer (_get_sm_direction).
+  - v2 market fetch was 1h candles only (no funding / no order book). Preserved.
+  - v2 recent-signals JSON cache -> ctx.state dedup map (same 240s TTL semantics).
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v2 defaults (egret-producer.py / egret-config.json)
+_DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL", "HYPE"]
+_DEFAULT_MIN_SCORE = 5            # v2 DEFAULT_MIN_SCORE / config minScore
+_DEFAULT_MARGIN_PCT = 15.0        # v2 config marginPct=0.15 (FRACTION) -> 15 PERCENT
+_DEFAULT_LEVERAGE = 4            # v2 DEFAULT_LEVERAGE
+_MAX_LEVERAGE = 5               # v2 MAX_LEVERAGE
+_DEFAULT_RECENT_TTL = 240        # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    Egret's universe is all main-DEX majors, so this only returns '' in practice."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[egret.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._num(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = scoring._num(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._num(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._num(_ms.get("totalMarginUsed", 0)), abs(scoring._num(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[egret.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _get_sm_direction(ctx, asset):
+    """Port of v2 fetch_sm_direction. Returns (crowded_direction, concentration_pct)
+    or (None, 0). READ-GUARDED.
+
+    crowded_direction = the side the smart-money crowd is piled onto;
+    concentration_pct = how concentrated (e.g. 78 = 78% of top traders on that side).
+    Verbatim from egret-producer.py: long_ratio >= 50 -> ('LONG', long_ratio);
+    else -> ('SHORT', 100 - long_ratio). NEUTRAL only when total == 0."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — smart-money is the GATE-1 input; a read miss degrades to no-fade
+        print(f"[egret.scan] leaderboard_get_markets read failed (no SM read -> skip asset): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and raw.get("success") is False):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._num(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def _asset_1h_candles(ctx, asset):
+    """1h candle list for `asset` (no funding / no order book — v2 fetch only 1h).
+    READ-GUARDED. Returns [] on any failure."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": asset,
+            "candle_intervals": ["1h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": _dex_for(asset),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[egret.scan] market_get_asset_data({asset}) read failed: {exc!r}", file=sys.stderr)
+        return []
+    if not md:
+        return []
+    if isinstance(md, dict) and md.get("success") is False:
+        return []
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return []
+    candles = d.get("candles", {}) or {}
+    return candles.get("1h", []) if isinstance(candles, dict) else []
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    universe = [a.upper() for a in inputs.get("universe", _DEFAULT_UNIVERSE)]
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    # defensive: a config that still stores the v2 FRACTION (0.15) -> x100 (15%).
+    if margin_pct <= 1.0:
+        margin_pct = margin_pct * 100.0
+    lev_default = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    leverage = min(lev_default, _MAX_LEVERAGE)   # v2 min(config.leverage, MAX_LEVERAGE)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── score every eligible whitelist candidate (XYZ banned; held + recently
+    #    signaled filtered BEFORE the per-asset MCP fetch, as in v2 main()) ──
+    candidates = []
+    scanned = 0
+    for coin in universe:
+        if not coin or coin.lower().startswith("xyz:"):   # XYZ not in egret universe
+            continue
+        cu = coin.upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        sm = _get_sm_direction(ctx, cu)
+        # GATE 1 short-circuit (avoid the candle fetch when the crowd isn't crowded),
+        # matching v2 build_thesis order (SM gate before market fetch).
+        sm_dir, sm_pct = sm
+        crowd_min = float(inputs.get("crowdingMinPct", scoring.DEFAULT_CROWDING_MIN_PCT))
+        if sm_dir not in ("LONG", "SHORT") or sm_pct < crowd_min:
+            continue
+        candles_1h = _asset_1h_candles(ctx, cu)
+        if not candles_1h:
+            continue
+        th = scoring.build_thesis(cu, candles_1h, sm, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets, "note": f"WAITING (min score {min_score:.0f})"}
+        print(f"[egret.scan] WAITING — no exhausted-crowd divergence (min score {min_score:.0f}); "
+              f"scanned={scanned} held={held_assets}", file=sys.stderr)
+    else:
+        # v2 emitted exactly the single best (highest score).
+        candidates.sort(key=lambda x: x["score"], reverse=True)
+        best = candidates[0]
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"],
+                  "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best["reasons"]}
+        print(f"[egret.scan] EMIT {best['coin']} {best['direction']} (fade) score={best['score']} "
+              f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:5]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],            # the FADE direction (opposite the crowd)
+            "marginPct": margin_pct,                   # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,                      # clamped to <= 5
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "smCrowdDirection": best["sm_crowd_direction"],
+                "smCrowdPct": best["sm_crowd_pct"],
+                "priceMomentumPct": best["price_momentum_pct"],
+                "rsi": best["rsi"],
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + this tick's result every tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[egret.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/egret/main/scanners/scoring.py
+++ b/strategies/egret/main/scanners/scoring.py
@@ -1,0 +1,172 @@
+"""EGRET — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Egret producer's `build_thesis` +
+exhausted-crowd fade scoring (egret-producer.py v1.0.1 / SKILL.md v1.0.0). The
+math/indexing is reproduced VERBATIM so a fidelity harness can diff this against
+the v2 producer on the same market snapshot. Behaviour-preserving quirks from v2
+are kept and flagged `# v2-quirk`.
+
+Egret is a CONTRARIAN FADER, not a momentum scorer. The thesis: when the
+Smart-Money crowd is extremely concentrated one way (>= crowdingMinPct) but price
+is NOT confirming over the recent window (divergence), the crowded side is
+exhausted and the unwind is the edge — fade it. Crowded LONG + price stalled/down
+-> FADE SHORT; crowded SHORT + price stalled/up -> FADE LONG. RSI exhaustion adds
+conviction.
+
+`sm` (the crowded side + concentration pct) is fetched by the caller and passed
+in, so this module stays pure. Multi-asset, single-pass, unit-testable on plain
+candle lists.
+
+Two HARD GATES (return None if either fails):
+  1. SM concentration >= crowdingMinPct (the crowd must be crowded), AND
+  2. price not confirming the crowd over the lookback (divergence).
+minScore is applied by the CALLER (scan.py), not here.
+"""
+
+# v2 producer defaults (egret-producer.py)
+DEFAULT_CROWDING_MIN_PCT = 70.0       # SM concentration must be >= this to be "crowded"
+DEFAULT_CROWDING_EXTREME_PCT = 80.0   # ultra-crowded bonus threshold
+DEFAULT_CONFIRM_MAX_PCT = 0.5         # if price moved less than this WITH the crowd, it's diverging
+DEFAULT_DIVERGENCE_LOOKBACK = 4       # 1h bars for the price-confirmation window
+
+
+def _f(c, primary="close", alt="c", default=0.0):
+    """Numeric accessor matching v2 `_f(c, primary, alt, default)`: pull `primary`
+    from a candle dict, fall back to `alt`, coerce to float. Plain-float callers
+    pass the value directly via `_num`."""
+    if isinstance(c, dict):
+        val = c.get(primary)
+        if val is None and alt:
+            val = c.get(alt)
+    else:
+        val = c
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _num(v, default=0.0):
+    """Plain scalar -> float (for non-candle values)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+# ── indicators (ported verbatim from v2 egret-producer.py) ──
+
+def price_momentum(candles, n_bars):
+    """% change over the last n_bars (1h bars). Verbatim from v2 price_momentum."""
+    if len(candles) < n_bars + 1:
+        return 0.0
+    old = _f(candles[-(n_bars + 1)], "close", "c")
+    new = _f(candles[-1], "close", "c")
+    if old <= 0:
+        return 0.0
+    return ((new - old) / old) * 100
+
+
+def calc_rsi(closes, period=14):
+    """RSI over the LAST `period` gains/losses. Verbatim from v2 calc_rsi
+    (trailing-window: gains[-period:] / losses[-period:])."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0.0, d))
+        losses.append(max(0.0, -d))
+    avg_g = sum(gains[-period:]) / period
+    avg_l = sum(losses[-period:]) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── the thesis (two gates + exhausted-crowd fade score), ported verbatim ──
+
+def build_thesis(asset, candles_1h, sm, entry_cfg):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned when ANY of:
+      - the crowded side is not LONG/SHORT (no SM read / NEUTRAL), OR
+      - SM concentration < crowdingMinPct (GATE 1 — crowd not crowded), OR
+      - insufficient 1h candle history (< 16 bars), OR
+      - price IS confirming the crowd (GATE 2 — no divergence, don't fade a
+        working trend).
+
+    minScore is NOT applied here — the caller gates on thesis['score'].
+
+    `sm` is (crowded_direction, concentration_pct) or (None, 0); the caller
+    fetches it (scan._get_sm_direction)."""
+    sm_dir, sm_pct = sm if sm else (None, 0.0)
+
+    # GATE 1 — extreme SM crowding
+    if sm_dir not in ("LONG", "SHORT"):
+        return None
+    crowd_min = float(entry_cfg.get("crowdingMinPct", DEFAULT_CROWDING_MIN_PCT))
+    crowd_extreme = float(entry_cfg.get("crowdingExtremePct", DEFAULT_CROWDING_EXTREME_PCT))
+    if sm_pct < crowd_min:
+        return None
+
+    if len(candles_1h) < 16:
+        return None
+    closes = [_f(c, "close", "c") for c in candles_1h]
+
+    lookback = int(entry_cfg.get("divergenceLookbackHours", DEFAULT_DIVERGENCE_LOOKBACK))
+    confirm_max = float(entry_cfg.get("confirmMaxPct", DEFAULT_CONFIRM_MAX_PCT))
+    mom = price_momentum(candles_1h, lookback)
+    rsi = calc_rsi(closes)
+
+    # GATE 2 — price NOT confirming the crowd (divergence)
+    # Crowded LONG but price hasn't risen (mom <= confirm_max) -> exhaustion -> FADE SHORT.
+    # Crowded SHORT but price hasn't fallen (mom >= -confirm_max) -> FADE LONG.
+    if sm_dir == "LONG":
+        if mom > confirm_max:
+            return None  # crowd long AND price rising — no divergence, don't fade a working trend
+        fade_direction = "SHORT"
+    else:  # SHORT
+        if mom < -confirm_max:
+            return None
+        fade_direction = "LONG"
+
+    score = 0
+    reasons = []
+
+    # SM crowding (gate-confirmed) + ultra-crowded bonus
+    score += 2
+    reasons.append(f"sm_crowded_{sm_dir.lower()}_{sm_pct:.0f}%")
+    if sm_pct >= crowd_extreme:
+        score += 1
+        reasons.append("sm_ultra_crowded")
+
+    # Divergence magnitude — the further price is from confirming, the stronger
+    if (sm_dir == "LONG" and mom <= -0.5) or (sm_dir == "SHORT" and mom >= 0.5):
+        score += 3
+        reasons.append(f"price_diverging_{mom:+.2f}%")
+    else:
+        score += 2
+        reasons.append(f"price_stalled_{mom:+.2f}%")
+
+    # RSI exhaustion confirms the fade
+    if fade_direction == "SHORT" and rsi >= 68:
+        score += 2
+        reasons.append(f"rsi_overbought_{rsi:.0f}")
+    elif fade_direction == "LONG" and rsi <= 32:
+        score += 2
+        reasons.append(f"rsi_oversold_{rsi:.0f}")
+    elif (fade_direction == "SHORT" and rsi >= 60) or (fade_direction == "LONG" and rsi <= 40):
+        score += 1
+        reasons.append(f"rsi_stretched_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": fade_direction,
+        "score": score,
+        "reasons": reasons,
+        "sm_crowd_direction": sm_dir,
+        "sm_crowd_pct": _num(sm_pct),
+        "price_momentum_pct": round(mom, 3),
+        "rsi": round(rsi, 1),
+    }

--- a/strategies/egret/strategy.yaml
+++ b/strategies/egret/strategy.yaml
@@ -1,0 +1,42 @@
+# Egret — Smart-Money Divergence Fader. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2
+# Egret (SKILL.md v1.0.0 / producer v1.0.1): fades an exhausted Smart-Money crowd on
+# a liquid-majors whitelist (BTC/ETH/SOL/HYPE) when extreme one-sided crowding is NOT
+# confirmed by price (divergence). Flat 15% margin, leverage <=5, TIGHT fader DSL,
+# maker-only entry. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: egret
+version: "1.0.0"
+
+catalog:
+  name: "Egret — Smart-Money Divergence Fader"
+  emoji: "🐦"
+  tagline: "Fades an exhausted crowd: when 70%+ of top traders are piled onto one side of BTC/ETH/SOL/HYPE but price refuses to follow (it stalls or rolls over against the crowd), the crowded side is out of fuel — Egret takes the other side, sized flat at 15% / <=5x, and banks the bounded snapback with a tight ratchet."
+  belief_plain: "When almost everyone good is leaning the same way on a coin but the price won't move with them, the trade is crowded and out of buyers (or sellers). Egret bets on the snap-back the other way, and because that bounce is small and quick, it locks in profit fast instead of holding for a big trend."
+  thesis: "Smart-money concentration is usually a confirmation signal — but at an extreme, with price refusing to confirm, it flips contrarian: a maximally-crowded side with no one left to push has only one way to resolve, the unwind. The edge is the bounded snapback, so the right design is the inverse of a momentum holder: maker-only non-urgent entry, a tight ratchet that banks the bounce, and time-cuts that exit a fade that didn't resolve quickly."
+  group: smart-money
+  archetype: contrarian_fade
+  sub_style: sm_crowding
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL", "HYPE"]
+  tags: [btc, eth, sol, hype, smart-money, contrarian, fade, mean-reversion, divergence, rsi, maker-only, tight-ratchet]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: EGRET_WALLET
+    funding_share: 1.0

--- a/strategies/hawk/main/runtime.yaml
+++ b/strategies/hawk/main/runtime.yaml
@@ -1,0 +1,144 @@
+# ── HAWK · single instance — breakout buyer / breakdown seller (basket) ───────
+# Runtime 3.0 port of the v2 Hawk (SKILL.md v1.0.0 / hawk-producer.py v1.0.1).
+# Liquid-majors basket (BTC/ETH/SOL): LONG a break above the 7d high / SHORT a
+# break below the 7d low, GATED by the smart-money leaderboard (net >= 55% in the
+# breakout direction). 5-component breakout score (max ~9, floor 5), flat 20%
+# margin / 5x leverage. Asymmetric DSL — TIGHT Phase 1 (max_loss 8%, retrace 5)
+# cuts failed breakouts fast; WIDE Phase 2 ladder (first lock at +10% ROE) lets a
+# real breakout run. hard_timeout 24h. Faithful port — see scanners/scoring.py
+# (math reproduced verbatim, v2-quirks flagged).
+name: hawk-main
+group: hawk
+version: 1.0.0
+description: >
+  HAWK — breakout buyer / breakdown seller on the liquid majors (BTC/ETH/SOL).
+  Goes LONG when the latest 1h close breaks ABOVE the prior 7-day (168h) high AND
+  the Senpi smart-money leaderboard is net long in the same direction at >= 55%;
+  SHORT on a break below the 7-day low with SM net short. The breakout and the
+  SM-direction agreement are HARD GATES; 4h-trend alignment and a volume-spike
+  confirm are score contributors (5 components, max ~9, floor 5). Flat sizing:
+  20% margin, 5x leverage (clamped to 5x max). Asymmetric DSL — tight Phase 1
+  (max_loss 8%) cuts failed breakouts fast, while a wide Phase 2 ratchet (first
+  lock at +10% ROE) lets a real breakout run; hard_timeout 24h kills a breakout
+  that never works. Onboarding-grade. Faithful port of the v2 Hawk v1.0.0 thesis
+  (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${HAWK_WALLET}"
+  slots: 1                                 # v2 strategy.slots 1
+  margin_pct: 20                           # baseline %; scan emits the flat marginPct per signal
+  default_leverage: 5                      # fallback; scan emits 5x per signal (clamped to MAX 5)
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: hawk_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                   # v2 producer cadence (5 min)
+    timeout_seconds: 180                    # v2 tick_timeout=180; ~1 read/asset + sm + account
+    default_signal_validity_seconds: 600    # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100            # dedup map + per-tick scan-results history
+    inputs:
+      universe: ["BTC", "ETH", "SOL"]       # v1 DEFAULT_UNIVERSE (validated live on HL main DEX 2026-06-29)
+      minScore: 5                           # v1 DEFAULT_MIN_SCORE / config.minScore
+      marginPct: 20                         # PERCENT of withdrawable (0,100]; flat (no conviction tiers)
+      leverage: 5                           # clamped to MAX_LEVERAGE 5 in scan.py
+      smTiltMinPct: 55                      # v1 DEFAULT_SM_TILT_MIN — SM-agreement gate
+      smStrongTiltPct: 70                   # v1 DEFAULT_SM_STRONG — +1 "strongly tilted" component
+      breakoutLookbackHours: 168            # v1 DEFAULT_BREAKOUT_LOOKBACK_HOURS (7 days)
+      recentSignalTtlSeconds: 240           # v1 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      breakoutPct: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      trend4h: { type: string, required: false }
+      volumeRatio: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: hawk_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [hawk_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true     # 2026-05-21 HYPE lesson: momentum/breakout entries must fill —
+                                            # maker-only can rest unfilled (CREATE_ORDER_RESTING). Taker
+                                            # fallback guarantees fill + DSL attach.
+        execution_timeout_seconds: 30       # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: hawk_main_signals
+
+# ── EXIT (DSL — preserved VERBATIM from the v2 hawk runtime.yaml) ──────────────
+# Asymmetric "breakout" profile: TIGHT Phase 1 (max_loss 8%, retrace 5) cuts a
+# failed breakout fast; WIDE Phase 2 ladder lets a real one run. hard_timeout 24h
+# kills a breakout that never works; weak_peak_cut 60min/3% kills stale chop;
+# dead_weight_cut DISABLED. Phase 2 FIRST lock at +10% ROE (reachable on realistic
+# winners — NOT the unreachable >+40% pattern). order_type FEE_OPTIMIZED_LIMIT,
+# taker fallback on (closes MUST happen). interval_seconds 60 (v2: REDUCE_ONLY-spam
+# mitigation when runtime position state lags HL).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true         # exit closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30           # v2: kept the maker attempt under the server connection window
+  dsl_preset:
+    hard_timeout:
+      enabled: true                         # v2: 24h cap — failed breakouts get cut
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: true                         # v2: 60min/3% — stale breakouts cut (self-limiting)
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                        # v2: DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 8.0                      # v2: TIGHT floor — failed breakouts must be cut fast
+      retrace_threshold: 5
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                # wide-by-design; FIRST lock at +10% ROE (NOT >+40%)
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200            # 72h (was data_retention_hours 72)
+  guard_rails:
+    daily_loss_limit_pct: 15                # v2 daily_loss_limit_pct
+    max_entries_per_day: 2                  # v2 onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 cooldown_minutes 60 -> 3600s (post-loss)
+    drawdown_halt_pct: 20                   # v2 drawdown_halt_pct (hard circuit breaker)
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400       # v2 per_asset_cooldown_minutes 240 -> 14400s (4h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/hawk/main/scanners/scan.py
+++ b/strategies/hawk/main/scanners/scan.py
@@ -1,0 +1,308 @@
+"""HAWK — supervised scanner (Runtime 3.0 port of the v2 Hawk breakout producer).
+
+Multi-asset, basket-gated (BTC/ETH/SOL by default). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - iterates the basket universe (XYZ banned; held + recently-signaled filtered
+    BEFORE the per-asset MCP fetch, as in v2 main()),
+  - for each candidate fetches 1h+4h candles + the smart-money lean and scores a
+    breakout thesis via the pure `scoring.build_thesis` (breakout + SM agreement
+    are HARD GATES; 4h-trend + volume are score contributors),
+  - emits the SINGLE highest-scoring candidate at/above `minScore` (v2 main()
+    emitted only `best`), sized by a flat margin PERCENT + clamped leverage.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit.
+No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs the v2 producer (hawk-producer.py v1.0.1 / SKILL.md v1.0.0):
+  - v2 sized margin as marginPct=0.20 (a FRACTION) * account_value -> marginUsd.
+    This port emits a `marginPct` PERCENT (default 20) and the runtime sizes
+    (marginPct/100)*withdrawable. The defensive "<=1.0 means a pasted fraction,
+    x100" guard converts a config that still carries 0.20 -> 20. Flat sizing (no
+    conviction tiers) is preserved verbatim.
+  - v2 leverage = min(config.leverage(5), MAX_LEVERAGE(5)). Preserved: clamp the
+    input leverage to MAX_LEVERAGE (5).
+  - v2 emitted exactly one signal (best, highest score). Preserved: scan() emits
+    <= 1 signal/tick.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=240) -> ctx.state dedup
+    map (same TTL + 4x-TTL prune semantics).
+  - v2 smart-money lean (fetch_sm_direction) thresholds reproduced VERBATIM in
+    _get_sm_direction (>=50 long_ratio -> LONG else SHORT; token compared UPPER).
+    Note this differs from bison's 58/42 band — Hawk's own thresholds are kept.
+  - v2 build_thesis short-circuited on data.get("success") False; the read-guard
+    here treats success:false as "skip asset" (None), same effect.
+  - v2's hawk_config.py docstring and runtime.yaml description called Hawk a
+    "single-asset BTC" strategy; the producer + config/hawk-config.json + SKILL.md
+    all define a 3-asset BTC/ETH/SOL breakout basket. The producer/config/SKILL
+    are source-of-truth — this port is a 3-asset basket. (Mismatch FLAGGED.)
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v1.0.1 defaults (hawk-producer.py / hawk-config.json)
+_UNIVERSE_DEFAULT = ["BTC", "ETH", "SOL"]
+_DEFAULT_MIN_SCORE = 5            # v1 DEFAULT_MIN_SCORE / config.minScore
+_DEFAULT_MARGIN_PCT = 20         # PERCENT; v2 config.marginPct=0.20 fraction -> 20%
+_DEFAULT_LEVERAGE = 5            # v1 DEFAULT_LEVERAGE / config.leverage
+_MAX_LEVERAGE = 5               # v1 MAX_LEVERAGE (hardcoded, not configurable)
+_DEFAULT_RECENT_TTL = 240        # v1 RECENT_SIGNAL_TTL_SEC — race-window dedup
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    Hawk's basket is liquid crypto majors, so this only ever returns '' in
+    practice (XYZ is also banned at scan level below)."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[hawk.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[hawk.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _get_sm_direction(ctx, coin):
+    """Net smart-money lean for `coin` from leaderboard_get_markets. Returns
+    (direction, tilt_pct) or (None, 0.0). READ-GUARDED.
+
+    Ported VERBATIM from v2 fetch_sm_direction (NOT bison's 58/42 band):
+      - token compared UPPER-cased against coin (assumed upper),
+      - long_ratio = long_pct/(long+short)*100,
+      - long_ratio >= 50 -> ("LONG", long_ratio), else ("SHORT", 100 - long_ratio),
+      - total == 0 -> ("NEUTRAL", 50.0); coin not found -> (None, 0.0)."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — smart-money is the entry GATE; a read failure must skip,
+        print(f"[hawk.scan] leaderboard_get_markets read failed (smart-money -> none): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and raw.get("success") is False):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct = 0.0
+    short_pct = 0.0
+    found = False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != coin:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def _asset_data(ctx, coin):
+    """{candles_1h, candles_4h} for `coin` or None. READ-GUARDED.
+    Ported from v2 fetch_market_data (1h/4h, no funding, no order book)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["1h", "4h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[hawk.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    if not isinstance(candles, dict):
+        return None
+    return {"candles_1h": candles.get("1h", []) or [],
+            "candles_4h": candles.get("4h", []) or []}
+
+
+# ── ctx.state: recent-signal dedup (port of v1 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    universe = [str(a).upper() for a in inputs.get("universe", _UNIVERSE_DEFAULT)]
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    base_margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))   # PERCENT in (0,100]
+    # defensive: a config that still stores margin as a FRACTION (e.g. 0.20) -> x100
+    if base_margin_pct <= 1.0:
+        base_margin_pct *= 100
+    lev_default = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── score every eligible basket candidate (XYZ banned; held + recently
+    #    signaled filtered BEFORE the per-asset MCP fetch, as in v2 main()) ──
+    candidates = []
+    scanned = 0
+    for coin in universe:
+        if not coin or coin.lower().startswith("xyz:"):   # XYZ banned (liquid-crypto basket)
+            continue
+        cu = coin.upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        sm = _get_sm_direction(ctx, cu)
+        th = scoring.build_thesis(coin, md["candles_1h"], md["candles_4h"], sm, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets,
+                  "note": f"WAITING — no breakout with SM agreement (min score {min_score:.0f})"}
+        print(f"[hawk.scan] WAITING — no breakout with SM agreement (min score {min_score:.0f}); "
+              f"scanned={scanned} held={held_assets}", file=sys.stderr)
+    else:
+        # v2 emitted exactly the single best (highest score).
+        candidates.sort(key=lambda x: x["score"], reverse=True)
+        best = candidates[0]
+
+        # flat margin PERCENT (v2 had no conviction tiers); leverage clamped to MAX.
+        margin_pct = base_margin_pct
+        leverage = min(lev_default, _MAX_LEVERAGE)
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"],
+                  "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best["reasons"]}
+        print(f"[hawk.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+              f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:6]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # clamped to MAX_LEVERAGE (5); runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "breakoutPct": best["breakout_pct"],
+                "smDirection": best["sm_direction"] or "NEUTRAL",
+                "smTiltPct": best["sm_tilt_pct"],
+                "trend4h": best["trend_4h"],
+                "volumeRatio": best["volume_ratio"],
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + this tick's result every tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[hawk.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/hawk/main/scanners/scoring.py
+++ b/strategies/hawk/main/scanners/scoring.py
@@ -1,0 +1,209 @@
+"""HAWK — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Hawk producer's `detect_breakout` +
+`trend_4h` + `volume_ratio` + `build_thesis` 5-component breakout scoring
+(SKILL.md v1.0.0 / hawk-producer.py v1.0.1). The math/indexing is reproduced
+VERBATIM so a fidelity harness can diff this against the v2 producer on the same
+market snapshot. Behaviour-preserving quirks from v2 are kept and flagged
+`# v2-quirk`; fix them only as a separate, labelled change AFTER the port is
+validated.
+
+Multi-asset, single-pass, unit-testable on plain candle lists. `sm` (smart-money
+lean) is fetched by the caller and passed in, so this module stays pure.
+
+THESIS (v2 verbatim): a breakout buyer / breakdown seller on the liquid majors.
+LONG when the latest 1h close breaks ABOVE the max of the prior 7d (168h) closes
+AND smart-money is net long in the same direction at >= smTiltMinPct (default 55%);
+SHORT when the latest 1h close breaks BELOW the min of the prior 7d closes AND SM
+is net short at >= 55%. Both the breakout and the SM-direction agreement are HARD
+GATES (return None if either fails); the 4h-trend alignment and volume are score
+contributors only. Max score ~9; minScore (default 5) is applied by the CALLER.
+"""
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts with a {primary, alt} fallback (close/c, high/h, low/l, volume/v);
+# the list branch is defensive and never fires on dict candles, so it does not
+# change v2 behaviour.
+
+def _f(v, d=0.0):
+    try:
+        return float(v if v is not None else d)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── indicators (ported verbatim from v2 hawk-producer.py) ──
+
+def detect_breakout(candles_1h, lookback_hours):
+    """(direction, magnitude_pct) when the latest 1h close breaks the lookback
+    high/low, else (None, 0.0). Verbatim from v2 detect_breakout.
+
+    Needs len(candles_1h) >= lookback_hours + 1 (the latest close plus a full
+    prior-closes window). The breakout level is max/min of the PRIOR closes
+    (window[:-1]) — the latest bar is excluded from its own range. LONG if
+    latest_close > high, SHORT if latest_close < low, else None."""
+    if len(candles_1h) < lookback_hours + 1:
+        return None, 0.0
+    window = candles_1h[-lookback_hours:]
+    latest = candles_1h[-1]
+    latest_close = _close(latest)
+    prior_closes = [_close(c) for c in window[:-1]]
+    if not prior_closes or latest_close <= 0:
+        return None, 0.0
+    high = max(prior_closes)
+    low = min(prior_closes)
+    if latest_close > high:
+        return "LONG", ((latest_close - high) / high) * 100
+    if latest_close < low:
+        return "SHORT", ((low - latest_close) / low) * 100
+    return None, 0.0
+
+
+def trend_4h(candles_4h, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH, else NEUTRAL. Verbatim from
+    v2 trend_4h. v2-quirk: STRICT (>) higher-low / lower-high counting, gate at
+    `>= total * 0.6` with total = lookback - 1. Reproduced exactly."""
+    if len(candles_4h) < lookback:
+        return "NEUTRAL"
+    lows = [_low(c) for c in candles_4h[-lookback:]]
+    highs = [_high(c) for c in candles_4h[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH"
+    if lower_highs >= total * 0.6:
+        return "BEARISH"
+    return "NEUTRAL"
+
+
+def volume_ratio(candles_1h):
+    """Latest 1h volume / mean of the prior 9 (candles[-10:-1]). Verbatim from v2
+    volume_ratio. Returns 1.0 when history is short or the prior mean is 0."""
+    if len(candles_1h) < 10:
+        return 1.0
+    avg_prior = sum(_vol(c) for c in candles_1h[-10:-1]) / 9
+    latest_vol = _vol(candles_1h[-1])
+    if avg_prior <= 0:
+        return 1.0
+    return latest_vol / avg_prior
+
+
+# ── the thesis (two hard gates + 5-component score), ported verbatim ──
+
+def build_thesis(coin, candles_1h, candles_4h, sm, inputs):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned when ANY of the v2 short-circuits fire:
+      - insufficient history (len(c1h) < lookback+1 or len(c4h) < 6), OR
+      - no breakout (detect_breakout -> None), OR
+      - SM gate fails: sm_dir not LONG/SHORT, OR sm_dir != breakout direction,
+        OR sm_tilt < smTiltMinPct.
+    minScore is NOT applied here — the caller gates on thesis['score'].
+
+    `sm` is the smart-money tuple (direction, tilt_pct) or (None, 0) — the caller
+    fetches it (scan._get_sm_direction)."""
+    lookback = int(inputs.get("breakoutLookbackHours", 168))
+    sm_min = float(inputs.get("smTiltMinPct", 55))
+    sm_strong = float(inputs.get("smStrongTiltPct", 70))
+
+    if len(candles_1h) < lookback + 1 or len(candles_4h) < 6:
+        return None
+
+    direction, magnitude_pct = detect_breakout(candles_1h, lookback)
+    if direction is None:
+        return None
+
+    # ── GATE: smart-money must agree with the breakout direction at >= sm_min ──
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    # 4h trend alignment (score contributor only — NOT a gate)
+    t4 = trend_4h(candles_4h)
+    trend_aligned = (
+        (direction == "LONG" and t4 == "BULLISH")
+        or (direction == "SHORT" and t4 == "BEARISH")
+    )
+
+    vol_x = volume_ratio(candles_1h)
+
+    score = 0
+    reasons = []
+
+    # Breakout magnitude (+3 / +2 / +1)
+    if magnitude_pct >= 1.0:
+        score += 3
+        reasons.append(f"breakout_strong_{magnitude_pct:+.2f}%")
+    elif magnitude_pct >= 0.3:
+        score += 2
+        reasons.append(f"breakout_{magnitude_pct:+.2f}%")
+    else:
+        score += 1
+        reasons.append(f"breakout_weak_{magnitude_pct:+.2f}%")
+
+    # SM aligned (gate-confirmed) (+2)
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+
+    # SM strongly tilted (+1)
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    # 4h trend aligned (+2)
+    if trend_aligned:
+        score += 2
+        reasons.append(f"4h_trend_aligned_{t4.lower()}")
+
+    # Volume confirmation >= 1.5x average (+1)
+    if vol_x >= 1.5:
+        score += 1
+        reasons.append(f"vol_{vol_x:.1f}x")
+
+    return {
+        "coin": coin,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "breakout_pct": round(magnitude_pct, 3),
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": _f(sm_tilt),
+        "trend_4h": t4,
+        "volume_ratio": round(vol_x, 2),
+    }

--- a/strategies/hawk/strategy.yaml
+++ b/strategies/hawk/strategy.yaml
@@ -1,0 +1,44 @@
+# Hawk — breakout buyer / breakdown seller with a Smart-Money direction gate. A
+# single-instance PACKAGE: this manifest + one self-contained runtime.yaml + scanners/.
+# A faithful Runtime 3.0 port of the v2 Hawk (SKILL.md v1.0.0): a liquid-majors basket
+# (BTC/ETH/SOL) that LONGs a break above the 7-day high / SHORTs a break below the 7-day
+# low, gated by the Senpi smart-money leaderboard, with an asymmetric DSL (tight Phase 1
+# to cut failed breakouts, wide Phase 2 to let real ones run). Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: hawk
+version: "1.0.0"
+
+catalog:
+  name: "Hawk — Breakout Buyer / Breakdown Seller"
+  emoji: "🦅"
+  tagline: "An onboarding-grade breakout trader on the liquid majors (BTC/ETH/SOL): goes LONG when price breaks above its 7-day high AND smart-money is net long, SHORT when it breaks below the 7-day low AND smart-money is net short, then cuts failed breakouts fast (tight 8% Phase 1) while letting a real one run on a wide Phase 2 ratchet."
+  belief_plain: "Watches BTC, ETH and SOL. When one of them breaks above its highest price of the last week and the best traders are also leaning long, it buys; when one breaks below its weekly low and the best traders are leaning short, it sells short. A fake breakout gets cut quickly, but a real one is given lots of room to run."
+  thesis: "Most breakout strategies lose because they fight the trend, chase fake breakouts into stop-hunts, or hold failed breakouts too long. Hawk requires three things at once — a genuine break of the 7-day range, the 4h trend pointing the same way, and the smart-money leaderboard net in the breakout direction — so it only fires on confirmed breaks. Then the asymmetry does the work: an 8% Phase 1 floor cuts a breakout that fails immediately, while a wide Phase 2 ladder (first lock only at +10% ROE) keeps the rare breakout that runs, because that tail pays for the quiet weeks."
+  group: breakout
+  archetype: breakout_momentum
+  sub_style: range_break
+  asset_classes: [major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: starter
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL"]
+  tags: [btc, eth, sol, multi-asset, breakout, breakdown, smart-money, range-break, onboarding, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: HAWK_WALLET
+    funding_share: 1.0

--- a/strategies/hedgehog/main/runtime.yaml
+++ b/strategies/hedgehog/main/runtime.yaml
@@ -1,0 +1,136 @@
+# ── HEDGEHOG · single instance — equal-weight BTC/ETH/SOL directional basket ──
+# Runtime 3.0 port of the v2 HEDGEHOG (hedgehog-producer.py v1.0.1 / SKILL.md
+# v1.0.0). Onboarding-tier major-crypto basket: each of BTC/ETH/SOL evaluated
+# INDEPENDENTLY (long OR short) on a HARD-GATED 4h trend + Smart-Money direction
+# thesis. Up to 3 simultaneous positions, flat 10% margin per leg, 5x leverage,
+# per-position DSL exits. Faithful port — see scanners/scoring.py (math verbatim).
+name: hedgehog-main
+group: hedgehog
+version: 3.0.0
+description: >
+  HEDGEHOG — equal-weight major-crypto basket (BTC + ETH + SOL), each leg
+  independently directional. Per asset: HARD GATES (4h trend non-neutral +
+  Smart-Money direction agrees with the 4h direction + SM tilt >= 55%), then a
+  simple 4-component score (max ~9): +3 4h trend, +2 1h confirm, +2 SM aligned,
+  +1 SM strongly tilted (>=70%). Emits the single highest-scoring unheld leg per
+  tick; the basket fills to 3 slots over ticks. Flat 10% margin per leg (max 30%
+  committed), 5x leverage. Per-position DSL — one leg going wrong doesn't drag
+  the others. Onboarding-tier: the diversification answer for "I want exposure to
+  crypto majors without picking one." Faithful port of v2 HEDGEHOG v1.0.0.
+
+strategy:
+  wallet: "${HEDGEHOG_WALLET}"
+  slots: 3                                # v2 strategy.slots 3 (one per asset)
+  margin_pct: 10                          # baseline %; scan emits the flat per-leg marginPct per signal
+  default_leverage: 5                     # fallback; scan emits 5x per signal
+  trading_risk: conservative
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: hedgehog_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 180                   # v2 tick_timeout=180; ~1 market read + 1 sm read per asset + account
+    default_signal_validity_seconds: 600   # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      universe: ["BTC", "ETH", "SOL"]      # v2 config universe (validated live on HL main DEX 2026-06-29)
+      minScore: 5                          # v2 minScore (DEFAULT_MIN_SCORE) — easy directional-confluence floor
+      smTiltMinPct: 55                     # v2 smTiltMinPct (DEFAULT_SM_TILT_MIN) — SM agreement gate
+      smStrongTiltPct: 70                  # v2 smStrongTiltPct (DEFAULT_SM_STRONG) — +1 strong-tilt bonus
+      marginPct: 10                        # PERCENT of withdrawable (0,100]; flat per leg (v2 0.10 fraction x100)
+      leverage: 5                          # clamped to [1,5] in scan.py (MAX_LEVERAGE)
+      recentSignalTtlSeconds: 240          # v1.0.1 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      trend4hStrength: { type: number, required: false }
+      trend1h: { type: string, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: hedgehog_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every gate (v2 LLM gate was pass-through)
+    scanners: [hedgehog_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # v2: maker-only entries rest and silently fail to open during fast
+                                           # moves (CREATE_ORDER_RESTING). Taker fallback guarantees fill + DSL attach.
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: hedgehog_main_signals
+
+# ── EXIT (DSL — ported VERBATIM from v2 runtime.yaml) ─────────────────────────
+# hard_timeout ENABLED (48h cap, v2 interval_in_minutes 2880). weak_peak_cut and
+# dead_weight_cut DISABLED (v2). Phase 1 max_loss 15% (per position). Phase 2
+# Bison-pattern wide ladder: FIRST lock at +10% ROE (reachable; NOT +40-80%), up
+# to T5 +100%/85% lock so multi-day winners ratchet. order_type FEE_OPTIMIZED_LIMIT,
+# taker fallback on (closes MUST happen). interval_seconds 60 (REDUCE_ONLY-spam
+# mitigation when runtime position state lags HL).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30          # v2 exit execution_timeout_seconds (60->30)
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # v2: ENABLED — 48h cap
+      interval_in_minutes: 2880
+    weak_peak_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0                    # v2: per-position catastrophic floor
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # wide-by-design; FIRST lock at +10% ROE (reachable)
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 25 }
+        - { trigger_pct: 30, lock_hw_pct: 40 }
+        - { trigger_pct: 50, lock_hw_pct: 60 }
+        - { trigger_pct: 75, lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # v2 data_retention_hours 72 -> 259200s (within [3600, 604800])
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 daily_loss_limit_pct
+    max_entries_per_day: 4                  # v2 max_entries_per_day (onboarding cap)
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 cooldown_minutes 60 -> 3600s
+    drawdown_halt_pct: 20                  # v2 drawdown_halt_pct (circuit breaker)
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400      # v2 per_asset_cooldown_minutes 240 -> 14400s (4h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/hedgehog/main/scanners/scan.py
+++ b/strategies/hedgehog/main/scanners/scan.py
@@ -1,0 +1,293 @@
+"""HEDGEHOG — supervised scanner (Runtime 3.0 port of the v2 HEDGEHOG basket).
+
+Equal-weight BTC + ETH + SOL basket; each asset evaluated INDEPENDENTLY (long OR
+short). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - iterates the universe, skipping held + recently-signaled assets,
+  - scores each remaining asset via the pure, HARD-GATED `scoring.build_thesis`
+    (4h trend non-neutral + SM direction agrees + SM tilt >= floor),
+  - emits the SINGLE highest-scoring candidate at/above `minScore`
+    (v2 main() emitted only `best`); over several ticks the basket fills to 3 slots.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT, flat per leg) plus
+a `leverage`; the runtime sizes the dollars, owns cooldowns/risk gates, and trails
+the per-position DSL exit. No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs hedgehog-producer.py v1.0.1:
+  - v2 computed marginUsd = account_value * marginPct (marginPct stored as a
+    FRACTION, 0.1) and emitted marginUsd. Runtime 3.0 sizes from a PERCENT in
+    (0,100], so this port emits `marginPct` top-level and converts the v2 fraction
+    x100 (0.1 -> 10). The defensive "<=1.0 means a pasted fraction, x100" guard is
+    applied so an operator who pastes 0.10 still gets 10%. The PER-LEG flat sizing
+    (no conviction tiers — every leg is the same %) is preserved verbatim.
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1 signal/tick;
+    the runtime fills the 3-slot basket across ticks.
+  - v2 SM direction (fetch_sm_direction): long_ratio >= 50 -> LONG (tilt=long_ratio),
+    else SHORT (tilt=100-long_ratio); a not-found token -> (None, 0.0); a found token
+    with zero total -> ("NEUTRAL", 50.0). Reproduced VERBATIM (these thresholds DIFFER
+    from Bison's 58/42 band — do not borrow Bison's).
+  - v2 fetched candle_intervals ["1h","4h"], include_funding=False,
+    include_order_book=False. Preserved exactly (HEDGEHOG scores no funding/RSI/
+    volume factors — simpler than Bison).
+  - v2 recent-signals JSON cache -> ctx.state dedup map (same 240s TTL, same 4x-TTL
+    prune semantics).
+  - v2 read-sanity guard (margin in use + empty positions -> skip tick) ported verbatim.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v2 defaults (hedgehog-producer.py / hedgehog-config.json)
+_UNIVERSE_DEFAULT = ["BTC", "ETH", "SOL"]
+_DEFAULT_RECENT_TTL = 240        # v1.0.1 RECENT_SIGNAL_TTL_SEC — race-window dedup
+_MAX_LEVERAGE = 5                # v1.0.1 MAX_LEVERAGE
+_DEFAULT_LEVERAGE = 5            # v1.0.1 DEFAULT_LEVERAGE
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    HEDGEHOG's universe is crypto majors only, so this returns '' in practice."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[hedgehog.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms, "accountValue", default=0))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos, "szi", default=0)
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", "")})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms, "totalMarginUsed", default=0),
+                   abs(scoring._f(_ms, "totalNtlPos", default=0)))
+    if _use > 1.0 and not positions:
+        print("[hedgehog.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _get_sm_direction(ctx, coin):
+    """Port of v2 fetch_sm_direction: net smart-money lean for `coin` from
+    leaderboard_get_markets. Returns (direction, tilt_pct). READ-GUARDED.
+
+    Verbatim thresholds (DIFFER from Bison): long_ratio >= 50 -> ("LONG", long_ratio);
+    else -> ("SHORT", 100 - long_ratio). Token not found -> (None, 0.0). Token found
+    but total tilt == 0 -> ("NEUTRAL", 50.0)."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — SM is a hard gate; a read failure -> None (asset skipped, tick survives)
+        print(f"[hedgehog.scan] leaderboard_get_markets read failed (smart-money -> None): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and raw.get("success") is False):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != coin.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m, "pct_of_top_traders_gain", "longPct", default=0)
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def _asset_data(ctx, coin):
+    """{candles_1h, candles_4h} for `coin` or None. READ-GUARDED.
+    Ported from v2 fetch_market_data (1h/4h, no funding, no order book)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["1h", "4h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[hedgehog.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    return {"candles_1h": candles.get("1h", []), "candles_4h": candles.get("4h", [])}
+
+
+# ── ctx.state: recent-signal dedup (port of v1.0.1 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    universe = inputs.get("universe", _UNIVERSE_DEFAULT)
+    min_score = float(inputs.get("minScore", 5))
+    margin_pct = float(inputs.get("marginPct", 10))     # PERCENT in (0,100]
+    leverage = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    # Defensive: a pasted FRACTION (<=1.0, e.g. v2's 0.1) -> PERCENT (x100).
+    if margin_pct <= 1.0:
+        margin_pct = margin_pct * 100.0
+
+    # leverage clamp: v1.0.1 min(int(leverage), MAX_LEVERAGE)
+    leverage = max(1, min(leverage, _MAX_LEVERAGE))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── score every eligible universe candidate; held + recently-signaled are
+    #    filtered BEFORE the per-asset MCP fetch, as in v2 main() ──
+    candidates = []
+    scanned = 0
+    for coin in universe:
+        if not coin:
+            continue
+        cu = coin.upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        sm = _get_sm_direction(ctx, coin)
+        th = scoring.build_thesis(coin, md["candles_1h"], md["candles_4h"], sm, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets, "note": f"WAITING (min score {min_score:.0f})"}
+        print(f"[hedgehog.scan] WAITING — no basket leg with 4h trend + SM agreement "
+              f"(min score {min_score:.0f}); scanned={scanned} held={held_assets}", file=sys.stderr)
+    else:
+        # v2 emitted exactly the single best (highest score).
+        candidates.sort(key=lambda x: x["score"], reverse=True)
+        best = candidates[0]
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"],
+                  "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best["reasons"]}
+        print(f"[hedgehog.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+              f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons']}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — flat per leg; runtime sizes the dollars
+            "leverage": leverage,             # 1..5; runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "trend4h": best["trend_4h"],
+                "trend4hStrength": best["trend_4h_strength"],
+                "trend1h": best["trend_1h"],
+                "smDirection": best["sm_direction"] or "NEUTRAL",
+                "smTiltPct": best["sm_tilt_pct"],
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + this tick's result every tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[hedgehog.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/hedgehog/main/scanners/scoring.py
+++ b/strategies/hedgehog/main/scanners/scoring.py
@@ -1,0 +1,102 @@
+"""HEDGEHOG — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 HEDGEHOG producer's `trend_structure`
++ `build_thesis` scoring (hedgehog-producer.py v1.0.1 / SKILL.md v1.0.0).
+The math/indexing is reproduced VERBATIM so a fidelity harness can diff this
+against the v2 producer on the same market snapshot.
+
+HEDGEHOG is an equal-weight BTC + ETH + SOL basket; each asset is evaluated
+INDEPENDENTLY (long OR short) on a hard-gated 4h trend + Smart-Money direction
+thesis. Unlike Bison (all factors are score contributors), HEDGEHOG has HARD
+GATES — if the 4h trend is NEUTRAL, or SM doesn't agree with the 4h direction,
+or SM tilt is below the floor, the thesis is rejected (returns None).
+
+Multi-asset, single-pass, unit-testable on plain candle lists. `sm` (smart-money
+lean) is fetched by the caller and passed in, so this module stays pure."""
+
+
+def _f(c, primary, alt=None, default=0.0):
+    """Verbatim port of v2 producer `_f`: pull primary key, fall back to alt,
+    coerce to float, default on failure."""
+    val = c.get(primary) if isinstance(c, dict) else None
+    if val is None and alt:
+        val = c.get(alt) if isinstance(c, dict) else None
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim from v2.
+
+    v2-quirk: counting uses STRICT > comparisons, the BULLISH/BEARISH gate is
+    `>= total * 0.6` where total = lookback - 1, and the returned strength is
+    higher_lows/total (BULLISH) or lower_highs/total (BEARISH). Reproduced
+    exactly."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_f(c, "low", "l") for c in candles[-lookback:]]
+    highs = [_f(c, "high", "h") for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def build_thesis(coin, candles_1h, candles_4h, sm, inputs):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    HARD GATES (any failure -> None, verbatim from v2):
+      - fewer than 6x 1h candles OR 6x 4h candles,
+      - 4h trend NEUTRAL,
+      - SM direction not LONG/SHORT, or SM direction != 4h direction,
+      - SM tilt < smTiltMinPct.
+
+    `sm` is the smart-money tuple (direction, tilt_pct) or (None, 0.0) — the
+    caller fetches it (fetch_sm_direction). minScore is NOT applied here; the
+    caller gates on thesis['score'] (v2 main() did the same)."""
+    sm_min = float(inputs.get("smTiltMinPct", 55))
+    sm_strong = float(inputs.get("smStrongTiltPct", 70))
+
+    if len(candles_4h) < 6 or len(candles_1h) < 6:
+        return None
+
+    t4, s4 = trend_structure(candles_4h)
+    t1, _ = trend_structure(candles_1h)
+    if t4 == "NEUTRAL":
+        return None
+
+    direction = "LONG" if t4 == "BULLISH" else "SHORT"
+
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    # Score (max ~9), verbatim from v2 build_thesis:
+    #   +3 4h trend (gate-confirmed)
+    #   +2 1h trend confirms 4h direction
+    #   +2 SM aligned (always granted once the SM gate passes)
+    #   +1 SM strongly tilted (>= smStrongTiltPct)
+    score = 3
+    reasons = [f"4h_{t4.lower()}_{s4:.0%}"]
+    if (direction == "LONG" and t1 == "BULLISH") or (direction == "SHORT" and t1 == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirms_{t1.lower()}")
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    return {
+        "coin": coin, "direction": direction, "score": score, "reasons": reasons,
+        "trend_4h": t4, "trend_4h_strength": round(s4, 4), "trend_1h": t1,
+        "sm_direction": sm_dir, "sm_tilt_pct": round(_f({"v": sm_tilt}, "v"), 2),
+    }

--- a/strategies/hedgehog/strategy.yaml
+++ b/strategies/hedgehog/strategy.yaml
@@ -1,0 +1,42 @@
+# Hedgehog — equal-weight major-crypto basket (BTC/ETH/SOL), each leg independently
+# directional. A single-instance PACKAGE: this manifest + one self-contained
+# runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2 HEDGEHOG (SKILL.md
+# v1.0.0): hard-gated 4h-trend + Smart-Money direction per asset, flat 10% margin per
+# leg, up to 3 simultaneous positions, per-position DSL exits.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: hedgehog
+version: "1.0.0"
+
+catalog:
+  name: "Hedgehog — Major Crypto Basket"
+  emoji: "🦔"
+  tagline: "Equal-weight BTC + ETH + SOL, each leg independently directional: every asset gets its own Smart-Money-confirmed 4h-trend signal (long OR short), so it can hold BTC long and ETH short at the same time — three slots, three independent positions, each with its own per-position stop."
+  belief_plain: "Trades only the three biggest crypto majors (BTC, ETH, SOL), one position per coin. For each coin it waits until the 4-hour trend and the best traders agree on the same direction before entering — going long if they're bullish, short if they're bearish — and manages each position on its own, so one coin going wrong doesn't drag the others down."
+  thesis: "Most basket strategies force the same direction across every asset; Hedgehog doesn't. Each of BTC/ETH/SOL gets its own independent Smart-Money-confirmed 4h-trend decision, so the diversification benefit is real — the per-asset directions are uncorrelated by construction. For a new user who wants 'exposure to crypto majors without picking one,' Hedgehog does the picking: it enters when the gates pass and lets a per-position DSL ratchet ride each leg on its own merits."
+  group: momentum
+  archetype: trend_following
+  sub_style: basket
+  asset_classes: [major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: conservative
+  tier: starter
+  leverage_max: 5
+  max_slots: 3
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL"]
+  tags: [btc, eth, sol, multi-asset, basket, momentum, smart-money, directional, onboarding, per-position-dsl]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: HEDGEHOG_WALLET
+    funding_share: 1.0

--- a/strategies/lemon/main/runtime.yaml
+++ b/strategies/lemon/main/runtime.yaml
@@ -1,0 +1,146 @@
+# ── LEMON · single instance — Degen Fader (Runtime 3.0 port of v2 Lemon v2.0.1) ──
+# Counter-trades a crowded, EXHAUSTING smart-money consensus on a fixed basket of 12
+# crypto majors + 4 XYZ commodity/index names. Emits the OPPOSITE direction to the SM
+# crowd (fade). Two-gate trend filter (MACRO_TREND_GATE crypto-only |BTC 4h|>3%,
+# PER_ASSET_TREND_GATE |asset 4h|>5%), MIN_SCORE 9, conviction leverage 5/7/10x capped
+# at 10x, MARGIN_PCT 30%. DSL is the ONLY exit — wide tiers give the reversal time to
+# mean-revert. Faithful port of the v2 producer thesis (all scoring/thresholds verbatim).
+name: lemon-main
+group: lemon
+version: 3.0.0
+description: >
+  LEMON — Degen Fader. Filters the smart-money leaderboard board to a fixed basket
+  (12 crypto majors + BRENTOIL/CL/GOLD/SP500) and fades a crowded consensus once it
+  starts exhausting (15m contribution <= 0.1, ideally collapsing). Scores the fade on
+  SM concentration, 15m/1h/4h velocity fade, 4h overextension, 1h reversal, funding,
+  and US-session; two trend gates block fading a real run (crypto MACRO |BTC 4h|>3%,
+  per-asset |4h|>5%). Emits ONE fade (opposite the crowd) at score >=9, leverage
+  5/7/10x by conviction (capped 10x), 30% margin, one slot. DSL is the ONLY exit (wide
+  tiers, first lock +5%/20%). Faithful port of the v2 Lemon v2.0.1 thesis.
+
+strategy:
+  wallet: "${LEMON_WALLET}"
+  slots: 1                                  # v2 slots:1 (1-slot fader)
+  margin_pct: 30                            # baseline %; scan emits the per-signal marginPct
+  default_leverage: 5                       # fallback; scan emits 5/7/10x per signal (v2 DEFAULT_LEVERAGE=5)
+  trading_risk: moderate                    # v2 runtime.yaml trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: lemon_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                    # v2 producer cadence (5 min)
+    timeout_seconds: 120                     # v2 tick_timeout=120; markets board + 1 funding read/candidate
+    default_signal_validity_seconds: 600     # 2x tick; a fresh re-score arrives next tick
+    state_history_max_count: 100             # per-asset cooldown map + per-tick scan results
+    inputs:
+      # ── universe (v2 TRACKED_CRYPTO + TRACKED_XYZ; v2 "SPX" -> live HL "SP500") ──
+      trackedCrypto: ["BTC", "ETH", "SOL", "HYPE", "AVAX", "DOGE", "LINK", "XRP", "ADA", "NEAR", "UNI", "AAVE"]
+      trackedXyz: ["BRENTOIL", "CL", "GOLD", "SP500"]
+      minScore: 9                            # v2 MIN_SCORE
+      marginPct: 30                          # PERCENT of withdrawable (0,100]; v2 MARGIN_PCT=0.30 (30%)
+      maxPositions: 1                        # producer-side held/slot guard (mirrors slots:1)
+      xyzBanned: false                       # v2 XYZ_BANNED=False — XYZ commodity/index names ARE faded
+      leaderboardLimit: 100                  # v2 fetch_sm_data limit=100
+      # ── fade gates / thresholds (v2 producer constants, verbatim) ──
+      minSmPct: 3.0                          # v2 MIN_SM_PCT
+      minSmTraders: 20                       # v2 MIN_SM_TRADERS
+      macroGateBtc4hPct: 3.0                 # v2 MACRO_GATE_BTC_4H_PCT (crypto-only)
+      perAssetGate4hPct: 5.0                 # v2 PER_ASSET_GATE_4H_PCT (2026-05-14 HYPE post-mortem)
+      # ── leverage (v2 LEVERAGE_TIERS [min_score, leverage] desc; MAX_LEVERAGE=10) ──
+      leverageTiers: [[13, 10], [11, 7], [9, 5]]
+      maxLeverage: 10                        # v2 MAX_LEVERAGE hard clamp
+      # ── per-asset cooldown (v2 producer backstop; runtime gate is primary) ──
+      perAssetCooldownSeconds: 7200          # v2 is_asset_cooled_down 120 min -> 7200s
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      isXyz: { type: boolean, required: false }
+      smDirection: { type: string, required: false }
+      smPct: { type: number, required: false }
+      smTraders: { type: number, required: false }
+      priceChg4h: { type: number, required: false }
+      contrib15m: { type: number, required: false }
+      reasons: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: lemon_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                      # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [lemon_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT        # v2 entry order_type
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true      # v2 entry ensure_execution_as_taker
+        execution_timeout_seconds: 60        # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: lemon_main_signals
+
+# ── EXIT (DSL — ported VERBATIM from v2 runtime.yaml) ─────────────────────────
+# Wide-by-design so a fade has time to mean-revert. hard_timeout 480m (8h), tighter
+# Phase-1 floor (15%, "fades fail fast") than the fleet 25%, and a graduated Phase-2
+# ladder whose FIRST lock at +5%/20% is REACHABLE (not >+40%) — no unreachable-DSL
+# flag needed. weak_peak_cut + dead_weight_cut KEPT as in v2 (basket fader, not a
+# single-asset agent — the time-cut-off rule applies to single-asset agents only).
+exit:
+  engine: dsl
+  interval_seconds: 30                       # v2 exit interval_seconds
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 480               # 8h — mean reversion can take hours (v2)
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 60
+      min_value: 2.0                         # cut if peak ROE never breaks 2% in 60m (v2)
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 45                # cut early stallers (v2)
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0                      # v2: tighter than fleet 25% — fades fail fast
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                 # v2 ladder (verbatim); first lock +5%/20% (reachable)
+        - { trigger_pct: 5,  lock_hw_pct: 20 }
+        - { trigger_pct: 10, lock_hw_pct: 40 }
+        - { trigger_pct: 15, lock_hw_pct: 60 }
+        - { trigger_pct: 20, lock_hw_pct: 75 }
+        - { trigger_pct: 30, lock_hw_pct: 85 }
+        - { trigger_pct: 50, lock_hw_pct: 92 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200             # v2 data_retention_hours 72 -> 259200s (within [3600, 604800])
+  guard_rails:
+    daily_loss_limit_pct: 15                 # v2 daily_loss_limit_pct
+    max_entries_per_day: 3                    # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false   # v2
+    max_consecutive_losses: 3                # v2 max_consecutive_losses
+    cooldown_seconds: 3600                    # v2 cooldown_minutes 60 -> 3600s
+    drawdown_halt_pct: 25                     # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false     # v2
+    per_asset_cooldown_seconds: 7200          # v2 per_asset_cooldown_minutes 120 -> 7200s
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/lemon/main/scanners/scan.py
+++ b/strategies/lemon/main/scanners/scan.py
@@ -1,0 +1,332 @@
+"""LEMON — supervised scanner (Runtime 3.0 port of the v2 Lemon "Degen Fader").
+
+BASKET fader. Per tick it:
+  - reads the account + held set (clearinghouse; dual-DEX equity via max(), never
+    sum(); plus the v2 read-sanity guard),
+  - fetches the smart-money leaderboard markets board and filters it to the fixed
+    TRACKED_ASSETS basket (12 crypto majors + 4 XYZ commodity/index names; XYZ is
+    NOT banned — v2 producer XYZ_BANNED=False),
+  - derives BTC 4h (crypto-only MACRO_TREND_GATE input),
+  - for each non-held, non-cooled-down candidate: scores the CONTRARIAN fade via the
+    pure `scoring.evaluate_fade` (with a read-guarded per-asset funding fetch and the
+    US-session clock bonus hoisted in),
+  - emits the SINGLE highest-scoring fade (v2 main() emitted only `best`), sized at
+    MARGIN_PCT (PERCENT) with conviction-tiered leverage (5/7/10x, clamped to 10x).
+
+The emitted `direction` is the OPPOSITE of the SM consensus by design — Lemon fades
+the crowd. Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus a
+`leverage`; the runtime sizes the dollars, owns slots/dedup/risk gates, and trails
+the DSL exit. No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs lemon-producer.py v2.0.1:
+  - v2 computed two contributors INSIDE evaluate_fade that require I/O or the clock:
+    the per-asset funding read (market_get_asset_data) and the US-session check
+    (datetime.utcnow()). To keep scoring.py pure, scan.py fetches funding (read-
+    guarded; None on failure => the +1 funding bonus simply can't fire, matching v2's
+    try/except: pass) and computes us_session, then passes both into evaluate_fade.
+    The scoring math is otherwise byte-for-byte the v2 logic.
+  - v2 SKILL.md is STALE (describes v1.1: XYZ_BANNED=True, MIN_SCORE 8, leverage to
+    20x, margin 50%). The PRODUCER + config + runtime.yaml are the truth and are what
+    this port reproduces: XYZ_BANNED=False, MIN_SCORE 9, leverage tiers 5/7/10 capped
+    at 10x, MARGIN_PCT 30%, plus the PER_ASSET_TREND_GATE the SKILL never mentions.
+  - v2 TRACKED_XYZ listed "SPX", but the live HL XYZ DEX / leaderboard token for the
+    S&P is "SP500" (HL meta has no "SPX"). With v2's list, "SPX" could NEVER match a
+    live market token, so that name was DEAD in v2. This port uses the live symbol
+    "SP500" so the S&P is actually tradeable. FLAGGED in the report.
+  - v2 per-asset cooldown (cfg.is_asset_cooled_down, 120 min, Python state file) is
+    reproduced in ctx.state here (the runtime also enforces per_asset_cooldown_seconds
+    7200 as the primary gate; this is the producer-side backstop, verbatim TTL).
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1 signal/tick.
+  - v2 margin_usd = account_value * MARGIN_PCT (0.30) computed in the producer. The
+    Runtime 3.0 port emits a PERCENT marginPct (30) and lets the runtime size the
+    dollars off withdrawable — same intent, no hardcoded account read for sizing.
+"""
+
+import sys
+import time
+from datetime import datetime, timezone
+
+import scoring
+
+# v2 producer universe (lemon-producer.py v2.0.1 TRACKED_CRYPTO + TRACKED_XYZ).
+# NOTE: v2's "SPX" -> live HL XYZ symbol is "SP500" (see FIDELITY NOTES).
+_TRACKED_CRYPTO_DEFAULT = ["BTC", "ETH", "SOL", "HYPE", "AVAX", "DOGE", "LINK",
+                           "XRP", "ADA", "NEAR", "UNI", "AAVE"]
+_TRACKED_XYZ_DEFAULT = ["BRENTOIL", "CL", "GOLD", "SP500"]
+
+_DEFAULT_MIN_SCORE = 9                 # v2 MIN_SCORE
+_DEFAULT_MARGIN_PCT = 30.0             # v2 MARGIN_PCT=0.30 -> 30 PERCENT
+_DEFAULT_MAX_POSITIONS = 1            # v2 slots:1
+_DEFAULT_LEADERBOARD_LIMIT = 100      # v2 fetch_sm_data limit=100
+_DEFAULT_PER_ASSET_COOLDOWN = 7200    # v2 per_asset_cooldown 120 min -> 7200s
+_DEFAULT_TTL = 7200                   # signal-dedup TTL (mirror per-asset cooldown)
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll back
+    the whole tick. Returns None on failure so the degrade paths apply."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[lemon.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets pass dex='xyz'; main-DEX assets pass ''."""
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+# ── ACCOUNT + HELD ASSETS (port of v2 cfg.get_positions, verbatim shape) ──
+
+def _get_account(ctx):
+    """(account_value, [held_coin, ...]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across main/xyz
+    (two views of ONE cross-margined wallet — summing double-counts the shared free
+    balance -> 2x sizing). Includes the v2 read-sanity guard (margin in use + empty
+    positions -> skip tick) verbatim."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    held, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring.safe_float(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring.safe_float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            coin = pos.get("coin", "")
+            if coin:
+                held.append(coin)
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning an
+    # EMPTY positions list; sizing or running the held-asset dedup off that re-enters
+    # held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring.safe_float(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring.safe_float(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not held:
+        print("[lemon.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, held
+
+
+# ── MARKET FETCHING (port of v2 fetch_sm_data, verbatim parse + normalize) ──
+
+def _fetch_sm_map(ctx, limit, tracked, xyz_banned):
+    """Returns {TOKEN: normalized_market} filtered to `tracked` (uppercase). XYZ is
+    kept unless xyz_banned (v2 XYZ_BANNED=False). Canonical asset uses the 'xyz:'
+    prefix for XYZ-DEX names exactly as v2 built it."""
+    raw = _read(ctx, "leaderboard_get_markets", {"limit": limit})
+    if not raw:
+        return {}
+    markets = raw
+    if isinstance(markets, dict):
+        markets = markets.get("data", markets)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return {}
+
+    tracked_set = {t.upper() for t in tracked}
+    sm_map = {}
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", "")).upper()
+        dex = str(m.get("dex", "")).lower()
+        if xyz_banned and dex == "xyz":
+            continue
+        if token not in tracked_set:
+            continue
+        sm_map[token] = {
+            "asset": f"xyz:{token}" if dex == "xyz" else token,
+            "dex": dex,
+            "is_xyz": dex == "xyz",
+            "direction": str(m.get("direction", "")).upper(),
+            "pct": scoring.safe_float(m.get("pct_of_top_traders_gain", 0)),
+            "traders": int(m.get("trader_count", 0)),
+            "price_chg_4h": scoring.safe_float(m.get("token_price_change_pct_4h", 0)),
+            "price_chg_1h": scoring.safe_float(m.get("token_price_change_pct_1h",
+                                               m.get("price_change_1h", 0))),
+            "contrib_15m": scoring.safe_float(m.get("contribution_pct_change_15m", 0)),
+            "contrib_1h": scoring.safe_float(m.get("contribution_pct_change_1h", 0)),
+            "contrib_4h": scoring.safe_float(m.get("contribution_pct_change_4h", 0)),
+        }
+    return sm_map
+
+
+def _get_funding(ctx, canonical):
+    """Per-asset funding rate via market_get_asset_data, or None. READ-GUARDED — on
+    any failure return None so the +1 funding bonus simply doesn't fire (v2 wrapped
+    this exact read in try/except: pass). Ported from v2 evaluate_fade's inline call."""
+    ad = _read(ctx, "market_get_asset_data", {
+        "asset": canonical,
+        "candle_intervals": [],
+        "include_funding": True,
+        "include_order_book": False,
+        "dex": _dex_for(canonical),
+    })
+    if not ad:
+        return None
+    d = ad.get("data", ad) if isinstance(ad, dict) else ad
+    if not isinstance(d, dict):
+        return None
+    ac = d.get("asset_context", d.get("assetContext", {}))
+    if not isinstance(ac, dict):
+        return None
+    return scoring.safe_float(ac.get("funding", 0))
+
+
+# ── ctx.state: per-asset cooldown + signal dedup (port of v2 asset-cooldowns.json) ──
+
+def _load_state(ctx):
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    cooldowns = dict(last.get("cooldowns") or {})   # {TOKEN: ts}  (per-asset cooldown)
+    return cooldowns
+
+
+def _is_cooled_down(cooldowns, token, cooldown_seconds, now):
+    """True if `token` is still within its per-asset cooldown window (v2
+    is_asset_cooled_down semantics: blocked while elapsed < cooldown)."""
+    last_ts = cooldowns.get(token.upper(), 0)
+    if not last_ts:
+        return False
+    return (now - last_ts) < cooldown_seconds
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    tracked_crypto = inputs.get("trackedCrypto", _TRACKED_CRYPTO_DEFAULT)
+    tracked_xyz = inputs.get("trackedXyz", _TRACKED_XYZ_DEFAULT)
+    tracked = list(tracked_crypto) + list(tracked_xyz)
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))      # PERCENT (0,100]
+    # defensive: a pasted FRACTION (<=1.0) means margin was stored as 0.30 -> 30%.
+    if 0 < margin_pct <= 1.0:
+        margin_pct *= 100.0
+    max_positions = int(inputs.get("maxPositions", _DEFAULT_MAX_POSITIONS))
+    xyz_banned = bool(inputs.get("xyzBanned", False))                      # v2 XYZ_BANNED=False
+    leaderboard_limit = int(inputs.get("leaderboardLimit", _DEFAULT_LEADERBOARD_LIMIT))
+    tiers = inputs.get("leverageTiers", scoring.DEFAULT_LEVERAGE_TIERS)
+    max_leverage = int(inputs.get("maxLeverage", scoring.MAX_LEVERAGE))
+    cooldown_seconds = float(inputs.get("perAssetCooldownSeconds", _DEFAULT_PER_ASSET_COOLDOWN))
+
+    cooldowns = _load_state(ctx)
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"cooldowns": cooldowns, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[lemon.scan] WARNING: state append failed; next tick may re-emit: {exc!r}",
+                  file=sys.stderr)
+
+    # ── account + held set ──
+    account_value, held_assets = _get_account(ctx)
+    if account_value <= 0:
+        print("[lemon.scan] WAITING — no account value; skip tick", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_account"})
+        return []
+    held_set = {h.upper() for h in held_assets}
+
+    # ── max-positions guard (1-slot fader) ──
+    if len(held_set) >= max_positions:
+        print(f"[lemon.scan] WAITING — riding open position(s): {sorted(held_set)}",
+              file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "max_positions",
+                  "held": sorted(held_set)})
+        return []
+
+    # ── SM markets board (filtered to the basket) ──
+    sm_map = _fetch_sm_map(ctx, leaderboard_limit, tracked, xyz_banned)
+    if not sm_map:
+        print("[lemon.scan] WAITING — no SM market data; skip tick", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_markets"})
+        return []
+
+    # BTC 4h for the crypto-only MACRO_TREND_GATE (v2 main()).
+    btc_4h = scoring.safe_float(sm_map.get("BTC", {}).get("price_chg_4h", 0))
+
+    # US session bonus input (v2 used datetime.utcnow().hour in evaluate_fade).
+    hour = datetime.now(timezone.utc).hour
+    us_session = 13 <= hour <= 21
+
+    # ── score each tracked candidate (held + cooldown filtered BEFORE scoring, v2 main()) ──
+    candidates = []
+    scanned = 0
+    for token, sm in sm_map.items():
+        if _is_cooled_down(cooldowns, token, cooldown_seconds, now):
+            continue
+        # skip if the canonical (possibly xyz:-prefixed) asset is held in any direction
+        if sm["asset"].upper() in held_set or token in held_set:
+            continue
+        scanned += 1
+        funding = _get_funding(ctx, sm["asset"])   # None => funding bonus can't fire
+        c = scoring.evaluate_fade(sm, btc_4h, funding, us_session, inputs)
+        if c is not None and c["score"] >= min_score:
+            candidates.append(c)
+
+    if not candidates:
+        print(f"[lemon.scan] WAITING — no fade signal (min score {min_score:.0f}); "
+              f"scanned={scanned} btc_4h={btc_4h:.2f} held={sorted(held_set)}",
+              file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_candidate",
+                  "scanned": scanned, "btc_4h": round(btc_4h, 3),
+                  "held": sorted(held_set)})
+        return []
+
+    # ── pick the single strongest fade (v2 main() emits only `best`) ──
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+    leverage = scoring.get_leverage_for_score(best["score"], tiers, max_leverage)
+
+    cooldowns[best["asset"].upper()] = now
+    # also key the bare token (XYZ canonical is 'xyz:NAME' but the board token is bare)
+    cooldowns[best["asset"].upper().replace("XYZ:", "")] = now
+
+    print(f"[lemon.scan] EMIT {best['asset']} {best['direction']} (fade {best['smDirection']}) "
+          f"score={best['score']} {leverage}x marginPct={margin_pct:.1f}% | {best['reasons'][:6]}",
+          file=sys.stderr)
+    _persist({"ts": now, "emitted": True, "asset": best["asset"],
+              "direction": best["direction"], "score": best["score"],
+              "leverage": leverage, "candidates": len(candidates),
+              "scanned": scanned, "btc_4h": round(btc_4h, 3)})
+
+    return [{
+        "asset": best["asset"],
+        "direction": best["direction"],            # FADE direction (opposite of SM) — by design
+        "marginPct": margin_pct,                   # PERCENT in (0,100] — runtime sizes the dollars
+        "leverage": leverage,                      # 5/7/10x by score; runtime applies + clamps
+        "data": {
+            "score": best["score"],
+            "leverage": leverage,
+            "direction": best["direction"],
+            "isXyz": bool(best["is_xyz"]),
+            "smDirection": best["smDirection"],
+            "smPct": float(best["smPct"]),
+            "smTraders": int(best["smTraders"]),
+            "priceChg4h": float(best["priceChg4h"]),
+            "contrib15m": float(best["contrib15m"]),
+            "reasons": best["reasons"],
+            "heldAssets": sorted(held_set),
+        },
+    }]

--- a/strategies/lemon/main/scanners/scoring.py
+++ b/strategies/lemon/main/scanners/scoring.py
@@ -1,0 +1,196 @@
+"""LEMON — pure thesis math (no I/O, no MCP, no clock-dependent reads).
+
+A faithful Runtime 3.0 port of the v2 Lemon producer's `evaluate_fade` +
+`get_leverage_for_score` (lemon-producer.py v2.0.1). The scoring, gates, leverage
+tiers, and direction-inversion are reproduced VERBATIM so a fidelity harness can
+diff this against the v2 producer on the same market snapshot. Behaviour-preserving
+quirks from v2 are kept and flagged `# v2-quirk`.
+
+LEMON is a DEGEN FADER: it counter-trades a crowded, exhausting smart-money
+consensus. The emitted `direction` is the OPPOSITE of the SM consensus by design
+(`fade_direction = SHORT if SM is LONG else LONG`).
+
+Pure module: `evaluate_fade` scores ONE normalized market dict. The two
+clock/MCP-dependent contributors the v2 producer computed INSIDE evaluate_fade are
+hoisted to the caller (scan.py) and passed in to keep this module pure:
+  - `funding`  : asset funding rate (v2 fetched market_get_asset_data inline) — None
+                 if the read failed (the +1 FUNDING_PAYS_FADE bonus then can't fire,
+                 exactly matching v2's try/except-pass degrade).
+  - `us_session`: whether the current UTC hour is 13..21 (v2 used datetime.utcnow()).
+The arithmetic, gate order, point weights, and thresholds are unchanged."""
+
+
+# ── v2 producer constants (verbatim from lemon-producer.py v2.0.1) ──
+MIN_SCORE = 9
+MACRO_GATE_BTC_4H_PCT = 3.0
+PER_ASSET_GATE_4H_PCT = 5.0          # 2026-05-14 HYPE +12.8% post-mortem gate
+MIN_SM_PCT = 3.0
+MIN_SM_TRADERS = 20
+
+# v2 LEVERAGE_TIERS (verbatim) — desc by min_score; DEFAULT_LEVERAGE=5 fallback,
+# MAX_LEVERAGE=10 hard clamp.
+DEFAULT_LEVERAGE_TIERS = [[13, 10], [11, 7], [9, 5]]
+DEFAULT_LEVERAGE = 5
+MAX_LEVERAGE = 10
+
+
+def safe_float(val, default=0.0):
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return default
+
+
+def get_leverage_for_score(score, tiers=None, max_leverage=MAX_LEVERAGE):
+    """v2 get_leverage_for_score — first tier whose min_score the candidate clears,
+    clamped to max_leverage. Falls back to DEFAULT_LEVERAGE (5) when no tier matches
+    (verbatim; a score below 9 can't reach here because MIN_SCORE gates candidates)."""
+    if tiers is None:
+        tiers = DEFAULT_LEVERAGE_TIERS
+    for t in tiers:
+        if score >= t[0]:
+            return min(int(t[1]), int(max_leverage))
+    return DEFAULT_LEVERAGE
+
+
+def evaluate_fade(sm, btc_4h, funding, us_session, thresholds=None):
+    """Score a fade for ONE normalized market dict `sm`. Returns a thesis dict (with
+    `score` and the FADE `direction`) or None when a hard gate rejects or the final
+    score < MIN_SCORE. Ported VERBATIM from v2 `evaluate_fade`.
+
+    `sm` keys (see scan._normalize_market): asset (canonical, may be 'xyz:NAME'),
+      is_xyz, direction (SM consensus), pct, traders, price_chg_4h, price_chg_1h,
+      contrib_15m, contrib_1h, contrib_4h.
+    `btc_4h`     : BTC 4h price change % (for the crypto-only MACRO_TREND_GATE).
+    `funding`    : asset funding rate, or None if unavailable (FUNDING bonus skipped).
+    `us_session` : bool — current UTC hour in [13, 21] (US_SESSION +1 bonus)."""
+    th = thresholds or {}
+    min_score = int(th.get("minScore", MIN_SCORE))
+    min_sm_pct = safe_float(th.get("minSmPct", MIN_SM_PCT))
+    min_sm_traders = int(th.get("minSmTraders", MIN_SM_TRADERS))
+    macro_gate = safe_float(th.get("macroGateBtc4hPct", MACRO_GATE_BTC_4H_PCT))
+    per_asset_gate = safe_float(th.get("perAssetGate4hPct", PER_ASSET_GATE_4H_PCT))
+
+    sm_direction = sm["direction"]
+    if sm_direction not in ("LONG", "SHORT"):
+        return None
+    fade_direction = "SHORT" if sm_direction == "LONG" else "LONG"
+
+    pct = sm["pct"]
+    traders = sm["traders"]
+    p4h = sm["price_chg_4h"]
+    p1h = sm["price_chg_1h"]
+    c15m = sm["contrib_15m"]
+    c1h = sm["contrib_1h"]
+    c4h = sm["contrib_4h"]
+
+    # ── HARD GATES (verbatim) ──
+    if pct < min_sm_pct or traders < min_sm_traders:
+        return None
+    # 15m must be fading (move exhausting)
+    if c15m > 0.1:
+        return None
+
+    # MACRO_TREND_GATE (crypto only; XYZ bypasses): don't fade during a BTC trend.
+    if not sm.get("is_xyz", False):
+        if abs(btc_4h) > macro_gate:
+            return None
+
+    # PER_ASSET_TREND_GATE (crypto + XYZ): 2026-05-14 HYPE +12.8% post-mortem. When
+    # the asset itself is in a strong directional run >= 5% over 4h AND the crowd is
+    # correctly riding it, the fade thesis fails — that's real trend, not exhaustion.
+    if sm_direction == "LONG" and p4h > per_asset_gate:
+        return None
+    if sm_direction == "SHORT" and p4h < -per_asset_gate:
+        return None
+
+    score = 0
+    reasons = []
+
+    # SM concentration tiers (+4 / +3 / +2 / +1)
+    if pct >= 20:
+        score += 4
+        reasons.append(f"DEGEN_PILE {pct:.1f}% ({traders}t) {sm_direction}")
+    elif pct >= 12:
+        score += 3
+        reasons.append(f"HEAVY_CROWD {pct:.1f}% ({traders}t) {sm_direction}")
+    elif pct >= 7:
+        score += 2
+        reasons.append(f"CROWDED {pct:.1f}% ({traders}t) {sm_direction}")
+    elif pct >= 3:
+        score += 1
+        reasons.append(f"LEANING {pct:.1f}% ({traders}t) {sm_direction}")
+
+    # 15m velocity exhaustion (+3 / +2 / +1)
+    if c15m < -2.0:
+        score += 3
+        reasons.append(f"15M_COLLAPSING {c15m:.2f}")
+    elif c15m < -0.5:
+        score += 2
+        reasons.append(f"15M_FADING {c15m:.2f}")
+    elif c15m < -0.1:
+        score += 1
+        reasons.append(f"15M_COOLING {c15m:.2f}")
+
+    # 1h velocity fading (+1)
+    if c1h < -0.5:
+        score += 1
+        reasons.append(f"1H_FADING {c1h:.2f}")
+
+    # 4h overextension in SM direction (+2 / +1)
+    if sm_direction == "LONG" and p4h > 3.0:
+        score += 2
+        reasons.append(f"OVEREXTENDED_LONG +{p4h:.1f}%")
+    elif sm_direction == "LONG" and p4h > 1.5:
+        score += 1
+        reasons.append(f"EXTENDED_LONG +{p4h:.1f}%")
+    elif sm_direction == "SHORT" and p4h < -3.0:
+        score += 2
+        reasons.append(f"OVEREXTENDED_SHORT {p4h:.1f}%")
+    elif sm_direction == "SHORT" and p4h < -1.5:
+        score += 1
+        reasons.append(f"EXTENDED_SHORT {p4h:.1f}%")
+
+    # 1h reversing toward the fade direction (+1)
+    if fade_direction == "LONG" and p1h > 0.1:
+        score += 1
+        reasons.append(f"1H_REVERSING +{p1h:.2f}%")
+    elif fade_direction == "SHORT" and p1h < -0.1:
+        score += 1
+        reasons.append(f"1H_REVERSING {p1h:.2f}%")
+
+    # 4h SM contribution weakening (+1)
+    if c4h < -1.0:
+        score += 1
+        reasons.append(f"4H_SM_WEAKENING {c4h:.1f}")
+
+    # Funding alignment (+1) — funding pays the fade side. None => read failed, skip
+    # (v2 wrapped this in try/except: pass, so an unavailable funding never fires it).
+    if funding is not None:
+        if fade_direction == "SHORT" and funding > 0.0002:
+            score += 1
+            reasons.append(f"FUNDING_PAYS_FADE +{funding * 100:.4f}%")
+        elif fade_direction == "LONG" and funding < -0.0002:
+            score += 1
+            reasons.append(f"FUNDING_PAYS_FADE {funding * 100:.4f}%")
+
+    # US session (+1) — 13..21 UTC (caller computes from the clock)
+    if us_session:
+        score += 1
+        reasons.append("US_SESSION")
+
+    if score < min_score:
+        return None
+
+    return {
+        "asset": sm["asset"],
+        "is_xyz": sm.get("is_xyz", False),
+        "direction": fade_direction,
+        "score": score,
+        "reasons": reasons,
+        "smDirection": sm_direction,
+        "smPct": pct,
+        "smTraders": traders,
+        "priceChg4h": p4h,
+        "contrib15m": c15m,
+    }

--- a/strategies/lemon/strategy.yaml
+++ b/strategies/lemon/strategy.yaml
@@ -1,0 +1,42 @@
+# Lemon — the Degen Fader. A single-instance PACKAGE: this manifest + one self-contained
+# runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2 Lemon (lemon-producer.py
+# v2.0.1): filters the smart-money leaderboard board to a fixed basket (12 crypto majors +
+# 4 XYZ commodity/index names) and FADES a crowded consensus once it starts exhausting,
+# entering OPPOSITE the crowd. MIN_SCORE 9, two trend gates, conviction leverage 5/7/10x,
+# 30% margin, one slot, DSL-only exits. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: lemon
+version: "1.0.0"
+
+catalog:
+  name: "Lemon — Degen Fader"
+  emoji: "🍋"
+  tagline: "Watches where the worst, most crowded traders are piling in across a fixed basket of 12 crypto majors and 4 commodity/index names — and once that one-sided crowd stops following through (its 15-minute momentum rolls over), takes the OTHER side at conviction-scaled leverage and lets a wide ratcheting stop ride the snap-back."
+  belief_plain: "When a lot of low-quality traders crowd hard onto one side of a coin and the move starts running out of steam, that crowd usually gets unwound. Lemon waits for the crowding to actually start fading on the 15-minute clock, blocks the trade if it's really a genuine trend (big BTC move or the asset itself ripping), then bets the OPPOSITE direction and trails a wide stop while the over-stretched move mean-reverts."
+  thesis: "Hyperliquid is full of high-leverage retail that piles into exhausted moves. A crowded smart-money consensus is only a fade setup once it STOPS following through — so Lemon gates on 15m exhaustion, not just crowding, and refuses to fade a real run (crypto MACRO gate on |BTC 4h|>3%, per-asset gate on |4h|>5%) because fading genuine trend is how a contrarian dies. Concentration + velocity-fade + overextension + reversal compound into a score; it fires the single best fade at score >=9, sizes leverage to conviction, and lets a wide DSL ride the mean reversion since reversals take hours, not minutes."
+  group: contrarian
+  archetype: contrarian_fade
+  sub_style: sm_crowding
+  asset_classes: [major_alts, commodities, indices]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 10
+  max_slots: 1
+  min_budget: 100
+  assets: ["BTC", "ETH", "SOL", "HYPE", "AVAX", "DOGE", "LINK", "XRP", "ADA", "NEAR", "UNI", "AAVE", "xyz:BRENTOIL", "xyz:CL", "xyz:GOLD", "xyz:SP500"]
+  tags: [degen-fader, contrarian, smart-money, crowd-exhaustion, mean-reversion, fade, basket, conviction-leverage, single-slot, xyz]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: LEMON_WALLET
+    funding_share: 1.0

--- a/strategies/lynx/main/runtime.yaml
+++ b/strategies/lynx/main/runtime.yaml
@@ -1,0 +1,146 @@
+# ── LYNX · single instance — adaptive MIN_SCORE self-tuner (Runtime 3.0 port of v2 Lynx v1.0.0) ──
+# Multi-asset momentum scorer on liquid majors (BTC/ETH/SOL/HYPE; max ~8 score).
+# Every auditEverySec (default 6h) the scanner pulls its OWN closed-trade history via
+# audit_query, buckets by entry score, and RAISES the adaptive MIN_SCORE above any
+# bucket at-or-above the floor that is bleeding (the Vulture v4.1 manual cull, on a
+# cron). Ratchets UP only; hard cap at maxMinScore. Floor + adjustment log persist in
+# ctx.state. DSL is the ONLY exit ("let winners run" — innovation is in entry, not
+# exit). Faithful port — scoring + self-tuning math reproduced verbatim in scanners/.
+name: lynx-main
+group: lynx
+version: 1.0.0
+description: >
+  LYNX — adaptive MIN_SCORE self-tuner. A multi-asset momentum scorer on liquid
+  majors (BTC/ETH/SOL/HYPE): 4h trend strength (+3/+2/+1), 1h confirmation (+2),
+  smart-money alignment (+2), volume rising (+1); max ~8. Every 6h it audits its own
+  closed-trade history (audit_query), buckets trades by the entry score logged in
+  ai_reasoning, and auto-raises MIN_SCORE above any bucket at-or-above the floor with
+  >= minBucketN samples and avg ROE < bleed threshold. Raise-only (a floor that
+  worked is never relaxed), capped at maxMinScore (7). Emits ONE signal/tick for the
+  highest-scoring candidate that clears the current floor. 1-5x leverage (default 3),
+  20% margin. DSL is the ONLY exit — wide "let winners run" ladder (first lock at +10%
+  ROE). Faithful port of the v2 Lynx v1.0.0 thesis (scoring + self-tuning verbatim).
+
+strategy:
+  wallet: "${LYNX_WALLET}"
+  slots: 1                                # v2 single-best emit, one position
+  margin_pct: 20                          # baseline %; scan emits per-signal marginPct
+  default_leverage: 3                     # fallback; scan emits 1-5x per signal (clamped to MAX_LEVERAGE 5)
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: lynx_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 180                   # account + 1 read/asset + sm/asset + (audit_query when due); v2 tick_timeout=240, sized down to actual reads
+    default_signal_validity_seconds: 600   # 2x tick; a fresh re-score arrives next tick
+    state_history_max_count: 100           # adaptive floor + audit log + dedup map + per-tick scan results
+    inputs:
+      whitelist: ["BTC", "ETH", "SOL", "HYPE"]   # v2 whitelist (validated live on HL main DEX 2026-06-29)
+      # ── momentum scorer ──
+      initialMinScore: 4                   # v2 initialMinScore (permissive — feeds the auditor)
+      smTiltMinPct: 55                     # v2 smTiltMinPct (SM-alignment gate)
+      marginPct: 20                        # PERCENT of withdrawable (0,100]; <=1.0 treated as a fraction (x100)
+      leverage: 3                          # v2 leverage; clamped to [1,5] in scan.py (MAX_LEVERAGE)
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+      # ── self-tuning audit (archetype #15) ──
+      # auditUserId enables the audit. Empty -> audit skipped, floor stays at
+      # initialMinScore forever (v2 behaviour). Find it via user_get_me / arena_leaderboard.
+      # NOT hardcoded — operator sets it per install (defaults to env LYNX_AUDIT_USER_ID).
+      auditUserId: "${LYNX_AUDIT_USER_ID}"
+      maxMinScore: 7                       # v2 maxMinScore — HARD ceiling; never tunes above
+      auditEverySec: 21600                 # v2 auditEverySec (6h between audits)
+      auditLimit: 200                      # v2 auditLimit (max closed-position records/audit)
+      minBucketN: 8                        # v2 minBucketN (min samples in a bucket to act)
+      bucketBleedThresholdPct: -1.0        # v2 bucketBleedThresholdPct (bucket avg ROE below -> cull)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      currentMinScore: { type: number, required: false }
+      trend4hPct: { type: number, required: false }
+      trend1hPct: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      volRising: { type: boolean, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: lynx_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan applied the (adaptive) floor; v2 LLM gate was pass-through
+    scanners: [lynx_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # v2 entry: taker fallback so a momentum entry never rests + silently misses the move
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: lynx_main_signals
+
+# ── EXIT (DSL — let-winners-run preset, ported VERBATIM from v2 runtime.yaml) ──────
+# Standard momentum-class let-winners-run. The Lynx innovation is in ENTRY selection
+# (the adaptive floor), not exit management — exits use the proven wide ladder.
+# hard_timeout 7d fail-safe; weak_peak_cut + dead_weight_cut OFF; Phase 1 max_loss 20%
+# / retrace 12; Phase 2 ladder FIRST lock at +10% ROE (reachable) -> +100%/85%.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # v2: enabled — 7d fail-safe
+      interval_in_minutes: 10080           # 7d
+    weak_peak_cut:
+      enabled: false                       # v2: disabled
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                       # v2: disabled
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0                    # v2 phase1.max_loss_pct
+      retrace_threshold: 12                 # v2 phase1.retrace_threshold
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # v2 phase2 ladder (verbatim) — first lock at +10% ROE
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 35,  lock_hw_pct: 50 }
+        - { trigger_pct: 60,  lock_hw_pct: 70 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 604800           # v2 data_retention_hours 168 -> 604800s (7d; at the [3600,604800] ceiling)
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 daily_loss_limit_pct
+    max_entries_per_day: 4                  # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false  # v2 bypass_max_entries_per_day_on_profit
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 cooldown_minutes 60 -> 3600s
+    drawdown_halt_pct: 22                  # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false  # v2 drawdown_reset_on_day_rollover
+    per_asset_cooldown_seconds: 14400      # v2 per_asset_cooldown_minutes 240 -> 14400s (4h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/lynx/main/scanners/scan.py
+++ b/strategies/lynx/main/scanners/scan.py
@@ -1,0 +1,438 @@
+"""LYNX — supervised scanner (Runtime 3.0 port of the v2 Lynx adaptive self-tuner).
+
+Multi-asset, whitelist-gated (BTC/ETH/SOL/HYPE by default). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - runs the SELF-TUNING AUDIT if due (every auditEverySec, default 6h): pulls its
+    OWN closed-trade history via audit_query, buckets by the entry score parsed from
+    each trade's ai_reasoning, and RAISES the adaptive MIN_SCORE above any bucket at
+    or above the current floor that is bleeding (n >= minBucketN, avg ROE < bleed
+    threshold). Ratchets UP only; caps at maxMinScore. The new floor + adjustment log
+    persist in ctx.state across ticks (v2 persisted them in lynx-state.json),
+  - scores every non-held, non-recently-signaled candidate via the pure
+    `scoring.build_thesis` using the CURRENT adaptive floor,
+  - emits the SINGLE highest-scoring candidate (v2 main() emitted only `best`),
+    sized by marginPct (PERCENT) + leverage.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`; the
+runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit. No
+daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs the v2 producer (lynx-producer.py v1.0.1):
+  - v2 persisted the adaptive floor + audit history in lynx-state.json (current_min_
+    score, last_audit_at, audit_count, adjustments). This port persists the SAME
+    fields in ctx.state (carried in the per-tick record under "lynx"). Semantics are
+    identical: first tick seeds current_min_score from initialMinScore; the audit
+    runs only when (now - last_audit_at) >= auditEverySec; raises are logged forever.
+    DEVIATION (unavoidable): ctx.state is BOUNDED (state_history_max_count); the v2
+    JSON adjustments log was unbounded. With a 6h audit cadence and a 200-record
+    bound, the full adjustment history is retained for well over a month of raises —
+    in practice unbounded for the floor's purpose. Each tick carries the latest
+    cumulative adjustments list forward so it is never lost to record eviction.
+  - v2 `senpiUserId` (config) gates the audit; this port reads it from inputs
+    (auditUserId). If absent, the audit is skipped (floor stays at initialMinScore)
+    exactly as in v2 — momentum scoring still runs. The wallet/user id are NOT
+    hardcoded (inputs / ${LYNX_WALLET} env via ctx.wallet).
+  - v2 build_thesis applied MIN_SCORE internally (returned None below floor). Port
+    preserves that — scoring.build_thesis takes current_min_score and gates on it.
+    scan() does NOT re-gate; it just collects non-None theses.
+  - v2 emitted exactly one signal (best, sorted by (score, |trend_4h|)). Preserved.
+  - v2 recent-signals JSON cache (240s TTL) -> ctx.state dedup map (same TTL).
+  - v2 marginPct was a FRACTION (0.20) * account_value -> marginUsd. This port emits
+    `marginPct` as a PERCENT (20); the runtime sizes (marginPct/100)*withdrawable.
+    The "<=1.0 means a pasted fraction, x100" guard normalizes a fraction default.
+  - v2 leverage default 3, clamped to MAX_LEVERAGE 5. Preserved (clamp [1,5]).
+  - v2 score normalization for the wire (score/8.0) is dropped — the contract takes
+    the raw score on data{}; the runtime owns any [0,1] normalization.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v2 defaults (lynx-producer.py / lynx-config.json)
+_WHITELIST_DEFAULT = ["BTC", "ETH", "SOL", "HYPE"]
+_DEFAULT_RECENT_TTL = 240            # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+_MAX_LEVERAGE = 5                    # v2 MAX_LEVERAGE (hardcoded clamp)
+_DEFAULT_LEVERAGE = 3               # v2 DEFAULT_LEVERAGE
+_DEFAULT_INITIAL_MIN_SCORE = 4      # v2 DEFAULT_INITIAL_MIN_SCORE (permissive — feeds the auditor)
+_DEFAULT_MAX_MIN_SCORE = 7          # v2 DEFAULT_MAX_MIN_SCORE — hard ceiling
+_DEFAULT_AUDIT_EVERY_SEC = 21600    # v2 DEFAULT_AUDIT_EVERY_SEC (6h)
+_DEFAULT_MIN_BUCKET_N = 8           # v2 DEFAULT_MIN_BUCKET_N
+_DEFAULT_BUCKET_BLEED_PCT = -1.0    # v2 DEFAULT_BUCKET_BLEED_PCT
+_DEFAULT_AUDIT_LIMIT = 200          # v2 DEFAULT_AUDIT_LIMIT
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    Lynx's default whitelist is all main-DEX majors, so this returns '' in practice."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+# ── account state (read-guarded; dual-DEX equity collapse + read-sanity guard) ──
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. account_value via max() across main/xyz (two views of ONE
+    cross-margined wallet — summing double-counts the shared free balance -> 2x
+    sizing). Ported verbatim from v2 cfg.get_positions, including the read-sanity
+    guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[lynx.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning an
+    # EMPTY positions list; sizing or running the held-asset dedup off that re-enters
+    # held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)), abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[lynx.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _get_sm_direction(ctx, coin):
+    """Port of v2 fetch_sm_direction: net smart-money lean for `coin` from
+    leaderboard_get_markets. Returns (direction, tilt_pct) or (None, 0). READ-GUARDED.
+
+    Verbatim v2 semantics: long_ratio >= 50 -> ("LONG", long_ratio), else
+    ("SHORT", 100 - long_ratio); both sides 0 -> ("NEUTRAL", 50); coin absent ->
+    (None, 0). The caller's sm_aligned gate requires tilt >= smTiltMinPct."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — smart-money is a score contributor; never crash the tick
+        print(f"[lynx.scan] leaderboard_get_markets read failed (smart-money -> neutral): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and raw.get("success") is False):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != coin.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+def _asset_data(ctx, coin):
+    """{candles{1h,4h}} for `coin` or None. READ-GUARDED.
+    Ported from v2 fetch_market_data (1h/4h, no funding/order book)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["1h", "4h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[lynx.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    return {"candles": d.get("candles", {}) or {}}
+
+
+def _fetch_closed_trades(ctx, user_id, limit):
+    """Pull closed-trade records via audit_query. Returns a list of
+    {score, roe_pct, ts} (best-effort extraction). READ-GUARDED — a failed read
+    yields [] so the audit simply finds no buckets and leaves the floor unchanged.
+    Ported from v2 fetch_closed_trades."""
+    if not user_id:
+        return []
+    try:
+        raw = ctx.senpi_mcp.call_tool("audit_query", {
+            "user_ids": [user_id],
+            "action_type": "close",
+            "limit": int(limit),
+        })
+    except Exception as exc:  # noqa: BLE001 — audit read must not roll back the tick
+        print(f"[lynx.scan] audit_query read failed (self-tune skipped this tick): {exc!r}",
+              file=sys.stderr)
+        return []
+    if not raw:
+        return []
+    d = raw.get("data", raw) if isinstance(raw, dict) else raw
+    entries = d if isinstance(d, list) else (d.get("entries", d.get("results", [])) if isinstance(d, dict) else [])
+    out = []
+    for e in entries or []:
+        if not isinstance(e, dict):
+            continue
+        reasoning = e.get("ai_reasoning") or e.get("reasoning") or ""
+        score = scoring.parse_score_from_reasoning(reasoning)
+        roe = e.get("roe_pct") or e.get("pnl_pct") or e.get("roi_pct")
+        try:
+            roe_v = float(roe) if roe is not None else 0.0
+        except (TypeError, ValueError):
+            roe_v = 0.0
+        ts = e.get("ts") or e.get("timestamp") or e.get("created_at")
+        out.append({"score": score, "roe_pct": roe_v, "ts": ts})
+    return out
+
+
+# ── self-tuning audit (the centerpiece) — operates on the persisted lynx state ──
+
+def _run_audit_if_due(ctx, lynx_state, inputs, now):
+    """If the audit interval has elapsed, pull closed trades, compute bucket stats,
+    and possibly RAISE current_min_score. Returns (updated_lynx_state, audit_summary
+    or None if skipped). Ported verbatim from v2 run_audit_if_due — the only change
+    is the data source (ctx.senpi_mcp audit_query vs cfg.mcp_call) and the state
+    carrier (ctx.state dict vs lynx-state.json)."""
+    audit_every = float(inputs.get("auditEverySec", _DEFAULT_AUDIT_EVERY_SEC))
+    last_audit_at = lynx_state.get("last_audit_at")
+    if last_audit_at is not None:
+        try:
+            if (now - float(last_audit_at)) < audit_every:
+                return lynx_state, None
+        except (TypeError, ValueError):
+            pass
+
+    user_id = (inputs.get("auditUserId") or "").strip() if isinstance(inputs.get("auditUserId"), str) else inputs.get("auditUserId")
+    if not user_id:
+        return lynx_state, {"skipped": "no auditUserId in inputs — self-tuning disabled (floor stays at initialMinScore)"}
+
+    initial_min = int(inputs.get("initialMinScore", _DEFAULT_INITIAL_MIN_SCORE))
+    trades = _fetch_closed_trades(ctx, user_id, int(inputs.get("auditLimit", _DEFAULT_AUDIT_LIMIT)))
+    bucket_stats = scoring.compute_bucket_stats(trades)
+    current_min = int(lynx_state.get("current_min_score") or initial_min)
+    min_n = int(inputs.get("minBucketN", _DEFAULT_MIN_BUCKET_N))
+    bleed_pct = float(inputs.get("bucketBleedThresholdPct", _DEFAULT_BUCKET_BLEED_PCT))
+    max_min = int(inputs.get("maxMinScore", _DEFAULT_MAX_MIN_SCORE))
+
+    recommended = scoring.recommend_min_score(bucket_stats, current_min, min_n, bleed_pct, max_min)
+    lynx_state = dict(lynx_state)
+    lynx_state["last_audit_at"] = float(now)
+    lynx_state["audit_count"] = int(lynx_state.get("audit_count", 0)) + 1
+
+    audit_summary = {
+        "trades_examined": len(trades),
+        "trades_with_score": sum(1 for t in trades if t.get("score") is not None),
+        "bucket_stats": {str(k): v for k, v in sorted(bucket_stats.items(), reverse=True)},
+        "current_min_score": current_min,
+        "recommended_min_score": recommended,
+        "updated": False,
+    }
+
+    if scoring.should_update_threshold(current_min, recommended):
+        adjustments = list(lynx_state.get("adjustments", []))
+        adjustments.append({
+            "ts": float(now),
+            "prev": current_min,
+            "new": recommended,
+            "trades_examined": len(trades),
+            "bleeding_buckets": scoring.bleeding_buckets(bucket_stats, current_min, min_n, bleed_pct),
+        })
+        lynx_state["adjustments"] = adjustments
+        lynx_state["current_min_score"] = recommended
+        audit_summary["updated"] = True
+        print(f"[lynx.scan] SELF-TUNE: MIN_SCORE {current_min} -> {recommended} "
+              f"(examined {len(trades)} trades)", file=sys.stderr)
+
+    return lynx_state, audit_summary
+
+
+# ── ctx.state: persisted lynx state (floor + audit log) + recent-signal dedup ──
+
+def _load_state(ctx):
+    """Return (lynx_state, signaled) from the latest ctx.state record. lynx_state
+    carries the adaptive floor + audit log; signaled is the dedup map. Both default
+    empty/seeded on first tick."""
+    default_lynx = {
+        "current_min_score": None,    # None = seed from initialMinScore
+        "last_audit_at": None,
+        "audit_count": 0,
+        "adjustments": [],
+    }
+    if ctx.state is None or len(ctx.state) == 0:
+        return default_lynx, {}
+    last = ctx.state.last() or {}
+    lynx_state = last.get("lynx")
+    lynx_state = dict(lynx_state) if isinstance(lynx_state, dict) else default_lynx
+    sig = last.get("signaled", {})
+    signaled = dict(sig) if isinstance(sig, dict) else {}
+    return lynx_state, signaled
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    whitelist = inputs.get("whitelist", _WHITELIST_DEFAULT)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+    initial_min = int(inputs.get("initialMinScore", _DEFAULT_INITIAL_MIN_SCORE))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    lynx_state, signaled = _load_state(ctx)
+    signaled = _prune_signaled(signaled, ttl, now)
+    if lynx_state.get("current_min_score") is None:
+        lynx_state["current_min_score"] = initial_min
+
+    # ── self-tuning audit (runs only when due; raises the floor) ──
+    lynx_state, audit_summary = _run_audit_if_due(ctx, lynx_state, inputs, now)
+    current_min_score = int(lynx_state.get("current_min_score", initial_min))
+
+    # ── score every eligible whitelist candidate (held + recently-signaled filtered
+    #    BEFORE the per-asset MCP fetch, as in v2 main()) ──
+    candidates = []
+    scanned = 0
+    for coin in whitelist:
+        if not coin:
+            continue
+        cu = str(coin).upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        candles = md["candles"]
+        sm = _get_sm_direction(ctx, coin)
+        th = scoring.build_thesis(
+            coin, candles.get("4h", []), candles.get("1h", []),
+            sm, current_min_score, inputs,
+        )
+        if th:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "minScore": current_min_score, "held": held_assets,
+                  "note": f"WAITING (MIN_SCORE {current_min_score})"}
+        print(f"[lynx.scan] WAITING — no asset cleared MIN_SCORE={current_min_score}; "
+              f"scanned={scanned} held={held_assets}"
+              + (f" | self-tune {audit_summary}" if audit_summary and audit_summary.get('updated') else ""),
+              file=sys.stderr)
+    else:
+        # v2 sorted by (score, |trend_4h_pct|) desc and emitted exactly best.
+        candidates.sort(key=lambda c: (c["score"], abs(c["trend_4h_pct"])), reverse=True)
+        best = candidates[0]
+
+        # marginPct PERCENT in (0,100]. v2 marginPct was a FRACTION (0.20); a value
+        # <= 1.0 is a pasted fraction -> x100 (dire/koala guard).
+        margin_pct = float(inputs.get("marginPct", 20))
+        if margin_pct <= 1.0:
+            margin_pct *= 100.0
+
+        leverage = min(int(inputs.get("leverage", _DEFAULT_LEVERAGE)), _MAX_LEVERAGE)
+        leverage = max(leverage, 1)
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"],
+                  "score": best["score"], "minScore": current_min_score,
+                  "leverage": leverage, "marginPct": round(margin_pct, 4),
+                  "held": held_assets, "reasons": best["reasons"]}
+        print(f"[lynx.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+              f"floor={current_min_score} {leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:5]}",
+              file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # 1..5; runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "currentMinScore": current_min_score,
+                "trend4hPct": best["trend_4h_pct"],
+                "trend1hPct": best["trend_1h_pct"],
+                "smDirection": best["sm_direction"] or "NONE",
+                "smTiltPct": best["sm_tilt_pct"],
+                "volRising": bool(best["vol_rising"]),
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist lynx state (floor + audit log) + dedup map + this tick's result
+    #    every tick; bounded by state_history_max_count. Each record carries the
+    #    full cumulative lynx_state forward so the floor + adjustments survive
+    #    record eviction. ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"lynx": lynx_state, "signaled": signaled,
+                              "audit": audit_summary, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[lynx.scan] WARNING: state append failed; floor/dedup may reset to "
+                  f"seed next tick: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/lynx/main/scanners/scoring.py
+++ b/strategies/lynx/main/scanners/scoring.py
@@ -1,0 +1,262 @@
+"""LYNX — pure thesis + self-tuning math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Lynx producer's two pure cores
+(SKILL.md v1.0.0):
+
+  1. The MOMENTUM SCORER (max ~8): 4h trend strength, 1h confirmation,
+     smart-money alignment, volume rising. Ported verbatim from
+     lynx-producer.py (pct_move, trend_direction, lynx_score).
+
+  2. The SELF-TUNER (archetype #15): given the agent's own closed-trade
+     history bucketed by the entry score logged in each trade, decide
+     whether to RAISE the MIN_SCORE floor above any bucket at-or-above the
+     current floor that has accumulated enough samples AND is bleeding.
+     Ported verbatim (parse_score_from_reasoning, compute_bucket_stats,
+     recommend_min_score, should_update_threshold). Lynx ratchets UP only —
+     it never lowers its own floor — and caps at maxMinScore.
+
+The math/indexing is reproduced VERBATIM so a fidelity harness can diff
+this against the v2 producer on the same snapshot. `scan.py` does the MCP
+reads + state; this module stays pure (plain candle lists + trade dicts)
+and unit-testable. `sm` (smart-money lean) is fetched by the caller and
+passed in.
+"""
+
+import re
+
+
+# ── coercion + candle accessors (dual-shape: dict {close|c} OR list) ──
+# v2 read dicts via _f(c, "close", "c"); the list branch is defensive and
+# never fires on dict candles, so it does not change v2 behaviour.
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ═══════════════════════════════════════════════════════════════
+# SELF-TUNER — pure logic (ported verbatim from lynx-producer.py)
+# ═══════════════════════════════════════════════════════════════
+
+_SCORE_RE = re.compile(r"\bscore[:\s=]+(\d+)\b", re.IGNORECASE)
+
+
+def parse_score_from_reasoning(text):
+    """Extract `score N` from ai_reasoning text. Looks for 'score 5' or
+    'score: 5' or 'Score=5' (case-insensitive). Returns int or None.
+    Verbatim from v2."""
+    if not text or not isinstance(text, str):
+        return None
+    m = _SCORE_RE.search(text)
+    if not m:
+        return None
+    try:
+        return int(m.group(1))
+    except (ValueError, IndexError):
+        return None
+
+
+def compute_bucket_stats(trades):
+    """Bucket trades by score and compute per-bucket stats. Verbatim from v2.
+
+    Each trade: {"score": int, "roe_pct": float} (other fields ignored).
+    Returns {score: {"n", "avg_roe_pct", "win_rate_pct"}}. Trades with no
+    score are dropped (no bucket). Win = ROE > 0."""
+    buckets = {}
+    for t in trades or []:
+        if not isinstance(t, dict):
+            continue
+        s = t.get("score")
+        if s is None:
+            continue
+        try:
+            score = int(s)
+            roe = float(t.get("roe_pct", 0))
+        except (TypeError, ValueError):
+            continue
+        b = buckets.setdefault(score, {"n": 0, "total_roe": 0.0, "wins": 0})
+        b["n"] += 1
+        b["total_roe"] += roe
+        if roe > 0:
+            b["wins"] += 1
+    out = {}
+    for score, b in buckets.items():
+        out[score] = {
+            "n": b["n"],
+            "avg_roe_pct": (b["total_roe"] / b["n"]) if b["n"] else 0.0,
+            "win_rate_pct": (b["wins"] * 100.0 / b["n"]) if b["n"] else 0.0,
+        }
+    return out
+
+
+def recommend_min_score(bucket_stats, current_min_score, min_bucket_n, bucket_bleed_pct, max_min_score):
+    """Decide whether to raise MIN_SCORE based on bucket stats. Verbatim from v2.
+
+    Rule: find the HIGHEST score bucket at-or-above the current floor that
+    has accumulated `min_bucket_n` samples AND is bleeding (avg_roe_pct
+    below `bucket_bleed_pct`). If found, recommend MIN_SCORE = that score + 1
+    (so the next eligible bucket starts above it). Caps at `max_min_score`.
+    If no bucket meets the bleed criterion, returns the current_min_score."""
+    bleeding_floors = [
+        score for score, stats in bucket_stats.items()
+        if score >= current_min_score
+        and stats["n"] >= min_bucket_n
+        and stats["avg_roe_pct"] < bucket_bleed_pct
+    ]
+    if not bleeding_floors:
+        return current_min_score
+    highest_bleeding = max(bleeding_floors)
+    recommended = highest_bleeding + 1
+    return min(recommended, max_min_score)
+
+
+def should_update_threshold(current, recommended, hysteresis=1):
+    """Only update if the recommended threshold is at least `hysteresis`
+    above the current. Prevents flapping on small noise. Verbatim from v2 —
+    note this is RAISE-ONLY (Lynx never lowers its own floor)."""
+    if recommended is None or current is None:
+        return False
+    return recommended >= current + hysteresis
+
+
+def bleeding_buckets(bucket_stats, current_min, min_n, bleed_pct):
+    """Helper for the adjustment audit-trail: the buckets that triggered a
+    raise (score >= floor, n >= min_n, avg_roe < bleed_pct). Mirrors the v2
+    `bleeding_buckets` list comprehension in run_audit_if_due."""
+    return [
+        {"score": s, "stats": v}
+        for s, v in bucket_stats.items()
+        if s >= current_min and v["n"] >= min_n and v["avg_roe_pct"] < bleed_pct
+    ]
+
+
+# ═══════════════════════════════════════════════════════════════
+# MOMENTUM SCORER — pure logic (ported verbatim from lynx-producer.py)
+# ═══════════════════════════════════════════════════════════════
+
+def pct_move(closes, lookback):
+    """% change over `lookback` bars back. Verbatim from v2 pct_move."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def trend_direction(strength_pct, threshold):
+    """LONG/SHORT/None from a signed % move vs an absolute threshold.
+    Verbatim from v2 trend_direction."""
+    if strength_pct is None or abs(strength_pct) < threshold:
+        return None
+    return "LONG" if strength_pct > 0 else "SHORT"
+
+
+def lynx_score(trend_strength_4h, trend_1h_aligned, sm_aligned, volume_rising):
+    """Compose a Lynx score from boolean / magnitude inputs. Verbatim from v2.
+
+    - 4h trend strength: +3 if |move| >= 4%, +2 if >= 2%, +1 if >= 1%
+    - 1h confirmation:   +2 if aligned to 4h direction
+    - SM aligned:        +2 if SM tilts in same direction past threshold
+    - Volume rising:     +1 if recent vol > prior baseline
+    Max ~8. Floor is the (adaptive) MIN_SCORE."""
+    s = 0
+    if trend_strength_4h is None:
+        return 0
+    abs_t = abs(trend_strength_4h)
+    if abs_t >= 4.0:
+        s += 3
+    elif abs_t >= 2.0:
+        s += 2
+    elif abs_t >= 1.0:
+        s += 1
+    if trend_1h_aligned:
+        s += 2
+    if sm_aligned:
+        s += 2
+    if volume_rising:
+        s += 1
+    return s
+
+
+# ── the thesis (direction + 4-component momentum score), ported verbatim ──
+
+def build_thesis(coin, candles_4h, candles_1h, sm, current_min_score, inputs):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned when:
+      - insufficient candle history (len(c4h) < 8 or len(c1h) < 8), OR
+      - no 4h trend direction resolves (|move_4h| < 1.0%), OR
+      - the score is below `current_min_score` (the v2 gate; the producer
+        applied MIN_SCORE inside build_thesis, so it is reproduced here).
+
+    `sm` is the smart-money tuple (direction, tilt_pct) or (None, 0) — the
+    caller fetches it (get_sm_direction)."""
+    sm_min = float(inputs.get("smTiltMinPct", 55))
+
+    closes_4h = [_close(c) for c in candles_4h]
+    closes_1h = [_close(c) for c in candles_1h]
+    if len(closes_4h) < 8 or len(closes_1h) < 8:
+        return None
+
+    move_4h = pct_move(closes_4h, 6)    # 24h on 4h bars
+    move_1h = pct_move(closes_1h, 4)    # 4h on 1h bars
+    direction = trend_direction(move_4h, 1.0)
+    if direction is None:
+        return None
+
+    one_h_aligned = (move_1h is not None) and ((move_1h > 0) == (move_4h > 0)) and (abs(move_1h) >= 0.5)
+
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    sm_aligned = (sm_dir == direction and sm_tilt >= sm_min)
+
+    # Volume surge: recent-3 vs prior-9 mean on 4h bars, ratio >= 1.3
+    vols = [_vol(c) for c in candles_4h]
+    vol_rising = False
+    if len(vols) >= 12:
+        recent = sum(vols[-3:]) / 3
+        baseline = sum(vols[-12:-3]) / 9
+        vol_rising = baseline > 0 and (recent / baseline) >= 1.3
+
+    score = lynx_score(move_4h, one_h_aligned, sm_aligned, vol_rising)
+    if score < current_min_score:
+        return None
+
+    reasons = [f"trend4h_{move_4h:+.1f}%", f"score_{score}", f"floor_{current_min_score}"]
+    if one_h_aligned:
+        reasons.append("1h_aligned")
+    if sm_aligned:
+        reasons.append(f"sm_{sm_tilt:.0f}%")
+    if vol_rising:
+        reasons.append("vol_rising")
+
+    return {
+        "coin": coin,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_4h_pct": round(move_4h, 2),
+        "trend_1h_pct": round(move_1h, 2) if move_1h is not None else 0.0,
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": _f(sm_tilt),
+        "vol_rising": vol_rising,
+    }

--- a/strategies/lynx/strategy.yaml
+++ b/strategies/lynx/strategy.yaml
@@ -1,0 +1,44 @@
+# Lynx — adaptive MIN_SCORE self-tuner. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2
+# Lynx (SKILL.md v1.0.0): a multi-asset momentum scorer on liquid majors
+# (BTC/ETH/SOL/HYPE) that audits its OWN closed-trade history every 6h (audit_query),
+# buckets trades by entry score, and auto-raises its MIN_SCORE floor above any
+# bucket that is bleeding — the Vulture v4.1 manual cull, productized as a scheduled
+# audit. DSL-only exits, "let winners run". Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: lynx
+version: "1.0.0"
+
+catalog:
+  name: "Lynx — Adaptive MIN_SCORE Self-Tuner"
+  emoji: "🐯"
+  tagline: "A multi-asset momentum holder on liquid majors (BTC/ETH/SOL/HYPE) that learns its own conviction floor: every 6 hours it audits its own closed trades, buckets them by entry score, and ratchets its MIN_SCORE up above any score band that has been losing money — then enters only candidates that clear the learned floor and lets a wide DSL ride the move."
+  belief_plain: "Trades the big, liquid coins (BTC, ETH, SOL, HYPE) on a simple momentum score. Every six hours it looks back at its own finished trades, figures out which score levels have actually been making money and which have been losing, and raises its own bar so it stops taking the kinds of trades that bled — it only ever raises the bar, never lowers it. When a coin clears the current bar it bets and trails a wide stop so a real move can run."
+  thesis: "A fixed entry threshold is a guess that goes stale: the market regime that made score-6 trades profitable last month may make them losers this month. Instead of an operator hand-tuning MIN_SCORE off a 30-trade table, Lynx bakes that loop into a scheduled audit — it reads its own closed-trade history, buckets by the entry score it logged, and raises the floor above any band whose realized ROE has turned negative with enough samples to trust. It ratchets up only (a floor that worked is never relaxed), caps at a hard ceiling, and otherwise runs a plain momentum scorer so the audit always has clean data to learn from."
+  group: momentum
+  archetype: trend_following
+  sub_style: adaptive
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL", "HYPE"]
+  tags: [btc, eth, sol, hype, multi-asset, momentum, smart-money, self-tuning, adaptive-threshold, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: LYNX_WALLET
+    funding_share: 1.0

--- a/strategies/marlin/main/runtime.yaml
+++ b/strategies/marlin/main/runtime.yaml
@@ -1,0 +1,145 @@
+# ── MARLIN · single instance — order-book imbalance momentum (BTC/ETH/SOL/HYPE) ──
+# Runtime 3.0 port of the v2 Marlin (SKILL.md v1.0.0). Liquid-majors basket, L2
+# order-book depth imbalance as the entry-TIMING edge on a momentum thesis: fires
+# only when book imbalance, 15m momentum, and smart-money direction all agree on the
+# same side. NOT a scalper — wide "let winners run" DSL + a 24h hard_timeout outer
+# bound (microstructure is short-horizon). Faithful port of the v2 producer thesis —
+# see scanners/scoring.py (math reproduced verbatim, v2-quirks flagged).
+name: marlin-main
+group: marlin
+version: 1.0.0
+description: >
+  MARLIN — order-book imbalance momentum on liquid majors (BTC/ETH/SOL/HYPE).
+  A persistent resting-depth imbalance in the L2 book is a near-term pressure tell:
+  bids >> asks = buy pressure (LONG), asks >> bids = sell pressure (SHORT). Three
+  hard gates, all required: book imbalance >= imbalanceMin on one side, 15m momentum
+  confirms that side (>= momMinPct), and smart-money direction agrees with tilt
+  >= smTiltMinPct (default 55%). Composite score (max ~9) with strong-imbalance,
+  5m-momentum, strong-SM, and volume-rising bonuses; floor minScore 5. Emits the
+  single highest-scoring candidate per tick. Fixed margin 15% of withdrawable,
+  leverage 4x (clamped to 5x max). DSL is the ONLY exit — wide ratchet ladder
+  (first lock at +10% ROE) + a 24h hard_timeout (the short-horizon outer bound).
+  Faithful port of the v2 Marlin v1.0.0 thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${MARLIN_WALLET}"
+  slots: 1                                # v2 emitted exactly one signal (best)
+  margin_pct: 15                          # baseline %; scan emits the fixed marginPct per signal
+  default_leverage: 4                     # fallback; scan emits 4x (clamped to 5x max) per signal
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: marlin_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 180                  # v2 producer cadence (3 min)
+    timeout_seconds: 150                   # v2 tick_timeout=150; ~1 asset_data read/asset + sm + account
+    default_signal_validity_seconds: 360   # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      universe: ["BTC", "ETH", "SOL", "HYPE"]  # v2 universe (validated live on HL main DEX 2026-06-29)
+      minScore: 5                          # v2 minScore / DEFAULT_MIN_SCORE
+      levelsN: 10                          # v2 levelsN — top N book levels per side summed
+      imbalanceMin: 1.5                    # v2 imbalanceMin — bid/ask depth ratio to call a side
+      imbalanceStrong: 2.5                 # v2 imbalanceStrong — strongly-imbalanced bonus
+      momMinPct: 0.1                       # v2 momMinPct — 15m momentum magnitude that confirms the side
+      smTiltMinPct: 55                     # v2 smTiltMinPct — smart-money tilt floor
+      marginPct: 15                        # PERCENT of withdrawable (v2 0.15 fraction -> 15 percent)
+      leverage: 4                          # clamped to [1,5] in scan.py (MAX_LEVERAGE=5)
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      imbalanceRatio: { type: number, required: false }
+      bidDepth: { type: number, required: false }
+      askDepth: { type: number, required: false }
+      mom15mPct: { type: number, required: false }
+      mom5mPct: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      volumeTrendPct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: marlin_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [marlin_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # momentum entry must fill — maker-only can rest unfilled
+                                           # (CREATE_ORDER_RESTING) and miss the move. Taker fallback
+                                           # guarantees fill + DSL attach. (v2 marlin_entry param.)
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: marlin_main_signals
+
+# ── EXIT (DSL — preserved VERBATIM from v2 marlin runtime.yaml) ───────────────
+# Wide "let winners run" ladder (first lock at +10% ROE) + a 24h hard_timeout as the
+# only time-based exit — the order-book/microstructure thesis is short-horizon, but
+# the move itself is given room. weak_peak_cut / dead_weight_cut DISABLED (verbatim).
+# Phase 1 max_loss 18%. order_type FEE_OPTIMIZED_LIMIT, taker fallback on (closes
+# MUST happen). interval_seconds 60 (v2).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # v2: ENABLED — 24h short-horizon outer bound
+      interval_in_minutes: 1440            # 24h — book-imbalance momentum is short-horizon
+    weak_peak_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 120
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0                    # v2 phase1.max_loss_pct
+      retrace_threshold: 8                  # v2 phase1.retrace_threshold
+      consecutive_breaches_required: 1      # v2 phase1.consecutive_breaches_required
+    phase2:
+      enabled: true
+      tiers:                               # wide-by-design; FIRST lock at +10% ROE (reachable)
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # 72h (v2 data_retention_hours 72 -> x3600)
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 risk.daily_loss_limit_pct
+    max_entries_per_day: 4                  # v2 risk.max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 risk.max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 cooldown_minutes 60 -> 3600s
+    drawdown_halt_pct: 22                  # v2 risk.drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 10800      # v2 per_asset_cooldown_minutes 180 -> 10800s (3h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/marlin/main/scanners/scan.py
+++ b/strategies/marlin/main/scanners/scan.py
@@ -1,0 +1,294 @@
+"""MARLIN — supervised scanner (Runtime 3.0 port of the v2 Marlin order-book-imbalance
+momentum strategy).
+
+Multi-asset basket (BTC/ETH/SOL/HYPE by default). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - for each non-held, non-recently-signaled candidate fetches market_get_asset_data
+    (5m/15m candles + L2 order_book) and the smart-money lean (leaderboard_get_markets),
+  - scores via the pure `scoring.build_thesis` (3 hard gates: book imbalance picks the
+    side, 15m momentum confirms it, smart-money agrees with tilt >= floor),
+  - emits the SINGLE highest-scoring candidate at/above `minScore` (v2 main() emitted
+    only `best`), sized at a FIXED margin percent + clamped leverage.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus a `leverage`; the
+runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit. No
+daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs the v2 producer (marlin-producer.py v1.0.1 / SKILL.md v1.0.0):
+  - v2 fixed margin: marginPct=0.15 (a FRACTION) * account_value -> marginUsd. This
+    port uses marginPct=15 (a PERCENT) and emits `marginPct`; the runtime sizes
+    (marginPct/100)*withdrawable. The <=1.0 guard converts a pasted fraction defensively.
+  - v2 leverage: min(int(leverage), MAX_LEVERAGE=5). Preserved: clamp to [1, 5].
+  - v2 emitted exactly one signal (best, highest score). Preserved: scan() emits <=1/tick.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=240, 4x-TTL prune) -> ctx.state
+    dedup map (same TTL semantics).
+  - v2 score wire-normalization (min(score/9, 1.0)) is dropped — the scaffold owns the
+    [0,1] wire score; we emit the raw integer score on data{} (per the scan contract).
+  - v2 fetch_sm_direction used >=50 long_ratio for the LONG/SHORT split; the gate only
+    accepts sm_dir == imbalance direction with tilt >= smTiltMinPct, so the split rule
+    is reproduced verbatim in _get_sm_direction.
+  - ARCHETYPE NOTE: the orchestrator hint labeled marlin "smart-money / leaderboard
+    momentum". The PRIMARY edge is the L2 ORDER-BOOK IMBALANCE (market_get_asset_data
+    order_book); smart-money (leaderboard_get_markets) is the THIRD confirming gate, not
+    the driver. Catalog declared sub_style=orderbook_pressure to reflect this.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v2 defaults (marlin-producer.py / marlin-config.json)
+_UNIVERSE_DEFAULT = ["BTC", "ETH", "SOL", "HYPE"]
+_DEFAULT_MIN_SCORE = 5            # v2 minScore / DEFAULT_MIN_SCORE
+_DEFAULT_MARGIN_PCT = 15.0       # v2 marginPct 0.15 fraction -> 15 PERCENT
+_DEFAULT_LEVERAGE = 4            # v2 DEFAULT_LEVERAGE
+_MAX_LEVERAGE = 5               # v2 MAX_LEVERAGE (hardcoded, not configurable)
+_DEFAULT_RECENT_TTL = 240        # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''. Marlin's
+    universe is all main-DEX majors, so this only ever returns '' in practice."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across main/xyz
+    (two views of ONE cross-margined wallet — summing double-counts the shared free
+    balance -> 2x sizing). assetPositions are enumerated across both sections. Ported
+    verbatim from v2 cfg.get_positions, including the read-sanity guard (margin in use
+    + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[marlin.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a corrupt
+    # clearinghouse read can report margin/notional IN USE while returning an EMPTY
+    # positions list; sizing or running the held-asset dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)), abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[marlin.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _asset_data(ctx, coin):
+    """Raw market_get_asset_data document (5m/15m candles + L2 order_book) for `coin`,
+    or None. READ-GUARDED. The raw doc is returned (not unwrapped) so
+    scoring.book_imbalance can read doc["data"]["order_book"] verbatim like v2."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["5m", "15m"],
+            "include_funding": False,
+            "include_order_book": True,
+            "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[marlin.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    return md if isinstance(md, dict) else None
+
+
+def _get_sm_direction(ctx, coin):
+    """Port of v2 fetch_sm_direction: net smart-money lean for `coin` from
+    leaderboard_get_markets. Returns (direction, tilt_pct) or (None, 0). READ-GUARDED.
+
+    Verbatim split: long_ratio >= 50 -> ("LONG", long_ratio); else ("SHORT", 100-long_ratio);
+    total<=0 -> ("NEUTRAL", 50); coin not found -> (None, 0)."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — smart-money is a hard gate; a read error -> neutral -> skip asset
+        print(f"[marlin.scan] leaderboard_get_markets read failed (smart-money -> none): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and raw.get("success") is False):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != coin.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    universe = [str(a).upper() for a in inputs.get("universe", _UNIVERSE_DEFAULT)]
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    # margin PERCENT in (0,100]. Defensive fraction->percent guard (v2 stored 0.15).
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:   # a value <=1.0 is a pasted FRACTION (e.g. 0.15) -> x100
+        margin_pct *= 100
+
+    leverage = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    leverage = max(1, min(leverage, _MAX_LEVERAGE))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── score every eligible candidate (held + recently-signaled filtered BEFORE the
+    #    per-asset MCP fetch, as in v2 main()) ──
+    candidates = []
+    scanned = 0
+    for coin in universe:
+        if not coin:
+            continue
+        if coin in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        data = md.get("data", {}) if isinstance(md, dict) else {}
+        candles = data.get("candles", {}) if isinstance(data, dict) else {}
+        candles_5m = candles.get("5m", []) or []
+        candles_15m = candles.get("15m", []) or []
+        sm = _get_sm_direction(ctx, coin)
+        th = scoring.build_thesis(coin, md, candles_5m, candles_15m, sm, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets, "note": f"WAITING (min score {min_score:.0f})"}
+        print(f"[marlin.scan] WAITING — no book-imbalance + momentum + SM alignment "
+              f"(min score {min_score:.0f}); scanned={scanned} held={held_assets}",
+              file=sys.stderr)
+    else:
+        # v2 emitted exactly the single best (highest score).
+        candidates.sort(key=lambda x: x["score"], reverse=True)
+        best = candidates[0]
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"],
+                  "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best["reasons"]}
+        print(f"[marlin.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+              f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:5]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # 1..5; runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "imbalanceRatio": best["imbalance_ratio"],
+                "bidDepth": best["bid_depth"],
+                "askDepth": best["ask_depth"],
+                "mom15mPct": best["mom_15m_pct"],
+                "mom5mPct": best["mom_5m_pct"],
+                "smDirection": best["sm_direction"] or "NEUTRAL",
+                "smTiltPct": best["sm_tilt_pct"],
+                "volumeTrendPct": best["volume_trend_pct"],
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + this tick's result every tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[marlin.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/marlin/main/scanners/scoring.py
+++ b/strategies/marlin/main/scanners/scoring.py
@@ -1,0 +1,204 @@
+"""MARLIN — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Marlin producer's microstructure helpers +
+`build_thesis` order-book-imbalance scoring (SKILL.md v1.0.0). The math/indexing is
+reproduced VERBATIM so a fidelity harness can diff this against the v2 producer on the
+same market snapshot. Behaviour-preserving quirks from v2 are kept and flagged
+`# v2-quirk`; fix them only as a separate, labelled change AFTER the port is validated.
+
+Multi-asset, single-pass, unit-testable on plain candle lists + a raw asset_data dict.
+`sm` (smart-money lean) is fetched by the caller (leaderboard_get_markets) and passed
+in, so this module stays pure.
+
+The thesis is GATED (not a pure scorer): three hard gates must all pass —
+  GATE 1: order-book imbalance picks the side (bid-heavy -> LONG, ask-heavy -> SHORT),
+  GATE 2: 15m momentum confirms that side,
+  GATE 3: smart-money direction agrees AND tilt >= smTiltMinPct.
+If any gate fails, build_thesis returns None. minScore is applied by the CALLER
+(scan.py), not here."""
+
+
+# v2 producer defaults (marlin-producer.py / marlin-config.json)
+DEFAULT_LEVELS_N = 10
+DEFAULT_IMBALANCE_MIN = 1.5
+DEFAULT_IMBALANCE_STRONG = 2.5
+DEFAULT_MOM_MIN_PCT = 0.1
+DEFAULT_SM_TILT_MIN = 55
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v if v is not None else d)
+    except (TypeError, ValueError):
+        return d
+
+
+def _f2(c, primary, alt=None, default=0.0):
+    """Dual-key float accessor (v2 _f): try `primary`, then `alt`, else default."""
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    return _f(val, default)
+
+
+# ── microstructure helpers (ported VERBATIM from v2 marlin-producer.py) ──
+
+def book_imbalance(asset_data, levels_n=DEFAULT_LEVELS_N):
+    """Return (imbalance_ratio, bid_depth, ask_depth) over the top `levels_n` book
+    levels per side. ratio > 1 = bid-heavy (buy pressure); < 1 = ask-heavy (sell
+    pressure). ratio is None when the book is unusable.
+
+    market_get_asset_data order_book shape: {"levels": [bids, asks]} where each side
+    is a list of {"px","sz","n"}; bids[0] is best bid, asks[0] best ask. Verbatim from
+    v2 (reads asset_data["data"]["order_book"])."""
+    ob = (asset_data.get("data", {}) or {}).get("order_book", {}) or {}
+    levels = ob.get("levels") or []
+    if not isinstance(levels, list) or len(levels) < 2:
+        return None, 0.0, 0.0
+    bids = levels[0][:levels_n] if isinstance(levels[0], list) else []
+    asks = levels[1][:levels_n] if isinstance(levels[1], list) else []
+    bid_depth = sum(_f2(l, "sz") for l in bids if isinstance(l, dict))
+    ask_depth = sum(_f2(l, "sz") for l in asks if isinstance(l, dict))
+    if bid_depth <= 0 and ask_depth <= 0:
+        return None, bid_depth, ask_depth
+    if ask_depth <= 0:
+        return float("inf"), bid_depth, ask_depth
+    return bid_depth / ask_depth, bid_depth, ask_depth
+
+
+def imbalance_direction(ratio, imbalance_min):
+    """Map an imbalance ratio to a trade side, or None if too balanced. Verbatim.
+    bid-heavy (ratio >= min) -> LONG; ask-heavy (ratio <= 1/min) -> SHORT."""
+    if ratio is None or imbalance_min <= 0:
+        return None
+    if ratio >= imbalance_min:
+        return "LONG"
+    if ratio <= (1.0 / imbalance_min):
+        return "SHORT"
+    return None
+
+
+def price_move_pct(candles, n_bars=1):
+    """% change over the last n_bars. Verbatim from v2 price_move_pct."""
+    if len(candles) < n_bars + 1:
+        return 0.0
+    old = _f2(candles[-(n_bars + 1)], "close", "c")
+    new = _f2(candles[-1], "close", "c")
+    if old <= 0:
+        return 0.0
+    return ((new - old) / old) * 100
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-half vs earlier-half average volume, % change. Verbatim from v2.
+
+    v2-quirk: requires len(candles) >= lookback (NOT lookback+2 like Bison), and the
+    earlier-half window is vols[:half] over the SAME last-`lookback` slice as the
+    recent-half. Reproduced exactly."""
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f2(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ── the thesis (3 hard gates + composite score), ported VERBATIM ──
+
+def build_thesis(coin, asset_data, candles_5m, candles_15m, sm, inputs):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned when:
+      - insufficient candle history (len(15m) < 2 or len(5m) < 2), OR
+      - GATE 1: order book does not resolve a side (too balanced / unusable), OR
+      - GATE 2: 15m momentum does not confirm the imbalance side, OR
+      - GATE 3: smart-money direction is missing / NEUTRAL / disagrees, OR tilt below floor.
+    minScore is NOT applied here — the caller gates on thesis['score'].
+
+    `asset_data` is the raw market_get_asset_data document (so book_imbalance can read
+    asset_data["data"]["order_book"]). `sm` is the smart-money tuple (direction, tilt)
+    or (None, 0) — the caller fetches it (fetch_sm_direction)."""
+    levels_n = int(inputs.get("levelsN", DEFAULT_LEVELS_N))
+    imb_min = float(inputs.get("imbalanceMin", DEFAULT_IMBALANCE_MIN))
+    imb_strong = float(inputs.get("imbalanceStrong", DEFAULT_IMBALANCE_STRONG))
+    mom_min = float(inputs.get("momMinPct", DEFAULT_MOM_MIN_PCT))
+    sm_min = float(inputs.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+
+    if len(candles_15m) < 2 or len(candles_5m) < 2:
+        return None
+
+    # GATE 1 — order-book imbalance picks the side
+    ratio, bid_depth, ask_depth = book_imbalance(asset_data, levels_n)
+    direction = imbalance_direction(ratio, imb_min)
+    if direction is None:
+        return None
+
+    # GATE 2 — short-term momentum must confirm the imbalance side
+    mom_15m = price_move_pct(candles_15m, 1)
+    if direction == "LONG" and mom_15m < mom_min:
+        return None
+    if direction == "SHORT" and mom_15m > -mom_min:
+        return None
+
+    # GATE 3 — Smart-Money agreement
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    mom_5m = price_move_pct(candles_5m, 1)
+    vol_pct = volume_trend(candles_5m)
+    # display ratio (inf -> large sentinel for telemetry; verbatim from v2)
+    disp_ratio = 99.0 if ratio == float("inf") else round(ratio, 3)
+
+    score = 0
+    reasons = []
+
+    # Imbalance magnitude (gate-confirmed) + strong bonus
+    score += 2
+    reasons.append(f"book_imbalance_{disp_ratio}x")
+    strong = (ratio == float("inf")) or (direction == "LONG" and ratio >= imb_strong) or \
+             (direction == "SHORT" and ratio <= (1.0 / imb_strong))
+    if strong:
+        score += 1
+        reasons.append("imbalance_strong")
+
+    # Momentum confirms (gate) + 5m alignment
+    score += 2
+    reasons.append(f"mom_15m_{mom_15m:+.2f}%")
+    if (direction == "LONG" and mom_5m > 0) or (direction == "SHORT" and mom_5m < 0):
+        score += 1
+        reasons.append(f"mom_5m_aligned_{mom_5m:+.2f}%")
+
+    # SM aligned (gate) + strong
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+    if sm_tilt >= 70:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    # Volume rising
+    if vol_pct > 10:
+        score += 1
+        reasons.append(f"vol_rising_{vol_pct:+.0f}%")
+
+    return {
+        "coin": coin,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "imbalance_ratio": disp_ratio,
+        "bid_depth": round(bid_depth, 2),
+        "ask_depth": round(ask_depth, 2),
+        "mom_15m_pct": round(mom_15m, 3),
+        "mom_5m_pct": round(mom_5m, 3),
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": _f(sm_tilt),
+        "volume_trend_pct": round(vol_pct, 2),
+    }

--- a/strategies/marlin/strategy.yaml
+++ b/strategies/marlin/strategy.yaml
@@ -1,0 +1,44 @@
+# Marlin — order-book imbalance momentum on liquid majors. A single-instance PACKAGE:
+# this manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0
+# port of the v2 Marlin (SKILL.md v1.0.0): a 4-name basket (BTC/ETH/SOL/HYPE) that uses
+# the L2 order-book depth imbalance as the entry-TIMING edge on a momentum thesis —
+# fires only when book imbalance, 15m momentum, and smart-money direction all agree —
+# then holds the move with a wide "let winners run" DSL + a 24h short-horizon outer
+# bound. NOT a scalper. DSL-only exits. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: marlin
+version: "1.0.0"
+
+catalog:
+  name: "Marlin — Order-Book Imbalance Momentum"
+  emoji: "🐟"
+  tagline: "Reads the L2 order book on BTC/ETH/SOL/HYPE — when resting depth is lopsided (bids far heavier than asks, or the reverse) that's directional pressure, but it only fires when 15m momentum and smart money agree, then hands the position to a wide DSL and lets the move run (it does not scalp)."
+  belief_plain: "Looks at how much resting buy vs sell interest is stacked in the order book of the big, liquid coins. A heavily one-sided book signals pressure in that direction — but a lopsided book alone is noise, so it only acts when short-term price momentum and the best traders are pointing the same way. Then it holds the trade with a wide trailing stop instead of flipping in and out."
+  thesis: "Order-book imbalance is a genuine microstructure edge, but trading it as a per-tick scalp just bleeds fees. Marlin uses the imbalance differently — as the entry-timing signal on a momentum thesis: the book says which side has pressure right now, momentum and smart money confirm the move is real, and then you hold it with a wide ratchet and let it work. Restricting the universe to four liquid majors keeps the imbalance reading reliable (thin books give garbage ratios), and a 24h hard timeout caps the short-horizon thesis without choking a real run."
+  group: smart-money
+  archetype: breakout_momentum
+  sub_style: orderbook_pressure
+  asset_classes: [major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 100
+  assets: ["BTC", "ETH", "SOL", "HYPE"]
+  tags: [btc, eth, sol, hype, order-book, imbalance, microstructure, momentum, smart-money, let-winners-run, single-slot]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: MARLIN_WALLET
+    funding_share: 1.0


### PR DESCRIPTION
## Author skill — data_retention captured + validator modernized
`validate_strategy.py` now (a) **rejects deprecated `data_retention_hours`** and requires `data_retention_seconds ∈ [3600,604800]`, and (b) validates the **Runtime 3.0 package shape** (scanners/scan.py defines `scan()`; sibling scoring.py; no `__init__.py`) — previously it crashed on every 3.0 package. All 44 packages now pass.

## Wave 2 ports (32 → 44)
badger, bald-eagle, bobcat, chameleon, coyote, dog, egret, hawk, hedgehog, lemon, lynx, marlin.
Read-guarded MCP, marginPct percent, HL-meta tickers, `data_retention_seconds` in range, **canonical catalog taxonomy** (+1 catalog warning across 12, vs the 28's drift), no `__init__.py`.

Fidelity catches:
- **bobcat / hawk / hedgehog** — v2 runtime.yaml was a stale BTC/big-tech template; thesis rebuilt from producer+config+SKILL (bobcat = 12-name big-tech equity basket).
- **bald-eagle** — dropped v2 `cancel_order` stale-purge (mutation; `scan()` is read-only) → runtime reconciliation owns it.
- **lemon** — stale SKILL.md (ported producer truth) + dead `SPX`→`SP500` ticker fix.
- **coyote / chameleon / dog / marlin** — archetype self-corrected from source (regime classifier / pairs_rv / contrarian_fade / orderbook).

Catalog glossary warnings remain a separate fleet-wide reconciliation (tracked).