### PR TITLE
fix(strategy-discover): invoke discover.py by full path, not workspace-relative

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -1,6 +1,19 @@
 
 
 
+## Running the engine
+
+The `exec` tool runs from the workspace (`/data/workspace`), **not** this skill directory, so a
+relative `python3 scripts/discover.py …` fails with `No such file or directory`. **Always invoke the
+script by its full path:**
+
+```
+python3 "$OPENCLAW_STATE_DIR/skills/senpi-strategy-discover/scripts/discover.py" [flags]
+```
+
+If `OPENCLAW_STATE_DIR` is unset, use the absolute path
+`python3 /data/.openclaw/skills/senpi-strategy-discover/scripts/discover.py [flags]`.
+
 ## Install — include the MCP helper
 
 The scripts in `scripts/` import a vendored MCP helper, `scripts/mcp_client.py`, at runtime.

--- a/senpi-strategy-discover/scripts/discover.py
+++ b/senpi-strategy-discover/scripts/discover.py
@@ -4,7 +4,9 @@
 The agent (LLM) runs this via the OpenClaw `exec` tool with discrete flags; it reads the JSON on
 stdout, RANKS the returned set itself (on risk / belief / worldview / thesis), and narrates 2-3 cards.
 
-  python3 discover.py --assets btc_eth --direction long_only
+`exec` runs from the workspace, NOT this skill dir, so invoke the script by its full path:
+
+  python3 "$OPENCLAW_STATE_DIR/skills/senpi-strategy-discover/scripts/discover.py" --assets btc_eth --direction long_only
 
 Contract (see docs/strategy-discover/discovery-architecture.md):
 - The SCRIPT only does CONCRETE set logic: it hard-rejects on the few unambiguous, explicitly-stated


### PR DESCRIPTION
## Problem

When running the `senpi-strategy-discover` skill, the agent tries `python3 scripts/discover.py …`. The `exec` tool's working directory is the workspace (`/data/workspace`), **not** the skill directory, so the relative path fails. The agent burns several round-trips (`cd /data`, workspace-relative retry, then `find`) before locating the script under `$OPENCLAW_STATE_DIR/skills/senpi-strategy-discover/scripts/`.

## Fix

Document the **full path** for invoking the bundled script, so it resolves regardless of cwd:

- **`senpi-strategy-discover/SKILL.md`** — added a short "Running the engine" note:
  ```
  python3 "$OPENCLAW_STATE_DIR/skills/senpi-strategy-discover/scripts/discover.py" [flags]
  ```
  with the absolute-path fallback (`/data/.openclaw/skills/senpi-strategy-discover/scripts/discover.py`) when `OPENCLAW_STATE_DIR` is unset.
- **`senpi-strategy-discover/scripts/discover.py`** — updated the docstring usage example to the same full path.

Scope is limited to the path: **+16 lines, no other changes.** The `SKILL.md` on `strategy-v2` stays as-is.

## Verification

- `discover.py` parses and `--help` runs.
- 12 discover engine tests pass (`tests/test_discover.py`). Engine logic is untouched — docs/comment only.

## Acceptance

On a fresh deployment, asking "select trading strategies" runs `discover.py` successfully on the **first** `exec` call, with no `find`/retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWD4Q8ZfKonkEnmTXoRNq

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and docstring-only changes; discovery engine behavior is unchanged.
> 
> **Overview**
> Agents were failing on the first `exec` because **`python3 scripts/discover.py`** is resolved from the workspace (`/data/workspace`), not the skill directory.
> 
> **`SKILL.md`** adds a **Running the engine** section that requires the full path via `$OPENCLAW_STATE_DIR/skills/senpi-strategy-discover/scripts/discover.py`, with a fixed fallback under `/data/.openclaw/...` when that env var is unset. The **`discover.py`** module docstring usage example is updated to the same invocation so it matches the skill docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3f0f8924cc3884d7a43cbd58e7ec33a01af65c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->