### PR TITLE
Runtime 3.0 Wave 3 (12 momentum + universe-scanner agents) -> 56 strategies

### DIFF
--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -173,6 +173,50 @@
       "sort_order": 2
     },
     {
+      "id": "owl",
+      "name": "Owl — Contrarian Crowding-Unwind Hunter",
+      "emoji": "🦉",
+      "tagline": "Scans every liquid Hyperliquid crypto perp (OI > $3M) for one-sided crowding — extreme funding + lopsided smart money + concentrated OI — then waits for that crowding to persist 1h+ AND for exhaustion to fire (volume fading, price stalling, RSI divergence) before fading the crowd. Conviction-scaled leverage (7/8/10) at 25% margin, with a macro gate that stands down when BTC's 4h move is extreme.",
+      "belief_plain": "The crowd is wrong at the extremes. When everyone piles onto one side of a coin — paying punishing funding, the best traders all leaning the same way, open interest stacking up — and the price then stops following through, the unwind is violent and predictable. Owl waits for both the crowded state AND the exhaustion trigger, then takes the other side. Most days it does nothing, because most days one or both is missing.",
+      "version": "1.0.0",
+      "thesis": "Crowded trades unwind violently. Owl's edge is timing the unwind: it never fades on crowding alone (which can persist and grind), it waits for crowding to PERSIST 1h+ and for distinct exhaustion signals (declining volume under extreme funding, price stalling against the crowd, capitulation wicks, 4h RSI divergence) to confirm the move is dying. Mean reversion fails in trending macro, so a hard gate blocks all fades when |BTC 4h| > 3%. XYZ banned — the funding/smart-money scoring is calibrated on crypto data shape.",
+      "tags": [
+        "contrarian",
+        "fade",
+        "crowding",
+        "funding-extreme",
+        "smart-money",
+        "exhaustion",
+        "mean-reversion",
+        "universe",
+        "macro-gate"
+      ],
+      "group": "contrarian",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "sm_crowding",
+      "sub_style_label": "Fades the crowded smart-money side once price stops following.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "position",
+      "cadence_seconds": 900,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 3
+    },
+    {
       "id": "pangolin",
       "name": "Pangolin — Funding-Rate Fader",
       "emoji": "🦔",
@@ -212,7 +256,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 3
+      "sort_order": 4
     },
     {
       "id": "tortoise",
@@ -452,6 +496,49 @@
       "sort_order": 3
     },
     {
+      "id": "falcon",
+      "name": "Falcon — Conversion-Event Momentum",
+      "emoji": "🦅",
+      "tagline": "Watches every Hyperliquid XYZ pre-IPO perpetual and fires the moment one converts to a normal equity perp — when the company IPOs, funding jumps ~100x, the leverage cap lifts and the price throttle comes off, opening a window of free price discovery. Falcon catches that flip and rides the post-conversion momentum with a wide let-winners-run stop (7d).",
+      "belief_plain": "A pre-IPO name on Hyperliquid is deliberately pinned — its price can barely move. The instant the company goes public the brakes come off all at once and the name often trends hard for days. Falcon detects that exact handover from a tell in the funding rate, then takes a single position in the direction it's already running and trails a wide stop so a real move can run.",
+      "version": "1.0.0",
+      "thesis": "The IPOP->equity conversion is a detectable regime change: funding normalizes ~100x, the max-leverage cap lifts, and the trade.xyz Discovery-Bounds price throttle is removed. The first hours-to-days after conversion are pure price discovery, which often trends in one direction. The edge is catching that flip from the instrument's funding/leverage signature, confirming directional momentum, and letting the discovery move run rather than fading it.",
+      "tags": [
+        "xyz",
+        "pre-ipo",
+        "ipo-conversion",
+        "conversion-event",
+        "momentum",
+        "price-discovery",
+        "let-winners-run",
+        "universe-scanner"
+      ],
+      "group": "momentum",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "ipo_moment",
+      "sub_style_label": "Trades the IPO conversion moment.",
+      "asset_classes": [
+        "pre_ipo"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 4
+    },
+    {
       "id": "hedgehog",
       "name": "Hedgehog — Major Crypto Basket",
       "emoji": "🦔",
@@ -498,7 +585,53 @@
       ],
       "max_slots": 3,
       "branch": "strategy-v2",
-      "sort_order": 4
+      "sort_order": 5
+    },
+    {
+      "id": "lemur",
+      "name": "Lemur — Pre-IPO Perpetual Trend Follower",
+      "emoji": "🦤",
+      "tagline": "Trades pre-IPO companies as perpetuals on Hyperliquid XYZ — today just SpaceX (xyz:SPCX). Auto-discovers IPOPs via the trade.xyz funding signature (~100x smaller funding) plus a <=5x pre-listing leverage cap and a $100k liquidity floor, then goes long or short when the 4h trend structure and Smart-Money lean agree. Leverage auto-caps to each name's own ceiling; a moderate DSL lets multi-day theses ride.",
+      "belief_plain": "Hyperliquid XYZ is one of the only places retail can trade private companies (like SpaceX) as perpetuals before they IPO. Lemur watches those pre-IPO names, waits for the 4-hour trend and the best traders to point the same way, then takes a single directional position and trails a stop. When a company actually goes public it stops qualifying and Lemur drops it automatically.",
+      "version": "1.0.0",
+      "thesis": "Pre-IPO perpetuals (IPOPs) are a structurally distinct product — a 0.005 funding multiplier (vs 0.5 for standard XYZ perps) and Discovery Bounds that throttle price velocity. That structural funding signature reliably identifies them with no hardcoded ticker list, so the universe future-proofs itself as trade.xyz lists new names and de-qualifies any that IPO. On those slow-moving names, a clean 4h trend confirmed by Smart-Money direction is enough edge to hold a directional swing and let a wide DSL ratchet capture the multi-day move.",
+      "tags": [
+        "pre-ipo",
+        "ipop",
+        "spacex",
+        "xyz",
+        "equities",
+        "trend-following",
+        "smart-money",
+        "auto-discovery",
+        "hyperliquid"
+      ],
+      "group": "momentum",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "pre_ipo",
+      "sub_style_label": "Trades pre-IPO perpetuals (IPOPs) before the company lists.",
+      "asset_classes": [
+        "pre_ipo"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "xyz:SPCX"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 900,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 6
     },
     {
       "id": "lynx",
@@ -549,7 +682,234 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 5
+      "sort_order": 7
+    },
+    {
+      "id": "meerkat",
+      "name": "Meerkat — Momentum-Event Sniper",
+      "emoji": "🦦",
+      "tagline": "A sentry that watches the momentum-event feed and snipes the freshest, highest-tier move the instant it fires: tier (event magnitude) + freshness gate the entry, smart-money alignment and rising volume add conviction, then it takes ONE position in the momentum direction and lets a wide DSL ride the burst.",
+      "belief_plain": "Watches a live feed of coins that just made a sharp move in the last few hours, and pounces only on the strongest, freshest ones — before the move is widely known. It sizes one bet in the direction of the move and trails a wide stop so a real burst can keep running, but cuts it loose after about a day and a half if it stalls.",
+      "version": "1.0.0",
+      "thesis": "Fresh momentum is the earliest, cleanest edge, and it decays fast — an event that's already 30+ minutes old is half-known and somebody else's trade. So the whole job is speed plus selectivity: only the strongest tiers, only while they're fresh, one position at a time. Smart-money lean and rising volume are confirmation bonuses, not gates, because the event fires faster than that data updates — waiting for confirmation forfeits the edge. A momentum burst pays out fast or it's stale, so a short hard timeout cuts a trade that hasn't moved.",
+      "tags": [
+        "momentum",
+        "momentum-event",
+        "sniper",
+        "freshness",
+        "tier",
+        "smart-money",
+        "universe-scanner",
+        "single-slot",
+        "let-winners-run"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "momentum_event",
+      "sub_style_label": "Snipes fresh momentum events the instant they fire.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 120,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 8
+    },
+    {
+      "id": "orca",
+      "name": "Orca — Gen-1 Vanilla Striker",
+      "emoji": "🐋",
+      "tagline": "A universe rank-jump sniper: watches the top-50 smart-money leaderboard every tick and fires only on a fresh FIRST_JUMP — a coin exploding 15+ ranks out of the deep field with 4h trend, 15m freshness, and a volume spike all confirming — then strikes ONE position at a fixed 7x and lets the DSL ride the breakout.",
+      "belief_plain": "Watches which coins the best traders are suddenly piling into and only acts when a name rockets up the leaderboard from deep in the pack — a fresh jump, not an already-crowded top name. It wants the move to be young (climbing fast in the last 15 minutes), going the same way the price is, and backed by a real volume spike before it takes a single shot.",
+      "version": "1.0.0",
+      "thesis": "The edge is in the FIRST jump, not the established leader. By the time a coin sits at the top of the smart-money board the move is priced in; the asymmetric entry is the moment a name explodes 15+ ranks out of the deep field (prev-rank >= 25) while its 4h trend, 15m contribution velocity, and 24h volume all confirm the same direction at once. That confluence is rare and decays fast, so the right move is to scan often (90s), strike once at a fixed 7x the instant it fires, skip the already-top names, and let a ratcheting DSL — not a fixed target — decide the exit so the occasional big breakout pays for the quiet weeks.",
+      "tags": [
+        "smart-money",
+        "momentum",
+        "breakout",
+        "rank-jump",
+        "first-jump",
+        "striker",
+        "universe-scanner",
+        "fixed-leverage"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "rank_jump",
+      "sub_style_label": "Catches leaderboard rank-jumps early.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 7,
+      "time_horizon": "swing",
+      "cadence_seconds": 90,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 9
+    },
+    {
+      "id": "otter",
+      "name": "Otter — Open Interest Velocity Hunter",
+      "emoji": "🦦",
+      "tagline": "Watches the rate of change of open interest across every liquid Hyperliquid crypto perp and fires at most a couple of positions — only when 1h OI jumps >=5% while price moves >=0.5% the same way (fresh leveraged money entering with conviction), 4h isn't unwinding, and the spread is tight. Sizes margin to conviction at 5/7/10x, then rides the flow 1-3h on a tight DSL.",
+      "belief_plain": "Open interest only grows when new leveraged money enters a perp. When that money piles in fast (OI up 5%+ in an hour) AND price moves the same direction, that's real conviction — not just a wick. Otter rides that fresh flow for an hour or three, then trails a tight stop. It does nothing on the much more common days when no coin shows that burst, and it never trades unwinds.",
+      "version": "1.0.0",
+      "thesis": "OI velocity — the delta of open interest over time — is a perp-native conviction signal nobody else in the fleet trades (others read OI only as a static size filter). Fresh OI growth aligned with price (the top two quadrants of the OI/price matrix) is new leveraged positioning with direction; unwinds (the bottom two) are exhaustion and get skipped. Confluence scoring (OI tier, 4h confirmation, price magnitude, smart-money lean, spread, time-of-day) at a high floor keeps it a sniper, and a tight DSL locks profit early because the flow edge is in the first 1-3 hours.",
+      "tags": [
+        "open-interest",
+        "oi-velocity",
+        "momentum",
+        "universe",
+        "flow",
+        "smart-money",
+        "conviction-sizing",
+        "short-hold",
+        "crypto"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "oi_confirmed",
+      "sub_style_label": "Enters a breakout only when open interest confirms (new money).",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 10
+    },
+    {
+      "id": "piranha",
+      "name": "Piranha — Liquidation-Cascade / Forced-Flow Hunter",
+      "emoji": "🐟",
+      "tagline": "Rides forced flow on crypto majors (BTC/ETH/SOL/HYPE): when open interest is unwinding fast (positions being force-closed) AND price is moving violently AND the 5-minute candle is still pushing the same way, it takes ONE position in the direction of the flow, sized 1-5x, and lets a wide DSL ratchet ride the squeeze with a 24h outer bound.",
+      "belief_plain": "A liquidation cascade is the cleanest momentum in crypto — it's forced flow, not opinion. When lots of positions are being force-closed at once, price gets shoved hard in one direction and the move feeds on itself until the leverage is flushed. Piranha reads the order flow underneath price (open-interest velocity + order-book depth) to confirm the move is forced, then rides it: OI down + price up = shorts squeezed, go long; OI down + price down = longs liquidated, go short.",
+      "version": "1.0.0",
+      "thesis": "Most agents react to price; the edge is reading the forced flow beneath it. Open interest dropping fast means positions are closing under duress, and when that coincides with a violent move and a thinning book on the side price is running into, there is little resistance left and the cascade continues. That signature is short-horizon and self-resolving, so the right move is one conviction entry in the flow direction, a wide ratchet that lets a squeeze extend, and a 24h hard timeout because if the cascade hasn't paid in a day it's over.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "hype",
+        "multi-asset",
+        "momentum",
+        "liquidation-cascade",
+        "forced-flow",
+        "open-interest",
+        "order-flow",
+        "microstructure",
+        "single-slot"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "liquidation_cascade",
+      "sub_style_label": "Rides liquidation cascades / forced flow.",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 180,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 11
+    },
+    {
+      "id": "python",
+      "name": "Python — The Patience Hunter",
+      "emoji": "🐍",
+      "tagline": "Scans the top 50 Hyperliquid crypto assets by volume and waits for one multi-day setup — 4h trend with macro direction, 1h agreeing, 15m confirming, smart money not opposing, RSI not extreme — then takes a single LONG-biased swing at 3-7x, sizes margin to conviction (25/30/40%), and holds for days behind a wide DSL (96h cap).",
+      "belief_plain": "Watches every liquid coin on Hyperliquid and does nothing until one setup lines up across the 4-hour, 1-hour and 15-minute timeframes with the best traders on the same side. Then it takes one well-sized, mostly-long swing and holds it for days behind a wide trailing stop, because the money is in the rare multi-day winner — not in trading often.",
+      "version": "1.0.0",
+      "thesis": "Every other agent strikes and rotates within hours; none hold for days, and that's the blind spot. The edge isn't a high win rate — it's NOT MISSING the one big multi-day move: a low win rate with a 3:1 win/loss ratio beats a high win rate with a thin one. So scan broadly, demand a real macro trend confirmed across three timeframes (never fighting a runaway counter-trend or a crowded smart-money side), tilt LONG, size to conviction, and let a wide DSL ride the move for days instead of getting chopped out early.",
+      "tags": [
+        "momentum",
+        "trend-following",
+        "universe",
+        "multi-day-hold",
+        "patience",
+        "smart-money",
+        "long-biased",
+        "conviction-margin",
+        "let-winners-run"
+      ],
+      "group": "momentum",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "trend_continuation",
+      "sub_style_label": "Trend Continuation",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 7,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 12
     },
     {
       "id": "sailfish",
@@ -599,7 +959,110 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 6
+      "sort_order": 13
+    },
+    {
+      "id": "salamander",
+      "name": "Salamander — Pullback Catcher",
+      "emoji": "🦎",
+      "tagline": "An onboarding-grade pullback trader on the liquid majors (BTC/ETH/SOL): buys a 3-7% dip inside an established bullish 4h trend (and shorts a 3-7% rally inside a bearish one) only when the smart-money leaderboard agrees with the trend direction, then gives the entry room on a wide Phase 1 while a wide Phase 2 ratchet lets the resumed trend run.",
+      "belief_plain": "Watches BTC, ETH and SOL. When one is in a clear up-trend on the 4-hour chart and dips 3-7% on the 1-hour chart while the best traders are still leaning long, it buys the dip; in a down-trend it shorts a 3-7% bounce. It needs all three to line up — trend, dip-in-the-band, and smart money agreeing — then it gives the trade room to work and trails a wide stop so the trend can keep running.",
+      "version": "1.0.0",
+      "thesis": "Pullbacks inside an established trend are one of the highest-edge setups: the trend has already proved itself, the counter-move offers a better entry, and a smart-money agreement filter screens out trend-break risk. The 3-7% band is the sweet spot — shallower is noise, deeper means the trend may be breaking, so you don't catch a falling knife. Because a resolved pullback resumes a trend that can run far, the exit is asymmetric: a wide Phase 1 floor lets the dip develop without a premature cut, and a wide Phase 2 ratchet (first lock only at +10% ROE) keeps the continuation that pays for the quiet weeks.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "multi-asset",
+        "pullback",
+        "buy-the-dip",
+        "short-the-rally",
+        "smart-money",
+        "trend-continuation",
+        "onboarding",
+        "let-winners-run"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "pullback",
+      "sub_style_label": "Buys the dip within an uptrend.",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 14
+    },
+    {
+      "id": "sheep",
+      "name": "Sheep — Triple-EMA Trend Follower",
+      "emoji": "🐑",
+      "tagline": "A long-only trend follower for beginners: buys a crypto major (BTC/ETH/SOL/HYPE) only when its fast EMA is above its slow EMA on all three timeframes (15m, 1h, 4h) at once, never shorts, and trails a balanced stop so a clean uptrend can run.",
+      "belief_plain": "Only buys when a coin is clearly going up by any chart reader's standard — the fast moving average has to be above the slow one on the 15-minute, 1-hour, AND 4-hour chart simultaneously. It never shorts (so there's no 'what's a short?' to learn), bets a little bigger when the trend is wider and the best traders agree, and then trails a stop so a real uptrend can keep running.",
+      "version": "1.0.0",
+      "thesis": "Most trend agents pick a single timeframe; Sheep insists on agreement across three before firing. That is a stricter filter (fewer trades) but each entry is 'obviously up' to any chart reader, which is exactly the property a beginner needs to trust the agent. Long-only by design removes the cognitive load of shorting, making this the onboarding-grade entry point into the fleet.",
+      "tags": [
+        "btc",
+        "eth",
+        "sol",
+        "hype",
+        "multi-asset",
+        "trend",
+        "ema-stack",
+        "triple-timeframe",
+        "long-only",
+        "onboarding",
+        "smart-money",
+        "let-winners-run"
+      ],
+      "group": "momentum",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "basket",
+      "sub_style_label": "Holds a whitelist basket of majors.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE"
+      ],
+      "direction": "long_only",
+      "risk_level": "conservative",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 15
     },
     {
       "id": "jaguar",
@@ -2206,6 +2669,50 @@
       "sort_order": 5
     },
     {
+      "id": "roach",
+      "name": "Roach — Striker Rank-Jump Sniper",
+      "emoji": "🪳",
+      "tagline": "A patient striker: watches the top-50 smart-money leaderboard and fires only on violent FIRST_JUMP / IMMEDIATE_MOVER rank explosions confirmed by 4h trend, 1h price, fresh 15m velocity, and a 1.5x volume spike — then sizes one bet and lets a tight ratchet ride it. Long silences are expected and correct.",
+      "belief_plain": "Cockroaches survive by not moving when there's nothing to chase. Roach watches which coins the best traders are suddenly piling into — a coin violently jumping up the leaderboard — and only buys when that rank-jump is backed by the 4-hour trend, the last hour's price, fresh momentum, and a real volume spike all agreeing. Most of the time it does nothing; the patience is the edge.",
+      "version": "1.0.0",
+      "thesis": "Most leaderboard movement is noise. Real edge is a violent, fresh rank-jump — a coin exploding from #25+ into the top of the smart-money board in a single scan — but only when it's confirmed by trend, price, fresh velocity, and volume at the same instant. Those explosions are rare, so the right move is to ban equities, demand a high composite score with multiple confirmations, take the few that qualify at fixed 7x sizing, and let a ratcheting DSL stop bank the move. Stalker-style accumulation entries were removed — fewer, higher-quality strikes beat more, mixed ones.",
+      "tags": [
+        "smart-money",
+        "breakout",
+        "rank-jump",
+        "first-jump",
+        "immediate-mover",
+        "universe-scanner",
+        "striker",
+        "volume-confirmed",
+        "patient"
+      ],
+      "group": "smart-money",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "rank_jump",
+      "sub_style_label": "Catches leaderboard rank-jumps early.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 7,
+      "time_horizon": "swing",
+      "cadence_seconds": 90,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 6
+    },
+    {
       "id": "whalehunter",
       "name": "WhaleHunter — Smart-Money Cohort Divergence",
       "emoji": "🐋",
@@ -2246,7 +2753,53 @@
       ],
       "max_slots": 6,
       "branch": "strategy-v2",
-      "sort_order": 6
+      "sort_order": 7
+    },
+    {
+      "id": "raccoon",
+      "name": "Raccoon — Weekend XYZ Reconciliation",
+      "emoji": "🦝",
+      "tagline": "Trades only the weekend, only on tokenized stocks & commodities (XYZ): while the underlying markets are closed and XYZ runs on an internal oracle, Raccoon positions in the direction sentiment has been pushing the price — and captures the snap-back when real external pricing resumes Monday open. Sizes 15% / 3x and rides a tight DSL with a 48h Monday-exit cap.",
+      "belief_plain": "From Friday evening to Sunday evening the real stock and commodity markets are closed, so tokenized versions on XYZ drift on an internal estimate instead of a live price. When trading resumes Monday, that estimate snaps to the true market price. Raccoon bets in the direction the weekend drift (plus the best traders) is leaning, and exits into that Monday snap — and only ever runs on the weekend.",
+      "version": "1.0.0",
+      "thesis": "Fri 17:00 ET -> Sun 18:00 ET, trade.xyz has no external price feed for equities/commodities and runs a 30-min EWMA internal oracle that drifts on impact-price activity. Accumulated weekend sentiment (>= 2% move + volume + smart-money agreement) shows up as directional oracle drift; when external pricing resumes Sunday evening the implied price reconciles to the real value. Positioning into that gap and exiting at the Monday-open snap is the edge — and confining all activity to the weekend window avoids weekday false signals and Lemur's 24/7 IPOP territory.",
+      "tags": [
+        "xyz",
+        "equities",
+        "commodities",
+        "weekend",
+        "reconciliation",
+        "oracle-gap",
+        "smart-money",
+        "snap-back",
+        "hard-timeout"
+      ],
+      "group": "xyz",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "weekend_gap",
+      "sub_style_label": "Trades the weekend stock-gap reconciliation.",
+      "asset_classes": [
+        "xyz_equities",
+        "commodities",
+        "indices"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 1
     }
   ]
 }

--- a/strategies/falcon/main/runtime.yaml
+++ b/strategies/falcon/main/runtime.yaml
@@ -1,0 +1,126 @@
+# ── FALCON · single instance — Conversion-Event Momentum (Runtime 3.0 port of v2 FALCON v1.0.1) ──
+name: falcon-main
+group: falcon
+version: 3.0.0
+description: >
+  FALCON — Conversion-Event Momentum (XYZ Pre-IPO -> equity). A Pre-IPO Perpetual
+  (IPOP) carries a structural funding signature (|funding| <= ~1e-7, max_leverage <= 5)
+  and is price-throttled by trade.xyz Discovery Bounds. When the company IPOs the
+  product CONVERTS to a standard equity perp — funding jumps ~100x, the leverage cap
+  lifts, the throttle is removed — opening a window of free price discovery. Each tick
+  Falcon classifies every xyz instrument IPOP vs STANDARD, detects IPOP->STANDARD flips
+  against a class cache, stamps flips into a conversionWindowHours eligibility window,
+  and emits the single highest-scoring name with confirmed post-conversion momentum.
+  Wide let-winners-run DSL (7d hard_timeout); one position at a time. Faithful port of
+  the v2 producer thesis. Distinct from Lemur, which trades the IPOP basket itself.
+
+strategy:
+  wallet: "${FALCON_WALLET}"
+  slots: 1                                # one conversion trade at a time
+  default_leverage: 4                     # v2 DEFAULT_LEVERAGE; scan emits clamped per-instrument cap (auto-clamped to venue max)
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: falcon_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 600                  # v2 producer cadence (10 min — conversions are rare, a window lasts days)
+    timeout_seconds: 240                   # v2 tick_timeout; universe scan + per-candidate candle/SM reads
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 100           # class cache + conversion window + dedup map + per-tick results
+    inputs:
+      ipopFundingMaxAbs: 1.0e-7            # |funding| <= this -> IPOP funding signature
+      ipopMaxLeverageCap: 5                # AND max_leverage <= this -> IPOP
+      conversionWindowHours: 72            # eligibility window after a detected flip
+      momentumLookbackBars: 6              # 1h bars for the post-conversion momentum read
+      minMomentumPct: 3.0                  # |move| floor to call a discovery trend
+      strongMomentumPct: 8.0               # |move| for the strong-momentum score bonus
+      smTiltMinPct: 55                     # SM tilt for the agreement bonus
+      smStrongTiltPct: 70                  # SM tilt for the strong-SM bonus
+      minScore: 5                          # v2 minScore floor (max score ~8)
+      marginPct: 15                        # PERCENT of withdrawable (0,100] — runtime sizes (marginPct/100)*withdrawable
+      leverage: 4                          # v2 DEFAULT_LEVERAGE; clamped to per-instrument cap and 10x in scan
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      momentumPct: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      volumeTrendPct: { type: number, required: false }
+      conversionEvent: { type: boolean, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: falcon_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan applied the conversion gate + momentum gate + score floor; v2 LLM gate was pass-through
+    scanners: [falcon_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # enter the discovery move — a resting maker (CREATE_ORDER_RESTING) misses the post-conversion run
+        execution_timeout_seconds: 30      # v2 entry timeout
+    context:
+      - type: signal
+        scanner: falcon_main_signals
+
+# EXIT — DSL, ported VERBATIM from v2 falcon runtime.yaml (let-winners-run preset).
+# Post-conversion price discovery can trend for days as a real spot reference arrives
+# and the leverage cap lifts. Wide ladder (T0 +10% / lock 0), max_loss 20%, time-cuts
+# OFF except a 7d hard_timeout. Phase 1 retrace trailing only. NO weak_peak_cut /
+# dead_weight_cut — they would churn a slow-developing discovery trend.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10080           # 7d — a conversion discovery trend can run for days
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 12
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 40 }
+        - { trigger_pct: 35,  lock_hw_pct: 60 }
+        - { trigger_pct: 60,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+risk:
+  data_retention_seconds: 345600           # v2 data_retention_hours 96 (×3600); within [3600, 604800]
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 2                  # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 7200                  # v2 cooldown_minutes 120 (2h post-loss freeze)
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 43200       # v2 per_asset_cooldown_minutes 720 (12h)

--- a/strategies/falcon/main/scanners/scan.py
+++ b/strategies/falcon/main/scanners/scan.py
@@ -1,0 +1,395 @@
+"""FALCON — supervised scanner (Runtime 3.0 port of the v2 FALCON producer).
+
+UNIVERSE SCANNER, emit-one. A faithful port of the v2 "Conversion-Event
+Momentum" strategy (falcon-producer.py v1.0.1 / SKILL.md v1.0.0): trade the
+moment a Hyperliquid XYZ Pre-IPO Perpetual (IPOP) CONVERTS to a standard equity
+perp (funding jumps ~100x, the leverage cap lifts, the trade.xyz Discovery-Bounds
+throttle is removed), riding the post-conversion price-discovery momentum.
+
+Per tick it:
+  1. READ-GUARDED market_list_instruments(dex="xyz") -> classify every xyz name
+     IPOP vs STANDARD by funding signature (|funding|<=ipopFundingMaxAbs AND
+     max_leverage<=ipopMaxLeverageCap = IPOP, else STANDARD).
+  2. Compare against the prior-tick class cache (ctx.state) -> detect
+     IPOP->STANDARD flips. A first sighting (no prior class) is NEVER a flip.
+  3. A flip stamps the name into a conversionWindowHours eligibility window
+     (also in ctx.state) so momentum that develops over hours/days stays
+     tradeable. Stale stamps are pruned.
+  4. Inside the window, require confirmed 1h-candle momentum
+     (|move over momentumLookbackBars| >= minMomentumPct) and SM agreement
+     bonus; score via the pure `scoring.build_thesis`.
+  5. Emit ONE signal for the single highest-scoring candidate clearing minScore
+     — a marginPct sizing INTENT plus a leverage clamped to the post-conversion
+     cap and MAX_LEVERAGE.
+
+Read-only + single-pass. NO daemon, NO push_signal, NO create_position — the
+runtime sizes the dollars, owns the cooldowns/risk gates/slots, and trails the
+DSL exit. Held-asset suppression and per-tick signal dedup live in ctx.state.
+
+FIDELITY NOTES vs the v2 producer (falcon-producer.py v1.0.1):
+  - v2 persisted THREE on-disk JSON caches: the recent-signals race-window
+    dedup (recent-signals.json), the instrument-class cache (instrument-
+    class.json), and the conversion-window cache (conversions.json). All three
+    are ported into a SINGLE ctx.state record per tick:
+      {"signaled": {coin: ts}, "classes": {name: cls}, "conversions": {name: ts},
+       "result": {...}}.
+    Same TTL/window semantics; transactional rollback replaces the atomic-write
+    pattern. The very first tick seeds the class cache with NO flips (verbatim).
+  - v2 main() ran `reconcile_conversions` UNCONDITIONALLY every tick (persist the
+    new class cache + stamp flips) even before any account/value gate. Preserved:
+    class-cache reconciliation runs every clean tick via the persisted state, so
+    flips are never missed while we wait for momentum.
+  - v2 fetch_sm_direction read leaderboard_get_markets PER candidate. Preserved
+    (read-guarded); SM is a score bonus, not a gate (sparse on fresh listings),
+    so an SM read failure degrades to NEUTRAL/no-bonus, never skips the tick.
+  - v2 margin was a FRACTION (0.15) * account_value -> marginUsd. This port emits
+    the PERCENT (15) as `marginPct`; the runtime sizes (marginPct/100)*
+    withdrawable. Defensive <=1.0 fraction->percent guard applied (koala/dire
+    pattern). Leverage clamp min(config, post-conversion cap, 10) is verbatim.
+  - DROPPED (read-only scan() cannot mutate): nothing — v2 Falcon had NO
+    order-lifecycle management (no cancel_order / resting-order purge). The
+    producer NEVER closed positions; the DSL owns exits, ported verbatim.
+  - v2's "no account value -> skip" and "held-asset -> never re-emit" gates are
+    preserved; the held check reads both sub-DEX views (dual-DEX equity collapse
+    via max(), never sum()).
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 240            # 4min — mirror v2 RECENT_SIGNAL_TTL_SEC (held-asset race-fix)
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll
+    back the whole tick (per the scan contract, ANY exception -> []). Returns
+    None on failure so the existing degrade paths apply."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[falcon.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+# ═══════════════════════════════════════════════════════════════
+# Universe scan + conversion detection
+# ═══════════════════════════════════════════════════════════════
+
+def scan_instruments(ctx, inputs):
+    """READ-GUARDED port of v2 scan_instruments: pull the xyz instrument list and
+    classify each IPOP vs STANDARD. Returns
+    {name: {"class", "max_leverage", "funding", "vol_usd"}} or {} on read failure."""
+    ipop_funding_max = float(inputs.get("ipopFundingMaxAbs", scoring.DEFAULT_IPOP_FUNDING_MAX))
+    ipop_lev_cap = int(inputs.get("ipopMaxLeverageCap", scoring.DEFAULT_IPOP_LEV_CAP))
+
+    raw = _read(ctx, "market_list_instruments", {"dex": "xyz"})
+    if not raw:
+        return {}
+    if isinstance(raw, dict) and raw.get("success") is False:
+        return {}
+    data = raw.get("data", raw) if isinstance(raw, dict) else raw
+    instruments = data.get("instruments", data) if isinstance(data, dict) else data
+    if not isinstance(instruments, list):
+        return {}
+
+    out = {}
+    for inst in instruments:
+        if not isinstance(inst, dict):
+            continue
+        name = str(inst.get("name", ""))
+        if not name.startswith("xyz:"):
+            continue
+        if inst.get("is_delisted", False):
+            continue
+        ctx_block = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        funding_abs = abs(scoring._f(ctx_block.get("funding", 0)))
+        try:
+            max_lev = int(inst.get("max_leverage", 5))
+        except (TypeError, ValueError):
+            max_lev = 5
+        out[name] = {
+            "class": scoring.classify_instrument(funding_abs, max_lev, ipop_funding_max, ipop_lev_cap),
+            "max_leverage": max_lev,
+            "funding": funding_abs,
+            "vol_usd": scoring._f(ctx_block.get("dayNtlVlm", 0)),
+        }
+    return out
+
+
+def reconcile_conversions(scan_map, prev_classes, prev_conversions, inputs, now):
+    """Port of v2 reconcile_conversions, over ctx.state instead of disk caches.
+
+    Compares this scan against the prior class cache, stamps any new
+    IPOP->STANDARD flip into the conversion window, prunes stale stamps. Returns
+    (new_classes, live_conversions, names_in_window)."""
+    window_hours = float(inputs.get("conversionWindowHours", scoring.DEFAULT_CONVERSION_WINDOW_HOURS))
+
+    new_classes = {}
+    conversions = dict(prev_conversions)
+    for name, info in scan_map.items():
+        curr_class = info["class"]
+        prev_class = prev_classes.get(name)
+        if scoring.detect_conversion(prev_class, curr_class):
+            conversions[name] = now
+        new_classes[name] = curr_class
+
+    cutoff = now - (window_hours * 3600.0)
+    live = {k: v for k, v in conversions.items() if v >= cutoff}
+    return new_classes, live, set(live.keys())
+
+
+# ═══════════════════════════════════════════════════════════════
+# Data fetchers (READ-GUARDED)
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_candles(ctx, asset):
+    """1h candles for `asset`. READ-GUARDED. Ported from v2 fetch_candles."""
+    data = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h"],
+        "include_funding": False,
+        "include_order_book": False,
+        "dex": "xyz",
+    })
+    if not data:
+        return []
+    if isinstance(data, dict) and data.get("success") is False:
+        return []
+    d = data.get("data", data) if isinstance(data, dict) else data
+    if not isinstance(d, dict):
+        return []
+    return d.get("candles", {}).get("1h", []) or []
+
+
+def fetch_sm_direction(ctx, asset):
+    """Net smart-money lean for `asset` from leaderboard_get_markets. READ-GUARDED.
+    Returns (direction, tilt_pct) or (None, 0.0). Ported verbatim from v2;
+    SM is a score bonus, so a failed read degrades to (None, 0.0)."""
+    raw = _read(ctx, "leaderboard_get_markets", {})
+    if not raw:
+        return None, 0.0
+    if isinstance(raw, dict) and raw.get("success") is False:
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+def _held_assets(ctx):
+    """Open positions across both sub-DEX views so we never emit on a coin the
+    runtime already holds. READ-GUARDED. Ported from v2 cfg.get_positions,
+    including the (account_value <= 0 -> skip) gate and the corrupt-read sanity
+    guard (margin in use + empty positions -> treat as no account value)."""
+    if not getattr(ctx, "wallet", None):
+        return 0.0, []
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    held, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        # one wallet, two sub-DEX views -> count equity ONCE via max() (summing
+        # double-counts the shared free balance -> 2x sizing).
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            if scoring._f(pos.get("szi", 0)) != 0:
+                c = str(pos.get("coin", "")).upper()
+                if c:
+                    held.append(c)
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim): a corrupt
+    # clearinghouse read can report margin/notional IN USE while returning an
+    # EMPTY positions list; sizing or running the held dedup off that re-enters
+    # held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not held:
+        print("[falcon.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, held
+
+
+# ═══════════════════════════════════════════════════════════════
+# scan() — detect conversions, score momentum, emit the best one
+# ═══════════════════════════════════════════════════════════════
+
+def scan(inputs, ctx):
+    now = time.time()
+    min_score = int(inputs.get("minScore", scoring.DEFAULT_MIN_SCORE))
+    config_leverage = int(inputs.get("leverage", scoring.DEFAULT_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+
+    # marginPct is a PERCENT in (0,100]. FLAGGED: defensively convert a value
+    # <= 1 (an operator who pasted the v2 FRACTION 0.15) into a PERCENT so it
+    # never silently sizes ~100x small (runtime sizes (marginPct/100)*withdrawable).
+    margin_pct = float(inputs.get("marginPct", scoring.DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        print(f"[falcon.scan] marginPct={margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
+
+    # ── load cross-tick state (the v2 class/conversion/signal caches) ──
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    prev_classes = dict(last.get("classes") or {})
+    prev_conversions = {k: float(v) for k, v in (last.get("conversions") or {}).items()
+                        if isinstance(v, (int, float))}
+    signaled = {k: float(v) for k, v in (last.get("signaled") or {}).items()
+                if isinstance(v, (int, float)) and (now - float(v)) < (ttl * 4)}
+
+    def _persist(classes, conversions, result):
+        if ctx.state is None:
+            return
+        rec = {"signaled": signaled, "classes": classes,
+               "conversions": conversions, "result": result}
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[falcon.scan] WARNING: state append failed; next tick may miss a "
+                  f"flip or re-emit a suppressed signal: {exc!r}", file=sys.stderr)
+
+    # ── account / held gate (v2 main(): no account value -> skip) ──
+    account_value, held = _held_assets(ctx)
+    held_set = {h.upper() for h in held}
+    if account_value <= 0:
+        # do NOT advance the class cache off a failed/empty account read; keep
+        # the prior caches so we don't lose flip history (verbatim intent).
+        print("[falcon.scan] no account value / clearinghouse read failed — skipping tick",
+              file=sys.stderr)
+        _persist(prev_classes, prev_conversions,
+                 {"ts": now, "emitted": False, "gate": "no_account_value"})
+        return []
+
+    # ── classify the xyz universe + reconcile conversions EVERY tick ──
+    scan_map = scan_instruments(ctx, inputs)
+    if not scan_map:
+        # market_list_instruments degraded to empty/cached: do not flip the cache
+        # to empty (that would erase known IPOP classes and miss the next flip).
+        print("[falcon.scan] market_list_instruments empty/failed — preserving caches, no signal",
+              file=sys.stderr)
+        # still prune the conversion window so stale stamps expire.
+        window_hours = float(inputs.get("conversionWindowHours", scoring.DEFAULT_CONVERSION_WINDOW_HOURS))
+        cutoff = now - (window_hours * 3600.0)
+        live = {k: v for k, v in prev_conversions.items() if v >= cutoff}
+        _persist(prev_classes, live,
+                 {"ts": now, "emitted": False, "gate": "no_universe"})
+        return []
+
+    new_classes, live_conversions, in_window = reconcile_conversions(
+        scan_map, prev_classes, prev_conversions, inputs, now)
+
+    if not in_window:
+        ipops_now = sorted(n for n, i in scan_map.items() if i["class"] == "IPOP")
+        print(f"[falcon.scan] WAITING — no IPOP->equity conversion inside the window "
+              f"(tracked={len(scan_map)}, ipops_now={len(ipops_now)})", file=sys.stderr)
+        _persist(new_classes, live_conversions,
+                 {"ts": now, "emitted": False, "gate": "no_conversion",
+                  "tracked": len(scan_map), "ipops_now": ipops_now,
+                  "held": sorted(held_set)})
+        return []
+
+    # ── score every in-window candidate (held + recently-signaled filtered
+    #    BEFORE the per-asset MCP fetch, as in v2 main()) ──
+    candidates = []
+    for name in sorted(in_window):
+        if name.upper() in held_set:
+            continue
+        last_sig = signaled.get(name.upper())
+        if last_sig is not None and (now - last_sig) < ttl:
+            continue
+        info = scan_map.get(name)
+        if not info:
+            continue  # converted name no longer listed
+        candles = fetch_candles(ctx, name)
+        if len(candles) < 8:
+            continue
+        sm_dir, sm_tilt = fetch_sm_direction(ctx, name)
+        th = scoring.build_thesis(name, info, candles, sm_dir, sm_tilt, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    if not candidates:
+        print(f"[falcon.scan] WAITING — conversion(s) in window but no confirmed momentum "
+              f">= minScore={min_score} (window={sorted(in_window)})", file=sys.stderr)
+        _persist(new_classes, live_conversions,
+                 {"ts": now, "emitted": False, "gate": "no_momentum",
+                  "conversions_in_window": sorted(in_window), "held": sorted(held_set)})
+        return []
+
+    # ── pick the single highest-scoring candidate (v2 emits only `best`) ──
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+    bu = best["coin"].upper()
+
+    leverage = scoring.leverage_for(config_leverage, best.get("max_leverage_cap", scoring.MAX_LEVERAGE))
+    signaled[bu] = now
+
+    result = {"ts": now, "emitted": True, "gate": "pass", "coin": best["coin"],
+              "direction": best["direction"], "score": best["score"],
+              "leverage": leverage, "marginPct": margin_pct,
+              "momentum_pct": best["momentum_pct"],
+              "conversions_in_window": sorted(in_window),
+              "candidates": len(candidates), "reasons": best["reasons"]}
+    print(f"[falcon.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+          f"{leverage}x margin={margin_pct}% mom={best['momentum_pct']:+.1f}% | {best['reasons'][:5]}",
+          file=sys.stderr)
+    _persist(new_classes, live_conversions, result)
+
+    return [{
+        "asset": best["coin"],
+        "direction": best["direction"],
+        "marginPct": margin_pct,                 # SIZING INTENT — PERCENT (0,100]; runtime sizes USD
+        "leverage": leverage,                    # clamped to post-conversion cap + 10x; runtime clamps to venue max
+        "data": {
+            "score": best["score"],
+            "leverage": leverage,
+            "direction": best["direction"],
+            "reasons": best["reasons"],
+            "momentumPct": best.get("momentum_pct") or 0.0,
+            "smDirection": best.get("sm_direction") or "NONE",
+            "smTiltPct": best.get("sm_tilt_pct") or 0.0,
+            "volumeTrendPct": best.get("volume_trend_pct") or 0.0,
+            "conversionEvent": True,
+            "heldAssets": sorted(held_set),
+        },
+    }]

--- a/strategies/falcon/main/scanners/scoring.py
+++ b/strategies/falcon/main/scanners/scoring.py
@@ -1,0 +1,191 @@
+"""FALCON — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 FALCON producer's conversion/momentum
+logic (falcon-producer.py v1.0.1 / SKILL.md v1.0.0, "Conversion-Event Momentum
+— XYZ Pre-IPO → equity"). The classification heuristic, conversion detector,
+momentum math, direction rule, volume trend, and the score table are reproduced
+VERBATIM so a fidelity harness can diff this against the v2 producer on the same
+xyz-instrument snapshot.
+
+`scan.py` owns the clock, the MCP reads, and the cross-tick class/conversion
+caches (ctx.state); this module stays pure and unit-testable on plain dicts.
+"""
+
+# ═══════════════════════════════════════════════════════════════
+# CONSTANTS — preserved verbatim from v2 falcon-producer.py v1.0.1
+# ═══════════════════════════════════════════════════════════════
+
+MAX_LEVERAGE = 10
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 5
+DEFAULT_SM_TILT_MIN = 55
+DEFAULT_SM_STRONG = 70
+
+# IPOP funding signature (the same heuristic Lemur uses to FIND IPOPs; Falcon
+# uses it to detect when one STOPS being an IPOP).
+DEFAULT_IPOP_FUNDING_MAX = 1e-7
+DEFAULT_IPOP_LEV_CAP = 5
+
+DEFAULT_MOMENTUM_LOOKBACK = 6       # 1h bars
+DEFAULT_MIN_MOMENTUM_PCT = 3.0     # |move| to call a discovery trend
+DEFAULT_STRONG_MOMENTUM_PCT = 8.0
+DEFAULT_CONVERSION_WINDOW_HOURS = 72   # how long after a flip a name stays eligible
+
+# marginPct here is a PERCENT of withdrawable in (0,100] — the Runtime 3.0 wire
+# convention — NOT the v2 fraction (0.15). v2 emitted marginUsd =
+# account_value * fraction; the runtime now sizes (marginPct/100)*withdrawable.
+DEFAULT_MARGIN_PCT = 15
+
+
+# ── numeric coercion (matches v2 _f / safe_float) ──
+
+def _f(v, primary=None, alt=None, default=0.0):
+    """Two call shapes preserved from v2:
+      _f(scalar)                  -> float(scalar) or default
+      _f(dict, primary, alt)      -> dict.get(primary) or dict.get(alt) (v2 candle _f)
+    """
+    if isinstance(v, dict):
+        val = v.get(primary)
+        if val is None and alt:
+            val = v.get(alt)
+    else:
+        val = v
+    try:
+        return float(val) if val is not None else float(default)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+# ═══════════════════════════════════════════════════════════════
+# Conversion / momentum logic (verbatim from v2, unit-testable)
+# ═══════════════════════════════════════════════════════════════
+
+def classify_instrument(funding_abs, max_leverage, ipop_funding_max, ipop_lev_cap):
+    """Classify an xyz equity instrument by its funding signature.
+
+    IPOP     = pre-listing product: |funding| <= ipop_funding_max AND
+               max_leverage <= ipop_lev_cap.
+    STANDARD = a normal equity perp: funding has normalized OR the leverage
+               cap has lifted.
+    Returns "IPOP" or "STANDARD". Verbatim from v2."""
+    try:
+        f = abs(float(funding_abs))
+        lev = int(max_leverage)
+    except (TypeError, ValueError):
+        return "STANDARD"
+    if f <= ipop_funding_max and lev <= ipop_lev_cap:
+        return "IPOP"
+    return "STANDARD"
+
+
+def detect_conversion(prev_class, curr_class):
+    """A conversion event is an IPOP that has become STANDARD since last tick.
+    Requires a known prior class (None prev = first sighting, not a flip).
+    Verbatim from v2."""
+    return prev_class == "IPOP" and curr_class == "STANDARD"
+
+
+def momentum_pct(closes, lookback):
+    """% change of the latest close vs the close `lookback` bars ago.
+    None if insufficient data or the reference price is non-positive.
+    Verbatim from v2."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def conversion_direction(momentum, min_momentum_pct):
+    """Direction to trade post-conversion price discovery: ride the momentum.
+    None if momentum is missing or below the minimum magnitude. Verbatim from v2."""
+    if momentum is None or abs(momentum) < min_momentum_pct:
+        return None
+    return "LONG" if momentum > 0 else "SHORT"
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-vs-earlier volume % change over `lookback` 1h candles. Verbatim from v2."""
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — score one freshly-converted instrument (verbatim v2 table)
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(name, scan_info, candles, sm_dir, sm_tilt, inputs=None):
+    """Score a freshly-converted instrument's post-conversion momentum.
+
+    `name`       = "xyz:NAME"
+    `scan_info`  = {"class", "max_leverage", "funding", "vol_usd"} from the scan
+    `candles`    = list of 1h candle dicts (caller fetched via MCP)
+    `sm_dir`     = smart-money net direction ("LONG"/"SHORT"/"NEUTRAL"/None)
+    `sm_tilt`    = smart-money tilt percent
+
+    Returns a scored thesis dict, or None if there is insufficient candle data
+    or no confirmed directional momentum. Score table is VERBATIM from v2
+    build_thesis (max ~8). Caller owns the clock and all MCP reads."""
+    inputs = inputs or {}
+    if len(candles) < 8:
+        return None
+    closes = [_f(c, "close", "c") for c in candles]
+
+    lookback = int(inputs.get("momentumLookbackBars", DEFAULT_MOMENTUM_LOOKBACK))
+    min_mom = float(inputs.get("minMomentumPct", DEFAULT_MIN_MOMENTUM_PCT))
+    strong_mom = float(inputs.get("strongMomentumPct", DEFAULT_STRONG_MOMENTUM_PCT))
+    sm_min = float(inputs.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(inputs.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+
+    mom = momentum_pct(closes, lookback)
+    direction = conversion_direction(mom, min_mom)
+    if direction is None:
+        return None
+
+    vol_trend = volume_trend(candles)
+
+    score = 0
+    reasons = ["converted_ipop_to_equity", f"mom_{mom:+.1f}%"]
+    score += 3  # inside conversion window + momentum >= min (gate-confirmed)
+    if abs(mom) >= strong_mom:
+        score += 2
+        reasons.append(f"mom_strong_{mom:+.1f}%")
+    # SM is often sparse on a freshly-listed name — agreement is a bonus, not a gate.
+    if sm_dir == direction and sm_tilt >= sm_min:
+        score += 1
+        reasons.append(f"sm_confirms_{sm_tilt:.0f}%")
+        if sm_tilt >= sm_strong:
+            score += 1
+            reasons.append("sm_strong")
+    if vol_trend > 15:
+        score += 1
+        reasons.append(f"vol_rising_{vol_trend:+.0f}%")
+
+    return {
+        "coin": name,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "momentum_pct": round(mom, 2),
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": sm_tilt,
+        "volume_trend_pct": round(vol_trend, 2),
+        "max_leverage_cap": scan_info.get("max_leverage", MAX_LEVERAGE),
+    }
+
+
+def leverage_for(config_leverage, max_leverage_cap):
+    """Clamp config leverage to the instrument's post-conversion leverage cap and
+    the global MAX_LEVERAGE. Verbatim from v2 main()'s clamp."""
+    return min(int(config_leverage), int(max_leverage_cap), MAX_LEVERAGE)

--- a/strategies/falcon/main/scanners/test_margin_pct.py
+++ b/strategies/falcon/main/scanners/test_margin_pct.py
@@ -1,0 +1,40 @@
+"""Guard: falcon's marginPct must be a PERCENT in (0,100], never a v2 fraction.
+
+v3.x runtime sizes `(marginPct/100)*withdrawable` (resolve-margin.ts), so a
+fraction like 0.15 sizes 0.15% of withdrawable — ~100x undersize, silent (no
+400, since 0.15 still satisfies the (0,100] bound). The v2 producer emitted
+marginUsd = account_value * 0.15; the Runtime 3.0 port emits the PERCENT (15) on
+the wire and lets the runtime size the dollars. This asserts both the
+runtime.yaml inputs.marginPct AND the scoring.py default are PERCENTs in [1,100].
+"""
+
+import os
+
+import yaml
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_RUNTIME_YAML = os.path.join(_HERE, "..", "runtime.yaml")
+
+
+def _scanner_inputs():
+    with open(_RUNTIME_YAML) as f:
+        spec = yaml.safe_load(f)
+    for s in spec["scanners"]:
+        if s.get("type") == "external_scanner":
+            return s["inputs"]
+    raise AssertionError("no external_scanner inputs in runtime.yaml")
+
+
+def test_runtime_margin_pct_is_percent_in_range():
+    pct = float(_scanner_inputs()["marginPct"])
+    # >=1 catches the fraction bug (0.15); <=100 is the wire upper bound.
+    assert 1 <= pct <= 100, f"runtime.yaml marginPct={pct} not a PERCENT in [1,100]"
+
+
+def test_scoring_default_margin_pct_is_percent_in_range():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("scoring", os.path.join(_HERE, "scoring.py"))
+    scoring = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(scoring)
+    assert 1 <= scoring.DEFAULT_MARGIN_PCT <= 100, (
+        f"scoring DEFAULT_MARGIN_PCT={scoring.DEFAULT_MARGIN_PCT} not a PERCENT in [1,100]")

--- a/strategies/falcon/strategy.yaml
+++ b/strategies/falcon/strategy.yaml
@@ -1,0 +1,42 @@
+# Falcon — Conversion-Event Momentum (XYZ Pre-IPO -> equity). A single-instance PACKAGE:
+# this manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port
+# of the v2 Falcon (falcon-producer.py v1.0.1 / SKILL.md v1.0.0): scans every Hyperliquid
+# XYZ instrument, classifies IPOP vs STANDARD by funding signature, detects the IPOP->equity
+# conversion flip, and rides the post-conversion price-discovery momentum with a wide DSL.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: falcon
+version: "1.0.0"
+
+catalog:
+  name: "Falcon — Conversion-Event Momentum"
+  emoji: "🦅"
+  tagline: "Watches every Hyperliquid XYZ pre-IPO perpetual and fires the moment one converts to a normal equity perp — when the company IPOs, funding jumps ~100x, the leverage cap lifts and the price throttle comes off, opening a window of free price discovery. Falcon catches that flip and rides the post-conversion momentum with a wide let-winners-run stop (7d)."
+  belief_plain: "A pre-IPO name on Hyperliquid is deliberately pinned — its price can barely move. The instant the company goes public the brakes come off all at once and the name often trends hard for days. Falcon detects that exact handover from a tell in the funding rate, then takes a single position in the direction it's already running and trails a wide stop so a real move can run."
+  thesis: "The IPOP->equity conversion is a detectable regime change: funding normalizes ~100x, the max-leverage cap lifts, and the trade.xyz Discovery-Bounds price throttle is removed. The first hours-to-days after conversion are pure price discovery, which often trends in one direction. The edge is catching that flip from the instrument's funding/leverage signature, confirming directional momentum, and letting the discovery move run rather than fading it."
+  group: momentum
+  archetype: single_market
+  sub_style: ipo_moment
+  asset_classes: [pre_ipo]
+  asset_scope: universe
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  leverage_max: 10
+  max_slots: 1
+  min_budget: 200
+  assets: []
+  tags: [xyz, pre-ipo, ipo-conversion, conversion-event, momentum, price-discovery, let-winners-run, universe-scanner]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: FALCON_WALLET
+    funding_share: 1.0

--- a/strategies/lemur/main/runtime.yaml
+++ b/strategies/lemur/main/runtime.yaml
@@ -1,0 +1,151 @@
+# ── LEMUR · single instance — Pre-IPO Perpetual (IPOP) trend follower ─────────
+# Runtime 3.0 port of the v2 LEMUR (SKILL.md v1.0.0 / lemur-producer.py v1.0.1).
+# Auto-discovers IPOPs on Hyperliquid XYZ via the structural funding signature
+# (abs(funding) <= 1e-7 = ~100x smaller than standard XYZ perps) + a pre-listing
+# leverage cap (<=5x) + a $100k liquidity floor. Today's universe: [xyz:SPCX].
+# Long OR short on 4h trend structure + Smart-Money agreement. Moderate DSL —
+# Discovery Bounds throttle IPOP velocity so positions don't snap as fast as
+# normal perps. Faithful port of the v2 producer thesis — see scanners/scoring.py
+# (IPOP filter + scoring reproduced verbatim, v2-quirks flagged).
+#
+# NOTE (runtime.yaml-vs-producer mismatch in v2): the v2 lemur/runtime.yaml was a
+# STALE BTC single-asset template (its description, decision_prompt, slots and
+# `volumeTrendPct` schema field all describe a BTC trend follower). The producer +
+# config/lemur-config.json + SKILL.md are unanimous that LEMUR is an XYZ IPOP
+# universe scanner. Per the port spec, producer+config+SKILL are source-of-truth;
+# this runtime.yaml reflects the IPOP thesis. Only the v2 runtime's DSL + risk
+# guard-rails are carried over (they already matched the SKILL.md IPOP tuning).
+name: lemur-main
+group: lemur
+version: 3.0.0
+description: >
+  LEMUR — Pre-IPO Perpetual (IPOP) trend follower on Hyperliquid XYZ.
+  Auto-discovers IPOPs from the live xyz: instrument list via the trade.xyz
+  structural funding signature (1% funding multiplier => abs(funding) <= 1e-7,
+  ~100x smaller than standard XYZ perps) + a pre-listing leverage cap (<=5x) +
+  a $100k daily-volume floor; XYZ names only, delisted dropped. Today that
+  returns [xyz:SPCX] (SpaceX); it auto-expands when trade.xyz lists more IPOPs
+  and auto-drops a name once it IPOs. Long OR short on 4h trend structure with a
+  Smart-Money direction gate (4-component score, max ~9, minScore 5). Leverage
+  auto-capped to each IPOP's own max_leverage (min of config 3x and the venue 5x
+  cap). One position at a time; a moderate DSL lets multi-day IPOP theses breathe
+  (Phase 1 max_loss 10%, wide Phase 2 ladder, time-cuts disabled — IPOPs trade
+  24/7). Faithful port of the v2 LEMUR v1.0.0 thesis.
+
+strategy:
+  wallet: "${LEMUR_WALLET}"
+  slots: 2                                 # SKILL.md: 2 (small IPOP universe today)
+  margin_pct: 15                           # baseline %; scan emits the marginPct intent per signal
+  default_leverage: 3                      # fallback; scan emits min(config, instrument cap, 5)
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: lemur_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900                   # v2 producer cadence (15 min — IPOPs move slower)
+    timeout_seconds: 240                    # v2 tick_timeout; universe + per-asset + sm + account reads
+    default_signal_validity_seconds: 1800   # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100            # dedup map + per-tick scan-results history
+    inputs:
+      minScore: 5                           # v2 DEFAULT_MIN_SCORE
+      leverage: 3                           # v2 config default; capped to instrument max + 5x venue cap
+      marginPct: 15                         # PERCENT of withdrawable (0,100]; v2 stored 0.15 fraction
+      smTiltMinPct: 55                      # v2 smTiltMinPct (SM agreement gate)
+      smStrongTiltPct: 70                   # v2 smStrongTiltPct (+1 scoring tier)
+      ipopFundingMaxAbs: 1.0e-7             # IPOP funding signature (abs funding <= 1e-7)
+      ipopMaxLeverageCap: 5                 # IPOP pre-listing leverage cap
+      ipopMinDailyVolUsd: 100000            # IPOP liquidity floor ($100k/day)
+      recentSignalTtlSeconds: 240           # v2 RECENT_SIGNAL_TTL_SEC race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      trend4hStrength: { type: number, required: false }
+      trend1h: { type: string, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+      ipopFlag: { type: boolean, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: lemur_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every gate (v2 LLM gate was pass-through)
+    scanners: [lemur_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true     # 2026-05-21 lesson: maker-only entries can rest unfilled — taker fallback ON
+        execution_timeout_seconds: 30       # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: lemur_main_signals
+
+# ── EXIT (DSL — ported VERBATIM from v2 lemur/runtime.yaml IPOP block) ─────────
+# Moderate, IPOP-tuned. Time-cuts all DISABLED (IPOPs trade 24/7, multi-day
+# theses welcome). Phase 1 max_loss 10% (Discovery Bounds limit downside
+# velocity). Phase 2 Bison-pattern wide ladder: first lock REACHABLE at +10% ROE
+# (lock 0), through +100% (lock 85). FEE_OPTIMIZED_LIMIT close with taker fallback.
+# interval_seconds 60 (REDUCE_ONLY-spam mitigation).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true         # exit closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: false                        # DISABLED — IPOPs trade 24/7, multi-day theses welcome
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: false                        # DISABLED
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                        # DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 10.0                     # v2: moderate floor (Discovery Bounds limit velocity)
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                # wide-by-design; FIRST lock at +10% ROE (reachable)
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 lemur/runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200            # v2 data_retention_hours 72 -> 259200s (within [3600,604800])
+  guard_rails:
+    daily_loss_limit_pct: 15                # v2 daily_loss_limit_pct
+    max_entries_per_day: 3                   # v2/SKILL onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3               # v2 max_consecutive_losses
+    cooldown_seconds: 3600                   # v2 cooldown_minutes 60 -> 3600s (post-loss freeze)
+    drawdown_halt_pct: 20                    # v2 drawdown_halt_pct (HARD STOP circuit breaker)
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 21600        # v2 per_asset_cooldown_minutes 360 -> 21600s (6h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/lemur/main/scanners/scan.py
+++ b/strategies/lemur/main/scanners/scan.py
@@ -1,0 +1,325 @@
+"""LEMUR — supervised scanner (Runtime 3.0 port of the v2 LEMUR IPOP producer).
+
+A faithful port of the v2 "Pre-IPO Perpetual (IPOP) trend follower" on
+Hyperliquid XYZ (lemur-producer.py v1.0.1 / SKILL.md v1.0.0). Per tick it:
+
+  1. Reads account state + held positions (dual-DEX equity via max(), never
+     sum()).
+  2. Auto-discovers the IPOP universe from the live xyz: instrument list via the
+     structural funding signature (market_list_instruments, dex="xyz"):
+     abs(funding) <= 1e-7 AND max_leverage <= 5 AND dayNtlVlm >= $100k AND not
+     delisted. Today that returns [xyz:SPCX]; it auto-expands/auto-drops as
+     trade.xyz lists/IPOs names.
+  3. Scores every non-held, non-recently-signaled IPOP through the pure
+     `scoring.build_thesis` (hard gate: 4h trend non-neutral + SM agreement;
+     4-component score, max ~9). Per-asset market data via market_get_asset_data
+     (1h/4h candles) and SM lean via leaderboard_get_markets.
+  4. Emits the SINGLE highest-scoring candidate at/above `minScore` (v2 main()
+     emitted only `best`), sized by a flat marginPct intent at IPOP-capped
+     leverage.
+
+Read-only + single-pass. NO daemon, NO push_signal, NO create_position — the
+runtime sizes the dollars, owns cooldowns/risk gates/slots, and trails the DSL
+exit. Held-asset suppression + per-tick signal dedup live in ctx.state
+(belt-and-suspenders alongside the runtime's per-asset cooldown gate).
+
+FIDELITY NOTES vs lemur-producer.py v1.0.1:
+  - v2 stored `marginPct` as a FRACTION (0.15) and computed marginUsd =
+    account_value * 0.15, emitting a USD figure. This port emits `marginPct` as
+    a PERCENT (15) at the top level and lets the runtime size
+    (marginPct/100)*withdrawable. The defensive `<=1.0 means a pasted fraction
+    -> x100` guard converts a fraction supplied via inputs. Sizing is otherwise
+    identical (15% of equity at default config).
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1 signal/tick.
+  - v2 recent-signals JSON cache -> ctx.state dedup map (same TTL semantics:
+    240s race-window, pruned at 4x TTL).
+  - v2 leverage = min(config_leverage, instrument max_leverage_cap, MAX_LEVERAGE=5).
+    Preserved verbatim in scoring.leverage_for.
+  - DROPPED (read-only scan cannot mutate): the v2 producer had no explicit
+    order-lifecycle management (no cancel_order / stale-order purge), so nothing
+    is dropped on that front. The v2 push_signal / record_signal mutations are
+    replaced by returning plain dicts + ctx.state, per the scan() contract.
+  - The v2 sub-DEX-aware account read (cfg.get_positions) is ported verbatim
+    including the read-sanity guard (margin in use + empty positions -> skip tick).
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 240               # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+_DEFAULT_MIN_SCORE = 5           # v2 DEFAULT_MIN_SCORE
+_DEFAULT_LEVERAGE = 3            # v2 DEFAULT_LEVERAGE (config default; capped per-instrument)
+_DEFAULT_MARGIN_PCT = 15         # v2 marginPct 0.15 (FRACTION) -> 15 (PERCENT)
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll
+    back the whole tick (per the contract, ANY exception rolls the tick to []).
+    Returns None on failure so the existing degrade paths apply."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[lemur.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    if not getattr(ctx, "wallet", None):
+        return 0.0, []
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", "")})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[lemur.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _fetch_ipop_universe(ctx, inputs):
+    """Auto-discover the IPOP universe from the live xyz: instrument list.
+    READ-GUARDED (market_list_instruments). Returns the v2-shape list
+    [{name, max_leverage, funding, vol_usd}] via the pure scoring filter."""
+    max_funding = float(inputs.get("ipopFundingMaxAbs", scoring.DEFAULT_IPOP_FUNDING_MAX))
+    max_lev = int(inputs.get("ipopMaxLeverageCap", scoring.DEFAULT_IPOP_LEV_CAP))
+    min_vol = float(inputs.get("ipopMinDailyVolUsd", scoring.DEFAULT_IPOP_MIN_VOL))
+
+    raw = _read(ctx, "market_list_instruments", {"dex": "xyz"})
+    if not raw:
+        return []
+    data = raw.get("data", raw) if isinstance(raw, dict) else raw
+    instruments = data.get("instruments", data) if isinstance(data, dict) else data
+    return scoring.filter_ipop_universe(instruments, max_funding, max_lev, min_vol)
+
+
+def _asset_data(ctx, coin):
+    """{candles_1h, candles_4h} for `coin` or None. READ-GUARDED.
+    Ported from v2 fetch_market_data (1h/4h candles; no funding/order-book)."""
+    md = _read(ctx, "market_get_asset_data", {
+        "asset": coin,
+        "candle_intervals": ["1h", "4h"],
+        "include_funding": False,
+        "include_order_book": False,
+        "dex": "xyz" if coin.lower().startswith("xyz:") else "",
+    })
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    return {
+        "candles_1h": candles.get("1h", []) if isinstance(candles, dict) else [],
+        "candles_4h": candles.get("4h", []) if isinstance(candles, dict) else [],
+    }
+
+
+def _get_sm_direction(ctx, asset):
+    """Port of v2 fetch_sm_direction: net smart-money lean for `asset` from
+    leaderboard_get_markets. Returns (direction, tilt_pct) or (None, 0.0) when
+    SM data is unavailable for the asset. READ-GUARDED.
+
+    Verbatim thresholds: long_ratio >= 50 -> LONG (ratio), else SHORT
+    (100-ratio); total<=0 -> ("NEUTRAL", 50.0)."""
+    raw = _read(ctx, "leaderboard_get_markets", {})
+    if not raw:
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def _resolve_margin_pct(inputs):
+    """marginPct intent as a PERCENT in (0,100]. v2 stored a FRACTION (0.15);
+    convert with the defensive `<=1.0 means a pasted fraction -> x100` guard."""
+    mp = scoring._f(inputs.get("marginPct", _DEFAULT_MARGIN_PCT), _DEFAULT_MARGIN_PCT)
+    if mp <= 1.0:                 # a fraction was pasted (e.g. 0.15) -> percent
+        mp *= 100.0
+    return mp
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    config_leverage = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    margin_pct = _resolve_margin_pct(inputs)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[lemur.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+
+    universe = _fetch_ipop_universe(ctx, inputs)
+    if not universe:
+        print("[lemur.scan] WAITING — no IPOPs in universe (no instruments match "
+              "funding+leverage+volume signature)", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_universe", "held": held_assets})
+        return []
+
+    # ── score every eligible IPOP (held + recently-signaled filtered BEFORE the
+    #    per-asset MCP fetch, as in v2 main()) ──
+    candidates = []
+    scanned = 0
+    for inst in universe:
+        coin = inst["name"]
+        if coin.upper() in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        sm = _get_sm_direction(ctx, coin)
+        th = scoring.build_thesis(coin, md["candles_1h"], md["candles_4h"], sm, inputs)
+        if th and th["score"] >= min_score:
+            th["max_leverage_cap"] = inst["max_leverage"]
+            candidates.append(th)
+
+    if not candidates:
+        print(f"[lemur.scan] WAITING — no IPOP setup with 4h trend + SM agreement "
+              f"(min score {min_score:.0f}); scanned={scanned} "
+              f"universe={[u['name'] for u in universe]} held={held_assets}", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_candidate", "scanned": scanned,
+                  "universe": [u["name"] for u in universe], "held": held_assets})
+        return []
+
+    # v2 emitted exactly the single best (highest score).
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    # leverage: min(config_leverage, instrument cap, venue MAX_LEVERAGE=5) — verbatim.
+    leverage = scoring.leverage_for(config_leverage,
+                                    best.get("max_leverage_cap", scoring.MAX_LEVERAGE))
+
+    signaled[best["coin"].upper()] = now
+    result = {"ts": now, "emitted": True, "gate": "pass", "coin": best["coin"],
+              "direction": best["direction"], "score": best["score"], "leverage": leverage,
+              "marginPct": round(margin_pct, 4), "held": held_assets,
+              "reasons": best["reasons"]}
+    print(f"[lemur.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+          f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:5]}", file=sys.stderr)
+    _persist(result)
+
+    return [{
+        "asset": best["coin"],
+        "direction": best["direction"],
+        "marginPct": margin_pct,             # SIZING INTENT — PERCENT (0,100]; runtime sizes USD
+        "leverage": leverage,                # min(config, instrument cap, 5); runtime clamps to venue max
+        "data": {
+            "score": best["score"],
+            "leverage": leverage,
+            "direction": best["direction"],
+            "reasons": best["reasons"],
+            "trend4h": best["trend_4h"],
+            "trend4hStrength": best["trend_4h_strength"],
+            "trend1h": best["trend_1h"],
+            "smDirection": best["sm_direction"],
+            "smTiltPct": best["sm_tilt_pct"],
+            "heldAssets": held_assets,
+            "ipopFlag": True,                # marker: this is a pre-IPO product
+        },
+    }]

--- a/strategies/lemur/main/scanners/scoring.py
+++ b/strategies/lemur/main/scanners/scoring.py
@@ -1,0 +1,211 @@
+"""LEMUR — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 LEMUR producer's IPOP universe filter +
+build_thesis 4-component scoring (lemur-producer.py v1.0.1 / SKILL.md v1.0.0).
+The math/indexing is reproduced VERBATIM so a fidelity harness can diff this
+against the v2 producer on the same market snapshot. Behaviour-preserving quirks
+from v2 are kept and flagged `# v2-quirk`.
+
+LEMUR is a Pre-IPO Perpetual (IPOP) trend follower on Hyperliquid XYZ. It
+auto-discovers IPOPs from the live xyz: instrument list via a structural funding
+signature (1% funding multiplier vs 0.5 standard => ~100x smaller funding rates)
++ a pre-listing leverage cap (<=5x) + a liquidity floor. Today's universe is
+[xyz:SPCX] (SpaceX); it auto-expands when trade.xyz lists more IPOPs and
+auto-drops a name once it IPOs (funding jumps ~100x out of the signature band).
+
+This module is single-pass, unit-testable on plain candle lists + instrument
+dicts. `sm` (smart-money lean) is fetched by the caller (scan.py) and passed in,
+so this module stays pure. minScore is applied by the CALLER, not here."""
+
+
+# v2 defaults (lemur-producer.py / lemur-config.json)
+DEFAULT_IPOP_FUNDING_MAX = 1e-7      # abs(funding) <= 1e-7 (1% multiplier => ~100x smaller)
+DEFAULT_IPOP_LEV_CAP = 5            # max_leverage <= 5 (pre-listing cap)
+DEFAULT_IPOP_MIN_VOL = 100000       # dayNtlVlm >= $100k liquidity floor
+DEFAULT_SM_TILT_MIN = 55           # smTiltMinPct
+DEFAULT_SM_STRONG = 70             # smStrongTiltPct
+MAX_LEVERAGE = 5                   # hardcoded venue ceiling for IPOPs
+SCORE_NORM_DIVISOR = 9.0           # v2 push_signal normalized score = score/9 (informational)
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# ── candle accessors (dual-shape: dict {high|h, low|l} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts via _f(c, "low", "l"); the list branch is defensive and never
+# fires on dict candles, so it does not change v2 behaviour.
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+# ── IPOP universe filter (ported verbatim from v2 fetch_ipop_universe) ──
+
+def is_ipop(inst, max_funding=DEFAULT_IPOP_FUNDING_MAX,
+            max_lev=DEFAULT_IPOP_LEV_CAP, min_vol=DEFAULT_IPOP_MIN_VOL):
+    """True iff `inst` matches the structural IPOP signature (verbatim v2):
+        name.startswith("xyz:") AND not is_delisted
+        AND max_leverage <= max_lev (pre-listing cap)
+        AND abs(funding) <= max_funding (1% multiplier => ~100x smaller)
+        AND dayNtlVlm >= min_vol (liquidity floor)."""
+    if not isinstance(inst, dict):
+        return False
+    name = inst.get("name", "")
+    if not name.startswith("xyz:"):
+        return False
+    if inst.get("is_delisted", False):
+        return False
+    # v2 cast: int(inst.get("max_leverage", 999)) — a missing field => 999 => excluded
+    try:
+        if int(inst.get("max_leverage", 999)) > max_lev:
+            return False
+    except (TypeError, ValueError):
+        return False
+    ctx = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+    funding_abs = abs(_f(ctx.get("funding", 0)))
+    if funding_abs > max_funding:
+        return False
+    vol_usd = _f(ctx.get("dayNtlVlm", 0))
+    if vol_usd < min_vol:
+        return False
+    return True
+
+
+def filter_ipop_universe(instruments, max_funding=DEFAULT_IPOP_FUNDING_MAX,
+                         max_lev=DEFAULT_IPOP_LEV_CAP, min_vol=DEFAULT_IPOP_MIN_VOL):
+    """Filter a raw instruments list to IPOP-signature dicts (verbatim v2 shape):
+    [{name, max_leverage, funding, vol_usd}]."""
+    universe = []
+    if not isinstance(instruments, list):
+        return universe
+    for inst in instruments:
+        if not is_ipop(inst, max_funding, max_lev, min_vol):
+            continue
+        ctx = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        universe.append({
+            "name": inst.get("name", ""),
+            "max_leverage": int(_f(inst.get("max_leverage", 5))),
+            "funding": abs(_f(ctx.get("funding", 0))),
+            "vol_usd": _f(ctx.get("dayNtlVlm", 0)),
+        })
+    return universe
+
+
+# ── trend structure (ported verbatim from v2 trend_structure) ──
+
+def trend_structure(candles, lookback=6):
+    """Higher lows => BULLISH, lower highs => BEARISH. Verbatim from v2.
+
+    v2-quirk: the BULLISH/BEARISH gate is `>= total * 0.6` where total =
+    lookback - 1, and strict (>) comparison for the higher-lows / lower-highs
+    count. Strength returned is higher_lows/total (BULLISH) or lower_highs/total
+    (BEARISH). Reproduced exactly."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+# ── the thesis (4h-trend gate + SM gate + 4-component score), verbatim ──
+
+def build_thesis(coin, candles_1h, candles_4h, sm, inputs):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned when:
+      - insufficient candle history (len(c4h) < 6 or len(c1h) < 6), OR
+      - 4h trend is NEUTRAL (hard gate), OR
+      - SM direction is available AND (NEUTRAL OR disagrees with 4h trend OR
+        tilt < smTiltMinPct).
+    minScore is NOT applied here — the caller gates on thesis['score'].
+
+    `sm` is the smart-money tuple (direction, tilt_pct) from the caller; when SM
+    data is unavailable the CALLER passes (None, 0.0) and this function applies
+    the v2 fallback: assume aligned at the minimum tilt (sm_data_sparse).
+
+    Score components (max ~9; verbatim v2):
+      +3  4h trend aligned (always added once 4h non-neutral gate passes)
+      +2  1h trend confirms the 4h direction
+      +2  SM aligned (or sm_data_sparse_assumed_aligned)
+      +1  SM strongly tilted (tilt >= smStrongTiltPct)"""
+    sm_min = float(inputs.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(inputs.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+
+    if len(candles_4h) < 6 or len(candles_1h) < 6:
+        return None
+
+    t4, s4 = trend_structure(candles_4h)
+    t1, _ = trend_structure(candles_1h)
+    if t4 == "NEUTRAL":
+        return None
+
+    direction = "LONG" if t4 == "BULLISH" else "SHORT"
+
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    # Note: IPOP SM data may be sparse pre-listing — fall back to 4h-trend-only.
+    if sm_dir is None:
+        sm_dir = direction      # fallback: assume aligned (SM data not available)
+        sm_tilt = sm_min        # minimum tilt for scoring purposes
+    elif sm_dir == "NEUTRAL" or sm_dir != direction:
+        return None
+    elif sm_tilt < sm_min:
+        return None
+
+    score = 0
+    reasons = []
+    score += 3
+    reasons.append(f"4h_{t4.lower()}_{s4:.0%}")
+    if (direction == "LONG" and t1 == "BULLISH") or (direction == "SHORT" and t1 == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirms_{t1.lower()}")
+    score += 2
+    # v2-quirk: the "sm_aligned" reason uses strict > DEFAULT_SM_TILT_MIN (55),
+    # NOT the configurable sm_min — reproduced exactly.
+    reasons.append(
+        f"sm_aligned_{sm_tilt:.0f}%" if sm_tilt > DEFAULT_SM_TILT_MIN
+        else "sm_data_sparse_assumed_aligned"
+    )
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    return {
+        "coin": coin,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_4h": t4,
+        "trend_4h_strength": round(s4, 4),
+        "trend_1h": t1,
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": round(_f(sm_tilt), 2),
+    }
+
+
+def leverage_for(config_leverage, instrument_max_leverage):
+    """Auto-cap config leverage to the IPOP's own max_leverage and the venue
+    ceiling. Verbatim v2: min(config_leverage, max_leverage_cap, MAX_LEVERAGE)."""
+    return min(int(config_leverage), int(instrument_max_leverage), MAX_LEVERAGE)

--- a/strategies/lemur/strategy.yaml
+++ b/strategies/lemur/strategy.yaml
@@ -1,0 +1,43 @@
+# Lemur — Pre-IPO Perpetual (IPOP) trend follower. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port
+# of the v2 Lemur (SKILL.md v1.0.0): auto-discovers IPOPs on Hyperliquid XYZ via the
+# trade.xyz funding signature (~100x smaller funding) + a <=5x pre-listing leverage cap
+# + a $100k liquidity floor, then trades 4h trend structure with a Smart-Money gate.
+# Today's universe is [xyz:SPCX]; long OR short; moderate DSL-only exits. Install/teardown
+# via senpi-strategy-ops.
+schema_version: 1
+
+id: lemur
+version: "1.0.0"
+
+catalog:
+  name: "Lemur — Pre-IPO Perpetual Trend Follower"
+  emoji: "🦤"
+  tagline: "Trades pre-IPO companies as perpetuals on Hyperliquid XYZ — today just SpaceX (xyz:SPCX). Auto-discovers IPOPs via the trade.xyz funding signature (~100x smaller funding) plus a <=5x pre-listing leverage cap and a $100k liquidity floor, then goes long or short when the 4h trend structure and Smart-Money lean agree. Leverage auto-caps to each name's own ceiling; a moderate DSL lets multi-day theses ride."
+  belief_plain: "Hyperliquid XYZ is one of the only places retail can trade private companies (like SpaceX) as perpetuals before they IPO. Lemur watches those pre-IPO names, waits for the 4-hour trend and the best traders to point the same way, then takes a single directional position and trails a stop. When a company actually goes public it stops qualifying and Lemur drops it automatically."
+  thesis: "Pre-IPO perpetuals (IPOPs) are a structurally distinct product — a 0.005 funding multiplier (vs 0.5 for standard XYZ perps) and Discovery Bounds that throttle price velocity. That structural funding signature reliably identifies them with no hardcoded ticker list, so the universe future-proofs itself as trade.xyz lists new names and de-qualifies any that IPO. On those slow-moving names, a clean 4h trend confirmed by Smart-Money direction is enough edge to hold a directional swing and let a wide DSL ratchet capture the multi-day move."
+  group: momentum
+  archetype: single_market
+  sub_style: pre_ipo
+  asset_classes: [pre_ipo]
+  asset_scope: single
+  direction: long_short
+  risk_level: moderate
+  tier: starter
+  leverage_max: 5
+  max_slots: 2
+  min_budget: 200
+  assets: ["xyz:SPCX"]
+  tags: [pre-ipo, ipop, spacex, xyz, equities, trend-following, smart-money, auto-discovery, hyperliquid]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: LEMUR_WALLET
+    funding_share: 1.0

--- a/strategies/meerkat/main/runtime.yaml
+++ b/strategies/meerkat/main/runtime.yaml
@@ -1,0 +1,141 @@
+# ── MEERKAT · single instance — momentum-event sniper (Runtime 3.0 port of v2 Meerkat v1.0.1) ──
+# EVENT-DRIVEN scanner. Reads the Senpi momentum-event feed
+# (leaderboard_get_momentum_events — the 4h rolling-window momentum / rank-jump
+# events), classifies each event's tier (|momentum| magnitude) + freshness,
+# scores tier + freshness + SM alignment + rising volume, and emits ONE signal
+# for the best fresh, high-tier event in the momentum direction. DSL is the ONLY
+# exit (let-winners-run, short 36h hard_timeout). Faithful port of the v2 thesis
+# — see scanners/scoring.py (math reproduced verbatim, v2-quirks flagged).
+name: meerkat-main
+group: meerkat
+version: 3.0.0
+description: >
+  MEERKAT — momentum-event sniper. Watches the Senpi momentum-event feed
+  (leaderboard_get_momentum_events) and snipes the FRESHEST, HIGHEST-TIER events
+  the instant they fire, entering in the momentum direction before the move is
+  broadly known. Tier (event magnitude: 3 >= 10%, 2 >= 5%) + freshness (age <=
+  30min) gate the entry; smart-money alignment + rising 1h volume are score
+  bonuses (not gates). Emits ONE signal/tick for the best event clearing score 4
+  (a fresh tier-2 event), sized 15% margin at 4x. DSL is the ONLY exit:
+  let-winners-run (T0 +10% / lock 0, max_loss 18%) with a SHORT 36h hard_timeout
+  (a momentum burst pays out fast or it is stale) and no weak_peak_cut. Faithful
+  port of the v2 Meerkat v1.0.1 thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${MEERKAT_WALLET}"
+  slots: 1                                  # 1-slot sniper (v2 slots: 1)
+  margin_pct: 15                            # baseline %; scan emits the per-signal marginPct (15%)
+  default_leverage: 4                       # fallback; scan emits 1-10x per signal (v2 DEFAULT_LEVERAGE=4)
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: meerkat_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 120                   # v2 producer cadence (2 min — momentum is time-sensitive)
+    timeout_seconds: 90                     # v2 tick_timeout=90; events feed + per-candidate sm + 1h-volume reads
+    default_signal_validity_seconds: 240    # 2x tick; a fresh momentum event re-scores next tick
+    state_history_max_count: 100            # dedup map + per-tick scan-results history
+    inputs:
+      minTier: 2                            # v2 minTier — snipe tier 2+ (set 3 for a pure tier-3 sniper)
+      tier2MinPct: 5.0                      # v2 tier2MinPct — |momentum| for tier 2
+      tier3MinPct: 10.0                     # v2 tier3MinPct — |momentum| for tier 3
+      maxEventAgeMinutes: 30.0              # v2 maxEventAgeMinutes — freshness gate
+      smTiltMinPct: 55                      # v2 smTiltMinPct — SM alignment bonus floor
+      smStrongTiltPct: 70                   # v2 smStrongTiltPct — +1 strong-SM bonus floor
+      minScore: 4                           # v2 minScore — producer floor (fresh tier-2 clears)
+      marginPct: 15                         # PERCENT of withdrawable (0,100]. v2 config marginPct=0.15 (FRACTION) ×100.
+                                            # v2 runtime.yaml had margin_pct:20 — producer/config win per port rule.
+      leverage: 4                           # v2 leverage default; scan clamps to MAX_LEVERAGE=10
+      recentSignalTtlSeconds: 240           # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      tier: { type: number, required: false }
+      magnitudePct: { type: number, required: false }
+      ageMin: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      volRising: { type: boolean, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: meerkat_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [meerkat_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true     # snipe the move NOW — a maker order that rests (CREATE_ORDER_RESTING)
+                                            # misses a fast momentum burst (v2 entry param, verbatim)
+        execution_timeout_seconds: 30       # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: meerkat_main_signals
+
+# ── EXIT (DSL — let-winners-run preset, ported VERBATIM from v2 v1.0.1) ──
+# A fresh momentum burst can extend, so let it run: wide ladder (T0 +10% / lock 0,
+# REACHABLE), max_loss 18%. But momentum is time-bounded — a burst that hasn't
+# paid out within ~36h is stale, so a SHORT hard_timeout cuts it. No weak_peak_cut
+# (it would churn a burst consolidating before extending). dead_weight_cut off.
+exit:
+  engine: dsl
+  interval_seconds: 60                      # v2 exit interval_seconds
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true         # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30           # v2 exit execution_timeout_seconds
+  dsl_preset:
+    hard_timeout:
+      enabled: true                         # v2: ENABLED — momentum is time-bounded
+      interval_in_minutes: 2160             # v2: 36h — a momentum burst pays out fast or it is stale
+    weak_peak_cut:
+      enabled: false                        # v2: DISABLED — would churn a consolidating burst
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                        # v2: DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0                     # v2: max_loss 18%
+      retrace_threshold: 10                  # v2 retrace_threshold
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                 # v2 v1.0.1 let-winners-run ladder (verbatim); FIRST lock at +10% (REACHABLE)
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 45 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+        - { trigger_pct: 90, lock_hw_pct: 88 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 172800            # v2 data_retention_hours 48 -> 48*3600 (within [3600, 604800])
+  guard_rails:
+    daily_loss_limit_pct: 15                 # v2 daily_loss_limit_pct
+    max_entries_per_day: 4                   # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3                # v2 max_consecutive_losses
+    cooldown_seconds: 2700                   # v2 cooldown_minutes 45 -> 2700s
+    drawdown_halt_pct: 22                    # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400        # v2 per_asset_cooldown_minutes 240 -> 14400s (4h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/meerkat/main/scanners/scan.py
+++ b/strategies/meerkat/main/scanners/scan.py
@@ -1,0 +1,337 @@
+"""MEERKAT — supervised scanner (Runtime 3.0 port of the v2 Meerkat momentum-event sniper).
+
+EVENT-DRIVEN scanner. Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - pulls the Senpi momentum-event feed (leaderboard_get_momentum_events — the
+    4h rolling-window momentum / rank-jump events),
+  - for each event: classifies |momentum| into a TIER (1/2/3), measures FRESHNESS
+    (minutes since it fired), extracts direction, fetches per-asset smart-money
+    lean (leaderboard_get_markets) + rising-1h-volume (market_get_asset_data),
+  - scores via the pure `scoring.build_thesis`, drops held / recently-signaled,
+  - emits the SINGLE best fresh tier>=minTier event clearing `minScore`, in the
+    momentum direction.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus a `leverage`;
+the runtime sizes the dollars, owns cooldowns/slots/risk gates, and trails the DSL
+exit. No daemon, no push_signal, no create_position, no order-lifecycle.
+
+The universe is DYNAMIC — there is no fixed ticker list; Meerkat trades whatever
+the momentum-event feed surfaces in the current 4h window (crypto majors + alts).
+So there is nothing to validate against the Hyperliquid meta at author time.
+
+FIDELITY NOTES vs the v2 producer (meerkat-producer.py v1.0.1):
+  - v2 sized margin as `account_value * marginPct` with marginPct a FRACTION
+    (config marginPct=0.15) -> marginUsd. This port emits `marginPct` as a
+    PERCENT in (0,100] and the runtime sizes (marginPct/100)*withdrawable. The
+    v2 config FRACTION 0.15 is converted ×100 -> 15 (PERCENT). A defensive guard
+    treats any value <= 1.0 as a pasted fraction and ×100 it. NOTE: the v2
+    runtime.yaml declared margin_pct: 20 which CONTRADICTS the producer/config
+    0.15 (=15%); per the source-of-truth order (producer + config win) this port
+    uses 15%. FLAGGED in the report.
+  - v2 emitted exactly one signal (best, sorted by score then tier then |mag|).
+    Preserved: scan() emits <= 1 signal/tick, identical sort key.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=240) -> ctx.state dedup
+    map with the same 240s TTL + 4×TTL prune window.
+  - v2's `_wrapper_client.push_signal` POST is dropped (the runtime ingests the
+    returned dict). v2 never called any mutation tool (close/cancel) — DSL owns
+    exits — so there is NO order-lifecycle behaviour to drop.
+  - leverage: v2 clamped `min(config.leverage, MAX_LEVERAGE=10)` (default 4).
+    Preserved verbatim (no MIN clamp in v2).
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 producer constants (defaults; overridable via inputs)
+_DEFAULT_MIN_TIER = 2               # v2 DEFAULT_MIN_TIER — snipe tier 2+
+_DEFAULT_TIER2_MIN_PCT = 5.0        # v2 DEFAULT_TIER2_MIN_PCT
+_DEFAULT_TIER3_MIN_PCT = 10.0       # v2 DEFAULT_TIER3_MIN_PCT
+_DEFAULT_MAX_EVENT_AGE_MIN = 30.0   # v2 DEFAULT_MAX_EVENT_AGE_MIN — freshness gate
+_DEFAULT_SM_TILT_MIN = 55           # v2 DEFAULT_SM_TILT_MIN
+_DEFAULT_SM_STRONG = 70             # v2 DEFAULT_SM_STRONG
+_DEFAULT_MIN_SCORE = 4              # v2 DEFAULT_MIN_SCORE (producer floor)
+_DEFAULT_MARGIN_PCT = 15.0         # v2 config marginPct 0.15 (FRACTION) ×100 -> 15 PERCENT
+_DEFAULT_LEVERAGE = 4              # v2 DEFAULT_LEVERAGE
+_MAX_LEVERAGE = 10                # v2 MAX_LEVERAGE (hardcoded clamp)
+_DEFAULT_RECENT_TTL = 240        # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll
+    back the whole tick. Returns None on failure so the degrade paths apply
+    (events empty -> WAITING; sm -> neutral; volume -> not-rising)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[meerkat.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+# ── ACCOUNT + HELD ASSETS (port of v2 cfg.get_positions, verbatim shape) ──
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring.safe_float(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring.safe_float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring.safe_float(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring.safe_float(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring.safe_float(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[meerkat.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+# ── MOMENTUM-EVENT FEED (port of v2 fetch_momentum_events, verbatim unwrap) ──
+
+def _fetch_momentum_events(ctx):
+    raw = _read(ctx, "leaderboard_get_momentum_events", {})
+    if not raw:
+        return []
+    if isinstance(raw, list):
+        return raw
+    d = raw.get("data", raw)
+    if isinstance(d, list):
+        return d
+    if isinstance(d, dict):
+        ev = d.get("events", d.get("momentum_events", d.get("results", [])))
+        return ev if isinstance(ev, list) else []
+    return []
+
+
+# ── SMART-MONEY LEAN (port of v2 fetch_sm_direction, verbatim) ──
+
+def _get_sm_direction(ctx, asset):
+    """Net smart-money lean for `asset` from leaderboard_get_markets. Returns
+    (direction, pct) or (None, 0). READ-GUARDED. Verbatim v2 thresholds:
+    long_ratio >= 50 -> LONG else SHORT; tilt is the dominant-side ratio."""
+    raw = _read(ctx, "leaderboard_get_markets", {})
+    if not raw or (isinstance(raw, dict) and not raw.get("success", True)):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring.safe_float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ── RISING 1h VOLUME (port of v2 fetch_volume_rising; MCP fetch here, math pure) ──
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _volume_rising(ctx, asset):
+    data = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h"],
+        "include_funding": False,
+        "include_order_book": False,
+        "dex": _dex_for(asset),
+    })
+    if not data or (isinstance(data, dict) and not data.get("success", True)):
+        return False
+    d = data.get("data", data) if isinstance(data, dict) else {}
+    candles = (d.get("candles", {}) or {}).get("1h", []) if isinstance(d, dict) else []
+    return scoring.volume_rising(candles)
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def _resolve_margin_pct(raw):
+    """v2 config margin was a FRACTION (0.15). Emit PERCENT in (0,100].
+    Defensive: any value <= 1.0 is a pasted fraction -> ×100 (dire/koala guard)."""
+    mp = float(raw)
+    if mp <= 1.0:
+        mp *= 100.0
+    return mp
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    min_tier = int(inputs.get("minTier", _DEFAULT_MIN_TIER))
+    tier2_min = float(inputs.get("tier2MinPct", _DEFAULT_TIER2_MIN_PCT))
+    tier3_min = float(inputs.get("tier3MinPct", _DEFAULT_TIER3_MIN_PCT))
+    max_age = float(inputs.get("maxEventAgeMinutes", _DEFAULT_MAX_EVENT_AGE_MIN))
+    sm_tilt_min = float(inputs.get("smTiltMinPct", _DEFAULT_SM_TILT_MIN))
+    sm_strong = float(inputs.get("smStrongTiltPct", _DEFAULT_SM_STRONG))
+    min_score = int(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    margin_pct = _resolve_margin_pct(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))  # PERCENT (0,100]
+    leverage = min(int(inputs.get("leverage", _DEFAULT_LEVERAGE)), _MAX_LEVERAGE)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    # event-classification config consumed by scoring.build_thesis
+    th_config = {
+        "minTier": min_tier, "tier2MinPct": tier2_min, "tier3MinPct": tier3_min,
+        "maxEventAgeMinutes": max_age, "smTiltMinPct": sm_tilt_min, "smStrongTiltPct": sm_strong,
+    }
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[meerkat.scan] no account value; skip tick", file=sys.stderr)
+        result = {"ts": now, "emitted": False, "gate": "no_account"}
+        _persist(ctx, {}, result)
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    events = _fetch_momentum_events(ctx)
+    if not events:
+        result = {"ts": now, "emitted": False, "gate": "no_events", "held": held_assets}
+        print(f"[meerkat.scan] WAITING — no momentum events in the feed; held={held_assets}",
+              file=sys.stderr)
+        _persist(ctx, signaled, result)
+        return []
+
+    # ── score every fresh tier>=minTier event (held + recently-signaled filtered
+    #    BEFORE the per-asset MCP fetch, as in v2 main()) ──
+    candidates = []
+    for event in events:
+        asset = scoring.event_asset(event)
+        if not asset or asset.upper() in held_set or _was_recently_signaled(signaled, asset, ttl, now):
+            continue
+        # cheap structural gate (tier + freshness + direction) BEFORE the SM/vol
+        # reads — match v2: build_thesis returns None early when the event can't
+        # clear, but the SM/vol fetches are needed for the score bonuses. We do
+        # the two reads then score (v2 fetched them inside build_thesis).
+        sm = _get_sm_direction(ctx, asset)
+        vol_rising = _volume_rising(ctx, asset)
+        th = scoring.build_thesis(event, th_config, now, sm, vol_rising)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "emitted": False, "gate": "no_candidate",
+                  "events_seen": len(events), "held": held_assets}
+        print(f"[meerkat.scan] WAITING — no fresh tier>={min_tier} event cleared minScore "
+              f"{min_score}; events_seen={len(events)} held={held_assets}", file=sys.stderr)
+    else:
+        # v2: highest score, tie-break by tier then |magnitude|.
+        candidates.sort(key=lambda c: (c["score"], c["tier"], abs(c["magnitude_pct"])), reverse=True)
+        best = candidates[0]
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "emitted": True, "coin": best["coin"], "direction": best["direction"],
+                  "tier": best["tier"], "magnitudePct": best["magnitude_pct"],
+                  "ageMin": best["age_min"], "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "candidates": len(candidates),
+                  "events_seen": len(events), "held": held_assets, "reasons": best["reasons"]}
+        print(f"[meerkat.scan] EMIT {best['coin']} {best['direction']} tier={best['tier']} "
+              f"mag={best['magnitude_pct']:+.1f}% score={best['score']} {leverage}x "
+              f"marginPct={margin_pct:.2f}% | {best['reasons'][:5]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # 1..10; runtime applies + clamps to venue max
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "tier": best["tier"],
+                "magnitudePct": best.get("magnitude_pct") or 0.0,
+                "ageMin": best.get("age_min") if best.get("age_min") is not None else 0.0,
+                "smDirection": best.get("sm_direction") or "NONE",
+                "smTiltPct": best.get("sm_tilt_pct") or 0.0,
+                "volRising": bool(best.get("vol_rising")),
+                "heldAssets": held_assets,
+            },
+        }]
+
+    _persist(ctx, signaled, result)
+    return out
+
+
+def _persist(ctx, signaled, result):
+    """Append dedup map + this tick's result every tick; bounded by
+    state_history_max_count. Read back via ctx.state.recent(n)."""
+    if ctx.state is None:
+        return
+    try:
+        ctx.state.append({"signaled": signaled, "result": result})
+    except Exception as exc:  # noqa: BLE001
+        print(f"[meerkat.scan] WARNING: state append failed; next tick may re-emit "
+              f"a suppressed signal: {exc!r}", file=sys.stderr)

--- a/strategies/meerkat/main/scanners/scoring.py
+++ b/strategies/meerkat/main/scanners/scoring.py
@@ -1,0 +1,184 @@
+"""MEERKAT — pure momentum-event thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Meerkat producer's pure functions
+(event_age_minutes, event_direction, momentum_tier, event_score) plus the
+defensive event-shape accessors. The math is reproduced VERBATIM from
+meerkat-producer.py v1.0.1 so a fidelity harness can diff this against the v2
+producer on the same momentum-event feed snapshot.
+
+All functions are pure: they take plain dicts / numbers (the caller in scan.py
+does the MCP reads + clock) so they remain unit-testable exactly as the v2
+tests/test_signal.py exercised them. The `now` timestamp and the smart-money
+tuple are passed IN, never read here.
+"""
+
+
+def safe_float(v, default=0.0):
+    """Verbatim v2 safe_float."""
+    try:
+        return float(v if v is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ── defensive event-shape accessors (verbatim v2) ──
+
+def event_asset(event):
+    if not isinstance(event, dict):
+        return ""
+    return str(event.get("token", event.get("coin", event.get("asset", event.get("symbol", ""))))).upper()
+
+
+def event_magnitude(event):
+    if not isinstance(event, dict):
+        return 0.0
+    return safe_float(
+        event.get("momentum", event.get("change_pct", event.get("changePct", event.get("delta", 0))))
+    )
+
+
+def event_timestamp(event):
+    if not isinstance(event, dict):
+        return None
+    return event.get("ts", event.get("timestamp", event.get("time", event.get("created_at"))))
+
+
+# ── pure momentum-event logic (unit-tested in v2 tests/test_signal.py) ──
+
+def event_age_minutes(event_ts, now_ts):
+    """Minutes since an event fired. event_ts may be epoch seconds or
+    milliseconds. None if missing/unparseable. Verbatim v2."""
+    if event_ts is None:
+        return None
+    try:
+        ts = float(event_ts)
+    except (TypeError, ValueError):
+        return None
+    if ts <= 0:
+        return None
+    if ts > 1e12:        # milliseconds → seconds
+        ts /= 1000.0
+    return (now_ts - ts) / 60.0
+
+
+def event_direction(event):
+    """LONG / SHORT for a momentum event: explicit direction/side, else the
+    sign of the momentum/change magnitude. None if undeterminable. Verbatim v2."""
+    if not isinstance(event, dict):
+        return None
+    d = str(event.get("direction", event.get("side", ""))).upper()
+    if d in ("LONG", "SHORT"):
+        return d
+    mag = safe_float(
+        event.get("momentum", event.get("change_pct", event.get("changePct", event.get("delta", 0))))
+    )
+    if mag > 0:
+        return "LONG"
+    if mag < 0:
+        return "SHORT"
+    return None
+
+
+def momentum_tier(magnitude_pct, tier2_min, tier3_min):
+    """Classify |momentum| into a tier: 3 (strongest) >= tier3_min,
+    2 >= tier2_min, else 1. Verbatim v2."""
+    m = abs(safe_float(magnitude_pct))
+    if m >= tier3_min:
+        return 3
+    if m >= tier2_min:
+        return 2
+    return 1
+
+
+def event_score(tier, fresh, sm_aligned, vol_rising):
+    """Score a momentum event (max ~7). Tier is the backbone; freshness is the
+    sniper edge; SM + volume are confirmation bonuses. Verbatim v2."""
+    score = {1: 1, 2: 2, 3: 3}.get(tier, 0)
+    if fresh:
+        score += 2
+    if sm_aligned:
+        score += 1
+    if vol_rising:
+        score += 1
+    return score
+
+
+def volume_rising(candles_1h, threshold=0.15):
+    """True if the asset's recent 1h volume is rising vs the prior window.
+    Verbatim port of v2 fetch_volume_rising's pure tail (the MCP fetch lives in
+    scan.py; this consumes the parsed 1h candle list).
+
+    Needs >= 6 candles; compares mean of last-3 vs first-3 of the trailing-6
+    window, returns True iff the rise exceeds `threshold` (v2: 0.15 = 15%)."""
+    if not isinstance(candles_1h, list) or len(candles_1h) < 6:
+        return False
+    vols = [safe_float(c.get("volume", c.get("v", 0)) if isinstance(c, dict) else 0)
+            for c in candles_1h[-6:]]
+    recent = sum(vols[-3:]) / 3
+    earlier = sum(vols[:3]) / 3
+    return earlier > 0 and (recent - earlier) / earlier > threshold
+
+
+# ── thesis builder (verbatim port of v2 build_thesis; SM tuple passed IN) ──
+
+def build_thesis(event, config, now, sm, vol_rising):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    Differs from v2 ONLY in that the smart-money tuple (sm_dir, sm_tilt) and the
+    vol_rising boolean are passed IN by the caller (which does the MCP reads),
+    keeping this module pure. The gate logic, tier classification, freshness
+    gate, scoring, and reason strings are reproduced VERBATIM.
+
+    Returns None when: no asset, no resolvable direction, tier < minTier, or the
+    event is stale (age > maxEventAgeMinutes). minScore is applied by the CALLER.
+    """
+    asset = event_asset(event)
+    if not asset:
+        return None
+    direction = event_direction(event)
+    if direction is None:
+        return None
+
+    mag = event_magnitude(event)
+    tier2 = float(config.get("tier2MinPct", 5.0))
+    tier3 = float(config.get("tier3MinPct", 10.0))
+    tier = momentum_tier(mag, tier2, tier3)
+    if tier < int(config.get("minTier", 2)):
+        return None
+
+    age = event_age_minutes(event_timestamp(event), now)
+    max_age = float(config.get("maxEventAgeMinutes", 30.0))
+    # No timestamp → treat as fresh (feed only returns current-window events).
+    fresh = age is None or age <= max_age
+    if not fresh:
+        return None
+
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    sm_min = float(config.get("smTiltMinPct", 55))
+    sm_strong = float(config.get("smStrongTiltPct", 70))
+    sm_aligned = (sm_dir == direction and sm_tilt >= sm_min)
+
+    score = event_score(tier, fresh, sm_aligned, vol_rising)
+    reasons = [f"momentum_event_{direction}", f"tier_{tier}", f"mag_{mag:+.1f}%"]
+    if fresh:
+        reasons.append("fresh" if age is None else f"fresh_{age:.0f}min")
+    if sm_aligned:
+        reasons.append(f"sm_confirms_{sm_tilt:.0f}%")
+        if sm_tilt >= sm_strong:
+            score += 1
+            reasons.append("sm_strong")
+    if vol_rising:
+        reasons.append("vol_rising")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "tier": tier,
+        "magnitude_pct": round(mag, 2),
+        "age_min": round(age, 1) if age is not None else None,
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": safe_float(sm_tilt),
+        "vol_rising": bool(vol_rising),
+    }

--- a/strategies/meerkat/strategy.yaml
+++ b/strategies/meerkat/strategy.yaml
@@ -1,0 +1,44 @@
+# Meerkat — momentum-event sniper. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the
+# v2 Meerkat (SKILL.md v1.0.0): an EVENT-DRIVEN scanner that reads the Senpi
+# momentum-event feed (leaderboard_get_momentum_events), classifies each event's
+# tier + freshness, picks the single best fresh high-tier event, and sizes 15%
+# margin at 4x. DSL-only exits, "let winners run" with a short 36h hard_timeout.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: meerkat
+version: "1.0.0"
+
+catalog:
+  name: "Meerkat — Momentum-Event Sniper"
+  emoji: "🦦"
+  tagline: "A sentry that watches the momentum-event feed and snipes the freshest, highest-tier move the instant it fires: tier (event magnitude) + freshness gate the entry, smart-money alignment and rising volume add conviction, then it takes ONE position in the momentum direction and lets a wide DSL ride the burst."
+  belief_plain: "Watches a live feed of coins that just made a sharp move in the last few hours, and pounces only on the strongest, freshest ones — before the move is widely known. It sizes one bet in the direction of the move and trails a wide stop so a real burst can keep running, but cuts it loose after about a day and a half if it stalls."
+  thesis: "Fresh momentum is the earliest, cleanest edge, and it decays fast — an event that's already 30+ minutes old is half-known and somebody else's trade. So the whole job is speed plus selectivity: only the strongest tiers, only while they're fresh, one position at a time. Smart-money lean and rising volume are confirmation bonuses, not gates, because the event fires faster than that data updates — waiting for confirmation forfeits the edge. A momentum burst pays out fast or it's stale, so a short hard timeout cuts a trade that hasn't moved."
+  group: momentum
+  archetype: breakout_momentum
+  sub_style: momentum_event
+  asset_classes: [universe_crypto]
+  asset_scope: universe
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 10
+  max_slots: 1
+  min_budget: 200
+  assets: []                # derived universe — coins come from the momentum-event feed each tick, not a fixed list
+  tags: [momentum, momentum-event, sniper, freshness, tier, smart-money, universe-scanner, single-slot, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: MEERKAT_WALLET
+    funding_share: 1.0

--- a/strategies/orca/main/runtime.yaml
+++ b/strategies/orca/main/runtime.yaml
@@ -1,0 +1,145 @@
+# ── ORCA · single instance — Gen-1 Vanilla Striker (Runtime 3.0 port of v2 ORCA v4.0.1) ──
+# UNIVERSE scanner. Scans the top-50 smart-money leaderboard markets (leaderboard_get_markets)
+# every tick, detects FIRST_JUMP / IMMEDIATE_MOVER rank explosions (rank-jump >= 15 off a
+# prev-rank >= 25), scores the base Striker model (score >= 9 with a 4-reason floor: first-jump,
+# immediate, contrib-explosion, velocity, deep-climber, climbing, US-session), confirms the 15m
+# freshness gate + volume (>=1.5x), and emits ONE signal for the single strongest candidate at a
+# FIXED 7x and 18% margin. XYZ banned, max 3 positions, 120-min per-asset cooldown. DSL is the
+# ONLY exit ("let winners run"). Faithful port of the v2 producer thesis — see scanners/scoring.py
+# (math reproduced verbatim, v2-quirks flagged).
+name: orca-main
+group: orca
+version: 3.0.0
+description: >
+  ORCA — Gen-1 Vanilla Striker. Universe rank-jump sniper: scans the top-50 smart-money
+  leaderboard markets every tick and fires only on a fresh FIRST_JUMP / IMMEDIATE_MOVER
+  explosion (rank-jump >= 15 off a prev-rank >= 25, 4h-aligned, 15m-fresh, volume >=1.5x)
+  that clears the base Striker score 9 with a 4-reason floor. Emits ONE signal for the single
+  strongest candidate at a FIXED 7x and 18% margin. XYZ banned, max 3 positions. DSL is the
+  ONLY exit ("let winners run": T0 +10% / lock 0, the rare big mover pays for the quiet weeks).
+  Faithful port of the v2 ORCA v4.0.1 thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${ORCA_WALLET}"
+  slots: 3                                 # v2 MAX_POSITIONS=3
+  margin_pct: 18                           # baseline %; scan emits the marginPct intent per signal
+  default_leverage: 7                      # v2 fixed 7x (MIN==MAX==DEFAULT); scan venue-clamps
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: orca_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 90                    # v2 producer_daemon interval_seconds=90
+    timeout_seconds: 120                    # v2 tick_timeout=120 (markets + per-candidate volume/limits reads)
+    default_signal_validity_seconds: 180    # 2x tick; a fresh re-score arrives next tick (rule action)
+    state_history_max_count: 100            # rank-history window (5 scans) + emit-cooldown/dedup maps
+    inputs:
+      minScore: 9                           # v2 STRIKER_MIN_SCORE
+      maxPositions: 3                       # v2 MAX_POSITIONS (producer-side held/slot guard; mirrors slots:3)
+      topN: 50                              # v2 TOP_N — score only the top-50 SM markets
+      leaderboardLimit: 100                 # v2 fetch_markets limit=100
+      leverageDefault: 7                    # v2 DEFAULT_LEVERAGE/MIN_LEVERAGE/MAX_LEVERAGE (fixed 7), venue-clamped in scan.py
+      marginPct: 18                         # PERCENT of withdrawable (0,100]; v2 MARGIN_PCT=0.18 (fraction) -> 18%
+      minVolRatio: 1.5                      # v2 STRIKER_MIN_VOL_RATIO (volume confirmation)
+      xyzBanned: true                       # v2 XYZ_BANNED — drop dex==xyz / xyz: markets
+      # ── cooldowns (v2 assetCooldownMinutes=120; runtime per-asset gate is primary) ──
+      perAssetCooldownSeconds: 7200         # v2 assetCooldownMinutes=120 -> 7200s (emit-time analogue)
+      recentSignalTtlSeconds: 7200          # signal-dedup TTL (mirrors per-asset cooldown)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      mode: { type: string, required: false }
+      currentRank: { type: number, required: false }
+      rankJump: { type: number, required: false }
+      isFirstJump: { type: boolean, required: false }
+      isContribExplosion: { type: boolean, required: false }
+      contribVelocity: { type: number, required: false }
+      volRatio: { type: number, required: false }
+      contribution: { type: number, required: false }
+      traders: { type: number, required: false }
+      priceChg4h: { type: number, required: false }
+      reasons: { type: string, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: orca_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [orca_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT       # v2 entry order_type
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true     # v2: a fresh-jump strike must fill — taker fallback at 60s
+        execution_timeout_seconds: 60       # v2 execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: orca_main_signals
+
+# ── EXIT (DSL — ported VERBATIM from v2 runtime.yaml v4.0.1) ──────────────────
+# v2 v4.0.1 "let winners run" ladder. Phase 2 FIRST lock is REACHABLE at +10% (lock 0)
+# — let a +10% mover retrace fully before any profit lock so the rare +50-100% trend
+# isn't capped (the HYPE post-mortem migrated Orca to the Bison ladder). Phase 1
+# max_loss 20%, retrace 8 (raised 3->8 in the 2026-05-21 HYPE post-mortem). Time cuts
+# preserved verbatim from v2 (hard_timeout 45m, weak_peak_cut 25m/3.0, dead_weight 15m).
+# order_type FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST happen).
+exit:
+  engine: dsl
+  interval_seconds: 30                      # v2 exit interval_seconds=30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                         # v2: enabled, 45m
+      interval_in_minutes: 45
+    weak_peak_cut:
+      enabled: true                         # v2: enabled, 25m / min_value 3.0
+      interval_in_minutes: 25
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: true                         # v2: enabled, 15m
+      interval_in_minutes: 15
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0                     # v2 phase1.max_loss_pct
+      retrace_threshold: 8                   # v2: raised 3->8 (HYPE post-mortem) to give trends room
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                 # v2 v4.0.1 "let winners run" ladder (verbatim)
+        - { trigger_pct: 10,  lock_hw_pct: 0 }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200            # v2 data_retention_hours 72 -> 259200s (within [3600, 604800])
+  guard_rails:
+    daily_loss_limit_pct: 15                # v2 guard_rails.daily_loss_limit_pct
+    max_entries_per_day: 6                  # v2 guard_rails.max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3               # v2 guard_rails.max_consecutive_losses
+    cooldown_seconds: 1800                  # v2 cooldown_minutes:30 -> 1800s (post-loss cooldown)
+    drawdown_halt_pct: 25                   # v2 guard_rails.drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false   # v2: avoid the next-day reset leak
+    per_asset_cooldown_seconds: 7200        # v2 per_asset_cooldown_minutes:120 -> 7200s (2h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/orca/main/scanners/scan.py
+++ b/strategies/orca/main/scanners/scan.py
@@ -1,0 +1,424 @@
+"""ORCA — supervised scanner (Runtime 3.0 port of the v2 ORCA Gen-1 Vanilla Striker).
+
+UNIVERSE scanner. Per tick: read the account + held set (clearinghouse, dual-DEX
+equity via max()), fetch the top-100 smart-money leaderboard markets and slice to the
+top-50 (XYZ banned), maintain a 5-scan rank history in ctx.state, score every eligible
+market via the pure `scoring.score_market` (FIRST_JUMP / IMMEDIATE_MOVER + base Striker
+points + contribution velocity / climbing), confirm volume (>=1.5x via market_get_asset_data)
+and the 15m freshness gate, apply the held / per-asset-cooldown / emit-dedup filters,
+pick the SINGLE strongest candidate that clears `minScore`, and emit ONE signal at the
+fixed 7x leverage and conviction margin. The runtime sizes the dollars (marginPct
+intent), owns slots/dedup/risk gates, and trails the DSL exit. Read-only + single-pass —
+no daemon, no push_signal, no create_position.
+
+Faithful port of the v2 producer `main()` + `detect_signals()` flow (orca-producer.py
+v4.0.1). v2-quirks preserved and flagged. The v2 producer's wallet-isolated JSON state
+files (scan-history.json / asset-cooldowns.json) collapse into ctx.state records here
+(the runtime owns the per-wallet isolation + transactional rollback).
+
+FIDELITY NOTES vs orca-producer.py v4.0.1:
+  - v2 emitted exactly ONE signal (the single highest-scoring `best`). Preserved:
+    scan() emits <= 1 signal/tick.
+  - v2 MARGIN_PCT was the FRACTION 0.18 (margin_usd = account_value * 0.18). This port
+    emits `marginPct` = 18 (PERCENT) at the top level; the runtime sizes
+    (marginPct/100)*withdrawable. Same dollar size for the same account. The dire/koala
+    defensive "<=1.0 means a pasted v2 fraction -> x100" guard is included.
+  - v2 leverage is FIXED 7 (MIN_LEVERAGE==MAX_LEVERAGE==DEFAULT_LEVERAGE==7), then run
+    through get_safe_leverage(wallet, asset, 7) = min(7, venue_max). Preserved verbatim:
+    the scan reads strategy_get_asset_trading_limits and clamps the fixed 7 to the venue
+    cap (read-guarded; degrades to 7 on any read failure, exactly as v2 did).
+  - v2 per-asset cooldown was 120 min, persisted in asset-cooldowns.json keyed at OPEN
+    time by the runtime/scanner-side opener. In Runtime 3.0 the scanner no longer opens
+    positions, so it cannot stamp an open time. This port keeps an EMIT cooldown in
+    ctx.state (an asset is suppressed for 120 min after it is emitted) as the closest
+    faithful analogue, AND the runtime's own per_asset_cooldown_seconds (7200s) is the
+    primary backstop. FLAGGED: emit-time vs open-time differ by the entry latency only.
+  - v2 daily-entry caps / dynamic slot sizing (maxEntriesPerDay) lived in Python state
+    files in v3.0 and were already declarative risk.guard_rails by v4.0.0; that migration
+    is honored here (risk.guard_rails owns it; no Python daily counter). The v2 v4.0.0
+    note explicitly calls the Python daily-counter state "vestigial."
+  - v2 had NO order-lifecycle management (no cancel_order / resting-order purge), so
+    section-4.2's "drop order lifecycle" rule has nothing to drop here. (Noted for the
+    report.)
+"""
+
+import sys
+import time
+from datetime import datetime, timezone
+
+import scoring
+
+# v2 producer constants (defaults; overridable via inputs)
+_DEFAULT_MIN_SCORE = scoring.STRIKER_MIN_SCORE        # 9
+_DEFAULT_MARGIN_PCT = scoring.MARGIN_PCT              # 18 PERCENT (v2 0.18 fraction)
+_DEFAULT_LEVERAGE = scoring.DEFAULT_LEVERAGE          # fixed 7
+_DEFAULT_MAX_POSITIONS = 3                            # v2 MAX_POSITIONS
+_DEFAULT_TOP_N = scoring.TOP_N                        # 50 — score only the top-50 SM markets
+_DEFAULT_LEADERBOARD_LIMIT = 100                     # v2 fetch_markets limit=100
+_DEFAULT_MIN_VOL_RATIO = scoring.STRIKER_MIN_VOL_RATIO  # 1.5 volume confirmation
+_DEFAULT_PER_ASSET_COOLDOWN = 7200                   # v2 assetCooldownMinutes=120 -> 7200s
+_DEFAULT_TTL = 7200                                  # signal-dedup TTL (mirror per-asset cooldown)
+_SCAN_HISTORY_MAX = 5                                # v2 save_scan_history keeps last 5 scans
+_XYZ_BANNED = True                                   # v2 XYZ_BANNED
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll back the
+    whole tick (per the contract ANY exception zeroes all emits). Returns None on failure
+    so the existing degrade paths apply (markets empty -> skip; volume read fails -> v2's
+    'return 0, True' permissive default; trading-limits read fails -> keep fixed 7x)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[orca.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+# ── ACCOUNT + HELD ASSETS (v2 cfg.get_positions, verbatim shape + read-sanity guard) ──
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]). READ-GUARDED. Dual-DEX equity collapse:
+    account_value via max() across main/xyz (two views of ONE cross-margined wallet —
+    summing double-counts the shared free balance -> 2x sizing). assetPositions are
+    per-sub-DEX so they're enumerated across both. Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring.safe_float(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring.safe_float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", "")})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a corrupt
+    # clearinghouse read can report margin/notional IN USE while returning an EMPTY
+    # positions list; sizing or running the held-asset dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring.safe_float(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring.safe_float(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[orca.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+# ── MARKET FETCHING (v2 fetch_markets + parse_scan, verbatim) ──
+
+def _fetch_markets(ctx, limit, top_n, xyz_banned):
+    """Top-N normalized SM markets (rank = list index+1). v2 parse_scan verbatim:
+    XYZ banned by dex OR `xyz:` token prefix; slice to TOP_N after filtering."""
+    raw = _read(ctx, "leaderboard_get_markets", {"limit": limit})
+    if not raw:
+        return None
+    markets_raw = []
+    if isinstance(raw, dict):
+        data = raw.get("data", raw)
+        if isinstance(data, dict):
+            markets_raw = data.get("markets", [])
+            if isinstance(markets_raw, dict):
+                markets_raw = markets_raw.get("markets", [])
+        elif isinstance(data, list):
+            markets_raw = data
+    elif isinstance(raw, list):
+        markets_raw = raw
+
+    markets = []
+    for i, m in enumerate(markets_raw):
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("asset", ""))).upper()
+        dex = m.get("dex", "")
+        if xyz_banned and (dex == "xyz" or token.lower().startswith("xyz:")):
+            continue
+        if not token:
+            continue
+        markets.append({
+            "token": token,
+            "dex": dex,
+            "rank": i + 1,                                   # v2: rank = pre-filter list index + 1
+            "direction": str(m.get("direction", "")).upper(),
+            "contribution": scoring.safe_float(m.get("pct_of_top_traders_gain", 0)),
+            "traders": int(m.get("trader_count", 0)),
+            "price_chg_4h": scoring.safe_float(m.get("token_price_change_pct_4h", 0)),
+            "price_chg_1h": scoring.safe_float(m.get("token_price_change_pct_1h",
+                                               m.get("price_change_1h", 0))),
+            "cc_15m": scoring.safe_float(m.get("contribution_pct_change_15m", 0)),
+        })
+    return markets[:top_n]
+
+
+def _snapshot_of(markets):
+    """Compact per-scan snapshot stored in ctx.state (mirrors v2 scan-history entries)."""
+    return [{"token": m["token"], "dex": m.get("dex", ""), "rank": m["rank"],
+             "contribution": m["contribution"]} for m in markets]
+
+
+def _find_in_snapshot(snapshot, token, dex):
+    """v2 get_market_in_scan — find (token,dex) in a stored scan snapshot, or None."""
+    for m in snapshot or []:
+        if m.get("token") == token and m.get("dex", "") == dex:
+            return m
+    return None
+
+
+def _check_asset_volume(ctx, token, dex, min_ratio):
+    """v2 check_asset_volume — (ratio, strong). dayNtlVlm / prevDayNtlVlm via
+    market_get_asset_data(1h). READ-GUARDED: v2 returns the PERMISSIVE (0, True) on any
+    failure or missing prevDayNtlVlm (a missing volume reference never blocks a strong
+    signal), so degrade to (0, True) here too."""
+    md = _read(ctx, "market_get_asset_data", {
+        "asset": token, "candle_intervals": ["1h"], "include_funding": False,
+        "dex": ("xyz" if str(dex).lower() == "xyz" else ""),
+    })
+    if not md:
+        return 0, True
+    ad = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(ad, dict):
+        return 0, True
+    ac = ad.get("asset_context", ad.get("assetContext", {}))
+    if not isinstance(ac, dict):
+        return 0, True
+    vol = scoring.safe_float(ac.get("dayNtlVlm", 0))
+    prev = scoring.safe_float(ac.get("prevDayNtlVlm", 0))
+    if prev > 0:
+        ratio = vol / prev
+        return ratio, ratio >= min_ratio
+    return 0, True
+
+
+def _safe_leverage(ctx, asset, dex, requested):
+    """v2 get_safe_leverage — clamp the fixed request to the venue max from
+    strategy_get_asset_trading_limits. READ-GUARDED: degrade to `requested` on any failure
+    (v2's `except: pass; return requested_leverage`)."""
+    limits = _read(ctx, "strategy_get_asset_trading_limits",
+                   {"strategy_wallet": ctx.wallet, "coin": asset})
+    if not limits:
+        return requested
+    data = limits.get("data", limits) if isinstance(limits, dict) else limits
+    if not isinstance(data, dict):
+        return requested
+    lev = data.get("leverage", {})
+    try:
+        if isinstance(lev, dict):
+            max_lev = int(float(lev.get("value", requested)))
+            return min(requested, max_lev)
+        if isinstance(lev, (int, float)):
+            return min(requested, int(lev))
+    except (TypeError, ValueError):
+        return requested
+    return requested
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    hour_utc = datetime.now(timezone.utc).hour
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    max_positions = int(inputs.get("maxPositions", _DEFAULT_MAX_POSITIONS))
+    top_n = int(inputs.get("topN", _DEFAULT_TOP_N))
+    leaderboard_limit = int(inputs.get("leaderboardLimit", _DEFAULT_LEADERBOARD_LIMIT))
+    leverage_default = int(inputs.get("leverageDefault", _DEFAULT_LEVERAGE))
+    min_vol_ratio = float(inputs.get("minVolRatio", _DEFAULT_MIN_VOL_RATIO))
+    xyz_banned = bool(inputs.get("xyzBanned", _XYZ_BANNED))
+    per_asset_cooldown = float(inputs.get("perAssetCooldownSeconds", _DEFAULT_PER_ASSET_COOLDOWN))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+
+    # marginPct is a PERCENT in (0,100]. FLAGGED: defensively convert a value <= 1 (an
+    # operator who pasted the v2 FRACTION 0.18) into a PERCENT so it never silently sizes
+    # ~100x small (resolve-margin sizes (marginPct/100)*withdrawable).
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        print(f"[orca.scan] marginPct={margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
+
+    # ── prior state (rank-history window, emit cooldown / dedup maps) ──
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    scan_history = list(last.get("scan_history") or [])     # [ [ {token,dex,rank,contribution}... ] ... ]
+    emit_cooldowns = dict(last.get("emit_cooldowns") or {})  # {ASSET: ts} — per-asset suppression
+    recent = dict(last.get("recent") or {})                  # {ASSET: ts} — signal-dedup
+
+    def _persist(extra=None):
+        if ctx.state is None:
+            return
+        rec = {
+            "ts": now,
+            "scan_history": scan_history[-_SCAN_HISTORY_MAX:],
+            "emit_cooldowns": emit_cooldowns,
+            "recent": recent,
+        }
+        if extra:
+            rec.update(extra)
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[orca.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+
+    # ── account state + held assets ──
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[orca.scan] cannot read account value (<=0); skip tick", file=sys.stderr)
+        _persist({"result": {"emitted": False, "gate": "no_account"}})
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    # ── max-positions guard (v2 MAX_POSITIONS=3) ──
+    if len(positions) >= max_positions:
+        print(f"[orca.scan] at max positions ({len(positions)}/{max_positions}): "
+              f"{sorted(held_set)}", file=sys.stderr)
+        _persist({"result": {"emitted": False, "gate": "max_positions", "held": sorted(held_set)}})
+        return []
+
+    # ── fetch + parse top-N SM markets ──
+    markets = _fetch_markets(ctx, leaderboard_limit, top_n, xyz_banned)
+    if markets is None:
+        print("[orca.scan] failed to fetch leaderboard_get_markets; skip tick", file=sys.stderr)
+        _persist({"result": {"emitted": False, "gate": "no_markets"}})
+        return []
+
+    # Build this scan's snapshot; need a prior scan to measure rank-jumps (v2:
+    # detect_signals returns [] when history is empty — still record this scan).
+    current_snapshot = _snapshot_of(markets)
+    if not scan_history:
+        scan_history.append(current_snapshot)
+        print(f"[orca.scan] WAITING — seeding scan history (scanned={len(markets)}); "
+              "need a prior scan to measure rank-jumps", file=sys.stderr)
+        _persist({"result": {"emitted": False, "gate": "history_seed", "scanned": len(markets)}})
+        return []
+
+    # v2: latest_prev = last scan; oldest_available = up to 5 scans back; prev_top50 set.
+    latest_prev = scan_history[-1]
+    oldest_available = scan_history[-min(len(scan_history), 5)]
+    prev_top50_tokens = {(m["token"], m.get("dex", "")) for m in latest_prev}
+
+    # ── score every eligible market (held / cooldown / dedup filtered as in v2 main) ──
+    candidates = []
+    scored = 0
+    for market in markets:
+        token = market["token"]
+        dex = market.get("dex", "")
+
+        prev_market = _find_in_snapshot(latest_prev, token, dex)
+        old_market = _find_in_snapshot(oldest_available, token, dex)
+
+        # contribution-velocity window: last <=5 scans of this (token,dex) + current.
+        recent_contribs = []
+        for snap in scan_history[-5:]:
+            m = _find_in_snapshot(snap, token, dex)
+            if m:
+                recent_contribs.append(m["contribution"])
+        recent_contribs.append(market["contribution"])
+
+        res = scoring.score_market(market, prev_market, old_market,
+                                   prev_top50_tokens, recent_contribs, hour_utc)
+        if res is None:
+            continue
+        score, reasons, meta = res
+        scored += 1
+        if score < min_score:
+            continue
+
+        # 15m velocity freshness gate (v2: `if cc_15m <= 0: continue`).
+        if scoring.safe_float(market.get("cc_15m", 0)) <= 0:
+            continue
+
+        # held / per-asset emit-cooldown / signal-dedup filters (v2 main()).
+        if token in held_set:
+            continue
+        ec = emit_cooldowns.get(token, 0)
+        if ec and (now - ec) < per_asset_cooldown:
+            continue
+        rc = recent.get(token, 0)
+        if rc and (now - rc) < ttl:
+            continue
+
+        # Volume confirmation (>=1.5x) — v2: scored gate first, THEN the per-asset volume
+        # MCP read; only ran for candidates that already cleared the score floor.
+        vol_ratio, vol_strong = _check_asset_volume(ctx, token, dex, min_vol_ratio)
+        if not vol_strong:
+            continue
+        reasons = list(reasons) + [f"VOL_CONFIRMED {vol_ratio:.1f}x"]
+
+        cand = dict(meta)
+        cand["token"] = token
+        cand["dex"] = dex if dex else None
+        cand["direction"] = market["direction"]
+        cand["score"] = score
+        cand["reasons"] = reasons
+        cand["volRatio"] = round(vol_ratio, 2)
+        candidates.append(cand)
+
+    # always record this scan into the rolling history (v2 always appended).
+    scan_history.append(current_snapshot)
+    scan_history = scan_history[-_SCAN_HISTORY_MAX:]
+
+    if not candidates:
+        print(f"[orca.scan] WAITING — no Striker signal (min score {min_score:.0f}); "
+              f"scanned={len(markets)} scored={scored} held={sorted(held_set)}", file=sys.stderr)
+        _persist({"result": {"emitted": False, "gate": "no_candidate",
+                             "scanned": len(markets), "scored": scored,
+                             "held": sorted(held_set)}})
+        return []
+
+    # ── pick the single strongest candidate (v2 sorted by score desc, emits best) ──
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+
+    # fixed 7x, clamped to the venue max (v2 get_safe_leverage on DEFAULT_LEVERAGE).
+    leverage = _safe_leverage(ctx, best["token"], best.get("dex"), leverage_default)
+
+    out = [{
+        "asset": best["token"],
+        "direction": best["direction"],
+        "marginPct": margin_pct,               # SIZING INTENT (PERCENT) — runtime sizes the dollars
+        "leverage": leverage,                  # fixed 7, venue-clamped; runtime applies
+        "data": {
+            "score": best["score"],
+            "leverage": leverage,
+            "direction": best["direction"],
+            "mode": best["mode"],
+            "currentRank": int(best["currentRank"]),
+            "rankJump": int(best["rankJump"]),
+            "isFirstJump": bool(best["isFirstJump"]),
+            "isContribExplosion": bool(best["isContribExplosion"]),
+            "contribVelocity": float(best["contribVelocity"]),
+            "volRatio": float(best["volRatio"]),
+            "contribution": float(best["contribution"]),
+            "traders": int(best["traders"]),
+            "priceChg4h": float(best["priceChg4h"]),
+            "reasons": " | ".join(best["reasons"]),
+            "heldAssets": sorted(held_set),
+        },
+    }]
+
+    # mark per-asset emit cooldown + signal-dedup for the emitted asset.
+    emit_cooldowns[best["token"]] = now
+    recent[best["token"]] = now
+    print(f"[orca.scan] EMIT {best['token']} {best['direction']} score={best['score']} "
+          f"{leverage}x marginPct={margin_pct:.2f}% | {' | '.join(best['reasons'][:6])}",
+          file=sys.stderr)
+    _persist({"result": {"emitted": True, "asset": best["token"], "direction": best["direction"],
+                         "score": best["score"], "leverage": leverage,
+                         "marginPct": round(margin_pct, 4), "rankJump": best["rankJump"],
+                         "candidates": len(candidates), "scanned": len(markets),
+                         "held": sorted(held_set)}})
+    return out

--- a/strategies/orca/main/scanners/scoring.py
+++ b/strategies/orca/main/scanners/scoring.py
@@ -1,0 +1,182 @@
+"""ORCA — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 ORCA producer's Gen-1 Vanilla Striker
+detection (`detect_signals` body + `time_of_day_modifier` + `check_4h_alignment`),
+SKILL.md / orca-producer.py v4.0.1. The arithmetic, gate order, point weights, and
+direction logic are reproduced VERBATIM so a fidelity harness can diff this against
+the v2 producer on the same scan snapshot.
+
+Behaviour-preserving quirks from v2 are kept and flagged `# v2-quirk`. Fix them only
+as a separate, labelled change AFTER the port is validated.
+
+UNIVERSE scanner: `score_market` scores ONE normalized market dict against the
+previous scan + a short rank-history window (FIRST_JUMP / IMMEDIATE_MOVER / contrib
+explosion / velocity / climbing). The caller (scan.py) iterates the top-50 SM
+leaderboard markets, maintains the scan history in ctx.state, picks the single
+strongest candidate, and resolves the fixed-7x leverage. Unit-testable on plain dicts.
+
+The ONE non-pure thing the v2 detect_signals did — `time_of_day_modifier()` reads the
+wall clock — is parameterized here: the caller passes the current UTC hour in so this
+module stays clock-free and unit-testable. The US-session arithmetic is verbatim.
+"""
+
+# ── thresholds (v2 producer constants, verbatim) ──
+TOP_N = 50                    # v2 TOP_N — score only the top-50 SM markets per scan
+STRIKER_MIN_SCORE = 9         # v2 STRIKER_MIN_SCORE
+STRIKER_MIN_REASONS = 4       # v2 STRIKER_MIN_REASONS — 4-reason floor
+STRIKER_MIN_RANK_JUMP = 15    # v2 STRIKER_MIN_RANK_JUMP
+STRIKER_MIN_PREV_RANK = 25    # v2 STRIKER_MIN_PREV_RANK
+STRIKER_MIN_VOL_RATIO = 1.5   # v2 STRIKER_MIN_VOL_RATIO (volume confirmation, applied in scan.py)
+
+# leverage is FIXED in v2 (MIN==MAX==DEFAULT==7); no score-tiering.
+DEFAULT_LEVERAGE = 7          # v2 DEFAULT_LEVERAGE / MIN_LEVERAGE / MAX_LEVERAGE
+MARGIN_PCT = 18.0             # v2 MARGIN_PCT=0.18 (FRACTION) -> 18 PERCENT
+
+
+def safe_float(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# backward-compat alias mirroring the v2 helper name used across the fleet
+_f = safe_float
+
+
+def check_4h_alignment(direction, price_chg_4h):
+    """v2 check_4h_alignment — the trade direction must agree with the 4h price move."""
+    if direction == "LONG" and price_chg_4h > 0:
+        return True
+    if direction == "SHORT" and price_chg_4h < 0:
+        return True
+    return False
+
+
+def time_of_day_modifier(hour_utc):
+    """v2 time_of_day_modifier — +1 score during the US session (13:00–21:00 UTC).
+    The v2 producer read the wall clock inside detect_signals; here the caller passes
+    the current UTC hour so this module stays pure / unit-testable. Arithmetic verbatim."""
+    if 13 <= hour_utc <= 21:
+        return 1, "US_SESSION"
+    return 0, None
+
+
+def score_market(market, latest_prev, oldest_available, prev_top50_tokens,
+                 recent_contribs, hour_utc):
+    """Score a single normalized market for a Gen-1 Striker FIRST_JUMP/IMMEDIATE_MOVER.
+    Returns (score, reasons, meta) or None when a hard gate rejects.
+
+    Ported VERBATIM from the v2 producer's `detect_signals` per-market body. The only
+    structural change: the rank-history lookups (latest_prev market, oldest market,
+    the contribution-velocity window, prev-top50 membership) are resolved by the caller
+    from ctx.state and handed in pre-computed, keeping this module pure / clock-free.
+    The arithmetic, gate order, point weights, and direction logic are unchanged.
+    The two reads that are NOT pure — wall clock (US session) and the volume-ratio
+    confirmation (an MCP read) — are parameterized: hour_utc is passed in; the volume
+    gate runs in scan.py AFTER this scorer clears, exactly as in v2 (score gate first,
+    then the per-asset volume MCP call).
+
+    market: normalized current-scan dict with keys:
+      token, dex, rank, direction, contribution, traders, price_chg_4h, price_chg_1h, cc_15m.
+    latest_prev: the same (token,dex) market dict from the most-recent prior scan, or None.
+    oldest_available: the same (token,dex) market dict from the oldest scan in window, or None.
+    prev_top50_tokens: set of (token,dex) present in the latest prior scan's top-50.
+    recent_contribs: [contribution, ...] across the window ending with THIS scan's contribution.
+    hour_utc: current UTC hour (for the US-session modifier).
+    """
+    token = market["token"]
+    dex = market.get("dex", "")
+    current_rank = market["rank"]
+    direction = market["direction"]
+    current_contrib = market["contribution"]
+
+    # Hard gate: skip the already-top names (no rank-jump room) — v2 `if rank <= 10: continue`.
+    if current_rank <= 10:
+        return None
+    # Hard gate: 4h trend must agree with the SM direction — v2 check_4h_alignment.
+    if not check_4h_alignment(direction, market.get("price_chg_4h", 0)):
+        return None
+
+    # Need a prior observation of this exact (token,dex) to measure the jump — v2 `if not prev_market: continue`.
+    prev_market = latest_prev
+    old_market = oldest_available
+    if not prev_market:
+        return None
+
+    rank_jump = prev_market["rank"] - current_rank
+
+    is_first_jump = False
+    is_immediate = False
+    is_contrib_explosion = False
+    reasons = []
+
+    if rank_jump >= 10 and prev_market["rank"] >= STRIKER_MIN_PREV_RANK:
+        is_immediate = True
+        reasons.append(f"IMMEDIATE_MOVER +{rank_jump} from #{prev_market['rank']}")
+        was_in_prev = (token, dex) in prev_top50_tokens
+        if not was_in_prev or prev_market["rank"] >= 30:
+            is_first_jump = True
+            reasons.append(f"FIRST_JUMP #{prev_market['rank']}->#{current_rank}")
+
+    if prev_market["contribution"] > 0:
+        contrib_ratio = current_contrib / prev_market["contribution"]
+        if contrib_ratio >= 3.0:
+            is_contrib_explosion = True
+            reasons.append(f"CONTRIB_EXPLOSION {contrib_ratio:.1f}x")
+
+    # Hard gates: must be at least a first-jump OR immediate mover, and clear the rank-jump floor.
+    if not is_first_jump and not is_immediate:
+        return None
+    if rank_jump < STRIKER_MIN_RANK_JUMP:
+        return None
+
+    # Contribution velocity (mean per-scan delta * 100) — v2 verbatim.
+    contrib_velocity = 0
+    if len(recent_contribs) >= 2:
+        deltas = [recent_contribs[i + 1] - recent_contribs[i]
+                  for i in range(len(recent_contribs) - 1)]
+        contrib_velocity = sum(deltas) / len(deltas) * 100
+
+    # ── Base Striker scoring (v2 verbatim point weights) ──
+    score = 0
+    if is_first_jump:
+        score += 3
+    if is_immediate:
+        score += 2
+    if is_contrib_explosion:
+        score += 2
+    if abs(contrib_velocity) > 10:
+        score += 2
+        reasons.append(f"HIGH_VELOCITY {abs(contrib_velocity):.1f}")
+    if prev_market["rank"] >= 40:
+        score += 1
+        reasons.append("DEEP_CLIMBER")
+    if old_market:
+        total_climb = old_market["rank"] - current_rank
+        if total_climb >= 10:
+            score += 1
+            reasons.append(f"CLIMBING +{total_climb} over scans")
+
+    tod_mod, tod_reason = time_of_day_modifier(hour_utc)
+    score += tod_mod
+    if tod_reason:
+        reasons.append(tod_reason)
+
+    # Score + reason floor — v2 verbatim.
+    if score < STRIKER_MIN_SCORE or len(reasons) < STRIKER_MIN_REASONS:
+        return None
+
+    meta = {
+        "mode": "STRIKER",
+        "currentRank": current_rank,
+        "rankJump": rank_jump,
+        "isFirstJump": is_first_jump,
+        "isImmediate": is_immediate,
+        "isContribExplosion": is_contrib_explosion,
+        "contribVelocity": round(contrib_velocity, 4),
+        "contribution": round(current_contrib * 100, 3),
+        "traders": market["traders"],
+        "priceChg4h": market.get("price_chg_4h", 0),
+    }
+    return score, reasons, meta

--- a/strategies/orca/strategy.yaml
+++ b/strategies/orca/strategy.yaml
@@ -1,0 +1,43 @@
+# Orca — Gen-1 Vanilla Striker. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2 ORCA
+# (SKILL.md / producer v4.0.1): a UNIVERSE scanner that watches the top-50 smart-money
+# leaderboard markets, detects fresh FIRST_JUMP / IMMEDIATE_MOVER rank explosions, and
+# strikes ONCE at a fixed 7x. DSL-only exits, "let winners run".
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: orca
+version: "1.0.0"
+
+catalog:
+  name: "Orca — Gen-1 Vanilla Striker"
+  emoji: "🐋"
+  tagline: "A universe rank-jump sniper: watches the top-50 smart-money leaderboard every tick and fires only on a fresh FIRST_JUMP — a coin exploding 15+ ranks out of the deep field with 4h trend, 15m freshness, and a volume spike all confirming — then strikes ONE position at a fixed 7x and lets the DSL ride the breakout."
+  belief_plain: "Watches which coins the best traders are suddenly piling into and only acts when a name rockets up the leaderboard from deep in the pack — a fresh jump, not an already-crowded top name. It wants the move to be young (climbing fast in the last 15 minutes), going the same way the price is, and backed by a real volume spike before it takes a single shot."
+  thesis: "The edge is in the FIRST jump, not the established leader. By the time a coin sits at the top of the smart-money board the move is priced in; the asymmetric entry is the moment a name explodes 15+ ranks out of the deep field (prev-rank >= 25) while its 4h trend, 15m contribution velocity, and 24h volume all confirm the same direction at once. That confluence is rare and decays fast, so the right move is to scan often (90s), strike once at a fixed 7x the instant it fires, skip the already-top names, and let a ratcheting DSL — not a fixed target — decide the exit so the occasional big breakout pays for the quiet weeks."
+  group: momentum
+  archetype: breakout_momentum
+  sub_style: rank_jump
+  asset_classes: [universe_crypto]
+  asset_scope: universe
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 7
+  max_slots: 3
+  min_budget: 200
+  assets: []                # derived universe — coins come from the top-50 SM leaderboard each tick, not a fixed list
+  tags: [smart-money, momentum, breakout, rank-jump, first-jump, striker, universe-scanner, fixed-leverage]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: ORCA_WALLET
+    funding_share: 1.0

--- a/strategies/otter/main/runtime.yaml
+++ b/strategies/otter/main/runtime.yaml
@@ -1,0 +1,133 @@
+# ── OTTER · single instance — Open Interest Velocity Hunter (Runtime 3.0 port of v2 OTTER v2.0.0) ──
+name: otter-main
+group: otter
+version: 3.0.0
+description: >
+  OTTER — Open Interest Velocity Hunter. The first fleet agent to trade OI delta
+  OVER TIME (not as a snapshot filter). Maintains a rolling 5h OI history per HL
+  crypto perp and fires ONLY when 1h OI delta >= 5% AND 1h price moves >= 0.5% in
+  the same direction — the TOP-LEFT (longs entering) or TOP-RIGHT (shorts entering)
+  quadrant of the OI/price matrix: fresh leveraged positioning with directional
+  conviction. 4h OI must not be net unwinding; OI >= $1M; spread <= 5 bps;
+  per-asset 240min cooldown. Multi-factor confluence scoring (OI tier + 4h confirm
+  + price magnitude + smart-money alignment + spread + time-of-day); MIN_SCORE 9
+  to fire. Score-scaled leverage (5/7/10) at 25% margin; rides 1-3h then a tight
+  DSL locks profit early. Faithful port of the v2 producer thesis (XYZ banned).
+  NOTE: XYZ is filtered by the 'xyz:' name prefix (the live combined instruments
+  response has no dex field — see scan.py).
+
+strategy:
+  wallet: "${OTTER_WALLET}"
+  slots: 2                                 # max 2 concurrent positions (v2 strategy.slots)
+  default_leverage: 5                       # fallback; scan emits per-score 5/7/10 (auto-clamped to venue max)
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: otter_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                   # v2 producer cadence (5 min) — defines the OI-history sampling rate
+    timeout_seconds: 240                    # v2 tick_timeout; universe + SM + top-N spread reads/tick
+    default_signal_validity_seconds: 900    # OI velocity decays fast; 15min TTL
+    state_history_max_count: 100            # rolling OI history + cooldowns + dedup map carried tick-to-tick
+    inputs:
+      minScore: 9                           # v2 MIN_SCORE floor
+      minOiDelta1hPct: 5.0                  # v2 MIN_OI_DELTA_1H_PCT — primary signal floor
+      minPriceAlignPct: 0.5                 # v2 MIN_PRICE_ALIGN_PCT — price/OI alignment floor
+      minOiUsd: 1000000                     # v2 MIN_OI_USD — liquidity floor
+      maxSpreadBps: 5                       # v2 MAX_SPREAD_BPS — entry quality gate
+      assetCooldownMinutes: 240             # v2 ASSET_COOLDOWN_MINUTES (defense-in-depth)
+      minSamplesToFire: 12                  # v2 MIN_SAMPLES_TO_FIRE (12 samples = 1h @ 5min)
+      smLimit: 100                          # leaderboard_get_markets aggregation depth
+      spreadCheckTopN: 3                    # v2 main() spread-checked the top 3 eligible
+      marginPct: 25                         # PERCENT of withdrawable (v2 fraction 0.25 ×100); runtime sizes (marginPct/100)*withdrawable
+      recentSignalTtlSeconds: 240           # per-tick race-window dedup
+      # leverageTiers: per-score [min_score, leverage]; omit -> scoring defaults (5/7/10)
+      leverageTiers: [[13, 10], [11, 7], [9, 5]]
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      oiDelta1hPct: { type: number }              # primary signal — 1h OI growth %
+      priceDelta1hPct: { type: number }           # 1h price move %
+      oiUsd: { type: number }                     # current OI in USD
+      oiDelta4hPct: { type: number, required: false }
+      priceDelta4hPct: { type: number, required: false }
+      spreadBps: { type: number, required: false }
+      smAligned: { type: boolean, required: false }
+      smPctOfTopTraders: { type: number, required: false }
+      markPx: { type: number, required: false }
+      samplesInHistory: { type: number, required: false }
+      reasons: { type: string, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: otter_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                      # the scan already applied every hard gate + score floor (v2 LLM was a pass-through rubber-stamp)
+    scanners: [otter_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false     # ENTRIES: cancel-and-skip if maker can't fill in 60s. OI velocity isn't urgent — taker fees would erase the edge.
+        execution_timeout_seconds: 60        # v2 Jackal/Roach standard
+    context:
+      - type: signal
+        scanner: otter_main_signals
+
+# EXIT — DSL, ported VERBATIM from v2 otter runtime.yaml. Otter is short-hold
+# (30-180min typical, 240min hard cap), so the DSL locks profit earlier than
+# long-hold strategies. Phase 2 first lock REACHABLE at +5% ROE (1% price move
+# at 5x — above wick noise, below typical OI-flow follow-through). Phase 1
+# max_loss 12% (~2.4% price stop at 5x). FEE_OPTIMIZED_LIMIT close with taker
+# fallback (flow can reverse violently if leveraged positions unwind).
+exit:
+  engine: dsl
+  interval_seconds: 30                       # v2 exit.interval_seconds
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true          # EXITS: taker fallback as safety floor on Phase 1 stops
+    execution_timeout_seconds: 60            # v2 Jackal/Roach standard
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 240               # 4h positioning thesis horizon
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 60                # if HW ROE < 1.5% in first hour, flow isn't translating
+      min_value: 1.5
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 90                # flat positions = thesis expired
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                      # ~2.4% price stop at 5x — clean cut on flow reversal
+      retrace_threshold: 5
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,  lock_hw_pct: 30 }   # +5% ROE = 1% price move at 5x — early profit lock (REACHABLE)
+        - { trigger_pct: 10, lock_hw_pct: 55 }
+        - { trigger_pct: 15, lock_hw_pct: 75 }
+        - { trigger_pct: 20, lock_hw_pct: 85 }   # monster flow continuation (rare but happens)
+
+risk:
+  data_retention_seconds: 259200             # v2 data_retention_hours 72 ×3600 (within [3600, 604800])
+  guard_rails:
+    daily_loss_limit_pct: 8                   # v2 daily_loss_limit_pct
+    max_entries_per_day: 8                    # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4                 # v2 max_consecutive_losses
+    cooldown_seconds: 0                        # v2 cooldown_minutes 0 — scan manages per-asset cooldowns
+    drawdown_halt_pct: 20                      # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 14400          # v2 per_asset_cooldown_minutes 240 ×60

--- a/strategies/otter/main/scanners/scan.py
+++ b/strategies/otter/main/scanners/scan.py
@@ -1,0 +1,441 @@
+"""OTTER — supervised scanner (Runtime 3.0 port of the v2 OTTER producer).
+
+Multi-asset UNIVERSE scanner, emit-one. A faithful port of the v2 "Open Interest
+Velocity Hunter" (otter-producer.py v2.0.0 / SKILL.md v2.0.1):
+
+  1. Read account state + open-position count (sizing context).
+  2. Build the universe — every HL crypto perp from `market_list_instruments`
+     with OI > 0 and a valid mark price (XYZ banned at parse time — different OI
+     dynamics; Bald Eagle's lane).
+  3. Maintain a ROLLING OI HISTORY per asset in ctx.state (last 60 samples =
+     5h at this scanner's ~5min cadence): append {ts, oi, mark_px} each tick.
+  4. Compute 1h + 4h OI/price deltas, apply the 4-quadrant TOP-only hard gates,
+     and score every survivor via the pure `scoring.evaluate_oi_velocity`.
+  5. Spread-gate the top eligible candidates (market_get_asset_data orderbook;
+     REJECT > 5 bps, +1/+2 bonus inside), then emit ONE signal for the single
+     highest-scoring survivor clearing MIN_SCORE — a marginPct sizing INTENT
+     plus a per-score leverage tier.
+
+Read-only + single-pass. NO daemon, NO push_signal, NO create_position — the
+runtime sizes the dollars, owns the cooldowns/risk gates/slots, and trails the
+DSL exit. The rolling OI history, per-asset cooldown, and per-tick signal dedup
+all live in ctx.state (belt-and-suspenders alongside the runtime's per-asset
+cooldown gate).
+
+FIDELITY NOTES vs the v2 producer (otter-producer.py v2.0.0):
+  - State migration: v2 persisted the rolling OI history to
+    state/<wallet-hash>/oi-history.json and per-asset cooldowns to
+    asset-cooldowns.json via atomic file writes. This port moves BOTH into
+    ctx.state (the runtime's transactional history store) — the only durable
+    cross-tick store available to a supervised scan(). The 60-sample/asset trim,
+    the 1h/4h lookbacks, the 240min per-asset cooldown semantics, and the
+    bootstrap window are all PRESERVED. Behaviour caveat: ctx.state advances ONLY
+    on a clean tick (any exception/timeout rolls it back), so a hard-failing tick
+    does not append an OI sample for that interval — the rolling window simply
+    skips that slot, exactly as a missed v2 cron tick would. The 1h/4h lookbacks
+    are by SAMPLE COUNT (12 / 48 back), not wall-clock, so a few skipped ticks
+    stretch the effective lookback slightly — identical to v2's count-based
+    lookback under missed crons. FLAGGED.
+  - DROPPED v2 plumbing: producer_daemon while-loop, push_signal HTTP POST,
+    fcntl producer.lock reentrancy guard, the OTTER_WALLET/STRATEGY_ADDRESS env
+    resolution + wallet-hash state dir, the openclaw CLI emit, and the
+    "fail-loud if wallet unset" branch — all owned by the Runtime 3.0 supervisor
+    now (ctx.wallet, the scaffold's delivery/dedup, single-pass execution). NO
+    order-lifecycle code existed in the v2 producer to drop (it never managed
+    orders). FLAGGED.
+  - Margin: v2 emitted marginUsd = account_value * OTTER_MARGIN_PCT (a FRACTION,
+    default 0.25). This port emits `marginPct` = 25 (a PERCENT) at the top level;
+    the runtime sizes (marginPct/100)*withdrawable. The defensive "<=1.0 means a
+    pasted fraction, ×100" guard is applied (dire/koala pattern). The 25%-of-
+    account INTENT is preserved.
+  - Universe size: v2 scored EVERY instrument with sufficient history (no top-N
+    cut). Preserved — the universe is the full crypto perp board minus XYZ.
+  - Emit: v2 main() emitted exactly one signal (the top eligible candidate that
+    cleared the spread gate). Preserved: scan() emits <= 1 signal/tick.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_RECENT_TTL = 240        # 4min — per-tick race-window dedup
+_DEFAULT_COOLDOWN_MIN = scoring.ASSET_COOLDOWN_MINUTES   # 240min per-asset cooldown
+_DEFAULT_MARGIN_PCT = 25.0       # PERCENT of withdrawable (v2 fraction 0.25 ×100)
+_TOP_N_SPREAD_CHECK = 3          # v2 main() spread-checked the top 3 eligible
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll
+    back the whole tick (the contract rolls ANY exception back to []). Returns
+    None on failure so the existing degrade paths apply (skip asset / neutral)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[otter.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _is_xyz(asset, dex=""):
+    """XYZ (HIP-3) equities/commodities — banned (different OI dynamics). v2
+    checked dex=='xyz' OR the 'xyz:' name prefix; the live combined
+    market_list_instruments response identifies XYZ ONLY by the name prefix, so
+    the dex check is kept for forward-compat but the prefix is the live signal."""
+    if not asset:
+        return False
+    if dex and str(dex).lower() == "xyz":
+        return True
+    return str(asset).lower().startswith("xyz:")
+
+
+# ═══════════════════════════════════════════════════════════════
+# ACCOUNT VALUE (sizing context)
+# ═══════════════════════════════════════════════════════════════
+
+def _get_account(ctx):
+    """(account_value, open_position_count) from strategy_get_clearinghouse_state.
+    READ-GUARDED. Verbatim port of v2 get_account_value: account value summed
+    across the main/xyz sub-DEX marginSummaries, non-zero positions counted."""
+    if not getattr(ctx, "wallet", None):
+        return None, 0
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return None, 0
+    data = ch.get("data", ch) if isinstance(ch, dict) else {}
+    if not isinstance(data, dict):
+        return None, 0
+    total_value = 0.0
+    pos_count = 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        total_value += scoring._f(ms.get("accountValue", 0))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            if scoring._f(pos.get("szi", 0)) != 0:
+                pos_count += 1
+    return total_value, pos_count
+
+
+# ═══════════════════════════════════════════════════════════════
+# UNIVERSE FETCH (read-guarded market_list_instruments)
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_instruments(ctx):
+    """Pull market_list_instruments. Returns list of {asset, dex, oi, mark_px,
+    oi_usd}. READ-GUARDED. Verbatim port of v2 fetch_instruments: OI + mark read
+    from the context-nested fields (Pangolin v1.3 fix), XYZ banned, oi<=0 /
+    mark<=0 dropped."""
+    raw = _read(ctx, "market_list_instruments", {})
+    if not raw:
+        return []
+    instruments = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(instruments, dict):
+        instruments = instruments.get("instruments", instruments.get("universe", []))
+    if not isinstance(instruments, list):
+        return []
+
+    parsed = []
+    for inst in instruments:
+        if not isinstance(inst, dict):
+            continue
+        name = str(inst.get("name", inst.get("coin", ""))).upper()
+        dex = str(inst.get("dex", "")).lower()
+        if not name:
+            continue
+        if _is_xyz(name, dex):
+            continue
+        ctx_block = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        oi = scoring._f(ctx_block.get("openInterest", inst.get("openInterest", 0)))
+        mark_px = scoring._f(ctx_block.get("markPx", ctx_block.get("midPx",
+                             inst.get("markPx", inst.get("midPx", 0)))))
+        if oi <= 0 or mark_px <= 0:
+            continue
+        parsed.append({
+            "asset": name,
+            "dex": dex,
+            "oi": oi,
+            "mark_px": mark_px,
+            "oi_usd": oi * mark_px,
+        })
+    return parsed
+
+
+# ═══════════════════════════════════════════════════════════════
+# SM CONCENTRATION (optional scoring bonus, not a hard gate)
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_sm_map(ctx, inputs):
+    """{asset: {direction, pct, traders}} for the SM concentration bonus.
+    READ-GUARDED. Verbatim port of v2 fetch_sm_map (XYZ skipped, pct ×100)."""
+    limit = int(inputs.get("smLimit", 100))
+    raw = _read(ctx, "leaderboard_get_markets", {"limit": limit})
+    if not raw:
+        return {}
+    sm = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(sm, dict):
+        sm = sm.get("markets", sm)
+    if isinstance(sm, dict):
+        sm = sm.get("markets", [])
+    if not isinstance(sm, list):
+        return {}
+    out = {}
+    for m in sm:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", "")).upper()
+        dex = str(m.get("dex", "")).lower()
+        if dex == "xyz":
+            continue
+        if not token:
+            continue
+        out[token] = {
+            "direction": str(m.get("direction", "")).upper(),
+            "pct": scoring._f(m.get("pct_of_top_traders_gain", 0)) * 100,
+            "traders": int(m.get("trader_count", 0) or 0),
+        }
+    return out
+
+
+# ═══════════════════════════════════════════════════════════════
+# SPREAD CHECK (required before emit) — per-candidate orderbook read
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_spread_bps(ctx, asset):
+    """Orderbook spread (bps) for one asset, or None on failure. READ-GUARDED.
+    Verbatim port of v2 fetch_spread_bps (best bid/ask -> spread over mid)."""
+    r = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": [],
+        "include_funding": False,
+        "include_order_book": True,
+    })
+    if not r:
+        return None
+    data = r.get("data", r) if isinstance(r, dict) else {}
+    if not isinstance(data, dict):
+        return None
+    ob = data.get("order_book") or data.get("orderBook") or {}
+    if not isinstance(ob, dict):
+        return None
+    bids = ob.get("bids") or []
+    asks = ob.get("asks") or []
+    if not bids or not asks:
+        return None
+    best_bid = scoring._f((bids[0] or {}).get("price") or (bids[0] or {}).get("px"))
+    best_ask = scoring._f((asks[0] or {}).get("price") or (asks[0] or {}).get("px"))
+    if best_bid <= 0 or best_ask <= 0:
+        return None
+    mid = (best_bid + best_ask) / 2
+    if mid <= 0:
+        return None
+    return (best_ask - best_bid) / mid * 10000
+
+
+# ═══════════════════════════════════════════════════════════════
+# ctx.state — rolling OI history + cooldowns + per-tick dedup
+# ═══════════════════════════════════════════════════════════════
+
+def _load_state(ctx):
+    """Return (history, cooldowns, recent) from the last clean tick.
+    history    = {asset: [{ts, oi, mark_px}, ...]} (oldest first, <=60/asset)
+    cooldowns  = {asset: emittedEpoch}
+    recent     = {asset: signaledEpoch} (race-window dedup)"""
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}, {}, {}
+    last = ctx.state.last() or {}
+    history = last.get("oi_history", {})
+    cooldowns = last.get("cooldowns", {})
+    recent = last.get("recent", {})
+    return (dict(history) if isinstance(history, dict) else {},
+            dict(cooldowns) if isinstance(cooldowns, dict) else {},
+            dict(recent) if isinstance(recent, dict) else {})
+
+
+def _update_history(history, instruments, now):
+    """Append the current sample per instrument; trim to HISTORY_MAX_SAMPLES.
+    Verbatim port of v2 update_history (delisted assets keep history but stop
+    accumulating). Returns the mutated history dict."""
+    for inst in instruments:
+        asset = inst["asset"]
+        sample = {"ts": now, "oi": inst["oi"], "mark_px": inst["mark_px"]}
+        if asset not in history:
+            history[asset] = []
+        history[asset].append(sample)
+        if len(history[asset]) > scoring.HISTORY_MAX_SAMPLES:
+            history[asset] = history[asset][-scoring.HISTORY_MAX_SAMPLES:]
+    return history
+
+
+def _is_cooled_down(cooldowns, asset, cooldown_minutes, now):
+    """v2 is_asset_cooled_down: True if last emit is within the cooldown window."""
+    last_emit = cooldowns.get(asset)
+    if last_emit is None:
+        return False
+    return ((now - last_emit) / 60) < cooldown_minutes
+
+
+# ═══════════════════════════════════════════════════════════════
+# MAIN SCAN
+# ═══════════════════════════════════════════════════════════════
+
+def scan(inputs, ctx):
+    now = time.time()
+    hour = time.gmtime(now).tm_hour
+    min_score = float(inputs.get("minScore", scoring.MIN_SCORE))
+    max_spread = float(inputs.get("maxSpreadBps", scoring.MAX_SPREAD_BPS))
+    cooldown_min = float(inputs.get("assetCooldownMinutes", _DEFAULT_COOLDOWN_MIN))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+    top_n = int(inputs.get("spreadCheckTopN", _TOP_N_SPREAD_CHECK))
+
+    # marginPct: PERCENT in (0,100]. Defensive fraction->percent guard
+    # (dire/koala): a pasted <=1.0 is a fraction; ×100.
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    history, cooldowns, recent = _load_state(ctx)
+    # prune the race-window dedup map (TTL)
+    recent = {k: v for k, v in recent.items() if (now - v) < ttl}
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        rec = {"oi_history": history, "cooldowns": cooldowns,
+               "recent": recent, "result": result}
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[otter.scan] WARNING: state append failed; rolling OI history "
+                  f"and cooldowns will not advance this tick: {exc!r}", file=sys.stderr)
+
+    # 1. Account value for sizing context (sizing itself is marginPct intent).
+    account_value, pos_count = _get_account(ctx)
+    if account_value is None or account_value <= 0:
+        print("[otter.scan] cannot read account value — skip tick", file=sys.stderr)
+        # do NOT advance history off a failed account read (matches v2 early-return)
+        _persist({"ts": now, "emitted": False, "gate": "no_account"})
+        return []
+
+    # 2. Fetch the crypto-perp universe (XYZ banned).
+    instruments = fetch_instruments(ctx)
+    if not instruments:
+        print("[otter.scan] market_list_instruments empty/failed — no signal", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_universe"})
+        return []
+
+    # 3. Append this tick's OI sample to the rolling history (then trim).
+    history = _update_history(history, instruments, now)
+
+    # 4. SM concentration map (optional bonus).
+    sm_map = fetch_sm_map(ctx, inputs)
+
+    # 5. Score every asset with sufficient history through the verbatim scorer.
+    candidates = []
+    bootstrapping = 0
+    for inst in instruments:
+        samples = history.get(inst["asset"], [])
+        sig = scoring.evaluate_oi_velocity(inst, samples, sm_map.get(inst["asset"]),
+                                           hour, inputs)
+        if sig == "BOOTSTRAP":
+            bootstrapping += 1
+            continue
+        if sig:
+            candidates.append(sig)
+
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+
+    # 6. min-score + per-asset cooldown filter.
+    eligible = [
+        c for c in candidates
+        if c["score"] >= min_score
+        and not _is_cooled_down(cooldowns, c["asset"], cooldown_min, now)
+    ]
+
+    total = len(instruments)
+    if not eligible and bootstrapping > 0:
+        avg = round(sum(len(s) for s in history.values()) / max(len(history), 1), 1)
+        print(f"[otter.scan] WAITING bootstrapping_history "
+              f"({bootstrapping}/{total} assets need more samples, avg {avg})",
+              file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "bootstrapping",
+                  "bootstrapping": bootstrapping, "candidates": len(candidates),
+                  "samples_avg": avg})
+        return []
+
+    if not eligible:
+        best = candidates[0] if candidates else None
+        note = ("no candidate passed score+cooldown" if not best else
+                f"best {best['asset']} {best['direction']} score={best['score']} (need >= {min_score:.0f})")
+        print(f"[otter.scan] WAITING — {note} (scanned {total})", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_eligible",
+                  "candidates": len(candidates)})
+        return []
+
+    # 7. Spread gate on the top-N eligible (per-candidate orderbook read).
+    emitted = None
+    for c in eligible[:top_n]:
+        # defense-in-depth dedup: skip if pushed within the race window
+        au = c["asset"].upper()
+        if recent.get(au) is not None and (now - recent[au]) < ttl:
+            c["reasons"].append("DEDUP_SKIP")
+            continue
+        spread_bps = fetch_spread_bps(ctx, c["asset"])
+        if not scoring.apply_spread_bonus(c, spread_bps, max_spread):
+            continue
+        if c["score"] < min_score:    # spread bonus could not lift it back over floor
+            continue
+        emitted = c
+        break
+
+    if not emitted:
+        print(f"[otter.scan] WAITING — all top {top_n} eligible failed spread/dedup gate",
+              file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "spread",
+                  "candidates": len(candidates), "eligible": len(eligible)})
+        return []
+
+    # 8. Emit the single best survivor. Score-scaled leverage; marginPct intent.
+    leverage = scoring.get_leverage_for_score(emitted["score"],
+                                              inputs.get("leverageTiers"))
+    au = emitted["asset"].upper()
+    cooldowns[au] = now
+    recent[au] = now
+
+    result = {"ts": now, "emitted": True, "gate": "pass", "asset": emitted["asset"],
+              "direction": emitted["direction"], "score": emitted["score"],
+              "leverage": leverage, "marginPct": margin_pct,
+              "open_positions": pos_count, "account_value": round(account_value, 2),
+              "reasons": emitted["reasons"]}
+    print(f"[otter.scan] EMIT {emitted['asset']} {emitted['direction']} "
+          f"score={emitted['score']} {leverage}x margin={margin_pct:.1f}% "
+          f"oiD1h={emitted['oi_delta_1h_pct']:+.1f}% pxD1h={emitted['price_delta_1h_pct']:+.2f}% "
+          f"| {' | '.join(emitted['reasons'])}", file=sys.stderr)
+    _persist(result)
+
+    oi_d_4h = emitted["oi_delta_4h_pct"]
+    px_d_4h = emitted["price_delta_4h_pct"]
+    return [{
+        "asset": emitted["asset"],
+        "direction": emitted["direction"],
+        "marginPct": margin_pct,                  # SIZING INTENT — PERCENT (0,100]; runtime sizes USD
+        "leverage": leverage,                     # score-tiered (5/7/10); runtime clamps to venue max
+        "data": {
+            "score": emitted["score"],
+            "leverage": leverage,
+            "direction": emitted["direction"],
+            "oiDelta1hPct": round(emitted["oi_delta_1h_pct"], 3),
+            "priceDelta1hPct": round(emitted["price_delta_1h_pct"], 3),
+            "oiUsd": round(emitted["oi_usd"], 2),
+            "oiDelta4hPct": round(oi_d_4h, 3) if oi_d_4h is not None else 0,
+            "priceDelta4hPct": round(px_d_4h, 3) if px_d_4h is not None else 0,
+            "spreadBps": round(emitted["spread_bps"], 2) if emitted["spread_bps"] is not None else 0,
+            "smAligned": bool(emitted["sm_aligned"]),
+            "smPctOfTopTraders": round(emitted["sm_pct"], 2),
+            "markPx": round(emitted["mark_px"], 6),
+            "samplesInHistory": int(emitted["samples"]),
+            "reasons": " | ".join(emitted.get("reasons", [])),
+        },
+    }]

--- a/strategies/otter/main/scanners/scoring.py
+++ b/strategies/otter/main/scanners/scoring.py
@@ -1,0 +1,263 @@
+"""OTTER — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 OTTER producer's OI-velocity thesis
+(otter-producer.py v2.0.0, "Open Interest Velocity Hunter"). The rolling-history
+delta math, the 4-quadrant hard gates, the multi-factor scoring table, and the
+conviction-scaled leverage tiers are reproduced VERBATIM so a fidelity harness
+can diff this against the v2 producer on the same OI-history snapshot.
+
+Multi-asset universe, single-pass, unit-testable on plain dicts. The caller
+(scan.py) owns the clock and the MCP reads; the time-of-day modifier and the
+delta computation take their `hour` / `samples` as arguments so this module
+stays pure.
+
+Behaviour-preserving v2 quirks are kept and flagged `# v2-quirk`."""
+
+# ── numeric coercion (matches v2 safe_float) ──
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v) if v is not None else d
+    except (TypeError, ValueError):
+        return d
+
+
+# ═══════════════════════════════════════════════════════════════
+# CONSTANTS — preserved verbatim from v2 otter-producer.py v2.0.0
+# ═══════════════════════════════════════════════════════════════
+
+MIN_SCORE = 9                      # high bar (Polar v2.4 / Cheetah v5.2 / Roach v1.1 pattern)
+MIN_OI_DELTA_1H_PCT = 5.0          # 1h OI delta floor — fresh leveraged flow
+MIN_PRICE_ALIGN_PCT = 0.5          # 1h price must move >= 0.5% in same direction as OI
+MIN_OI_USD = 1_000_000            # liquidity floor
+MAX_SPREAD_BPS = 5                 # entry quality gate
+ASSET_COOLDOWN_MINUTES = 240       # per-asset cooldown (defense-in-depth alongside runtime)
+
+# Rolling history config — 5min cadence, 60 samples = 5h window
+HISTORY_MAX_SAMPLES = 60
+SAMPLES_FOR_1H = 12                # 12 samples × 5 min = 60 min
+SAMPLES_FOR_4H = 48               # 48 samples × 5 min = 240 min
+MIN_SAMPLES_TO_FIRE = SAMPLES_FOR_1H   # need >= 1h of history to compute the 1h delta
+
+# Conviction-scaled leverage (Polar v2.4 / Bald Eagle v3.0 pattern)
+LEVERAGE_TIERS = [
+    {"min_score": 13, "leverage": 10},
+    {"min_score": 11, "leverage": 7},
+    {"min_score": 9,  "leverage": 5},
+]
+DEFAULT_LEVERAGE = 5
+
+
+def get_leverage_for_score(score, tiers=None):
+    """Returns leverage for the score tier. Ported verbatim from v2
+    get_leverage_for_score; the fallback (5x) matches v2 DEFAULT_LEVERAGE."""
+    for tier in (tiers or LEVERAGE_TIERS):
+        if score >= tier["min_score"]:
+            return tier["leverage"]
+    return DEFAULT_LEVERAGE
+
+
+def time_of_day_modifier(hour):
+    """UTC time-of-day adjustment (caller owns the clock — keeps this pure).
+    Verbatim from v2 time_of_day_modifier (same logic as Roach/Bloodhound)."""
+    if 4 <= hour < 14:
+        return 1, "tod_active_window"
+    elif hour >= 18 or hour < 2:
+        return -2, "tod_chop_zone"
+    return 0, None
+
+
+# ═══════════════════════════════════════════════════════════════
+# DELTA COMPUTATION — preserved verbatim from v2 compute_deltas
+# ═══════════════════════════════════════════════════════════════
+
+def compute_deltas(samples):
+    """Compute 1h and 4h OI delta % + price delta % from a list of samples
+    (oldest first). Each sample = {ts, oi, mark_px}. Returns dict with computed
+    deltas or None if insufficient history. Verbatim from v2 compute_deltas."""
+    n = len(samples)
+    if n < SAMPLES_FOR_1H + 1:
+        return None  # need at least 1h + current
+
+    current = samples[-1]
+    sample_1h_ago = samples[-(SAMPLES_FOR_1H + 1)] if n >= SAMPLES_FOR_1H + 1 else None
+    sample_4h_ago = samples[-(SAMPLES_FOR_4H + 1)] if n >= SAMPLES_FOR_4H + 1 else None
+
+    out = {
+        "samples": n,
+        "current_oi": current["oi"],
+        "current_px": current["mark_px"],
+        "oi_delta_1h_pct": None,
+        "price_delta_1h_pct": None,
+        "oi_delta_4h_pct": None,
+        "price_delta_4h_pct": None,
+    }
+
+    if sample_1h_ago and sample_1h_ago["oi"] > 0 and sample_1h_ago["mark_px"] > 0:
+        out["oi_delta_1h_pct"] = (current["oi"] - sample_1h_ago["oi"]) / sample_1h_ago["oi"] * 100
+        out["price_delta_1h_pct"] = (current["mark_px"] - sample_1h_ago["mark_px"]) / sample_1h_ago["mark_px"] * 100
+
+    if sample_4h_ago and sample_4h_ago["oi"] > 0 and sample_4h_ago["mark_px"] > 0:
+        out["oi_delta_4h_pct"] = (current["oi"] - sample_4h_ago["oi"]) / sample_4h_ago["oi"] * 100
+        out["price_delta_4h_pct"] = (current["mark_px"] - sample_4h_ago["mark_px"]) / sample_4h_ago["mark_px"] * 100
+
+    return out
+
+
+# ═══════════════════════════════════════════════════════════════
+# 4-QUADRANT FILTER + SCORING — preserved verbatim from v2
+# build_candidates' per-asset body
+# ═══════════════════════════════════════════════════════════════
+
+def evaluate_oi_velocity(asset_info, samples, sm, hour, inputs=None):
+    """Score one asset for an OI-velocity TOP-quadrant setup.
+
+    `asset_info` = {asset, oi, mark_px, oi_usd}
+    `samples`    = rolling history list [{ts, oi, mark_px}, ...] (oldest first)
+    `sm`         = {direction, pct, traders} or None (SM concentration bonus)
+    `hour`       = current UTC hour (caller owns the clock — keeps this pure)
+
+    Returns scored candidate dict (spread_bps still None) or None if any hard
+    gate fails / insufficient history. Hard gates, scoring tables, and bonus
+    magnitudes are VERBATIM from v2 build_candidates. The `spread` bonus and the
+    spread REJECT gate live in scan.py (they need a per-candidate MCP read), as
+    in v2 main()."""
+    inputs = inputs or {}
+    min_oi_usd = float(inputs.get("minOiUsd", MIN_OI_USD))
+    min_oi_delta = float(inputs.get("minOiDelta1hPct", MIN_OI_DELTA_1H_PCT))
+    min_price_align = float(inputs.get("minPriceAlignPct", MIN_PRICE_ALIGN_PCT))
+    min_samples = int(inputs.get("minSamplesToFire", MIN_SAMPLES_TO_FIRE))
+
+    asset = asset_info["asset"]
+    oi_usd = asset_info["oi_usd"]
+
+    # Liquidity floor
+    if oi_usd < min_oi_usd:
+        return None
+
+    # Need at least 1h of history + current sample.
+    if len(samples) < min_samples + 1:
+        return "BOOTSTRAP"
+
+    deltas = compute_deltas(samples)
+    if not deltas or deltas["oi_delta_1h_pct"] is None:
+        return "BOOTSTRAP"
+
+    oi_d_1h = deltas["oi_delta_1h_pct"]
+    px_d_1h = deltas["price_delta_1h_pct"]
+    oi_d_4h = deltas.get("oi_delta_4h_pct")
+    px_d_4h = deltas.get("price_delta_4h_pct")
+
+    # ── HARD GATE 1: 1h OI delta floor ──
+    if abs(oi_d_1h) < min_oi_delta:
+        return None
+
+    # ── HARD GATE 2: top-quadrant only (OI ↑) ──
+    # Bottom quadrants (OI ↓) are unwinding signals → Pangolin/Owl territory.
+    if oi_d_1h <= 0:
+        return None
+
+    # ── HARD GATE 3: 1h price aligned with conviction direction ──
+    # OI growing but price flat / ambiguous (could be hedging) — skip.
+    if px_d_1h is None:
+        return None
+    if abs(px_d_1h) < min_price_align:
+        return None
+    # Flow direction = price direction (OI is growing, so flow adds liquidity to
+    # whichever side price is going).
+    flow_direction = "LONG" if px_d_1h > 0 else "SHORT"
+
+    # ── HARD GATE 4: 4h OI not net unwinding ──
+    # If 1h OI is up but 4h OI is down, the 1h is an inversion of a longer unwind.
+    if oi_d_4h is not None and oi_d_4h < 0:
+        return None
+
+    # ─── SCORING (verbatim v2 tables) ───
+    score = 0.0
+    reasons = [
+        f"OI_DELTA_1H {oi_d_1h:+.1f}%",
+        f"PRICE_DELTA_1H {px_d_1h:+.2f}%",
+    ]
+
+    # 1h OI delta tier (4-6 points)
+    abs_oi_d = abs(oi_d_1h)
+    if abs_oi_d > 20:
+        score += 6
+        reasons.append("OI_TIER_EXTREME")
+    elif abs_oi_d > 10:
+        score += 5
+        reasons.append("OI_TIER_HIGH")
+    else:
+        score += 4
+        reasons.append("OI_TIER_BASE")
+
+    # 4h confirmation (+2) or contradiction (-2)
+    if oi_d_4h is not None:
+        if oi_d_4h >= 10:
+            score += 2
+            reasons.append(f"OI_4H_CONFIRMS {oi_d_4h:+.1f}%")
+        elif oi_d_4h < 0:
+            score -= 2
+            reasons.append(f"OI_4H_CONTRADICTS {oi_d_4h:+.1f}%")
+
+    # 1h price magnitude
+    abs_px_d = abs(px_d_1h)
+    if abs_px_d > 2:
+        score += 2
+        reasons.append("PRICE_STRONG")
+    elif abs_px_d > 1:
+        score += 1
+        reasons.append("PRICE_MODERATE")
+
+    # SM concentration alignment
+    sm_aligned = False
+    sm_pct = 0.0
+    if sm:
+        sm_dir = sm.get("direction", "")
+        sm_pct = sm.get("pct", 0)
+        if sm_dir == flow_direction and sm_pct >= 5:
+            score += 2
+            sm_aligned = True
+            reasons.append(f"SM_ALIGNED {sm_pct:.1f}%")
+
+    # Time-of-day modifier
+    tod_mod, tod_reason = time_of_day_modifier(hour)
+    score += tod_mod
+    if tod_reason:
+        reasons.append(tod_reason)
+
+    return {
+        "asset": asset,
+        "direction": flow_direction,
+        "score": round(score, 2),
+        "oi_delta_1h_pct": oi_d_1h,
+        "oi_delta_4h_pct": oi_d_4h,
+        "price_delta_1h_pct": px_d_1h,
+        "price_delta_4h_pct": px_d_4h,
+        "oi_usd": oi_usd,
+        "mark_px": deltas["current_px"],
+        "samples": deltas["samples"],
+        "sm_aligned": sm_aligned,
+        "sm_pct": sm_pct,
+        "reasons": reasons,
+        "spread_bps": None,        # filled in by scan.py for the top scorer(s)
+    }
+
+
+def apply_spread_bonus(candidate, spread_bps, max_spread_bps=MAX_SPREAD_BPS):
+    """Verbatim port of the v2 main() spread gate + bonus. Mutates `candidate`
+    (score + reasons + spread_bps) and returns True if it PASSES the spread gate
+    (<= max_spread_bps), False if it should be skipped. `spread_bps` is the
+    measured orderbook spread or None (None -> skip, as in v2)."""
+    candidate["spread_bps"] = spread_bps
+    if spread_bps is None or spread_bps > max_spread_bps:
+        candidate["reasons"].append(f"SKIP_SPREAD {spread_bps}")
+        return False
+    if spread_bps <= 2:
+        candidate["score"] += 2
+        candidate["reasons"].append(f"SPREAD_TIGHT {spread_bps:.1f}bps")
+    else:
+        candidate["score"] += 1
+        candidate["reasons"].append(f"SPREAD_OK {spread_bps:.1f}bps")
+    return True

--- a/strategies/otter/strategy.yaml
+++ b/strategies/otter/strategy.yaml
@@ -1,0 +1,42 @@
+# Otter — Open Interest Velocity Hunter. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2
+# Otter (otter-producer.py v2.0.0 / SKILL.md v2.0.1): the first fleet agent to trade
+# OI delta OVER TIME — maintains a rolling 5h OI history per HL crypto perp and fires
+# the single best TOP-quadrant (fresh leveraged flow) candidate, score-tiered sizing,
+# DSL-only exits. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: otter
+version: "1.0.0"
+
+catalog:
+  name: "Otter — Open Interest Velocity Hunter"
+  emoji: "🦦"
+  tagline: "Watches the rate of change of open interest across every liquid Hyperliquid crypto perp and fires at most a couple of positions — only when 1h OI jumps >=5% while price moves >=0.5% the same way (fresh leveraged money entering with conviction), 4h isn't unwinding, and the spread is tight. Sizes margin to conviction at 5/7/10x, then rides the flow 1-3h on a tight DSL."
+  belief_plain: "Open interest only grows when new leveraged money enters a perp. When that money piles in fast (OI up 5%+ in an hour) AND price moves the same direction, that's real conviction — not just a wick. Otter rides that fresh flow for an hour or three, then trails a tight stop. It does nothing on the much more common days when no coin shows that burst, and it never trades unwinds."
+  thesis: "OI velocity — the delta of open interest over time — is a perp-native conviction signal nobody else in the fleet trades (others read OI only as a static size filter). Fresh OI growth aligned with price (the top two quadrants of the OI/price matrix) is new leveraged positioning with direction; unwinds (the bottom two) are exhaustion and get skipped. Confluence scoring (OI tier, 4h confirmation, price magnitude, smart-money lean, spread, time-of-day) at a high floor keeps it a sniper, and a tight DSL locks profit early because the flow edge is in the first 1-3 hours."
+  group: momentum
+  archetype: breakout_momentum
+  sub_style: oi_confirmed
+  asset_classes: [universe_crypto]
+  asset_scope: universe
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  leverage_max: 10
+  max_slots: 2
+  min_budget: 200
+  assets: []
+  tags: [open-interest, oi-velocity, momentum, universe, flow, smart-money, conviction-sizing, short-hold, crypto]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: OTTER_WALLET
+    funding_share: 1.0

--- a/strategies/owl/main/runtime.yaml
+++ b/strategies/owl/main/runtime.yaml
@@ -1,0 +1,141 @@
+# ── OWL · single instance — Pure Contrarian Crowding-Unwind Hunter (Runtime 3.0 port of v2 OWL v8.0.1) ──
+name: owl-main
+group: owl
+version: 3.0.0
+description: >
+  OWL — pure contrarian crowding-unwind hunter. Scans EVERY liquid HL crypto perp
+  (OI > $3M, no top-N truncation; XYZ banned) for one-sided crowding (extreme funding +
+  lopsided smart money + concentrated OI), waits for crowding to PERSIST >=1h AND for
+  exhaustion confluence to fire (volume declining, price stalling vs the crowd, capitulation
+  wick, 4h RSI divergence), then fades the crowd. Combined score >=12 to fire; conviction-
+  scaled leverage (7/8/10 by score) at 25% margin. MACRO_TREND_GATE blocks all fades when
+  |BTC 4h move| > 3% (mean reversion fails in trending regimes). One emit/tick; the runtime
+  sizes, owns cooldowns/risk gates/slots, and trails the DSL exit. Faithful port of the v2
+  producer thesis (frozen at v7.1). NOTE: XYZ is filtered by the 'XYZ:' name prefix (the live
+  combined instruments response carries no dex field — see scan.py).
+
+strategy:
+  wallet: "${OWL_WALLET}"
+  slots: 2                                 # v2 strategy.slots: 2
+  default_leverage: 8                      # fallback; scan emits per-score 7/8/10 (auto-clamped to venue max)
+  trading_risk: moderate                   # v2 trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: owl_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900                   # v2 producer cadence (15 min)
+    timeout_seconds: 600                    # v2 tick_timeout 600; universe scan does many per-asset MCP reads
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 100            # crowding persistence ledger + cooldown map + per-tick result history
+    inputs:
+      minOiUsd: 3000000                     # v2 MIN_OI_USD — $3M liquidity floor; ALL perps above it (no top-N)
+      smLimit: 200                          # v2 leaderboard_get_markets limit=200
+      minCrowdingScore: 6                   # v2 MIN_CROWDING_SCORE (v6.2)
+      minPersistHours: 1                    # v2 MIN_PERSIST_HOURS (v6.0)
+      belowThresholdTolerance: 2            # v2 BELOW_THRESHOLD_TOLERANCE (v5.3 noise-tick guard)
+      minExhaustionScore: 5                 # v2 MIN_EXHAUSTION_SCORE
+      minExhaustionSignals: 2               # v2 MIN_EXHAUSTION_SIGNALS
+      minCombinedScore: 12                  # v2 MIN_COMBINED_SCORE (v6.0)
+      minFundingAnnualizedPct: 12           # v2 MIN_FUNDING_ANNUALIZED_PCT (v5.2)
+      macroGateBtc4hPct: 3.0                # v2 MACRO_GATE_BTC_4H_PCT (v7.1)
+      assetCooldownMinutes: 360             # v2 ASSET_COOLDOWN_MINUTES — 6h post-emit per-asset cooldown
+      marginPct: 25                         # PERCENT of withdrawable (0,100]; v2 MARGIN_PCT 0.25 (fraction) x100
+      # leverageTiers: per-score [min_score, leverage]; omit -> scoring defaults (7/8/10 by score)
+      leverageTiers: [[16, 10], [14, 8], [12, 7]]
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      crowdDirection: { type: string }
+      crowdingScore: { type: number }
+      exhaustionScore: { type: number }
+      persistenceHours: { type: number }
+      fundingAnnualizedPct: { type: number, required: false }
+      smTilt: { type: number, required: false }
+      smLongPct: { type: number, required: false }
+      oiUsd: { type: number, required: false }
+      priceChg4hPct: { type: number, required: false }
+      rsi4h: { type: number, required: false }
+      peakCrowdingScore: { type: number, required: false }
+      exhaustionSignals: { type: string, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: owl_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every hard gate + score floor + cooldown
+    scanners: [owl_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false    # ENTRIES: cancel-and-skip if maker can't fill in 60s. Contrarian unwinds aren't urgent at detection.
+        execution_timeout_seconds: 60       # v2 owl_entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: owl_main_signals
+
+# EXIT — DSL, ported VERBATIM from the v2 v8.0.1 dsl_preset block. Owl is patient on
+# entries (1h persistence) but contrarian entries retrace hard before working: Phase 1
+# max_loss 35% gives the thesis room; Phase 2 starts at +5% (Lemon-pattern first-leg
+# capture) because the unwind's first leg is reliable but 50%+ extensions are rare.
+# FIDELITY: the v2 runtime DESCRIPTION prose said "retrace 15, 3 breaches" but the v2
+# dsl_preset BLOCK had retrace_threshold 8 / consecutive_breaches_required 1 — the
+# structured block wins (source-of-truth order); flagged in the port report.
+exit:
+  engine: dsl
+  interval_seconds: 30                      # v2 exit.interval_seconds 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true         # EXITS: taker fallback as safety floor. Phase 1 stops at 35% ROE = real trouble; exits MUST happen.
+    execution_timeout_seconds: 60           # v2 exit execution_timeout_seconds
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 480              # 8h max — contrarian thesis unwind window
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 120
+      min_value: 2.0                        # peak ROE floor; below this in 2h = thesis failed
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 30               # v6.0 Lemon-pattern fast loser cut
+    phase1:
+      enabled: true
+      max_loss_pct: 35.0                     # wide — contrarian entries retrace hard before working
+      retrace_threshold: 8                   # v2 dsl_preset block value (NOT the "15" in the prose)
+      consecutive_breaches_required: 1       # v2 dsl_preset block value (NOT the "3" in the prose)
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,  lock_hw_pct: 20 }   # v6.0 first-leg capture (Lemon-pattern). REACHABLE.
+        - { trigger_pct: 10, lock_hw_pct: 35 }
+        - { trigger_pct: 20, lock_hw_pct: 50 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 50, lock_hw_pct: 78 }
+        - { trigger_pct: 75, lock_hw_pct: 88 }   # rare but happens — full unwind cascade
+
+# RISK GUARDRAILS — declarative; runtime enforces. v2 risk fields converted to seconds.
+# The producer's PnL-aware dynamic daily cap + post-loss asset cooldown were defense-in-depth;
+# the runtime guard_rails now own enforcement (per v2 config _runtime_owns). The scanner ALSO
+# keeps a per-asset emit cooldown in ctx.state (belt-and-suspenders) and the crowding-
+# persistence ledger that gates the thesis.
+risk:
+  data_retention_seconds: 259200            # v2 data_retention_hours 72 -> 72*3600
+  guard_rails:
+    daily_loss_limit_pct: 10                # v2 daily_loss_limit_pct (contrarian tolerates short-term losses)
+    max_entries_per_day: 4                  # v2 upper bound of dynamicSlots (4 at +$400 PnL)
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4               # v2 max_consecutive_losses
+    cooldown_seconds: 0                      # v2 cooldown_minutes 0 — scanner manages cooldowns
+    drawdown_halt_pct: 25                    # v2 drawdown_halt_pct — explicit -25% HARD STOP
+    drawdown_reset_on_day_rollover: true     # v2 drawdown_reset_on_day_rollover
+    per_asset_cooldown_seconds: 21600        # v2 per_asset_cooldown_minutes 360 -> 360*60 (6h post-loss)

--- a/strategies/owl/main/scanners/scan.py
+++ b/strategies/owl/main/scanners/scan.py
@@ -1,0 +1,481 @@
+"""OWL — supervised scanner (Runtime 3.0 port of the v2 OWL producer).
+
+Multi-asset universe, emit-one. A faithful port of the v2 OWL "Pure Contrarian
+Crowding-Unwind Hunter" (SKILL.md / producer v8.0.1, thesis frozen at v7.1):
+
+  1. Build the universe — EVERY HL crypto perp with OI > $3M (no top-N
+     truncation; XYZ banned), from market_list_instruments.
+  2. Pull the smart-money positioning map (leaderboard_get_markets, limit=200):
+     per-coin long%/trader-count, AND BTC's 4h price change for the macro gate.
+  3. MACRO_TREND_GATE: if |BTC 4h move| > 3%, stand down (mean reversion fails
+     in trending regimes).
+  4. Score crowding per asset (funding extremity + SM tilt + OI concentration)
+     and update the cross-tick PERSISTENCE ledger in ctx.state.
+  5. For assets that have persisted >=1h above the crowding floor, fetch 1h/4h
+     candles and detect exhaustion (volume declining, price stalling vs crowd,
+     capitulation wick, 4h RSI divergence).
+  6. Filter combined score (crowding + exhaustion) >= 12 + per-asset emit
+     cooldown, then EMIT ONE signal for the single highest-scoring candidate —
+     a marginPct sizing INTENT plus a per-score leverage tier. The entry
+     direction is the OPPOSITE of the crowd direction (Owl fades the crowd).
+
+Read-only + single-pass. NO daemon, NO push_signal, NO create_position — the
+runtime sizes the dollars, owns the cooldowns/risk gates/slots, and trails the
+DSL exit.
+
+FIDELITY NOTES vs owl-producer.py v8.0.1 (thesis frozen at v7.1):
+  - Crowding score, exhaustion detection, funding annualization, the persistence
+    ledger semantics (firstSeen/ts/peakScore/belowThresholdCount + 2-tick
+    tolerance), the MACRO_TREND_GATE (|BTC 4h| > 3%), conviction leverage tiers
+    (7/8/10 by score), and all gate thresholds are ported VERBATIM (see scoring.py).
+  - SIZING: v2 MARGIN_PCT 0.25 was a FRACTION; the producer emitted
+    marginUsd = account_value * 0.25. This port emits a top-level `marginPct`
+    PERCENT (25) and the runtime sizes (marginPct/100)*withdrawable. Defensive
+    <=1.0 guard treats a pasted fraction as a percent (x100).
+  - PERSISTENCE STATE: v2 persisted crowding-history.json / asset-cooldowns.json
+    under state/<wallet-hash>/. This port keeps the crowding-persistence ledger
+    AND a per-asset emit-cooldown map in ctx.state (transactional, rolled back on
+    a failed tick). Semantics preserved verbatim.
+  - DROPPED (runtime owns it now, per the v2 config _runtime_owns block): the
+    producer-side PnL-aware dynamic daily cap (get_dynamic_daily_cap) +
+    trade-counter.json + equity-baseline.json. The runtime guard_rails enforce
+    max_entries_per_day, drawdown_halt_pct, daily_loss_limit_pct, and the
+    per_asset_cooldown. FLAGGED in the port report. The producer's account-value
+    read (for sizing + the dynamic cap) is therefore dropped; the runtime sizes
+    from withdrawable via marginPct. Held-asset suppression is kept (the v2
+    push_signal held-asset skip).
+  - DROPPED: the v2 wallet-not-resolved fail-loud path and the equity-baseline
+    capture (sizing is the runtime's job now).
+  - v2 emitted exactly one signal (candidates[:1], top by combined score).
+    Preserved: scan() emits <= 1 signal/tick.
+
+PORT NOTE (XYZ ban): the v2 producer filtered XYZ via inst.get("dex") == "xyz"
+OR a "xyz:" name prefix. The live combined market_list_instruments response
+carries NO dex field — XYZ equities are identified ONLY by the "XYZ:" name
+prefix (e.g. "XYZ:SP500"). This port bans XYZ by name prefix (matching condor /
+kodiak), faithfully implementing the v2 INTENT (XYZ banned) against the real
+response shape."""
+
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll
+    back the whole tick (per the scan contract, ANY exception rolls the tick to
+    []). Returns None on failure so the existing degrade paths apply."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[owl.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _is_xyz(coin):
+    """XYZ equities/commodities are identified by the 'XYZ:' name prefix in the
+    live combined market_list_instruments response (no dex field exists)."""
+    return str(coin).upper().startswith("XYZ:")
+
+
+# ═══════════════════════════════════════════════════════════════
+# UNIVERSE FETCH — v6.1: ALL crypto perps with OI > $3M, no top-N truncation
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_all_assets(ctx, inputs):
+    """Every HL crypto perp with OI > minOiUsd (XYZ banned). Ported verbatim
+    from v2 fetch_all_assets, with the XYZ ban switched from the (absent) dex
+    field to the real 'XYZ:' name prefix. Sorted by OI desc (v2 parity)."""
+    min_oi = float(inputs.get("minOiUsd", scoring.MIN_OI_USD))
+    raw = _read(ctx, "market_list_instruments", {})
+    if not raw:
+        return []
+    instruments = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(instruments, dict):
+        instruments = instruments.get("instruments", instruments.get("universe", []))
+    if not isinstance(instruments, list):
+        return []
+
+    assets = []
+    for inst in instruments:
+        if not isinstance(inst, dict):
+            continue
+        coin = inst.get("coin") or inst.get("name", "")
+        coin = str(coin).upper() if coin else ""
+        if not coin:
+            continue
+        if _is_xyz(coin):                          # XYZ ban (name-prefix; see module docstring)
+            continue
+        if inst.get("is_delisted"):                # PORT-ADD: drop delisted (harmless; stale ctx)
+            continue
+        # v1.3: funding/OI/price are nested in `context`, not top-level.
+        ctx_block = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        oi = scoring._f(ctx_block.get("openInterest", inst.get("openInterest", 0)))
+        mark_px = scoring._f(ctx_block.get("markPx", ctx_block.get("midPx",
+                             inst.get("markPx", inst.get("midPx", 0)))))
+        funding = scoring._f(ctx_block.get("funding", inst.get("funding", 0)))
+        oi_usd = oi * mark_px if mark_px > 0 else 0
+        if oi_usd >= min_oi:
+            assets.append({
+                "coin": coin,
+                "oi": oi,
+                "oi_usd": oi_usd,
+                "price": mark_px,
+                "funding": funding,
+            })
+    assets.sort(key=lambda x: x["oi_usd"], reverse=True)
+    return assets
+
+
+# ═══════════════════════════════════════════════════════════════
+# SM POSITIONING MAP + BTC 4h MACRO — one MCP call, shared across all assets
+# ═══════════════════════════════════════════════════════════════
+
+def fetch_sm_positioning_map(ctx, inputs):
+    """Returns (sm_map, btc_p4h) where sm_map = {coin: (long_pct, trader_count)}
+    for crypto markets and btc_p4h is BTC's 4h price change percent (macro gate).
+
+    Ported verbatim from v2 fetch_sm_positioning_map (v7.0/v7.1): ONE call per
+    scan; BTC 4h move extracted from the same response (no extra MCP cost)."""
+    limit = int(inputs.get("smLimit", 200))
+    raw = _read(ctx, "leaderboard_get_markets", {"limit": limit})
+    if not raw:
+        return {}, 0.0
+    sm = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(sm, dict):
+        sm = sm.get("markets", sm.get("leaderboard", sm))
+    if isinstance(sm, dict):
+        sm = sm.get("markets", [])
+    if not isinstance(sm, list):
+        return {}, 0.0
+
+    out = {}
+    btc_p4h = 0.0
+    for m in sm:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if not token or _is_xyz(token):            # v2: skip dex=="xyz"; live shape -> name prefix
+            continue
+        # v7.1: capture BTC's 4h move from the same scan (macro gate input)
+        if token == "BTC":
+            btc_p4h = scoring._f(m.get("token_price_change_pct_4h",
+                                 m.get("price_change_4h", 0)))
+        direction = str(m.get("direction", "")).lower()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        trader_count = int(m.get("trader_count", m.get("traderCount", 0)) or 0)
+        if direction == "long":
+            out[token] = (pct * 100, trader_count)
+        elif direction == "short":
+            out[token] = ((1 - pct) * 100, trader_count)
+    return out, btc_p4h
+
+
+def fetch_candles(ctx, coin):
+    """1h + 4h candle lists for `coin` (exhaustion inputs). READ-GUARDED.
+    Ported from v2 detect_exhaustion's market_get_asset_data call."""
+    md = _read(ctx, "market_get_asset_data", {
+        "asset": coin,
+        "candle_intervals": ["1h", "4h"],
+        "include_funding": True,
+        "include_order_book": False,
+    })
+    if not md:
+        return [], []
+    if isinstance(md, dict) and md.get("success") is False:
+        return [], []
+    inner = md.get("data", md) if isinstance(md, dict) else {}
+    candles = (inner.get("candles", {}) or {}) if isinstance(inner, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _held_assets(ctx):
+    """Currently-held coins (both sub-DEX views) so we never emit on a coin the
+    runtime already holds — belt-and-suspenders alongside the runtime cooldown.
+    READ-GUARDED. A failed read returns [] (runtime per_asset_cooldown is the
+    safety floor). Ported from v2 fetch_held_assets / push_signal held-skip."""
+    if not getattr(ctx, "wallet", None):
+        return []
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    held = []
+    if isinstance(data, dict):
+        for section in ("main", "xyz"):
+            s = data.get(section, {})
+            if not isinstance(s, dict):
+                continue
+            for ap in s.get("assetPositions", []) or []:
+                pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+                if scoring._f(pos.get("szi", 0)) != 0:
+                    c = str(pos.get("coin", "")).upper()
+                    if c:
+                        held.append(c)
+    return held
+
+
+# ═══════════════════════════════════════════════════════════════
+# PERSISTENCE LEDGER (ctx.state) — port of v2 crowding-history.json
+# ═══════════════════════════════════════════════════════════════
+
+def _load_state(ctx):
+    """Return (history, cooldowns) from the last clean tick. history tracks
+    crowding persistence per coin; cooldowns tracks per-asset emit timestamps."""
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}, {}
+    last = ctx.state.last() or {}
+    hist = last.get("history", {})
+    cools = last.get("cooldowns", {})
+    return (dict(hist) if isinstance(hist, dict) else {},
+            dict(cools) if isinstance(cools, dict) else {})
+
+
+def _check_persistence(history, coin, crowd_score, now, min_persist_hours):
+    """Track how long crowding has been elevated. Returns (persisted, hours, peak).
+    Ported verbatim from v2 check_persistence (resets belowThresholdCount on a
+    hit; tracks peakScore; persisted once hours >= MIN_PERSIST_HOURS)."""
+    if coin not in history:
+        history[coin] = {
+            "firstSeen": now,
+            "ts": now,
+            "peakScore": crowd_score,
+            "belowThresholdCount": 0,
+        }
+        return False, 0, crowd_score
+
+    entry = history[coin]
+    hours = (now - scoring._f(entry.get("ts", now))) / 3600
+    if crowd_score > entry.get("peakScore", 0):
+        entry["peakScore"] = crowd_score
+    entry["belowThresholdCount"] = 0
+    return hours >= min_persist_hours, hours, entry.get("peakScore", crowd_score)
+
+
+def _mark_below_threshold(history, coin, tolerance):
+    """Mark a coin below threshold. Returns True if persistence should be cleared
+    (exceeded tolerance). v5.3: 2 consecutive below-threshold scans before clear.
+    Ported verbatim from v2 mark_below_threshold."""
+    if coin not in history:
+        return True  # nothing to track
+    entry = history[coin]
+    below_count = entry.get("belowThresholdCount", 0) + 1
+    entry["belowThresholdCount"] = below_count
+    return below_count > tolerance
+
+
+def _is_asset_cooled_down(cooldowns, coin, now, cooldown_minutes):
+    """v2 is_asset_cooled_down: True if last emit was within cooldown_minutes."""
+    entry = cooldowns.get(coin)
+    if not entry:
+        return False
+    last_emit = scoring._f(entry.get("emittedTimestamp", 0))
+    return ((now - last_emit) / 60) < cooldown_minutes
+
+
+# ═══════════════════════════════════════════════════════════════
+# SIZING
+# ═══════════════════════════════════════════════════════════════
+
+def _coerce_tiers(tiers):
+    """Accept the runtime-yaml tier shape [[min_score, leverage], ...] and convert
+    to the dict form scoring.get_leverage_for_score expects. None -> v2 defaults."""
+    if not tiers:
+        return None
+    out = []
+    for t in tiers:
+        if isinstance(t, dict):
+            out.append(t)
+        elif isinstance(t, (list, tuple)) and len(t) >= 2:
+            out.append({"min_score": t[0], "leverage": t[1]})
+    return out or None
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    min_crowding = float(inputs.get("minCrowdingScore", scoring.MIN_CROWDING_SCORE))
+    min_persist_hours = float(inputs.get("minPersistHours", scoring.MIN_PERSIST_HOURS))
+    tolerance = int(inputs.get("belowThresholdTolerance", scoring.BELOW_THRESHOLD_TOLERANCE))
+    min_ex_score = float(inputs.get("minExhaustionScore", scoring.MIN_EXHAUSTION_SCORE))
+    min_ex_signals = int(inputs.get("minExhaustionSignals", scoring.MIN_EXHAUSTION_SIGNALS))
+    min_combined = float(inputs.get("minCombinedScore", scoring.MIN_COMBINED_SCORE))
+    min_funding_ann = float(inputs.get("minFundingAnnualizedPct", scoring.MIN_FUNDING_ANNUALIZED_PCT))
+    macro_gate = float(inputs.get("macroGateBtc4hPct", scoring.MACRO_GATE_BTC_4H_PCT))
+    cooldown_minutes = float(inputs.get("assetCooldownMinutes", scoring.ASSET_COOLDOWN_MINUTES))
+    margin_pct = float(inputs.get("marginPct", 25))             # PERCENT in (0,100]
+    if margin_pct <= 1.0:                                       # defensive: a pasted fraction -> percent
+        margin_pct *= 100.0
+    tiers = _coerce_tiers(inputs.get("leverageTiers"))
+
+    history, cooldowns = _load_state(ctx)
+
+    def _persist(result=None):
+        if ctx.state is None:
+            return
+        rec = {"history": history, "cooldowns": cooldowns}
+        if result is not None:
+            rec["result"] = result
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[owl.scan] WARNING: state append failed; persistence/cooldown may "
+                  f"reset next tick: {exc!r}", file=sys.stderr)
+
+    # 1. Universe
+    assets = fetch_all_assets(ctx, inputs)
+    if not assets:
+        print("[owl.scan] market_list_instruments empty/failed — no signal", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_universe"})
+        return []
+
+    # 2. SM positioning map + BTC 4h macro (one call)
+    sm_map, btc_p4h = fetch_sm_positioning_map(ctx, inputs)
+
+    # 3. MACRO_TREND_GATE — fades unsafe in trending regimes (v7.1, VERBATIM)
+    if abs(btc_p4h) > macro_gate:
+        print(f"[owl.scan] MACRO_GATE — BTC 4h {btc_p4h:+.2f}% > {macro_gate}% — "
+              f"fades unsafe; standing down (scanned {len(assets)})", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "macro", "btc_p4h": round(btc_p4h, 3),
+                  "totalAssets": len(assets), "smCovered": len(sm_map)})
+        return []
+
+    # 4. Score crowding per asset + update persistence ledger
+    crowding_results = []
+    for asset in assets:
+        coin = asset["coin"]
+        sm_long_pct, sm_count = sm_map.get(coin, (50, 0))
+        crowd_score, crowd_direction, details = scoring.score_crowding(
+            asset, sm_long_pct, sm_count, min_funding_ann)
+
+        if crowd_score >= min_crowding and crowd_direction:
+            persisted, hours, peak = _check_persistence(
+                history, coin, crowd_score, now, min_persist_hours)
+            crowding_results.append({
+                "asset": coin,
+                "crowd_score": crowd_score,
+                "crowd_direction": crowd_direction,
+                "details": details,
+                "asset_data": asset,
+                "sm_long_pct": sm_long_pct,
+                "sm_tilt": abs(sm_long_pct - 50),
+                "persisted": persisted,
+                "hours": hours,
+                "peak_score": peak,
+            })
+        else:
+            if _mark_below_threshold(history, coin, tolerance):
+                history.pop(coin, None)
+
+    # 5. Filter to persisted candidates only (>= min_persist_hours above floor)
+    persisted = [c for c in crowding_results if c["persisted"]]
+    if not persisted:
+        print(f"[owl.scan] WAITING — {len(crowding_results)} above crowding floor, none "
+              f"persisted >={min_persist_hours:.0f}h (scanned {len(assets)})", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_persisted",
+                  "totalAssets": len(assets), "smCovered": len(sm_map),
+                  "crowding_above_floor": len(crowding_results), "btc_p4h": round(btc_p4h, 3)})
+        return []
+
+    # 6. Detect exhaustion only for persisted candidates (saves MCP calls)
+    candidates = []
+    for c in persisted:
+        coin = c["asset"]
+        crowd_dir = c["crowd_direction"]
+        candles_1h, candles_4h = fetch_candles(ctx, coin)
+        ex_score, ex_signals, p4h, rsi = scoring.detect_exhaustion(
+            candles_1h, candles_4h, crowd_dir)
+        if ex_score < min_ex_score or len(ex_signals) < min_ex_signals:
+            continue
+        combined = c["crowd_score"] + ex_score
+        if combined < min_combined:
+            continue
+        # Per-asset emit cooldown (defense-in-depth alongside runtime cooldown)
+        if _is_asset_cooled_down(cooldowns, coin, now, cooldown_minutes):
+            continue
+
+        funding_ann = scoring.funding_annualized_pct(c["asset_data"]["funding"])
+        reasons = list(c["details"]) + ex_signals + [f"persistence_{c['hours']:.1f}h"]
+        candidates.append({
+            "asset": coin,
+            "crowd_direction": crowd_dir,
+            "fade_direction": scoring.fade_direction(crowd_dir),
+            "crowding_score": c["crowd_score"],
+            "exhaustion_score": ex_score,
+            "combined_score": combined,
+            "persistence_hours": c["hours"],
+            "peak_crowding_score": c["peak_score"],
+            "funding_ann": funding_ann,
+            "sm_long_pct": c["sm_long_pct"],
+            "sm_tilt": c["sm_tilt"],
+            "oi_usd": c["asset_data"]["oi_usd"],
+            "price_chg_4h": p4h,
+            "rsi": rsi,
+            "exhaustion_signals": ex_signals,
+            "reasons": reasons,
+        })
+
+    if not candidates:
+        print(f"[owl.scan] WAITING — {len(persisted)} persisted but no exhaustion "
+              f"confluence >= {min_combined:.0f} (scanned {len(assets)})", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_exhaustion",
+                  "totalAssets": len(assets), "smCovered": len(sm_map),
+                  "persisted": len(persisted), "btc_p4h": round(btc_p4h, 3)})
+        return []
+
+    # 7. Pick the single highest-scoring candidate (v2 candidates[:1])
+    candidates.sort(key=lambda c: c["combined_score"], reverse=True)
+    held = {h.upper() for h in _held_assets(ctx)}
+
+    best = None
+    for c in candidates:
+        if c["asset"].upper() in held:                  # v2 push_signal held-asset skip
+            continue
+        best = c
+        break
+
+    if best is None:
+        print(f"[owl.scan] SKIP — top candidates all already held {sorted(held)}",
+              file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "held",
+                  "candidates": len(candidates), "held": sorted(held)})
+        return []
+
+    leverage = scoring.get_leverage_for_score(best["combined_score"], tiers)
+    cooldowns[best["asset"]] = {"emittedTimestamp": now}    # v2 mark_asset_emitted
+
+    result = {"ts": now, "emitted": True, "gate": "pass", "coin": best["asset"],
+              "direction": best["fade_direction"], "crowdDirection": best["crowd_direction"],
+              "score": best["combined_score"], "crowdingScore": best["crowding_score"],
+              "exhaustionScore": best["exhaustion_score"], "leverage": leverage,
+              "marginPct": margin_pct, "persistenceHours": round(best["persistence_hours"], 2),
+              "btc_p4h": round(btc_p4h, 3), "candidates": len(candidates)}
+    print(f"[owl.scan] EMIT {best['asset']} {best['fade_direction']} (fade {best['crowd_direction']}) "
+          f"combined={best['combined_score']} crowd={best['crowding_score']} ex={best['exhaustion_score']} "
+          f"persist={best['persistence_hours']:.1f}h {leverage}x margin={margin_pct:.0f}% | "
+          f"{best['reasons']}", file=sys.stderr)
+    _persist(result)
+
+    return [{
+        "asset": best["asset"],
+        "direction": best["fade_direction"],            # OPPOSITE of the crowd — Owl is contrarian
+        "marginPct": margin_pct,                         # SIZING INTENT — PERCENT (0,100]; runtime sizes USD
+        "leverage": leverage,                            # conviction-scaled 7/8/10 (10x cap); runtime clamps
+        "data": {
+            "score": best["combined_score"],
+            "leverage": leverage,
+            "crowdDirection": best["crowd_direction"],
+            "crowdingScore": best["crowding_score"],
+            "exhaustionScore": best["exhaustion_score"],
+            "persistenceHours": round(best["persistence_hours"], 2),
+            "fundingAnnualizedPct": round(best["funding_ann"], 2),
+            "smTilt": round(best["sm_tilt"], 2),
+            "smLongPct": round(best["sm_long_pct"], 2),
+            "oiUsd": round(best["oi_usd"], 2),
+            "priceChg4hPct": round(best["price_chg_4h"], 3),
+            "rsi4h": round(best["rsi"], 1) if best.get("rsi") is not None else 0,
+            "peakCrowdingScore": best["peak_crowding_score"],
+            "exhaustionSignals": " | ".join(best.get("exhaustion_signals", [])),
+            "reasons": best["reasons"],
+        },
+    }]

--- a/strategies/owl/main/scanners/scoring.py
+++ b/strategies/owl/main/scanners/scoring.py
@@ -1,0 +1,209 @@
+"""OWL — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 OWL producer's contrarian crowding-unwind
+scoring (SKILL.md / producer v8.0.1, thesis frozen at v7.1). The crowding score,
+exhaustion detection, funding annualization, and leverage tiers are reproduced
+VERBATIM so a fidelity harness can diff this against the v2 producer on the same
+market snapshot. Behaviour-preserving v2 quirks are kept and flagged `# v2-quirk`.
+
+Multi-asset universe, single-pass, unit-testable on plain dicts/candle lists. The
+caller (scan.py) owns the clock, the MCP reads, and the cross-tick persistence
+ledger; this module is pure functions over numbers."""
+
+# ── numeric coercion (matches v2 safe_float) ──
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v) if v is not None else d
+    except (TypeError, ValueError):
+        return d
+
+
+# ═══════════════════════════════════════════════════════════════
+# CONSTANTS — preserved verbatim from the v2 v7.1 producer
+# ═══════════════════════════════════════════════════════════════
+
+MIN_OI_USD = 3_000_000               # v2 MIN_OI_USD — $3M liquidity floor (no top-N truncation)
+MIN_CROWDING_SCORE = 6               # v2 MIN_CROWDING_SCORE (v6.2: lowered 8->6)
+MIN_PERSIST_HOURS = 1                # v2 MIN_PERSIST_HOURS (v6.0: lowered 4->1)
+BELOW_THRESHOLD_TOLERANCE = 2        # v2 BELOW_THRESHOLD_TOLERANCE (v5.3 noise-tick guard)
+MIN_EXHAUSTION_SCORE = 5             # v2 MIN_EXHAUSTION_SCORE
+MIN_EXHAUSTION_SIGNALS = 2           # v2 MIN_EXHAUSTION_SIGNALS
+MIN_COMBINED_SCORE = 12              # v2 MIN_COMBINED_SCORE (v6.0: lowered 14->12)
+MIN_FUNDING_ANNUALIZED_PCT = 12      # v2 MIN_FUNDING_ANNUALIZED_PCT (v5.2: was 20)
+MACRO_GATE_BTC_4H_PCT = 3.0          # v2 MACRO_GATE_BTC_4H_PCT (v7.1)
+ASSET_COOLDOWN_MINUTES = 360         # v2 ASSET_COOLDOWN_MINUTES — 6h post-emit per-asset cooldown
+
+# Conviction-scaled leverage (v2 LEVERAGE_TIERS; Polar v2.4 / Bald Eagle v3.0 pattern)
+DEFAULT_LEVERAGE = 7                  # v2 DEFAULT_LEVERAGE
+LEVERAGE_TIERS = [
+    {"min_score": 16, "leverage": 10},
+    {"min_score": 14, "leverage": 8},
+    {"min_score": 12, "leverage": 7},
+]
+
+
+def get_leverage_for_score(score, tiers=None):
+    """Returns the leverage for the score tier. Ported verbatim from v2
+    get_leverage_for_score; the fallback (7) matches v2 DEFAULT_LEVERAGE."""
+    for tier in (tiers or LEVERAGE_TIERS):
+        if score >= tier["min_score"]:
+            return tier["leverage"]
+    return DEFAULT_LEVERAGE
+
+
+def funding_annualized_pct(funding):
+    """v2: abs(hourly funding) * 8760 (= * 24 * 365) -> annualized percent."""
+    return abs(_f(funding)) * 8760
+
+
+# ═══════════════════════════════════════════════════════════════
+# CROWDING SCORING — preserved verbatim from v2 score_crowding (v6.2)
+# ═══════════════════════════════════════════════════════════════
+
+def score_crowding(asset, sm_long_pct, sm_count, min_funding_ann=MIN_FUNDING_ANNUALIZED_PCT):
+    """Score how crowded an asset is. Higher = more one-sided.
+    Returns (score, crowd_direction, details).
+
+    `asset` = {coin, oi_usd, funding, ...}
+    `sm_long_pct` = smart-money long percentage for this coin (50 = neutral)
+    `sm_count` = trader count (carried for parity; not used in the v2 score)
+
+    Scoring tables/thresholds are VERBATIM from the v2 producer."""
+    funding = _f(asset.get("funding", 0))
+    funding_ann = abs(funding) * 8760  # hourly funding x 24 x 365 = annualized %
+
+    score = 0
+    details = []
+    crowd_direction = None
+
+    # Funding extremity (biggest signal)
+    if funding_ann >= 60:
+        score += 4
+        details.append(f"funding_extreme_{funding_ann:.0f}%ann")
+        crowd_direction = "LONG" if funding > 0 else "SHORT"
+    elif funding_ann >= 40:
+        score += 3
+        details.append(f"funding_high_{funding_ann:.0f}%ann")
+        crowd_direction = "LONG" if funding > 0 else "SHORT"
+    elif funding_ann >= min_funding_ann:
+        score += 2
+        details.append(f"funding_elevated_{funding_ann:.0f}%ann")
+        crowd_direction = "LONG" if funding > 0 else "SHORT"
+    else:
+        details.append(f"funding_below_floor_{funding_ann:.0f}%ann")
+        if funding != 0:
+            crowd_direction = "LONG" if funding > 0 else "SHORT"
+
+    # SM concentration (top traders tilted one way)
+    sm_tilt = abs(sm_long_pct - 50)
+    if sm_tilt > 20:
+        score += 3
+        sm_dir = "LONG" if sm_long_pct > 50 else "SHORT"
+        details.append(f"sm_tilted_{sm_dir}_{sm_long_pct:.0f}%")
+        if (funding > 0 and sm_long_pct > 50) or (funding < 0 and sm_long_pct < 50):
+            score += 1
+            details.append("sm_confirms_funding")
+    elif sm_tilt > 12:
+        score += 1
+        details.append(f"sm_leaning_{sm_long_pct:.0f}%")
+
+    # OI concentration (positions building, not churning)
+    oi_usd = _f(asset.get("oi_usd", 0))
+    if oi_usd > 20_000_000:
+        score += 2
+        details.append(f"oi_concentrated_{oi_usd/1e6:.0f}M")
+    elif oi_usd > 10_000_000:
+        score += 1
+        details.append(f"oi_moderate_{oi_usd/1e6:.0f}M")
+
+    return score, crowd_direction, details
+
+
+# ═══════════════════════════════════════════════════════════════
+# EXHAUSTION DETECTION — preserved verbatim from v2 detect_exhaustion (v6.2)
+# ═══════════════════════════════════════════════════════════════
+
+def detect_exhaustion(candles_1h, candles_4h, crowd_direction):
+    """Check whether the crowded trade is showing exhaustion signals.
+
+    Pure: takes the already-fetched 1h/4h candle lists (caller does the MCP read)
+    and the crowd direction. Returns (score, signals_list, price_chg_4h, rsi).
+
+    Candle field access mirrors v2 (volume/v/vlm, close/c). Thresholds/weights are
+    VERBATIM from the v2 producer."""
+    candles_1h = candles_1h or []
+    candles_4h = candles_4h or []
+
+    if len(candles_1h) < 12 or len(candles_4h) < 6:
+        return 0, [], 0, None
+
+    score = 0
+    signals = []
+
+    def _vol(c):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+
+    def _close(c):
+        return _f(c.get("close", c.get("c", 0)))
+
+    # SIGNAL 1: Volume declining while funding stays extreme = exhaustion building
+    if len(candles_1h) >= 8:
+        recent_vol = sum(_vol(c) for c in candles_1h[-3:]) / 3
+        earlier_vol = sum(_vol(c) for c in candles_1h[-8:-3]) / 5
+        if earlier_vol > 0 and recent_vol < earlier_vol * 0.7:
+            score += 3
+            signals.append(f"volume_declining_{recent_vol/earlier_vol:.0%}")
+
+    # SIGNAL 2: Price stalling despite extreme positioning
+    closes_4h = [_close(c) for c in candles_4h[-4:]]
+    price_change_4h = 0
+    if len(closes_4h) >= 4 and closes_4h[-4] > 0:
+        price_change_4h = ((closes_4h[-1] - closes_4h[-4]) / closes_4h[-4]) * 100
+        if crowd_direction == "LONG" and price_change_4h < 0.5:
+            score += 3
+            signals.append(f"price_stalled_crowd_long_{price_change_4h:+.1f}%")
+        elif crowd_direction == "SHORT" and price_change_4h > -0.5:
+            score += 3
+            signals.append(f"price_stalled_crowd_short_{price_change_4h:+.1f}%")
+
+    # SIGNAL 3: Volume spike without price follow-through (capitulation wick)
+    if len(candles_1h) >= 6:
+        latest_vol = _vol(candles_1h[-1])
+        avg_vol = sum(_vol(c) for c in candles_1h[-6:-1]) / 5
+        latest_close = _close(candles_1h[-1])
+        prev_close = _close(candles_1h[-2])
+        price_move = ((latest_close - prev_close) / prev_close * 100) if prev_close > 0 else 0
+        if avg_vol > 0 and latest_vol > avg_vol * 2.0 and abs(price_move) < 1.0:
+            score += 2
+            signals.append(f"vol_spike_{latest_vol/avg_vol:.1f}x_no_follow_through")
+
+    # SIGNAL 4: 4h RSI divergence (price flat/up but RSI declining = momentum dying)
+    closes_4h_full = [_close(c) for c in candles_4h]
+    rsi = None
+    if len(closes_4h_full) >= 15:
+        gains, losses = [], []
+        for i in range(1, len(closes_4h_full)):
+            d = closes_4h_full[i] - closes_4h_full[i - 1]
+            gains.append(max(0, d))
+            losses.append(max(0, -d))
+        period = 14
+        if len(gains) >= period:
+            avg_g = sum(gains[-period:]) / period
+            avg_l = sum(losses[-period:]) / period
+            rsi = 100 - (100 / (1 + avg_g / avg_l)) if avg_l > 0 else 100
+
+            if crowd_direction == "LONG" and rsi < 55:
+                score += 2
+                signals.append(f"rsi_divergence_crowd_long_rsi_{rsi:.0f}")
+            elif crowd_direction == "SHORT" and rsi > 45:
+                score += 2
+                signals.append(f"rsi_divergence_crowd_short_rsi_{rsi:.0f}")
+
+    return score, signals, price_change_4h, rsi
+
+
+def fade_direction(crowd_direction):
+    """Owl is contrarian — the entry direction is the OPPOSITE of the crowd."""
+    return "SHORT" if crowd_direction == "LONG" else "LONG"

--- a/strategies/owl/strategy.yaml
+++ b/strategies/owl/strategy.yaml
@@ -1,0 +1,42 @@
+# Owl — Pure Contrarian Crowding-Unwind Hunter. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2 Owl
+# (SKILL.md v8.0.1 / producer v8.0.1, thesis frozen at v7.1): counter-trade crowded crypto
+# perps once crowding persists >=1h AND exhaustion confluence fires, fade the crowd, MACRO
+# gate, conviction-scaled leverage (7/8/10), DSL-only exits. Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: owl
+version: "1.0.0"
+
+catalog:
+  name: "Owl — Contrarian Crowding-Unwind Hunter"
+  emoji: "🦉"
+  tagline: "Scans every liquid Hyperliquid crypto perp (OI > $3M) for one-sided crowding — extreme funding + lopsided smart money + concentrated OI — then waits for that crowding to persist 1h+ AND for exhaustion to fire (volume fading, price stalling, RSI divergence) before fading the crowd. Conviction-scaled leverage (7/8/10) at 25% margin, with a macro gate that stands down when BTC's 4h move is extreme."
+  belief_plain: "The crowd is wrong at the extremes. When everyone piles onto one side of a coin — paying punishing funding, the best traders all leaning the same way, open interest stacking up — and the price then stops following through, the unwind is violent and predictable. Owl waits for both the crowded state AND the exhaustion trigger, then takes the other side. Most days it does nothing, because most days one or both is missing."
+  thesis: "Crowded trades unwind violently. Owl's edge is timing the unwind: it never fades on crowding alone (which can persist and grind), it waits for crowding to PERSIST 1h+ and for distinct exhaustion signals (declining volume under extreme funding, price stalling against the crowd, capitulation wicks, 4h RSI divergence) to confirm the move is dying. Mean reversion fails in trending macro, so a hard gate blocks all fades when |BTC 4h| > 3%. XYZ banned — the funding/smart-money scoring is calibrated on crypto data shape."
+  group: contrarian
+  archetype: contrarian_fade
+  sub_style: sm_crowding
+  asset_classes: [universe_crypto]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 10
+  max_slots: 2
+  min_budget: 200
+  assets: []
+  tags: [contrarian, fade, crowding, funding-extreme, smart-money, exhaustion, mean-reversion, universe, macro-gate]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: OWL_WALLET
+    funding_share: 1.0

--- a/strategies/piranha/main/runtime.yaml
+++ b/strategies/piranha/main/runtime.yaml
@@ -1,0 +1,142 @@
+# ── PIRANHA · single instance — liquidation-cascade / forced-flow hunter ──────
+# Runtime 3.0 port of the v2 Piranha (SKILL.md v1.0.0, producer v1.0.1). Crypto-
+# majors whitelist (BTC/ETH/SOL/HYPE), forced-flow scoring (OI unwind + violent
+# move + ongoing 5m + thin book + volume spike + SM align, max ~9), flat 15%
+# margin, 1-5x leverage (default 4), DSL exits (wide ratchet + 24h hard_timeout —
+# forced flow is short-horizon). Faithful port of the v2 producer thesis — see
+# scanners/scoring.py (math reproduced verbatim).
+name: piranha-main
+group: piranha
+version: 3.0.0
+description: >
+  PIRANHA — liquidation-cascade / forced-flow hunter on crypto majors
+  (BTC/ETH/SOL/HYPE). Enters when open interest is unwinding fast (positions
+  force-closing, >=3% over 1h) AND price is moving violently (>=2% over 1h) AND
+  the 5m candle is still moving the same way — riding the forced flow: OI down +
+  price up = shorts squeezed -> LONG; OI down + price down = longs liquidated ->
+  SHORT. Thin book on the move side + volume spike + smart-money alignment add
+  conviction (max ~9). Flat 15% margin, 1-5x leverage (default 4). DSL is the
+  ONLY exit — wide ratchet ladder (first lock at +10% ROE) so a squeeze can run,
+  with a 24h hard_timeout outer bound (forced flow resolves fast). Faithful port
+  of the v2 Piranha v1.0.1 thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${PIRANHA_WALLET}"
+  slots: 1                                 # v2 strategy.slots 1
+  margin_pct: 15                           # baseline %; scan emits the flat marginPct per signal
+  default_leverage: 4                      # fallback; scan emits 1-5x per signal (default 4)
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: piranha_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 180                   # v2 producer cadence (3 min — forced-flow windows are short)
+    timeout_seconds: 150                    # v2 tick_timeout=150; up to ~1 read/asset + sm + account
+    default_signal_validity_seconds: 360    # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100            # dedup map + OI cache + per-tick scan-results history
+    inputs:
+      universe: ["BTC", "ETH", "SOL", "HYPE"] # v2 universe (validated live on HL main DEX 2026-06-29)
+      minScore: 5                           # v2 minScore (producer floor)
+      oiDropMinPct: 3.0                      # v2 oiDropMinPct — OI must fall >= this % (1h) to confirm forced flow
+      oiDropStrongPct: 6.0                   # v2 oiDropStrongPct — strong-unwind bonus threshold
+      priceMoveMinPct: 2.0                   # v2 priceMoveMinPct — 1h move magnitude that marks "violent"
+      volSpikePct: 50.0                      # v2 volSpikePct — 5m volume-spike bonus threshold
+      marginPct: 15                          # PERCENT of withdrawable (0,100]; flat (v2 marginPct 0.15 -> 15)
+      leverage: 4                            # clamped to <= 5 in scan.py (MAX_LEVERAGE)
+      recentSignalTtlSeconds: 240            # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      oiChangePct: { type: number, required: false }
+      oiSource: { type: string, required: false }
+      move1hPct: { type: number, required: false }
+      move5mPct: { type: number, required: false }
+      bidDepth: { type: number, required: false }
+      askDepth: { type: number, required: false }
+      volumeTrendPct: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: piranha_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                      # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [piranha_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true      # forced-flow entries must fill NOW — a maker order would rest
+                                             # and miss the move (CREATE_ORDER_RESTING). Taker fallback on.
+        execution_timeout_seconds: 30        # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: piranha_main_signals
+
+# ── EXIT (DSL — ported VERBATIM from v2 runtime.yaml) ─────────────────────────
+# A squeeze can extend far, so let it run; but forced flow is short-horizon, so a
+# 24h hard_timeout is the outer bound. Phase 1 max_loss 18% cuts a cascade that
+# reverses on you (V-shaped). weak_peak_cut / dead_weight_cut off. Phase 2 first
+# lock at +10% ROE (reachable — NOT the unreachable +40% case). order_type
+# FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST happen).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true          # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30            # v2 exit execution_timeout_seconds
+  dsl_preset:
+    hard_timeout:
+      enabled: true                          # v2: ENABLED — forced flow resolves fast; 24h outer bound
+      interval_in_minutes: 1440              # 24h
+    weak_peak_cut:
+      enabled: false                         # v2: DISABLED
+      interval_in_minutes: 120
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                         # v2: DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0                      # v2 phase1 max_loss_pct
+      retrace_threshold: 8                    # v2 phase1 retrace_threshold
+      consecutive_breaches_required: 1        # v2 phase1 consecutive_breaches_required
+    phase2:
+      enabled: true
+      tiers:                                  # v2 phase2 ladder verbatim; FIRST lock at +10% ROE (reachable)
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 25 }
+        - { trigger_pct: 30, lock_hw_pct: 40 }
+        - { trigger_pct: 50, lock_hw_pct: 60 }
+        - { trigger_pct: 75, lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200             # v2 data_retention_hours 72 -> 72h
+  guard_rails:
+    daily_loss_limit_pct: 15                  # v2 daily_loss_limit_pct
+    max_entries_per_day: 4                     # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false  # v2 bypass_max_entries_per_day_on_profit
+    max_consecutive_losses: 3                 # v2 max_consecutive_losses
+    cooldown_seconds: 3600                     # v2 cooldown_minutes 60 -> 3600s
+    drawdown_halt_pct: 22                      # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false      # v2 drawdown_reset_on_day_rollover
+    per_asset_cooldown_seconds: 10800          # v2 per_asset_cooldown_minutes 180 -> 10800s (3h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/piranha/main/scanners/scan.py
+++ b/strategies/piranha/main/scanners/scan.py
@@ -1,0 +1,307 @@
+"""PIRANHA — supervised scanner (Runtime 3.0 port of the v2 Piranha forced-flow hunter).
+
+Multi-asset, whitelist-gated (BTC/ETH/SOL/HYPE). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - for every non-held, non-recently-signaled candidate: reads market data
+    (5m/1h candles + asset_context.openInterest + oi_velocity + L2 order_book),
+    resolves OI velocity (prefers the oi_velocity object; self-computes from the
+    ctx.state OI cache when null), reads smart-money lean, and scores the pure
+    forced-flow thesis via `scoring.build_thesis`,
+  - emits the SINGLE highest-scoring candidate at/above `minScore`
+    (v2 main() emitted only `best`), sized by a flat margin PERCENT.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus a `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit.
+No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs the v2 producer (piranha-producer.py v1.0.1):
+  - OI-velocity self-compute fallback: v2 persisted the last-seen openInterest per
+    asset to state/oi-state.json (read_oi_state/record_oi) and compared on the next
+    tick. This port stores the OI cache in ctx.state instead (the runtime's
+    transactional store; no file I/O from a read-only scan). SEMANTICS preserved:
+    the cache is refreshed for EVERY scanned asset every tick (even when the thesis
+    returns None early on insufficient history), so a freshly-started Piranha needs
+    one tick per asset to warm the cache before the "computed" fallback can fire.
+    FLAGGED: ctx.state is bounded by state_history_max_count and rolls back on a
+    failed tick — same effective behaviour as the v2 file cache (a missed tick just
+    delays the self-compute), but the OI cache no longer survives a full restart
+    that wipes state history. The oi_velocity object (primary source) is unaffected.
+  - v2 sized marginUsd = account_value * marginPct (marginPct=0.15, a FRACTION).
+    This port emits `marginPct` as a PERCENT in (0,100]; the runtime sizes
+    (marginPct/100)*withdrawable. The v2 fraction 0.15 -> 15 (PERCENT). A defensive
+    "<=1.0 means a pasted fraction, x100" guard is applied (dire/koala pattern).
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1 signal/tick.
+  - v2 recent-signals JSON cache -> ctx.state dedup map (same TTL semantics).
+  - DROPPED (read-only scan cannot mutate): none — the v2 producer had no
+    order-lifecycle management (no cancel_order / has_resting_orders / stale-order
+    purge), so nothing in that family was dropped. The producer NEVER closed
+    positions; DSL owns exits, unchanged.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v2 defaults (piranha-producer.py / piranha-config.json)
+_DEFAULT_UNIVERSE = ["BTC", "ETH", "SOL", "HYPE"]
+_DEFAULT_MIN_SCORE = 5
+_MAX_LEVERAGE = 5                # v2 MAX_LEVERAGE
+_DEFAULT_LEVERAGE = 4           # v2 DEFAULT_LEVERAGE
+_DEFAULT_RECENT_TTL = 240       # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    Piranha's universe is crypto majors, so this only ever returns '' in practice."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[piranha.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)), abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[piranha.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _asset_data(ctx, coin):
+    """Raw market_get_asset_data document for `coin` (5m/1h candles + OI + L2 book)
+    or None. READ-GUARDED. Ported from v2 fetch_market_data."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["5m", "1h"],
+            "include_funding": False,
+            "include_order_book": True,
+            "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[piranha.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    return md
+
+
+def _get_sm_direction(ctx, coin):
+    """Port of v2 fetch_sm_direction: net smart-money lean for `coin` from
+    leaderboard_get_markets. Returns (direction, tilt) or (None, 0.0). READ-GUARDED.
+
+    Verbatim thresholds: long_ratio >= 50 -> LONG (tilt=long_ratio), else SHORT
+    (tilt=100-long_ratio); total<=0 -> ('NEUTRAL', 50.0)."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — smart-money is an optional +1 confirm; never crash the tick
+        print(f"[piranha.scan] leaderboard_get_markets read failed (smart-money -> none): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and not raw.get("success", True)):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != coin:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_state(ctx):
+    """Latest persisted state record: {signaled:{}, oi:{}, result:{}} or empties."""
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}, {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    oi = last.get("oi", {})
+    return (dict(sig) if isinstance(sig, dict) else {},
+            dict(oi) if isinstance(oi, dict) else {})
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def _prev_oi(oi_cache, coin):
+    """Last-seen openInterest for `coin` from the ctx.state OI cache, or None."""
+    entry = oi_cache.get(coin.upper())
+    if isinstance(entry, dict):
+        return scoring._f(entry.get("oi", 0)) or None
+    return None
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    universe = [a.upper() for a in inputs.get("universe", _DEFAULT_UNIVERSE)]
+    min_score = int(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    margin_pct = float(inputs.get("marginPct", 15))   # PERCENT in (0,100]
+    # defensive: a pasted FRACTION (e.g. 0.15) means percent — convert x100 (dire/koala guard)
+    if margin_pct <= 1.0:
+        margin_pct *= 100
+    leverage = min(int(inputs.get("leverage", _DEFAULT_LEVERAGE)), _MAX_LEVERAGE)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled, oi_cache = _load_state(ctx)
+    signaled = _prune_signaled(signaled, ttl, now)
+
+    # ── score every eligible candidate; held + recently-signaled filtered BEFORE
+    #    the per-asset MCP fetch, as in v2 main(). The OI cache is refreshed for
+    #    EVERY asset that returns market data (even on a None thesis), mirroring
+    #    v2's record_oi being called on every build_thesis pass. ──
+    candidates = []
+    scanned = 0
+    for coin in universe:
+        if not coin:
+            continue
+        cu = coin.upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        # refresh OI cache for the self-compute fallback (verbatim: record on every pass)
+        cur_oi = scoring.current_oi(md)
+        if cur_oi > 0:
+            oi_cache[cu] = {"oi": cur_oi, "ts": now}
+        sm = _get_sm_direction(ctx, cu)
+        th = scoring.build_thesis(coin, md, _prev_oi(oi_cache, coin), sm, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets, "note": f"WAITING (min score {min_score})"}
+        print(f"[piranha.scan] WAITING — no forced-flow / liquidation-unwind signature "
+              f"(min score {min_score}); scanned={scanned} held={held_assets}", file=sys.stderr)
+    else:
+        # v2 emitted exactly the single best (highest score).
+        candidates.sort(key=lambda c: c["score"], reverse=True)
+        best = candidates[0]
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"],
+                  "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best["reasons"]}
+        print(f"[piranha.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+              f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:6]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # 1..5; runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "oiChangePct": best["oi_change_pct"],
+                "oiSource": best["oi_source"],
+                "move1hPct": best["move_1h_pct"],
+                "move5mPct": best["move_5m_pct"],
+                "bidDepth": best["bid_depth"],
+                "askDepth": best["ask_depth"],
+                "volumeTrendPct": best["volume_trend_pct"],
+                "smDirection": best["sm_direction"] or "NONE",
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + OI cache + this tick's result every tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.last(). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "oi": oi_cache, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[piranha.scan] WARNING: state append failed; next tick may re-emit a "
+                  f"suppressed signal or warm OI cache again: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/piranha/main/scanners/scoring.py
+++ b/strategies/piranha/main/scanners/scoring.py
@@ -1,0 +1,235 @@
+"""PIRANHA — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Piranha producer's microstructure helpers
++ forced-flow thesis builder (SKILL.md v1.0.0, producer v1.0.1). The math/indexing
+is reproduced VERBATIM so a fidelity harness can diff this against the v2 producer
+on the same market snapshot. Behaviour-preserving quirks from v2 are kept.
+
+Thesis: ride FORCED FLOW. When open interest is unwinding fast (positions being
+force-closed / liquidated) AND price is moving violently in one direction, that's
+forced flow — liquidations begetting liquidations.
+  - OI dropping + price spiking UP   = shorts squeezed   -> ride LONG
+  - OI dropping + price dropping HARD = longs liquidated  -> ride SHORT
+
+GATES (all required, applied inside build_thesis -> None if any fails):
+  1. OI velocity known (None -> cache warming -> skip)
+  2. OI unwinding >= oiDropMinPct over 1h (oi_pct <= -oiDropMinPct)
+  3. |1h price move| >= priceMoveMinPct
+  4. 5m candle still moving the SAME way as the 1h move (flow ongoing)
+
+SCORE components (max ~9):
+  +2 OI unwind (gate-confirmed)
+  +1 OI unwind strong (<= -oiDropStrongPct)
+  +2 violent 1h move (gate-confirmed)
+  +1 5m acceleration (|move_5m| >= priceMoveMinPct/2)
+  +1 book thin on the side price is running into
+  +1 volume spike (>= volSpikePct)
+  +1 smart-money aligned with the flow (>= 55%)
+
+minScore is applied by the CALLER (scan.py), not here.
+
+OI velocity self-compute (oi_velocity_1h with a prev-OI value) and the recent-OI
+cache live in scan.py / ctx.state — this module receives the resolved prev-OI and
+stays pure (no file I/O).
+"""
+
+
+def _f(c, primary="close", alt=None, default=0.0):
+    """Tolerant float getter. Mirrors v2 `_f(c, primary, alt, default)`.
+
+    When `c` is a dict, reads c[primary] (falling back to c[alt] when primary is
+    None). When `c` is a bare value, coerces it directly. Verbatim semantics from
+    the v2 producer's `_f`."""
+    if isinstance(c, dict):
+        val = c.get(primary)
+        if val is None and alt:
+            val = c.get(alt)
+    else:
+        val = c
+    try:
+        return float(val if val is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+# ═══════════════════════════════════════════════════════════════
+# Microstructure helpers (ported verbatim from v2 piranha-producer.py)
+# ═══════════════════════════════════════════════════════════════
+
+def price_move_pct(candles, n_bars):
+    """Signed % move over the last n_bars candles. Verbatim from v2."""
+    if len(candles) < n_bars + 1:
+        return 0.0
+    old = _f(candles[-(n_bars + 1)], "close", "c")
+    new = _f(candles[-1], "close", "c")
+    if old <= 0:
+        return 0.0
+    return ((new - old) / old) * 100
+
+
+def oi_velocity_1h(asset_data, prev_oi):
+    """(oi_change_pct_1h, source). Prefers the oi_velocity object; falls back to a
+    self-computed delta from the persisted last-OI value (prev_oi) supplied by the
+    caller. None if neither is available. Verbatim from v2 except the prev-OI is
+    passed in (caller owns the cache) instead of read from a file here.
+
+    Returns (None, "unavailable") when OI velocity cannot be resolved."""
+    data = asset_data.get("data", {}) if isinstance(asset_data, dict) else {}
+    ctx = data.get("asset_context", {}) or {}
+    cur_oi = _f(ctx, "openInterest")
+    oiv = data.get("oi_velocity")
+    if isinstance(oiv, dict):
+        ch = oiv.get("oi_change_pct")
+        if isinstance(ch, dict) and ch.get("1h") is not None:
+            try:
+                return float(ch["1h"]), "oi_velocity"
+            except (TypeError, ValueError):
+                pass
+    if cur_oi > 0 and prev_oi and float(prev_oi) > 0:
+        return ((cur_oi - float(prev_oi)) / float(prev_oi)) * 100, "computed"
+    return None, "unavailable"
+
+
+def current_oi(asset_data):
+    """The current openInterest for this asset, or 0.0. Used by the caller to
+    refresh the OI-state cache every tick (warms the self-compute fallback)."""
+    data = asset_data.get("data", {}) if isinstance(asset_data, dict) else {}
+    ctx = data.get("asset_context", {}) or {}
+    return _f(ctx, "openInterest")
+
+
+def book_thin_side(asset_data):
+    """(bid_depth, ask_depth) summed over the visible L2 book levels. A thin ask
+    side means little resistance above (favors an up-move); thin bid side means
+    little support below (favors a down-move). Verbatim from v2."""
+    data = asset_data.get("data", {}) if isinstance(asset_data, dict) else {}
+    ob = data.get("order_book", {}) or {}
+    levels = ob.get("levels") or []
+    if len(levels) < 2:
+        return 0.0, 0.0
+    bids, asks = levels[0], levels[1]
+    bid_depth = sum(_f(l, "sz") for l in bids if isinstance(l, dict))
+    ask_depth = sum(_f(l, "sz") for l in asks if isinstance(l, dict))
+    return bid_depth, ask_depth
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-half vs earlier-half average volume, % change. Verbatim from v2.
+
+    v2-quirk: requires len(candles) >= lookback (NOT lookback+2 like bison's
+    volume_trend) and slices the full window (vols = candles[-lookback:]).
+    Reproduced exactly."""
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_f(c, "volume", "v") for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — ride the forced flow (ported verbatim from v2)
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(asset, asset_data, prev_oi, sm, inputs):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned when any GATE fails:
+      - insufficient candle history (len(c1h) < 3 or len(c5m) < 4),
+      - OI velocity unknown (cache warming),
+      - OI not unwinding >= oiDropMinPct,
+      - |1h move| < priceMoveMinPct,
+      - 5m no longer moving the 1h direction (flow reversed).
+    minScore is NOT applied here — the caller gates on thesis['score'].
+
+    `asset_data` is the raw market_get_asset_data document (or its inner shape);
+    `prev_oi` is the last-seen openInterest for this asset (or None) supplied by
+    the caller's OI cache; `sm` is the smart-money tuple (direction, tilt) or
+    (None, 0.0). All fetching/caching is done by scan.py so this stays pure."""
+    oi_drop_min = float(inputs.get("oiDropMinPct", 3.0))
+    oi_strong = float(inputs.get("oiDropStrongPct", 6.0))
+    move_min = float(inputs.get("priceMoveMinPct", 2.0))
+    vol_spike = float(inputs.get("volSpikePct", 50.0))
+
+    data = asset_data.get("data", {}) if isinstance(asset_data, dict) else {}
+    candles = data.get("candles", {}) or {}
+    candles_1h = candles.get("1h", []) or []
+    candles_5m = candles.get("5m", []) or []
+    if len(candles_1h) < 3 or len(candles_5m) < 4:
+        return None  # insufficient history (caller still refreshes the OI cache)
+
+    # GATE 1 — OI unwinding fast (positions force-closing)
+    oi_pct, oi_src = oi_velocity_1h(asset_data, prev_oi)
+    if oi_pct is None:
+        return None  # OI unknown (cache warming) — can't confirm forced flow
+    if oi_pct > -oi_drop_min:
+        return None  # OI not falling fast enough — no liquidation/unwind signature
+
+    # GATE 2 — violent price move (the flow direction)
+    move_1h = price_move_pct(candles_1h, 1)
+    if abs(move_1h) < move_min:
+        return None
+    direction = "LONG" if move_1h > 0 else "SHORT"   # ride the forced flow
+
+    # GATE 3 — 5m must still be moving the same way (flow ongoing, not reversed)
+    move_5m = price_move_pct(candles_5m, 1)
+    if (direction == "LONG" and move_5m <= 0) or (direction == "SHORT" and move_5m >= 0):
+        return None
+
+    bid_depth, ask_depth = book_thin_side(asset_data)
+    vol_pct = volume_trend(candles_5m)
+
+    score = 0
+    reasons = []
+
+    # OI unwind magnitude (gate-confirmed) + strong bonus
+    score += 2
+    reasons.append(f"oi_unwind_{oi_pct:+.1f}%_{oi_src}")
+    if oi_pct <= -oi_strong:
+        score += 1
+        reasons.append("oi_unwind_strong")
+
+    # Violent move (gate-confirmed) + acceleration
+    score += 2
+    reasons.append(f"move_1h_{move_1h:+.2f}%")
+    if abs(move_5m) >= move_min / 2:
+        score += 1
+        reasons.append(f"accel_5m_{move_5m:+.2f}%")
+
+    # Thin book on the side price is running into = little resistance left
+    thin_into = (direction == "LONG" and ask_depth > 0 and bid_depth > ask_depth * 1.3) or \
+                (direction == "SHORT" and bid_depth > 0 and ask_depth > bid_depth * 1.3)
+    if thin_into:
+        score += 1
+        reasons.append("book_thin_into_move")
+
+    # Volume spike confirms forced activity
+    if vol_pct >= vol_spike:
+        score += 1
+        reasons.append(f"vol_spike_{vol_pct:+.0f}%")
+
+    # SM aligned with the flow (optional confirm)
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    if sm_dir == direction and sm_tilt >= 55:
+        score += 1
+        reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "oi_change_pct": round(oi_pct, 3),
+        "oi_source": oi_src,
+        "move_1h_pct": round(move_1h, 3),
+        "move_5m_pct": round(move_5m, 3),
+        "bid_depth": round(bid_depth, 2),
+        "ask_depth": round(ask_depth, 2),
+        "volume_trend_pct": round(vol_pct, 2),
+        "sm_direction": sm_dir if sm_dir else "NONE",
+    }

--- a/strategies/piranha/strategy.yaml
+++ b/strategies/piranha/strategy.yaml
@@ -1,0 +1,44 @@
+# Piranha — liquidation-cascade / forced-flow hunter. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of
+# the v2 Piranha (SKILL.md v1.0.0, producer v1.0.1): a crypto-majors whitelist scanner
+# (BTC/ETH/SOL/HYPE) that rides forced flow — OI unwinding fast + a violent price move +
+# an ongoing 5m candle — scores it (max ~9), picks the single strongest candidate, and
+# sizes flat 15% margin at 1-5x. DSL-only exits, wide ratchet + 24h hard_timeout.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: piranha
+version: "1.0.0"
+
+catalog:
+  name: "Piranha — Liquidation-Cascade / Forced-Flow Hunter"
+  emoji: "🐟"
+  tagline: "Rides forced flow on crypto majors (BTC/ETH/SOL/HYPE): when open interest is unwinding fast (positions being force-closed) AND price is moving violently AND the 5-minute candle is still pushing the same way, it takes ONE position in the direction of the flow, sized 1-5x, and lets a wide DSL ratchet ride the squeeze with a 24h outer bound."
+  belief_plain: "A liquidation cascade is the cleanest momentum in crypto — it's forced flow, not opinion. When lots of positions are being force-closed at once, price gets shoved hard in one direction and the move feeds on itself until the leverage is flushed. Piranha reads the order flow underneath price (open-interest velocity + order-book depth) to confirm the move is forced, then rides it: OI down + price up = shorts squeezed, go long; OI down + price down = longs liquidated, go short."
+  thesis: "Most agents react to price; the edge is reading the forced flow beneath it. Open interest dropping fast means positions are closing under duress, and when that coincides with a violent move and a thinning book on the side price is running into, there is little resistance left and the cascade continues. That signature is short-horizon and self-resolving, so the right move is one conviction entry in the flow direction, a wide ratchet that lets a squeeze extend, and a 24h hard timeout because if the cascade hasn't paid in a day it's over."
+  group: momentum
+  archetype: breakout_momentum
+  sub_style: liquidation_cascade
+  asset_classes: [major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL", "HYPE"]
+  tags: [btc, eth, sol, hype, multi-asset, momentum, liquidation-cascade, forced-flow, open-interest, order-flow, microstructure, single-slot]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: PIRANHA_WALLET
+    funding_share: 1.0

--- a/strategies/python/main/runtime.yaml
+++ b/strategies/python/main/runtime.yaml
@@ -1,0 +1,145 @@
+# ── PYTHON · single instance — The Patience Hunter (Runtime 3.0 port of v2 PYTHON v2.0.0) ──
+# Multi-asset universe scanner, multi-day hold. Scans the top 50 HL crypto assets
+# by 24h notional volume (market_list_instruments), scores each non-held name
+# through a multi-gate, LONG-biased thesis (4h/1h trend structure, 1d candle,
+# smart-money lean, funding, volume ratio, RSI, move-exhaustion), and emits the
+# single best >= MIN_SCORE 8. Conviction-tiered margin (25/30/40%) at a 7x
+# leverage cap, up to 2 concurrent positions, DSL-only exits with a 96h hard
+# timeout — the snake waits, then holds for days. Faithful port of the v2 producer
+# thesis (XYZ + stablecoins banned). See scanners/scoring.py (math verbatim).
+name: python-main
+group: python
+version: 3.0.0
+description: >
+  PYTHON — The Patience Hunter, a multi-asset universe scanner built for
+  multi-day holds. Scans the top 50 HL crypto assets by 24h notional volume and
+  enters only when the 4h trend has macro direction, the 1h trend agrees, 15m
+  momentum confirms, the move isn't a runaway counter-trend (MACRO_TREND_GATE),
+  smart money doesn't oppose (HARD BLOCK), and RSI isn't extreme — scoring the
+  rest (4h strength, 1h/1d momentum, LONG-bias bonus, SM alignment, funding,
+  volume, RSI room, move-exhaustion penalty) and firing the single best >=
+  MIN_SCORE 8. Conviction-scaled margin (25/30/40%) at 3-7x leverage, up to 2
+  concurrent positions. DSL is the ONLY exit — a 96h hard timeout and a wide
+  Phase 2 ladder let a real multi-day winner run instead of getting chopped out.
+  Faithful port of the v2 PYTHON v2.0.0 thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${PYTHON_WALLET}"
+  slots: 2                                # v2 MAX_POSITIONS 2
+  margin_pct: 25                          # baseline %; scan emits the conviction-tier marginPct per signal
+  default_leverage: 3                     # v2 DEFAULT_LEVERAGE; scan emits 3/5/7 per score
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: python_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 600                  # v2 producer cadence (10 min)
+    timeout_seconds: 300                   # v2 tick_timeout=300; universe board + SM + 1 read/asset
+    default_signal_validity_seconds: 1200  # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      universeSize: 50                     # top N HL crypto by 24h notional volume (v2 UNIVERSE_SIZE)
+      minOiUsd: 1000000                    # OI >= $1M hard floor (v2 MIN_OI_USD)
+      minDayNtlVlm: 1000000                # 24h notional volume >= $1M floor (v2)
+      minScore: 8                          # v2 MIN_SCORE (casts a wider net than Condor's 12)
+      maxPositions: 2                      # v2 MAX_POSITIONS
+      minTraderCount: 30                   # SM-map trader-depth gate (v2 MIN_TRADER_COUNT)
+      recentSignalTtlSeconds: 240          # race-window dedup (belt-and-suspenders vs runtime cooldown)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      trend1h: { type: string, required: false }
+      mom1h: { type: number, required: false }
+      mom4h: { type: number, required: false }
+      mom1d: { type: number, required: false }
+      funding: { type: number, required: false }
+      rsi: { type: number, required: false }
+      volRatio: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: python_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every hard gate + score floor
+                                           # (v2 LLM gate was an explicit pass-through "honor the signal")
+    scanners: [python_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # 2026-05-21 v2 fix: maker-only entries rest and silently
+                                           # fail to open during the fast moves we most want to catch
+                                           # (CREATE_ORDER_RESTING). Taker fallback guarantees fill + DSL.
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: python_main_signals
+
+# ── EXIT (DSL — ported VERBATIM from v2 PYTHON v2.0.0 runtime.yaml) ───────────
+# Patience profile: the whole point is to NOT exit early. hard_timeout 96h (4
+# days — pr0br000's max hold was 114h). weak_peak_cut DISABLED (v1.2/v2.0:
+# multi-day patience thesis). dead_weight_cut 24h (was 1440min). Phase 1 max_loss
+# 20% / retrace 10. Phase 2 wide-by-design: first lock REACHABLE at +5% (lock
+# 15%) -> 5-tier ladder through +100% (lock 94%) so monster-winner tails run.
+# FEE_OPTIMIZED_LIMIT close with taker fallback (closes MUST happen).
+exit:
+  engine: dsl
+  interval_seconds: 30                     # v2 exit interval_seconds
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # v2 exit: taker fallback — closes MUST happen
+    execution_timeout_seconds: 60          # v2 exit execution_timeout_seconds
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # v2: ENABLED — 96h cap on a stalled hold
+      interval_in_minutes: 5760            # 96h = 4 days (preserved verbatim from v2)
+    weak_peak_cut:
+      enabled: false                       # v2 v1.2/v2.0: DISABLED — multi-day patience thesis
+      interval_in_minutes: 2880
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: true                        # v2: ENABLED — 24h no movement = dead
+      interval_in_minutes: 1440
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0                    # v2: patient on losers too
+      retrace_threshold: 10
+      consecutive_breaches_required: 1     # Senpi runtime is single-breach only
+    phase2:
+      enabled: true
+      tiers:                               # wide-by-design; FIRST lock REACHABLE at +5% (lock 15%)
+        - { trigger_pct: 5,   lock_hw_pct: 15 }
+        - { trigger_pct: 12,  lock_hw_pct: 35 }
+        - { trigger_pct: 25,  lock_hw_pct: 60 }
+        - { trigger_pct: 50,  lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 94 }
+
+# ── RISK guard rails (from v2 runtime.yaml; hours/minutes -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # v2 data_retention_hours 72 -> 72*3600
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 guard_rails.daily_loss_limit_pct
+    max_entries_per_day: 3                  # v2 guard_rails.max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 guard_rails.max_consecutive_losses
+    cooldown_seconds: 7200                  # v2 cooldown_minutes 120 -> 7200s (2h post-loss freeze)
+    drawdown_halt_pct: 25                   # v2 drawdown_halt_pct (HARD STOP circuit breaker)
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 43200       # v2 ASSET_COOLDOWN 720min / per_asset_cooldown_minutes 720 -> 12h
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/python/main/scanners/scan.py
+++ b/strategies/python/main/scanners/scan.py
@@ -1,0 +1,388 @@
+"""PYTHON — supervised scanner (Runtime 3.0 port of the v2 PYTHON producer).
+
+Multi-asset universe, emit-one. A faithful port of the v2 "Patience Hunter"
+multi-day-hold agent (SKILL.md v2.0.0 / python-producer.py v2.0.1):
+
+  1. Build the universe — top 50 HL crypto assets by 24h notional volume
+     (market_list_instruments), with XYZ + stablecoins banned, OI >= $1M and
+     24h notional volume >= $1M floors.
+  2. Pull smart-money positioning per coin (leaderboard_get_markets): net
+     long/short lean, consensus %, trader_count (>= 30 gate), 15m contribution
+     velocity.
+  3. For every non-held, non-recently-signaled universe asset, fetch 15m/1h/4h/1d
+     candles + funding (market_get_asset_data) and score through the pure,
+     multi-gate `scoring.build_thesis` (4h trend != NEUTRAL, 1h == 4h,
+     MACRO_TREND_GATE, 15m confirm, SM HARD BLOCK, RSI extremes; then the
+     verbatim v2 scoring table + LONG-bias bonus).
+  4. Emit ONE signal for the single highest-scoring candidate clearing
+     MIN_SCORE (8) — a marginPct sizing INTENT (PERCENT, conviction-tiered
+     25/30/40) plus a per-score leverage tier (3/5/7). v2 main() emitted only
+     `best`.
+
+Read-only + single-pass. NO daemon, NO push_signal, NO create_position — the
+runtime sizes the dollars, owns cooldowns/risk gates/slots, and trails the DSL
+exit. Held-asset suppression and per-tick signal dedup live in ctx.state
+(belt-and-suspenders alongside the runtime's per-asset cooldown gate).
+
+FIDELITY NOTES vs python-producer.py v2.0.1:
+  - DROPPED v2 order-lifecycle/mutation behavior: there was none beyond
+    push_signal (v2 had no cancel_order / resting-order purge). The producer's
+    push_signal + the LLM pass-through OPEN_POSITION action are replaced by the
+    scan emitting a plain candidate; the runtime executes. The v2 LLM gate was a
+    pure pass-through ("honor the signal unless structurally broken"), so the
+    OPEN_POSITION action is decision_mode: rule here (gates already applied in
+    scan/scoring) — behaviour-equivalent.
+  - DROPPED v2 get_safe_leverage (strategy_get_asset_trading_limits read that
+    clamped desired leverage to the per-asset HL max). The runtime clamps
+    leverage to the venue max at execution, so the extra read is redundant in
+    Runtime 3.0; the score-tier leverage (3/5/7, MAX 7) is emitted directly.
+    FLAGGED — the emitted leverage may briefly exceed a thin coin's venue cap
+    before the runtime clamps it; the cap was always <= the asset max anyway.
+  - DROPPED v2 cfg.is_asset_cooled_down (12h per-asset cooldown via a local JSON
+    state file). The runtime owns per-asset cooldown via
+    risk.guard_rails.per_asset_cooldown_seconds (43200s = 12h, ported below).
+    The ctx.state recent-signal dedup is an additional race-window guard.
+  - v2 stored margin as a FRACTION (0.25/0.30/0.40 * account_value -> marginUsd);
+    this port emits marginPct PERCENT (25/30/40) and the runtime sizes the USD.
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1/tick.
+  - v2 recent-signals were implicit (no JSON cache in the producer); this port
+    adds a ctx.state dedup map (TTL) as a belt-and-suspenders race-window guard,
+    matching the bison/condor ports.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 240            # 4min race-window dedup (matches condor/bison ports)
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll
+    back the whole tick (per the scan contract ANY exception -> []). Returns None
+    on failure so the existing degrade paths apply (skip asset / empty universe /
+    empty SM map -> emit nothing this tick)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[python.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _is_xyz(name):
+    """XYZ (HIP-3) equities/commodities are identified by the 'xyz:' name prefix
+    (lowercase as returned by the HL combined instruments meta). v2 banned them
+    via `name.startswith('xyz:')`; preserved verbatim (case-insensitive here)."""
+    return name.lower().startswith("xyz:")
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip)."""
+    if not getattr(ctx, "wallet", None):
+        return 0.0, []
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "direction": "LONG" if szi > 0 else "SHORT"})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[python.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def get_universe(ctx, inputs):
+    """Top N HL crypto assets by 24h notional volume — ported VERBATIM from v2
+    get_universe. Drops XYZ ('xyz:' prefix), stablecoins, OI < $1M floor, and
+    24h notional volume < $1M floor; sorts by volume desc; returns top N."""
+    universe_size = int(inputs.get("universeSize", scoring.UNIVERSE_SIZE))
+    min_oi = float(inputs.get("minOiUsd", scoring.MIN_OI_USD))
+    min_vlm = float(inputs.get("minDayNtlVlm", scoring.MIN_DAY_NTL_VLM))
+    raw = _read(ctx, "market_list_instruments", {})
+    if not raw:
+        return []
+    data = raw.get("data", raw) if isinstance(raw, dict) else raw
+    instruments = data.get("instruments", data) if isinstance(data, dict) else data
+    if not isinstance(instruments, list):
+        return []
+
+    filtered = []
+    for inst in instruments:
+        if not isinstance(inst, dict):
+            continue
+        # v2 read inst.get("name"); the live top level is "name". (context also
+        # carries "coin"; either resolves to the same casing.)
+        name = str(inst.get("name") or inst.get("coin") or "")
+        if not name or _is_xyz(name):
+            continue
+        if name.upper() in scoring.STABLECOINS_BANNED:
+            continue
+        ctx_block = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        day_ntl_vlm = scoring._f(ctx_block.get("dayNtlVlm", inst.get("dayNtlVlm", 0)))
+        oi = scoring._f(ctx_block.get("openInterest", inst.get("openInterest", 0)))
+        mark_px = scoring._f(ctx_block.get("markPx", inst.get("markPx", 0)))
+        oi_usd = oi * mark_px
+
+        if oi_usd < min_oi:
+            continue
+        if day_ntl_vlm < min_vlm:
+            continue
+
+        filtered.append({
+            "coin": name,
+            "volume": day_ntl_vlm,
+            "oi_usd": oi_usd,
+            "markPx": mark_px,
+            "maxLeverage": int(inst.get("maxLeverage", 10) or 10),
+        })
+    filtered.sort(key=lambda x: -x["volume"])
+    return filtered[:universe_size]
+
+
+def get_sm_map(ctx, inputs):
+    """Per-coin net smart-money lean from leaderboard_get_markets — ported
+    VERBATIM from v2 get_sm_map. Returns {TOKEN: (direction, pct, traders,
+    cc_15m)}; only tokens with traders >= MIN_TRADER_COUNT (30) and non-zero
+    long/short total are included. long_ratio > 58 -> LONG, < 42 -> SHORT, else
+    NEUTRAL. READ-GUARDED."""
+    min_traders = int(inputs.get("minTraderCount", scoring.MIN_TRADER_COUNT))
+    raw = _read(ctx, "leaderboard_get_markets", {})
+    if not raw:
+        return {}
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return {}
+
+    by_coin = {}
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if not token:
+            continue
+        direction = str(m.get("direction", "")).lower()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        traders = int(m.get("trader_count", m.get("traderCount", 0)) or 0)
+        cc_15m = scoring._f(m.get("contribution_pct_change_15m", 0))
+
+        entry = by_coin.setdefault(token, {"long_pct": 0, "short_pct": 0,
+                                           "traders": 0, "cc_15m": 0})
+        if direction == "long":
+            entry["long_pct"] = pct
+            entry["traders"] = max(entry["traders"], traders)
+            entry["cc_15m"] = cc_15m
+        elif direction == "short":
+            entry["short_pct"] = pct
+            entry["traders"] = max(entry["traders"], traders)
+            entry["cc_15m"] = cc_15m
+
+    result = {}
+    for token, d in by_coin.items():
+        total = d["long_pct"] + d["short_pct"]
+        if total == 0 or d["traders"] < min_traders:
+            continue
+        long_ratio = (d["long_pct"] / total) * 100
+        if long_ratio > 58:
+            result[token] = ("LONG", long_ratio, d["traders"], d["cc_15m"])
+        elif long_ratio < 42:
+            result[token] = ("SHORT", 100 - long_ratio, d["traders"], d["cc_15m"])
+        else:
+            result[token] = ("NEUTRAL", 50, d["traders"], d["cc_15m"])
+    return result
+
+
+def _asset_data(ctx, coin):
+    """{candles{15m,1h,4h,1d}, funding} for `coin` or None. READ-GUARDED.
+    Ported from v2 build_thesis's market_get_asset_data call (15m/1h/4h/1d +
+    funding). Universe is crypto-only (XYZ banned), so dex is always main ('')."""
+    md = _read(ctx, "market_get_asset_data", {
+        "asset": coin,
+        "candle_intervals": ["15m", "1h", "4h", "1d"],
+        "include_funding": True,
+        "include_order_book": False,
+    })
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    asset_ctx = d.get("asset_context", d.get("assetContext", d)) if isinstance(d, dict) else {}
+    funding = scoring._f(asset_ctx.get("funding", d.get("funding", 0)))
+    return {"candles": candles, "funding": funding}
+
+
+def scan(inputs, ctx):
+    max_positions = int(inputs.get("maxPositions", 2))     # v2 MAX_POSITIONS 2
+    min_score = float(inputs.get("minScore", scoring.MIN_SCORE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist(result=None):
+        if ctx.state is None:
+            return
+        rec = {"recent": recent}
+        if result is not None:
+            rec["result"] = result
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[python.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    # Account + held positions. v2 required account_value > 0 to act.
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[python.scan] WAITING — no account value", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_account_value"})
+        return []
+
+    held = {p["coin"].upper() for p in positions if p.get("coin")}
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+
+    # v2: at MAX_POSITIONS the producer still scanned but the LLM/dedup never
+    # opened a new slot. Honor it as a clean gate — DSL manages the held exits.
+    if len(held) >= max_positions:
+        print(f"[python.scan] RIDING {sorted(held)} — at maxPositions={max_positions}. "
+              f"DSL manages exits.", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "riding", "held": sorted(held)})
+        return []
+
+    universe = get_universe(ctx, inputs)
+    if not universe:
+        print("[python.scan] market_list_instruments empty/failed — no signal", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_universe"})
+        return []
+
+    sm_map = get_sm_map(ctx, inputs)   # may be {} — SM is a contributor, not a hard requirement
+
+    # Score every eligible universe asset through the verbatim v2 scorer. Held +
+    # recently-signaled coins are filtered BEFORE the per-asset MCP fetch (as in
+    # v2 main()'s open_coins / cooldown checks).
+    candidates = []
+    scanned = 0
+    for asset in universe:
+        coin = asset["coin"]
+        cu = coin.upper()
+        if cu in held:
+            continue
+        if recent.get(cu) is not None and (now - recent[cu]) < ttl:
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        candles = md["candles"]
+        sm_info = sm_map.get(cu)
+        th = scoring.build_thesis(
+            coin,
+            candles.get("15m", []), candles.get("1h", []),
+            candles.get("4h", []), candles.get("1d", []),
+            md["funding"], asset["maxLeverage"], sm_info,
+        )
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    if not candidates:
+        print(f"[python.scan] HUNTING — no patience-hold candidate >= MIN_SCORE={min_score:.0f} "
+              f"(scanned {scanned}/{len(universe)}) held={held_assets}", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_candidate",
+                  "scanned": scanned, "min_score": min_score, "held": held_assets})
+        return []
+
+    # Pick the single highest-scoring candidate (v2 emitted only `best`).
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+    bu = best["coin"].upper()
+
+    # Defense in depth: never emit on a held coin; dedup the race window.
+    if bu in held:
+        print(f"[python.scan] SKIP {best['coin']} — already held", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "held", "best": best["coin"]})
+        return []
+    if recent.get(bu) is not None and (now - recent[bu]) < ttl:
+        print(f"[python.scan] DEDUP_SKIP {best['coin']} — pushed within {ttl:.0f}s (race window)",
+              file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "dedup", "best": best["coin"]})
+        return []
+
+    # Conviction-scaled sizing — per-score leverage tier + margin PERCENT intent.
+    leverage = scoring.get_leverage_for_score(best["score"])
+    margin_pct = scoring.get_margin_pct(best["score"])
+    # Defensive fraction->percent guard (per dire/koala): a value <= 1.0 is a
+    # pasted FRACTION (e.g. 0.25); scale ×100. v2 tiers already emit 25/30/40.
+    if margin_pct <= 1.0:
+        margin_pct = margin_pct * 100
+    recent[bu] = now
+
+    result = {"ts": now, "emitted": True, "gate": "pass", "coin": best["coin"],
+              "direction": best["direction"], "score": best["score"],
+              "leverage": leverage, "marginPct": round(margin_pct, 4),
+              "scanned": scanned, "held": held_assets, "reasons": best["reasons"]}
+    print(f"[python.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+          f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:6]}", file=sys.stderr)
+    _persist(result)
+
+    return [{
+        "asset": best["coin"],
+        "direction": best["direction"],
+        "marginPct": margin_pct,                 # SIZING INTENT — PERCENT (0,100]; runtime sizes USD
+        "leverage": leverage,                    # score-tiered 3/5/7 (MAX 7); runtime clamps to venue max
+        "data": {
+            "score": best["score"],
+            "leverage": leverage,
+            "direction": best["direction"],
+            "reasons": best["reasons"],
+            "trend4h": best["trend_4h"],
+            "trend1h": best["trend_1h"],
+            "mom1h": best["mom_1h"],
+            "mom4h": best["mom_4h"],
+            "mom1d": best["mom_1d"],
+            "funding": best["funding"],
+            "rsi": best["rsi"],
+            "volRatio": best["vol_ratio"],
+            "heldAssets": held_assets,
+        },
+    }]

--- a/strategies/python/main/scanners/scoring.py
+++ b/strategies/python/main/scanners/scoring.py
@@ -1,0 +1,326 @@
+"""PYTHON — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 PYTHON producer's `build_thesis` +
+"Patience Hunter" multi-day-hold scoring (SKILL.md v2.0.0 / python-producer.py
+v2.0.1). The indicators, hard gates, scoring table, leverage tiers, and margin
+tiers are reproduced VERBATIM so a fidelity harness can diff this against the v2
+producer on the same market snapshot. Behaviour-preserving v2 quirks are kept and
+flagged `# v2-quirk`; fix them only as a separate, labelled change AFTER the port
+is validated.
+
+Multi-asset universe scorer, single-pass, unit-testable on plain candle lists.
+`sm_info` (the smart-money tuple for this coin) is fetched by the caller and passed
+in, so this module stays pure (no MCP, no clock).
+
+The thesis is GATED (unlike Bison's all-contributors scorer): build_thesis returns
+None whenever any hard gate fails (insufficient candles, 4h trend NEUTRAL, 1h !=
+4h, MACRO_GATE counter-trend, 15m momentum doesn't confirm, SM opposes = HARD
+BLOCK, RSI extreme). MIN_SCORE is applied by the CALLER (scan.py)."""
+
+
+# ═══════════════════════════════════════════════════════════════
+# CONSTANTS — preserved verbatim from v1.2 / v2.0.1 producer
+# ═══════════════════════════════════════════════════════════════
+
+UNIVERSE_SIZE = 50
+MIN_OI_USD = 1_000_000
+MIN_DAY_NTL_VLM = 1_000_000          # v2: day_ntl_vlm < 1_000_000 -> drop
+MIN_TRADER_COUNT = 30                 # SM map gate (wider than Condor's 50)
+MIN_SCORE = 8
+STABLECOINS_BANNED = {"USDC", "USDT", "USDE", "FDUSD", "DAI"}  # v2 verbatim set
+
+MACRO_GATE_THRESHOLD_PCT = 10.0
+LONG_BIAS_BONUS = 1
+
+# Sizing tiers — leverage by score (verbatim v2 LEVERAGE_TIERS).
+MAX_LEVERAGE = 7
+DEFAULT_LEVERAGE = 3
+LEVERAGE_TIERS = [
+    {"min_score": 12, "leverage": 7},
+    {"min_score": 10, "leverage": 5},
+    {"min_score": 8,  "leverage": 3},
+]
+
+# Margin tiers — PERCENT of withdrawable in (0,100], the Runtime 3.0 wire
+# convention. v2 stored these as FRACTIONS (0.25/0.30/0.40) and emitted
+# marginUsd = account_value * fraction; the runtime now sizes
+# (marginPct/100)*withdrawable, so these are ×100 (25/30/40 PERCENT). The score
+# CUTOFFS (12 / 10) are preserved verbatim.
+MARGIN_PCT_BASE = 25.0
+MARGIN_PCT_STRONG = 30.0
+MARGIN_PCT_APEX = 40.0
+
+
+# ── numeric coercion (matches v2 safe_float) ──
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts only; the list branch is defensive and never fires on dict
+# candles, so it does not change v2 behaviour.
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── indicators (ported verbatim from v2 python-producer.py) ──
+
+def price_momentum(candles, n_bars=1):
+    """% change over the last n_bars. Verbatim from v2 price_momentum."""
+    if len(candles) < n_bars + 1:
+        return 0
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    if old == 0:
+        return 0
+    return ((new - old) / old) * 100
+
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim from v2.
+
+    v2-quirk: the BULLISH/BEARISH gate is `>= total * 0.55` where total =
+    lookback - 1 (Python's threshold is 0.55, distinct from Bison's 0.6 and
+    Kodiak's variant). The strength returned is higher_lows/total (BULLISH) or
+    lower_highs/total (BEARISH). Reproduced exactly."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.55:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.55:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def volume_ratio(candles, lookback=10):
+    """Latest bar volume vs the trailing `lookback`-bar average. Verbatim v2."""
+    if len(candles) < lookback + 1:
+        return 1.0
+    vols = [_vol(c) for c in candles[-(lookback + 1):-1]]
+    avg = sum(vols) / len(vols) if vols else 1
+    latest = _vol(candles[-1])
+    return latest / avg if avg > 0 else 1.0
+
+
+def calc_rsi(closes, period=14):
+    """RSI. Verbatim from v2 calc_rsi (trailing-window, last `period`)."""
+    if len(closes) < period + 1:
+        return 50
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── sizing tiers (ported verbatim from v2 get_leverage_for_score / get_margin_pct) ──
+
+def get_leverage_for_score(score):
+    """Leverage by score tier. Verbatim from v2 get_leverage_for_score."""
+    for tier in LEVERAGE_TIERS:
+        if score >= tier["min_score"]:
+            return tier["leverage"]
+    return DEFAULT_LEVERAGE
+
+
+def get_margin_pct(score):
+    """Conviction-scaled margin PERCENT in (0,100]. Ported from v2 get_margin_pct.
+
+    v2 returned a FRACTION (0.40/0.30/0.25) multiplied by account_value to get
+    marginUsd; this returns the equivalent PERCENT (40/30/25) and the runtime
+    sizes (marginPct/100)*withdrawable. Score CUTOFFS (12 / 10) verbatim."""
+    if score >= 12:
+        return MARGIN_PCT_APEX
+    elif score >= 10:
+        return MARGIN_PCT_STRONG
+    return MARGIN_PCT_BASE
+
+
+# ── the thesis (multi-gate scorer), ported verbatim from v2 build_thesis ──
+
+def build_thesis(coin, candles_15m, candles_1h, candles_4h, candles_1d,
+                 funding, max_lev, sm_info):
+    """Score a single coin for multi-day-hold potential. Returns a thesis dict
+    (with `score`) or None when any HARD GATE fails. Ported VERBATIM from v2
+    build_thesis.
+
+    None is returned when:
+      - insufficient candle history (15m<8 or 1h<6 or 4h<6), OR
+      - 4h trend is NEUTRAL (no macro direction), OR
+      - 1h trend disagrees with 4h, OR
+      - MACRO_GATE: |mom_4h| > 10% AND the move runs counter to direction, OR
+      - 15m momentum doesn't confirm direction (LONG: <0.1; SHORT: >-0.1), OR
+      - SM opposes direction (HARD BLOCK), OR
+      - RSI extreme (LONG: >78; SHORT: <22).
+
+    MIN_SCORE is NOT applied here — the caller gates on thesis['score'].
+
+    `sm_info` is the smart-money tuple (direction, pct, count, cc_15m) for this
+    coin, or None. The caller fetches it (get_sm_map)."""
+    macro_gate = float(MACRO_GATE_THRESHOLD_PCT)
+
+    if len(candles_15m) < 8 or len(candles_1h) < 6 or len(candles_4h) < 6:
+        return None
+    price = _close(candles_15m[-1])
+
+    trend_4h, trend_strength_4h = trend_structure(candles_4h)
+    if trend_4h == "NEUTRAL":
+        return None
+    direction = "LONG" if trend_4h == "BULLISH" else "SHORT"
+
+    trend_1h, _ = trend_structure(candles_1h)
+    if trend_1h != trend_4h:
+        return None
+
+    mom_1h = price_momentum(candles_1h, 2)
+    mom_4h = price_momentum(candles_4h, 1)
+    mom_15m = price_momentum(candles_15m, 1)
+    mom_1d = price_momentum(candles_1d, 1) if len(candles_1d) >= 2 else 0
+
+    # MACRO TREND GATE — no counter-trend against runaway moves > 10%
+    if abs(mom_4h) > macro_gate:
+        if (direction == "LONG" and mom_4h < 0) or (direction == "SHORT" and mom_4h > 0):
+            return None
+
+    # 15m momentum confirmation
+    if direction == "LONG" and mom_15m < 0.1:
+        return None
+    if direction == "SHORT" and mom_15m > -0.1:
+        return None
+
+    score = 0
+    reasons = []
+
+    # 4h trend strength
+    if trend_strength_4h >= 0.8:
+        score += 4
+        reasons.append(f"4h_strong_{trend_4h}")
+    elif trend_strength_4h >= 0.6:
+        score += 3
+        reasons.append(f"4h_{trend_4h}")
+    else:
+        score += 2
+        reasons.append(f"4h_weak_{trend_4h}")
+
+    # 1h momentum
+    if abs(mom_1h) > 1.0:
+        score += 2
+        reasons.append(f"1h_strong_{mom_1h:+.2f}%")
+    elif abs(mom_1h) > 0.5:
+        score += 1
+        reasons.append(f"1h_ok_{mom_1h:+.2f}%")
+
+    # 1d candle trend
+    if len(candles_1d) >= 3:
+        if direction == "LONG" and mom_1d > 1.0:
+            score += 2; reasons.append(f"1d_bullish_{mom_1d:+.1f}%")
+        elif direction == "SHORT" and mom_1d < -1.0:
+            score += 2; reasons.append(f"1d_bearish_{mom_1d:+.1f}%")
+        elif direction == "LONG" and mom_1d > 0:
+            score += 1; reasons.append("1d_up")
+        elif direction == "SHORT" and mom_1d < 0:
+            score += 1; reasons.append("1d_down")
+
+    # LONG bias bonus (pr0br000 insight — top 5 winners were all LONG)
+    if direction == "LONG":
+        score += LONG_BIAS_BONUS
+        reasons.append("LONG_bias")
+
+    # Smart-money alignment / HARD BLOCK
+    if sm_info:
+        sm_dir, sm_pct, sm_count, sm_cc_15m = sm_info
+        if sm_dir == direction:
+            score += 2
+            reasons.append(f"sm_aligned_{sm_pct:.0f}%_{sm_count}t")
+            if sm_pct > 70:
+                score += 1
+                reasons.append("sm_strongly_tilted")
+        elif sm_dir != "NEUTRAL" and sm_dir != direction:
+            return None  # HARD BLOCK
+        if sm_cc_15m > 0.3:
+            score += 1
+            reasons.append(f"15m_fresh +{sm_cc_15m:.2f}")
+
+    # Funding alignment
+    if direction == "LONG" and funding < 0:
+        score += 1; reasons.append(f"funding_pays_long_{funding:+.4f}")
+    elif direction == "SHORT" and funding > 0:
+        score += 1; reasons.append(f"funding_pays_short_{funding:+.4f}")
+    elif (direction == "LONG" and funding > 0.01) or (direction == "SHORT" and funding < -0.01):
+        score -= 1; reasons.append(f"funding_crowded_{funding:+.4f}")
+
+    # Volume ratio
+    vol_1h = volume_ratio(candles_1h)
+    if vol_1h >= 1.3:
+        score += 1; reasons.append(f"vol_{vol_1h:.1f}x")
+    elif vol_1h < 0.6:
+        score -= 1; reasons.append("vol_weak")
+
+    # RSI filter (hard block on extremes; +1 for midrange room)
+    closes_1h = [_close(c) for c in candles_1h]
+    rsi = calc_rsi(closes_1h)
+    if direction == "LONG" and rsi > 78:
+        return None
+    if direction == "SHORT" and rsi < 22:
+        return None
+    if (direction == "LONG" and 50 < rsi < 68) or (direction == "SHORT" and 32 < rsi < 50):
+        score += 1; reasons.append(f"rsi_room_{rsi:.0f}")
+
+    # Move-exhaustion / move-tiring penalty (with-trend overextension)
+    if abs(mom_4h) >= 6.0:
+        if (direction == "LONG" and mom_4h > 0) or (direction == "SHORT" and mom_4h < 0):
+            score -= 2; reasons.append(f"MOVE_EXHAUSTION_{mom_4h:+.1f}%")
+    elif abs(mom_4h) >= 4.0:
+        if (direction == "LONG" and mom_4h > 0) or (direction == "SHORT" and mom_4h < 0):
+            score -= 1; reasons.append(f"MOVE_TIRING_{mom_4h:+.1f}%")
+
+    return {
+        "coin": coin, "direction": direction, "score": score, "reasons": reasons,
+        "price": price, "trend_4h": trend_4h, "trend_1h": trend_1h,
+        "mom_1h": round(mom_1h, 3), "mom_4h": round(mom_4h, 3), "mom_1d": round(mom_1d, 3),
+        "funding": funding, "rsi": round(rsi, 1), "vol_ratio": round(vol_1h, 2),
+        "max_lev": max_lev,
+    }

--- a/strategies/python/strategy.yaml
+++ b/strategies/python/strategy.yaml
@@ -1,0 +1,42 @@
+# Python — The Patience Hunter. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2
+# PYTHON (SKILL.md v2.0.0): a multi-asset universe scanner built for multi-day holds
+# that scans the top 50 HL crypto assets, scores each through a multi-gate LONG-biased
+# thesis, fires the single best >= MIN_SCORE 8, conviction-tiered sizing, DSL-only
+# exits with a 96h hard timeout. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: python
+version: "1.0.0"
+
+catalog:
+  name: "Python — The Patience Hunter"
+  emoji: "🐍"
+  tagline: "Scans the top 50 Hyperliquid crypto assets by volume and waits for one multi-day setup — 4h trend with macro direction, 1h agreeing, 15m confirming, smart money not opposing, RSI not extreme — then takes a single LONG-biased swing at 3-7x, sizes margin to conviction (25/30/40%), and holds for days behind a wide DSL (96h cap)."
+  belief_plain: "Watches every liquid coin on Hyperliquid and does nothing until one setup lines up across the 4-hour, 1-hour and 15-minute timeframes with the best traders on the same side. Then it takes one well-sized, mostly-long swing and holds it for days behind a wide trailing stop, because the money is in the rare multi-day winner — not in trading often."
+  thesis: "Every other agent strikes and rotates within hours; none hold for days, and that's the blind spot. The edge isn't a high win rate — it's NOT MISSING the one big multi-day move: a low win rate with a 3:1 win/loss ratio beats a high win rate with a thin one. So scan broadly, demand a real macro trend confirmed across three timeframes (never fighting a runaway counter-trend or a crowded smart-money side), tilt LONG, size to conviction, and let a wide DSL ride the move for days instead of getting chopped out early."
+  group: momentum
+  archetype: trend_following
+  sub_style: trend_continuation
+  asset_classes: [universe_crypto]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 7
+  max_slots: 2
+  min_budget: 200
+  assets: []
+  tags: [momentum, trend-following, universe, multi-day-hold, patience, smart-money, long-biased, conviction-margin, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: PYTHON_WALLET
+    funding_share: 1.0

--- a/strategies/raccoon/main/runtime.yaml
+++ b/strategies/raccoon/main/runtime.yaml
@@ -1,0 +1,124 @@
+# ── RACCOON · single instance — Weekend XYZ Reconciliation (Runtime 3.0 port of v2 RACCOON v1.0.1) ──
+name: raccoon-main
+group: raccoon
+version: 3.0.0
+description: >
+  RACCOON — weekend XYZ reconciliation trader. ONLY fires during the trade.xyz
+  no-external-price window (Fri 22:00 UTC -> Mon 00:00 UTC) when XYZ runs on its
+  internal 30-min EWMA oracle. Scans the live XYZ universe (non-delisted, 24h vol
+  >= $1M, max_leverage >= 10 to exclude 5x IPOPs which are Lemur's territory),
+  detects a >= 2% 48h directional move with volume confirmation + smart-money
+  agreement (tilt >= 55%), and positions in that direction to capture the Monday-
+  open snap-back when external pricing resumes. Emits ONE best candidate at 15%
+  margin / 3x (5x cap). Tight DSL: Phase 1 12% max_loss, Phase 2 locks fast at
+  +5%, hard_timeout 48h forces a Monday-open exit. Faithful port of the v2 thesis.
+  NOTE: the v2 runtime.yaml was a STALE BTC-trend template; the producer + config
+  + SKILL define the weekend-XYZ thesis above — this port follows those.
+
+strategy:
+  wallet: "${RACCOON_WALLET}"
+  slots: 3                                 # SKILL.md slots 3
+  default_leverage: 3                       # fallback; scan emits 3x (5x cap; auto-clamped to venue max)
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: raccoon_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                   # v2 producer cadence (5 min)
+    timeout_seconds: 180                    # v2 tick_timeout; universe-sized per-asset MCP reads/tick
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 100            # dedup map + per-tick scan-results history
+    inputs:
+      minVolUsd: 1000000                    # universe liquidity floor (24h notional)
+      minMaxLeverage: 10                    # excludes 5x IPOPs (Lemur's territory)
+      minScore: 5                           # v2 DEFAULT_MIN_SCORE / config minScore
+      minMoveAbsPct: 2.0                    # 48h directional-move gate
+      smTiltMinPct: 55                      # SM-agreement floor (gate)
+      smStrongTiltPct: 70                   # SM strongly-tilted scoring bonus
+      marginPct: 15                         # PERCENT of withdrawable (0,100] — runtime sizes (marginPct/100)*withdrawable
+      leverage: 3                           # v2 DEFAULT_LEVERAGE (clamped to 5 in scan)
+      recentSignalTtlSeconds: 240           # v2 RECENT_SIGNAL_TTL_SEC race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      movePct: { type: number, required: false }
+      volRatio: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      weekendWindow: { type: boolean, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: raccoon_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every hard gate (weekend window, move, SM agreement + tilt) + score floor
+    scanners: [raccoon_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false    # ALO patience on entry (v2 entry)
+        execution_timeout_seconds: 30       # v2 entry timeout
+    context:
+      - type: signal
+        scanner: raccoon_main_signals
+
+# EXIT — DSL, ported VERBATIM from the v2 runtime.yaml exit block (consistent with
+# SKILL.md's weekend-tuned DSL table). Tight: Phase 1 12% max_loss (retrace 8),
+# Phase 2 locks FAST at +5% (lock 30%) to bank the reconciliation snap, hard_timeout
+# 48h forces a Monday-open exit so positions don't camp through the next week. Time
+# cuts (weak_peak/dead_weight) DISABLED. FEE_OPTIMIZED_LIMIT close with taker fallback.
+exit:
+  engine: dsl
+  interval_seconds: 60                      # v2: 60s (REDUCE_ONLY spam mitigation)
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true         # exit closes MUST happen — taker fallback is the floor
+    execution_timeout_seconds: 30           # v2 exit timeout
+  dsl_preset:
+    hard_timeout:
+      enabled: true                         # 48h — forces Monday-open exit
+      interval_in_minutes: 2880
+    weak_peak_cut:
+      enabled: false                        # DISABLED (v2)
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                        # DISABLED (v2)
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,   lock_hw_pct: 30 }    # lock fast on the reconciliation snap (REACHABLE)
+        - { trigger_pct: 10,  lock_hw_pct: 50 }
+        - { trigger_pct: 20,  lock_hw_pct: 65 }
+        - { trigger_pct: 35,  lock_hw_pct: 75 }
+        - { trigger_pct: 60,  lock_hw_pct: 85 }
+
+risk:
+  data_retention_seconds: 259200            # v2 data_retention_hours 72 -> 72*3600
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 4                   # v2 onboarding cap
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 3600                   # v2 cooldown_minutes 60
+    drawdown_halt_pct: 20                    # HARD STOP circuit breaker
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 28800        # v2 per_asset_cooldown_minutes 480 (8h)

--- a/strategies/raccoon/main/scanners/scan.py
+++ b/strategies/raccoon/main/scanners/scan.py
@@ -1,0 +1,377 @@
+"""RACCOON — supervised scanner (Runtime 3.0 port of the v2 RACCOON producer).
+
+Weekend XYZ reconciliation trader. ONLY emits during the trade.xyz no-external-
+price window (Fri 22:00 UTC -> Mon 00:00 UTC) when XYZ runs on its internal
+30-min EWMA oracle. Per tick it:
+  - hard-gates on the weekend window (outside it: emit nothing, one stderr line),
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - builds the XYZ universe via market_list_instruments(dex="xyz") filtered to
+    non-delisted names with 24h vol >= minVolUsd and max_leverage >= minMaxLeverage
+    (the >=10 floor excludes 5x IPOPs, which are Lemur's territory),
+  - for each non-held, non-recently-signaled XYZ name: detects a >= minMoveAbsPct
+    48h directional move, confirms smart-money agreement + tilt floor, scores it,
+  - emits the SINGLE highest-scoring candidate at/above minScore (v2 main()
+    emitted only `best`), sized by a flat margin PERCENT + leverage clamp.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates/slots, and trails the DSL
+exit. No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs the v2 producer (raccoon-producer.py v1.0.1):
+  - market_list_instruments universe filter ported VERBATIM (xyz: prefix,
+    non-delisted, dayNtlVlm >= minVolUsd, max_leverage >= minMaxLeverage). The
+    live response shape (success/data/instruments/name/max_leverage/is_delisted/
+    context.dayNtlVlm) matches the v2 extraction exactly — confirmed against
+    market_list_instruments(dex="xyz").
+  - in_weekend_window + detect_directional_move + the 5-component scoring table
+    ported VERBATIM (scoring.py). The wall clock is read once here (datetime.now)
+    and passed to the pure scoring.in_weekend_window so scoring.py stays clock-free.
+  - v2 fetch_sm_direction (per-asset leaderboard_get_markets lookup, long_ratio
+    derivation) ported VERBATIM as _get_sm_direction. v2 re-fetched the FULL
+    leaderboard once PER asset inside build_thesis; this port fetches it ONCE per
+    tick and caches a {token -> long/short pct} map, then resolves each asset from
+    the cache. Identical thesis values, far fewer reads (universe-sized N -> 1).
+    FLAGGED as the only behavioural optimisation.
+  - v2 sizing used marginPct (a FRACTION, 0.15 in raccoon-config.json) *
+    account_value -> marginUsd. This port uses marginPct=15 (a PERCENT) and emits
+    `marginPct`; the runtime sizes (marginPct/100)*withdrawable. Value preserved
+    (0.15 -> 15%). Defensive koala-pattern guard: an input <= 1.0 is treated as a
+    pasted v2 fraction and x100'd.
+  - leverage clamp min(leverage, MAX_LEVERAGE=5) preserved verbatim.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=240) -> ctx.state dedup map
+    (same TTL semantics, same 4x-TTL prune horizon).
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1 signal/tick.
+  - DROPPED v2 order-lifecycle behaviour: NONE. The v2 producer never managed order
+    lifecycle (no cancel_order / has_resting_orders / stale-order purge) — push_signal
+    is the only mutation and is replaced by the return list, so nothing is dropped.
+  - DROPPED: the v2 fixed-time wall-clock gate is now read from the supervisor's tick
+    rather than a daemon loop. Behaviour identical (gate evaluated every tick).
+"""
+
+import sys
+import time
+from datetime import datetime, timezone
+
+import scoring
+
+_DEFAULT_RECENT_TTL = 240        # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+
+
+def _read(ctx, name, args):
+    """READ-GUARD: a transient/permission error on a read must NOT roll back the
+    whole tick. Returns None on failure so the existing degrade paths apply."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[raccoon.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    if not getattr(ctx, "wallet", None):
+        return 0.0, []
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", "")})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[raccoon.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def fetch_weekend_universe(ctx, inputs):
+    """XYZ universe via market_list_instruments(dex="xyz"), filtered VERBATIM from
+    v2 fetch_weekend_universe: xyz: prefix, non-delisted, dayNtlVlm >= minVolUsd,
+    max_leverage >= minMaxLeverage (the >=10 floor excludes 5x IPOPs). READ-GUARDED."""
+    min_vol = float(inputs.get("minVolUsd", scoring.DEFAULT_MIN_VOL_USD))
+    min_max_lev = int(inputs.get("minMaxLeverage", scoring.DEFAULT_MIN_MAX_LEV))
+
+    raw = _read(ctx, "market_list_instruments", {"dex": "xyz"})
+    if not raw:
+        return []
+    if isinstance(raw, dict) and raw.get("success") is False:
+        return []
+    data = raw.get("data", raw) if isinstance(raw, dict) else raw
+    instruments = data.get("instruments", data) if isinstance(data, dict) else data
+    if not isinstance(instruments, list):
+        return []
+
+    universe = []
+    for inst in instruments:
+        if not isinstance(inst, dict):
+            continue
+        name = str(inst.get("name", ""))
+        if not name.startswith("xyz:"):
+            continue
+        if inst.get("is_delisted", False):
+            continue
+        # Exclude IPOPs (max_leverage < floor) which are Lemur's territory.
+        if int(scoring._f(inst.get("max_leverage", 0))) < min_max_lev:
+            continue
+        cblk = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        vol_usd = scoring._f(cblk.get("dayNtlVlm", 0))
+        if vol_usd < min_vol:
+            continue
+        universe.append({"name": name, "vol_usd": vol_usd})
+    return universe
+
+
+def _fetch_sm_map(ctx):
+    """ONE leaderboard_get_markets read -> {TOKEN: (long_pct, short_pct)} cache.
+
+    v2 re-fetched the whole leaderboard once per asset inside build_thesis; this
+    port fetches it ONCE per tick and resolves each asset from the cache (same
+    thesis values). READ-GUARDED — degrades to {} so SM resolves to (None, 0)
+    and every asset's SM-agreement gate fails (emit nothing, never crash)."""
+    raw = _read(ctx, "leaderboard_get_markets", {})
+    if not raw:
+        return {}
+    if isinstance(raw, dict) and raw.get("success") is False:
+        return {}
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return {}
+
+    sm_map = {}
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if not token:
+            continue
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        lp, sp = sm_map.get(token, (0.0, 0.0))
+        if d == "LONG":
+            lp = pct
+        elif d == "SHORT":
+            sp = pct
+        sm_map[token] = (lp, sp)
+    return sm_map
+
+
+def _sm_direction(sm_map, asset):
+    """Net smart-money lean for `asset` from the cached SM map. Ported VERBATIM
+    from v2 fetch_sm_direction long_ratio derivation. Returns (direction, pct)."""
+    entry = sm_map.get(asset.upper())
+    if entry is None:
+        return None, 0.0
+    long_pct, short_pct = entry
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def _asset_candles_1h(ctx, asset):
+    """1h candles for `asset` (XYZ dex) or [] on failure. READ-GUARDED.
+    Ported from v2 fetch_market_data (1h/4h candles, no funding, no order book)."""
+    md = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "include_funding": False,
+        "include_order_book": False,
+        "dex": "xyz",
+    })
+    if not md:
+        return []
+    if isinstance(md, dict) and md.get("success") is False:
+        return []
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return []
+    candles = d.get("candles", {}) or {}
+    c1h = candles.get("1h", [])
+    return c1h if isinstance(c1h, list) else []
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    now_dt = datetime.now(timezone.utc)
+    min_score = float(inputs.get("minScore", scoring.DEFAULT_MIN_SCORE))
+    lev_default = int(inputs.get("leverage", scoring.DEFAULT_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    # marginPct is a PERCENT in (0,100]. Defensive koala-pattern guard: a value
+    # <= 1.0 (operator pasted the v2 FRACTION 0.15) is treated as a fraction and
+    # x100'd so it never silently sizes ~100x small.
+    margin_pct = float(inputs.get("marginPct", scoring.DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        print(f"[raccoon.scan] marginPct={margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    def _persist(result=None):
+        if ctx.state is None:
+            return
+        rec = {"signaled": signaled}
+        if result is not None:
+            rec["result"] = result
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[raccoon.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+
+    # ── HARD GATE: weekend window (Fri 22:00 UTC -> Mon 00:00 UTC) ──
+    if not scoring.in_weekend_window(now_dt):
+        print("[raccoon.scan] WAITING — OUTSIDE_WEEKEND_WINDOW "
+              "(Raccoon only fires Fri 22:00 UTC -> Mon 00:00 UTC)", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "outside_window"})
+        return []
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[raccoon.scan] WAITING — no account value", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_account"})
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    universe = fetch_weekend_universe(ctx, inputs)
+    if not universe:
+        print("[raccoon.scan] WAITING — no XYZ instruments match liquidity/leverage filter",
+              file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_universe", "held": held_assets})
+        return []
+
+    sm_map = _fetch_sm_map(ctx)   # one read/tick; SM-agreement gate fails closed if empty
+
+    candidates = []
+    scanned = 0
+    for inst in universe:
+        coin = inst["name"]
+        cu = coin.upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        c1h = _asset_candles_1h(ctx, coin)
+        if len(c1h) < 24:
+            continue
+        sm_dir, sm_tilt = _sm_direction(sm_map, coin)
+        th = scoring.build_thesis(coin, c1h, sm_dir, sm_tilt, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    if not candidates:
+        print(f"[raccoon.scan] WAITING — in weekend window but no qualifying XYZ move + "
+              f"SM agreement (universe={len(universe)}, scanned={scanned})", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_candidate",
+                  "universe": len(universe), "scanned": scanned, "held": held_assets})
+        return []
+
+    # v2 emitted exactly the single best (highest score).
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    best = candidates[0]
+    bu = best["coin"].upper()
+
+    # Defense in depth: never emit on a held coin, and dedup the race window.
+    if bu in held_set:
+        print(f"[raccoon.scan] SKIP {best['coin']} — already held", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "held", "best": best["coin"]})
+        return []
+    if _was_recently_signaled(signaled, best["coin"], ttl, now):
+        print(f"[raccoon.scan] DEDUP_SKIP {best['coin']} — pushed within {ttl:.0f}s (race window)",
+              file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "dedup", "best": best["coin"]})
+        return []
+
+    # leverage: clamp v2 default into [1, MAX_LEVERAGE=5] (verbatim).
+    leverage = min(lev_default, scoring.MAX_LEVERAGE)
+
+    signaled[bu] = now
+    result = {"ts": now, "emitted": True, "gate": "pass", "coin": best["coin"],
+              "direction": best["direction"], "score": best["score"], "leverage": leverage,
+              "marginPct": round(margin_pct, 4), "universe": len(universe),
+              "candidates": len(candidates), "held": held_assets, "reasons": best["reasons"]}
+    print(f"[raccoon.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+          f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:5]}", file=sys.stderr)
+    _persist(result)
+
+    return [{
+        "asset": best["coin"],
+        "direction": best["direction"],
+        "marginPct": margin_pct,                 # PERCENT in (0,100] — runtime sizes the dollars
+        "leverage": leverage,                    # <= 5; runtime clamps to venue max
+        "data": {
+            "score": best["score"],
+            "leverage": leverage,
+            "direction": best["direction"],
+            "reasons": best["reasons"],
+            "movePct": best["move_pct"],
+            "volRatio": best["vol_ratio"],
+            "smDirection": best["sm_direction"],
+            "smTiltPct": best["sm_tilt_pct"],
+            "weekendWindow": True,
+            "heldAssets": held_assets,
+        },
+    }]

--- a/strategies/raccoon/main/scanners/scoring.py
+++ b/strategies/raccoon/main/scanners/scoring.py
@@ -1,0 +1,160 @@
+"""RACCOON — pure thesis math (no I/O, no MCP, no wall-clock).
+
+A faithful Runtime 3.0 port of the v2 RACCOON producer's directional-move
+detection + weekend-window gate + per-asset scoring (SKILL.md / producer
+v1.0.1, "Weekend XYZ reconciliation trader"). The gate thresholds, scoring
+table, and weekend-window boundaries are reproduced VERBATIM so a fidelity
+harness can diff this against the v2 producer on the same snapshot.
+
+Pure + unit-testable on plain lists/dicts. The caller (scan.py) owns the clock
+and the MCP reads; `in_weekend_window` takes the UTC `datetime` as an argument so
+this module never calls `datetime.now()` itself (keeps it pure)."""
+
+from datetime import timezone
+
+# ═══════════════════════════════════════════════════════════════
+# CONSTANTS — preserved verbatim from the v2 raccoon-producer.py v1.0.1
+# ═══════════════════════════════════════════════════════════════
+
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 3
+DEFAULT_MIN_SCORE = 5
+DEFAULT_SM_TILT_MIN = 55          # smTiltMinPct — SM-agreement floor (gate)
+DEFAULT_SM_STRONG = 70           # smStrongTiltPct — strongly-tilted scoring bonus
+DEFAULT_MIN_MOVE_PCT = 2.0       # minMoveAbsPct — directional-move gate
+DEFAULT_MIN_VOL_USD = 1_000_000  # minVolUsd — universe liquidity floor
+DEFAULT_MIN_MAX_LEV = 10         # minMaxLeverage — excludes IPOPs (max_lev 5, Lemur's territory)
+
+# Margin is a PERCENT of withdrawable in (0,100] — the Runtime 3.0 wire
+# convention — NOT the v2 fraction (0.15). v2 emitted marginUsd =
+# account_value * 0.15; the runtime now sizes (marginPct/100)*withdrawable.
+DEFAULT_MARGIN_PCT = 15.0        # v2 config marginPct 0.15 -> 15 PERCENT
+
+# Weekend window: Fri 22:00 UTC -> Mon 00:00 UTC (the trade.xyz no-external-price
+# window when XYZ uses its internal oracle only). VERBATIM from v2.
+WEEKEND_START_DOW = 4   # Friday (Python weekday(): Mon=0 .. Sun=6)
+WEEKEND_START_HOUR = 22
+WEEKEND_END_DOW = 0     # Monday
+WEEKEND_END_HOUR = 0
+
+
+def _f(v, d=0.0):
+    """Numeric coercion (matches v2 _f)."""
+    try:
+        return float(v) if v is not None else d
+    except (TypeError, ValueError):
+        return d
+
+
+def in_weekend_window(now):
+    """True iff `now` (a tz-aware UTC datetime) falls in Fri 22:00 UTC ->
+    Mon 00:00 UTC. Ported VERBATIM from v2 in_weekend_window. The caller passes
+    `now` so this stays pure (no datetime.now() here)."""
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    dow = now.weekday()   # 0=Mon, 4=Fri, 5=Sat, 6=Sun
+    hour = now.hour
+    if dow == WEEKEND_START_DOW and hour >= WEEKEND_START_HOUR:   # Fri >= 22:00
+        return True
+    if dow == 5 or dow == 6:                                      # Sat / Sun — all day
+        return True
+    if dow == WEEKEND_END_DOW and hour < WEEKEND_END_HOUR:        # Mon < 00:00 (never true; covered by Sun)
+        return True
+    return False
+
+
+def detect_directional_move(candles_1h, min_pct):
+    """Returns (direction, abs_move_pct, vol_x). Looks at the move from ~48h ago
+    (approximating Friday close) to the latest 1h close, with volume confirmation
+    (recent 6h avg vs prior 18h avg). Ported VERBATIM from v2 detect_directional_move.
+
+    Returns (None, 0.0, 1.0) when there is insufficient history or the move is below
+    `min_pct`."""
+    if len(candles_1h) < 24:
+        return None, 0.0, 1.0
+    # Compare latest close vs ~48h ago (approximates Fri close -> now move).
+    earlier = (_f(candles_1h[-48].get("close", candles_1h[-48].get("c")))
+               if len(candles_1h) >= 48
+               else _f(candles_1h[0].get("close", candles_1h[0].get("c"))))
+    latest = _f(candles_1h[-1].get("close", candles_1h[-1].get("c")))
+    if earlier <= 0 or latest <= 0:
+        return None, 0.0, 1.0
+    move_pct = ((latest - earlier) / earlier) * 100
+    abs_move = abs(move_pct)
+    if abs_move < min_pct:
+        return None, 0.0, 1.0
+    # Volume ratio: recent 6h avg vs prior 18h avg.
+    if len(candles_1h) >= 24:
+        recent_vol = sum(_f(c.get("volume", c.get("v"))) for c in candles_1h[-6:]) / 6
+        prior_vol = sum(_f(c.get("volume", c.get("v"))) for c in candles_1h[-24:-6]) / 18
+        vol_x = recent_vol / prior_vol if prior_vol > 0 else 1.0
+    else:
+        vol_x = 1.0
+    direction = "LONG" if move_pct > 0 else "SHORT"
+    return direction, abs_move, vol_x
+
+
+def build_thesis(asset, candles_1h, sm_dir, sm_tilt, inputs=None):
+    """Score one XYZ asset for the weekend-reconciliation setup.
+
+    `candles_1h` = list of 1h candle dicts (oldest -> newest)
+    `sm_dir`     = smart-money direction for this asset ("LONG"/"SHORT"/"NEUTRAL"/None)
+    `sm_tilt`    = smart-money tilt PERCENT for this asset
+    `inputs`     = optional overrides (minMoveAbsPct/smTiltMinPct/smStrongTiltPct)
+
+    Returns a scored thesis dict, or None if any hard gate fails. Gate thresholds
+    and the scoring table are VERBATIM from v2 build_thesis."""
+    inputs = inputs or {}
+    min_pct = float(inputs.get("minMoveAbsPct", DEFAULT_MIN_MOVE_PCT))
+    sm_min = float(inputs.get("smTiltMinPct", DEFAULT_SM_TILT_MIN))
+    sm_strong = float(inputs.get("smStrongTiltPct", DEFAULT_SM_STRONG))
+
+    if len(candles_1h) < 24:
+        return None
+
+    direction, move_pct, vol_x = detect_directional_move(candles_1h, min_pct)
+    if direction is None:
+        return None
+
+    # HARD GATE: SM direction must exist AND agree with the move.
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    # HARD GATE: SM tilt floor.
+    if sm_tilt < sm_min:
+        return None
+
+    score = 0
+    reasons = []
+    # Move magnitude
+    if move_pct >= 4.0:
+        score += 3
+        reasons.append(f"move_strong_{move_pct:+.2f}%")
+    elif move_pct >= 2.5:
+        score += 2
+        reasons.append(f"move_{move_pct:+.2f}%")
+    else:
+        score += 1
+        reasons.append(f"move_weak_{move_pct:+.2f}%")
+    # SM aligned (gate-confirmed)
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+    # SM strongly tilted
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+    # Volume confirmation
+    if vol_x >= 1.5:
+        score += 1
+        reasons.append(f"vol_{vol_x:.1f}x")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        # v2 signed move_pct in the data block (negative for SHORT)
+        "move_pct": round(move_pct, 3) if direction == "LONG" else -round(move_pct, 3),
+        "vol_ratio": round(vol_x, 2),
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": sm_tilt,
+    }

--- a/strategies/raccoon/strategy.yaml
+++ b/strategies/raccoon/strategy.yaml
@@ -1,0 +1,42 @@
+# Raccoon — Weekend XYZ Reconciliation. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2
+# Raccoon (SKILL.md / producer v1.0.1): a weekend-only XYZ specialist that scans the
+# live XYZ universe during the trade.xyz no-external-price window and positions for
+# the Monday-open price snap-back. DSL-only exits. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: raccoon
+version: "1.0.0"
+
+catalog:
+  name: "Raccoon — Weekend XYZ Reconciliation"
+  emoji: "🦝"
+  tagline: "Trades only the weekend, only on tokenized stocks & commodities (XYZ): while the underlying markets are closed and XYZ runs on an internal oracle, Raccoon positions in the direction sentiment has been pushing the price — and captures the snap-back when real external pricing resumes Monday open. Sizes 15% / 3x and rides a tight DSL with a 48h Monday-exit cap."
+  belief_plain: "From Friday evening to Sunday evening the real stock and commodity markets are closed, so tokenized versions on XYZ drift on an internal estimate instead of a live price. When trading resumes Monday, that estimate snaps to the true market price. Raccoon bets in the direction the weekend drift (plus the best traders) is leaning, and exits into that Monday snap — and only ever runs on the weekend."
+  thesis: "Fri 17:00 ET -> Sun 18:00 ET, trade.xyz has no external price feed for equities/commodities and runs a 30-min EWMA internal oracle that drifts on impact-price activity. Accumulated weekend sentiment (>= 2% move + volume + smart-money agreement) shows up as directional oracle drift; when external pricing resumes Sunday evening the implied price reconciles to the real value. Positioning into that gap and exiting at the Monday-open snap is the edge — and confining all activity to the weekend window avoids weekday false signals and Lemur's 24/7 IPOP territory."
+  group: xyz
+  archetype: single_market
+  sub_style: weekend_gap
+  asset_classes: [xyz_equities, commodities, indices]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: starter
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 3
+  min_budget: 200
+  assets: []
+  tags: [xyz, equities, commodities, weekend, reconciliation, oracle-gap, smart-money, snap-back, hard-timeout]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: RACCOON_WALLET
+    funding_share: 1.0

--- a/strategies/roach/main/runtime.yaml
+++ b/strategies/roach/main/runtime.yaml
@@ -1,0 +1,149 @@
+# ── ROACH · single instance — Striker-only smart-money rank-jump sniper ──────
+# Runtime 3.0 port of the v2 Roach (SKILL.md v3.0.0 / runtime.yaml v1.3.0). A
+# UNIVERSE scanner over the top-50 smart-money leaderboard markets: detects violent
+# FIRST_JUMP / IMMEDIATE_MOVER rank-jump explosions, gated by 4h-trend alignment,
+# 1h price confirmation, cc_15m >= 0.5 freshness, score >= 10 (4+ reasons), and
+# 1.5x volume confirmation. XYZ banned at scan level. Stalker mode permanently
+# disabled. Long stretches of silence are EXPECTED and correct — the patience is
+# the edge. Faithful port of the v2 producer thesis — see scanners/scoring.py
+# (detection math reproduced verbatim, v2-quirks flagged).
+name: roach-main
+group: roach
+version: 3.0.0
+description: >
+  ROACH — Striker-only smart-money rank-jump sniper. Scans the top-50 smart-money
+  leaderboard markets (leaderboard_get_markets) every tick, detects violent
+  FIRST_JUMP from #25+ (rank jump >= 15 OR contribVelocity >= 15) and IMMEDIATE_MOVER
+  explosions, then gates on a hard 4h-trend block, cc_15m >= 0.5 freshness, 1h price
+  alignment >= 0.1%, composite score >= 10 with 4+ reasons, and 1.5x volume
+  confirmation. XYZ equities banned at scan level. Stalker mode permanently disabled.
+  Fixed sizing: 25% margin, 7x leverage. DSL exits with maker-first FEE_OPTIMIZED_LIMIT
+  (fee recovery): Phase 1 max_loss 18% / 3-retrace, Phase 2 ratchet (5/40, 10/55,
+  15/75, 20/85), hard_timeout 120min, weak_peak 45min, dead_weight 25min. Faithful
+  port of the v2 Roach v3.0.0 thesis (all detection thresholds verbatim).
+
+strategy:
+  wallet: "${ROACH_WALLET}"
+  slots: 2                                # v2 strategy.slots = 2 (v2 reopened from v1.3 lockdown of 1)
+  margin_pct: 25                          # baseline %; scan emits marginPct per signal (v2 marginUsd $250 == 25% of design budget)
+  default_leverage: 7                     # v2 default_leverage 7 (v1.1 ceiling; fallback, scan emits 7 per signal)
+  trading_risk: moderate                  # v2 strategy.trading_risk = moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: roach_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 90                   # v2 producer cadence (90s tick)
+    timeout_seconds: 180                   # v2 tick_timeout=180 (markets + up to ~N per-asset volume reads)
+    default_signal_validity_seconds: 270   # 3x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # scan-history (60 scans) + per-asset cooldown map + per-tick result
+    inputs:
+      topN: 50                             # v2 TOP_N (markets scored per scan)
+      leaderboardLimit: 100                # v2 fetch_markets limit=100
+      maxHistoryScans: 60                  # v2 MAX_HISTORY_SCANS (rank-jump history depth)
+      assetCooldownSeconds: 7200           # v2 ASSET_COOLDOWN_MINUTES=120 -> 7200s (producer-side emit suppression)
+      leverage: 7                          # v2 DEFAULT_LEVERAGE (ROACH_LEVERAGE)
+      marginPct: 25                        # PERCENT of withdrawable (0,100]; v2 marginUsd $250 == 25% of design budget
+      minVolRatio: 1.5                     # v2 MIN_VOL_RATIO (v1.1 loosened from 2.0)
+    signal_data_schema:
+      mode: { type: string }                                       # always "STRIKER" (Stalker disabled)
+      score: { type: number }                                      # composite score (>=10 in v1.1+)
+      rankJump: { type: number }                                   # current vs previous scan rank delta
+      currentRank: { type: number }                               # rank at signal time
+      prevRank: { type: number, required: false }
+      contribVelocity: { type: number, required: false }
+      volRatio: { type: number, required: false }
+      priceChg4h: { type: number, required: false }
+      priceChg1h: { type: number, required: false }
+      cc15m: { type: number, required: false }
+      traders: { type: number, required: false }
+      contribution: { type: number, required: false }
+      isFirstJump: { type: boolean, required: false }
+      isContribExplosion: { type: boolean, required: false }
+      reasons: { type: string, required: false }                  # joined " | " (array won't pass strict schema)
+      leverage: { type: number }                                  # producer-asserted; runtime enforces
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: roach_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [roach_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # Roach is breakout-thesis: an invalidated breakout that can't maker-fill
+                                           # is more dangerous than a saved fee (v2 entry rationale, verbatim).
+        execution_timeout_seconds: 60      # v2 entry execution_timeout_seconds (15s/30s fall to taker; 60s lands maker)
+    context:
+      - type: signal
+        scanner: roach_main_signals
+
+# ── EXIT (DSL — ported VERBATIM from v2 runtime.yaml v1.3.0 / SKILL.md v3.0.0) ──
+# v1 used MARKET orders for SL/TP (every close took the HL taker fee). v2 switches to
+# FEE_OPTIMIZED_LIMIT with maker-first + 60s + taker fallback — expected recovery
+# ~50-70% of HL exit fees. Taker fallback preserved: an invalidated striker breakout
+# that can't maker-fill is more dangerous than a saved fee.
+# DSL preset numbers preserved from v1.2 + v2.1 ratchet patch:
+#   hard_timeout 120min  (v1.1: 25 -> 120, strikers need runway)
+#   weak_peak_cut 45min @ min 3.0 (v1.1 widening)
+#   dead_weight_cut 25min (v1.1: 8 -> 25)
+#   phase1 max_loss 18% / retrace 3 / 1 breach (preserved)
+#   phase2 tiers v2.1 ratchet (T0 5/40, T1 10/55, 15/75, 20/85) — first lock REACHABLE
+#     at +5% ROE (NOT +40% — well within reach of realistic Striker winners).
+exit:
+  engine: dsl
+  interval_seconds: 30                     # v2 exit.interval_seconds
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # Roach exits MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 60          # v2 exit execution_timeout_seconds (gives ALO a real chance)
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 120             # v1.1: 25 -> 120 (strikers need runway)
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 45              # v1.1: 12 -> 45
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 25              # v1.1: 8 -> 25
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 3
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # v2.1 fleet-wide DSL ratchet patch (verbatim)
+        - { trigger_pct: 5,  lock_hw_pct: 40 }   # v2.1: trigger 7 -> 5
+        - { trigger_pct: 10, lock_hw_pct: 55 }   # v2.1: trigger 12 -> 10
+        - { trigger_pct: 15, lock_hw_pct: 75 }
+        - { trigger_pct: 20, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml v1.3.0; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # v2 data_retention_hours 72 -> 259200s
+  guard_rails:
+    daily_loss_limit_pct: 10               # v2 daily_loss_limit_pct
+    max_entries_per_day: 6                  # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false  # v2 bypass_max_entries_per_day_on_profit
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 1800                 # v2 cooldown_minutes 30 -> 1800s (post-loss freeze)
+    drawdown_halt_pct: 25                  # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: true   # v2 drawdown_reset_on_day_rollover
+    per_asset_cooldown_seconds: 7200       # v2 per_asset_cooldown_minutes 120 -> 7200s (matches producer-side filter)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false             # v2 dsl_notify_sl_updates
+  action_lifecycle: true

--- a/strategies/roach/main/scanners/scan.py
+++ b/strategies/roach/main/scanners/scan.py
@@ -1,0 +1,267 @@
+"""ROACH — supervised scanner (Runtime 3.0 port of the v2 Roach Striker producer).
+
+UNIVERSE scanner, Striker-ONLY (Stalker permanently disabled since v1.0). Per tick it:
+  - fetches the top-50 smart-money leaderboard markets (XYZ banned at parse level),
+  - builds the current scan snapshot and reads the prior-scan history from ctx.state,
+  - runs the pure `scoring.detect_striker_signals` (FIRST_JUMP / IMMEDIATE_MOVER +
+    rank-jump / contribution-velocity, 4h-trend hard block, score >= 10 w/ 4+ reasons,
+    cc_15m >= 0.5 freshness, 1h price alignment),
+  - applies the VOLUME-confirmation gate last (per-asset market_get_asset_data read,
+    vol >= 1.5x of trailing 6h avg) — the exact position it held in v2,
+  - drops candidates still in the producer-side 120min per-asset cooldown (ctx.state),
+  - sorts highest-score-first and emits EVERY surviving candidate (v2 main() pushed
+    all of them; the runtime's `slots`/per-asset cooldown/risk gates own the ceiling),
+  - sized at a fixed margin PERCENT intent + fixed leverage; the runtime sizes dollars,
+    owns cooldowns/risk gates, and trails the DSL exit.
+
+Read-only + single-pass — no daemon, no while-loop, no sleep, no push_signal, no
+create_position. The v2 producer's wallet-isolated JSON state files (scan-history,
+asset-cooldowns, last-emitted) collapse into ctx.state records here (the runtime owns
+per-wallet isolation + transactional rollback).
+
+FIDELITY NOTES vs roach-producer.py v3.0.0:
+  - SIZING: v2 emitted `marginUsd: 250` (a flat DOLLAR amount, ROACH_MARGIN_USD) plus
+    `leverage: 7` inside data{}. The v2 runtime.yaml's strategy.margin_pct was 25 and
+    config.json describes "$1k budget x 2 slots x 25% margin" — so $250 IS 25% of the
+    intended budget. Per the Runtime 3.0 sizing contract this port emits `marginPct: 25`
+    (PERCENT in (0,100]) + `leverage: 7` at the TOP level; the runtime sizes
+    (marginPct/100)*withdrawable, which scales with any budget instead of pinning a
+    literal $250. The dollar amount at the design budget is identical. The defensive
+    "<=1.0 means a pasted fraction -> x100" guard is applied to the input.
+  - VOLUME GATE is an MCP read (market_get_asset_data) and therefore lives in scan.py,
+    not the pure scoring.py. It is applied in the IDENTICAL pipeline position as v2's
+    `check_asset_volume` call inside detect_striker_signals (after the 1h-confirm gate,
+    before the candidate is finalized). The `VOL_CONFIRMED {ratio}x` reason and the
+    volRatio data field are produced here, verbatim.
+  - EMIT-ALL: v2 main() sorted candidates by score desc and pushed ALL of them (each
+    gated by the producer-side cooldown). This port preserves that (no top-1 cap) and
+    lets the runtime slots:2 / per-asset cooldown / max_entries_per_day own the ceiling.
+  - DROPPED v2 order-lifecycle: v2 had no cancel_order / resting-order purge in the
+    producer (signal-only already), so nothing to drop on that axis. v2's
+    push_signal()/SenpiClient HTTP POST is replaced by returning signal dicts.
+  - STATE: v2 scan-history.json (MAX_HISTORY_SCANS=60) + asset-cooldowns.json collapse
+    into one ctx.state record per tick: {scans:[...], cooldowns:{TOKEN: ts}, result:{}}.
+  - `is_erratic_history` is preserved verbatim in scoring.py but, as in v2, is never
+    called by the detector — dead in both. FLAGGED in the report.
+"""
+
+import sys
+import time
+from datetime import datetime, timezone
+
+import scoring
+
+# v2 producer constants (hardcoded fleet-tuned; only sizing + cadence-adjacent
+# knobs are exposed via inputs).
+_DEFAULT_TOP_N = 50                 # v2 TOP_N
+_DEFAULT_MAX_HISTORY_SCANS = 60     # v2 MAX_HISTORY_SCANS
+_DEFAULT_ASSET_COOLDOWN_SEC = 7200  # v2 ASSET_COOLDOWN_MINUTES=120 -> 7200s
+_DEFAULT_LEVERAGE = 7               # v2 DEFAULT_LEVERAGE (ROACH_LEVERAGE)
+_DEFAULT_MARGIN_PCT = 25.0          # v2 marginUsd $250 == 25% of design budget (see header)
+_DEFAULT_MIN_VOL_RATIO = scoring.MIN_VOL_RATIO  # 1.5x
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll back
+    the whole tick. Returns None on failure so the existing degrade paths apply
+    (markets empty -> persist history-only, emit nothing; volume read empty -> the
+    candidate fails the volume gate and is dropped, exactly as v2)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[roach.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+# ── MARKET FETCH (port of v2 fetch_markets) ──
+
+def _fetch_markets(ctx, limit):
+    """v2 fetch_markets: leaderboard_get_markets(limit=100). Returns raw market
+    list or None (None -> v2 returned status:error 'failed to fetch markets')."""
+    raw = _read(ctx, "leaderboard_get_markets", {"limit": limit})
+    if not raw:
+        return None
+    data = raw.get("data", raw) if isinstance(raw, dict) else raw
+    markets = data.get("markets", data) if isinstance(data, dict) else data
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None
+    return markets
+
+
+# ── VOLUME CONFIRMATION (port of v2 check_asset_volume) ──
+
+def _check_asset_volume(ctx, token, dex, min_vol_ratio):
+    """Check if raw asset volume is alive. Returns (ratio, is_strong).
+    Verbatim parse from v2 check_asset_volume (1h candles, latest vs trailing-5 avg).
+    READ-GUARDED — a failed read returns (0, False) -> candidate dropped, as v2."""
+    asset_name = f"{dex}:{token}" if dex else token
+    data = _read(ctx, "market_get_asset_data", {
+        "asset": asset_name,
+        "candle_intervals": ["1h"],
+        "include_funding": False,
+        "include_order_book": False,
+        "dex": dex or "",
+    })
+    if not data:
+        return 0, False
+
+    candle_data = data.get("data", data) if isinstance(data, dict) else data
+    if isinstance(candle_data, dict):
+        candles = candle_data.get("candles", {}).get("1h", [])
+    else:
+        return 0, False
+
+    if len(candles) < 6:
+        return 0, False
+
+    vols = [scoring._f(c.get("volume", c.get("v", c.get("vlm", 0)))) for c in candles[-6:]]
+    avg_vol = sum(vols[:-1]) / len(vols[:-1]) if len(vols) > 1 else 1
+    latest_vol = vols[-1] if vols else 0
+    ratio = latest_vol / avg_vol if avg_vol > 0 else 0
+    return ratio, ratio >= min_vol_ratio
+
+
+# ── ctx.state: scan-history + per-asset cooldowns (port of v2 JSON state files) ──
+
+def _load_state(ctx):
+    """Returns (history_dict, cooldowns_dict) from the latest ctx.state record."""
+    if ctx.state is None or len(ctx.state) == 0:
+        return {"scans": []}, {}
+    last = ctx.state.last() or {}
+    scans = last.get("scans") or []
+    cooldowns = last.get("cooldowns") or {}
+    history = {"scans": list(scans) if isinstance(scans, list) else []}
+    return history, dict(cooldowns) if isinstance(cooldowns, dict) else {}
+
+
+def _is_asset_cooled_down(cooldowns, token, now, cooldown_sec):
+    """Producer-side cooldown — emit-suppression. Port of v2 is_asset_cooled_down
+    (seconds instead of minutes). Runtime ALSO enforces per_asset_cooldown_seconds
+    independently as a second line of defense."""
+    entry = cooldowns.get(token)
+    if not entry:
+        return False
+    last_emit_ts = entry.get("emittedTimestamp", 0) if isinstance(entry, dict) else 0
+    return (now - last_emit_ts) < cooldown_sec
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    now_dt = datetime.now(timezone.utc)
+    now_iso = now_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    now_hour = now_dt.hour
+
+    top_n = int(inputs.get("topN", _DEFAULT_TOP_N))
+    leaderboard_limit = int(inputs.get("leaderboardLimit", 100))
+    max_history = int(inputs.get("maxHistoryScans", _DEFAULT_MAX_HISTORY_SCANS))
+    cooldown_sec = float(inputs.get("assetCooldownSeconds", _DEFAULT_ASSET_COOLDOWN_SEC))
+    leverage = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    min_vol_ratio = float(inputs.get("minVolRatio", _DEFAULT_MIN_VOL_RATIO))
+
+    # sizing intent: PERCENT in (0,100]. Defensive fraction->percent guard (dire/koala
+    # pattern): a value <= 1.0 is almost certainly a pasted fraction (0.25) -> x100.
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    history, cooldowns = _load_state(ctx)
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({
+                "scans": history.get("scans", [])[-max_history:],
+                "cooldowns": cooldowns,
+                "result": result,
+            })
+        except Exception as exc:  # noqa: BLE001
+            print(f"[roach.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+
+    # ── fetch + parse current scan ──
+    raw = _fetch_markets(ctx, leaderboard_limit)
+    if raw is None:
+        # v2: status:error 'failed to fetch markets'. Do NOT append a snapshot or
+        # advance history on a failed fetch (rank-jump detection needs clean history).
+        print("[roach.scan] failed to fetch leaderboard_get_markets; skip tick",
+              file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_markets"})
+        return []
+
+    current_scan = scoring.parse_scan(raw, now_iso, top_n)
+
+    # ── detect striker candidates (pure; up to but not including volume gate) ──
+    candidates = scoring.detect_striker_signals(current_scan, history, now_hour)
+
+    # ── persist scan history ALWAYS (v2 appends the snapshot even with 0 signals;
+    #    rank-jump detection requires history continuity) ──
+    history["scans"].append(current_scan)
+
+    # ── VOLUME confirmation gate (MCP read; same pipeline position as v2) ──
+    confirmed = []
+    for s in candidates:
+        vol_ratio, vol_strong = _check_asset_volume(
+            ctx, s["token"], s.get("dex") or "", min_vol_ratio)
+        if not vol_strong:
+            continue
+        s["reasons"].append(f"VOL_CONFIRMED {vol_ratio:.1f}x")
+        s["volRatio"] = round(vol_ratio, 2)
+        confirmed.append(s)
+
+    # ── producer-side per-asset cooldown (defense-in-depth; runtime gate is primary) ──
+    confirmed = [s for s in confirmed
+                 if not _is_asset_cooled_down(cooldowns, s["token"], now, cooldown_sec)]
+
+    # ── sort highest score first (v2 main()) ──
+    confirmed.sort(key=lambda s: s["score"], reverse=True)
+
+    if not confirmed:
+        print(f"[roach.scan] WAITING — no Striker explosion; markets={len(current_scan['markets'])} "
+              f"scansInHistory={len(history['scans'])} candidates={len(candidates)}",
+              file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "totalMarkets": len(current_scan["markets"]),
+                  "scansInHistory": len(history["scans"]), "candidates": len(candidates)})
+        return []
+
+    # ── emit every surviving candidate; mark each emitted asset's cooldown ──
+    out = []
+    emitted_assets = []
+    for s in confirmed:
+        cooldowns[s["token"]] = {"emittedTimestamp": now, "setAt": now_iso}
+        emitted_assets.append(s["asset"])
+        out.append({
+            "asset": s["asset"],
+            "direction": s["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # 7x default; runtime applies + venue-clamps
+            "data": {
+                "mode": s["mode"],
+                "score": s["score"],
+                "rankJump": s["rankJump"],
+                "currentRank": s["currentRank"],
+                "prevRank": s.get("prevRank", 0),
+                "contribVelocity": s.get("contribVelocity", 0),
+                "volRatio": s.get("volRatio", 0),
+                "priceChg4h": s.get("priceChg4h", 0),
+                "priceChg1h": s.get("priceChg1h", 0),
+                "cc15m": s.get("cc15m", 0),
+                "traders": s.get("traders", 0),
+                "contribution": s.get("contribution", 0),
+                "isFirstJump": bool(s.get("isFirstJump", False)),
+                "isContribExplosion": bool(s.get("isContribExplosion", False)),
+                "reasons": " | ".join(s.get("reasons", [])),
+                "leverage": leverage,
+            },
+        })
+
+    print(f"[roach.scan] EMIT {len(out)} striker(s): "
+          + ", ".join(f"{s['asset']} {s['direction']} score={s['score']} "
+                      f"+{s['rankJump']}->#{s['currentRank']}" for s in confirmed[:4]),
+          file=sys.stderr)
+    _persist({"ts": now, "emitted": True, "totalMarkets": len(current_scan["markets"]),
+              "scansInHistory": len(history["scans"]), "candidates": len(candidates),
+              "signals": len(out), "assets": emitted_assets})
+    return out

--- a/strategies/roach/main/scanners/scoring.py
+++ b/strategies/roach/main/scanners/scoring.py
@@ -1,0 +1,303 @@
+"""ROACH — pure thesis math (no I/O, no MCP, no clock-as-arg-free-state).
+
+A faithful Runtime 3.0 port of the v2 Roach producer's Striker-detection logic
+(`detect_striker_signals` + helpers, roach-producer.py v3.0.0). The math/indexing
+is reproduced VERBATIM so a fidelity harness can diff this against the v2 producer
+on the same scan snapshot + history. Behaviour-preserving quirks from v2 are kept
+and flagged `# v2-quirk`; fix them only as a separate, labelled change AFTER the
+port is validated.
+
+UNIVERSE scanner: the caller (scan.py) fetches the top-50 smart-money leaderboard
+markets (XYZ banned), builds the current scan snapshot, hands in the prior-scan
+history (from ctx.state), runs `detect_striker_signals`, and — for each surviving
+candidate — does the per-asset volume confirmation read and the final volume gate.
+
+Two pure pieces here:
+  - `parse_scan(raw_markets, now_iso, top_n)` — normalize raw leaderboard markets
+    into a scan snapshot (XYZ filtered).
+  - `detect_striker_signals(current_scan, history, now_hour)` — the verbatim v1.2
+    Striker detector EXCEPT the volume gate (which needs an MCP read). It returns
+    candidates that have passed every gate UP TO volume; scan.py applies the volume
+    gate last (exactly the order in v2 detect_striker_signals).
+
+`now_hour` (UTC hour 0-23) is passed in so the time-of-day modifier stays a pure
+function (no datetime.now inside scoring)."""
+
+
+# ── STRIKER CONSTANTS (HARDCODED — fleet-tuned, not operator-set) ──
+# Verbatim from roach-producer.py v3.0.0.
+TOP_N = 50
+ERRATIC_REVERSAL_THRESHOLD = 5
+MIN_SCORE = 10                  # v1.1: tightened from 9
+MIN_REASONS = 4
+MIN_RANK_JUMP = 15
+MIN_VELOCITY_OVERRIDE = 15
+MIN_VELOCITY_FLOOR = 15         # v1.1: tightened from 10
+MIN_VOL_RATIO = 1.5             # v1.1: loosened from 2.0
+MIN_CC_15M = 0.5                # v1.2: tightened from 0
+MIN_PRICE_1H_ALIGN_PCT = 0.1    # v1.2
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# ── SCAN SNAPSHOT (port of v2 parse_scan) ──
+
+def parse_scan(raw_markets, now_iso, top_n=TOP_N):
+    """Parse raw leaderboard markets into a scan snapshot.
+    HARDCODED: xyz: assets filtered at scan level — never enter the signal pipeline.
+    Verbatim from v2 parse_scan (now-string passed in to keep this pure)."""
+    scan = {"time": now_iso, "markets": []}
+    for i, m in enumerate((raw_markets or [])[:top_n]):
+        if not isinstance(m, dict):
+            continue
+        token = m.get("token", "")
+        dex = m.get("dex", "")
+        # XYZ ban (Fox data: SNDK -$57, GOLD -$8, CRCL -$9, MU -$7)
+        if dex and str(dex).lower() == "xyz":
+            continue
+        if str(token).lower().startswith("xyz:"):
+            continue
+        scan["markets"].append({
+            "token": token,
+            "dex": dex,
+            "rank": i + 1,
+            "direction": m.get("direction", ""),
+            "contribution": round(_f(m.get("pct_of_top_traders_gain", 0)), 6),
+            "traders": m.get("trader_count", 0),
+            "price_chg_4h": round(_f(m.get("token_price_change_pct_4h", 0)) or 0, 4),
+            "price_chg_1h": round(_f(m.get("token_price_change_pct_1h",
+                                          m.get("price_change_1h", 0))) or 0, 4),
+            "cc_15m": _f(m.get("contribution_pct_change_15m", 0) or 0),
+        })
+    return scan
+
+
+def get_market_in_scan(scan, token, dex=""):
+    """Verbatim from v2 get_market_in_scan."""
+    for m in scan["markets"]:
+        if m["token"] == token and m.get("dex", "") == dex:
+            return m
+    return None
+
+
+# ── HELPERS (verbatim from v2) ──
+
+def is_erratic_history(rank_history, exclude_last=False):
+    """Detect zigzag rank patterns. Verbatim from v2 (kept for fidelity; v2 never
+    calls it from detect_striker_signals, so it is dead in both v2 and this port —
+    preserved verbatim, FLAGGED as unused-in-v2)."""
+    nums = [r for r in rank_history if r is not None]
+    if exclude_last and len(nums) > 1:
+        nums = nums[:-1]
+    if len(nums) < 3:
+        return False
+    for i in range(1, len(nums) - 1):
+        prev_delta = nums[i] - nums[i - 1]
+        next_delta = nums[i + 1] - nums[i]
+        if prev_delta < 0 and next_delta > ERRATIC_REVERSAL_THRESHOLD:
+            return True
+        if prev_delta > 0 and next_delta < -ERRATIC_REVERSAL_THRESHOLD:
+            return True
+    return False
+
+
+def time_of_day_modifier(now_hour):
+    """UTC time-of-day scoring adjustment. Verbatim from v2 (UTC hour passed in
+    to keep this pure)."""
+    hour = now_hour
+    if 4 <= hour < 14:
+        return 1, "time_bonus_optimal_window"
+    elif hour >= 18 or hour < 2:
+        return -2, "time_penalty_chop_zone"
+    return 0, None
+
+
+def check_4h_alignment(direction, price_chg_4h):
+    """4H trend must agree with signal direction. Hard block. Verbatim from v2."""
+    if direction == "LONG" and price_chg_4h < 0:
+        return False
+    if direction == "SHORT" and price_chg_4h > 0:
+        return False
+    return True
+
+
+# ── STRIKER DETECTION (v1.2 logic, verbatim EXCEPT the trailing volume gate) ──
+
+def detect_striker_signals(current_scan, history, now_hour):
+    """Detect violent FIRST_JUMP / IMMEDIATE_MOVER signals.
+
+    Logic preserved verbatim from roach-producer.py v3.0.0 `detect_striker_signals`
+    EXCEPT the final volume-confirmation gate (`check_asset_volume`), which requires
+    an MCP read (`market_get_asset_data`) and therefore cannot live in this pure
+    module. scan.py applies that gate immediately after, in the SAME position in the
+    pipeline, so emit semantics are identical.
+
+    Returns a list of candidate dicts that have passed every gate up to (but not
+    including) volume confirmation. Each candidate carries the `reasons` list as
+    built so far; scan.py appends `VOL_CONFIRMED ...` after the volume read, exactly
+    as v2 did."""
+    prev_scans = history.get("scans", [])
+    if not prev_scans:
+        return []
+
+    latest_prev = prev_scans[-1]
+    oldest_available = prev_scans[-min(len(prev_scans), 5)]
+
+    prev_top50_tokens = set()
+    for m in latest_prev["markets"]:
+        prev_top50_tokens.add((m["token"], m.get("dex", "")))
+
+    signals = []
+
+    for market in current_scan["markets"]:
+        token = market["token"]
+        dex = market.get("dex", "")
+        current_rank = market["rank"]
+        direction = str(market["direction"]).upper()
+        current_contrib = market["contribution"]
+
+        # Destination ceiling: reject if in top 10
+        if current_rank <= 10:
+            continue
+
+        # 4H trend alignment (hard block)
+        if not check_4h_alignment(direction, market.get("price_chg_4h", 0)):
+            continue
+
+        prev_market = get_market_in_scan(latest_prev, token, dex)
+        old_market = get_market_in_scan(oldest_available, token, dex)
+
+        if not prev_market:
+            continue
+
+        rank_jump = prev_market["rank"] - current_rank
+
+        # ── FIRST_JUMP detection ──
+        is_first_jump = False
+        is_immediate = False
+        is_contrib_explosion = False
+        reasons = []
+
+        if rank_jump >= 10 and prev_market["rank"] >= 25:
+            is_immediate = True
+            reasons.append(f"IMMEDIATE_MOVER +{rank_jump} from #{prev_market['rank']}")
+
+            was_in_prev = (token, dex) in prev_top50_tokens
+            if not was_in_prev or prev_market["rank"] >= 30:
+                is_first_jump = True
+                reasons.append(f"FIRST_JUMP #{prev_market['rank']}->#{current_rank}")
+
+        # Contribution explosion
+        if prev_market["contribution"] > 0:
+            contrib_ratio = current_contrib / prev_market["contribution"]
+            if contrib_ratio >= 3.0:
+                is_contrib_explosion = True
+                reasons.append(f"CONTRIB_EXPLOSION {contrib_ratio:.1f}x")
+
+        if not is_first_jump and not is_immediate:
+            continue
+
+        # Velocity computation
+        contrib_velocity = 0
+        recent_contribs = []
+        for scan in prev_scans[-5:]:
+            m = get_market_in_scan(scan, token, dex)
+            if m:
+                recent_contribs.append(m["contribution"])
+        recent_contribs.append(current_contrib)
+        if len(recent_contribs) >= 2:
+            deltas = [recent_contribs[i + 1] - recent_contribs[i]
+                      for i in range(len(recent_contribs) - 1)]
+            contrib_velocity = sum(deltas) / len(deltas) * 100
+
+        abs_velocity = abs(contrib_velocity)
+
+        if rank_jump < MIN_RANK_JUMP and abs_velocity < MIN_VELOCITY_OVERRIDE:
+            continue
+
+        # Velocity floor
+        if abs_velocity < MIN_VELOCITY_FLOOR:
+            if is_first_jump and contrib_velocity > 0:
+                pass
+            else:
+                continue
+
+        # ── SCORING ──
+        score = 0
+        if is_first_jump:
+            score += 3
+        if is_immediate:
+            score += 2
+        if is_contrib_explosion:
+            score += 2
+        if abs_velocity > 10:
+            score += 2
+            reasons.append(f"HIGH_VELOCITY {abs_velocity:.1f}")
+
+        if prev_market["rank"] >= 40:
+            score += 1
+            reasons.append("DEEP_CLIMBER")
+
+        if old_market:
+            total_climb = old_market["rank"] - current_rank
+            if total_climb >= 10:
+                score += 1
+                reasons.append(f"CLIMBING +{total_climb} over scans")
+
+        tod_mod, tod_reason = time_of_day_modifier(now_hour)
+        score += tod_mod
+        if tod_reason:
+            reasons.append(tod_reason)
+
+        if score < MIN_SCORE or len(reasons) < MIN_REASONS:
+            continue
+
+        # 15m velocity freshness gate
+        cc_15m = _f(market.get("cc_15m", 0))
+        if cc_15m < MIN_CC_15M:
+            continue
+
+        # 1h price confirmation of direction
+        p1h = _f(market.get("price_chg_1h", 0))
+        if direction == "LONG" and p1h < MIN_PRICE_1H_ALIGN_PCT:
+            continue
+        if direction == "SHORT" and p1h > -MIN_PRICE_1H_ALIGN_PCT:
+            continue
+        reasons.append(f"1H_CONFIRMS {p1h:+.2f}%")
+
+        # NOTE: the volume-confirmation gate (check_asset_volume / vol >= 1.5x) is
+        # applied by scan.py immediately after this, via an MCP read. Candidates
+        # returned here have NOT yet passed volume; scan.py drops the ones that
+        # fail and appends "VOL_CONFIRMED {ratio}x" to those that pass — verbatim
+        # position in the v2 pipeline.
+
+        # Build canonical asset id (no XYZ — already filtered out)
+        asset_id = token
+
+        signals.append({
+            "asset": asset_id,
+            "token": token,
+            "dex": dex if dex else None,
+            "direction": direction,
+            "mode": "STRIKER",
+            "score": score,
+            "reasons": reasons,
+            "currentRank": current_rank,
+            "prevRank": prev_market["rank"],
+            "rankJump": rank_jump,
+            "isFirstJump": is_first_jump,
+            "isContribExplosion": is_contrib_explosion,
+            "contribVelocity": round(contrib_velocity, 4),
+            "contribution": round(current_contrib * 100, 3),
+            "traders": market["traders"],
+            "priceChg4h": market.get("price_chg_4h", 0),
+            "priceChg1h": p1h,
+            "cc15m": cc_15m,
+        })
+
+    return signals

--- a/strategies/roach/strategy.yaml
+++ b/strategies/roach/strategy.yaml
@@ -1,0 +1,45 @@
+# Roach — Striker-only smart-money rank-jump sniper. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of
+# the v2 Roach (SKILL.md v3.0.0): a UNIVERSE scanner over the top-50 smart-money
+# leaderboard markets that detects violent FIRST_JUMP / IMMEDIATE_MOVER rank-jump
+# explosions, gates them hard (4h trend, 1h price, cc_15m freshness, score >= 10 w/ 4+
+# reasons, 1.5x volume), and emits at fixed 25% margin / 7x leverage. Stalker mode
+# permanently disabled. DSL-only exits with maker-first fee recovery. "Silence is correct."
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: roach
+version: "1.0.0"
+
+catalog:
+  name: "Roach — Striker Rank-Jump Sniper"
+  emoji: "🪳"
+  tagline: "A patient striker: watches the top-50 smart-money leaderboard and fires only on violent FIRST_JUMP / IMMEDIATE_MOVER rank explosions confirmed by 4h trend, 1h price, fresh 15m velocity, and a 1.5x volume spike — then sizes one bet and lets a tight ratchet ride it. Long silences are expected and correct."
+  belief_plain: "Cockroaches survive by not moving when there's nothing to chase. Roach watches which coins the best traders are suddenly piling into — a coin violently jumping up the leaderboard — and only buys when that rank-jump is backed by the 4-hour trend, the last hour's price, fresh momentum, and a real volume spike all agreeing. Most of the time it does nothing; the patience is the edge."
+  thesis: "Most leaderboard movement is noise. Real edge is a violent, fresh rank-jump — a coin exploding from #25+ into the top of the smart-money board in a single scan — but only when it's confirmed by trend, price, fresh velocity, and volume at the same instant. Those explosions are rare, so the right move is to ban equities, demand a high composite score with multiple confirmations, take the few that qualify at fixed 7x sizing, and let a ratcheting DSL stop bank the move. Stalker-style accumulation entries were removed — fewer, higher-quality strikes beat more, mixed ones."
+  group: smart-money
+  archetype: breakout_momentum
+  sub_style: rank_jump
+  asset_classes: [universe_crypto]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 7
+  max_slots: 2
+  min_budget: 200
+  assets: []                # derived universe — coins come from the top-50 SM leaderboard each tick, not a fixed list
+  tags: [smart-money, breakout, rank-jump, first-jump, immediate-mover, universe-scanner, striker, volume-confirmed, patient]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: ROACH_WALLET
+    funding_share: 1.0

--- a/strategies/salamander/main/runtime.yaml
+++ b/strategies/salamander/main/runtime.yaml
@@ -1,0 +1,149 @@
+# ── SALAMANDER · single instance — pullback catcher within a trend (basket) ───
+# Runtime 3.0 port of the v2 Salamander (SKILL.md v1.0.0 / salamander-producer.py
+# v1.0.1). Liquid-majors basket (BTC/ETH/SOL): LONG a 3-7% 1h dip inside a bullish
+# 4h trend / SHORT a 3-7% 1h rally inside a bearish 4h trend, GATED by the
+# smart-money leaderboard (net >= 55% in the trend direction). 5-component pullback
+# score (max ~9, floor 5), flat 20% margin / 5x leverage. Asymmetric DSL — WIDE
+# Phase 1 (max_loss 10%, retrace 6) gives a pullback room to develop; WIDE Phase 2
+# ladder (first lock at +10% ROE) lets the resumed trend run. hard_timeout 48h.
+# Faithful port — see scanners/scoring.py (math reproduced verbatim, v2-quirks
+# flagged).
+name: salamander-main
+group: salamander
+version: 1.0.0
+description: >
+  SALAMANDER — pullback catcher within an established 4h trend on the liquid
+  majors (BTC/ETH/SOL). Goes LONG when the 4h trend is BULLISH AND the latest 1h
+  close has pulled back 3-7% from the recent (prior 24h) high AND the Senpi
+  smart-money leaderboard is net long in the same direction at >= 55%; SHORT when
+  the 4h trend is BEARISH AND the 1h close has rallied 3-7% from the recent low
+  with SM net short. The 4h-trend-non-neutral gate, the 3-7% pullback band, and
+  the SM-direction agreement are ALL HARD GATES; the 4-6% midpoint and a strong-SM
+  (>=70%) tilt are score contributors (5 components, max ~9, floor 5). Flat sizing:
+  20% margin, 5x leverage (clamped to 5x max). Asymmetric DSL — a wide Phase 1
+  (max_loss 10%) gives the dip room to develop, while a wide Phase 2 ratchet (first
+  lock at +10% ROE) lets the resumed trend run; hard_timeout 48h cuts a pullback
+  that never resolves. Onboarding-grade. Faithful port of the v2 Salamander v1.0.0
+  thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${SALAMANDER_WALLET}"
+  slots: 1                                 # v2 strategy.slots 1
+  margin_pct: 20                           # baseline %; scan emits the flat marginPct per signal
+  default_leverage: 5                      # fallback; scan emits 5x per signal (clamped to MAX 5)
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: salamander_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                   # v2 producer cadence (5 min)
+    timeout_seconds: 180                    # v2 tick_timeout=180; ~1 read/asset + sm + account
+    default_signal_validity_seconds: 600    # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100            # dedup map + per-tick scan-results history
+    inputs:
+      universe: ["BTC", "ETH", "SOL"]       # v1 DEFAULT_UNIVERSE / config.universe (validated live on HL main DEX 2026-06-29)
+      minScore: 5                           # v1 DEFAULT_MIN_SCORE / config.minScore
+      marginPct: 20                         # PERCENT of withdrawable (0,100]; flat (no conviction tiers)
+      leverage: 5                           # clamped to MAX_LEVERAGE 5 in scan.py
+      smTiltMinPct: 55                      # v1 DEFAULT_SM_TILT_MIN — SM-agreement gate
+      smStrongTiltPct: 70                   # v1 DEFAULT_SM_STRONG — +1 "strongly tilted" component
+      pullbackMinPct: 3.0                   # v1 DEFAULT_PULLBACK_MIN — pullback band floor
+      pullbackMaxPct: 7.0                   # v1 DEFAULT_PULLBACK_MAX — pullback band ceiling
+      pullbackLookbackHours: 24             # v1 DEFAULT_PULLBACK_LOOKBACK — recent high/low window
+      recentSignalTtlSeconds: 240           # v1 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      pullbackPct: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: salamander_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [salamander_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true     # 2026-05-21 HYPE lesson: trend-continuation entries must fill —
+                                            # maker-only can rest unfilled (CREATE_ORDER_RESTING). Taker
+                                            # fallback guarantees fill + DSL attach.
+        execution_timeout_seconds: 30       # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: salamander_main_signals
+
+# ── EXIT (DSL — preserved VERBATIM from the v2 salamander runtime.yaml) ────────
+# Asymmetric "pullback" profile: WIDE Phase 1 (max_loss 10%, retrace 6) gives a
+# pullback room to develop (vs Hawk's tighter breakout floor of 8%); WIDE Phase 2
+# ladder lets the resumed trend run. hard_timeout 48h kills a pullback that never
+# resolves; weak_peak_cut 90min/3% kills stale pullbacks; dead_weight_cut DISABLED.
+# Phase 2 FIRST lock at +10% ROE (reachable on realistic winners — NOT the
+# unreachable >+40% pattern). order_type FEE_OPTIMIZED_LIMIT, taker fallback on
+# (closes MUST happen). interval_seconds 60 (v2: REDUCE_ONLY-spam mitigation when
+# runtime position state lags HL).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true         # exit closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30           # v2: kept the maker attempt under the server connection window
+  dsl_preset:
+    hard_timeout:
+      enabled: true                         # v2: 48h cap — failed pullbacks get cut
+      interval_in_minutes: 2880
+    weak_peak_cut:
+      enabled: true                         # v2: 90min/3% — stale pullbacks cut (self-limiting)
+      interval_in_minutes: 90
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                        # v2: DISABLED
+      interval_in_minutes: 90
+    phase1:
+      enabled: true
+      max_loss_pct: 10.0                     # v2: WIDE floor — pullbacks within a trend need room
+      retrace_threshold: 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                # wide-by-design "let winners run"; FIRST lock at +10% ROE (NOT >+40%)
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200            # 72h (was data_retention_hours 72)
+  guard_rails:
+    daily_loss_limit_pct: 15                # v2 daily_loss_limit_pct
+    max_entries_per_day: 2                  # v2 onboarding: fewer-stronger
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 cooldown_minutes 60 -> 3600s (post-loss)
+    drawdown_halt_pct: 20                   # v2 drawdown_halt_pct (hard circuit breaker)
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400       # v2 per_asset_cooldown_minutes 240 -> 14400s (4h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/salamander/main/scanners/scan.py
+++ b/strategies/salamander/main/scanners/scan.py
@@ -1,0 +1,323 @@
+"""SALAMANDER — supervised scanner (Runtime 3.0 port of the v2 Salamander pullback producer).
+
+Multi-asset, basket-gated (BTC/ETH/SOL by default). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - iterates the basket universe (XYZ banned; held + recently-signaled filtered
+    BEFORE the per-asset MCP fetch, as in v2 main()),
+  - for each candidate fetches 1h+4h candles + the smart-money lean and scores a
+    pullback thesis via the pure `scoring.build_thesis` (4h-trend non-neutral,
+    pullback in the 3-7% band, and SM-direction agreement are ALL HARD GATES;
+    the midpoint and strong-SM bonuses are score contributors),
+  - emits the SINGLE highest-scoring candidate at/above `minScore` (v2 main()
+    emitted only `best`), sized by a flat margin PERCENT + clamped leverage.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit.
+No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs the v2 producer (salamander-producer.py VERSION 1.0.1; the file
+header label is "v1.0.0" and SKILL.md is v1.0.0 — the VERSION constant 1.0.1 is
+cited as authoritative):
+  - v2 sized margin as marginPct=0.20 (a FRACTION) * account_value -> marginUsd.
+    This port emits a `marginPct` PERCENT (default 20) and the runtime sizes
+    (marginPct/100)*withdrawable. The defensive "<=1.0 means a pasted fraction,
+    x100" guard converts a config that still carries 0.20 -> 20. Flat sizing (no
+    conviction tiers) is preserved verbatim.
+  - v2 leverage = min(config.leverage(5), MAX_LEVERAGE(5)). Preserved: clamp the
+    input leverage to MAX_LEVERAGE (5).
+  - v2 emitted exactly one signal (best, highest score). Preserved: scan() emits
+    <= 1 signal/tick.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=240) -> ctx.state dedup
+    map (same TTL + 4x-TTL prune semantics).
+  - v2 smart-money lean (fetch_sm_direction) thresholds reproduced VERBATIM in
+    _get_sm_direction (long_ratio >= 50 -> LONG else SHORT; token compared UPPER;
+    total<=0 -> NEUTRAL/50; not found -> (None, 0.0)). NOT bison's 58/42 band.
+  - v2 build_thesis short-circuited on data.get("success") False; the read-guard
+    here treats success:false as "skip asset" (None), same effect.
+  - v2's salamander_config.py docstring AND runtime.yaml description called
+    Salamander a "single-asset BTC" trend follower; the producer (DEFAULT_UNIVERSE
+    + per-asset universe loop in main()), config/salamander-config.json
+    ("universe": ["BTC","ETH","SOL"]) and SKILL.md ("Universe: BTC, ETH, SOL") all
+    define a 3-asset BTC/ETH/SOL PULLBACK basket. The producer/config/SKILL are
+    source-of-truth — this port is a 3-asset basket pullback catcher. (Mismatch
+    FLAGGED.) The v2 runtime.yaml's SALAMANDER_BTC_TREND signal_type, the BTC-only
+    LLM decision_prompt, and the "is BTC trending?" description are stale-template
+    residue and were NOT ported.
+  - DSL ported VERBATIM from the v2 runtime.yaml exit block (the producer docstring
+    says "24h cap" / "T0 +5% / lock 30" but the runtime.yaml — which OWNS the DSL —
+    has hard_timeout 2880min/48h and T0 +10%/lock 0; runtime.yaml is authoritative
+    for DSL per the spec, and SKILL.md agrees with it: 48h, T0 +10%/lock 0). (FLAGGED.)
+  - The v2 producer has NO order-lifecycle management (no cancel_order /
+    has_resting_orders / stale-order purge), so nothing of that kind was dropped.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v1.0.1 defaults (salamander-producer.py / salamander-config.json)
+_UNIVERSE_DEFAULT = ["BTC", "ETH", "SOL"]
+_DEFAULT_MIN_SCORE = 5            # v1 DEFAULT_MIN_SCORE / config.minScore
+_DEFAULT_MARGIN_PCT = 20         # PERCENT; v2 config.marginPct=0.20 fraction -> 20%
+_DEFAULT_LEVERAGE = 5            # v1 DEFAULT_LEVERAGE / config.leverage
+_MAX_LEVERAGE = 5               # v1 MAX_LEVERAGE (hardcoded, not configurable)
+_DEFAULT_RECENT_TTL = 240        # v1 RECENT_SIGNAL_TTL_SEC — race-window dedup
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    Salamander's basket is liquid crypto majors, so this only ever returns '' in
+    practice (XYZ is also banned at scan level below)."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[salamander.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[salamander.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _get_sm_direction(ctx, coin):
+    """Net smart-money lean for `coin` from leaderboard_get_markets. Returns
+    (direction, tilt_pct) or (None, 0.0). READ-GUARDED.
+
+    Ported VERBATIM from v2 fetch_sm_direction (NOT bison's 58/42 band):
+      - token compared UPPER-cased against coin (assumed upper),
+      - long_ratio = long_pct/(long+short)*100,
+      - long_ratio >= 50 -> ("LONG", long_ratio), else ("SHORT", 100 - long_ratio),
+      - total <= 0 -> ("NEUTRAL", 50.0); coin not found -> (None, 0.0)."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — smart-money is the entry GATE; a read failure must skip,
+        print(f"[salamander.scan] leaderboard_get_markets read failed (smart-money -> none): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and raw.get("success") is False):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct = 0.0
+    short_pct = 0.0
+    found = False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != coin:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def _asset_data(ctx, coin):
+    """{candles_1h, candles_4h} for `coin` or None. READ-GUARDED.
+    Ported from v2 fetch_market_data (1h/4h, no funding, no order book)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["1h", "4h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[salamander.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    if not isinstance(candles, dict):
+        return None
+    return {"candles_1h": candles.get("1h", []) or [],
+            "candles_4h": candles.get("4h", []) or []}
+
+
+# ── ctx.state: recent-signal dedup (port of v1 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    universe = [str(a).upper() for a in inputs.get("universe", _UNIVERSE_DEFAULT)]
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    base_margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))   # PERCENT in (0,100]
+    # defensive: a config that still stores margin as a FRACTION (e.g. 0.20) -> x100
+    if base_margin_pct <= 1.0:
+        print(f"[salamander.scan] marginPct={base_margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({base_margin_pct * 100})", file=sys.stderr)
+        base_margin_pct *= 100
+    lev_default = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── score every eligible basket candidate (XYZ banned; held + recently
+    #    signaled filtered BEFORE the per-asset MCP fetch, as in v2 main()) ──
+    candidates = []
+    scanned = 0
+    for coin in universe:
+        if not coin or coin.lower().startswith("xyz:"):   # XYZ banned (liquid-crypto basket)
+            continue
+        cu = coin.upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        sm = _get_sm_direction(ctx, cu)
+        th = scoring.build_thesis(coin, md["candles_1h"], md["candles_4h"], sm, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets,
+                  "note": f"WAITING — no pullback in trend with SM agreement (min score {min_score:.0f})"}
+        print(f"[salamander.scan] WAITING — no pullback in trend with SM agreement "
+              f"(min score {min_score:.0f}); scanned={scanned} held={held_assets}", file=sys.stderr)
+    else:
+        # v2 emitted exactly the single best (highest score).
+        candidates.sort(key=lambda x: x["score"], reverse=True)
+        best = candidates[0]
+
+        # flat margin PERCENT (v2 had no conviction tiers); leverage clamped to MAX.
+        margin_pct = base_margin_pct
+        leverage = min(lev_default, _MAX_LEVERAGE)
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"],
+                  "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best["reasons"]}
+        print(f"[salamander.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+              f"{leverage}x marginPct={margin_pct:.2f}% | {best['reasons'][:6]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # clamped to MAX_LEVERAGE (5); runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "trend4h": best["trend_4h"],
+                "pullbackPct": best["pullback_pct"],
+                "smDirection": best["sm_direction"] or "NEUTRAL",
+                "smTiltPct": best["sm_tilt_pct"],
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + this tick's result every tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[salamander.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/salamander/main/scanners/scoring.py
+++ b/strategies/salamander/main/scanners/scoring.py
@@ -1,0 +1,192 @@
+"""SALAMANDER — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Salamander producer's `trend_4h` +
+`detect_pullback` + `build_thesis` 5-component pullback scoring (SKILL.md v1.0.0 /
+salamander-producer.py v1.0.1). The math/indexing is reproduced VERBATIM so a
+fidelity harness can diff this against the v2 producer on the same market
+snapshot. Behaviour-preserving quirks from v2 are kept and flagged `# v2-quirk`;
+fix them only as a separate, labelled change AFTER the port is validated.
+
+Multi-asset, single-pass, unit-testable on plain candle lists. `sm` (smart-money
+lean) is fetched by the caller and passed in, so this module stays pure.
+
+THESIS (v2 verbatim): buy the dip in an uptrend / short the rally in a downtrend.
+LONG when the 4h trend is BULLISH AND the latest 1h close has pulled back 3-7%
+from the recent (prior 24h) high AND smart-money is net LONG at >= smTiltMinPct
+(default 55%); SHORT when the 4h trend is BEARISH AND the latest 1h close has
+rallied 3-7% from the recent (prior 24h) low AND SM is net SHORT at >= 55%. The
+4h-trend-non-neutral gate, the pullback band, and the SM-direction agreement are
+ALL HARD GATES (return None if any fails). The midpoint (4-6%) and strong-SM
+(>=70%) bonuses are score contributors only. Max score ~9; minScore (default 5)
+is applied by the CALLER.
+"""
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts with a {primary, alt} fallback (close/c, high/h, low/l, volume/v)
+# via its own `_f(c, primary, alt)`; here that fallback lives in the accessors. The
+# list branch is defensive and never fires on dict candles, so it does not change
+# v2 behaviour.
+
+def _f(v, d=0.0):
+    try:
+        return float(v if v is not None else d)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+# ── indicators (ported verbatim from v2 salamander-producer.py) ──
+
+def trend_4h(candles_4h, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH, else NEUTRAL. Verbatim from
+    v2 trend_4h. v2-quirk: STRICT (>) higher-low / lower-high counting, gate at
+    `>= total * 0.6` with total = lookback - 1. Reproduced exactly."""
+    if len(candles_4h) < lookback:
+        return "NEUTRAL"
+    lows = [_low(c) for c in candles_4h[-lookback:]]
+    highs = [_high(c) for c in candles_4h[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH"
+    if lower_highs >= total * 0.6:
+        return "BEARISH"
+    return "NEUTRAL"
+
+
+def detect_pullback(candles_1h, lookback_hours, min_pct, max_pct, trend):
+    """(direction, pullback_pct) when a counter-move within the trend lands in the
+    [min_pct, max_pct] band, else (None, 0.0). Verbatim from v2 detect_pullback.
+
+    For a BULLISH trend: how far the latest 1h close is BELOW the recent (prior
+    24h) high. If 3-7%, it's a LONG dip.
+    For a BEARISH trend: how far the latest 1h close is ABOVE the recent (prior
+    24h) low. If 3-7%, it's a SHORT rally.
+
+    v2-quirk: the recent high/low is taken over window[:-1] (the prior closes,
+    excluding the latest bar). Needs len(candles_1h) >= lookback_hours + 1;
+    NEUTRAL trend -> (None, 0.0)."""
+    if len(candles_1h) < lookback_hours + 1 or trend == "NEUTRAL":
+        return None, 0.0
+    window = candles_1h[-lookback_hours:]
+    closes = [_close(c) for c in window]
+    if not closes or closes[-1] <= 0:
+        return None, 0.0
+    if trend == "BULLISH":
+        recent_high = max(closes[:-1])
+        if recent_high <= 0:
+            return None, 0.0
+        pullback_pct = ((recent_high - closes[-1]) / recent_high) * 100
+        if min_pct <= pullback_pct <= max_pct:
+            return "LONG", pullback_pct
+    else:  # BEARISH
+        recent_low = min(closes[:-1])
+        if recent_low <= 0:
+            return None, 0.0
+        rally_pct = ((closes[-1] - recent_low) / recent_low) * 100
+        if min_pct <= rally_pct <= max_pct:
+            return "SHORT", rally_pct
+    return None, 0.0
+
+
+# ── the thesis (three hard gates + 5-component score), ported verbatim ──
+
+def build_thesis(coin, candles_1h, candles_4h, sm, inputs):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned when ANY of the v2 short-circuits fire:
+      - insufficient history (len(c1h) < lookback+1 or len(c4h) < 6), OR
+      - 4h trend NEUTRAL, OR
+      - no pullback in band (detect_pullback -> None), OR
+      - SM gate fails: sm_dir not LONG/SHORT, OR sm_dir != pullback direction,
+        OR sm_tilt < smTiltMinPct.
+    minScore is NOT applied here — the caller gates on thesis['score'].
+
+    `sm` is the smart-money tuple (direction, tilt_pct) or (None, 0) — the caller
+    fetches it (scan._get_sm_direction)."""
+    lookback = int(inputs.get("pullbackLookbackHours", 24))
+    min_pct = float(inputs.get("pullbackMinPct", 3.0))
+    max_pct = float(inputs.get("pullbackMaxPct", 7.0))
+    sm_min = float(inputs.get("smTiltMinPct", 55))
+    sm_strong = float(inputs.get("smStrongTiltPct", 70))
+
+    if len(candles_1h) < lookback + 1 or len(candles_4h) < 6:
+        return None
+
+    # ── GATE: 4h trend must be non-neutral (the foundation) ──
+    t4 = trend_4h(candles_4h)
+    if t4 == "NEUTRAL":
+        return None
+
+    # ── GATE: a 1h pullback/rally in the 3-7% band, in the trend direction ──
+    direction, pullback_pct = detect_pullback(candles_1h, lookback, min_pct, max_pct, t4)
+    if direction is None:
+        return None
+
+    # ── GATE: smart-money must agree with the trend/pullback direction at >= sm_min ──
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    if sm_dir not in ("LONG", "SHORT") or sm_dir != direction:
+        return None
+    if sm_tilt < sm_min:
+        return None
+
+    score = 0
+    reasons = []
+
+    # 4h trend aligned (gate-confirmed, this is the foundation) (+3)
+    score += 3
+    reasons.append(f"4h_{t4.lower()}_trend")
+
+    # Pullback in the 3-7% sweet spot (gate-confirmed) (+2)
+    score += 2
+    reasons.append(f"pullback_{pullback_pct:+.2f}%")
+
+    # Midpoint bonus (4-6% ideal — too shallow = noise, too deep = trend break) (+1)
+    if 4.0 <= pullback_pct <= 6.0:
+        score += 1
+        reasons.append("pullback_in_midpoint")
+
+    # SM aligned (gate-confirmed) (+2)
+    score += 2
+    reasons.append(f"sm_aligned_{sm_tilt:.0f}%")
+
+    # SM strongly tilted (>= 70%) (+1)
+    if sm_tilt >= sm_strong:
+        score += 1
+        reasons.append("sm_strongly_tilted")
+
+    return {
+        "coin": coin,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "trend_4h": t4,
+        "pullback_pct": round(pullback_pct, 3),
+        "sm_direction": sm_dir,
+        "sm_tilt_pct": _f(sm_tilt),
+    }

--- a/strategies/salamander/strategy.yaml
+++ b/strategies/salamander/strategy.yaml
@@ -1,0 +1,46 @@
+# Salamander — pullback catcher within an established trend, with a Smart-Money
+# direction gate. A single-instance PACKAGE: this manifest + one self-contained
+# runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2 Salamander
+# (SKILL.md v1.0.0): a liquid-majors basket (BTC/ETH/SOL) that LONGs a 3-7% dip
+# inside a bullish 4h trend / SHORTs a 3-7% rally inside a bearish 4h trend, gated
+# by the Senpi smart-money leaderboard, with an asymmetric DSL (wide Phase 1 so a
+# pullback has room to develop, wide Phase 2 to let the resumed trend run).
+# Salamander is the pullback half of the Hawk(breakouts)/Salamander(pullbacks)
+# technical-pattern pair. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: salamander
+version: "1.0.0"
+
+catalog:
+  name: "Salamander — Pullback Catcher"
+  emoji: "🦎"
+  tagline: "An onboarding-grade pullback trader on the liquid majors (BTC/ETH/SOL): buys a 3-7% dip inside an established bullish 4h trend (and shorts a 3-7% rally inside a bearish one) only when the smart-money leaderboard agrees with the trend direction, then gives the entry room on a wide Phase 1 while a wide Phase 2 ratchet lets the resumed trend run."
+  belief_plain: "Watches BTC, ETH and SOL. When one is in a clear up-trend on the 4-hour chart and dips 3-7% on the 1-hour chart while the best traders are still leaning long, it buys the dip; in a down-trend it shorts a 3-7% bounce. It needs all three to line up — trend, dip-in-the-band, and smart money agreeing — then it gives the trade room to work and trails a wide stop so the trend can keep running."
+  thesis: "Pullbacks inside an established trend are one of the highest-edge setups: the trend has already proved itself, the counter-move offers a better entry, and a smart-money agreement filter screens out trend-break risk. The 3-7% band is the sweet spot — shallower is noise, deeper means the trend may be breaking, so you don't catch a falling knife. Because a resolved pullback resumes a trend that can run far, the exit is asymmetric: a wide Phase 1 floor lets the dip develop without a premature cut, and a wide Phase 2 ratchet (first lock only at +10% ROE) keeps the continuation that pays for the quiet weeks."
+  group: momentum
+  archetype: breakout_momentum
+  sub_style: pullback
+  asset_classes: [major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: starter
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL"]
+  tags: [btc, eth, sol, multi-asset, pullback, buy-the-dip, short-the-rally, smart-money, trend-continuation, onboarding, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: SALAMANDER_WALLET
+    funding_share: 1.0

--- a/strategies/sheep/main/runtime.yaml
+++ b/strategies/sheep/main/runtime.yaml
@@ -1,0 +1,136 @@
+# ── SHEEP · single instance — long-only triple-EMA-stacked trend follower ─────
+# Runtime 3.0 port of the v2 Sheep (SKILL.md v1.0.0, producer v1.0.1). Crypto-
+# majors whitelist (BTC/ETH/SOL/HYPE), fires LONG only when fast EMA > slow EMA
+# on ALL THREE timeframes (15m + 1h + 4h). Never shorts. Score boosts from 4h/1h
+# spread magnitude + smart-money tilt (SM is a bonus, never a gate). Balanced
+# DSL, ONBOARDING TIER. Faithful port — see scanners/scoring.py (math verbatim).
+name: sheep-main
+group: sheep
+version: 1.0.0
+description: >
+  SHEEP — long-only triple-EMA-stacked trend follower on crypto majors
+  (BTC/ETH/SOL/HYPE). Fires LONG only when the fast EMA is above the slow EMA on
+  ALL THREE timeframes (15m + 1h + 4h) for a whitelisted asset. Never shorts — a
+  triple-timeframe stack is a visual rule a beginner can sanity-check on any
+  chart. Score = 3 (full stack) + bonuses for wider 4h spread (>=1%), wider 1h
+  spread (>=0.5%), and aligned smart-money lean (>=55%, +1 strong >=70%); floor
+  minScore 4. Single best emit/tick, 20% margin, 3x (cap 5x). DSL is the ONLY
+  exit (balanced preset: max_loss 12%, 72h hard_timeout, weak_peak_cut at 6h/3%,
+  laddered phase-2 lock). Faithful port of the v2 Sheep v1.0.0 thesis. ONBOARDING.
+
+strategy:
+  wallet: "${SHEEP_WALLET}"
+  slots: 1                                 # v2 strategy.slots 1
+  margin_pct: 20                           # baseline %; scan emits the per-signal marginPct
+  default_leverage: 3                      # fallback; scan emits 3x (cap 5x) per signal
+  trading_risk: conservative
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: sheep_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 180                   # v2 tick_timeout=180; ~1 read/asset + sm + account
+    default_signal_validity_seconds: 600   # 2x tick; a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      whitelist: ["BTC", "ETH", "SOL", "HYPE"]  # v2 whitelist (validated live on HL main DEX 2026-06-29)
+      emaFast: 9                           # v2 emaFast / DEFAULT_EMA_FAST
+      emaSlow: 21                          # v2 emaSlow / DEFAULT_EMA_SLOW
+      minStackedFrames: 3                  # v2 minStackedFrames (3 = require all three timeframes)
+      smTiltMinPct: 55                     # v2 smTiltMinPct / DEFAULT_SM_TILT_MIN (SM bonus floor)
+      smStrongTiltPct: 70                  # v2 smStrongTiltPct / DEFAULT_SM_STRONG (+1 strong bonus)
+      minScore: 4                          # v2 minScore / DEFAULT_MIN_SCORE (floor)
+      marginPct: 20                        # PERCENT of withdrawable (0,100]; v2 fraction 0.20 -> 20
+      leverage: 3                          # clamped to [1,5] in scan.py (MAX_LEVERAGE=5)
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      spread4hPct: { type: number, required: false }
+      spread1hPct: { type: number, required: false }
+      stackScore: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: sheep_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [sheep_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # ride the trend NOW — a maker order that rests
+                                           # (CREATE_ORDER_RESTING) misses extension (v2 entry param).
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: sheep_main_signals
+
+# ── EXIT (DSL — balanced preset, ported VERBATIM from v2 runtime.yaml) ─────────
+# Trends extend; Sheep participates in extension while protecting against
+# reversal. Balanced ladder + max_loss 12% + weak_peak_cut to bail from
+# flat-but-tired positions. Phase-2 first lock at +8% ROE (reachable on real
+# winners). interval_seconds 60 (fleet-standard REDUCE_ONLY-spam mitigation).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 4320            # 72h — trends can develop over days
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360             # 6h
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # first lock at +8% ROE (reachable)
+        - { trigger_pct: 8,  lock_hw_pct: 0 }
+        - { trigger_pct: 15, lock_hw_pct: 40 }
+        - { trigger_pct: 25, lock_hw_pct: 60 }
+        - { trigger_pct: 40, lock_hw_pct: 75 }
+        - { trigger_pct: 70, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # 72h (was data_retention_hours 72)
+  guard_rails:
+    daily_loss_limit_pct: 12               # v2 risk.daily_loss_limit_pct
+    max_entries_per_day: 3                  # v2 risk.max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 risk.max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 risk.cooldown_minutes 60 -> 3600s
+    drawdown_halt_pct: 20                  # v2 risk.drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400      # v2 risk.per_asset_cooldown_minutes 240 -> 14400s (4h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/sheep/main/scanners/scan.py
+++ b/strategies/sheep/main/scanners/scan.py
@@ -1,0 +1,307 @@
+"""SHEEP — supervised scanner (Runtime 3.0 port of the v2 Sheep producer).
+
+Long-only triple-EMA-stacked trend follower. Multi-asset, whitelist-gated
+(BTC/ETH/SOL/HYPE by default). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - for each non-held, non-recently-signaled whitelist asset, fetches 15m/1h/4h
+    candles and scores via the pure `scoring.build_thesis` (HARD GATE: fast EMA >
+    slow EMA on ALL `minStackedFrames` timeframes),
+  - emits the SINGLE highest-scoring candidate at/above `minScore`, sorted by
+    (score, 4h spread) — exactly as v2 main() emitted only `best`.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus a `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit.
+No daemon, no push_signal, no create_position. Sheep never shorts.
+
+FIDELITY NOTES vs sheep-producer.py v1.0.1:
+  - v2 DEFAULT_MARGIN_PCT / config marginPct was 0.20 (a FRACTION) * account_value
+    -> marginUsd. This port carries marginPct=20 (a PERCENT) in runtime.yaml and
+    emits a top-level `marginPct`; the runtime sizes (marginPct/100)*withdrawable.
+    A defensive guard converts a value <= 1.0 (an operator who pasted the v2
+    fraction) to a PERCENT (*100) and logs it. FLAGGED.
+  - v2 emitted exactly one signal (best, sorted by score then 4h spread). Preserved:
+    scan() emits <= 1 signal/tick.
+  - v2 recent-signals.json cache (RECENT_SIGNAL_TTL_SEC=240, 4x-TTL prune) -> ctx.state
+    dedup map with identical TTL semantics.
+  - v2 `push_signal` skipped if the coin was already held; here held assets are
+    filtered BEFORE the per-asset MCP fetch (as in v2 main()), and heldAssets is
+    also carried in data{} for the rule action's belt-and-braces.
+  - v2 fetch_sm_direction SM logic (>=50 long-ratio split, NEUTRAL on zero total)
+    is ported verbatim in _get_sm_direction — note this differs from bison's
+    58/42 thresholds; Sheep's is the v2 Sheep mapping. SM is a BONUS, never a gate.
+  - v2 wrapped the producer in a daemon (interval 300s, tick_timeout 180); that
+    loop is OWNED by the runtime here. The producer's order-lifecycle code was
+    nil (Sheep never closes — DSL owns exits), so nothing was dropped on that axis.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v2 defaults (sheep-producer.py / sheep-config.json)
+_DEFAULT_WHITELIST = ["BTC", "ETH", "SOL", "HYPE"]
+_DEFAULT_MIN_SCORE = 4            # v2 DEFAULT_MIN_SCORE / config minScore
+_DEFAULT_MARGIN_PCT = 20.0       # PERCENT (v2 fraction 0.20 -> 20)
+_DEFAULT_LEVERAGE = 3            # v2 DEFAULT_LEVERAGE / config leverage
+_MAX_LEVERAGE = 5               # v2 MAX_LEVERAGE (hardcoded cap)
+_DEFAULT_TTL = 240              # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    Sheep's default whitelist is crypto majors (all main-DEX), but honour an
+    operator-supplied xyz: prefix defensively."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[sheep.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)), abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[sheep.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _asset_data(ctx, coin):
+    """{candles{}} for `coin` or None. READ-GUARDED.
+    Ported from v2 fetch_market_data: market_get_asset_data over 15m/1h/4h,
+    no funding, no order book."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["15m", "1h", "4h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[sheep.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    return {"candles": candles}
+
+
+def _get_sm_direction(ctx, coin):
+    """Port of v2 fetch_sm_direction: net smart-money lean for `coin` from
+    leaderboard_get_markets. Returns (direction, tilt_pct) or (None, 0).
+    READ-GUARDED. SM is a BONUS, never a gate.
+
+    Verbatim v2 mapping: per-coin long_pct/short_pct from pct_of_top_traders_gain;
+    if total <= 0 -> ("NEUTRAL", 50.0); else long_ratio = long_pct/total*100, and
+    ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio).
+    Note this 50-split differs from bison's 58/42 — Sheep uses the v2 Sheep map."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — smart-money is a score contributor; never crash the tick
+        print(f"[sheep.scan] leaderboard_get_markets read failed (smart-money -> neutral): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and raw.get("success") is False):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != coin.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    whitelist = inputs.get("whitelist", _DEFAULT_WHITELIST)
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    lev_default = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+
+    # marginPct is a PERCENT in (0,100]. FLAGGED: defensively convert a value <= 1.0
+    # (an operator who pasted the v2 FRACTION 0.20) into a PERCENT so it never
+    # silently sizes ~100x small (the runtime sizes (marginPct/100)*withdrawable).
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        print(f"[sheep.scan] marginPct={margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── score every eligible whitelist candidate; held + recently-signaled are
+    #    filtered BEFORE the per-asset MCP fetch, exactly as v2 main() did ──
+    candidates = []
+    scanned = 0
+    for coin in whitelist:
+        if not coin:
+            continue
+        cu = str(coin).upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        candles = md["candles"]
+        sm = _get_sm_direction(ctx, coin)
+        th = scoring.build_thesis(
+            cu,
+            candles.get("15m", []), candles.get("1h", []), candles.get("4h", []),
+            sm, inputs,
+        )
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets, "note": f"WAITING (min score {min_score:.0f})"}
+        print(f"[sheep.scan] WAITING — no whitelisted asset has a full 15m+1h+4h "
+              f"EMA-stacked-bullish setup (min score {min_score:.0f}); "
+              f"scanned={scanned} held={held_assets}", file=sys.stderr)
+    else:
+        # v2 sorted by (score, spread_4h_pct) desc and emitted exactly the best.
+        candidates.sort(key=lambda c: (c["score"], c["spread_4h_pct"]), reverse=True)
+        best = candidates[0]
+
+        # leverage: clamp v2 default into [1, MAX_LEVERAGE] (verbatim min(lev, MAX))
+        leverage = min(lev_default, _MAX_LEVERAGE)
+
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "emitted": True,
+                  "coin": best["coin"], "direction": "LONG",
+                  "score": best["score"], "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best["reasons"]}
+        print(f"[sheep.scan] EMIT {best['coin']} LONG score={best['score']} "
+              f"{leverage}x marginPct={margin_pct:.2f}% stack={best['stack_score']} "
+              f"spread4h={best['spread_4h_pct']:+.2f}% | {best['reasons'][:5]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": "LONG",                 # Sheep never shorts
+            "marginPct": margin_pct,             # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,                # 1..5; runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": "LONG",
+                "reasons": best["reasons"],
+                "spread4hPct": best["spread_4h_pct"],
+                "spread1hPct": best["spread_1h_pct"],
+                "stackScore": best["stack_score"],
+                "smDirection": best["sm_direction"] or "NONE",
+                "smTiltPct": best["sm_tilt_pct"],
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + this tick's result every tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[sheep.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/sheep/main/scanners/scoring.py
+++ b/strategies/sheep/main/scanners/scoring.py
@@ -1,0 +1,143 @@
+"""SHEEP — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Sheep producer's EMA-stack logic +
+spread/SM scoring (sheep-producer.py v1.0.1, SKILL.md v1.0.0). The math is
+reproduced VERBATIM so a fidelity harness can diff this module against the v2
+producer on the same candle snapshot. Behaviour-preserving quirks from v2 are
+kept and flagged `# v2-quirk`.
+
+Long-only, multi-asset (whitelist), single-pass, unit-testable on plain candle
+lists. `sm` (smart-money lean) is fetched by the caller and passed in, so this
+module stays pure.
+
+The thesis is a HARD GATE on the EMA stack: fire LONG only when fast EMA >
+slow EMA on ALL `minStackedFrames` of {15m, 1h, 4h} (default 3 = all three).
+Below the gate -> None. Above it, score from spread magnitude + SM bonus.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    """Dual-shape close accessor (dict {close|c} OR list [t,o,h,l,c,v]).
+    v2 read dicts only via _f(c, "close", "c"); the list branch is defensive
+    and never fires on dict candles, so it does not change v2 behaviour."""
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def closes(candles):
+    return [_close(c) for c in candles]
+
+
+# ── EMA + stack logic (ported VERBATIM from v2 sheep-producer.py) ──
+
+def ema(cs, period):
+    """Exponential moving average. Returns the final EMA value, or None for
+    insufficient data. Verbatim from v2 ema(): SMA seed over the first
+    `period` closes, then the standard k=2/(period+1) recurrence."""
+    if not cs or len(cs) < period:
+        return None
+    k = 2.0 / (period + 1.0)
+    seed = sum(cs[:period]) / period
+    ema_val = seed
+    for c in cs[period:]:
+        ema_val = (c - ema_val) * k + ema_val
+    return ema_val
+
+
+def is_stacked_bullish(cs, fast_period, slow_period):
+    """True if fast EMA > slow EMA on this single timeframe. Verbatim from v2."""
+    f = ema(cs, fast_period)
+    s = ema(cs, slow_period)
+    if f is None or s is None:
+        return False
+    return f > s
+
+
+def stack_score(stacks_per_timeframe):
+    """How many of the per-timeframe stack booleans are True. Verbatim from v2."""
+    return sum(1 for s in stacks_per_timeframe if s)
+
+
+def fast_slow_spread(cs, fast_period, slow_period):
+    """% spread of fast EMA above slow EMA on this timeframe. Negative when
+    fast is below slow. None for insufficient data. Verbatim from v2."""
+    f = ema(cs, fast_period)
+    s = ema(cs, slow_period)
+    if f is None or s is None or s <= 0:
+        return None
+    return ((f - s) / s) * 100.0
+
+
+# ── the thesis (gate on full stack, then spread + SM scoring) ──
+
+def build_thesis(coin, candles_15m, candles_1h, candles_4h, sm, inputs):
+    """Port of v2 build_thesis. Returns a LONG thesis dict (with `score`) or
+    None. Sheep is long-only.
+
+    None is returned ONLY when the EMA stack count < minStackedFrames (the
+    only hard gate). minScore is applied by the CALLER (scan.py), not here.
+
+    `sm` is the smart-money tuple (direction, tilt_pct) or (None, 0) — the
+    caller fetches it (leaderboard_get_markets); SM is a BONUS, never a gate.
+    """
+    fast = int(inputs.get("emaFast", 9))
+    slow = int(inputs.get("emaSlow", 21))
+    min_stacked = int(inputs.get("minStackedFrames", 3))
+    sm_min = _f(inputs.get("smTiltMinPct", 55))
+    sm_strong = _f(inputs.get("smStrongTiltPct", 70))
+
+    cs_15m = closes(candles_15m)
+    cs_1h = closes(candles_1h)
+    cs_4h = closes(candles_4h)
+
+    stacks = [
+        is_stacked_bullish(cs_15m, fast, slow),
+        is_stacked_bullish(cs_1h, fast, slow),
+        is_stacked_bullish(cs_4h, fast, slow),
+    ]
+    score_stack = stack_score(stacks)
+    if score_stack < min_stacked:
+        return None
+
+    spread_4h = fast_slow_spread(cs_4h, fast, slow) or 0.0
+    spread_1h = fast_slow_spread(cs_1h, fast, slow) or 0.0
+
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+
+    # Score: base 3 for the full triple-stack, then spread + SM bonuses (verbatim)
+    s = 3
+    reasons = [f"{coin}_stack_15m_1h_4h", f"spread_4h_{spread_4h:+.2f}%"]
+    if spread_4h >= 1.0:
+        s += 1
+        reasons.append("trend_strong_4h")
+    if spread_1h >= 0.5:
+        s += 1
+        reasons.append("trend_strong_1h")
+    if sm_dir == "LONG" and sm_tilt >= sm_min:
+        s += 1
+        reasons.append(f"sm_long_{sm_tilt:.0f}%")
+        if sm_tilt >= sm_strong:
+            s += 1
+            reasons.append("sm_strong")
+
+    return {
+        "coin": coin,
+        "direction": "LONG",
+        "score": s,
+        "reasons": reasons,
+        "spread_4h_pct": round(spread_4h, 2),
+        "spread_1h_pct": round(spread_1h, 2),
+        "stack_score": score_stack,
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": _f(sm_tilt),
+    }

--- a/strategies/sheep/strategy.yaml
+++ b/strategies/sheep/strategy.yaml
@@ -1,0 +1,42 @@
+# Sheep — long-only triple-EMA-stacked trend follower. A single-instance PACKAGE:
+# this manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime
+# 3.0 port of the v2 Sheep (SKILL.md v1.0.0): fires LONG only when fast EMA > slow
+# EMA on ALL THREE timeframes (15m+1h+4h) for a crypto-majors whitelist
+# (BTC/ETH/SOL/HYPE). Never shorts. ONBOARDING TIER. Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: sheep
+version: "1.0.0"
+
+catalog:
+  name: "Sheep — Triple-EMA Trend Follower"
+  emoji: "🐑"
+  tagline: "A long-only trend follower for beginners: buys a crypto major (BTC/ETH/SOL/HYPE) only when its fast EMA is above its slow EMA on all three timeframes (15m, 1h, 4h) at once, never shorts, and trails a balanced stop so a clean uptrend can run."
+  belief_plain: "Only buys when a coin is clearly going up by any chart reader's standard — the fast moving average has to be above the slow one on the 15-minute, 1-hour, AND 4-hour chart simultaneously. It never shorts (so there's no 'what's a short?' to learn), bets a little bigger when the trend is wider and the best traders agree, and then trails a stop so a real uptrend can keep running."
+  thesis: "Most trend agents pick a single timeframe; Sheep insists on agreement across three before firing. That is a stricter filter (fewer trades) but each entry is 'obviously up' to any chart reader, which is exactly the property a beginner needs to trust the agent. Long-only by design removes the cognitive load of shorting, making this the onboarding-grade entry point into the fleet."
+  group: momentum
+  archetype: trend_following
+  sub_style: basket
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: basket
+  direction: long_only
+  risk_level: conservative
+  tier: starter
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 100
+  assets: ["BTC", "ETH", "SOL", "HYPE"]
+  tags: [btc, eth, sol, hype, multi-asset, trend, ema-stack, triple-timeframe, long-only, onboarding, smart-money, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: SHEEP_WALLET
+    funding_share: 1.0


### PR DESCRIPTION
Wave 3 of the v2→3.0 migration (44→56). 6 momentum/event snipers + 6 universe scanners.

Each: read-guarded MCP (incl. `market_list_instruments` on the scanners), marginPct percent, `data_retention_seconds` in range, canonical catalog taxonomy, no `__init__.py`. All 56 packages pass the modernized validator.

Catches: stale BTC-template (bobcat-class) corrected on lemur/salamander/raccoon; python byte-identical (8000/8000 indicator + 5000-snapshot parity). Glossary drift remains a separate fleet-wide reconciliation (tracked).