### PR TITLE
Runtime 3.0 Wave 4 (10 multi-instance funds, 21 instances) -> 66 strategies

### DIFF
--- a/strategies/boar/long/runtime.yaml
+++ b/strategies/boar/long/runtime.yaml
@@ -1,0 +1,131 @@
+# ── BOAR · LONG book — the HARD-MONEY leg (LONG scarce real assets) ──
+name: boar-long
+group: boar
+version: 3.0.0
+description: >
+  BOAR LONG — Hard Money vs Paper (debasement) thesis fund, the LONG leg (Runtime 3.0 port
+  of v2 Boar v1.0). This book LONGS scarce real assets — GOLD, BTC (digital gold), SILVER,
+  PLATINUM, PALLADIUM — what holds up when fiat is debased under fiscal dominance, but only
+  when ABSOLUTE trend confirms (4h structure not bearish + positive own momentum), with an
+  RSI blow-off guard. Cross-sectional relative strength tilts ranking/size but never benches
+  a genuinely-trending name. Per-name size = account_value * marginPct * conviction weight
+  (GOLD/BTC the 1.2x cores; thinner precious sized down). Pairs with the SHORT "paper" book
+  on a separate wallet; the P&L is the real-assets-beat-paper-claims spread. CAVEAT: the
+  loosest hedge of the family — in a liquidity melt-up gold AND stocks can rise together.
+  Metals/BTC trade 24/7 on Hyperliquid — no market-hours gating.
+
+strategy:
+  wallet: "${BOAR_LONG_WALLET}"
+  # ── FUNDING DEFAULT: net-long-hard-money tilt (the split is an OPERATOR decision set by
+  #    wallet funding, NOT a runtime field). This hard-money book defaults larger than the
+  #    paper book; fund 50/50 for a tighter (still imperfect) hedge. ──
+  slots: 4
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: boar_long_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — debasement-trend cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map
+    inputs:
+      leg: "long"
+      # ── Curated HARD-MONEY universe (validated against the live HL board, authoring time):
+      #    precious metals on XYZ + BTC on the main DEX. All 5 names confirmed live. ──
+      universe: ["xyz:GOLD", "BTC", "xyz:SILVER", "xyz:PLATINUM", "xyz:PALLADIUM"]
+      sizingWeights:
+        GOLD: 1.2          # core hard money
+        BTC: 1.2           # co-core (digital gold)
+        SILVER: 1.0
+        PLATINUM: 0.7      # thinner precious
+        PALLADIUM: 0.6     # thinner precious
+        _default: 1.0
+      minScore: 5
+      marginPct: 18          # PERCENT of withdrawable (0,100]; runtime sizes (marginPct/100 * weight)*withdrawable
+      maxLeverage: 5         # strict clamp, then each name's HL venue max (metals/BTC clamp lower, in-scan)
+      maxSlots: 4
+      rankPoolSize: 12       # small hard-money basket — score it all each tick
+      rsThresholdPct: 3.0
+      rsiOverbought: 84      # blow-off guard — don't chase an overbought have (v2 long-config)
+      volFloorPctOfMedian: 0.2
+      minUniverseForMedianGate: 5   # 5-name basket -> skip the median gate (Mongoose-bricking note)
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      weight: { type: number, required: false }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: boar_long_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # the scan already applied the universe + absolute-trend gate + RS tiebreaker + conviction size + venue clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [boar_long_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: boar_long_signals
+
+# ── EXIT (DSL — moderate; let the debasement trend run, cut reversers; ported VERBATIM from v2 runtime-long.yaml) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10080          # 7d — the debasement trend persists; let winners run
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h — cut a winner that peaked then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 960            # 16h — recycle a position going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 16.0                  # BTC vol in the metals basket
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 20,  lock_hw_pct: 40 }   # first LOCK — reachable
+        - { trigger_pct: 35,  lock_hw_pct: 60 }
+        - { trigger_pct: 60,  lock_hw_pct: 78 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6                # basket rotation as leadership shifts
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600                # v2 cooldown_minutes 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 14400     # v2 per_asset_cooldown_minutes 240

--- a/strategies/boar/long/scanners/scan.py
+++ b/strategies/boar/long/scanners/scan.py
@@ -1,0 +1,322 @@
+"""BOAR — supervised scanner (shared verbatim by both books).
+
+Direction-parametrized via inputs.leg: the `long` instance passes leg=long (the HARD-MONEY
+book — LONG scarce real assets: GOLD, BTC, SILVER, PLATINUM, PALLADIUM); the `short`
+instance passes leg=short (the PAPER book — SHORT the broad market + rate-sensitive growth:
+SP500, RIVN, DKNG, HIMS). A faithful Runtime 3.0 port of the v2 boar-producer.py main() —
+the thematic universe build + absolute-trend scoring + per-name conviction sizing are
+preserved exactly. Read-only, single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin)
+  2. build the live THEMATIC universe: the curated whitelist (config.universe) intersected
+     with the live instrument board + a relative-to-market liquidity floor — but the
+     median-vol gate is SKIPPED for small curated lists (< minUniverseForMedianGate names),
+     since on a tiny basket it drops an intentionally-thinner name and can collapse the
+     universe to 1 (v2 Mongoose-bricking note). The curation IS the liquidity decision.
+  3. rank the universe by 24h relative strength (own 24h return - the universe mean) — used
+     only as a SCORE TIEBREAKER; ABSOLUTE trend is the hard gate inside scoring
+  4. score each pooled name (absolute-trend gate, excess bonus), dedup held + recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT = base_margin_pct * conviction weight; the
+     runtime sizes the dollars) + a per-name venue-clamped leverage; the runtime owns slots,
+     dedup, execution, DSL.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (asia-ai NASDAQ-bug class). Per the scan
+contract ANY uncaught exception rolls the whole tick back to [], so one bad read would
+silently kill all emits — hence each read degrades to None/[] instead of propagating.
+
+FIDELITY NOTES vs boar-producer.py v1.0.0
+- DROPPED v2 order-lifecycle behaviour: none present in boar's producer (boar never called
+  cancel_order / has_resting_orders / stale-order purge — it only pushed signals), so
+  nothing to drop. The runtime's reconciliation owns order lifecycle.
+- v2 marginPct is a FRACTION (0.18 long / 0.15 short); this port carries it as a PERCENT
+  input (18 / 15). A defensive guard ×100's any value <= 1.0 (a pasted fraction).
+- Per-name conviction weight is BAKED INTO the emitted marginPct (see scoring.sizing_weight)
+  so the runtime reproduces v2's account_value * marginPct(fraction) * weight exactly.
+- The free-margin affordability cap is per-name (weight-aware), mirroring v2's
+  decrement-as-you-commit loop so a mixed-size basket never emits an un-fundable order.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[boar.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts and
+    makes every size 2x). Boar holds both xyz equities/metals and main-DEX BTC on the same
+    wallet, so both sections routinely carry positions. Free margin = equity - committed."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an
+    # EMPTY positions list is a corrupt read — sizing or held-dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return ─────────────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, vol (dayNtlVlm), ret24h}. Skips delisted. Verbatim v2
+    get_universe_meta() + ret_24h() + day_vol() folded together."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns
+    ([], []) and the universe loop skips it (asia-ai per-asset read-guard)."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate):
+    """The curated thematic whitelist intersected with the live board + a relative liquidity
+    floor (>= vol_floor_pct of the whitelist's median 24h vol; NO hardcoded $). v2-quirk:
+    SMALL curated lists (< min_for_gate live names) SKIP the median gate — on a tiny basket
+    it drops an intentionally-thinner name and can collapse the universe to 1, bricking the
+    book (v2 Mongoose short, 2026-06-22). Below the threshold, keep every live (vol>0) name —
+    the curation IS the liquidity decision. Verbatim v2 build_universe()."""
+    cand = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue                                        # not on the live board — drop
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        cand.append((name, vol))
+    if not cand:
+        return []
+    if len(cand) < int(min_for_gate):                       # v2-quirk: skip gate on small lists
+        return [n for n, _ in cand]
+    vols = sorted(v for _, v in cand)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in cand if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    whitelist = inputs.get("universe", [])
+    weights = inputs.get("sizingWeights", {"_default": 1.0})
+    min_score = int(inputs.get("minScore", 5))
+    base_margin_pct = float(inputs.get("marginPct", 18))     # PERCENT of withdrawable (0,100]
+    # defensive: a pasted v2 FRACTION (<= 1.0, e.g. 0.18) -> percent (dire/koala guard)
+    if base_margin_pct <= 1.0:
+        base_margin_pct *= 100.0
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 4))
+    rank_pool = int(inputs.get("rankPoolSize", 12))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    min_for_gate = int(inputs.get("minUniverseForMedianGate", 5))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent, "ts": now})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[boar.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist()
+        print(f"[boar.scan] leg={leg} WAITING — no account value / corrupt read",
+              file=sys.stderr)
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist()
+        print(f"[boar.scan] leg={leg} WAITING — slots full ({len(held)}/{max_slots})",
+              file=sys.stderr)
+        return []
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate)
+
+    # ── Cross-sectional relative strength over the thematic universe (used only as a score
+    #    TIEBREAKER; absolute trend is the gate inside scoring.score_thematic) ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = meta.get("ret24h") if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 1:                                          # v2-quirk: thematic universe too thin
+        _persist()
+        print(f"[boar.scan] leg={leg} WAITING — thematic universe too thin "
+              f"(scanned={len(universe)})", file=sys.stderr)
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=(leg == "long"))     # leaders first (long) / laggards first (short)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_thematic(name, c1, c4, excess, own, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist()
+        print(f"[boar.scan] leg={leg} WAITING — no name cleared min score {min_score} "
+              f"(scanned={len(universe)} pool={len(pool)} mean_rs={mean_rs:.2f})",
+              file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: emit best-scoring first, sizing each by its conviction weight, and cap to what
+    # the wallet can actually FUND. free margin decrements as we commit so a mixed basket of
+    # different-sized names never emits an un-fundable order (insufficient-funds re-emit spam).
+    out = []
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], weights)
+        margin_pct = base_margin_pct * weight                # conviction baked into the PERCENT
+        margin_usd = (margin_pct / 100.0) * account_value
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # per-name venue clamp
+        if margin_usd <= 0 or leverage <= 0:
+            continue
+        if margin_usd * 1.1 > free_margin:                   # 1.1 = fee/slippage headroom
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": round(margin_pct, 4),               # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                            # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "direction": direction,
+                "weight": weight,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+            },
+        })
+        open_slots -= 1
+        free_margin -= margin_usd * 1.1
+        recent[th["coin"].upper()] = now
+
+    _persist()
+    print(f"[boar.scan] leg={leg} scanned={len(universe)} pool={len(pool)} "
+          f"candidates={len(candidates)} emitted={len(out)} mean_rs={mean_rs:.2f} "
+          f"elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/boar/long/scanners/scoring.py
+++ b/strategies/boar/long/scanners/scoring.py
@@ -1,0 +1,221 @@
+"""BOAR — pure thematic-trend thesis math (no I/O, no MCP, no clock). Shared verbatim by
+both books; direction is passed in (`leg` = "long" for the HARD-MONEY book, "short" for
+the PAPER book). A faithful port of the v2 boar-producer.py scoring — the gates and the
+point weights are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is
+load-bearing and must NOT be redesigned). Unit-testable on plain candle lists.
+
+FIDELITY NOTES vs boar-producer.py v1.0.0
+- Boar's universe is THEMATIC (every name is already a thesis pick), so ABSOLUTE trend is
+  the HARD GATE and cross-sectional relative strength (`excess`) is only a BONUS tiebreaker
+  that never disqualifies a genuinely-trending name. This differs from Cougar (where the
+  excess SIGN is itself a hard gate). Ported exactly: a have with positive trend but
+  lagging peers still scores; a lagging name is `noted, not penalized`.
+- Per-name sizing weights (conviction multipliers) are preserved: v2 sized
+  `margin = account_value * marginPct(fraction) * weight`. This port emits a PERCENT
+  `marginPct` intent and BAKES the weight in: `marginPct_emit = base_margin_pct * weight`,
+  so the runtime's `(marginPct_emit/100) * accountValue` reproduces the v2 dollar size
+  exactly. Weight clamp [0.1, 3.0] is verbatim.
+- score is kept as the raw integer on data{}; v2's score/9.0 [0,1] wire normalisation is
+  the scaffold's job now (NORM_DIV retained for reference only).
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score.
+# The 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and
+# only retain NORM_DIV for the v2-equivalent normalised score if a caller wants it.
+NORM_DIV = 9.0
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def _bare(asset):
+    """Bare ticker for sizing-weight lookups: 'xyz:GOLD' -> 'GOLD'. Verbatim v2 _bare()."""
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_thematic(asset, candles_1h, candles_4h, excess, own24h, leg, inputs):
+    """ABSOLUTE-trend thematic score for one name, given its excess return vs the
+    leg-universe mean (`excess`, a BONUS tiebreaker only) and its own 24h return (`own24h`,
+    the absolute-momentum sign). Returns a thesis dict or None. The point weights + skip
+    gates are copied VERBATIM from the v2 boar-producer score_thematic() — do NOT redesign.
+
+    leg == "long":  long a HAVE (hard money) only while its 4h is NOT bearish (blow-off guard)
+    leg == "short": short a HAVE-NOT (paper) only while its 4h is NOT bullish (capitulation guard)
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if leg == "long":
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":                             # v2-quirk
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1                                      # v2-quirk: neutral 4h still scores
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")        # v2-quirk: noted, NOT penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 84))
+        if rsi > rsi_ob:                                    # v2-quirk: blow-off guard
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":                             # v2-quirk
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1                                      # v2-quirk: neutral 4h still scores
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")       # v2-quirk: noted, NOT penalized
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:                                    # v2-quirk: capitulation guard
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+def sizing_weight(asset, weights):
+    """Per-group conviction multiplier (GOLD/BTC the cores, thin precious + meme shorts down).
+    Keyed by bare ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim v2
+    sizing_weight() — load-bearing: the per-name conviction sizing IS the thesis."""
+    if not isinstance(weights, dict):
+        weights = {"_default": 1.0}
+    try:
+        w = float(weights.get(_bare(asset), weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: metals/equities cap
+    LOWER at the venue than crypto — over-leveraging a name is a venue reject, so this clamp
+    is load-bearing, not cosmetic. Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/boar/short/runtime.yaml
+++ b/strategies/boar/short/runtime.yaml
@@ -1,0 +1,128 @@
+# ── BOAR · SHORT book — the PAPER leg (the hedge: SHORT the paper economy) ──
+name: boar-short
+group: boar
+version: 3.0.0
+description: >
+  BOAR SHORT — Hard Money vs Paper (debasement) thesis fund, the SHORT leg / the hedge
+  (Runtime 3.0 port of v2 Boar v1.0). This book SHORTS the "paper" economy — the broad
+  market via the SP500 index PLUS rate-sensitive long-duration growth (RIVN, DKNG, HIMS) —
+  the fiat-denominated financial claims that lose most as the term premium rises under
+  fiscal dominance, but only when ABSOLUTE trend confirms (4h structure not bullish +
+  negative own momentum), with a CAPITULATION guard so it never shorts an exhausted bottom.
+  Per-name size = account_value * marginPct * conviction weight (SP500 1.2x anchor; growth
+  names 0.6x — small + squeeze-prone). Pairs with the LONG hard-money book on a separate
+  wallet; the P&L is the real-assets-beat-paper-claims spread. The rate-sensitive tilt
+  tightens the debasement hedge vs a pure index short. Tokenized equities/indices trade
+  24/7 on Hyperliquid — no market-hours gating.
+
+strategy:
+  wallet: "${BOAR_SHORT_WALLET}"
+  # ── FUNDING DEFAULT: net-long-hard-money tilt (the split is an OPERATOR decision set by
+  #    wallet funding, NOT a runtime field). This paper book defaults the same slots (4) but
+  #    lower leverage (4x) than the hard-money book; fund 50/50 for a tighter hedge. ──
+  slots: 4
+  default_leverage: 4
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: boar_short_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — debasement-trend cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map
+    inputs:
+      leg: "short"
+      # ── Curated PAPER universe (validated against the live HL board, authoring time):
+      #    SP500 broad-market anchor + rate-sensitive growth on XYZ. All 4 names confirmed live. ──
+      universe: ["xyz:SP500", "xyz:RIVN", "xyz:DKNG", "xyz:HIMS"]
+      sizingWeights:
+        SP500: 1.2         # broad paper-claims anchor
+        _default: 0.6      # rate-sensitive growth — small + squeeze-prone
+      minScore: 5
+      marginPct: 15          # PERCENT of withdrawable (0,100]; runtime sizes (marginPct/100 * weight)*withdrawable
+      maxLeverage: 4         # strict clamp (short squeezes are violent), then each name's HL venue max (in-scan)
+      maxSlots: 4
+      rankPoolSize: 8        # v2 short-config rankPoolSize
+      rsThresholdPct: 3.0
+      rsiOversold: 18        # capitulation guard — never short an exhausted bottom
+      volFloorPctOfMedian: 0.2
+      minUniverseForMedianGate: 5   # 4-name basket -> skip the median gate (Mongoose-bricking note)
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      weight: { type: number, required: false }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: boar_short_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # the scan already applied the universe + absolute-downtrend gate + capitulation guard + RS tiebreaker + conviction size + venue clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [boar_short_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: boar_short_signals
+
+# ── EXIT (DSL — tighter; short theses decay faster, squeezes are violent; ported VERBATIM from v2 runtime-short.yaml) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 7200           # 5d — shorter than the long book
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h — cut a short that bottomed then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 720            # 12h — recycle a short going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                  # tighter than long book — squeeze protection
+      retrace_threshold: 7
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 18,  lock_hw_pct: 45 }   # first LOCK — reachable
+        - { trigger_pct: 35,  lock_hw_pct: 65 }
+        - { trigger_pct: 60,  lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 5
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 5400                # v2 cooldown_minutes 90
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 18000     # v2 per_asset_cooldown_minutes 300

--- a/strategies/boar/short/scanners/scan.py
+++ b/strategies/boar/short/scanners/scan.py
@@ -1,0 +1,322 @@
+"""BOAR — supervised scanner (shared verbatim by both books).
+
+Direction-parametrized via inputs.leg: the `long` instance passes leg=long (the HARD-MONEY
+book — LONG scarce real assets: GOLD, BTC, SILVER, PLATINUM, PALLADIUM); the `short`
+instance passes leg=short (the PAPER book — SHORT the broad market + rate-sensitive growth:
+SP500, RIVN, DKNG, HIMS). A faithful Runtime 3.0 port of the v2 boar-producer.py main() —
+the thematic universe build + absolute-trend scoring + per-name conviction sizing are
+preserved exactly. Read-only, single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin)
+  2. build the live THEMATIC universe: the curated whitelist (config.universe) intersected
+     with the live instrument board + a relative-to-market liquidity floor — but the
+     median-vol gate is SKIPPED for small curated lists (< minUniverseForMedianGate names),
+     since on a tiny basket it drops an intentionally-thinner name and can collapse the
+     universe to 1 (v2 Mongoose-bricking note). The curation IS the liquidity decision.
+  3. rank the universe by 24h relative strength (own 24h return - the universe mean) — used
+     only as a SCORE TIEBREAKER; ABSOLUTE trend is the hard gate inside scoring
+  4. score each pooled name (absolute-trend gate, excess bonus), dedup held + recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT = base_margin_pct * conviction weight; the
+     runtime sizes the dollars) + a per-name venue-clamped leverage; the runtime owns slots,
+     dedup, execution, DSL.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (asia-ai NASDAQ-bug class). Per the scan
+contract ANY uncaught exception rolls the whole tick back to [], so one bad read would
+silently kill all emits — hence each read degrades to None/[] instead of propagating.
+
+FIDELITY NOTES vs boar-producer.py v1.0.0
+- DROPPED v2 order-lifecycle behaviour: none present in boar's producer (boar never called
+  cancel_order / has_resting_orders / stale-order purge — it only pushed signals), so
+  nothing to drop. The runtime's reconciliation owns order lifecycle.
+- v2 marginPct is a FRACTION (0.18 long / 0.15 short); this port carries it as a PERCENT
+  input (18 / 15). A defensive guard ×100's any value <= 1.0 (a pasted fraction).
+- Per-name conviction weight is BAKED INTO the emitted marginPct (see scoring.sizing_weight)
+  so the runtime reproduces v2's account_value * marginPct(fraction) * weight exactly.
+- The free-margin affordability cap is per-name (weight-aware), mirroring v2's
+  decrement-as-you-commit loop so a mixed-size basket never emits an un-fundable order.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[boar.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts and
+    makes every size 2x). Boar holds both xyz equities/metals and main-DEX BTC on the same
+    wallet, so both sections routinely carry positions. Free margin = equity - committed."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an
+    # EMPTY positions list is a corrupt read — sizing or held-dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return ─────────────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, vol (dayNtlVlm), ret24h}. Skips delisted. Verbatim v2
+    get_universe_meta() + ret_24h() + day_vol() folded together."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns
+    ([], []) and the universe loop skips it (asia-ai per-asset read-guard)."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate):
+    """The curated thematic whitelist intersected with the live board + a relative liquidity
+    floor (>= vol_floor_pct of the whitelist's median 24h vol; NO hardcoded $). v2-quirk:
+    SMALL curated lists (< min_for_gate live names) SKIP the median gate — on a tiny basket
+    it drops an intentionally-thinner name and can collapse the universe to 1, bricking the
+    book (v2 Mongoose short, 2026-06-22). Below the threshold, keep every live (vol>0) name —
+    the curation IS the liquidity decision. Verbatim v2 build_universe()."""
+    cand = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue                                        # not on the live board — drop
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        cand.append((name, vol))
+    if not cand:
+        return []
+    if len(cand) < int(min_for_gate):                       # v2-quirk: skip gate on small lists
+        return [n for n, _ in cand]
+    vols = sorted(v for _, v in cand)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in cand if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    whitelist = inputs.get("universe", [])
+    weights = inputs.get("sizingWeights", {"_default": 1.0})
+    min_score = int(inputs.get("minScore", 5))
+    base_margin_pct = float(inputs.get("marginPct", 18))     # PERCENT of withdrawable (0,100]
+    # defensive: a pasted v2 FRACTION (<= 1.0, e.g. 0.18) -> percent (dire/koala guard)
+    if base_margin_pct <= 1.0:
+        base_margin_pct *= 100.0
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 4))
+    rank_pool = int(inputs.get("rankPoolSize", 12))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    min_for_gate = int(inputs.get("minUniverseForMedianGate", 5))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent, "ts": now})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[boar.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist()
+        print(f"[boar.scan] leg={leg} WAITING — no account value / corrupt read",
+              file=sys.stderr)
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist()
+        print(f"[boar.scan] leg={leg} WAITING — slots full ({len(held)}/{max_slots})",
+              file=sys.stderr)
+        return []
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate)
+
+    # ── Cross-sectional relative strength over the thematic universe (used only as a score
+    #    TIEBREAKER; absolute trend is the gate inside scoring.score_thematic) ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = meta.get("ret24h") if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 1:                                          # v2-quirk: thematic universe too thin
+        _persist()
+        print(f"[boar.scan] leg={leg} WAITING — thematic universe too thin "
+              f"(scanned={len(universe)})", file=sys.stderr)
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=(leg == "long"))     # leaders first (long) / laggards first (short)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_thematic(name, c1, c4, excess, own, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist()
+        print(f"[boar.scan] leg={leg} WAITING — no name cleared min score {min_score} "
+              f"(scanned={len(universe)} pool={len(pool)} mean_rs={mean_rs:.2f})",
+              file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: emit best-scoring first, sizing each by its conviction weight, and cap to what
+    # the wallet can actually FUND. free margin decrements as we commit so a mixed basket of
+    # different-sized names never emits an un-fundable order (insufficient-funds re-emit spam).
+    out = []
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], weights)
+        margin_pct = base_margin_pct * weight                # conviction baked into the PERCENT
+        margin_usd = (margin_pct / 100.0) * account_value
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # per-name venue clamp
+        if margin_usd <= 0 or leverage <= 0:
+            continue
+        if margin_usd * 1.1 > free_margin:                   # 1.1 = fee/slippage headroom
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": round(margin_pct, 4),               # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                            # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "direction": direction,
+                "weight": weight,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+            },
+        })
+        open_slots -= 1
+        free_margin -= margin_usd * 1.1
+        recent[th["coin"].upper()] = now
+
+    _persist()
+    print(f"[boar.scan] leg={leg} scanned={len(universe)} pool={len(pool)} "
+          f"candidates={len(candidates)} emitted={len(out)} mean_rs={mean_rs:.2f} "
+          f"elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/boar/short/scanners/scoring.py
+++ b/strategies/boar/short/scanners/scoring.py
@@ -1,0 +1,221 @@
+"""BOAR — pure thematic-trend thesis math (no I/O, no MCP, no clock). Shared verbatim by
+both books; direction is passed in (`leg` = "long" for the HARD-MONEY book, "short" for
+the PAPER book). A faithful port of the v2 boar-producer.py scoring — the gates and the
+point weights are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is
+load-bearing and must NOT be redesigned). Unit-testable on plain candle lists.
+
+FIDELITY NOTES vs boar-producer.py v1.0.0
+- Boar's universe is THEMATIC (every name is already a thesis pick), so ABSOLUTE trend is
+  the HARD GATE and cross-sectional relative strength (`excess`) is only a BONUS tiebreaker
+  that never disqualifies a genuinely-trending name. This differs from Cougar (where the
+  excess SIGN is itself a hard gate). Ported exactly: a have with positive trend but
+  lagging peers still scores; a lagging name is `noted, not penalized`.
+- Per-name sizing weights (conviction multipliers) are preserved: v2 sized
+  `margin = account_value * marginPct(fraction) * weight`. This port emits a PERCENT
+  `marginPct` intent and BAKES the weight in: `marginPct_emit = base_margin_pct * weight`,
+  so the runtime's `(marginPct_emit/100) * accountValue` reproduces the v2 dollar size
+  exactly. Weight clamp [0.1, 3.0] is verbatim.
+- score is kept as the raw integer on data{}; v2's score/9.0 [0,1] wire normalisation is
+  the scaffold's job now (NORM_DIV retained for reference only).
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score.
+# The 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and
+# only retain NORM_DIV for the v2-equivalent normalised score if a caller wants it.
+NORM_DIV = 9.0
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def _bare(asset):
+    """Bare ticker for sizing-weight lookups: 'xyz:GOLD' -> 'GOLD'. Verbatim v2 _bare()."""
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_thematic(asset, candles_1h, candles_4h, excess, own24h, leg, inputs):
+    """ABSOLUTE-trend thematic score for one name, given its excess return vs the
+    leg-universe mean (`excess`, a BONUS tiebreaker only) and its own 24h return (`own24h`,
+    the absolute-momentum sign). Returns a thesis dict or None. The point weights + skip
+    gates are copied VERBATIM from the v2 boar-producer score_thematic() — do NOT redesign.
+
+    leg == "long":  long a HAVE (hard money) only while its 4h is NOT bearish (blow-off guard)
+    leg == "short": short a HAVE-NOT (paper) only while its 4h is NOT bullish (capitulation guard)
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if leg == "long":
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":                             # v2-quirk
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1                                      # v2-quirk: neutral 4h still scores
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")        # v2-quirk: noted, NOT penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 84))
+        if rsi > rsi_ob:                                    # v2-quirk: blow-off guard
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":                             # v2-quirk
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1                                      # v2-quirk: neutral 4h still scores
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")       # v2-quirk: noted, NOT penalized
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:                                    # v2-quirk: capitulation guard
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+def sizing_weight(asset, weights):
+    """Per-group conviction multiplier (GOLD/BTC the cores, thin precious + meme shorts down).
+    Keyed by bare ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim v2
+    sizing_weight() — load-bearing: the per-name conviction sizing IS the thesis."""
+    if not isinstance(weights, dict):
+        weights = {"_default": 1.0}
+    try:
+        w = float(weights.get(_bare(asset), weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: metals/equities cap
+    LOWER at the venue than crypto — over-leveraging a name is a venue reject, so this clamp
+    is load-bearing, not cosmetic. Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/boar/strategy.yaml
+++ b/strategies/boar/strategy.yaml
@@ -1,0 +1,48 @@
+# Boar — Hard Money vs Paper (debasement) long/short thesis fund. A two-instance PACKAGE:
+# this manifest + two self-contained runtime.yaml books (long "hard money" / short "paper"
+# on SEPARATE wallets, so the longs and shorts can coexist) + per-instance scanners/ (the
+# scan.py + scoring.py are shared verbatim; direction is parametrized by inputs.leg). A
+# faithful Runtime 3.0 port of the v2 Boar v1.0 thematic absolute-trend engine over a curated
+# hard-money basket (LONG) and paper basket (SHORT) on Hyperliquid (XYZ + main DEX).
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: boar
+version: "1.0.0"
+
+catalog:
+  name: "Boar — Hard Money vs Paper"
+  emoji: "🥇"
+  tagline: "Bets on currency debasement: LONGS scarce real assets (GOLD, BTC, SILVER, PLATINUM, PALLADIUM) on the hard-money wallet and SHORTS the paper economy (SP500 + rate-sensitive growth RIVN/DKNG/HIMS) on the paper wallet — each leg trend-confirmed and conviction-sized. The P&L is the real-assets-beat-paper-claims spread."
+  belief_plain: "Buys gold, bitcoin and other scarce real assets while shorting the broad stock market and rate-sensitive growth stocks at the same time, on two separate wallets, betting that as governments run big deficits and rates stay high, hard money beats paper claims."
+  thesis: "Fiscal dominance / currency debasement: as deficits compound and the term premium rises, scarce real assets (gold, BTC, silver) outperform fiat-denominated financial claims. Express it as a long/short — long hard money, short paper — so the edge is the spread, not market direction. Each name only trades when its own absolute 4h/1h trend confirms (cross-sectional relative strength only tilts ranking and size). HONEST CAVEAT: the loosest hedge of the family — in a pure liquidity melt-up gold AND stocks can rise together; the short tilts to rate-sensitive names to tighten it. Best deployed as a tilt, not a market-neutral bet."
+  group: multi-asset-whitelist
+  archetype: trend_following      # absolute trend is the HARD gate per leg; wide let-winners-run DSL
+  sub_style: basket               # curated thematic whitelist baskets (hard money / paper), conviction-weighted
+  asset_classes: [commodities, btc_eth, indices, xyz_equities]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 8
+  min_budget: 400
+  assets: ["xyz:GOLD", "BTC", "xyz:SILVER", "xyz:PLATINUM", "xyz:PALLADIUM", "xyz:SP500", "xyz:RIVN", "xyz:DKNG", "xyz:HIMS"]
+  tags: [debasement, hard-money, gold, btc, silver, metals, sp500, hedge-fund, long-short, thematic, trend-confirmed, conviction-sizing, xyz]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: long
+    runtime: long/runtime.yaml
+    wallet_env: BOAR_LONG_WALLET
+    funding_share: 0.5
+  - name: short
+    runtime: short/runtime.yaml
+    wallet_env: BOAR_SHORT_WALLET
+    funding_share: 0.5

--- a/strategies/camel/harvest/runtime.yaml
+++ b/strategies/camel/harvest/runtime.yaml
@@ -1,0 +1,124 @@
+# ── CAMEL · HARVEST book — SHORT the most-positive-funding names (short collects funding) ──
+name: camel-harvest
+group: camel
+version: 3.0.0
+description: >
+  CAMEL HARVEST — funding-carry hedge fund, SHORT book (Runtime 3.0 port of v2 Camel v1.0).
+  This book ranks the liquid main-DEX crypto cross-section by FUNDING descending and SHORTS
+  the most-positive-funding names (longs pay shorts -> the short COLLECTS the funding), gated
+  so it never shorts a fresh 4h uptrend (squeeze risk dwarfs the carry) — it prefers crowded
+  longs that are rolling over (4h bearish/neutral, RSI overbought, 24h turning down). Pairs
+  with the PAYOUT book on a separate, equally-funded wallet; the two skew the fund slightly
+  net-neutral. The edge is CARRY (a recurring funding inefficiency), with trend/RSI as
+  exhaustion confirmation + risk control — NOT market direction. SHORT only.
+
+strategy:
+  wallet: "${CAMEL_HARVEST_WALLET}"
+  slots: 4
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: camel_harvest_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — carry cadence (keep turnover modest)
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map (recent-signals.json -> ctx.state)
+    inputs:
+      leg: "harvest"
+      minScore: 4
+      marginPct: 18          # PERCENT of withdrawable (0,100]; runtime sizes (marginPct/100)*withdrawable. v2 fraction 0.18 -> 18
+      maxLeverage: 5         # strict clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 4
+      rankPoolSize: 12       # only the top-12 by funding get candles for confirmation
+      universeMaxNames: 60   # cap the liquid main-DEX crypto cohort to the top 60 by 24h vol
+      volFloorPctOfMedian: 0.2
+      minNotionalPctOfEquity: 0.01
+      venueMinNotionalUsd: 10
+      # Funding entry floor + tiers (HOURLY decimal). 0.00003/hr ~= 26%/yr.
+      fundingFloorHourly: 0.00003
+      fundingTier2Hourly: 0.00006        # ~53%/yr
+      fundingTier3Hourly: 0.0001         # ~88%/yr
+      rsiOverbought: 70                  # exhaustion confirmation for shorts
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      fundingAnnPct: { type: number, required: false }
+      own24h: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: camel_harvest_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # scan already applied funding rank + 4h/RSI gate + clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [camel_harvest_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: camel_harvest_signals
+
+# ── EXIT (DSL — carry management, tighter than a momentum leg; ported VERBATIM from v2) ──
+# Carry P&L per period is small, so a price loss must be cut before it dwarfs the funding
+# collected. Tight phase1; lock funding gains as the fade works; stall-cuts ON (a flat carry
+# position is recycled into a fresher extreme); 3d timeout (funding regimes decay).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 4320           # 3d — funding regimes decay
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 240            # 4h
+      min_value: 1.5
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h — recycle a flat carry position
+    phase1:
+      enabled: true
+      max_loss_pct: 10.0
+      retrace_threshold: 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 6, lock_hw_pct: 0 }     # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 14, lock_hw_pct: 45 }   # first LOCK — reachable
+        - { trigger_pct: 28, lock_hw_pct: 65 }
+        - { trigger_pct: 50, lock_hw_pct: 80 }
+        - { trigger_pct: 90, lock_hw_pct: 90 }
+
+risk:
+  data_retention_seconds: 345600       # 96h (was data_retention_hours: 96)
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 6
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600                # v2 cooldown_minutes 60
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 10800     # v2 per_asset_cooldown_minutes 180

--- a/strategies/camel/harvest/scanners/scan.py
+++ b/strategies/camel/harvest/scanners/scan.py
@@ -1,0 +1,343 @@
+"""CAMEL — supervised scanner (shared VERBATIM by both books; this file is byte-identical
+in harvest/ and payout/). Direction-parametrized via the `leg` input: the `harvest`
+instance passes leg="harvest" (SHORT the most-positive-funding names — short collects the
+funding) and the `payout` instance passes leg="payout" (LONG the most-negative-funding
+names — long gets paid to hold). A faithful Runtime 3.0 port of the v2 camel-producer.py:
+the funding rank + carry scoring + leverage clamp + affordability cap are preserved exactly.
+Read-only, single-pass — no daemon, no push_signal, no create_position, no order lifecycle.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin)
+  2. build the live universe ONCE: all liquid main-DEX crypto perps on the live instrument
+     board (XYZ excluded — XYZ funding is sparse), capped to universeMaxNames by 24h volume,
+     then a relative liquidity floor (>= volFloorPctOfMedian of the cohort median; NO $ floor)
+  3. rank that universe by FUNDING — harvest: DESC (most positive); payout: ASC (most
+     negative) — and take the top rankPoolSize
+  4. fetch 1h+4h candles for each pooled name, score with the v2 carry gates, dedup held +
+     recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT, the runtime sizes) + a per-name
+     venue-clamped leverage; the runtime owns slots, dedup, execution, DSL.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (per the contract ANY exception rolls the tick
+back to []). The universe is built live from the instrument board, so a name that delists or
+goes thin between the board pull and a per-asset candle fetch is skipped, not fatal.
+
+FIDELITY NOTES vs camel-producer.py v1.0.0:
+  - DROPPED v2's order-lifecycle / re-emit-spam plumbing that depended on MUTATIONS or daemon
+    state: v2 wrote a recent-signals JSON file (race-window dedup) — ported to ctx.state
+    (same 180s TTL semantics). v2 had no cancel_order/has_resting_orders, so nothing
+    mutation-bearing was dropped beyond the daemon loop + push_signal + the JSON cache file.
+  - v2 config stored marginPct as a FRACTION (0.18). This port treats inputs.marginPct as a
+    PERCENT (18) and emits top-level marginPct; the runtime sizes (marginPct/100)*withdrawable.
+    The runtime.yaml inputs ship marginPct: 18. A defensive guard converts a value <= 1.0
+    (a pasted fraction) to a percent so a mis-set config can't silently 1/100th the size.
+  - v2 computed margin_usd = account_value * margin_pct then affordability off free margin.
+    This port emits the marginPct INTENT (runtime owns the $ sizing) but preserves the v2
+    affordability cap so an open slot with no free margin doesn't re-emit an un-fillable order
+    every tick — sized as (marginPct/100)*accountValue per name + 1.1 fee/slippage headroom.
+  - v2 minNotional gate (max(accountValue*minNotionalPctOfEquity, venueMinNotionalUsd) vs
+    marginPct*leverage) is preserved: drop a pooled name whose intended notional is below the
+    HL venue minimum order value.
+  - v2's first-seen ledger helpers were declared-but-UNUSED scaffold; not ported.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+HOURS_PER_YEAR = scoring.HOURS_PER_YEAR
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[camel.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+def _f(v):
+    try:
+        return float(v or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts and
+    makes every size 2x). Free margin = equity - committed margin. READ-GUARDED."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, _f(ms.get("accountValue", 0)))
+        used = max(used, _f(ms.get("totalMarginUsed", 0)), abs(_f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = _f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": _f(pos.get("marginUsed", 0)),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an
+    # EMPTY positions list is a corrupt read — sizing or running the held-dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        print("[camel.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + funding + 24h vol + 24h return ───────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, funding, vol, ret24h}. Skips delisted + XYZ. One instrument-
+    board call carries funding / markPx / prevDayPx / dayNtlVlm per asset. Verbatim v2
+    get_universe_meta() + funding_hourly() + ret_24h() + day_vol() folded together."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out, canonical = {}, []
+    if not resp:
+        return out, canonical
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name or not isinstance(name, str):
+            continue
+        if name.lower().startswith("xyz:"):                 # v2-quirk: XYZ excluded (funding sparse)
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        mark, prev = _f(ctxd.get("markPx", 0)), _f(ctxd.get("prevDayPx", 0))
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else 0.0
+        try:
+            funding = float(ctxd.get("funding", 0) or 0)
+        except (TypeError, ValueError):
+            funding = None
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "funding": funding,
+            "vol": _f(ctxd.get("dayNtlVlm", 0)),
+            "ret24h": ret24,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+        canonical.append(name)
+    return out, canonical
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset. Guarded — a bad name returns ([], []) and the loop
+    skips it. Verbatim v2 fetch_candles(["1h","4h"])."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    if isinstance(resp, dict) and resp.get("success") is False:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(canonical, meta_map, max_names, vol_floor_pct):
+    """Liquid main-DEX crypto perps (XYZ already excluded in _get_universe_meta), capped to
+    the top max_names by 24h volume, then a relative liquidity floor (>= vol_floor_pct of the
+    top-N cohort median; NO hardcoded $). Verbatim v2 build_universe()."""
+    seen, pool = set(), []
+    for name in canonical:
+        if not isinstance(name, str):
+            continue
+        key = name.upper()
+        if key in seen:
+            continue
+        meta = meta_map.get(name) or meta_map.get(key)
+        if not meta:
+            continue
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        seen.add(key)
+        pool.append((name, vol))
+    pool.sort(key=lambda x: x[1], reverse=True)
+    pool = pool[:max_names]
+    if not pool:
+        return []
+    vols = sorted(v for _, v in pool)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in pool if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "harvest") or "harvest").strip().lower()
+    direction = "SHORT" if leg == "harvest" else "LONG"
+    min_score = int(inputs.get("minScore", 4))
+
+    # marginPct is a PERCENT in (0,100]. v2 stored it as a FRACTION (0.18); a defensive
+    # guard converts a pasted fraction (<= 1.0) to a percent so a mis-set config can't
+    # silently 1/100th the size (dire/koala guard).
+    margin_pct = float(inputs.get("marginPct", 18))
+    if 0 < margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 4))
+    rank_pool = int(inputs.get("rankPoolSize", 12))
+    max_names = int(inputs.get("universeMaxNames", 60))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    min_notional_pct = float(inputs.get("minNotionalPctOfEquity", 0.01))
+    venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[camel.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist()
+        return []                                            # no value / corrupt read — skip tick
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist()
+        print(f"[camel.scan] leg={leg} WAITING — slots full ({len(held)}/{max_slots})",
+              file=sys.stderr)
+        return []                                            # book full — runtime also caps via slots
+
+    meta_map, canonical = _get_universe_meta(ctx)
+    universe = _build_universe(canonical, meta_map, max_names, vol_floor_pct)
+
+    # ── Rank by FUNDING (no candle fetch): harvest = most POSITIVE, payout = most NEGATIVE ──
+    funded = []  # (name, funding, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        f = meta.get("funding") if meta else None
+        if f is None:
+            continue
+        funded.append((name, f, meta))
+    if len(funded) < 3:                                      # v2-quirk: too thin to rank funding
+        _persist()
+        print(f"[camel.scan] leg={leg} WAITING — no funding data to rank (universe={len(universe)})",
+              file=sys.stderr)
+        return []
+
+    funded.sort(key=lambda x: x[1], reverse=(leg == "harvest"))
+    pool = funded[:rank_pool]
+
+    candidates = []
+    for name, f, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        own = meta.get("ret24h") if meta else 0.0
+        thesis = scoring.score_carry(name, c1, c4, f, own, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist()
+        top_ann = round(pool[0][1] * HOURS_PER_YEAR * 100, 1) if pool else 0
+        print(f"[camel.scan] leg={leg} WAITING — no name cleared min score {min_score}; "
+              f"scanned={len(universe)} pool={len(pool)} top_funding_annpct={top_ann}",
+              file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: never emit more than the wallet can actually FUND. An open slot with no free
+    # margin re-emits an un-fillable order every tick (insufficient-funds spam). free margin
+    # sized as (marginPct/100)*accountValue per name + 1.1 fee/slippage headroom.
+    per_name_margin = (margin_pct / 100.0) * account_value
+    affordable = int(free_margin / (per_name_margin * 1.1)) if per_name_margin > 0 else 0
+    to_emit = candidates[:max(0, min(open_slots, affordable))]
+
+    # v2 minNotional gate: drop a name whose intended notional is below the HL venue minimum.
+    min_notional = max(account_value * min_notional_pct, venue_min_notional)
+
+    out = []
+    for th in to_emit:
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # v2-quirk: per-name venue clamp
+        if leverage <= 0:
+            continue
+        notional = per_name_margin * leverage
+        if notional < min_notional:
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": margin_pct,                           # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                              # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "fundingAnnPct": round(th.get("fundingAnnPct", 0), 1),
+                "own24h": round(th.get("own24h", 0), 2),
+                "heldAssets": held,
+            },
+        })
+        recent[th["coin"].upper()] = now
+
+    _persist()
+    print(f"[camel.scan] leg={leg} EMIT={len(out)} scanned={len(universe)} pool={len(pool)} "
+          f"candidates={len(candidates)} open_slots={open_slots} "
+          f"top_funding_annpct={round(pool[0][1] * HOURS_PER_YEAR * 100, 1)} "
+          f"elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/camel/harvest/scanners/scoring.py
+++ b/strategies/camel/harvest/scanners/scoring.py
@@ -1,0 +1,192 @@
+"""CAMEL — pure funding-carry thesis math (no I/O, no MCP, no clock). Shared VERBATIM by
+both books (this file is byte-identical in harvest/ and payout/); the direction is passed
+in via `leg` ("harvest" = SHORT the most-positive-funding names that collect funding;
+"payout" = LONG the most-negative-funding names that get paid to hold). A faithful port of
+the v2 camel-producer.py scoring — the funding tiers, the 4h-trend gates, the RSI
+confirmation, and the 24h roll-over/bounce points are copied EXACTLY (marked `# v2-quirk`
+where the v2 behaviour is load-bearing and must not be redesigned). Unit-testable on plain
+candle lists.
+
+The edge is CARRY: funding magnitude drives the base score (1/2/3 tiers), with 4h trend +
+RSI + 24h direction as EXHAUSTION confirmation and a hard disqualify on a fresh trend
+against the carry (squeeze risk on the harvest short / knife-catch on the payout long).
+"""
+
+# Funding is HOURLY decimal in the instrument context; annualized = x 8760 (v2 HOURS_PER_YEAR).
+HOURS_PER_YEAR = 8760.0
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/8.0, 1.0) as the [0,1] wire score.
+# The 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and
+# only expose NORM_DIV for a caller that wants the v2-equivalent normalised score.
+NORM_DIV = 8.0
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows = BULLISH, lower-highs = BEARISH over the last `lookback`. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_carry(asset, candles_1h, candles_4h, fund, own24h, leg, inputs):
+    """Score one carry candidate. `fund` is the asset's HOURLY funding (decimal); `own24h`
+    is its 24h % return (from the instrument context). Returns a thesis dict or None
+    (None = disqualified). The point weights + skip gates are copied VERBATIM from the v2
+    camel-producer score_carry() — do NOT redesign.
+
+    leg == "harvest": SHORT the most-POSITIVE funding (short collects); needs fund >= floor;
+                      never short a fresh 4h uptrend (squeeze risk dwarfs the carry).
+    leg == "payout":  LONG the most-NEGATIVE funding (long gets paid); needs fund <= -floor;
+                      never long a fresh 4h downtrend (don't catch a knife).
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:          # v2-quirk: needs >=8 1h, >=6 4h
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    floor = float(inputs.get("fundingFloorHourly", 0.00003))
+    t2 = float(inputs.get("fundingTier2Hourly", 0.00006))
+    t3 = float(inputs.get("fundingTier3Hourly", 0.0001))
+    ann = fund * HOURS_PER_YEAR * 100.0                     # annualized %
+
+    trend4, s4 = trend_structure(candles_4h)
+    rsi = calc_rsi(closes1)
+
+    score = 0
+    reasons = []
+
+    if leg == "harvest":
+        # v2-quirk: need meaningful POSITIVE funding to short-collect.
+        if fund < floor:
+            return None
+        if fund >= t3:
+            score += 3
+        elif fund >= t2:
+            score += 2
+        else:
+            score += 1
+        reasons.append(f"funding_short_{ann:+.0f}%/yr")
+        # v2-quirk: never short a fresh uptrend — squeeze risk dwarfs the carry.
+        if trend4 == "BULLISH":
+            return None
+        if trend4 == "BEARISH":
+            score += 2
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        rsi_ob = float(inputs.get("rsiOverbought", 70))
+        if rsi >= rsi_ob:
+            score += 1
+            reasons.append(f"rsi_ob_{rsi:.0f}")
+        if own <= 0:
+            score += 1
+            reasons.append(f"rolling_over_{own:+.1f}%")
+        elif own >= 5:
+            score -= 1
+            reasons.append(f"still_ripping_{own:+.1f}%")
+    else:  # payout
+        # v2-quirk: need meaningful NEGATIVE funding to long-collect.
+        if fund > -floor:
+            return None
+        if fund <= -t3:
+            score += 3
+        elif fund <= -t2:
+            score += 2
+        else:
+            score += 1
+        reasons.append(f"funding_long_{ann:+.0f}%/yr")
+        # v2-quirk: never long a fresh downtrend — don't catch a knife.
+        if trend4 == "BEARISH":
+            return None
+        if trend4 == "BULLISH":
+            score += 2
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        rsi_os = float(inputs.get("rsiOversold", 30))
+        if rsi <= rsi_os:
+            score += 1
+            reasons.append(f"rsi_os_{rsi:.0f}")
+        if own >= 0:
+            score += 1
+            reasons.append(f"bouncing_{own:+.1f}%")
+        elif own <= -5:
+            score -= 1
+            reasons.append(f"still_crashing_{own:+.1f}%")
+
+    return {
+        "coin": asset,
+        "direction": "SHORT" if leg == "harvest" else "LONG",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "fundingAnnPct": ann,
+        "own24h": own,
+    }
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: per-name venue cap
+    is load-bearing (over-leveraging a thin name is a venue reject), not cosmetic. Verbatim
+    v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/camel/payout/runtime.yaml
+++ b/strategies/camel/payout/runtime.yaml
@@ -1,0 +1,124 @@
+# ── CAMEL · PAYOUT book — LONG the most-negative-funding names (long gets paid to hold) ──
+name: camel-payout
+group: camel
+version: 3.0.0
+description: >
+  CAMEL PAYOUT — funding-carry hedge fund, LONG book (Runtime 3.0 port of v2 Camel v1.0).
+  This book ranks the liquid main-DEX crypto cross-section by FUNDING ascending and LONGS the
+  most-negative-funding names (shorts pay longs -> the long gets PAID to hold), gated so it
+  never longs a fresh 4h downtrend (don't catch a knife) — it prefers crowded shorts that are
+  capitulating (4h bullish/neutral, RSI oversold, 24h bouncing). Pairs with the HARVEST book
+  on a separate, equally-funded wallet; the two skew the fund slightly net-neutral. The edge
+  is CARRY (a recurring funding inefficiency), with trend/RSI as exhaustion confirmation +
+  risk control — NOT market direction. LONG only.
+
+strategy:
+  wallet: "${CAMEL_PAYOUT_WALLET}"
+  slots: 4
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: camel_payout_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — carry cadence (keep turnover modest)
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map (recent-signals.json -> ctx.state)
+    inputs:
+      leg: "payout"
+      minScore: 4
+      marginPct: 18          # PERCENT of withdrawable (0,100]; runtime sizes (marginPct/100)*withdrawable. v2 fraction 0.18 -> 18
+      maxLeverage: 5         # strict clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 4
+      rankPoolSize: 12       # only the bottom-12 by funding get candles for confirmation
+      universeMaxNames: 60   # cap the liquid main-DEX crypto cohort to the top 60 by 24h vol
+      volFloorPctOfMedian: 0.2
+      minNotionalPctOfEquity: 0.01
+      venueMinNotionalUsd: 10
+      # Funding entry floor + tiers (HOURLY decimal). 0.00003/hr ~= 26%/yr (magnitude).
+      fundingFloorHourly: 0.00003
+      fundingTier2Hourly: 0.00006        # ~53%/yr
+      fundingTier3Hourly: 0.0001         # ~88%/yr
+      rsiOversold: 30                    # capitulation confirmation for longs
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      fundingAnnPct: { type: number, required: false }
+      own24h: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: camel_payout_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # scan already applied funding rank + 4h/RSI gate + clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [camel_payout_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: camel_payout_signals
+
+# ── EXIT (DSL — carry management, tighter than a momentum leg; ported VERBATIM from v2) ──
+# Carry P&L per period is small, so a price loss must be cut before it dwarfs the funding
+# collected. Tight phase1; lock funding gains as the bounce works; stall-cuts ON (a flat
+# carry position is recycled into a fresher extreme); 3d timeout (funding regimes decay).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 4320           # 3d — funding regimes decay
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 240            # 4h
+      min_value: 1.5
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h — recycle a flat carry position
+    phase1:
+      enabled: true
+      max_loss_pct: 10.0
+      retrace_threshold: 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 6, lock_hw_pct: 0 }     # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 14, lock_hw_pct: 45 }   # first LOCK — reachable
+        - { trigger_pct: 28, lock_hw_pct: 65 }
+        - { trigger_pct: 50, lock_hw_pct: 80 }
+        - { trigger_pct: 90, lock_hw_pct: 90 }
+
+risk:
+  data_retention_seconds: 345600       # 96h (was data_retention_hours: 96)
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 6
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600                # v2 cooldown_minutes 60
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 10800     # v2 per_asset_cooldown_minutes 180

--- a/strategies/camel/payout/scanners/scan.py
+++ b/strategies/camel/payout/scanners/scan.py
@@ -1,0 +1,343 @@
+"""CAMEL — supervised scanner (shared VERBATIM by both books; this file is byte-identical
+in harvest/ and payout/). Direction-parametrized via the `leg` input: the `harvest`
+instance passes leg="harvest" (SHORT the most-positive-funding names — short collects the
+funding) and the `payout` instance passes leg="payout" (LONG the most-negative-funding
+names — long gets paid to hold). A faithful Runtime 3.0 port of the v2 camel-producer.py:
+the funding rank + carry scoring + leverage clamp + affordability cap are preserved exactly.
+Read-only, single-pass — no daemon, no push_signal, no create_position, no order lifecycle.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin)
+  2. build the live universe ONCE: all liquid main-DEX crypto perps on the live instrument
+     board (XYZ excluded — XYZ funding is sparse), capped to universeMaxNames by 24h volume,
+     then a relative liquidity floor (>= volFloorPctOfMedian of the cohort median; NO $ floor)
+  3. rank that universe by FUNDING — harvest: DESC (most positive); payout: ASC (most
+     negative) — and take the top rankPoolSize
+  4. fetch 1h+4h candles for each pooled name, score with the v2 carry gates, dedup held +
+     recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT, the runtime sizes) + a per-name
+     venue-clamped leverage; the runtime owns slots, dedup, execution, DSL.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (per the contract ANY exception rolls the tick
+back to []). The universe is built live from the instrument board, so a name that delists or
+goes thin between the board pull and a per-asset candle fetch is skipped, not fatal.
+
+FIDELITY NOTES vs camel-producer.py v1.0.0:
+  - DROPPED v2's order-lifecycle / re-emit-spam plumbing that depended on MUTATIONS or daemon
+    state: v2 wrote a recent-signals JSON file (race-window dedup) — ported to ctx.state
+    (same 180s TTL semantics). v2 had no cancel_order/has_resting_orders, so nothing
+    mutation-bearing was dropped beyond the daemon loop + push_signal + the JSON cache file.
+  - v2 config stored marginPct as a FRACTION (0.18). This port treats inputs.marginPct as a
+    PERCENT (18) and emits top-level marginPct; the runtime sizes (marginPct/100)*withdrawable.
+    The runtime.yaml inputs ship marginPct: 18. A defensive guard converts a value <= 1.0
+    (a pasted fraction) to a percent so a mis-set config can't silently 1/100th the size.
+  - v2 computed margin_usd = account_value * margin_pct then affordability off free margin.
+    This port emits the marginPct INTENT (runtime owns the $ sizing) but preserves the v2
+    affordability cap so an open slot with no free margin doesn't re-emit an un-fillable order
+    every tick — sized as (marginPct/100)*accountValue per name + 1.1 fee/slippage headroom.
+  - v2 minNotional gate (max(accountValue*minNotionalPctOfEquity, venueMinNotionalUsd) vs
+    marginPct*leverage) is preserved: drop a pooled name whose intended notional is below the
+    HL venue minimum order value.
+  - v2's first-seen ledger helpers were declared-but-UNUSED scaffold; not ported.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+HOURS_PER_YEAR = scoring.HOURS_PER_YEAR
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[camel.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+def _f(v):
+    try:
+        return float(v or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts and
+    makes every size 2x). Free margin = equity - committed margin. READ-GUARDED."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, _f(ms.get("accountValue", 0)))
+        used = max(used, _f(ms.get("totalMarginUsed", 0)), abs(_f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = _f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": _f(pos.get("marginUsed", 0)),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an
+    # EMPTY positions list is a corrupt read — sizing or running the held-dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        print("[camel.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + funding + 24h vol + 24h return ───────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, funding, vol, ret24h}. Skips delisted + XYZ. One instrument-
+    board call carries funding / markPx / prevDayPx / dayNtlVlm per asset. Verbatim v2
+    get_universe_meta() + funding_hourly() + ret_24h() + day_vol() folded together."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out, canonical = {}, []
+    if not resp:
+        return out, canonical
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name or not isinstance(name, str):
+            continue
+        if name.lower().startswith("xyz:"):                 # v2-quirk: XYZ excluded (funding sparse)
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        mark, prev = _f(ctxd.get("markPx", 0)), _f(ctxd.get("prevDayPx", 0))
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else 0.0
+        try:
+            funding = float(ctxd.get("funding", 0) or 0)
+        except (TypeError, ValueError):
+            funding = None
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "funding": funding,
+            "vol": _f(ctxd.get("dayNtlVlm", 0)),
+            "ret24h": ret24,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+        canonical.append(name)
+    return out, canonical
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset. Guarded — a bad name returns ([], []) and the loop
+    skips it. Verbatim v2 fetch_candles(["1h","4h"])."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    if isinstance(resp, dict) and resp.get("success") is False:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(canonical, meta_map, max_names, vol_floor_pct):
+    """Liquid main-DEX crypto perps (XYZ already excluded in _get_universe_meta), capped to
+    the top max_names by 24h volume, then a relative liquidity floor (>= vol_floor_pct of the
+    top-N cohort median; NO hardcoded $). Verbatim v2 build_universe()."""
+    seen, pool = set(), []
+    for name in canonical:
+        if not isinstance(name, str):
+            continue
+        key = name.upper()
+        if key in seen:
+            continue
+        meta = meta_map.get(name) or meta_map.get(key)
+        if not meta:
+            continue
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        seen.add(key)
+        pool.append((name, vol))
+    pool.sort(key=lambda x: x[1], reverse=True)
+    pool = pool[:max_names]
+    if not pool:
+        return []
+    vols = sorted(v for _, v in pool)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in pool if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "harvest") or "harvest").strip().lower()
+    direction = "SHORT" if leg == "harvest" else "LONG"
+    min_score = int(inputs.get("minScore", 4))
+
+    # marginPct is a PERCENT in (0,100]. v2 stored it as a FRACTION (0.18); a defensive
+    # guard converts a pasted fraction (<= 1.0) to a percent so a mis-set config can't
+    # silently 1/100th the size (dire/koala guard).
+    margin_pct = float(inputs.get("marginPct", 18))
+    if 0 < margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 4))
+    rank_pool = int(inputs.get("rankPoolSize", 12))
+    max_names = int(inputs.get("universeMaxNames", 60))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    min_notional_pct = float(inputs.get("minNotionalPctOfEquity", 0.01))
+    venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[camel.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist()
+        return []                                            # no value / corrupt read — skip tick
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist()
+        print(f"[camel.scan] leg={leg} WAITING — slots full ({len(held)}/{max_slots})",
+              file=sys.stderr)
+        return []                                            # book full — runtime also caps via slots
+
+    meta_map, canonical = _get_universe_meta(ctx)
+    universe = _build_universe(canonical, meta_map, max_names, vol_floor_pct)
+
+    # ── Rank by FUNDING (no candle fetch): harvest = most POSITIVE, payout = most NEGATIVE ──
+    funded = []  # (name, funding, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        f = meta.get("funding") if meta else None
+        if f is None:
+            continue
+        funded.append((name, f, meta))
+    if len(funded) < 3:                                      # v2-quirk: too thin to rank funding
+        _persist()
+        print(f"[camel.scan] leg={leg} WAITING — no funding data to rank (universe={len(universe)})",
+              file=sys.stderr)
+        return []
+
+    funded.sort(key=lambda x: x[1], reverse=(leg == "harvest"))
+    pool = funded[:rank_pool]
+
+    candidates = []
+    for name, f, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        own = meta.get("ret24h") if meta else 0.0
+        thesis = scoring.score_carry(name, c1, c4, f, own, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist()
+        top_ann = round(pool[0][1] * HOURS_PER_YEAR * 100, 1) if pool else 0
+        print(f"[camel.scan] leg={leg} WAITING — no name cleared min score {min_score}; "
+              f"scanned={len(universe)} pool={len(pool)} top_funding_annpct={top_ann}",
+              file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: never emit more than the wallet can actually FUND. An open slot with no free
+    # margin re-emits an un-fillable order every tick (insufficient-funds spam). free margin
+    # sized as (marginPct/100)*accountValue per name + 1.1 fee/slippage headroom.
+    per_name_margin = (margin_pct / 100.0) * account_value
+    affordable = int(free_margin / (per_name_margin * 1.1)) if per_name_margin > 0 else 0
+    to_emit = candidates[:max(0, min(open_slots, affordable))]
+
+    # v2 minNotional gate: drop a name whose intended notional is below the HL venue minimum.
+    min_notional = max(account_value * min_notional_pct, venue_min_notional)
+
+    out = []
+    for th in to_emit:
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # v2-quirk: per-name venue clamp
+        if leverage <= 0:
+            continue
+        notional = per_name_margin * leverage
+        if notional < min_notional:
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": margin_pct,                           # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                              # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "fundingAnnPct": round(th.get("fundingAnnPct", 0), 1),
+                "own24h": round(th.get("own24h", 0), 2),
+                "heldAssets": held,
+            },
+        })
+        recent[th["coin"].upper()] = now
+
+    _persist()
+    print(f"[camel.scan] leg={leg} EMIT={len(out)} scanned={len(universe)} pool={len(pool)} "
+          f"candidates={len(candidates)} open_slots={open_slots} "
+          f"top_funding_annpct={round(pool[0][1] * HOURS_PER_YEAR * 100, 1)} "
+          f"elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/camel/payout/scanners/scoring.py
+++ b/strategies/camel/payout/scanners/scoring.py
@@ -1,0 +1,192 @@
+"""CAMEL — pure funding-carry thesis math (no I/O, no MCP, no clock). Shared VERBATIM by
+both books (this file is byte-identical in harvest/ and payout/); the direction is passed
+in via `leg` ("harvest" = SHORT the most-positive-funding names that collect funding;
+"payout" = LONG the most-negative-funding names that get paid to hold). A faithful port of
+the v2 camel-producer.py scoring — the funding tiers, the 4h-trend gates, the RSI
+confirmation, and the 24h roll-over/bounce points are copied EXACTLY (marked `# v2-quirk`
+where the v2 behaviour is load-bearing and must not be redesigned). Unit-testable on plain
+candle lists.
+
+The edge is CARRY: funding magnitude drives the base score (1/2/3 tiers), with 4h trend +
+RSI + 24h direction as EXHAUSTION confirmation and a hard disqualify on a fresh trend
+against the carry (squeeze risk on the harvest short / knife-catch on the payout long).
+"""
+
+# Funding is HOURLY decimal in the instrument context; annualized = x 8760 (v2 HOURS_PER_YEAR).
+HOURS_PER_YEAR = 8760.0
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/8.0, 1.0) as the [0,1] wire score.
+# The 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and
+# only expose NORM_DIV for a caller that wants the v2-equivalent normalised score.
+NORM_DIV = 8.0
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows = BULLISH, lower-highs = BEARISH over the last `lookback`. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_carry(asset, candles_1h, candles_4h, fund, own24h, leg, inputs):
+    """Score one carry candidate. `fund` is the asset's HOURLY funding (decimal); `own24h`
+    is its 24h % return (from the instrument context). Returns a thesis dict or None
+    (None = disqualified). The point weights + skip gates are copied VERBATIM from the v2
+    camel-producer score_carry() — do NOT redesign.
+
+    leg == "harvest": SHORT the most-POSITIVE funding (short collects); needs fund >= floor;
+                      never short a fresh 4h uptrend (squeeze risk dwarfs the carry).
+    leg == "payout":  LONG the most-NEGATIVE funding (long gets paid); needs fund <= -floor;
+                      never long a fresh 4h downtrend (don't catch a knife).
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:          # v2-quirk: needs >=8 1h, >=6 4h
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    floor = float(inputs.get("fundingFloorHourly", 0.00003))
+    t2 = float(inputs.get("fundingTier2Hourly", 0.00006))
+    t3 = float(inputs.get("fundingTier3Hourly", 0.0001))
+    ann = fund * HOURS_PER_YEAR * 100.0                     # annualized %
+
+    trend4, s4 = trend_structure(candles_4h)
+    rsi = calc_rsi(closes1)
+
+    score = 0
+    reasons = []
+
+    if leg == "harvest":
+        # v2-quirk: need meaningful POSITIVE funding to short-collect.
+        if fund < floor:
+            return None
+        if fund >= t3:
+            score += 3
+        elif fund >= t2:
+            score += 2
+        else:
+            score += 1
+        reasons.append(f"funding_short_{ann:+.0f}%/yr")
+        # v2-quirk: never short a fresh uptrend — squeeze risk dwarfs the carry.
+        if trend4 == "BULLISH":
+            return None
+        if trend4 == "BEARISH":
+            score += 2
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        rsi_ob = float(inputs.get("rsiOverbought", 70))
+        if rsi >= rsi_ob:
+            score += 1
+            reasons.append(f"rsi_ob_{rsi:.0f}")
+        if own <= 0:
+            score += 1
+            reasons.append(f"rolling_over_{own:+.1f}%")
+        elif own >= 5:
+            score -= 1
+            reasons.append(f"still_ripping_{own:+.1f}%")
+    else:  # payout
+        # v2-quirk: need meaningful NEGATIVE funding to long-collect.
+        if fund > -floor:
+            return None
+        if fund <= -t3:
+            score += 3
+        elif fund <= -t2:
+            score += 2
+        else:
+            score += 1
+        reasons.append(f"funding_long_{ann:+.0f}%/yr")
+        # v2-quirk: never long a fresh downtrend — don't catch a knife.
+        if trend4 == "BEARISH":
+            return None
+        if trend4 == "BULLISH":
+            score += 2
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        rsi_os = float(inputs.get("rsiOversold", 30))
+        if rsi <= rsi_os:
+            score += 1
+            reasons.append(f"rsi_os_{rsi:.0f}")
+        if own >= 0:
+            score += 1
+            reasons.append(f"bouncing_{own:+.1f}%")
+        elif own <= -5:
+            score -= 1
+            reasons.append(f"still_crashing_{own:+.1f}%")
+
+    return {
+        "coin": asset,
+        "direction": "SHORT" if leg == "harvest" else "LONG",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "fundingAnnPct": ann,
+        "own24h": own,
+    }
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: per-name venue cap
+    is load-bearing (over-leveraging a thin name is a venue reject), not cosmetic. Verbatim
+    v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/camel/strategy.yaml
+++ b/strategies/camel/strategy.yaml
@@ -1,0 +1,48 @@
+# Camel — funding-carry hedge fund. A two-instance PACKAGE: this manifest + two
+# self-contained runtime.yaml books (harvest SHORT / payout LONG on SEPARATE wallets,
+# so the positive-funding shorts and negative-funding longs coexist) + per-instance
+# scanners/. A faithful Runtime 3.0 port of the v2 Camel v1.0 funding-carry engine: one
+# producer ranked the live liquid main-DEX crypto cross-section by funding and took the
+# side that COLLECTS the funding, gated to exhausting crowds. Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: camel
+version: "1.0.0"
+
+catalog:
+  name: "Camel — Funding Carry Hedge Fund"
+  emoji: "🐫"
+  tagline: "Harvests funding carry across the liquid main-DEX crypto cross-section: the HARVEST book SHORTS the most-positive-funding names (longs pay shorts → short collects) and the PAYOUT book LONGS the most-negative-funding names (shorts pay longs → paid to hold) — both gated to EXHAUSTING crowds (4h trend + RSI confirmation) so price doesn't fight the carry — on two equally-funded wallets that net the fund slightly market-neutral."
+  belief_plain: "On Hyperliquid you get paid (or pay) funding every hour for holding a perp. Camel always takes the side that COLLECTS that payment — it shorts coins where longs are paying through the nose, and longs coins where shorts are paying — but only on crowds that are running out of steam, so the price doesn't move against it while it banks the funding."
+  thesis: "Funding is a recurring, structural inefficiency: when a trade gets too crowded, the funding rate blows out and the collecting side gets paid to hold. The edge is that carry, not market direction — so Camel ranks the whole liquid crypto board by funding and takes the most-extreme collecting side, but only when the crowded trade is exhausting (4h rolling over for shorts / capitulating for longs, RSI confirming) so price doesn't fight the carry. Taking some shorts and some longs also skews the fund net-neutral as a by-product."
+  group: carry
+  archetype: contrarian_fade      # collects extreme funding on exhausting (one-sided, stalling) crowds
+  sub_style: funding_extreme      # the carry edge IS extreme funding
+  asset_classes: [universe_crypto]
+  asset_scope: universe
+  direction: long_short           # harvest book short_only, payout book long_only; the PACKAGE is both
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 8                    # 4 per book × 2 books
+  min_budget: 400
+  assets: []                      # dynamic universe — the live liquid main-DEX crypto board, ranked by funding
+  tags: [funding, carry, basis, market-neutral, hedge-fund, contrarian, exhaustion, universe-crypto, two-book]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: harvest
+    runtime: harvest/runtime.yaml
+    wallet_env: CAMEL_HARVEST_WALLET
+    funding_share: 0.5
+  - name: payout
+    runtime: payout/runtime.yaml
+    wallet_env: CAMEL_PAYOUT_WALLET
+    funding_share: 0.5

--- a/strategies/caracal/breakout/runtime.yaml
+++ b/strategies/caracal/breakout/runtime.yaml
@@ -1,0 +1,128 @@
+# ── CARACAL · BREAKOUT book — crypto volatility compression->expansion (Runtime 3.0 port of v2 Caracal v1.0, LEG=breakout) ──
+name: caracal-breakout
+group: caracal
+version: 3.0.0
+description: >
+  CARACAL BREAKOUT — crypto volatility compression->expansion (Runtime 3.0 port of
+  the v2 caracal-producer.py, CARACAL_LEG=breakout). One of two volatility books.
+  Scans the liquid main-DEX crypto universe (top universeMaxNames by 24h volume) for
+  names coiled in a low-volatility squeeze (recent ATR << baseline ATR) that break
+  their recent range with an expansion surge, and rides the break direction — LONG on
+  an upside break, SHORT on a downside break. BOTH directions. Pairs with the CATALYST
+  book (XYZ, ../catalyst) on a SEPARATE wallet. The edge is VOLATILITY (compression
+  precedes expansion), not a directional view. slots 3, marginPct 18, strict 5x clamp
+  then each name's HL venue max; tight fast-capture DSL (a failed breakout reverses
+  fast). The scan applied breakout + coil + surge + 4h scoring, the 5x clamp, and
+  held-asset dedup — so the entry action is rule-mode (v2 LLM gate was pass-through).
+
+strategy:
+  wallet: "${CARACAL_BREAKOUT_WALLET}"
+  slots: 3
+  default_leverage: 5                     # fallback; scan emits per-name venue-clamped <=5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: caracal_breakout_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 tickSeconds (5 min)
+    timeout_seconds: 180                   # universe-level: 1 instrument-board read + per-name candle fetches
+    default_signal_validity_seconds: 900
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      minScore: 5                          # v2 minScore (producer floor)
+      marginPct: 18                        # PERCENT of withdrawable (0,100]; v2 stored 0.18 FRACTION -> ×100
+      maxLeverage: 5                       # strict clamp, then each name's HL venue max (in-scan)
+      maxSlots: 3
+      universeMaxNames: 20                 # bounds per-tick candle fetches (crypto board)
+      volFloorPctOfMedian: 0.2             # relative-to-market liquidity gate (NO hardcoded $)
+      breakoutBars: 20                     # prior-range lookback for the break
+      recentBars: 10                       # ATR window — recent vol
+      baseBars: 30                         # ATR window — baseline vol
+      squeezeTight: 0.70                   # recent/baseline ATR <= this = tight coil (+2)
+      squeezeLoose: 0.90                   # ... <= this = mild coil (+1)
+      surgeStrong: 2.0                     # breakout-bar TR / baseline ATR >= this (+2)
+      surgeMod: 1.3                        # ... >= this (+1)
+      minNotionalPctOfEquity: 0.01         # min notional floor scales with budget
+      venueMinNotionalUsd: 10              # HL venue minimum order value floor
+      recentSignalTtlSeconds: 180          # v2 RECENT_SIGNAL_TTL_SEC race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      squeeze: { type: number, required: false }
+      surge: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: caracal_breakout_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # scan applied breakout test + coil/surge scoring + 5x clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [caracal_breakout_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # breakouts need timely fills — taker fallback
+        execution_timeout_seconds: 30      # v2 entry timeout
+    context:
+      - type: signal
+        scanner: caracal_breakout_signals
+
+# ── EXIT (DSL — tight vol-breakout capture; ported VERBATIM from v2 runtime-breakout.yaml) ──
+# A failed breakout reverses fast, so cut quickly (tight phase1) and lock gains as the
+# expansion runs. Stall-cuts ON (a breakout that goes nowhere has failed). 2d hard_timeout
+# — vol events resolve fast. First phase2 lock REACHABLE at +8% (lock 30%).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880            # 2d — vol events resolve fast
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 180             # 3h — a stalled breakout has failed
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 360             # 6h
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 7
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,   lock_hw_pct: 30 }
+        - { trigger_pct: 18,  lock_hw_pct: 50 }
+        - { trigger_pct: 35,  lock_hw_pct: 68 }
+        - { trigger_pct: 60,  lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 90 }
+
+risk:
+  data_retention_seconds: 259200           # 72h (was data_retention_hours: 72)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 8                  # breakouts cluster; vol events are episodic
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 5
+    cooldown_seconds: 2700                  # v2 cooldown_minutes 45
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 7200        # v2 per_asset_cooldown_minutes 120

--- a/strategies/caracal/breakout/scanners/scan.py
+++ b/strategies/caracal/breakout/scanners/scan.py
@@ -1,0 +1,354 @@
+"""CARACAL (BREAKOUT book) — supervised scanner (Runtime 3.0 port of the v2
+caracal-producer.py, CARACAL_LEG=breakout).
+
+Volatility compression->expansion on the liquid main-DEX CRYPTO universe.
+It trades MOVEMENT, not a directional view: each name that breaks its recent
+range FROM a low-volatility coil is taken LONG (break up) or SHORT (break
+down). One of two books; the CATALYST book runs the identical engine on XYZ
+(see ../../catalyst/). Per tick scan() does:
+
+  1. read the wallet clearinghouse — account value, held names, free margin
+     (dual-DEX equity via max(), NEVER sum — two views of one cross-margined
+     wallet; v2 cfg.get_positions, incl. the read-sanity $0/funding guard).
+  2. build the live CRYPTO universe (market_list_instruments, top
+     universeMaxNames by 24h volume, relative-to-market liquidity floor — NO
+     hardcoded $).
+  3. per non-held / non-recently-signaled name, fetch 1h+4h candles and score
+     via the pure scoring.score_vol_breakout (breakout + coil + surge + 4h
+     agreement); keep candidates >= minScore.
+  4. emit up to min(open_slots, affordable) candidates as marginPct sizing
+     INTENTS (PERCENT) + per-name venue-clamped leverage; the runtime sizes
+     the dollars, owns slots/cooldowns/risk gates, and trails the DSL exit.
+
+Read-only + single-pass. NO daemon, NO push_signal, NO create_position.
+
+FIDELITY NOTES vs caracal-producer.py v1.0.0 (CARACAL_LEG=breakout):
+  - v2 stored marginPct=0.18 as a FRACTION and computed marginUsd =
+    account_value * 0.18 itself. This port emits `marginPct`=18 (PERCENT) at
+    the top level; the runtime sizes (marginPct/100)*withdrawable. A defensive
+    "<=1.0 means a pasted fraction -> ×100" guard is applied. TIERS/CLAMPS
+    otherwise verbatim.
+  - v2's recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=180) -> ctx.state
+    dedup map with the same TTL + 4x-TTL prune semantics.
+  - v2's free-margin AFFORDABILITY cap (free_margin / (margin_usd*1.1)) is
+    preserved as read-only math so we never emit more entries than the wallet
+    can fund (avoids insufficient-funds create spam). It uses an absolute
+    marginUsd derived from account_value*fraction for the affordability count
+    ONLY; the emitted wire size remains the PERCENT intent.
+  - v2's per-tick `min_notional` venue/equity floor is preserved: a candidate
+    whose notional (margin_usd*leverage) is below the floor is dropped.
+  - DROPPED (mutations the read-only scan() cannot perform; the runtime owns
+    them): nothing — the v2 producer had NO order-lifecycle management
+    (no cancel_order / has_resting_orders / stale-order purge). push_signal +
+    record_signal are replaced by the return list + ctx.state.
+  - v2 emitted up to `open_slots` best candidates; preserved (emit-all up to
+    the slot/affordability cap, runtime applies the ceiling).
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180        # v2 RECENT_SIGNAL_TTL_SEC — held-asset race-fix dedup window
+_WANT_XYZ = False         # BREAKOUT book = main-DEX crypto
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must
+    NOT roll back the whole tick (the contract rolls a raised exception back to
+    []). Returns None so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad read must not kill the universe tick
+        print(f"[caracal-breakout.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+def _dex_for(asset):
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+# ── account / positions (READ-GUARDED; ported from v2 cfg.get_positions) ──
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin).
+
+    The 'main' and 'xyz' clearinghouse sections are TWO VIEWS of ONE
+    cross-margined wallet — accountValue is taken ONCE via max() across
+    sections, NEVER summed (summing double-counts the shared balance -> 2x
+    sizing). assetPositions ARE per-sub-DEX so they are enumerated across both.
+    Includes the v2 read-sanity guard: margin in use + empty positions list =
+    corrupt read -> skip the tick (avoids pyramiding / mis-sizing)."""
+    if not getattr(ctx, "wallet", None):
+        return 0.0, [], 0.0
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, [], 0.0
+
+    positions, account_value, committed = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s.get("marginSummary"), dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            margin = scoring._f(pos.get("marginUsed", 0))
+            committed += margin
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": margin,
+            })
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim): margin in
+    # use while positions is empty == corrupt read; skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[caracal-breakout.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+
+    free_margin = max(0.0, account_value - committed)
+    return account_value, positions, free_margin
+
+
+# ── universe (READ-GUARDED; ported from v2 get_universe_meta + build_universe) ──
+
+def _build_universe(ctx, inputs):
+    """Liquid names on the leg's DEX (crypto), capped to universeMaxNames by 24h
+    volume, then a relative-to-market liquidity floor (NO hardcoded $). Returns
+    (universe[str], meta_map{name->{max_leverage}}). Ported verbatim from v2
+    get_universe_meta + build_universe."""
+    max_names = int(inputs.get("universeMaxNames", scoring.UNIVERSE_MAX_NAMES))
+    pct = float(inputs.get("volFloorPctOfMedian", scoring.VOL_FLOOR_PCT_OF_MEDIAN))
+
+    raw = _read(ctx, "market_list_instruments", {})
+    if not raw:
+        return [], {}
+    data = _unwrap(raw)
+    insts = data.get("instruments", data) if isinstance(data, dict) else data
+    if not isinstance(insts, list):
+        return [], {}
+
+    meta_map, pool = {}, []
+    for inst in insts:
+        if not isinstance(inst, dict):
+            continue
+        if inst.get("is_delisted"):
+            continue
+        ctx_block = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        name = inst.get("name") or ctx_block.get("coin")
+        if not name or not isinstance(name, str):
+            continue
+        is_xyz = name.lower().startswith("xyz:")
+        if is_xyz != _WANT_XYZ:          # BREAKOUT = crypto only (drop XYZ)
+            continue
+        vol = scoring._f(ctx_block.get("dayNtlVlm", inst.get("dayNtlVlm", 0)))
+        if vol <= 0:
+            continue
+        meta_map[name] = {"max_leverage": inst.get("max_leverage", inst.get("maxLeverage"))}
+        meta_map[name.upper()] = meta_map[name]
+        pool.append((name, vol))
+
+    if not pool:
+        return [], {}
+    pool.sort(key=lambda x: x[1], reverse=True)
+    pool = pool[:max_names]
+    # relative-to-market liquidity gate (NO hardcoded $): keep names whose 24h
+    # volume is >= volFloorPctOfMedian of the top-N cohort's median.
+    vols = sorted(v for _, v in pool)
+    median = vols[len(vols) // 2]
+    floor = pct * median
+    universe = [n for n, v in pool if v >= floor]
+    return universe, meta_map
+
+
+def _fetch_candles(ctx, asset):
+    """{c1, c4} 1h/4h candle lists for `asset`, or None. READ-GUARDED.
+    Ported from v2 fetch_candles."""
+    md = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = _unwrap(md)
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    if not isinstance(candles, dict):
+        return None
+    return {"c1": candles.get("1h", []) or [], "c4": candles.get("4h", []) or []}
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals-<leg>.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def _norm_margin_pct(raw):
+    """Defensive fraction->percent guard (dire/koala pattern): a value <=1.0 was
+    almost certainly pasted as a FRACTION (v2 stored 0.18); ×100 -> a PERCENT."""
+    mp = float(raw)
+    if 0 < mp <= 1.0:
+        mp *= 100.0
+    return mp
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    min_score = float(inputs.get("minScore", scoring.MIN_SCORE))
+    margin_pct = _norm_margin_pct(inputs.get("marginPct", scoring.MARGIN_PCT))   # PERCENT (0,100]
+    max_lev = int(inputs.get("maxLeverage", scoring.MAX_LEVERAGE))
+    max_slots = int(inputs.get("maxSlots", scoring.MAX_SLOTS))
+    min_notional_pct = float(inputs.get("minNotionalPctOfEquity", 0.01))
+    venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        print("[caracal-breakout.scan] no account value — skipping tick", file=sys.stderr)
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    open_slots = max_slots - len(held_assets)
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[caracal-breakout.scan] WARNING: state append failed; next tick may "
+                  f"re-emit a suppressed signal: {exc!r}", file=sys.stderr)
+
+    if open_slots <= 0:
+        print(f"[caracal-breakout.scan] WAITING — slots full ({len(held_assets)}/{max_slots}) "
+              f"held={held_assets}; DSL manages exits", file=sys.stderr)
+        _persist({"ts": now, "emitted": 0, "gate": "slots_full", "held": held_assets})
+        return []
+
+    universe, meta_map = _build_universe(ctx, inputs)
+    if not universe:
+        print("[caracal-breakout.scan] market_list_instruments empty/failed — no signal", file=sys.stderr)
+        _persist({"ts": now, "emitted": 0, "gate": "no_universe"})
+        return []
+
+    candidates = []
+    scanned = 0
+    for name in universe:
+        if name.upper() in held_set:
+            continue
+        if _was_recently_signaled(signaled, name, ttl, now):
+            continue
+        scanned += 1
+        md = _fetch_candles(ctx, name)
+        if not md:
+            continue
+        th = scoring.score_vol_breakout(name, md["c1"], md["c4"], inputs)
+        if th and th["score"] >= min_score:
+            th["_meta"] = meta_map.get(name) or meta_map.get(name.upper()) or {}
+            candidates.append(th)
+
+    if not candidates:
+        print(f"[caracal-breakout.scan] WAITING — no coiled breakout >= minScore {min_score:.0f} "
+              f"(scanned {scanned})", file=sys.stderr)
+        _persist({"ts": now, "emitted": 0, "gate": "no_candidate", "scanned": scanned,
+                  "min_score": min_score, "held": held_assets})
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # AFFORDABILITY cap (v2): never emit more entries than the wallet can FUND.
+    # margin_usd is the ABSOLUTE dollar margin for the affordability count only;
+    # the emitted wire size is the PERCENT intent (runtime sizes the dollars).
+    margin_usd = round(account_value * (margin_pct / 100.0), 2)
+    affordable = int(free_margin / (margin_usd * 1.1)) if margin_usd > 0 else 0  # 1.1 = fee/slippage headroom
+    min_notional = max(account_value * min_notional_pct, venue_min_notional)
+    cap = min(open_slots, affordable)
+    to_emit = candidates[:cap]
+
+    out, emitted = [], []
+    for th in to_emit:
+        leverage = scoring.clamp_leverage(max_lev, (th.get("_meta") or {}).get("max_leverage"))
+        notional = margin_usd * leverage
+        if leverage <= 0 or notional < min_notional:
+            continue
+        signaled[th["coin"].upper()] = now
+        out.append({
+            "asset": th["coin"],
+            "direction": th["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # <=5, venue-clamped; runtime applies it
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": th["direction"],
+                "reasons": th["reasons"],
+                "trend4h": th.get("trend4h"),
+                "squeeze": round(scoring._f(th.get("squeeze")), 3),
+                "surge": round(scoring._f(th.get("surge")), 2),
+                "heldAssets": held_assets,
+            },
+        })
+        emitted.append({"coin": th["coin"], "direction": th["direction"],
+                        "score": th["score"], "leverage": leverage,
+                        "squeeze": round(scoring._f(th.get("squeeze")), 2),
+                        "surge": round(scoring._f(th.get("surge")), 2)})
+
+    if out:
+        summary = ", ".join(f"{e['coin']} {e['direction']} s{e['score']} {e['leverage']}x" for e in emitted)
+        print(f"[caracal-breakout.scan] EMIT {len(out)} | {summary} "
+              f"marginPct={margin_pct:.0f}% scanned={scanned}", file=sys.stderr)
+    else:
+        print(f"[caracal-breakout.scan] WAITING — candidates found but none affordable/clear notional "
+              f"(scanned {scanned}, free_margin={free_margin:.0f})", file=sys.stderr)
+
+    _persist({"ts": now, "emitted": len(out), "gate": "pass" if out else "unaffordable",
+              "scanned": scanned, "candidates": len(candidates), "open_slots": open_slots,
+              "account_value": round(account_value, 2), "held": held_assets,
+              "emit": emitted})
+    return out

--- a/strategies/caracal/breakout/scanners/scoring.py
+++ b/strategies/caracal/breakout/scanners/scoring.py
@@ -1,0 +1,200 @@
+"""CARACAL (BREAKOUT book) — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 caracal-producer.py volatility
+compression->expansion scorer (SKILL.md "Caracal v1.0"). The technical
+helpers (true range / ATR / trend structure) and the `score_vol_breakout`
+scoring table — range breakout + compression precondition + expansion surge
++ higher-TF agreement — are reproduced VERBATIM so a fidelity harness can
+diff this against the v2 producer on the same candle snapshot.
+
+This is the CRYPTO book (wantXyz=false): the universe is the liquid main-DEX
+crypto cross-section. The CATALYST book runs the IDENTICAL engine on the XYZ
+DEX; the two scoring modules differ only by docstring/persona — the math is
+shared by construction (verbatim).
+
+Single-pass, unit-testable on plain candle lists. The caller (scan.py) owns
+the clock and the MCP reads."""
+
+# Score normalization divisor for the 0..1 ingest-ranking score (v2 NORM_DIV).
+# Retained for parity with the v2 wire score; the Runtime 3.0 wire emits the
+# raw integer score on data{} and the runtime ranks — kept here so a harness
+# can reproduce the v2 normalized value if needed.
+NORM_DIV = 8.0
+
+# ── v2 defaults (caracal-producer.py _DEFAULTS["breakout"] / config) ──
+MIN_SCORE = 5
+MARGIN_PCT = 18          # PERCENT in (0,100] — v2 stored 0.18 (FRACTION); ×100 here
+MAX_LEVERAGE = 5
+MAX_SLOTS = 3
+VOL_FLOOR_PCT_OF_MEDIAN = 0.2
+UNIVERSE_MAX_NAMES = 20
+BREAKOUT_BARS = 20       # prior-range lookback for the break
+RECENT_BARS = 10         # ATR window — "recent" vol
+BASE_BARS = 30           # ATR window — baseline vol
+SQUEEZE_TIGHT = 0.70     # recent/baseline ATR <= this = tight coil
+SQUEEZE_LOOSE = 0.90     # ... <= this = mild coil
+SURGE_STRONG = 2.0       # breakout-bar TR / baseline ATR
+SURGE_MOD = 1.3
+
+
+# ── numeric coercion ──
+
+def _f(v, d=0.0):
+    try:
+        return float(v) if v is not None else d
+    except (TypeError, ValueError):
+        return d
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical helpers — ported VERBATIM from caracal-producer.py
+# ═══════════════════════════════════════════════════════════════
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])      # [t, o, h, l, c, v] ohlcv array shape
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def trend_structure(candles, lookback=6):
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def true_range(c, prev_close):
+    h, l = _high(c), _low(c)
+    return max(h - l, abs(h - prev_close), abs(l - prev_close))
+
+
+def atr(candles, period):
+    """Average true range over the last `period` bars."""
+    if len(candles) < 2:
+        return 0.0
+    trs = []
+    for i in range(1, len(candles)):
+        trs.append(true_range(candles[i], _close(candles[i - 1])))
+    w = trs[-period:] if len(trs) >= period else trs
+    return sum(w) / len(w) if w else 0.0
+
+
+# ═══════════════════════════════════════════════════════════════
+# Volatility-breakout scoring — compression precedes expansion
+# (ported VERBATIM from caracal-producer.py score_vol_breakout)
+# ═══════════════════════════════════════════════════════════════
+
+def score_vol_breakout(asset, c1, c4, config=None):
+    """Detect a range breakout from a low-volatility coil and ride the break
+    direction. `c1` = 1h candles, `c4` = 4h candles. Returns None if no
+    breakout / not enough data. The caller fetches the candles; this stays
+    pure so a harness can replay v2 snapshots."""
+    config = config or {}
+    look = int(config.get("breakoutBars", BREAKOUT_BARS))
+    recent_bars = int(config.get("recentBars", RECENT_BARS))
+    base_bars = int(config.get("baseBars", BASE_BARS))
+    sq_tight = float(config.get("squeezeTight", SQUEEZE_TIGHT))
+    sq_loose = float(config.get("squeezeLoose", SQUEEZE_LOOSE))
+    surge_strong = float(config.get("surgeStrong", SURGE_STRONG))
+    surge_mod = float(config.get("surgeMod", SURGE_MOD))
+
+    if not c1 or not c4:
+        return None
+    need = max(look, base_bars) + 2
+    if len(c1) < need or len(c4) < 6:
+        return None
+    highs = [_high(c) for c in c1]
+    lows = [_low(c) for c in c1]
+    closes = [_close(c) for c in c1]
+    price = closes[-1]
+
+    # Range breakout vs the prior `look` bars (excluding the current bar).
+    prior_high = max(highs[-(look + 1):-1])
+    prior_low = min(lows[-(look + 1):-1])
+    broke_up = price > prior_high
+    broke_dn = price < prior_low
+    if not (broke_up or broke_dn):
+        return None
+    direction = "LONG" if broke_up else "SHORT"
+
+    a_recent = atr(c1[-(recent_bars + 1):], recent_bars)
+    a_base = atr(c1[-(base_bars + 1):], base_bars)
+    squeeze = (a_recent / a_base) if a_base > 0 else 1.0
+    last_tr = true_range(c1[-1], closes[-2])
+    surge = (last_tr / a_base) if a_base > 0 else 0.0
+    trend4, _ = trend_structure(c4)
+
+    score = 0
+    reasons = [f"breakout_{'up' if broke_up else 'down'}"]
+    score += 3  # the breakout trigger
+
+    # Compression precondition — the edge. A coil scores; no coil is penalized.
+    if squeeze <= sq_tight:
+        score += 2
+        reasons.append(f"coil_{squeeze:.2f}")
+    elif squeeze <= sq_loose:
+        score += 1
+        reasons.append(f"coil_{squeeze:.2f}")
+    else:
+        score -= 1
+        reasons.append(f"no_coil_{squeeze:.2f}")
+
+    # Expansion surge — the breakout bar should be an outsized move.
+    if surge >= surge_strong:
+        score += 2
+        reasons.append(f"surge_{surge:.1f}x")
+    elif surge >= surge_mod:
+        score += 1
+        reasons.append(f"surge_{surge:.1f}x")
+
+    # Higher-TF agreement (a break with the 4h structure follows through more).
+    if (broke_up and trend4 == "BULLISH") or (broke_dn and trend4 == "BEARISH"):
+        score += 1
+        reasons.append(f"4h_{trend4.lower()}_agree")
+    elif (broke_up and trend4 == "BEARISH") or (broke_dn and trend4 == "BULLISH"):
+        score -= 1
+        reasons.append("4h_against")
+
+    return {
+        "coin": asset, "direction": direction, "score": score,
+        "reasons": reasons, "price": price,
+        "squeeze": squeeze, "surge": surge, "trend4h": trend4,
+    }
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp desired leverage to [1, venue_max]. Ported verbatim from v2
+    clamp_leverage. A missing/invalid venue cap falls back to `desired`."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = int(desired)
+    if venue <= 0:
+        venue = int(desired)
+    return max(1, min(int(desired), venue))

--- a/strategies/caracal/catalyst/runtime.yaml
+++ b/strategies/caracal/catalyst/runtime.yaml
@@ -1,0 +1,128 @@
+# ── CARACAL · CATALYST book — XYZ event/catalyst volatility expansion (Runtime 3.0 port of v2 Caracal v1.0, LEG=catalyst) ──
+name: caracal-catalyst
+group: caracal
+version: 3.0.0
+description: >
+  CARACAL CATALYST — XYZ event/catalyst volatility compression->expansion (Runtime 3.0
+  port of the v2 caracal-producer.py, CARACAL_LEG=catalyst). One of two volatility books.
+  Same compression->expansion engine as the BREAKOUT book, but on the XYZ DEX (equities /
+  energy / metals / indices): scans the liquid XYZ universe (top universeMaxNames by 24h
+  volume) for coiled names breaking their range with an expansion surge, and rides the
+  break direction — LONG up, SHORT down. Captures oil-geopolitics and AI-infra moves as
+  direction-agnostic volatility events, 24/7 (XYZ trades through weekends — NO market-hours
+  gating). BOTH directions. Pairs with the BREAKOUT book (crypto, ../breakout) on a
+  SEPARATE wallet. The edge is VOLATILITY, not a directional view. slots 3, marginPct 18,
+  strict 5x clamp then each name's HL venue max; tight fast-capture DSL. The scan applied
+  breakout + coil + surge + 4h scoring, the 5x clamp, and held-asset dedup — so the entry
+  action is rule-mode (v2 LLM gate was pass-through).
+
+strategy:
+  wallet: "${CARACAL_CATALYST_WALLET}"
+  slots: 3
+  default_leverage: 5                     # fallback; scan emits per-name venue-clamped <=5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: caracal_catalyst_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 tickSeconds (5 min)
+    timeout_seconds: 180                   # universe-level: 1 instrument-board read + per-name candle fetches
+    default_signal_validity_seconds: 900
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      minScore: 5                          # v2 minScore (producer floor)
+      marginPct: 18                        # PERCENT of withdrawable (0,100]; v2 stored 0.18 FRACTION -> ×100
+      maxLeverage: 5                       # strict clamp, then each name's HL venue max (in-scan)
+      maxSlots: 3
+      universeMaxNames: 15                 # bounds per-tick candle fetches (thinner XYZ board)
+      volFloorPctOfMedian: 0.2             # relative-to-market liquidity gate (NO hardcoded $; adapts to thin XYZ)
+      breakoutBars: 20                     # prior-range lookback for the break
+      recentBars: 10                       # ATR window — recent vol
+      baseBars: 30                         # ATR window — baseline vol
+      squeezeTight: 0.70                   # recent/baseline ATR <= this = tight coil (+2)
+      squeezeLoose: 0.90                   # ... <= this = mild coil (+1)
+      surgeStrong: 2.0                     # breakout-bar TR / baseline ATR >= this (+2)
+      surgeMod: 1.3                        # ... >= this (+1)
+      minNotionalPctOfEquity: 0.01         # min notional floor scales with budget
+      venueMinNotionalUsd: 10              # HL venue minimum order value floor
+      recentSignalTtlSeconds: 180          # v2 RECENT_SIGNAL_TTL_SEC race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      squeeze: { type: number, required: false }
+      surge: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: caracal_catalyst_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # scan applied breakout test + coil/surge scoring + 5x clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [caracal_catalyst_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # breakouts need timely fills — taker fallback
+        execution_timeout_seconds: 30      # v2 entry timeout
+    context:
+      - type: signal
+        scanner: caracal_catalyst_signals
+
+# ── EXIT (DSL — tight vol-breakout capture; ported VERBATIM from v2 runtime-catalyst.yaml) ──
+# A failed breakout reverses fast, so cut quickly and lock gains as the expansion runs.
+# Stall-cuts ON. 2d hard_timeout — vol events resolve fast. First phase2 lock REACHABLE at +8%.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880            # 2d
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 180             # 3h
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 360             # 6h
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 7
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,   lock_hw_pct: 30 }
+        - { trigger_pct: 18,  lock_hw_pct: 50 }
+        - { trigger_pct: 35,  lock_hw_pct: 68 }
+        - { trigger_pct: 60,  lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 90 }
+
+risk:
+  data_retention_seconds: 259200           # 72h (was data_retention_hours: 72)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 8
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 5
+    cooldown_seconds: 2700                  # v2 cooldown_minutes 45
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 7200        # v2 per_asset_cooldown_minutes 120

--- a/strategies/caracal/catalyst/scanners/scan.py
+++ b/strategies/caracal/catalyst/scanners/scan.py
@@ -1,0 +1,358 @@
+"""CARACAL (CATALYST book) — supervised scanner (Runtime 3.0 port of the v2
+caracal-producer.py, CARACAL_LEG=catalyst).
+
+Volatility compression->expansion on the liquid XYZ universe (equities /
+energy / metals / indices). Same engine as the BREAKOUT (crypto) book — it
+trades MOVEMENT, not a directional view: each XYZ name that breaks its recent
+range FROM a low-volatility coil is taken LONG (break up) or SHORT (break
+down). Captures oil-geopolitics and AI-infra moves as direction-agnostic vol
+events, 24/7 (XYZ trades through weekends). One of two books; the BREAKOUT
+book runs the identical engine on crypto (see ../../breakout/). Per tick
+scan() does:
+
+  1. read the wallet clearinghouse — account value, held names, free margin
+     (dual-DEX equity via max(), NEVER sum — two views of one cross-margined
+     wallet; v2 cfg.get_positions, incl. the read-sanity $0/funding guard).
+  2. build the live XYZ universe (market_list_instruments, top universeMaxNames
+     by 24h volume, relative-to-market liquidity floor — NO hardcoded $; XYZ is
+     thinner than crypto majors, but the gate is relative so it adapts).
+  3. per non-held / non-recently-signaled name, fetch 1h+4h candles (dex='xyz')
+     and score via the pure scoring.score_vol_breakout (breakout + coil + surge
+     + 4h agreement); keep candidates >= minScore.
+  4. emit up to min(open_slots, affordable) candidates as marginPct sizing
+     INTENTS (PERCENT) + per-name venue-clamped leverage; the runtime sizes
+     the dollars, owns slots/cooldowns/risk gates, and trails the DSL exit.
+
+Read-only + single-pass. NO daemon, NO push_signal, NO create_position.
+
+FIDELITY NOTES vs caracal-producer.py v1.0.0 (CARACAL_LEG=catalyst):
+  - v2 stored marginPct=0.18 as a FRACTION and computed marginUsd =
+    account_value * 0.18 itself. This port emits `marginPct`=18 (PERCENT) at
+    the top level; the runtime sizes (marginPct/100)*withdrawable. A defensive
+    "<=1.0 means a pasted fraction -> ×100" guard is applied. TIERS/CLAMPS
+    otherwise verbatim.
+  - v2's recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=180) -> ctx.state
+    dedup map with the same TTL + 4x-TTL prune semantics.
+  - v2's free-margin AFFORDABILITY cap (free_margin / (margin_usd*1.1)) is
+    preserved as read-only math so we never emit more entries than the wallet
+    can fund (avoids insufficient-funds create spam).
+  - v2's per-tick `min_notional` venue/equity floor is preserved: a candidate
+    whose notional (margin_usd*leverage) is below the floor is dropped.
+  - DROPPED (mutations the read-only scan() cannot perform): nothing — the v2
+    producer had NO order-lifecycle management (no cancel_order /
+    has_resting_orders / stale-order purge). push_signal + record_signal are
+    replaced by the return list + ctx.state.
+  - XYZ asset names carry the `xyz:` prefix as returned by the instrument
+    board (e.g. xyz:GOLD, xyz:NVDA, xyz:SP500/XYZ100); candle fetches route
+    with dex='xyz'. XYZ trades 24/7 — NO weekend gating.
+  - v2 emitted up to `open_slots` best candidates; preserved (emit-all up to
+    the slot/affordability cap, runtime applies the ceiling).
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180        # v2 RECENT_SIGNAL_TTL_SEC — held-asset race-fix dedup window
+_WANT_XYZ = True          # CATALYST book = XYZ DEX (equities/energy/metals/indices)
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must
+    NOT roll back the whole tick (the contract rolls a raised exception back to
+    []). Returns None so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad read must not kill the universe tick
+        print(f"[caracal-catalyst.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+def _dex_for(asset):
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+# ── account / positions (READ-GUARDED; ported from v2 cfg.get_positions) ──
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin).
+
+    The 'main' and 'xyz' clearinghouse sections are TWO VIEWS of ONE
+    cross-margined wallet — accountValue is taken ONCE via max() across
+    sections, NEVER summed (summing double-counts the shared balance -> 2x
+    sizing). assetPositions ARE per-sub-DEX so they are enumerated across both.
+    Includes the v2 read-sanity guard: margin in use + empty positions list =
+    corrupt read -> skip the tick (avoids pyramiding / mis-sizing)."""
+    if not getattr(ctx, "wallet", None):
+        return 0.0, [], 0.0
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, [], 0.0
+
+    positions, account_value, committed = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s.get("marginSummary"), dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            margin = scoring._f(pos.get("marginUsed", 0))
+            committed += margin
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": margin,
+            })
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim): margin in
+    # use while positions is empty == corrupt read; skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[caracal-catalyst.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+
+    free_margin = max(0.0, account_value - committed)
+    return account_value, positions, free_margin
+
+
+# ── universe (READ-GUARDED; ported from v2 get_universe_meta + build_universe) ──
+
+def _build_universe(ctx, inputs):
+    """Liquid names on the leg's DEX (XYZ), capped to universeMaxNames by 24h
+    volume, then a relative-to-market liquidity floor (NO hardcoded $). Returns
+    (universe[str], meta_map{name->{max_leverage}}). Ported verbatim from v2
+    get_universe_meta + build_universe."""
+    max_names = int(inputs.get("universeMaxNames", scoring.UNIVERSE_MAX_NAMES))
+    pct = float(inputs.get("volFloorPctOfMedian", scoring.VOL_FLOOR_PCT_OF_MEDIAN))
+
+    raw = _read(ctx, "market_list_instruments", {})
+    if not raw:
+        return [], {}
+    data = _unwrap(raw)
+    insts = data.get("instruments", data) if isinstance(data, dict) else data
+    if not isinstance(insts, list):
+        return [], {}
+
+    meta_map, pool = {}, []
+    for inst in insts:
+        if not isinstance(inst, dict):
+            continue
+        if inst.get("is_delisted"):
+            continue
+        ctx_block = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        name = inst.get("name") or ctx_block.get("coin")
+        if not name or not isinstance(name, str):
+            continue
+        is_xyz = name.lower().startswith("xyz:")
+        if is_xyz != _WANT_XYZ:          # CATALYST = XYZ only (drop crypto)
+            continue
+        vol = scoring._f(ctx_block.get("dayNtlVlm", inst.get("dayNtlVlm", 0)))
+        if vol <= 0:
+            continue
+        meta_map[name] = {"max_leverage": inst.get("max_leverage", inst.get("maxLeverage"))}
+        meta_map[name.upper()] = meta_map[name]
+        pool.append((name, vol))
+
+    if not pool:
+        return [], {}
+    pool.sort(key=lambda x: x[1], reverse=True)
+    pool = pool[:max_names]
+    # relative-to-market liquidity gate (NO hardcoded $): keep names whose 24h
+    # volume is >= volFloorPctOfMedian of the top-N cohort's median.
+    vols = sorted(v for _, v in pool)
+    median = vols[len(vols) // 2]
+    floor = pct * median
+    universe = [n for n, v in pool if v >= floor]
+    return universe, meta_map
+
+
+def _fetch_candles(ctx, asset):
+    """{c1, c4} 1h/4h candle lists for `asset`, or None. READ-GUARDED.
+    Ported from v2 fetch_candles (XYZ routes with dex='xyz')."""
+    md = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = _unwrap(md)
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    if not isinstance(candles, dict):
+        return None
+    return {"c1": candles.get("1h", []) or [], "c4": candles.get("4h", []) or []}
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals-<leg>.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def _norm_margin_pct(raw):
+    """Defensive fraction->percent guard (dire/koala pattern): a value <=1.0 was
+    almost certainly pasted as a FRACTION (v2 stored 0.18); ×100 -> a PERCENT."""
+    mp = float(raw)
+    if 0 < mp <= 1.0:
+        mp *= 100.0
+    return mp
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    min_score = float(inputs.get("minScore", scoring.MIN_SCORE))
+    margin_pct = _norm_margin_pct(inputs.get("marginPct", scoring.MARGIN_PCT))   # PERCENT (0,100]
+    max_lev = int(inputs.get("maxLeverage", scoring.MAX_LEVERAGE))
+    max_slots = int(inputs.get("maxSlots", scoring.MAX_SLOTS))
+    min_notional_pct = float(inputs.get("minNotionalPctOfEquity", 0.01))
+    venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        print("[caracal-catalyst.scan] no account value — skipping tick", file=sys.stderr)
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    open_slots = max_slots - len(held_assets)
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[caracal-catalyst.scan] WARNING: state append failed; next tick may "
+                  f"re-emit a suppressed signal: {exc!r}", file=sys.stderr)
+
+    if open_slots <= 0:
+        print(f"[caracal-catalyst.scan] WAITING — slots full ({len(held_assets)}/{max_slots}) "
+              f"held={held_assets}; DSL manages exits", file=sys.stderr)
+        _persist({"ts": now, "emitted": 0, "gate": "slots_full", "held": held_assets})
+        return []
+
+    universe, meta_map = _build_universe(ctx, inputs)
+    if not universe:
+        print("[caracal-catalyst.scan] market_list_instruments empty/failed — no signal", file=sys.stderr)
+        _persist({"ts": now, "emitted": 0, "gate": "no_universe"})
+        return []
+
+    candidates = []
+    scanned = 0
+    for name in universe:
+        if name.upper() in held_set:
+            continue
+        if _was_recently_signaled(signaled, name, ttl, now):
+            continue
+        scanned += 1
+        md = _fetch_candles(ctx, name)
+        if not md:
+            continue
+        th = scoring.score_vol_breakout(name, md["c1"], md["c4"], inputs)
+        if th and th["score"] >= min_score:
+            th["_meta"] = meta_map.get(name) or meta_map.get(name.upper()) or {}
+            candidates.append(th)
+
+    if not candidates:
+        print(f"[caracal-catalyst.scan] WAITING — no coiled breakout >= minScore {min_score:.0f} "
+              f"(scanned {scanned})", file=sys.stderr)
+        _persist({"ts": now, "emitted": 0, "gate": "no_candidate", "scanned": scanned,
+                  "min_score": min_score, "held": held_assets})
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # AFFORDABILITY cap (v2): never emit more entries than the wallet can FUND.
+    # margin_usd is the ABSOLUTE dollar margin for the affordability count only;
+    # the emitted wire size is the PERCENT intent (runtime sizes the dollars).
+    margin_usd = round(account_value * (margin_pct / 100.0), 2)
+    affordable = int(free_margin / (margin_usd * 1.1)) if margin_usd > 0 else 0  # 1.1 = fee/slippage headroom
+    min_notional = max(account_value * min_notional_pct, venue_min_notional)
+    cap = min(open_slots, affordable)
+    to_emit = candidates[:cap]
+
+    out, emitted = [], []
+    for th in to_emit:
+        leverage = scoring.clamp_leverage(max_lev, (th.get("_meta") or {}).get("max_leverage"))
+        notional = margin_usd * leverage
+        if leverage <= 0 or notional < min_notional:
+            continue
+        signaled[th["coin"].upper()] = now
+        out.append({
+            "asset": th["coin"],
+            "direction": th["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # <=5, venue-clamped; runtime applies it
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": th["direction"],
+                "reasons": th["reasons"],
+                "trend4h": th.get("trend4h"),
+                "squeeze": round(scoring._f(th.get("squeeze")), 3),
+                "surge": round(scoring._f(th.get("surge")), 2),
+                "heldAssets": held_assets,
+            },
+        })
+        emitted.append({"coin": th["coin"], "direction": th["direction"],
+                        "score": th["score"], "leverage": leverage,
+                        "squeeze": round(scoring._f(th.get("squeeze")), 2),
+                        "surge": round(scoring._f(th.get("surge")), 2)})
+
+    if out:
+        summary = ", ".join(f"{e['coin']} {e['direction']} s{e['score']} {e['leverage']}x" for e in emitted)
+        print(f"[caracal-catalyst.scan] EMIT {len(out)} | {summary} "
+              f"marginPct={margin_pct:.0f}% scanned={scanned}", file=sys.stderr)
+    else:
+        print(f"[caracal-catalyst.scan] WAITING — candidates found but none affordable/clear notional "
+              f"(scanned {scanned}, free_margin={free_margin:.0f})", file=sys.stderr)
+
+    _persist({"ts": now, "emitted": len(out), "gate": "pass" if out else "unaffordable",
+              "scanned": scanned, "candidates": len(candidates), "open_slots": open_slots,
+              "account_value": round(account_value, 2), "held": held_assets,
+              "emit": emitted})
+    return out

--- a/strategies/caracal/catalyst/scanners/scoring.py
+++ b/strategies/caracal/catalyst/scanners/scoring.py
@@ -1,0 +1,199 @@
+"""CARACAL (CATALYST book) — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 caracal-producer.py volatility
+compression->expansion scorer (SKILL.md "Caracal v1.0"). The technical
+helpers (true range / ATR / trend structure) and the `score_vol_breakout`
+scoring table — range breakout + compression precondition + expansion surge
++ higher-TF agreement — are reproduced VERBATIM so a fidelity harness can
+diff this against the v2 producer on the same candle snapshot.
+
+This is the XYZ book (wantXyz=true): the universe is the liquid XYZ DEX
+cross-section (equities / energy / metals / indices). It captures
+oil-geopolitics and AI-infra moves as direction-agnostic VOLATILITY events,
+24/7 (XYZ trades through weekends). The engine is IDENTICAL to the BREAKOUT
+(crypto) book — only the universe DEX differs; this module is the verbatim
+twin of ../../breakout/scanners/scoring.py.
+
+Single-pass, unit-testable on plain candle lists. The caller (scan.py) owns
+the clock and the MCP reads."""
+
+# Score normalization divisor for the 0..1 ingest-ranking score (v2 NORM_DIV).
+NORM_DIV = 8.0
+
+# ── v2 defaults (caracal-producer.py _DEFAULTS["catalyst"] / config) ──
+MIN_SCORE = 5
+MARGIN_PCT = 18          # PERCENT in (0,100] — v2 stored 0.18 (FRACTION); ×100 here
+MAX_LEVERAGE = 5
+MAX_SLOTS = 3
+VOL_FLOOR_PCT_OF_MEDIAN = 0.2
+UNIVERSE_MAX_NAMES = 15  # XYZ book caps at 15 (v2 _DEFAULTS["catalyst"], thinner board)
+BREAKOUT_BARS = 20       # prior-range lookback for the break
+RECENT_BARS = 10         # ATR window — "recent" vol
+BASE_BARS = 30           # ATR window — baseline vol
+SQUEEZE_TIGHT = 0.70     # recent/baseline ATR <= this = tight coil
+SQUEEZE_LOOSE = 0.90     # ... <= this = mild coil
+SURGE_STRONG = 2.0       # breakout-bar TR / baseline ATR
+SURGE_MOD = 1.3
+
+
+# ── numeric coercion ──
+
+def _f(v, d=0.0):
+    try:
+        return float(v) if v is not None else d
+    except (TypeError, ValueError):
+        return d
+
+
+# ═══════════════════════════════════════════════════════════════
+# Technical helpers — ported VERBATIM from caracal-producer.py
+# ═══════════════════════════════════════════════════════════════
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])      # [t, o, h, l, c, v] ohlcv array shape
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def trend_structure(candles, lookback=6):
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def true_range(c, prev_close):
+    h, l = _high(c), _low(c)
+    return max(h - l, abs(h - prev_close), abs(l - prev_close))
+
+
+def atr(candles, period):
+    """Average true range over the last `period` bars."""
+    if len(candles) < 2:
+        return 0.0
+    trs = []
+    for i in range(1, len(candles)):
+        trs.append(true_range(candles[i], _close(candles[i - 1])))
+    w = trs[-period:] if len(trs) >= period else trs
+    return sum(w) / len(w) if w else 0.0
+
+
+# ═══════════════════════════════════════════════════════════════
+# Volatility-breakout scoring — compression precedes expansion
+# (ported VERBATIM from caracal-producer.py score_vol_breakout)
+# ═══════════════════════════════════════════════════════════════
+
+def score_vol_breakout(asset, c1, c4, config=None):
+    """Detect a range breakout from a low-volatility coil and ride the break
+    direction. `c1` = 1h candles, `c4` = 4h candles. Returns None if no
+    breakout / not enough data. The caller fetches the candles; this stays
+    pure so a harness can replay v2 snapshots."""
+    config = config or {}
+    look = int(config.get("breakoutBars", BREAKOUT_BARS))
+    recent_bars = int(config.get("recentBars", RECENT_BARS))
+    base_bars = int(config.get("baseBars", BASE_BARS))
+    sq_tight = float(config.get("squeezeTight", SQUEEZE_TIGHT))
+    sq_loose = float(config.get("squeezeLoose", SQUEEZE_LOOSE))
+    surge_strong = float(config.get("surgeStrong", SURGE_STRONG))
+    surge_mod = float(config.get("surgeMod", SURGE_MOD))
+
+    if not c1 or not c4:
+        return None
+    need = max(look, base_bars) + 2
+    if len(c1) < need or len(c4) < 6:
+        return None
+    highs = [_high(c) for c in c1]
+    lows = [_low(c) for c in c1]
+    closes = [_close(c) for c in c1]
+    price = closes[-1]
+
+    # Range breakout vs the prior `look` bars (excluding the current bar).
+    prior_high = max(highs[-(look + 1):-1])
+    prior_low = min(lows[-(look + 1):-1])
+    broke_up = price > prior_high
+    broke_dn = price < prior_low
+    if not (broke_up or broke_dn):
+        return None
+    direction = "LONG" if broke_up else "SHORT"
+
+    a_recent = atr(c1[-(recent_bars + 1):], recent_bars)
+    a_base = atr(c1[-(base_bars + 1):], base_bars)
+    squeeze = (a_recent / a_base) if a_base > 0 else 1.0
+    last_tr = true_range(c1[-1], closes[-2])
+    surge = (last_tr / a_base) if a_base > 0 else 0.0
+    trend4, _ = trend_structure(c4)
+
+    score = 0
+    reasons = [f"breakout_{'up' if broke_up else 'down'}"]
+    score += 3  # the breakout trigger
+
+    # Compression precondition — the edge. A coil scores; no coil is penalized.
+    if squeeze <= sq_tight:
+        score += 2
+        reasons.append(f"coil_{squeeze:.2f}")
+    elif squeeze <= sq_loose:
+        score += 1
+        reasons.append(f"coil_{squeeze:.2f}")
+    else:
+        score -= 1
+        reasons.append(f"no_coil_{squeeze:.2f}")
+
+    # Expansion surge — the breakout bar should be an outsized move.
+    if surge >= surge_strong:
+        score += 2
+        reasons.append(f"surge_{surge:.1f}x")
+    elif surge >= surge_mod:
+        score += 1
+        reasons.append(f"surge_{surge:.1f}x")
+
+    # Higher-TF agreement (a break with the 4h structure follows through more).
+    if (broke_up and trend4 == "BULLISH") or (broke_dn and trend4 == "BEARISH"):
+        score += 1
+        reasons.append(f"4h_{trend4.lower()}_agree")
+    elif (broke_up and trend4 == "BEARISH") or (broke_dn and trend4 == "BULLISH"):
+        score -= 1
+        reasons.append("4h_against")
+
+    return {
+        "coin": asset, "direction": direction, "score": score,
+        "reasons": reasons, "price": price,
+        "squeeze": squeeze, "surge": surge, "trend4h": trend4,
+    }
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp desired leverage to [1, venue_max]. Ported verbatim from v2
+    clamp_leverage. A missing/invalid venue cap falls back to `desired`."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = int(desired)
+    if venue <= 0:
+        venue = int(desired)
+    return max(1, min(int(desired), venue))

--- a/strategies/caracal/strategy.yaml
+++ b/strategies/caracal/strategy.yaml
@@ -1,0 +1,48 @@
+# Caracal — Volatility Hedge Fund. A two-instance PACKAGE: this manifest + two
+# self-contained runtime.yaml books (breakout = crypto / catalyst = XYZ, on SEPARATE
+# wallets, ~equally funded) + per-book scanners/. A faithful Runtime 3.0 port of the v2
+# Caracal v1.0 volatility compression->expansion engine (caracal-producer.py, one script
+# driven by CARACAL_LEG into two books). It trades MOVEMENT, not a directional view: each
+# book takes the breakout LONG or SHORT, whichever way a coiled name breaks. Install/
+# teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: caracal
+version: "1.0.0"
+
+catalog:
+  name: "Caracal — Volatility Hedge Fund"
+  emoji: "🐱"
+  tagline: "Two volatility books on two wallets — one scans liquid crypto, the other scans tokenized stocks/commodities/indices (XYZ) — for names coiled in a low-volatility squeeze that break their recent range with an expansion surge, then rides the break direction (LONG up / SHORT down). It trades MOVEMENT, not a view: the edge is that compression precedes expansion."
+  belief_plain: "Watches the market for coins and stocks that have gone quiet (price barely moving), then pounces the moment one breaks out of its quiet range with a big jump — going long if it breaks up, short if it breaks down. It runs two separate pots: one for crypto, one for tokenized stocks and commodities. The bet is on the size of the move, not its direction."
+  thesis: "Volatility is the edge. A breakout FROM a low-volatility coil has far higher follow-through than a breakout in already-volatile tape — compression precedes expansion. Caracal only fires when a name has been coiling (recent ATR << baseline ATR) AND breaks its range AND the breakout bar is an outsized move, then rides whichever way it broke. Splitting crypto (breakout book) from tokenized stocks/commodities/indices (catalyst book) lets it capture oil-geopolitics and AI-infra moves 24/7 alongside crypto vol, on two separately-funded wallets that net to a direction-agnostic volatility harvester."
+  group: momentum
+  archetype: breakout_momentum
+  sub_style: range_break
+  asset_classes: [universe_crypto, xyz_equities, commodities, indices]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 6
+  min_budget: 400
+  assets: []
+  tags: [volatility, breakout, compression-expansion, coiled-spring, atr-squeeze, range-break, crypto, xyz, equities, commodities, indices, long-short, two-book, market-neutral-vol]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: breakout
+    runtime: breakout/runtime.yaml
+    wallet_env: CARACAL_BREAKOUT_WALLET
+    funding_share: 0.5
+  - name: catalyst
+    runtime: catalyst/runtime.yaml
+    wallet_env: CARACAL_CATALYST_WALLET
+    funding_share: 0.5

--- a/strategies/caribou/long/runtime.yaml
+++ b/strategies/caribou/long/runtime.yaml
@@ -1,0 +1,147 @@
+# ── CARIBOU · LONG sleeve — the long book of a cross-asset trend fund (managed futures / CTA) ──
+name: caribou-long
+group: caribou
+version: 3.0.0
+description: >
+  CARIBOU LONG — the long book of a cross-asset trend fund (managed futures / CTA). Runtime 3.0
+  port of v2 Caribou v1.0.0 (CARIBOU_LEG=long). Trend-follows the WHOLE Hyperliquid instrument
+  board across every asset class — crypto, xyz stocks, indices, metals, energy — opening LONGS on
+  assets in a confirmed UPTREND (4h structure bullish is the hard gate; the daily aligns; 24h
+  momentum confirms; an RSI blow-off guard refines). Each asset is judged against its OWN history
+  (time-series trend). Positions are sized to EQUAL RISK by volatility parity (margin scales
+  inversely with the asset's ATR%, normalized to a reference vol, clamped) and capped per asset
+  CLASS at 40% of equity, so the book stays diversified across uncorrelated classes — the CTA edge.
+  Pairs with the SHORT sleeve on a SEPARATE wallet; the two are independent, so the fund may hold
+  the same asset long here and short there. Diversification across uncorrelated trends is the edge;
+  net beta is near zero. The producer-side LLM gate was a pass-through, so the scan applies the
+  trend gate + vol-parity sizing + class cap + dedup and the entry runs rule-mode.
+
+strategy:
+  wallet: "${CARIBOU_LONG_WALLET}"
+  slots: 8                                # diversified book across classes
+  default_leverage: 3                     # baseLeverage; scan bumps apex trends to maxLeverage then venue-clamps
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: caribou_long_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 tickSeconds — cross-asset trend cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50            # signal-dedup map + per-tick result
+    inputs:
+      leg: "long"
+      # ── trend gate / scoring (v2 caribou-long-config.json, verbatim) ──
+      minScore: 5
+      apexScore: 7                         # apex trend -> maxLeverage
+      strongMomPct: 5.0                    # 24h move for the extra momentum point
+      rsiOverbought: 80                    # blow-off guard — don't chase an overbought uptrend
+      # ── vol-parity sizing (FRACTIONS of equity; scan emits the PERCENT marginPct) ──
+      baseRiskPct: 0.08                    # margin a REFERENCE-vol asset gets, as fraction of equity
+      referenceVolPct: 3.0                 # "typical" daily ATR% — the vol-parity anchor
+      minMarginPct: 0.03                   # floor per position (fraction of equity)
+      maxMarginPct: 0.15                   # cap per position (fraction of equity)
+      classMarginCapPct: 0.40              # max total margin per asset CLASS (fraction of equity)
+      # ── leverage / book ──
+      baseLeverage: 3
+      maxLeverage: 5                       # strict sleeve clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 8
+      # ── universe ranking / liquidity (instrument-board context, no candle fetch) ──
+      perClassMaxNames: 12                 # liquidity-cap per class before ranking
+      rankPerClass: 6                      # top movers per class to confirm with candles
+      volFloorPctOfMedian: 0.2             # within-class relative liquidity gate (no $ floor)
+      recentSignalTtlSeconds: 180          # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+      # ── asset-class map (classification reference data; xyz: names not in metals/energy/
+      #    indices fall through to "equity"; non-xyz names are "crypto") — verbatim v2 ──
+      classMetals: ["GOLD", "SILVER", "PLATINUM", "PALLADIUM", "COPPER"]
+      classEnergy: ["BRENTOIL", "CL", "WTI", "NATGAS", "GAS", "HEATOIL", "GASOLINE", "URNM"]
+      classIndices: ["SP500", "NASDAQ", "NDX", "US500", "US100", "DJIA", "US30", "RUSSELL", "RUT", "VIX"]
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      assetClass: { type: string, required: false }
+      trend4h: { type: string, required: false }
+      trend1d: { type: string, required: false }
+      volPct: { type: number, required: false }
+      own24h: { type: number, required: false }
+      rsi: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: caribou_long_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # v2 LLM gate was pass-through; scan already applied trend gate + vol-parity + class cap + dedup
+    scanners: [caribou_long_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # a trend-follower MUST catch the move — taker fallback guarantees fill + DSL attach
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: caribou_long_signals
+
+# ── EXIT (DSL — ASYMMETRIC TREND PROFILE: cut losers fast, let winners RUN; ported VERBATIM
+#    from v2 runtime-long.yaml). Time-cuts OFF — a trend fund must let a trend run for weeks.
+#    Tight Phase 1 + a WIDE Phase 2 ladder (first LOCK at +25% -> 35%, reachable). ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 20160
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 720             # self-limiting only — cut a position that's gone nowhere for a long time
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 1440
+    phase1:
+      enabled: true
+      max_loss_pct: 14.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 12, lock_hw_pct: 0 }     # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 25, lock_hw_pct: 35 }    # first LOCK — reachable
+        - { trigger_pct: 50, lock_hw_pct: 55 }
+        - { trigger_pct: 90, lock_hw_pct: 72 }
+        - { trigger_pct: 150, lock_hw_pct: 84 }
+
+risk:
+  data_retention_seconds: 604800           # 168h (was data_retention_hours: 168)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 8                  # diversified book opens across classes; trend is slow, not churny
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 6               # trend takes many small losses before the big trend — don't halt on normal chop
+    cooldown_seconds: 3600                  # v2 cooldown_minutes 60
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 14400       # v2 per_asset_cooldown_minutes 240
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/caribou/long/scanners/scan.py
+++ b/strategies/caribou/long/scanners/scan.py
@@ -1,0 +1,385 @@
+"""CARIBOU — supervised scanner (shared verbatim by both sleeves).
+
+Direction-parametrized cross-asset TREND FUND (managed futures / CTA): the `long` instance
+passes leg=long (longs confirmed UPTRENDS), the `short` instance passes leg=short (shorts
+confirmed DOWNTRENDS). A faithful Runtime 3.0 port of the v2 caribou-producer.py v1.0.0 — the
+class bucketing, momentum ranking, time-series trend scoring, vol-parity sizing and per-class
+diversification cap are preserved EXACTLY. Read-only, single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value via max(main,xyz) — never sum; held names;
+     current per-class deployed margin for the class cap)
+  2. build the universe from the WHOLE live instrument board (crypto + xyz stocks/indices/
+     metals/energy), bucket by asset class, apply a per-class top-N + relative-median liquidity
+     gate, then rank each class by 24h momentum IN THE SLEEVE'S DIRECTION and keep the top
+     `rankPerClass` movers — all from instrument-board CONTEXT, NO candle fetch here
+  3. confirm + score the trend on each finalist (candle fetch happens here), keep score>=minScore
+  4. sort by score, apply the per-class margin cap (40% of equity per class) so the book stays
+     diversified across classes — the entire CTA edge
+  5. emit a top-level marginPct INTENT (PERCENT, vol-parity sized) + a per-name venue-clamped
+     leverage; the runtime owns slots, dedup, affordability, execution, and the DSL exit.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (asia-ai NASDAQ-bug class). Per the scan contract
+ANY uncaught exception rolls the whole tick back to [] — one bad read would silently kill all
+emits — so every read degrades (skip asset / empty universe / neutral) instead of propagating.
+
+FIDELITY NOTES vs caribou-producer.py v1.0.0:
+  - v2 sized in absolute marginUsd via vol_parity_margin() = account_value * pct (a FRACTION
+    clamped to [0.03, 0.15]). This port emits the SAME vol-parity pct as a PERCENT (marginPct,
+    pct*100) and the runtime sizes (marginPct/100)*withdrawable. Formula + clamps verbatim.
+  - PER-CLASS MARGIN CAP preserved (the core CTA diversification edge): current per-class
+    deployed margin is read from open positions and expressed as % of equity; a candidate whose
+    class would exceed classMarginCapPct (40%) is skipped. Because the runtime (not the scan)
+    sizes the actual dollars, this cap is computed on the EMITTED marginPct intents + the
+    observed deployed margin %, which is the faithful percent-space equivalent of the v2 USD cap.
+  - DROPPED (runtime owns these in 3.0; FLAGGED): the v2 affordability gate (margin*1.1 >
+    free_margin) and the open-slots accounting that capped emits to (maxSlots - held) — both are
+    the runtime's job now (slots + reconciliation). The scan still suppresses HELD names and
+    recently-signalled names (belt-and-suspenders dedup in ctx.state) and emits at most
+    `maxSlots` candidates so it never floods.
+  - v2 normalised the wire score to min(score/8, 1.0); the 3.0 scaffold owns the wire envelope,
+    so the raw integer score rides on data{}.
+  - v2 recent-signals JSON cache -> ctx.state dedup map (same TTL semantics).
+  - v2 read-sanity guard (margin in use + empty positions -> skip tick) preserved verbatim.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll back
+    the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[caribou.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions (verbatim v2 get_positions; dual-DEX max(), read-sanity guard) ──
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts]). The 'main' and 'xyz' clearinghouse sections
+    are TWO VIEWS of ONE cross-margined wallet — accountValue is taken ONCE via max() across
+    sections, NEVER summed (v2-quirk: summing double-counts the shared balance -> 2x sizing).
+    READ-GUARDED inside _read. Includes the v2 read-sanity guard."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, []
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": scoring._f(pos.get("marginUsed", 0)),
+            })
+    # v2 read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an EMPTY
+    # positions list is a corrupt read — sizing or held-dedup off that re-enters held names.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[caribou.scan] read-sanity guard: margin in use but empty positions — skip tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+# ── live instrument board (verbatim v2 get_universe_meta + ret_24h + day_vol folded) ──
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, ret24h, vol}. Includes xyz instruments (Caribou trades every
+    class). Skips delisted. Verbatim v2 get_universe_meta()/ret_24h()/day_vol()."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out, canonical = {}, []
+    if not resp:
+        return out, canonical
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+        canonical.append(name)
+    return out, canonical
+
+
+def _fetch_candles(ctx, asset):
+    """4h + 1d candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns
+    ([], []) and the universe loop skips it (asia-ai per-asset read-guard)."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["4h", "1d"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], [], None
+    d = _unwrap(resp)
+    if isinstance(d, dict) and d.get("success") is False:
+        return [], [], None
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    asset_ctx = (d.get("asset_context", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("4h", []) or [], candles.get("1d", []) or [], asset_ctx
+
+
+def _own_24h_from_ctx(asset_ctx):
+    """24h return from the per-asset context (verbatim v2 ret_24h on md ctx)."""
+    if not isinstance(asset_ctx, dict):
+        return None
+    try:
+        mark = float(asset_ctx.get("markPx", 0) or 0)
+        prev = float(asset_ctx.get("prevDayPx", 0) or 0)
+    except (TypeError, ValueError):
+        return None
+    if prev <= 0 or mark <= 0:
+        return None
+    return (mark - prev) / prev * 100.0
+
+
+# ── class pools — verbatim v2 build_class_pools (rank from CONTEXT, no candle fetch) ──
+
+def _build_class_pools(inputs, meta_map, canonical, leg):
+    """Bucket the universe by asset class; within each class apply a top-N-by-vol liquidity cap
+    + a relative-to-median gate; then rank by 24h momentum in the sleeve's direction and keep
+    the top `rankPerClass` movers. Returns {class: [(name, meta), ...]}. Ranking is from
+    context only — NO candle fetch here. Verbatim v2 build_class_pools()."""
+    per_class_max = int(inputs.get("perClassMaxNames", scoring.DEFAULTS["perClassMaxNames"]))
+    rank_per = int(inputs.get("rankPerClass", scoring.DEFAULTS["rankPerClass"]))
+    vfloor = float(inputs.get("volFloorPctOfMedian", scoring.DEFAULTS["volFloorPctOfMedian"]))
+
+    buckets = {}
+    seen = set()
+    for name in canonical:
+        if not isinstance(name, str):
+            continue
+        key = name.upper()
+        if key in seen:
+            continue
+        meta = meta_map.get(name) or meta_map.get(key)
+        if not meta:
+            continue
+        v = meta.get("vol", 0.0)
+        if v <= 0:
+            continue
+        seen.add(key)
+        buckets.setdefault(scoring.classify(name, inputs), []).append((name, meta, v))
+
+    pools = {}
+    for cls, names in buckets.items():
+        names.sort(key=lambda x: x[2], reverse=True)
+        names = names[:per_class_max]
+        if not names:
+            continue
+        vols = sorted(v for _, _, v in names)
+        median = vols[len(vols) // 2]
+        floor = vfloor * median
+        liquid = [(n, m) for n, m, v in names if v >= floor]
+        scored = []
+        for n, m in liquid:
+            r = m.get("ret24h")
+            if r is None:
+                continue
+            scored.append((n, m, r))
+        scored.sort(key=lambda x: x[2], reverse=(leg == "long"))
+        # long: most positive movers; short: most negative movers
+        finalists = [(n, m) for n, m, r in scored
+                     if (r > 0 if leg == "long" else r < 0)][:rank_per]
+        pools[cls] = finalists
+    return pools
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    min_score = int(inputs.get("minScore", scoring.DEFAULTS["minScore"]))
+    max_lev = int(inputs.get("maxLeverage", scoring.DEFAULTS["maxLeverage"]))
+    max_slots = int(inputs.get("maxSlots", scoring.DEFAULTS["maxSlots"]))
+    class_cap_pct = float(inputs.get("classMarginCapPct", scoring.DEFAULTS["classMarginCapPct"]))
+    class_cap_pct = class_cap_pct / 100.0 if class_cap_pct > 1.0 else class_cap_pct  # frac guard
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("signaled") or {}).items() if (now - v) < ttl * 4}
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"signaled": recent, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[caribou.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+
+    account_value, positions = _get_positions(ctx)
+    if account_value <= 0:
+        _persist({"ts": now, "leg": leg, "emitted": False, "gate": "no_account_value"})
+        print(f"[caribou.scan] leg={leg} WAITING — no account value / corrupt read",
+              file=sys.stderr)
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    meta_map, canonical = _get_universe_meta(ctx)
+    if not canonical:
+        _persist({"ts": now, "leg": leg, "emitted": False, "gate": "no_universe"})
+        print(f"[caribou.scan] leg={leg} WAITING — instrument board empty/failed",
+              file=sys.stderr)
+        return []
+
+    pools = _build_class_pools(inputs, meta_map, canonical, leg)
+
+    # ── Confirm + score the trend on each class's finalists (candle fetch happens here) ──
+    candidates = []
+    scanned = 0
+    for cls, finalists in pools.items():
+        for name, meta in finalists:
+            if name.upper() in held_set:
+                continue
+            if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+                continue
+            scanned += 1
+            c4, cd, asset_ctx = _fetch_candles(ctx, name)
+            if len(c4) < 6:
+                continue
+            own = _own_24h_from_ctx(asset_ctx)
+            if own is None:
+                own = meta.get("ret24h")     # fall back to board context
+            th = scoring.score_trend(name, c4, cd, own, leg, inputs)
+            if th and th["score"] >= min_score:
+                th["_meta"] = meta
+                th["assetClass"] = cls
+                candidates.append(th)
+
+    if not candidates:
+        _persist({"ts": now, "leg": leg, "emitted": False, "gate": "no_candidate",
+                  "scanned": scanned, "classes": {c: len(f) for c, f in pools.items()},
+                  "min_score": min_score, "held": held})
+        print(f"[caribou.scan] leg={leg} WAITING — no asset cleared min score {min_score} "
+              f"(scanned {scanned}, classes {{{', '.join(f'{c}:{len(f)}' for c, f in pools.items())}}})",
+              file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # ── Per-class margin cap (in PERCENT-of-equity space). Current per-class deployed margin %
+    #    is read from open positions; a candidate whose class would exceed classMarginCapPct is
+    #    skipped — the book stays diversified across classes (the CTA edge). Verbatim v2 intent. ──
+    class_deployed_pct = {}
+    for p in positions:
+        cls = scoring.classify(p.get("coin", ""), inputs)
+        pct = (scoring._f(p.get("margin", 0)) / account_value * 100.0) if account_value > 0 else 0.0
+        class_deployed_pct[cls] = class_deployed_pct.get(cls, 0.0) + pct
+    class_cap = class_cap_pct * 100.0   # PERCENT
+
+    out = []
+    emitted = []
+    skipped_cap = []
+    for th in candidates:
+        if len(out) >= max_slots:
+            break
+        cls = th["assetClass"]
+        margin_pct = scoring.vol_parity_margin_pct(th["vol_pct"], inputs)
+        if margin_pct <= 0:
+            continue
+        # per-class diversification cap
+        if class_deployed_pct.get(cls, 0.0) + margin_pct > class_cap:
+            skipped_cap.append(f"{th['coin']}({cls})")
+            continue
+        desired_lev = scoring.conviction_leverage(th["score"], inputs)
+        desired_lev = min(desired_lev, max_lev)               # strict sleeve cap
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(desired_lev, venue_max)
+        if leverage <= 0:
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": margin_pct,                          # PERCENT (0,100] — runtime sizes the $
+            "leverage": leverage,                             # venue-clamped, <= sleeve max
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "assetClass": cls,
+                "trend4h": th.get("trend4h"),
+                "trend1d": th.get("trend1d"),
+                "volPct": th.get("vol_pct"),
+                "own24h": th.get("own24h"),
+                "rsi": th.get("rsi"),
+                "heldAssets": held,
+            },
+        })
+        class_deployed_pct[cls] = class_deployed_pct.get(cls, 0.0) + margin_pct
+        recent[th["coin"].upper()] = now
+        emitted.append({"coin": th["coin"], "class": cls, "score": th["score"],
+                        "leverage": leverage, "marginPct": margin_pct})
+
+    result = {"ts": now, "leg": leg, "emitted": bool(out), "gate": "pass" if out else "all_capped",
+              "scanned": scanned, "candidates": len(candidates), "signals": len(out),
+              "classes": {c: len(f) for c, f in pools.items()},
+              "class_deployed_pct": {k: round(v, 2) for k, v in class_deployed_pct.items()},
+              "skipped_class_cap": skipped_cap, "held": held,
+              "account_value": round(account_value, 2),
+              "elapsed_sec": round(time.time() - run_start, 2), "details": emitted}
+    _persist(result)
+    print(f"[caribou.scan] leg={leg} {'EMIT' if out else 'WAITING'} scanned={scanned} "
+          f"candidates={len(candidates)} signals={len(out)} "
+          f"classes={{{', '.join(f'{c}:{len(f)}' for c, f in pools.items())}}} "
+          f"skipped_cap={skipped_cap} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/caribou/long/scanners/scoring.py
+++ b/strategies/caribou/long/scanners/scoring.py
@@ -1,0 +1,286 @@
+"""CARIBOU — pure cross-asset trend math (no I/O, no MCP, no clock). Shared verbatim by
+both sleeves; direction is passed in (`leg` = "long" for the uptrend book, "short" for the
+downtrend book). A faithful port of the v2 caribou-producer.py scoring + vol-parity sizing +
+asset-class classification — the gates, point weights, vol-parity formula and class map are
+copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be
+redesigned). Unit-testable on plain candle lists.
+
+FIDELITY: this module reproduces, verbatim, the v2 producer's:
+  - trend_structure / calc_rsi / atr_pct technicals
+  - score_trend long/short scoring table (4h hard gate, +3; daily align +/-2; 24h mom +1;
+    strong-mom +1; RSI blow-off/capitulation guard -2)
+  - vol-parity sizing: pct = baseRiskPct * (referenceVolPct / asset_ATR%), clamped to
+    [minMarginPct, maxMarginPct]. v2 emitted this as a FRACTION * account_value -> marginUsd;
+    the 3.0 scan emits the PERCENT (pct*100) and the runtime sizes the dollars.
+  - classify(): crypto | equity | index | metal | energy.
+"""
+
+# v2-quirk: raw-score normaliser. v2 emitted min(score/8.0, 1.0) as the [0,1] wire score
+# (NORM_DIV = 8.0, max raw ~3+2+1+1 = 7). The 3.0 scaffold owns the wire envelope, so the raw
+# integer score is kept on data{}; NORM_DIV is retained only for a v2-equivalent normalised score.
+NORM_DIV = 8.0
+
+# Per-sleeve defaults (config.json / runtime inputs override every one). Copied from the v2
+# producer _DEFAULTS so the pure module can be exercised standalone.
+DEFAULTS = {
+    "minScore": 5,
+    "apexScore": 7,
+    "baseLeverage": 3,
+    "maxLeverage": 5,
+    "maxSlots": 8,
+    "baseRiskPct": 0.08,         # FRACTION of equity a REFERENCE-vol asset gets (vol-parity anchor)
+    "referenceVolPct": 3.0,      # "typical" daily ATR% — the vol-parity normaliser
+    "minMarginPct": 0.03,        # FRACTION floor per position
+    "maxMarginPct": 0.15,        # FRACTION cap per position
+    "classMarginCapPct": 0.40,   # FRACTION — max total margin per asset CLASS
+    "perClassMaxNames": 12,
+    "rankPerClass": 6,
+    "volFloorPctOfMedian": 0.2,
+    "strongMomPct": 5.0,
+    "rsiOverbought": 80,
+    "rsiOversold": 20,
+    "classMetals": ["GOLD", "SILVER", "PLATINUM", "PALLADIUM", "COPPER"],
+    "classEnergy": ["BRENTOIL", "CL", "WTI", "NATGAS", "GAS", "HEATOIL", "GASOLINE", "URNM"],
+    "classIndices": ["SP500", "NASDAQ", "NDX", "US500", "US100", "DJIA", "US30", "RUSSELL", "RUT", "VIX"],
+}
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v) if v is not None else d
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    return 0.0
+
+
+# ── technicals (verbatim v2) ──────────────────────────────────────────────────
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def atr_pct(candles, period=14):
+    """Average True Range as % of last price — the volatility-parity input. Returns None if
+    not computable (caller falls back to reference vol). Verbatim v2."""
+    if len(candles) < 3:
+        return None
+    trs = []
+    for i in range(1, len(candles)):
+        h, lo, pc = _high(candles[i]), _low(candles[i]), _close(candles[i - 1])
+        if h <= 0 or lo <= 0 or pc <= 0:
+            continue
+        trs.append(max(h - lo, abs(h - pc), abs(lo - pc)))
+    if not trs:
+        return None
+    atr = sum(trs[-period:]) / len(trs[-period:])
+    price = _close(candles[-1])
+    if price <= 0:
+        return None
+    return atr / price * 100.0
+
+
+# ── asset-class classification (verbatim v2) ──────────────────────────────────
+
+def classify(asset, inputs):
+    """Map an instrument to an asset class: crypto | equity | index | metal | energy.
+    Verbatim v2 classify(): xyz: names not in metals/energy/indices fall through to "equity";
+    non-xyz names are "crypto"."""
+    name = asset.split(":", 1)[1] if ":" in asset else asset
+    name = name.upper()
+    if not asset.lower().startswith("xyz:"):
+        return "crypto"
+    if name in set(inputs.get("classMetals", DEFAULTS["classMetals"])):
+        return "metal"
+    if name in set(inputs.get("classEnergy", DEFAULTS["classEnergy"])):
+        return "energy"
+    if name in set(inputs.get("classIndices", DEFAULTS["classIndices"])):
+        return "index"
+    return "equity"   # any other xyz name is a single-name stock
+
+
+# ── trend scoring (time-series, per asset) — verbatim v2 score_trend ──────────
+
+def score_trend(asset, candles_4h, candles_1d, own24h, leg, inputs):
+    """Confirm + score a trend on ONE asset. Returns the thesis (incl. vol_pct for vol-parity
+    sizing) or None to disqualify. 4h is the HARD gate; the daily aligns; momentum + RSI guard
+    refine. Point weights + gates copied VERBATIM from the v2 producer score_trend() — do NOT
+    redesign.
+
+    leg == "long":  long a confirmed 4h UPTREND   (BULLISH 4h structure is the hard gate)
+    leg == "short": short a confirmed 4h DOWNTREND (BEARISH 4h structure is the hard gate)
+    """
+    if len(candles_4h) < 6:
+        return None
+    closes4 = [_close(c) for c in candles_4h]
+    price = closes4[-1]
+    if price <= 0:
+        return None
+
+    trend4, s4 = trend_structure(candles_4h)
+    trendd, sd = trend_structure(candles_1d) if len(candles_1d) >= 6 else ("NEUTRAL", 0)
+    rsi = calc_rsi(closes4)
+    own = own24h if own24h is not None else 0.0
+
+    # Vol estimate for parity sizing — prefer daily ATR, fall back to 4h, then referenceVolPct.
+    vol = atr_pct(candles_1d) if len(candles_1d) >= 3 else None
+    if vol is None or vol <= 0:
+        vol = atr_pct(candles_4h)
+    if vol is None or vol <= 0:
+        vol = float(inputs.get("referenceVolPct", DEFAULTS["referenceVolPct"]))
+
+    strong = float(inputs.get("strongMomPct", DEFAULTS["strongMomPct"]))
+    score, reasons = 0, []
+
+    if leg == "long":
+        if trend4 != "BULLISH":                              # v2-quirk: 4h uptrend is the hard gate
+            return None
+        score += 3
+        reasons.append(f"4h_uptrend_{s4:.0%}")
+        if trendd == "BULLISH":
+            score += 2
+            reasons.append(f"1d_uptrend_{sd:.0%}")
+        elif trendd == "BEARISH":
+            score -= 2
+            reasons.append("1d_conflict")
+        if own > 0:
+            score += 1
+            reasons.append(f"mom_{own:+.1f}%")
+        if own >= strong:
+            score += 1
+            reasons.append("mom_strong")
+        rsi_ob = float(inputs.get("rsiOverbought", DEFAULTS["rsiOverbought"]))
+        if rsi > rsi_ob:                                     # v2-quirk: don't chase a blow-off
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        if trend4 != "BEARISH":                              # v2-quirk: 4h downtrend is the hard gate
+            return None
+        score += 3
+        reasons.append(f"4h_downtrend_{s4:.0%}")
+        if trendd == "BEARISH":
+            score += 2
+            reasons.append(f"1d_downtrend_{sd:.0%}")
+        elif trendd == "BULLISH":
+            score -= 2
+            reasons.append("1d_conflict")
+        if own < 0:
+            score += 1
+            reasons.append(f"mom_{own:+.1f}%")
+        if own <= -strong:
+            score += 1
+            reasons.append("mom_strong")
+        rsi_os = float(inputs.get("rsiOversold", DEFAULTS["rsiOversold"]))
+        if rsi < rsi_os:                                     # v2-quirk: don't short a capitulation
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": round(rsi, 1),
+        "trend4h": trend4,
+        "trend1d": trendd,
+        "own24h": round(own, 2),
+        "vol_pct": round(vol, 3),
+    }
+
+
+# ── vol-parity sizing — verbatim v2 vol_parity_margin, in PERCENT ─────────────
+
+def vol_parity_margin_pct(vol_pct, inputs):
+    """Vol-parity sizing as a PERCENT of equity in (0,100]. Margin scales INVERSELY with the
+    asset's volatility, normalized to a reference vol, then clamped to [minMarginPct,
+    maxMarginPct] of equity. A calm asset gets more margin; a wild one gets less — equal risk.
+
+    v2-quirk: the v2 vol_parity_margin() computed this fraction then multiplied by
+    account_value to get marginUsd. The 3.0 runtime sizes the dollars from a PERCENT intent,
+    so we return the same fraction * 100 (the formula + clamps are identical)."""
+    base = float(inputs.get("baseRiskPct", DEFAULTS["baseRiskPct"]))
+    ref = float(inputs.get("referenceVolPct", DEFAULTS["referenceVolPct"]))
+    lo = float(inputs.get("minMarginPct", DEFAULTS["minMarginPct"]))
+    hi = float(inputs.get("maxMarginPct", DEFAULTS["maxMarginPct"]))
+    # Defensive: a pasted PERCENT (e.g. 8) instead of a FRACTION (0.08) for baseRiskPct/clamps
+    # would blow sizing up 100x. v2 stored these as FRACTIONS (<=1.0); coerce anything >1.0
+    # back to a fraction (matching the dire/koala fraction-vs-percent guard).
+    base = base / 100.0 if base > 1.0 else base
+    lo = lo / 100.0 if lo > 1.0 else lo
+    hi = hi / 100.0 if hi > 1.0 else hi
+    if vol_pct <= 0:
+        vol_pct = ref
+    pct = base * (ref / vol_pct)
+    pct = max(lo, min(hi, pct))
+    return round(pct * 100.0, 4)   # -> PERCENT in (0,100]
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))
+
+
+def conviction_leverage(score, inputs):
+    """apex trend -> maxLeverage, else baseLeverage (verbatim v2). Returns the DESIRED leverage
+    before the per-name venue clamp."""
+    apex = int(inputs.get("apexScore", DEFAULTS["apexScore"]))
+    base_lev = int(inputs.get("baseLeverage", DEFAULTS["baseLeverage"]))
+    max_lev = int(inputs.get("maxLeverage", DEFAULTS["maxLeverage"]))
+    return max_lev if score >= apex else base_lev

--- a/strategies/caribou/short/runtime.yaml
+++ b/strategies/caribou/short/runtime.yaml
@@ -1,0 +1,147 @@
+# ── CARIBOU · SHORT sleeve — the short book of a cross-asset trend fund, and its crisis-alpha engine ──
+name: caribou-short
+group: caribou
+version: 3.0.0
+description: >
+  CARIBOU SHORT — the short book of a cross-asset trend fund (managed futures / CTA), and its
+  crisis-alpha engine. Runtime 3.0 port of v2 Caribou v1.0.0 (CARIBOU_LEG=short). Trend-follows
+  the WHOLE Hyperliquid instrument board across every asset class — crypto, xyz stocks, indices,
+  metals, energy — opening SHORTS on assets in a confirmed DOWNTREND (4h structure bearish is the
+  hard gate; the daily aligns; 24h momentum confirms; an RSI capitulation guard refines). When
+  markets break, this sleeve is short the fallers across every class — that is the managed-futures
+  hedge. Each asset is judged against its OWN history (time-series trend). Positions are sized to
+  EQUAL RISK by volatility parity and capped per asset CLASS at 40% of equity, so the book stays
+  diversified across uncorrelated classes — the CTA edge. Pairs with the LONG sleeve on a SEPARATE
+  wallet; the two are independent, so the fund may hold the same asset short here and long there.
+  The producer-side LLM gate was a pass-through, so the scan applies the trend gate + vol-parity
+  sizing + class cap + dedup and the entry runs rule-mode.
+
+strategy:
+  wallet: "${CARIBOU_SHORT_WALLET}"
+  slots: 8                                # diversified book across classes
+  default_leverage: 3                     # baseLeverage; scan bumps apex trends to maxLeverage then venue-clamps
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: caribou_short_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 tickSeconds — cross-asset trend cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50            # signal-dedup map + per-tick result
+    inputs:
+      leg: "short"
+      # ── trend gate / scoring (v2 caribou-short-config.json, verbatim) ──
+      minScore: 5
+      apexScore: 7                         # apex trend -> maxLeverage
+      strongMomPct: 5.0                    # 24h move for the extra momentum point
+      rsiOversold: 20                      # capitulation guard — don't short a capitulation
+      # ── vol-parity sizing (FRACTIONS of equity; scan emits the PERCENT marginPct) ──
+      baseRiskPct: 0.08                    # margin a REFERENCE-vol asset gets, as fraction of equity
+      referenceVolPct: 3.0                 # "typical" daily ATR% — the vol-parity anchor
+      minMarginPct: 0.03                   # floor per position (fraction of equity)
+      maxMarginPct: 0.15                   # cap per position (fraction of equity)
+      classMarginCapPct: 0.40              # max total margin per asset CLASS (fraction of equity)
+      # ── leverage / book ──
+      baseLeverage: 3
+      maxLeverage: 5                       # strict sleeve clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 8
+      # ── universe ranking / liquidity (instrument-board context, no candle fetch) ──
+      perClassMaxNames: 12                 # liquidity-cap per class before ranking
+      rankPerClass: 6                      # top movers per class to confirm with candles
+      volFloorPctOfMedian: 0.2             # within-class relative liquidity gate (no $ floor)
+      recentSignalTtlSeconds: 180          # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+      # ── asset-class map (classification reference data; xyz: names not in metals/energy/
+      #    indices fall through to "equity"; non-xyz names are "crypto") — verbatim v2 ──
+      classMetals: ["GOLD", "SILVER", "PLATINUM", "PALLADIUM", "COPPER"]
+      classEnergy: ["BRENTOIL", "CL", "WTI", "NATGAS", "GAS", "HEATOIL", "GASOLINE", "URNM"]
+      classIndices: ["SP500", "NASDAQ", "NDX", "US500", "US100", "DJIA", "US30", "RUSSELL", "RUT", "VIX"]
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      assetClass: { type: string, required: false }
+      trend4h: { type: string, required: false }
+      trend1d: { type: string, required: false }
+      volPct: { type: number, required: false }
+      own24h: { type: number, required: false }
+      rsi: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: caribou_short_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # v2 LLM gate was pass-through; scan already applied trend gate + vol-parity + class cap + dedup
+    scanners: [caribou_short_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # a trend-follower MUST catch the move — taker fallback guarantees fill + DSL attach
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: caribou_short_signals
+
+# ── EXIT (DSL — ASYMMETRIC TREND PROFILE: cut losers fast, let winners RUN; ported VERBATIM
+#    from v2 runtime-short.yaml). Time-cuts OFF — a trend fund must let a trend run for weeks.
+#    Tight Phase 1 + a WIDE Phase 2 ladder (first LOCK at +25% -> 35%, reachable). ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # exit closes MUST happen — taker fallback is the safety floor
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 20160
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 720             # self-limiting only — cut a position that's gone nowhere for a long time
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 1440
+    phase1:
+      enabled: true
+      max_loss_pct: 14.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 12, lock_hw_pct: 0 }     # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 25, lock_hw_pct: 35 }    # first LOCK — reachable
+        - { trigger_pct: 50, lock_hw_pct: 55 }
+        - { trigger_pct: 90, lock_hw_pct: 72 }
+        - { trigger_pct: 150, lock_hw_pct: 84 }
+
+risk:
+  data_retention_seconds: 604800           # 168h (was data_retention_hours: 168)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 8                  # diversified book opens across classes; trend is slow, not churny
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 6               # trend takes many small losses before the big trend — don't halt on normal chop
+    cooldown_seconds: 3600                  # v2 cooldown_minutes 60
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 14400       # v2 per_asset_cooldown_minutes 240
+
+notifications:
+  telegram_chat_id: "${TELEGRAM_CHAT_ID}"
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/caribou/short/scanners/scan.py
+++ b/strategies/caribou/short/scanners/scan.py
@@ -1,0 +1,385 @@
+"""CARIBOU — supervised scanner (shared verbatim by both sleeves).
+
+Direction-parametrized cross-asset TREND FUND (managed futures / CTA): the `long` instance
+passes leg=long (longs confirmed UPTRENDS), the `short` instance passes leg=short (shorts
+confirmed DOWNTRENDS). A faithful Runtime 3.0 port of the v2 caribou-producer.py v1.0.0 — the
+class bucketing, momentum ranking, time-series trend scoring, vol-parity sizing and per-class
+diversification cap are preserved EXACTLY. Read-only, single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value via max(main,xyz) — never sum; held names;
+     current per-class deployed margin for the class cap)
+  2. build the universe from the WHOLE live instrument board (crypto + xyz stocks/indices/
+     metals/energy), bucket by asset class, apply a per-class top-N + relative-median liquidity
+     gate, then rank each class by 24h momentum IN THE SLEEVE'S DIRECTION and keep the top
+     `rankPerClass` movers — all from instrument-board CONTEXT, NO candle fetch here
+  3. confirm + score the trend on each finalist (candle fetch happens here), keep score>=minScore
+  4. sort by score, apply the per-class margin cap (40% of equity per class) so the book stays
+     diversified across classes — the entire CTA edge
+  5. emit a top-level marginPct INTENT (PERCENT, vol-parity sized) + a per-name venue-clamped
+     leverage; the runtime owns slots, dedup, affordability, execution, and the DSL exit.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (asia-ai NASDAQ-bug class). Per the scan contract
+ANY uncaught exception rolls the whole tick back to [] — one bad read would silently kill all
+emits — so every read degrades (skip asset / empty universe / neutral) instead of propagating.
+
+FIDELITY NOTES vs caribou-producer.py v1.0.0:
+  - v2 sized in absolute marginUsd via vol_parity_margin() = account_value * pct (a FRACTION
+    clamped to [0.03, 0.15]). This port emits the SAME vol-parity pct as a PERCENT (marginPct,
+    pct*100) and the runtime sizes (marginPct/100)*withdrawable. Formula + clamps verbatim.
+  - PER-CLASS MARGIN CAP preserved (the core CTA diversification edge): current per-class
+    deployed margin is read from open positions and expressed as % of equity; a candidate whose
+    class would exceed classMarginCapPct (40%) is skipped. Because the runtime (not the scan)
+    sizes the actual dollars, this cap is computed on the EMITTED marginPct intents + the
+    observed deployed margin %, which is the faithful percent-space equivalent of the v2 USD cap.
+  - DROPPED (runtime owns these in 3.0; FLAGGED): the v2 affordability gate (margin*1.1 >
+    free_margin) and the open-slots accounting that capped emits to (maxSlots - held) — both are
+    the runtime's job now (slots + reconciliation). The scan still suppresses HELD names and
+    recently-signalled names (belt-and-suspenders dedup in ctx.state) and emits at most
+    `maxSlots` candidates so it never floods.
+  - v2 normalised the wire score to min(score/8, 1.0); the 3.0 scaffold owns the wire envelope,
+    so the raw integer score rides on data{}.
+  - v2 recent-signals JSON cache -> ctx.state dedup map (same TTL semantics).
+  - v2 read-sanity guard (margin in use + empty positions -> skip tick) preserved verbatim.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll back
+    the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[caribou.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions (verbatim v2 get_positions; dual-DEX max(), read-sanity guard) ──
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts]). The 'main' and 'xyz' clearinghouse sections
+    are TWO VIEWS of ONE cross-margined wallet — accountValue is taken ONCE via max() across
+    sections, NEVER summed (v2-quirk: summing double-counts the shared balance -> 2x sizing).
+    READ-GUARDED inside _read. Includes the v2 read-sanity guard."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, []
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": scoring._f(pos.get("marginUsed", 0)),
+            })
+    # v2 read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an EMPTY
+    # positions list is a corrupt read — sizing or held-dedup off that re-enters held names.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[caribou.scan] read-sanity guard: margin in use but empty positions — skip tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+# ── live instrument board (verbatim v2 get_universe_meta + ret_24h + day_vol folded) ──
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, ret24h, vol}. Includes xyz instruments (Caribou trades every
+    class). Skips delisted. Verbatim v2 get_universe_meta()/ret_24h()/day_vol()."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out, canonical = {}, []
+    if not resp:
+        return out, canonical
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+        canonical.append(name)
+    return out, canonical
+
+
+def _fetch_candles(ctx, asset):
+    """4h + 1d candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns
+    ([], []) and the universe loop skips it (asia-ai per-asset read-guard)."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["4h", "1d"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], [], None
+    d = _unwrap(resp)
+    if isinstance(d, dict) and d.get("success") is False:
+        return [], [], None
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    asset_ctx = (d.get("asset_context", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("4h", []) or [], candles.get("1d", []) or [], asset_ctx
+
+
+def _own_24h_from_ctx(asset_ctx):
+    """24h return from the per-asset context (verbatim v2 ret_24h on md ctx)."""
+    if not isinstance(asset_ctx, dict):
+        return None
+    try:
+        mark = float(asset_ctx.get("markPx", 0) or 0)
+        prev = float(asset_ctx.get("prevDayPx", 0) or 0)
+    except (TypeError, ValueError):
+        return None
+    if prev <= 0 or mark <= 0:
+        return None
+    return (mark - prev) / prev * 100.0
+
+
+# ── class pools — verbatim v2 build_class_pools (rank from CONTEXT, no candle fetch) ──
+
+def _build_class_pools(inputs, meta_map, canonical, leg):
+    """Bucket the universe by asset class; within each class apply a top-N-by-vol liquidity cap
+    + a relative-to-median gate; then rank by 24h momentum in the sleeve's direction and keep
+    the top `rankPerClass` movers. Returns {class: [(name, meta), ...]}. Ranking is from
+    context only — NO candle fetch here. Verbatim v2 build_class_pools()."""
+    per_class_max = int(inputs.get("perClassMaxNames", scoring.DEFAULTS["perClassMaxNames"]))
+    rank_per = int(inputs.get("rankPerClass", scoring.DEFAULTS["rankPerClass"]))
+    vfloor = float(inputs.get("volFloorPctOfMedian", scoring.DEFAULTS["volFloorPctOfMedian"]))
+
+    buckets = {}
+    seen = set()
+    for name in canonical:
+        if not isinstance(name, str):
+            continue
+        key = name.upper()
+        if key in seen:
+            continue
+        meta = meta_map.get(name) or meta_map.get(key)
+        if not meta:
+            continue
+        v = meta.get("vol", 0.0)
+        if v <= 0:
+            continue
+        seen.add(key)
+        buckets.setdefault(scoring.classify(name, inputs), []).append((name, meta, v))
+
+    pools = {}
+    for cls, names in buckets.items():
+        names.sort(key=lambda x: x[2], reverse=True)
+        names = names[:per_class_max]
+        if not names:
+            continue
+        vols = sorted(v for _, _, v in names)
+        median = vols[len(vols) // 2]
+        floor = vfloor * median
+        liquid = [(n, m) for n, m, v in names if v >= floor]
+        scored = []
+        for n, m in liquid:
+            r = m.get("ret24h")
+            if r is None:
+                continue
+            scored.append((n, m, r))
+        scored.sort(key=lambda x: x[2], reverse=(leg == "long"))
+        # long: most positive movers; short: most negative movers
+        finalists = [(n, m) for n, m, r in scored
+                     if (r > 0 if leg == "long" else r < 0)][:rank_per]
+        pools[cls] = finalists
+    return pools
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    min_score = int(inputs.get("minScore", scoring.DEFAULTS["minScore"]))
+    max_lev = int(inputs.get("maxLeverage", scoring.DEFAULTS["maxLeverage"]))
+    max_slots = int(inputs.get("maxSlots", scoring.DEFAULTS["maxSlots"]))
+    class_cap_pct = float(inputs.get("classMarginCapPct", scoring.DEFAULTS["classMarginCapPct"]))
+    class_cap_pct = class_cap_pct / 100.0 if class_cap_pct > 1.0 else class_cap_pct  # frac guard
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("signaled") or {}).items() if (now - v) < ttl * 4}
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"signaled": recent, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[caribou.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+
+    account_value, positions = _get_positions(ctx)
+    if account_value <= 0:
+        _persist({"ts": now, "leg": leg, "emitted": False, "gate": "no_account_value"})
+        print(f"[caribou.scan] leg={leg} WAITING — no account value / corrupt read",
+              file=sys.stderr)
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    meta_map, canonical = _get_universe_meta(ctx)
+    if not canonical:
+        _persist({"ts": now, "leg": leg, "emitted": False, "gate": "no_universe"})
+        print(f"[caribou.scan] leg={leg} WAITING — instrument board empty/failed",
+              file=sys.stderr)
+        return []
+
+    pools = _build_class_pools(inputs, meta_map, canonical, leg)
+
+    # ── Confirm + score the trend on each class's finalists (candle fetch happens here) ──
+    candidates = []
+    scanned = 0
+    for cls, finalists in pools.items():
+        for name, meta in finalists:
+            if name.upper() in held_set:
+                continue
+            if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+                continue
+            scanned += 1
+            c4, cd, asset_ctx = _fetch_candles(ctx, name)
+            if len(c4) < 6:
+                continue
+            own = _own_24h_from_ctx(asset_ctx)
+            if own is None:
+                own = meta.get("ret24h")     # fall back to board context
+            th = scoring.score_trend(name, c4, cd, own, leg, inputs)
+            if th and th["score"] >= min_score:
+                th["_meta"] = meta
+                th["assetClass"] = cls
+                candidates.append(th)
+
+    if not candidates:
+        _persist({"ts": now, "leg": leg, "emitted": False, "gate": "no_candidate",
+                  "scanned": scanned, "classes": {c: len(f) for c, f in pools.items()},
+                  "min_score": min_score, "held": held})
+        print(f"[caribou.scan] leg={leg} WAITING — no asset cleared min score {min_score} "
+              f"(scanned {scanned}, classes {{{', '.join(f'{c}:{len(f)}' for c, f in pools.items())}}})",
+              file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # ── Per-class margin cap (in PERCENT-of-equity space). Current per-class deployed margin %
+    #    is read from open positions; a candidate whose class would exceed classMarginCapPct is
+    #    skipped — the book stays diversified across classes (the CTA edge). Verbatim v2 intent. ──
+    class_deployed_pct = {}
+    for p in positions:
+        cls = scoring.classify(p.get("coin", ""), inputs)
+        pct = (scoring._f(p.get("margin", 0)) / account_value * 100.0) if account_value > 0 else 0.0
+        class_deployed_pct[cls] = class_deployed_pct.get(cls, 0.0) + pct
+    class_cap = class_cap_pct * 100.0   # PERCENT
+
+    out = []
+    emitted = []
+    skipped_cap = []
+    for th in candidates:
+        if len(out) >= max_slots:
+            break
+        cls = th["assetClass"]
+        margin_pct = scoring.vol_parity_margin_pct(th["vol_pct"], inputs)
+        if margin_pct <= 0:
+            continue
+        # per-class diversification cap
+        if class_deployed_pct.get(cls, 0.0) + margin_pct > class_cap:
+            skipped_cap.append(f"{th['coin']}({cls})")
+            continue
+        desired_lev = scoring.conviction_leverage(th["score"], inputs)
+        desired_lev = min(desired_lev, max_lev)               # strict sleeve cap
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(desired_lev, venue_max)
+        if leverage <= 0:
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": margin_pct,                          # PERCENT (0,100] — runtime sizes the $
+            "leverage": leverage,                             # venue-clamped, <= sleeve max
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "assetClass": cls,
+                "trend4h": th.get("trend4h"),
+                "trend1d": th.get("trend1d"),
+                "volPct": th.get("vol_pct"),
+                "own24h": th.get("own24h"),
+                "rsi": th.get("rsi"),
+                "heldAssets": held,
+            },
+        })
+        class_deployed_pct[cls] = class_deployed_pct.get(cls, 0.0) + margin_pct
+        recent[th["coin"].upper()] = now
+        emitted.append({"coin": th["coin"], "class": cls, "score": th["score"],
+                        "leverage": leverage, "marginPct": margin_pct})
+
+    result = {"ts": now, "leg": leg, "emitted": bool(out), "gate": "pass" if out else "all_capped",
+              "scanned": scanned, "candidates": len(candidates), "signals": len(out),
+              "classes": {c: len(f) for c, f in pools.items()},
+              "class_deployed_pct": {k: round(v, 2) for k, v in class_deployed_pct.items()},
+              "skipped_class_cap": skipped_cap, "held": held,
+              "account_value": round(account_value, 2),
+              "elapsed_sec": round(time.time() - run_start, 2), "details": emitted}
+    _persist(result)
+    print(f"[caribou.scan] leg={leg} {'EMIT' if out else 'WAITING'} scanned={scanned} "
+          f"candidates={len(candidates)} signals={len(out)} "
+          f"classes={{{', '.join(f'{c}:{len(f)}' for c, f in pools.items())}}} "
+          f"skipped_cap={skipped_cap} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/caribou/short/scanners/scoring.py
+++ b/strategies/caribou/short/scanners/scoring.py
@@ -1,0 +1,286 @@
+"""CARIBOU — pure cross-asset trend math (no I/O, no MCP, no clock). Shared verbatim by
+both sleeves; direction is passed in (`leg` = "long" for the uptrend book, "short" for the
+downtrend book). A faithful port of the v2 caribou-producer.py scoring + vol-parity sizing +
+asset-class classification — the gates, point weights, vol-parity formula and class map are
+copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be
+redesigned). Unit-testable on plain candle lists.
+
+FIDELITY: this module reproduces, verbatim, the v2 producer's:
+  - trend_structure / calc_rsi / atr_pct technicals
+  - score_trend long/short scoring table (4h hard gate, +3; daily align +/-2; 24h mom +1;
+    strong-mom +1; RSI blow-off/capitulation guard -2)
+  - vol-parity sizing: pct = baseRiskPct * (referenceVolPct / asset_ATR%), clamped to
+    [minMarginPct, maxMarginPct]. v2 emitted this as a FRACTION * account_value -> marginUsd;
+    the 3.0 scan emits the PERCENT (pct*100) and the runtime sizes the dollars.
+  - classify(): crypto | equity | index | metal | energy.
+"""
+
+# v2-quirk: raw-score normaliser. v2 emitted min(score/8.0, 1.0) as the [0,1] wire score
+# (NORM_DIV = 8.0, max raw ~3+2+1+1 = 7). The 3.0 scaffold owns the wire envelope, so the raw
+# integer score is kept on data{}; NORM_DIV is retained only for a v2-equivalent normalised score.
+NORM_DIV = 8.0
+
+# Per-sleeve defaults (config.json / runtime inputs override every one). Copied from the v2
+# producer _DEFAULTS so the pure module can be exercised standalone.
+DEFAULTS = {
+    "minScore": 5,
+    "apexScore": 7,
+    "baseLeverage": 3,
+    "maxLeverage": 5,
+    "maxSlots": 8,
+    "baseRiskPct": 0.08,         # FRACTION of equity a REFERENCE-vol asset gets (vol-parity anchor)
+    "referenceVolPct": 3.0,      # "typical" daily ATR% — the vol-parity normaliser
+    "minMarginPct": 0.03,        # FRACTION floor per position
+    "maxMarginPct": 0.15,        # FRACTION cap per position
+    "classMarginCapPct": 0.40,   # FRACTION — max total margin per asset CLASS
+    "perClassMaxNames": 12,
+    "rankPerClass": 6,
+    "volFloorPctOfMedian": 0.2,
+    "strongMomPct": 5.0,
+    "rsiOverbought": 80,
+    "rsiOversold": 20,
+    "classMetals": ["GOLD", "SILVER", "PLATINUM", "PALLADIUM", "COPPER"],
+    "classEnergy": ["BRENTOIL", "CL", "WTI", "NATGAS", "GAS", "HEATOIL", "GASOLINE", "URNM"],
+    "classIndices": ["SP500", "NASDAQ", "NDX", "US500", "US100", "DJIA", "US30", "RUSSELL", "RUT", "VIX"],
+}
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v) if v is not None else d
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    return 0.0
+
+
+# ── technicals (verbatim v2) ──────────────────────────────────────────────────
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def atr_pct(candles, period=14):
+    """Average True Range as % of last price — the volatility-parity input. Returns None if
+    not computable (caller falls back to reference vol). Verbatim v2."""
+    if len(candles) < 3:
+        return None
+    trs = []
+    for i in range(1, len(candles)):
+        h, lo, pc = _high(candles[i]), _low(candles[i]), _close(candles[i - 1])
+        if h <= 0 or lo <= 0 or pc <= 0:
+            continue
+        trs.append(max(h - lo, abs(h - pc), abs(lo - pc)))
+    if not trs:
+        return None
+    atr = sum(trs[-period:]) / len(trs[-period:])
+    price = _close(candles[-1])
+    if price <= 0:
+        return None
+    return atr / price * 100.0
+
+
+# ── asset-class classification (verbatim v2) ──────────────────────────────────
+
+def classify(asset, inputs):
+    """Map an instrument to an asset class: crypto | equity | index | metal | energy.
+    Verbatim v2 classify(): xyz: names not in metals/energy/indices fall through to "equity";
+    non-xyz names are "crypto"."""
+    name = asset.split(":", 1)[1] if ":" in asset else asset
+    name = name.upper()
+    if not asset.lower().startswith("xyz:"):
+        return "crypto"
+    if name in set(inputs.get("classMetals", DEFAULTS["classMetals"])):
+        return "metal"
+    if name in set(inputs.get("classEnergy", DEFAULTS["classEnergy"])):
+        return "energy"
+    if name in set(inputs.get("classIndices", DEFAULTS["classIndices"])):
+        return "index"
+    return "equity"   # any other xyz name is a single-name stock
+
+
+# ── trend scoring (time-series, per asset) — verbatim v2 score_trend ──────────
+
+def score_trend(asset, candles_4h, candles_1d, own24h, leg, inputs):
+    """Confirm + score a trend on ONE asset. Returns the thesis (incl. vol_pct for vol-parity
+    sizing) or None to disqualify. 4h is the HARD gate; the daily aligns; momentum + RSI guard
+    refine. Point weights + gates copied VERBATIM from the v2 producer score_trend() — do NOT
+    redesign.
+
+    leg == "long":  long a confirmed 4h UPTREND   (BULLISH 4h structure is the hard gate)
+    leg == "short": short a confirmed 4h DOWNTREND (BEARISH 4h structure is the hard gate)
+    """
+    if len(candles_4h) < 6:
+        return None
+    closes4 = [_close(c) for c in candles_4h]
+    price = closes4[-1]
+    if price <= 0:
+        return None
+
+    trend4, s4 = trend_structure(candles_4h)
+    trendd, sd = trend_structure(candles_1d) if len(candles_1d) >= 6 else ("NEUTRAL", 0)
+    rsi = calc_rsi(closes4)
+    own = own24h if own24h is not None else 0.0
+
+    # Vol estimate for parity sizing — prefer daily ATR, fall back to 4h, then referenceVolPct.
+    vol = atr_pct(candles_1d) if len(candles_1d) >= 3 else None
+    if vol is None or vol <= 0:
+        vol = atr_pct(candles_4h)
+    if vol is None or vol <= 0:
+        vol = float(inputs.get("referenceVolPct", DEFAULTS["referenceVolPct"]))
+
+    strong = float(inputs.get("strongMomPct", DEFAULTS["strongMomPct"]))
+    score, reasons = 0, []
+
+    if leg == "long":
+        if trend4 != "BULLISH":                              # v2-quirk: 4h uptrend is the hard gate
+            return None
+        score += 3
+        reasons.append(f"4h_uptrend_{s4:.0%}")
+        if trendd == "BULLISH":
+            score += 2
+            reasons.append(f"1d_uptrend_{sd:.0%}")
+        elif trendd == "BEARISH":
+            score -= 2
+            reasons.append("1d_conflict")
+        if own > 0:
+            score += 1
+            reasons.append(f"mom_{own:+.1f}%")
+        if own >= strong:
+            score += 1
+            reasons.append("mom_strong")
+        rsi_ob = float(inputs.get("rsiOverbought", DEFAULTS["rsiOverbought"]))
+        if rsi > rsi_ob:                                     # v2-quirk: don't chase a blow-off
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        if trend4 != "BEARISH":                              # v2-quirk: 4h downtrend is the hard gate
+            return None
+        score += 3
+        reasons.append(f"4h_downtrend_{s4:.0%}")
+        if trendd == "BEARISH":
+            score += 2
+            reasons.append(f"1d_downtrend_{sd:.0%}")
+        elif trendd == "BULLISH":
+            score -= 2
+            reasons.append("1d_conflict")
+        if own < 0:
+            score += 1
+            reasons.append(f"mom_{own:+.1f}%")
+        if own <= -strong:
+            score += 1
+            reasons.append("mom_strong")
+        rsi_os = float(inputs.get("rsiOversold", DEFAULTS["rsiOversold"]))
+        if rsi < rsi_os:                                     # v2-quirk: don't short a capitulation
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": round(rsi, 1),
+        "trend4h": trend4,
+        "trend1d": trendd,
+        "own24h": round(own, 2),
+        "vol_pct": round(vol, 3),
+    }
+
+
+# ── vol-parity sizing — verbatim v2 vol_parity_margin, in PERCENT ─────────────
+
+def vol_parity_margin_pct(vol_pct, inputs):
+    """Vol-parity sizing as a PERCENT of equity in (0,100]. Margin scales INVERSELY with the
+    asset's volatility, normalized to a reference vol, then clamped to [minMarginPct,
+    maxMarginPct] of equity. A calm asset gets more margin; a wild one gets less — equal risk.
+
+    v2-quirk: the v2 vol_parity_margin() computed this fraction then multiplied by
+    account_value to get marginUsd. The 3.0 runtime sizes the dollars from a PERCENT intent,
+    so we return the same fraction * 100 (the formula + clamps are identical)."""
+    base = float(inputs.get("baseRiskPct", DEFAULTS["baseRiskPct"]))
+    ref = float(inputs.get("referenceVolPct", DEFAULTS["referenceVolPct"]))
+    lo = float(inputs.get("minMarginPct", DEFAULTS["minMarginPct"]))
+    hi = float(inputs.get("maxMarginPct", DEFAULTS["maxMarginPct"]))
+    # Defensive: a pasted PERCENT (e.g. 8) instead of a FRACTION (0.08) for baseRiskPct/clamps
+    # would blow sizing up 100x. v2 stored these as FRACTIONS (<=1.0); coerce anything >1.0
+    # back to a fraction (matching the dire/koala fraction-vs-percent guard).
+    base = base / 100.0 if base > 1.0 else base
+    lo = lo / 100.0 if lo > 1.0 else lo
+    hi = hi / 100.0 if hi > 1.0 else hi
+    if vol_pct <= 0:
+        vol_pct = ref
+    pct = base * (ref / vol_pct)
+    pct = max(lo, min(hi, pct))
+    return round(pct * 100.0, 4)   # -> PERCENT in (0,100]
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))
+
+
+def conviction_leverage(score, inputs):
+    """apex trend -> maxLeverage, else baseLeverage (verbatim v2). Returns the DESIRED leverage
+    before the per-name venue clamp."""
+    apex = int(inputs.get("apexScore", DEFAULTS["apexScore"]))
+    base_lev = int(inputs.get("baseLeverage", DEFAULTS["baseLeverage"]))
+    max_lev = int(inputs.get("maxLeverage", DEFAULTS["maxLeverage"]))
+    return max_lev if score >= apex else base_lev

--- a/strategies/caribou/strategy.yaml
+++ b/strategies/caribou/strategy.yaml
@@ -1,0 +1,48 @@
+# Caribou — Cross-Asset Trend Fund (managed futures / CTA). A two-instance PACKAGE: this
+# manifest + two self-contained runtime.yaml books (long / short on SEPARATE wallets, so the
+# fund may hold the SAME asset long in one sleeve and short in the other) + per-book scanners/.
+# A faithful Runtime 3.0 port of the v2 Caribou v1.0.0 (CARIBOU_LEG-selected producer): a
+# time-series trend follower over the WHOLE Hyperliquid instrument board (crypto + xyz stocks,
+# indices, metals, energy), bucketed by asset class, vol-parity (equal-risk) sized, capped per
+# class so the book can never collapse into one class. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: caribou
+version: "1.0.0"
+
+catalog:
+  name: "Caribou — Cross-Asset Trend Fund"
+  emoji: "🦌"
+  tagline: "Trend-follows the WHOLE Hyperliquid board across every asset class (crypto, tokenized stocks, indices, metals, energy): longs the confirmed uptrends and shorts the confirmed downtrends on two separate wallets, sizes every position to EQUAL RISK by volatility parity, and caps each asset class at 40% of equity so the book stays diversified. Managed futures, on-chain."
+  belief_plain: "Follows the trend everywhere at once — crypto, stocks, gold, oil, indices — buying what's going up and shorting what's going down, on two separate wallets. It bets the SAME risk on each position (smaller on wild assets, bigger on calm ones) and never lets any one type of market take over the book, so the curve stays smooth and it can make money even when stocks are crashing."
+  thesis: "You want the most-proven hedge-fund category — managed futures (CTA) — on-chain. Its entire edge is cross-asset diversification: trends show up in different markets at different times, so the more uncorrelated markets you trend-follow, the smoother the curve. Long the uptrends and short the downtrends across uncorrelated classes nets to ~zero market beta and is crisis-positive (the short sleeve shorts the fallers when everything bleeds). Each asset is judged against its OWN history (time-series trend), sized to equal risk, and capped by class."
+  group: multi-asset-whitelist
+  archetype: trend_following     # time-series trend follower across every class
+  sub_style: trend_follower      # cross-asset CTA / managed-futures trend following
+  asset_classes: [universe_crypto, commodities, indices, xyz_equities]
+  asset_scope: universe          # scans the whole live instrument board, no fixed whitelist
+  direction: long_short          # long sleeve + short sleeve on separate wallets
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 8
+  min_budget: 400
+  assets: []                     # dynamic universe — bucketed from the live instrument board
+  tags: [managed-futures, cta, trend-following, cross-asset, vol-parity, equal-risk, crisis-alpha, long-short, diversified, hedge-fund]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: long
+    runtime: long/runtime.yaml
+    wallet_env: CARIBOU_LONG_WALLET
+    funding_share: 0.5
+  - name: short
+    runtime: short/runtime.yaml
+    wallet_env: CARIBOU_SHORT_WALLET
+    funding_share: 0.5

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -54,6 +54,51 @@
       "sort_order": 1
     },
     {
+      "id": "camel",
+      "name": "Camel — Funding Carry Hedge Fund",
+      "emoji": "🐫",
+      "tagline": "Harvests funding carry across the liquid main-DEX crypto cross-section: the HARVEST book SHORTS the most-positive-funding names (longs pay shorts → short collects) and the PAYOUT book LONGS the most-negative-funding names (shorts pay longs → paid to hold) — both gated to EXHAUSTING crowds (4h trend + RSI confirmation) so price doesn't fight the carry — on two equally-funded wallets that net the fund slightly market-neutral.",
+      "belief_plain": "On Hyperliquid you get paid (or pay) funding every hour for holding a perp. Camel always takes the side that COLLECTS that payment — it shorts coins where longs are paying through the nose, and longs coins where shorts are paying — but only on crowds that are running out of steam, so the price doesn't move against it while it banks the funding.",
+      "version": "1.0.0",
+      "thesis": "Funding is a recurring, structural inefficiency: when a trade gets too crowded, the funding rate blows out and the collecting side gets paid to hold. The edge is that carry, not market direction — so Camel ranks the whole liquid crypto board by funding and takes the most-extreme collecting side, but only when the crowded trade is exhausting (4h rolling over for shorts / capitulating for longs, RSI confirming) so price doesn't fight the carry. Taking some shorts and some longs also skews the fund net-neutral as a by-product.",
+      "tags": [
+        "funding",
+        "carry",
+        "basis",
+        "market-neutral",
+        "hedge-fund",
+        "contrarian",
+        "exhaustion",
+        "universe-crypto",
+        "two-book"
+      ],
+      "group": "carry",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "funding_extreme",
+      "sub_style_label": "Fades extreme funding rates.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 300,
+      "min_budget": 400,
+      "instance_count": 2,
+      "funding_split": [
+        0.5,
+        0.5
+      ],
+      "max_slots": 8,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
       "id": "bald-eagle",
       "name": "Bald Eagle — XYZ Macro Fader",
       "emoji": "🦅",
@@ -356,6 +401,77 @@
       "sort_order": 1
     },
     {
+      "id": "elephant",
+      "name": "Elephant — Global-Macro Hedge Fund",
+      "emoji": "🐘",
+      "tagline": "Trades the cross-asset macro complex — equity indices, precious metals, energy, FX (all on XYZ) plus BTC — on two books and two wallets: the TREND book rides the durable multi-timeframe macro trend (both directions); the FADE book fades short-TF over-extensions back to regime (both directions, with a knife guard). The edge is GLOBAL MACRO — the complex moves on regime, not crypto noise.",
+      "belief_plain": "Trades the big global markets — stock indices, gold/silver/copper, oil and gas, the major currencies, and Bitcoin. One book rides the slow, durable trends (buying things going up, shorting things going down); a second book on a separate wallet bets on stretched moves snapping back. It only fades a snap-back when the bigger trend isn't fighting it.",
+      "version": "1.0.0",
+      "thesis": "Crypto-only funds all crowd the same coins; the cross-asset macro complex (indices / metals / energy / FX) moves on macro regime — oil on geopolitics, indices on the AI-equity bid, metals on risk-off — and is uncorrelated with crypto noise. Running a trend book AND a mean-reversion book on the same macro whitelist, on two wallets, harvests both the durable direction and the over-extensions without the two conflicting. These markets trade 24/7 on Hyperliquid XYZ, so the fund never has to wait for a market open.",
+      "tags": [
+        "macro",
+        "global-macro",
+        "cross-asset",
+        "indices",
+        "metals",
+        "energy",
+        "fx",
+        "btc",
+        "xyz",
+        "trend",
+        "mean-reversion",
+        "contrarian-fade",
+        "two-book",
+        "long-short"
+      ],
+      "group": "macro",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "basket",
+      "sub_style_label": "Holds a whitelist basket of majors.",
+      "asset_classes": [
+        "indices",
+        "commodities",
+        "btc_eth"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "xyz:SP500",
+        "xyz:XYZ100",
+        "xyz:JP225",
+        "xyz:KR200",
+        "xyz:NIFTY",
+        "xyz:IBOV",
+        "xyz:GOLD",
+        "xyz:SILVER",
+        "xyz:PLATINUM",
+        "xyz:COPPER",
+        "xyz:BRENTOIL",
+        "xyz:CL",
+        "xyz:NATGAS",
+        "xyz:EUR",
+        "xyz:JPY",
+        "xyz:GBP",
+        "xyz:DXY"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": null,
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 300,
+      "min_budget": 400,
+      "instance_count": 2,
+      "funding_split": [
+        0.6,
+        0.4
+      ],
+      "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
       "id": "badger",
       "name": "Badger — OI-Divergence Breakout Anticipator",
       "emoji": "🦡",
@@ -454,6 +570,59 @@
       "sort_order": 2
     },
     {
+      "id": "caracal",
+      "name": "Caracal — Volatility Hedge Fund",
+      "emoji": "🐱",
+      "tagline": "Two volatility books on two wallets — one scans liquid crypto, the other scans tokenized stocks/commodities/indices (XYZ) — for names coiled in a low-volatility squeeze that break their recent range with an expansion surge, then rides the break direction (LONG up / SHORT down). It trades MOVEMENT, not a view: the edge is that compression precedes expansion.",
+      "belief_plain": "Watches the market for coins and stocks that have gone quiet (price barely moving), then pounces the moment one breaks out of its quiet range with a big jump — going long if it breaks up, short if it breaks down. It runs two separate pots: one for crypto, one for tokenized stocks and commodities. The bet is on the size of the move, not its direction.",
+      "version": "1.0.0",
+      "thesis": "Volatility is the edge. A breakout FROM a low-volatility coil has far higher follow-through than a breakout in already-volatile tape — compression precedes expansion. Caracal only fires when a name has been coiling (recent ATR << baseline ATR) AND breaks its range AND the breakout bar is an outsized move, then rides whichever way it broke. Splitting crypto (breakout book) from tokenized stocks/commodities/indices (catalyst book) lets it capture oil-geopolitics and AI-infra moves 24/7 alongside crypto vol, on two separately-funded wallets that net to a direction-agnostic volatility harvester.",
+      "tags": [
+        "volatility",
+        "breakout",
+        "compression-expansion",
+        "coiled-spring",
+        "atr-squeeze",
+        "range-break",
+        "crypto",
+        "xyz",
+        "equities",
+        "commodities",
+        "indices",
+        "long-short",
+        "two-book",
+        "market-neutral-vol"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "range_break",
+      "sub_style_label": "Buys/sells the break of a multi-day range.",
+      "asset_classes": [
+        "universe_crypto",
+        "xyz_equities",
+        "commodities",
+        "indices"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 400,
+      "instance_count": 2,
+      "funding_split": [
+        0.5,
+        0.5
+      ],
+      "max_slots": 6,
+      "branch": "strategy-v2",
+      "sort_order": 3
+    },
+    {
       "id": "condor",
       "name": "Condor — One Amazing Trade per Day",
       "emoji": "🦅",
@@ -493,7 +662,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 3
+      "sort_order": 4
     },
     {
       "id": "falcon",
@@ -536,7 +705,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "hedgehog",
@@ -585,7 +754,7 @@
       ],
       "max_slots": 3,
       "branch": "strategy-v2",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "lemur",
@@ -631,7 +800,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 6
+      "sort_order": 7
     },
     {
       "id": "lynx",
@@ -682,7 +851,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 7
+      "sort_order": 8
     },
     {
       "id": "meerkat",
@@ -726,7 +895,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 8
+      "sort_order": 9
     },
     {
       "id": "orca",
@@ -769,7 +938,7 @@
       ],
       "max_slots": 3,
       "branch": "strategy-v2",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "otter",
@@ -813,7 +982,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "piranha",
@@ -865,7 +1034,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "python",
@@ -909,7 +1078,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "sailfish",
@@ -959,7 +1128,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "salamander",
@@ -1009,7 +1178,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "sheep",
@@ -1062,7 +1231,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 15
+      "sort_order": 16
     },
     {
       "id": "jaguar",
@@ -1102,6 +1271,128 @@
         1.0
       ],
       "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
+      "id": "cub",
+      "name": "Cub — Two-Speed-Market Long/Short + Pre-IPO",
+      "emoji": "🐅",
+      "tagline": "Longs the structural winners of a K-shaped world (the AI complex on Hyperliquid XYZ + crypto winners HYPE/SOL) and shorts the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) — both trend-confirmed on separate wallets — plus a ~10% pre-IPO ramp satellite that auto-discovers pre-IPO perpetuals (IPOPs) and rides them into their listing.",
+      "belief_plain": "The world is splitting into haves and have-nots: AI companies and crypto's winners keep booming while the broad economy and the rest of crypto struggle. Cub buys the booming side and shorts the struggling side at the same time on separate wallets, so it makes money on the GAP between the two — and keeps a small slice aimed at the next SpaceX before it goes public.",
+      "version": "1.0.0",
+      "thesis": "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their funding signature and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open.",
+      "tags": [
+        "k-shaped",
+        "two-speed",
+        "ai-complex",
+        "hedge-fund",
+        "long-short",
+        "dispersion",
+        "xyz",
+        "equities",
+        "crypto",
+        "pre-ipo",
+        "ipop",
+        "hype",
+        "sp500"
+      ],
+      "group": "multi-asset-thematic",
+      "archetype": "structural_neutral",
+      "archetype_label": "Structural / Neutral",
+      "sub_style": "pairs_rv",
+      "sub_style_label": "Trades a pair's ratio back to its mean (relative value).",
+      "asset_classes": [
+        "xyz_equities",
+        "major_alts",
+        "indices",
+        "pre_ipo"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:NVDA",
+        "xyz:AMD",
+        "xyz:MRVL",
+        "xyz:ARM",
+        "xyz:AVGO",
+        "xyz:TSM",
+        "xyz:ASML",
+        "xyz:MU",
+        "xyz:CRWV",
+        "xyz:GOOGL",
+        "xyz:MSFT",
+        "xyz:META",
+        "xyz:AMZN",
+        "xyz:ORCL",
+        "xyz:PLTR",
+        "xyz:SPCX",
+        "HYPE",
+        "SOL",
+        "xyz:SP500",
+        "ETH",
+        "XRP",
+        "DOGE",
+        "AVAX",
+        "LINK"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 300,
+      "min_budget": 600,
+      "instance_count": 3,
+      "funding_split": [
+        0.55,
+        0.35,
+        0.1
+      ],
+      "max_slots": 12,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
+      "id": "octopus",
+      "name": "Octopus — Market-Neutral Crypto Long/Short",
+      "emoji": "🐙",
+      "tagline": "Ranks the live liquid main-DEX crypto cross-section by 24h relative strength every tick, then LONGS the strongest names (long book) and SHORTS the weakest (short book) — both trend-confirmed — on two equally-funded wallets so the pair is ~market-neutral and harvests crypto dispersion.",
+      "belief_plain": "Buys the strongest crypto coins and shorts the weakest at the same time, on two separate wallets, so it makes money on the GAP between winners and losers instead of betting on the whole market going up or down.",
+      "version": "1.0.0",
+      "thesis": "The edge is dispersion, not direction. In a HYPE-dominates / alts-crushed regime the long book gravitates to the leaders and the short book to the carnage, and the two equally-funded notionals offset market beta — so the return is driven by the spread between strong and weak names. The universe is the live liquid board, not a fixed list, so it always ranks whatever is actually trading and liquid right now.",
+      "tags": [
+        "crypto",
+        "hedge-fund",
+        "long-short",
+        "market-neutral",
+        "dispersion",
+        "relative-strength",
+        "universe",
+        "cross-sectional"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "structural_neutral",
+      "archetype_label": "Structural / Neutral",
+      "sub_style": "pairs_rv",
+      "sub_style_label": "Trades a pair's ratio back to its mean (relative value).",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 300,
+      "min_budget": 400,
+      "instance_count": 2,
+      "funding_split": [
+        0.5,
+        0.5
+      ],
+      "max_slots": 8,
       "branch": "strategy-v2",
       "sort_order": 1
     },
@@ -1157,6 +1448,117 @@
       "max_slots": 7,
       "branch": "strategy-v2",
       "sort_order": 1
+    },
+    {
+      "id": "boar",
+      "name": "Boar — Hard Money vs Paper",
+      "emoji": "🥇",
+      "tagline": "Bets on currency debasement: LONGS scarce real assets (GOLD, BTC, SILVER, PLATINUM, PALLADIUM) on the hard-money wallet and SHORTS the paper economy (SP500 + rate-sensitive growth RIVN/DKNG/HIMS) on the paper wallet — each leg trend-confirmed and conviction-sized. The P&L is the real-assets-beat-paper-claims spread.",
+      "belief_plain": "Buys gold, bitcoin and other scarce real assets while shorting the broad stock market and rate-sensitive growth stocks at the same time, on two separate wallets, betting that as governments run big deficits and rates stay high, hard money beats paper claims.",
+      "version": "1.0.0",
+      "thesis": "Fiscal dominance / currency debasement: as deficits compound and the term premium rises, scarce real assets (gold, BTC, silver) outperform fiat-denominated financial claims. Express it as a long/short — long hard money, short paper — so the edge is the spread, not market direction. Each name only trades when its own absolute 4h/1h trend confirms (cross-sectional relative strength only tilts ranking and size). HONEST CAVEAT: the loosest hedge of the family — in a pure liquidity melt-up gold AND stocks can rise together; the short tilts to rate-sensitive names to tighten it. Best deployed as a tilt, not a market-neutral bet.",
+      "tags": [
+        "debasement",
+        "hard-money",
+        "gold",
+        "btc",
+        "silver",
+        "metals",
+        "sp500",
+        "hedge-fund",
+        "long-short",
+        "thematic",
+        "trend-confirmed",
+        "conviction-sizing",
+        "xyz"
+      ],
+      "group": "multi-asset-whitelist",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "basket",
+      "sub_style_label": "Holds a whitelist basket of majors.",
+      "asset_classes": [
+        "commodities",
+        "btc_eth",
+        "indices",
+        "xyz_equities"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:GOLD",
+        "BTC",
+        "xyz:SILVER",
+        "xyz:PLATINUM",
+        "xyz:PALLADIUM",
+        "xyz:SP500",
+        "xyz:RIVN",
+        "xyz:DKNG",
+        "xyz:HIMS"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 300,
+      "min_budget": 400,
+      "instance_count": 2,
+      "funding_split": [
+        0.5,
+        0.5
+      ],
+      "max_slots": 8,
+      "branch": "strategy-v2",
+      "sort_order": 2
+    },
+    {
+      "id": "caribou",
+      "name": "Caribou — Cross-Asset Trend Fund",
+      "emoji": "🦌",
+      "tagline": "Trend-follows the WHOLE Hyperliquid board across every asset class (crypto, tokenized stocks, indices, metals, energy): longs the confirmed uptrends and shorts the confirmed downtrends on two separate wallets, sizes every position to EQUAL RISK by volatility parity, and caps each asset class at 40% of equity so the book stays diversified. Managed futures, on-chain.",
+      "belief_plain": "Follows the trend everywhere at once — crypto, stocks, gold, oil, indices — buying what's going up and shorting what's going down, on two separate wallets. It bets the SAME risk on each position (smaller on wild assets, bigger on calm ones) and never lets any one type of market take over the book, so the curve stays smooth and it can make money even when stocks are crashing.",
+      "version": "1.0.0",
+      "thesis": "You want the most-proven hedge-fund category — managed futures (CTA) — on-chain. Its entire edge is cross-asset diversification: trends show up in different markets at different times, so the more uncorrelated markets you trend-follow, the smoother the curve. Long the uptrends and short the downtrends across uncorrelated classes nets to ~zero market beta and is crisis-positive (the short sleeve shorts the fallers when everything bleeds). Each asset is judged against its OWN history (time-series trend), sized to equal risk, and capped by class.",
+      "tags": [
+        "managed-futures",
+        "cta",
+        "trend-following",
+        "cross-asset",
+        "vol-parity",
+        "equal-risk",
+        "crisis-alpha",
+        "long-short",
+        "diversified",
+        "hedge-fund"
+      ],
+      "group": "multi-asset-whitelist",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "trend_follower",
+      "sub_style_label": "Trend Follower",
+      "asset_classes": [
+        "universe_crypto",
+        "commodities",
+        "indices",
+        "xyz_equities"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 300,
+      "min_budget": 400,
+      "instance_count": 2,
+      "funding_split": [
+        0.5,
+        0.5
+      ],
+      "max_slots": 8,
+      "branch": "strategy-v2",
+      "sort_order": 3
     },
     {
       "id": "cougar",
@@ -1219,7 +1621,63 @@
       ],
       "max_slots": 8,
       "branch": "strategy-v2",
-      "sort_order": 2
+      "sort_order": 4
+    },
+    {
+      "id": "eel",
+      "name": "Eel — Electrons vs Hydrocarbons",
+      "emoji": "⚡",
+      "tagline": "Bets AI datacenters are a structural new source of electricity demand: LONGS the AI-power complex on Hyperliquid XYZ (uranium, gas-fired power, grid copper, fuel cells, rare-earth) and SHORTS crude oil — both trend-confirmed, on two separate wallets — so the pair is energy-sector-neutral and harvests the electrons-vs-barrels spread.",
+      "belief_plain": "Buys the things that make electricity for AI datacenters (uranium, natural gas, copper, fuel cells, rare-earth) and shorts crude oil at the same time, on two separate wallets, so it makes money on power BEATING oil rather than on energy going up or down.",
+      "version": "1.0.0",
+      "thesis": "AI datacenter electricity demand is a structural new bid for the power complex, while crude oil is the legacy transport fuel barely levered to AI. Both legs are energy, so a broad energy move washes out and the P&L is the dispersion — power outperforming oil. Each book only acts when ABSOLUTE trend confirms (long power on a non-bearish 4h; short oil on a non-bullish 4h, with a capitulation guard), with cross-sectional relative strength as a size/rank tiebreaker. Commodities trade ~24/7 on Hyperliquid, so the book never waits for a market open.",
+      "tags": [
+        "energy",
+        "power",
+        "uranium",
+        "natgas",
+        "copper",
+        "crude-oil",
+        "ai-datacenter",
+        "long-short",
+        "market-neutral",
+        "dispersion",
+        "xyz",
+        "commodities"
+      ],
+      "group": "multi-asset-whitelist",
+      "archetype": "structural_neutral",
+      "archetype_label": "Structural / Neutral",
+      "sub_style": "pairs_rv",
+      "sub_style_label": "Trades a pair's ratio back to its mean (relative value).",
+      "asset_classes": [
+        "commodities"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:URNM",
+        "xyz:NATGAS",
+        "xyz:COPPER",
+        "xyz:BE",
+        "xyz:USAR",
+        "xyz:BRENTOIL",
+        "xyz:CL"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 300,
+      "min_budget": 400,
+      "instance_count": 2,
+      "funding_split": [
+        0.55,
+        0.45
+      ],
+      "max_slots": 6,
+      "branch": "strategy-v2",
+      "sort_order": 5
     },
     {
       "id": "kestrel",
@@ -1279,7 +1737,152 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 3
+      "sort_order": 6
+    },
+    {
+      "id": "lion",
+      "name": "Lion — Two-Speed-Market Cross-Asset L/S",
+      "emoji": "🦁",
+      "tagline": "Bets on a K-shaped divergence: LONGS the structural winners (the AI complex on Hyperliquid XYZ + the crypto winners HYPE/SOL) on the 'haves' wallet, and SHORTS the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) on the 'have-nots' wallet. Both trend-confirmed on absolute structure, with relative strength as a tiebreaker and per-name conviction sizing (HYPE big, SOL small, SP500 core). The edge is the DISPERSION between the two speeds, not market direction.",
+      "belief_plain": "Buys the booming AI stocks and crypto winners while shorting the broad stock market and the alts losing ground, each on its own wallet — so it makes money on the GAP between the world's fast lane and slow lane rather than on the market going up or down. It only buys names actually trending up and only shorts names actually rolling over, and bets bigger on its highest-conviction picks.",
+      "version": "1.0.0",
+      "thesis": "The world is splitting into two speeds: the AI complex and HYPE/SOL keep booming while the broad U.S. economy and the rest of crypto struggle. Express it as one thematic long/short book — long the haves, short the have-nots — and the P&L is the dispersion between the two, not the market's direction. The hard gate is ABSOLUTE trend (never long a downtrend, never short an uptrend, even for a thesis name); cross-sectional relative strength only tilts size and ranking. Net exposure is the operator's dial (default modest net-long), set by how much capital each wallet holds.",
+      "tags": [
+        "k-shaped",
+        "two-speed",
+        "ai-complex",
+        "long-short",
+        "cross-asset",
+        "dispersion",
+        "conviction-sizing",
+        "hedge-fund",
+        "xyz",
+        "hype"
+      ],
+      "group": "multi-asset-whitelist",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "rotation",
+      "sub_style_label": "Always holds the strongest of a basket; rotates as leadership changes.",
+      "asset_classes": [
+        "xyz_equities",
+        "major_alts",
+        "indices"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:NVDA",
+        "xyz:AMD",
+        "xyz:MRVL",
+        "xyz:ARM",
+        "xyz:AVGO",
+        "xyz:INTC",
+        "xyz:TSM",
+        "xyz:ASML",
+        "xyz:CBRS",
+        "xyz:MU",
+        "xyz:SMSN",
+        "xyz:SKHX",
+        "xyz:SNDK",
+        "xyz:CRWV",
+        "xyz:NBIS",
+        "xyz:DELL",
+        "xyz:LITE",
+        "xyz:GOOGL",
+        "xyz:MSFT",
+        "xyz:META",
+        "xyz:AMZN",
+        "xyz:ORCL",
+        "xyz:PLTR",
+        "xyz:NOW",
+        "xyz:IBM",
+        "xyz:SPCX",
+        "xyz:QNT",
+        "HYPE",
+        "SOL",
+        "xyz:SP500",
+        "ETH",
+        "XRP",
+        "DOGE",
+        "AVAX",
+        "LINK",
+        "ADA",
+        "LTC",
+        "NEAR",
+        "APT"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 300,
+      "min_budget": 400,
+      "instance_count": 2,
+      "funding_split": [
+        0.6,
+        0.4
+      ],
+      "max_slots": 9,
+      "branch": "strategy-v2",
+      "sort_order": 7
+    },
+    {
+      "id": "mongoose",
+      "name": "Mongoose — On-Chain Finance vs Legacy",
+      "emoji": "🪙",
+      "tagline": "Bets money is migrating on-chain: LONGS the on-chain financial rails (HYPE the venue + Circle/CRCL + Coinbase/COIN + Robinhood/HOOD + BTC treasuries MSTR/PURRDAT) on one wallet and SHORTS legacy finance + broad financial-beta (Blackstone/BX + SP500) on another — both trend-confirmed on absolute 4h/1h structure — so the P&L is the disruptor-vs-incumbent spread.",
+      "belief_plain": "Buys the companies and tokens that are pulling finance on-chain (the crypto exchange, the stablecoin issuer, the BTC treasuries) and at the same time shorts the old-finance incumbents and the broad market, on two separate wallets. It only buys names that are actually trending up and only shorts names actually rolling over, and it bets bigger on its highest-conviction picks (HYPE and Circle).",
+      "version": "1.0.0",
+      "thesis": "Money is migrating on-chain — stablecoins, crypto exchanges and BTC treasuries are eating legacy financial rails. You want to own the disruptors and short the incumbents so the return is the GAP between them, not the direction of the market. HONEST CAVEAT: the hedge is cross-sector and the short universe is thin (few pure legacy-finance names list on the venue yet), so the short leg leans on the broad index — it nets down market beta rather than perfectly isolating the pair, and the long book is the strong, high-conviction side.",
+      "tags": [
+        "on-chain-finance",
+        "hedge-fund",
+        "long-short",
+        "disruptor-vs-incumbent",
+        "hype",
+        "stablecoins",
+        "crypto-treasuries",
+        "conviction-sizing",
+        "xyz",
+        "thematic"
+      ],
+      "group": "multi-asset-whitelist",
+      "archetype": "structural_neutral",
+      "archetype_label": "Structural / Neutral",
+      "sub_style": "pairs_rv",
+      "sub_style_label": "Trades a pair's ratio back to its mean (relative value).",
+      "asset_classes": [
+        "xyz_equities",
+        "indices",
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "HYPE",
+        "xyz:CRCL",
+        "xyz:COIN",
+        "xyz:HOOD",
+        "xyz:MSTR",
+        "xyz:PURRDAT",
+        "xyz:BX",
+        "xyz:SP500"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 300,
+      "min_budget": 400,
+      "instance_count": 2,
+      "funding_split": [
+        0.65,
+        0.35
+      ],
+      "max_slots": 7,
+      "branch": "strategy-v2",
+      "sort_order": 8
     },
     {
       "id": "ox",
@@ -1339,7 +1942,7 @@
       ],
       "max_slots": 14,
       "branch": "strategy-v2",
-      "sort_order": 4
+      "sort_order": 9
     },
     {
       "id": "rhino",
@@ -1403,7 +2006,7 @@
       ],
       "max_slots": 6,
       "branch": "strategy-v2",
-      "sort_order": 5
+      "sort_order": 10
     },
     {
       "id": "scorpion",
@@ -1470,7 +2073,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 6
+      "sort_order": 11
     },
     {
       "id": "spider",
@@ -1533,7 +2136,7 @@
       ],
       "max_slots": 7,
       "branch": "strategy-v2",
-      "sort_order": 7
+      "sort_order": 12
     },
     {
       "id": "thesis-fund",
@@ -1591,7 +2194,7 @@
       ],
       "max_slots": 6,
       "branch": "strategy-v2",
-      "sort_order": 8
+      "sort_order": 13
     },
     {
       "id": "vulture",
@@ -1662,7 +2265,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 9
+      "sort_order": 14
     },
     {
       "id": "wolf",
@@ -1723,7 +2326,7 @@
       ],
       "max_slots": 6,
       "branch": "strategy-v2",
-      "sort_order": 10
+      "sort_order": 15
     },
     {
       "id": "coyote",

--- a/strategies/cub/long/runtime.yaml
+++ b/strategies/cub/long/runtime.yaml
@@ -1,0 +1,131 @@
+# ── CUB · LONG "haves" book — long the structural winners of a two-speed (K-shaped) world ──
+name: cub-long
+group: cub
+version: 3.0.0
+description: >
+  CUB LONG ("haves" book) — two-speed-market (K-shaped) cross-asset long/short fund (Runtime 3.0
+  port of v2 Cub v1.0.0, CUB_LEG=long). This book LONGS the structural winners of a K-shaped world:
+  the AI complex on Hyperliquid XYZ (HIP-3: NVDA, AMD, MRVL, TSM, ASML, ARM, AVGO, CRWV, PLTR,
+  ORCL, …) PLUS the crypto winners (HYPE large, SOL modest) — but only when ABSOLUTE trend confirms
+  (4h structure bullish + positive own momentum), with a blow-off guard. Cross-sectional relative
+  strength tilts size/ranking but never benches a genuinely-trending winner. Per-name size scales
+  with account value and a conviction weight (HYPE 1.5x, SOL 0.6x, AI equities 1.0x). Pairs with the
+  SHORT "have-nots" book + the PREIPO satellite on separate wallets; the P&L is the DISPERSION
+  between the two speeds. Tokenized equities trade 24/7 on Hyperliquid — no market-hours gating.
+
+strategy:
+  wallet: "${CUB_LONG_WALLET}"
+  # NET-EXPOSURE DEFAULT: modest NET-LONG tilt (~60/40) — an OPERATOR decision (wallet funding split
+  # + per-leg knobs), NOT runtime-enforced. This book defaults larger (slots 5, margin_pct 18) than
+  # the short book to express the directional AI/HYPE conviction.
+  slots: 5
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: cub_long_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — cross-asset cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map
+    inputs:
+      # curated "haves" thematic universe (AI complex on HL XYZ + crypto winners) — all 29 names
+      # validated against the live HL meta (main + xyz DEX) at authoring time.
+      universe: ["xyz:NVDA", "xyz:AMD", "xyz:MRVL", "xyz:ARM", "xyz:AVGO", "xyz:INTC", "xyz:TSM", "xyz:ASML", "xyz:CBRS", "xyz:MU", "xyz:SMSN", "xyz:SKHX", "xyz:SNDK", "xyz:CRWV", "xyz:NBIS", "xyz:DELL", "xyz:LITE", "xyz:GOOGL", "xyz:MSFT", "xyz:META", "xyz:AMZN", "xyz:ORCL", "xyz:PLTR", "xyz:NOW", "xyz:IBM", "xyz:SPCX", "xyz:QNT", "HYPE", "SOL"]
+      sizingWeights:                       # per-name conviction (bare ticker keys); clamped [0.1,3.0]
+        HYPE: 1.5
+        SOL: 0.6
+        SPCX: 0.6
+        QNT: 0.5
+        CBRS: 0.7
+        NBIS: 0.7
+        _default: 1.0
+      minScore: 5
+      marginPct: 18           # PERCENT of withdrawable (0,100]; baked × conviction weight per name
+      maxLeverage: 5          # strict clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 5
+      rankPoolSize: 30        # large AI universe — score the whole complex each tick
+      rsThresholdPct: 3.0
+      rsiOverbought: 82       # blow-off guard — don't chase an overbought leader
+      volFloorPctOfMedian: 0.2
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+      weight: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: cub_long_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # scan already applied universe + abs-trend gate + RS + clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [cub_long_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: cub_long_signals
+
+# ── EXIT (DSL — moderate; let two-speed winners run, cut reversers; ported VERBATIM from v2) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10080          # 7d — the AI trend persists; let winners run
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h — cut a winner that peaked then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 960            # 16h — recycle a position going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 16.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 40 }
+        - { trigger_pct: 35, lock_hw_pct: 60 }
+        - { trigger_pct: 60, lock_hw_pct: 78 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # v2 data_retention_hours 168 -> 604800s (7d cap)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6               # basket rotation as leadership shifts
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600               # v2 cooldown_minutes 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 14400    # v2 per_asset_cooldown_minutes 240

--- a/strategies/cub/long/scanners/scan.py
+++ b/strategies/cub/long/scanners/scan.py
@@ -1,0 +1,318 @@
+"""CUB · LONG "haves" book — supervised scanner (Runtime 3.0 port of cub-producer.py CUB_LEG=long).
+
+Longs the structural winners of a two-speed (K-shaped) world: the AI complex on Hyperliquid XYZ
+(NVDA/AMD/MRVL/TSM/ASML/ARM/AVGO/CRWV/PLTR/ORCL/…) plus the crypto winners (HYPE large, SOL
+modest), trend-confirmed. A faithful port of the v2 cub-producer's curated-thematic long book.
+Read-only, single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin; dual-DEX equity via
+     max(), never sum() — main + xyz are two views of ONE cross-margined wallet)
+  2. build the curated thematic universe (inputs.universe — the "haves"), intersected with the live
+     instrument board + a relative liquidity floor (>= volFloorPctOfMedian of the whitelist median
+     24h vol; NO hardcoded $)
+  3. rank the universe by 24h cross-sectional relative strength (own 24h - universe mean), take the
+     top rankPoolSize (LEADERS first)
+  4. score each pooled name with the v2 ABSOLUTE-trend gate + excess-as-tiebreaker thesis; dedup
+     held + recently-signalled
+  5. emit, best-score first, a top-level conviction-weighted marginPct INTENT (PERCENT, the runtime
+     sizes the $) + a per-name venue-clamped leverage; cap to what the wallet can FUND.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips without
+rolling back the whole universe tick (asia-ai NASDAQ-bug class).
+
+FIDELITY NOTES vs cub-producer.py v1.0.0 (CUB_LEG=long):
+  - v2 sized margin_usd = account_value * marginPct(FRACTION 0.18) * sizingWeight, then emitted a
+    USD figure. This port emits a top-level `marginPct` as a PERCENT and bakes the per-name
+    conviction weight INTO it: marginPct = base_margin_pct_percent * sizing_weight (then the runtime
+    sizes (marginPct/100)*withdrawable). The defensive `<=1.0 means a pasted fraction -> x100` guard
+    converts a fraction supplied via inputs (so 0.18 -> 18). Sizing is otherwise identical.
+  - v2 ranked the WHOLE board sort then took rankPoolSize; preserved (leaders first for the long leg).
+  - v2 funding cap: never emit more than free margin can fund (1.1 fee/slippage headroom); ported.
+  - v2 recent-signals JSON cache -> ctx.state dedup map (same TTL: 180s race-window).
+  - v2 SM lean was NOT used in the long/short books' score_thematic (it is a curated thematic book,
+    not a smart-money book) — nothing dropped there.
+  - DROPPED (read-only scan cannot mutate): the v2 producer had no order-lifecycle mutations
+    (cancel_order / stale-order purge), so nothing is dropped on that front; push_signal /
+    record_signal are replaced by returning plain dicts + ctx.state per the scan() contract.
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 _DEFAULTS["long"] / cub-long-config.json
+_HAVES_DEFAULT = [
+    "xyz:NVDA", "xyz:AMD", "xyz:MRVL", "xyz:ARM", "xyz:AVGO", "xyz:INTC",
+    "xyz:TSM", "xyz:ASML", "xyz:CBRS", "xyz:MU", "xyz:SMSN", "xyz:SKHX",
+    "xyz:SNDK", "xyz:CRWV", "xyz:NBIS", "xyz:DELL", "xyz:LITE", "xyz:GOOGL",
+    "xyz:MSFT", "xyz:META", "xyz:AMZN", "xyz:ORCL", "xyz:PLTR", "xyz:NOW",
+    "xyz:IBM", "xyz:SPCX", "xyz:QNT", "HYPE", "SOL",
+]
+_HAVES_WEIGHTS_DEFAULT = {
+    "HYPE": 1.5, "SOL": 0.6, "SPCX": 0.6, "QNT": 0.5,
+    "CBRS": 0.7, "NBIS": 0.7, "_default": 1.0,
+}
+_DEFAULT_TTL = 180   # v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+_DIRECTION = "LONG"
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll back the
+    whole tick (per the contract ANY exception rolls the tick to []). Returns None so the caller's
+    degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[cub.long.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+def _resolve_margin_pct(inputs, default_pct):
+    """marginPct base intent as a PERCENT in (0,100]. v2 stored a FRACTION (0.18); convert with
+    the defensive `<=1.0 means a pasted fraction -> x100` guard."""
+    mp = scoring._f(inputs.get("marginPct", default_pct), default_pct)
+    if mp <= 1.0:                 # a fraction was pasted (e.g. 0.18) -> percent
+        mp *= 100.0
+    return mp
+
+
+# ── account / positions (dual-DEX collapse + read-sanity guard, verbatim v2) ──
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). accountValue via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts -> 2x sizing). Free
+    margin = equity - committed margin. Includes the v2 read-sanity guard."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "margin": scoring._f(pos.get("marginUsed", 0)),
+            })
+    # v2 read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but EMPTY positions
+    # is a corrupt read — sizing/held-dedup off that re-enters held names. Skip the tick.
+    if used > 1.0 and not positions:
+        print("[cub.long.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return + ctx ──
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, ctx{...}}. Skips delisted. Verbatim v2 get_universe_meta() — keeps the
+    raw instrument context so ret_24h/day_vol/IPOP-signature reads work off it."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ctx": inst.get("context", {}) if isinstance(inst.get("context"), dict) else {},
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns ([],[]) and
+    the universe loop skips it."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    d = _unwrap(resp)
+    if isinstance(d, dict) and d.get("success") is False:
+        return [], []
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map, vol_floor_pct):
+    """The curated thematic whitelist intersected with the live board + a relative liquidity floor
+    (>= vol_floor_pct of the whitelist's MEDIAN 24h vol; NO hardcoded $). Names not live / too thin
+    are dropped, so new listings auto-join. Verbatim v2 build_universe()."""
+    cand = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue
+        vol = scoring.day_vol(meta)
+        if vol <= 0:
+            continue
+        cand.append((name, vol))
+    if not cand:
+        return []
+    vols = sorted(v for _, v in cand)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in cand if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    whitelist = inputs.get("universe", _HAVES_DEFAULT)
+    weights = inputs.get("sizingWeights", _HAVES_WEIGHTS_DEFAULT)
+    min_score = int(inputs.get("minScore", 5))
+    base_margin_pct = _resolve_margin_pct(inputs, 18)        # PERCENT of withdrawable (0,100]
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 5))
+    rank_pool = int(inputs.get("rankPoolSize", 30))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[cub.long.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist()
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist()
+        return []                                            # book full — runtime also caps via slots
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map, vol_floor_pct)
+
+    # ── Cross-sectional relative-strength rank (excess vs mean is a TIEBREAKER, not a gate) ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = scoring.ret_24h(meta) if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 2:                                          # v2-quirk: thematic universe too thin
+        _persist()
+        print("[cub.long.scan] WAITING — thematic universe too thin to evaluate", file=sys.stderr)
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=True)                # leaders first (long leg)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        thesis = scoring.score_thematic(name, c1, c4, excess, own, _DIRECTION, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist()
+        print(f"[cub.long.scan] WAITING — no name cleared min score {min_score}; "
+              f"scanned={len(universe)} pool={len(pool)} held={held}", file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # ── Emit best-scoring first, conviction-weighted size, capped to what the wallet can FUND.
+    #    free margin decremented as we commit (1.1 fee/slippage headroom) so a mixed basket never
+    #    emits an un-fundable order (which would re-emit insufficient-funds every tick). ──
+    out = []
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], weights)
+        margin_pct = round(base_margin_pct * weight, 4)      # PERCENT intent (conviction-weighted)
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)
+        if margin_pct <= 0 or leverage <= 0:
+            continue
+        # fund check: equivalent $ margin vs free margin (the runtime sizes from withdrawable;
+        # account_value is the available proxy here, matching v2's free-margin gate).
+        margin_usd = (margin_pct / 100.0) * account_value
+        if margin_usd * 1.1 > free_margin:                   # 1.1 = fee/slippage headroom (v2)
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": _DIRECTION,
+            "marginPct": margin_pct,                          # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                             # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": _DIRECTION,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+                "weight": weight,
+                "heldAssets": held,
+            },
+        })
+        recent[th["coin"].upper()] = now
+        open_slots -= 1
+        free_margin -= margin_usd * 1.1
+
+    _persist()
+    print(f"[cub.long.scan] scanned={len(universe)} pool={len(pool)} candidates={len(candidates)} "
+          f"emitted={len(out)} mean_rs={mean_rs:.2f} elapsed={time.time() - run_start:.2f}s",
+          file=sys.stderr)
+    return out

--- a/strategies/cub/long/scanners/scoring.py
+++ b/strategies/cub/long/scanners/scoring.py
@@ -1,0 +1,295 @@
+"""CUB — pure thesis math (no I/O, no MCP, no clock). Shared verbatim by all three books
+(long "haves", short "have-nots", preipo pre-IPO ramp); the direction and the universe builder
+differ per book but the scoring is one function. A faithful Runtime 3.0 port of the v2
+cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights + the IPOP
+discovery filter are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing
+and must not be redesigned). Unit-testable on plain candle lists + instrument dicts.
+
+KEY DISTINCTION FROM COUGAR (do not "simplify" toward cougar): in Cub the hard gate is
+ABSOLUTE TREND (long a have only while it actually trends up; short a have-not only while it
+actually rolls over). Cross-sectional excess return vs the leg-universe mean is a SCORE
+MODIFIER / TIEBREAKER, NOT a disqualifier — a genuinely-trending winner is NOT benched on a day
+its peers ran harder. Cougar instead gates on excess (long requires excess>=0); Cub does not.
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score. The
+# 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and only use
+# NORM_DIV if a caller wants the v2-equivalent normalised score.
+NORM_DIV = 9.0
+
+# v2 preipo defaults (cub-producer.py _DEFAULTS["preipo"] / cub-preipo-config.json)
+DEFAULT_IPOP_FUNDING_MAX = 1e-7    # IPOP funding signature (throttled pre-listing)
+DEFAULT_IPOP_LEV_CAP = 5           # IPOP leverage signature
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts only; the list branch is defensive and never fires on dict candles.
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return _f(c[2])
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return _f(c[3])
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    return 0.0
+
+
+# ── indicators (ported verbatim from v2 cub-producer.py) ──
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows = BULLISH, lower-highs = BEARISH over the last `lookback` candles.
+    Verbatim v2 trend_structure (>= total*0.6 gate, total = lookback-1)."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Simple-average RSI over the last `period` deltas. Verbatim v2 calc_rsi."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── bare-ticker helper (sizing-weight + dedup lookups: 'xyz:NVDA' -> 'NVDA') ──
+
+def bare(asset):
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+# ── the thematic thesis: ABSOLUTE trend is the gate, excess is a tiebreaker ──
+
+def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inputs):
+    """Port of v2 score_thematic. Returns a thesis dict (with `score`) or None.
+
+    `direction` is "LONG" (haves + preipo discovered IPOPs) or "SHORT" (have-nots).
+    `excess` = the asset's 24h return minus the leg-universe mean (cross-sectional).
+    `own24h`  = the asset's own 24h return (sign is an absolute-momentum component).
+
+    None is returned ONLY when: insufficient candle history (len(c1h) < 8 or len(c4h) < 6),
+    OR the ABSOLUTE-trend hard gate fails (long: 4h BEARISH; short: 4h BULLISH).
+    minScore is applied by the CALLER (scan.py), not here.
+
+    v2-quirk: excess is a SCORE MODIFIER (bonus only), NOT a gate — never disqualifies a
+    genuinely-trending name. Do NOT add cougar's `excess < 0 -> return None` here.
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if direction == "LONG":     # haves (curated) + preipo (discovered IPOPs)
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")  # noted, not penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 82))
+        if rsi > rsi_ob:
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # SHORT — have-nots
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+# ── sizing weight + leverage clamp (ported verbatim from v2) ──
+
+def sizing_weight(asset, weights):
+    """Per-group conviction multiplier (HYPE large, SOL modest, SP500 core). Keyed by bare
+    ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim v2 sizing_weight()."""
+    if not isinstance(weights, dict):
+        weights = {"_default": 1.0}
+    try:
+        w = float(weights.get(bare(asset), weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: xyz equities + IPOPs
+    cap LOW at the venue — over-leveraging is a venue reject, so this clamp is load-bearing.
+    Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))
+
+
+# ── IPOP discovery filter (preipo leg only; ported verbatim from v2 ipop_universe) ──
+
+def is_ipop(name, meta, max_funding=DEFAULT_IPOP_FUNDING_MAX, lev_cap=DEFAULT_IPOP_LEV_CAP,
+            min_day_vol=0.0):
+    """True iff a live xyz: instrument matches the structural IPOP signature (verbatim v2):
+        name.startswith("xyz:")
+        AND 0 < venue max_leverage <= lev_cap (the throttled pre-listing leverage cap)
+        AND abs(funding) <= max_funding (the throttled pre-listing funding signature)
+        AND 24h notional volume >= min_day_vol (budget-relative liquidity floor)."""
+    if not isinstance(name, str) or not name.lower().startswith("xyz:"):
+        return False
+    if not isinstance(meta, dict):
+        return False
+    try:
+        lev = int(meta.get("max_leverage"))
+    except (TypeError, ValueError):
+        return False
+    if lev <= 0 or lev > lev_cap:               # IPOP leverage signature
+        return False
+    ctx = meta.get("ctx", {}) if isinstance(meta.get("ctx"), dict) else {}
+    try:
+        funding_abs = abs(_f(ctx.get("funding", 0)))
+    except (TypeError, ValueError):
+        return False
+    if funding_abs > max_funding:               # IPOP funding signature
+        return False
+    if day_vol(meta) < min_day_vol:             # budget-relative liquidity
+        return False
+    return True
+
+
+# ── instrument-board accessors (ported verbatim from v2) ──
+
+def day_vol(meta):
+    """24h notional volume from an instrument's context. Verbatim v2 day_vol()."""
+    ctx = (meta.get("ctx", {}) if isinstance(meta, dict) else {}) or {}
+    try:
+        return _f(ctx.get("dayNtlVlm", 0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def ret_24h(meta):
+    """24h % return from markPx vs prevDayPx. None when unavailable. Verbatim v2 ret_24h()."""
+    ctx = (meta.get("ctx", {}) if isinstance(meta, dict) else {}) or {}
+    try:
+        mark = _f(ctx.get("markPx", 0))
+        prev = _f(ctx.get("prevDayPx", 0))
+    except (TypeError, ValueError):
+        return None
+    if prev <= 0 or mark <= 0:
+        return None
+    return (mark - prev) / prev * 100.0

--- a/strategies/cub/preipo/runtime.yaml
+++ b/strategies/cub/preipo/runtime.yaml
@@ -1,0 +1,125 @@
+# ── CUB · PREIPO satellite — the ~10% pre-IPO ramp sleeve (Lemur IPOP-discovery method) ──
+name: cub-preipo
+group: cub
+version: 3.0.0
+description: >
+  CUB PREIPO (satellite) — the ~10% pre-IPO ramp sleeve of the Cub combined fund (~90% Lion
+  two-speed AI long/short + ~10% pre-IPO). Runtime 3.0 port of v2 Cub v1.0.0, CUB_LEG=preipo. This
+  book auto-DISCOVERS pre-IPO perpetuals (IPOPs) on Hyperliquid XYZ by their structural funding
+  signature (|funding| <= ipopFundingMaxAbs AND venue max_leverage <= ipopMaxLeverageCap — the
+  throttled pre-listing state) and LONGS the ones with a confirming absolute 4h/1h uptrend, riding
+  the pre-listing ramp (the SpaceX / Cerebras pattern). No static universe — discovered every tick,
+  so the next IPOP auto-joins on listing. Blow-off guard loosened (pre-IPO names run hot). LONG only.
+  Episodic by design — most ticks may find 0-2 IPOPs. The IPOP liquidity floor is BUDGET-RELATIVE
+  (no hardcoded $). Runs on its OWN wallet, funded with ~10% of Cub's combined pool (allocation =
+  the operator's funding split across the three book wallets, NOT a runtime field). Pairs with the
+  LONG "haves" + SHORT "have-nots" books that carry the ~90% Lion engine.
+
+strategy:
+  wallet: "${CUB_PREIPO_WALLET}"
+  # ALLOCATION ~10% of Cub's combined pool — an OPERATOR funding decision, NOT runtime-enforced.
+  slots: 3
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: cub_preipo_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50
+    inputs:
+      # NO static universe — IPOPs are DISCOVERED each tick by the funding+leverage signature below.
+      sizingWeights:
+        _default: 1.0
+      minScore: 4             # pre-IPO data is sparse — slightly lower bar
+      marginPct: 15           # PERCENT of withdrawable (0,100]; × conviction weight per name
+      maxLeverage: 5          # IPOPs are venue-capped at 5x anyway; clamp then each name's HL venue max
+      maxSlots: 3
+      rankPoolSize: 16
+      ipopFundingMaxAbs: 1.0e-7   # IPOP funding signature (throttled pre-listing)
+      ipopMaxLeverageCap: 5       # IPOP leverage signature
+      ipopLiqVolMultiple: 30      # budget-relative IPOP liquidity floor (× position notional)
+      rsThresholdPct: 3.0
+      rsiOverbought: 88       # pre-IPO ramps run hot; loosen the blow-off guard
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+      weight: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: cub_preipo_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # scan already applied IPOP discovery + abs-trend gate + budget-relative liquidity floor + clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [cub_preipo_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: cub_preipo_signals
+
+# ── EXIT (DSL — let the ramp run; slightly tighter max-loss than haves; ported VERBATIM from v2) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 7200           # 5d — ride the ramp, but pre-IPO theses are time-boxed to the listing
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h — cut a ramp that peaked then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 960            # 16h
+    phase1:
+      enabled: true
+      max_loss_pct: 14.0                  # tighter than haves (16) — pre-IPO gaps on news
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 40 }
+        - { trigger_pct: 35, lock_hw_pct: 60 }
+        - { trigger_pct: 60, lock_hw_pct: 78 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # v2 data_retention_hours 168 -> 604800s (7d cap)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 4
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 5400               # v2 cooldown_minutes 90
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 14400    # v2 per_asset_cooldown_minutes 240

--- a/strategies/cub/preipo/scanners/scan.py
+++ b/strategies/cub/preipo/scanners/scan.py
@@ -1,0 +1,277 @@
+"""CUB · PREIPO satellite — supervised scanner (Runtime 3.0 port of cub-producer.py CUB_LEG=preipo).
+
+The ~10% pre-IPO ramp sleeve (Lemur IPOP-discovery method). Each tick it auto-DISCOVERS pre-IPO
+perpetuals (IPOPs) from the live Hyperliquid XYZ board by their structural funding signature
+(|funding| <= ipopFundingMaxAbs AND venue max_leverage <= ipopMaxLeverageCap — the throttled
+pre-listing state), then LONGS the ones with a confirming absolute 4h/1h uptrend (rides the
+pre-listing ramp; blow-off guard loosened since pre-IPO names run hot). There is NO static universe
+— it is discovered every tick, so a new IPOP (the next SpaceX/Cerebras) auto-joins the moment it
+lists. LONG-only. Episodic by design — most ticks may find 0-2 IPOPs. Read-only, single-pass.
+
+The IPOP liquidity floor is BUDGET-RELATIVE (24h vol >= ipopLiqVolMultiple × standard position
+notional) — the IPOP universe is too small for a median gate, and a $ floor is never hardcoded.
+
+READ-GUARD: market_list_instruments + every per-asset market_get_asset_data is wrapped so one bad
+read degrades (empty universe / skip name), never rolls back the whole tick.
+
+FIDELITY NOTES vs cub-producer.py v1.0.0 (CUB_LEG=preipo):
+  - v2 sized margin_usd = account_value * marginPct(FRACTION 0.15) * sizingWeight (USD). This port
+    emits a top-level `marginPct` PERCENT × per-name conviction weight (preipo sizingWeights default
+    is just {_default:1.0}, so weight is 1.0 unless overridden). The runtime sizes
+    (marginPct/100)*withdrawable. The budget-relative IPOP liquidity floor uses the FRACTION form
+    (base_margin_pct/100) so it reproduces v2's exact threshold:
+      min_day_vol = ipopLiqVolMultiple × (account_value × margin_frac × max_lev).
+    `<=1.0 means a pasted fraction -> x100` guard converts a fraction supplied via inputs.
+  - v2 ranked the discovered IPOPs leaders-first (reverse=True for the LONG preipo leg); the
+    too-thin guard is len(rs) < 1 (vs < 2 for long/short). Both preserved.
+  - v2 funding cap (free margin, 1.1 headroom); ported.
+  - v2 recent-signals JSON cache -> ctx.state dedup (180s race-window).
+  - v2 SM was a noted bonus-only concern for IPOPs but score_thematic itself does NOT consume SM in
+    any leg — nothing dropped.
+  - DROPPED (read-only scan cannot mutate): v2 had no order-lifecycle mutations; push_signal /
+    record_signal replaced by returning plain dicts + ctx.state per the scan() contract.
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 _DEFAULTS["preipo"] / cub-preipo-config.json
+_WEIGHTS_DEFAULT = {"_default": 1.0}
+_DEFAULT_TTL = 180
+_DIRECTION = "LONG"   # preipo is a long-only ramp book
+
+
+def _read(ctx, name, args):
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad read must not kill the discovery tick
+        print(f"[cub.preipo.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+def _resolve_margin_pct(inputs, default_pct):
+    mp = scoring._f(inputs.get("marginPct", default_pct), default_pct)
+    if mp <= 1.0:                 # a fraction was pasted (e.g. 0.15) -> percent
+        mp *= 100.0
+    return mp
+
+
+def _get_positions(ctx):
+    """(account_value, [positions], free_margin). accountValue via max() across main/xyz; v2
+    read-sanity guard (margin in use but empty positions -> skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "margin": scoring._f(pos.get("marginUsed", 0)),
+            })
+    if used > 1.0 and not positions:
+        print("[cub.preipo.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+def _get_universe_meta(ctx):
+    """(meta_map name -> {max_leverage, ctx{...}}, canonical [names in board order]). Skips delisted.
+    Verbatim v2 get_universe_meta() — keeps the raw instrument context for the IPOP signature."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out, canonical = {}, []
+    if not resp:
+        return out, canonical
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ctx": inst.get("context", {}) if isinstance(inst.get("context"), dict) else {},
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+        canonical.append(name)
+    return out, canonical
+
+
+def _ipop_universe(canonical, meta_map, max_funding, lev_cap, min_day_vol):
+    """Lemur-method pre-IPO discovery (verbatim v2 ipop_universe). Returns the live xyz IPOP names
+    matching the funding+leverage signature AND clearing the budget-relative liquidity floor."""
+    out = []
+    for name in canonical:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if scoring.is_ipop(name, meta, max_funding=max_funding, lev_cap=lev_cap,
+                           min_day_vol=min_day_vol):
+            out.append(name)
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    d = _unwrap(resp)
+    if isinstance(d, dict) and d.get("success") is False:
+        return [], []
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    weights = inputs.get("sizingWeights", _WEIGHTS_DEFAULT)
+    min_score = int(inputs.get("minScore", 4))
+    base_margin_pct = _resolve_margin_pct(inputs, 15)        # PERCENT of withdrawable (0,100]
+    margin_frac = base_margin_pct / 100.0                    # FRACTION form for the budget-relative floor
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 3))
+    rank_pool = int(inputs.get("rankPoolSize", 16))
+    max_funding = float(inputs.get("ipopFundingMaxAbs", scoring.DEFAULT_IPOP_FUNDING_MAX))
+    lev_cap = int(inputs.get("ipopMaxLeverageCap", scoring.DEFAULT_IPOP_LEV_CAP))
+    liq_mult = float(inputs.get("ipopLiqVolMultiple", 30))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[cub.preipo.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist()
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist()
+        return []
+
+    meta_map, canonical = _get_universe_meta(ctx)
+    # budget-relative IPOP liquidity floor (NO hardcoded $); verbatim v2 min_day_vol math.
+    min_day_vol = liq_mult * (account_value * margin_frac * float(max_lev))
+    universe = _ipop_universe(canonical, meta_map, max_funding, lev_cap, min_day_vol)
+
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = scoring.ret_24h(meta) if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 1:                                          # v2-quirk: preipo too-thin guard (< 1)
+        _persist()
+        print("[cub.preipo.scan] WAITING — no live IPOPs ramping", file=sys.stderr)
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=True)                # leaders first (long ramp leg)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)
+        thesis = scoring.score_thematic(name, c1, c4, excess, own, _DIRECTION, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist()
+        print(f"[cub.preipo.scan] WAITING — no IPOP cleared min score {min_score}; "
+              f"universe={universe} held={held}", file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    out = []
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], weights)
+        margin_pct = round(base_margin_pct * weight, 4)
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)
+        if margin_pct <= 0 or leverage <= 0:
+            continue
+        margin_usd = (margin_pct / 100.0) * account_value
+        if margin_usd * 1.1 > free_margin:                   # 1.1 = fee/slippage headroom (v2)
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": _DIRECTION,
+            "marginPct": margin_pct,
+            "leverage": leverage,
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": _DIRECTION,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+                "weight": weight,
+                "heldAssets": held,
+            },
+        })
+        recent[th["coin"].upper()] = now
+        open_slots -= 1
+        free_margin -= margin_usd * 1.1
+
+    _persist()
+    print(f"[cub.preipo.scan] universe={len(universe)} pool={len(pool)} candidates={len(candidates)} "
+          f"emitted={len(out)} mean_rs={mean_rs:.2f} elapsed={time.time() - run_start:.2f}s",
+          file=sys.stderr)
+    return out

--- a/strategies/cub/preipo/scanners/scoring.py
+++ b/strategies/cub/preipo/scanners/scoring.py
@@ -1,0 +1,295 @@
+"""CUB — pure thesis math (no I/O, no MCP, no clock). Shared verbatim by all three books
+(long "haves", short "have-nots", preipo pre-IPO ramp); the direction and the universe builder
+differ per book but the scoring is one function. A faithful Runtime 3.0 port of the v2
+cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights + the IPOP
+discovery filter are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing
+and must not be redesigned). Unit-testable on plain candle lists + instrument dicts.
+
+KEY DISTINCTION FROM COUGAR (do not "simplify" toward cougar): in Cub the hard gate is
+ABSOLUTE TREND (long a have only while it actually trends up; short a have-not only while it
+actually rolls over). Cross-sectional excess return vs the leg-universe mean is a SCORE
+MODIFIER / TIEBREAKER, NOT a disqualifier — a genuinely-trending winner is NOT benched on a day
+its peers ran harder. Cougar instead gates on excess (long requires excess>=0); Cub does not.
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score. The
+# 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and only use
+# NORM_DIV if a caller wants the v2-equivalent normalised score.
+NORM_DIV = 9.0
+
+# v2 preipo defaults (cub-producer.py _DEFAULTS["preipo"] / cub-preipo-config.json)
+DEFAULT_IPOP_FUNDING_MAX = 1e-7    # IPOP funding signature (throttled pre-listing)
+DEFAULT_IPOP_LEV_CAP = 5           # IPOP leverage signature
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts only; the list branch is defensive and never fires on dict candles.
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return _f(c[2])
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return _f(c[3])
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    return 0.0
+
+
+# ── indicators (ported verbatim from v2 cub-producer.py) ──
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows = BULLISH, lower-highs = BEARISH over the last `lookback` candles.
+    Verbatim v2 trend_structure (>= total*0.6 gate, total = lookback-1)."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Simple-average RSI over the last `period` deltas. Verbatim v2 calc_rsi."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── bare-ticker helper (sizing-weight + dedup lookups: 'xyz:NVDA' -> 'NVDA') ──
+
+def bare(asset):
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+# ── the thematic thesis: ABSOLUTE trend is the gate, excess is a tiebreaker ──
+
+def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inputs):
+    """Port of v2 score_thematic. Returns a thesis dict (with `score`) or None.
+
+    `direction` is "LONG" (haves + preipo discovered IPOPs) or "SHORT" (have-nots).
+    `excess` = the asset's 24h return minus the leg-universe mean (cross-sectional).
+    `own24h`  = the asset's own 24h return (sign is an absolute-momentum component).
+
+    None is returned ONLY when: insufficient candle history (len(c1h) < 8 or len(c4h) < 6),
+    OR the ABSOLUTE-trend hard gate fails (long: 4h BEARISH; short: 4h BULLISH).
+    minScore is applied by the CALLER (scan.py), not here.
+
+    v2-quirk: excess is a SCORE MODIFIER (bonus only), NOT a gate — never disqualifies a
+    genuinely-trending name. Do NOT add cougar's `excess < 0 -> return None` here.
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if direction == "LONG":     # haves (curated) + preipo (discovered IPOPs)
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")  # noted, not penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 82))
+        if rsi > rsi_ob:
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # SHORT — have-nots
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+# ── sizing weight + leverage clamp (ported verbatim from v2) ──
+
+def sizing_weight(asset, weights):
+    """Per-group conviction multiplier (HYPE large, SOL modest, SP500 core). Keyed by bare
+    ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim v2 sizing_weight()."""
+    if not isinstance(weights, dict):
+        weights = {"_default": 1.0}
+    try:
+        w = float(weights.get(bare(asset), weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: xyz equities + IPOPs
+    cap LOW at the venue — over-leveraging is a venue reject, so this clamp is load-bearing.
+    Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))
+
+
+# ── IPOP discovery filter (preipo leg only; ported verbatim from v2 ipop_universe) ──
+
+def is_ipop(name, meta, max_funding=DEFAULT_IPOP_FUNDING_MAX, lev_cap=DEFAULT_IPOP_LEV_CAP,
+            min_day_vol=0.0):
+    """True iff a live xyz: instrument matches the structural IPOP signature (verbatim v2):
+        name.startswith("xyz:")
+        AND 0 < venue max_leverage <= lev_cap (the throttled pre-listing leverage cap)
+        AND abs(funding) <= max_funding (the throttled pre-listing funding signature)
+        AND 24h notional volume >= min_day_vol (budget-relative liquidity floor)."""
+    if not isinstance(name, str) or not name.lower().startswith("xyz:"):
+        return False
+    if not isinstance(meta, dict):
+        return False
+    try:
+        lev = int(meta.get("max_leverage"))
+    except (TypeError, ValueError):
+        return False
+    if lev <= 0 or lev > lev_cap:               # IPOP leverage signature
+        return False
+    ctx = meta.get("ctx", {}) if isinstance(meta.get("ctx"), dict) else {}
+    try:
+        funding_abs = abs(_f(ctx.get("funding", 0)))
+    except (TypeError, ValueError):
+        return False
+    if funding_abs > max_funding:               # IPOP funding signature
+        return False
+    if day_vol(meta) < min_day_vol:             # budget-relative liquidity
+        return False
+    return True
+
+
+# ── instrument-board accessors (ported verbatim from v2) ──
+
+def day_vol(meta):
+    """24h notional volume from an instrument's context. Verbatim v2 day_vol()."""
+    ctx = (meta.get("ctx", {}) if isinstance(meta, dict) else {}) or {}
+    try:
+        return _f(ctx.get("dayNtlVlm", 0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def ret_24h(meta):
+    """24h % return from markPx vs prevDayPx. None when unavailable. Verbatim v2 ret_24h()."""
+    ctx = (meta.get("ctx", {}) if isinstance(meta, dict) else {}) or {}
+    try:
+        mark = _f(ctx.get("markPx", 0))
+        prev = _f(ctx.get("prevDayPx", 0))
+    except (TypeError, ValueError):
+        return None
+    if prev <= 0 or mark <= 0:
+        return None
+    return (mark - prev) / prev * 100.0

--- a/strategies/cub/short/runtime.yaml
+++ b/strategies/cub/short/runtime.yaml
@@ -1,0 +1,128 @@
+# ── CUB · SHORT "have-nots" book — short the laggards of a two-speed (K-shaped) world ──
+name: cub-short
+group: cub
+version: 3.0.0
+description: >
+  CUB SHORT ("have-nots" book) — two-speed-market (K-shaped) cross-asset long/short fund (Runtime
+  3.0 port of v2 Cub v1.0.0, CUB_LEG=short). This book SHORTS the laggards of a K-shaped world: the
+  broad U.S. market via the SP500 index product (the "economy suffers" core) PLUS a curated, gated
+  basket of laggard crypto majors/alts (the "rest of crypto struggles" bet) — but only when ABSOLUTE
+  trend confirms (4h structure bearish + negative momentum), with a CAPITULATION guard so it never
+  shorts an exhausted bottom. Cross-sectional relative weakness tilts size/ranking. Per-name size
+  scales with account value and a conviction weight (SP500 1.2x core, alts 0.7x — alts squeeze).
+  Pairs with the LONG "haves" book on a separate wallet. Longing AI names while shorting SP500
+  (which contains them) isolates the AI-vs-broad-market spread by design. Tokenized equities trade
+  24/7 on Hyperliquid — no market-hours gating.
+
+strategy:
+  wallet: "${CUB_SHORT_WALLET}"
+  # NET-EXPOSURE DEFAULT: modest NET-LONG tilt (~60/40) — an OPERATOR decision, NOT runtime-enforced.
+  # This book defaults smaller (slots 4, margin_pct 15, 4x cap) than the long book — short squeezes
+  # are violent and the thesis is directionally bullish-AI/HYPE.
+  slots: 4
+  default_leverage: 4
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: cub_short_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50
+    inputs:
+      # curated "have-nots" thematic universe (SP500 macro core + laggard alts) — all 10 names
+      # validated against the live HL meta (main + xyz DEX) at authoring time. BTC deliberately
+      # omitted (too reflexive to short cleanly).
+      universe: ["xyz:SP500", "ETH", "XRP", "DOGE", "AVAX", "LINK", "ADA", "LTC", "NEAR", "APT"]
+      sizingWeights:                       # SP500 core weight, laggard alts small (squeeze)
+        SP500: 1.2
+        _default: 0.7
+      minScore: 5
+      marginPct: 15           # PERCENT of withdrawable (0,100]; baked × conviction weight per name
+      maxLeverage: 4          # 4x clamp (short squeezes are violent), then each name's HL venue max
+      maxSlots: 4
+      rankPoolSize: 16
+      rsThresholdPct: 3.0
+      rsiOversold: 18         # capitulation guard — never short an exhausted bottom
+      volFloorPctOfMedian: 0.2
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+      weight: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: cub_short_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # scan already applied universe + abs-downtrend gate + capitulation guard + RS + clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [cub_short_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: cub_short_signals
+
+# ── EXIT (DSL — tighter; short theses decay faster, squeezes are violent; ported VERBATIM from v2) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 7200           # 5d — shorter than the long book
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h — cut a short that bottomed then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 720            # 12h — recycle a short going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                  # tighter than long book — squeeze protection
+      retrace_threshold: 7
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8, lock_hw_pct: 0 }
+        - { trigger_pct: 18, lock_hw_pct: 45 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 60, lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # v2 data_retention_hours 168 -> 604800s (7d cap)
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 5
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 5400               # v2 cooldown_minutes 90
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 18000    # v2 per_asset_cooldown_minutes 300

--- a/strategies/cub/short/scanners/scan.py
+++ b/strategies/cub/short/scanners/scan.py
@@ -1,0 +1,282 @@
+"""CUB · SHORT "have-nots" book — supervised scanner (Runtime 3.0 port of cub-producer.py CUB_LEG=short).
+
+Shorts the laggards of a two-speed (K-shaped) world: the broad U.S. market via the SP500 index
+product (the "economy suffers" core) plus a curated, gated basket of laggard crypto majors/alts
+(the "rest of crypto struggles" bet), trend-confirmed with a CAPITULATION guard (never short an
+exhausted bottom). A faithful port of the v2 cub-producer's curated-thematic short book. Read-only,
+single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin; dual-DEX equity via
+     max(), never sum())
+  2. build the curated thematic universe (inputs.universe — the "have-nots"), intersected with the
+     live board + a relative liquidity floor (NO hardcoded $)
+  3. rank by 24h cross-sectional relative strength, take the bottom rankPoolSize (LAGGARDS first)
+  4. score each pooled name with the v2 ABSOLUTE-downtrend gate + excess-as-tiebreaker thesis;
+     dedup held + recently-signalled
+  5. emit, best-score first, a top-level conviction-weighted marginPct INTENT (PERCENT) + a per-name
+     venue-clamped leverage; cap to what the wallet can FUND.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips without
+rolling back the whole universe tick.
+
+FIDELITY NOTES vs cub-producer.py v1.0.0 (CUB_LEG=short):
+  - v2 sized margin_usd = account_value * marginPct(FRACTION 0.15) * sizingWeight (USD). This port
+    emits a top-level `marginPct` PERCENT with the per-name conviction weight baked in
+    (marginPct = base_margin_pct_percent * sizing_weight); the runtime sizes
+    (marginPct/100)*withdrawable. `<=1.0 means a pasted fraction -> x100` guard converts a fraction.
+  - v2 ranked laggards-first (reverse=False for the short leg); preserved.
+  - v2 funding cap (free margin, 1.1 headroom); ported.
+  - v2 recent-signals JSON cache -> ctx.state dedup (180s race-window).
+  - DROPPED (read-only scan cannot mutate): v2 had no order-lifecycle mutations; push_signal /
+    record_signal replaced by returning plain dicts + ctx.state per the scan() contract.
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 _DEFAULTS["short"] / cub-short-config.json
+_HAVE_NOTS_DEFAULT = ["xyz:SP500", "ETH", "XRP", "DOGE", "AVAX", "LINK", "ADA", "LTC", "NEAR", "APT"]
+_HAVE_NOTS_WEIGHTS_DEFAULT = {"SP500": 1.2, "_default": 0.7}
+_DEFAULT_TTL = 180
+_DIRECTION = "SHORT"
+
+
+def _read(ctx, name, args):
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[cub.short.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+def _resolve_margin_pct(inputs, default_pct):
+    mp = scoring._f(inputs.get("marginPct", default_pct), default_pct)
+    if mp <= 1.0:                 # a fraction was pasted (e.g. 0.15) -> percent
+        mp *= 100.0
+    return mp
+
+
+def _get_positions(ctx):
+    """(account_value, [positions], free_margin). accountValue via max() across main/xyz; v2
+    read-sanity guard (margin in use but empty positions -> skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "margin": scoring._f(pos.get("marginUsed", 0)),
+            })
+    if used > 1.0 and not positions:
+        print("[cub.short.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, ctx{...}}. Skips delisted. Verbatim v2 get_universe_meta()."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ctx": inst.get("context", {}) if isinstance(inst.get("context"), dict) else {},
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    d = _unwrap(resp)
+    if isinstance(d, dict) and d.get("success") is False:
+        return [], []
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map, vol_floor_pct):
+    """Curated whitelist ∩ live board + relative liquidity floor (>= vol_floor_pct of median 24h
+    vol; NO hardcoded $). Verbatim v2 build_universe()."""
+    cand = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue
+        vol = scoring.day_vol(meta)
+        if vol <= 0:
+            continue
+        cand.append((name, vol))
+    if not cand:
+        return []
+    vols = sorted(v for _, v in cand)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in cand if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    whitelist = inputs.get("universe", _HAVE_NOTS_DEFAULT)
+    weights = inputs.get("sizingWeights", _HAVE_NOTS_WEIGHTS_DEFAULT)
+    min_score = int(inputs.get("minScore", 5))
+    base_margin_pct = _resolve_margin_pct(inputs, 15)        # PERCENT of withdrawable (0,100]
+    max_lev = int(inputs.get("maxLeverage", 4))
+    max_slots = int(inputs.get("maxSlots", 4))
+    rank_pool = int(inputs.get("rankPoolSize", 16))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[cub.short.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist()
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist()
+        return []
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map, vol_floor_pct)
+
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = scoring.ret_24h(meta) if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 2:                                          # v2-quirk: thematic universe too thin
+        _persist()
+        print("[cub.short.scan] WAITING — thematic universe too thin to evaluate", file=sys.stderr)
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=False)               # laggards first (short leg)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)
+        thesis = scoring.score_thematic(name, c1, c4, excess, own, _DIRECTION, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist()
+        print(f"[cub.short.scan] WAITING — no name cleared min score {min_score}; "
+              f"scanned={len(universe)} pool={len(pool)} held={held}", file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    out = []
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], weights)
+        margin_pct = round(base_margin_pct * weight, 4)
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)
+        if margin_pct <= 0 or leverage <= 0:
+            continue
+        margin_usd = (margin_pct / 100.0) * account_value
+        if margin_usd * 1.1 > free_margin:                   # 1.1 = fee/slippage headroom (v2)
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": _DIRECTION,
+            "marginPct": margin_pct,
+            "leverage": leverage,
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": _DIRECTION,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+                "weight": weight,
+                "heldAssets": held,
+            },
+        })
+        recent[th["coin"].upper()] = now
+        open_slots -= 1
+        free_margin -= margin_usd * 1.1
+
+    _persist()
+    print(f"[cub.short.scan] scanned={len(universe)} pool={len(pool)} candidates={len(candidates)} "
+          f"emitted={len(out)} mean_rs={mean_rs:.2f} elapsed={time.time() - run_start:.2f}s",
+          file=sys.stderr)
+    return out

--- a/strategies/cub/short/scanners/scoring.py
+++ b/strategies/cub/short/scanners/scoring.py
@@ -1,0 +1,295 @@
+"""CUB — pure thesis math (no I/O, no MCP, no clock). Shared verbatim by all three books
+(long "haves", short "have-nots", preipo pre-IPO ramp); the direction and the universe builder
+differ per book but the scoring is one function. A faithful Runtime 3.0 port of the v2
+cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights + the IPOP
+discovery filter are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing
+and must not be redesigned). Unit-testable on plain candle lists + instrument dicts.
+
+KEY DISTINCTION FROM COUGAR (do not "simplify" toward cougar): in Cub the hard gate is
+ABSOLUTE TREND (long a have only while it actually trends up; short a have-not only while it
+actually rolls over). Cross-sectional excess return vs the leg-universe mean is a SCORE
+MODIFIER / TIEBREAKER, NOT a disqualifier — a genuinely-trending winner is NOT benched on a day
+its peers ran harder. Cougar instead gates on excess (long requires excess>=0); Cub does not.
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score. The
+# 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and only use
+# NORM_DIV if a caller wants the v2-equivalent normalised score.
+NORM_DIV = 9.0
+
+# v2 preipo defaults (cub-producer.py _DEFAULTS["preipo"] / cub-preipo-config.json)
+DEFAULT_IPOP_FUNDING_MAX = 1e-7    # IPOP funding signature (throttled pre-listing)
+DEFAULT_IPOP_LEV_CAP = 5           # IPOP leverage signature
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts only; the list branch is defensive and never fires on dict candles.
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return _f(c[2])
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return _f(c[3])
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    return 0.0
+
+
+# ── indicators (ported verbatim from v2 cub-producer.py) ──
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows = BULLISH, lower-highs = BEARISH over the last `lookback` candles.
+    Verbatim v2 trend_structure (>= total*0.6 gate, total = lookback-1)."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Simple-average RSI over the last `period` deltas. Verbatim v2 calc_rsi."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── bare-ticker helper (sizing-weight + dedup lookups: 'xyz:NVDA' -> 'NVDA') ──
+
+def bare(asset):
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+# ── the thematic thesis: ABSOLUTE trend is the gate, excess is a tiebreaker ──
+
+def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inputs):
+    """Port of v2 score_thematic. Returns a thesis dict (with `score`) or None.
+
+    `direction` is "LONG" (haves + preipo discovered IPOPs) or "SHORT" (have-nots).
+    `excess` = the asset's 24h return minus the leg-universe mean (cross-sectional).
+    `own24h`  = the asset's own 24h return (sign is an absolute-momentum component).
+
+    None is returned ONLY when: insufficient candle history (len(c1h) < 8 or len(c4h) < 6),
+    OR the ABSOLUTE-trend hard gate fails (long: 4h BEARISH; short: 4h BULLISH).
+    minScore is applied by the CALLER (scan.py), not here.
+
+    v2-quirk: excess is a SCORE MODIFIER (bonus only), NOT a gate — never disqualifies a
+    genuinely-trending name. Do NOT add cougar's `excess < 0 -> return None` here.
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if direction == "LONG":     # haves (curated) + preipo (discovered IPOPs)
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")  # noted, not penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 82))
+        if rsi > rsi_ob:
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # SHORT — have-nots
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+# ── sizing weight + leverage clamp (ported verbatim from v2) ──
+
+def sizing_weight(asset, weights):
+    """Per-group conviction multiplier (HYPE large, SOL modest, SP500 core). Keyed by bare
+    ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim v2 sizing_weight()."""
+    if not isinstance(weights, dict):
+        weights = {"_default": 1.0}
+    try:
+        w = float(weights.get(bare(asset), weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: xyz equities + IPOPs
+    cap LOW at the venue — over-leveraging is a venue reject, so this clamp is load-bearing.
+    Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))
+
+
+# ── IPOP discovery filter (preipo leg only; ported verbatim from v2 ipop_universe) ──
+
+def is_ipop(name, meta, max_funding=DEFAULT_IPOP_FUNDING_MAX, lev_cap=DEFAULT_IPOP_LEV_CAP,
+            min_day_vol=0.0):
+    """True iff a live xyz: instrument matches the structural IPOP signature (verbatim v2):
+        name.startswith("xyz:")
+        AND 0 < venue max_leverage <= lev_cap (the throttled pre-listing leverage cap)
+        AND abs(funding) <= max_funding (the throttled pre-listing funding signature)
+        AND 24h notional volume >= min_day_vol (budget-relative liquidity floor)."""
+    if not isinstance(name, str) or not name.lower().startswith("xyz:"):
+        return False
+    if not isinstance(meta, dict):
+        return False
+    try:
+        lev = int(meta.get("max_leverage"))
+    except (TypeError, ValueError):
+        return False
+    if lev <= 0 or lev > lev_cap:               # IPOP leverage signature
+        return False
+    ctx = meta.get("ctx", {}) if isinstance(meta.get("ctx"), dict) else {}
+    try:
+        funding_abs = abs(_f(ctx.get("funding", 0)))
+    except (TypeError, ValueError):
+        return False
+    if funding_abs > max_funding:               # IPOP funding signature
+        return False
+    if day_vol(meta) < min_day_vol:             # budget-relative liquidity
+        return False
+    return True
+
+
+# ── instrument-board accessors (ported verbatim from v2) ──
+
+def day_vol(meta):
+    """24h notional volume from an instrument's context. Verbatim v2 day_vol()."""
+    ctx = (meta.get("ctx", {}) if isinstance(meta, dict) else {}) or {}
+    try:
+        return _f(ctx.get("dayNtlVlm", 0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def ret_24h(meta):
+    """24h % return from markPx vs prevDayPx. None when unavailable. Verbatim v2 ret_24h()."""
+    ctx = (meta.get("ctx", {}) if isinstance(meta, dict) else {}) or {}
+    try:
+        mark = _f(ctx.get("markPx", 0))
+        prev = _f(ctx.get("prevDayPx", 0))
+    except (TypeError, ValueError):
+        return None
+    if prev <= 0 or mark <= 0:
+        return None
+    return (mark - prev) / prev * 100.0

--- a/strategies/cub/strategy.yaml
+++ b/strategies/cub/strategy.yaml
@@ -1,0 +1,60 @@
+# Cub — Two-speed-market (K-shaped) cross-asset long/short fund + pre-IPO satellite.
+# A THREE-instance PACKAGE: this manifest + three self-contained runtime.yaml sleeves on
+# THREE separate wallets (long "haves" / short "have-nots" / preipo pre-IPO ramp) + per-sleeve
+# scanners/. A faithful Runtime 3.0 port of the v2 Cub v1.0.0 engine (cub-producer.py driven by
+# CUB_LEG into long / short / preipo books, on origin/main). Cub is a variation of Lion: ~90%
+# to the two-speed AI long/short engine (long + short) and ~10% to the pre-IPO ramp satellite.
+# Install/teardown via senpi-strategy-ops.
+#
+# NET EXPOSURE + 90/10 ALLOCATION ARE OPERATOR DECISIONS, not runtime-enforced fields — set by
+# how much capital is funded into each of the three wallets (plus per-leg slots / margin_pct /
+# sizingWeights). Default = modest NET-LONG tilt across long+short (~60/40) + ~10% preipo.
+schema_version: 1
+
+id: cub
+version: "1.0.0"
+
+catalog:
+  name: "Cub — Two-Speed-Market Long/Short + Pre-IPO"
+  emoji: "🐅"
+  tagline: "Longs the structural winners of a K-shaped world (the AI complex on Hyperliquid XYZ + crypto winners HYPE/SOL) and shorts the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) — both trend-confirmed on separate wallets — plus a ~10% pre-IPO ramp satellite that auto-discovers pre-IPO perpetuals (IPOPs) and rides them into their listing."
+  belief_plain: "The world is splitting into haves and have-nots: AI companies and crypto's winners keep booming while the broad economy and the rest of crypto struggle. Cub buys the booming side and shorts the struggling side at the same time on separate wallets, so it makes money on the GAP between the two — and keeps a small slice aimed at the next SpaceX before it goes public."
+  thesis: "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their funding signature and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open."
+  group: multi-asset-thematic
+  archetype: structural_neutral   # cross-asset L/S dispersion — net beta set by operator funding split
+  sub_style: pairs_rv             # cross-sectional relative-value (haves vs have-nots dispersion)
+  asset_classes: [xyz_equities, major_alts, indices, pre_ipo]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 12           # long 5 + short 4 + preipo 3
+  min_budget: 600         # 3 wallets; ~90% across long+short / ~10% preipo — each needs working size
+  assets: ["xyz:NVDA", "xyz:AMD", "xyz:MRVL", "xyz:ARM", "xyz:AVGO", "xyz:TSM", "xyz:ASML", "xyz:MU", "xyz:CRWV", "xyz:GOOGL", "xyz:MSFT", "xyz:META", "xyz:AMZN", "xyz:ORCL", "xyz:PLTR", "xyz:SPCX", "HYPE", "SOL", "xyz:SP500", "ETH", "XRP", "DOGE", "AVAX", "LINK"]
+  tags: [k-shaped, two-speed, ai-complex, hedge-fund, long-short, dispersion, xyz, equities, crypto, pre-ipo, ipop, hype, sp500]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+# THREE sleeves on THREE separate wallets (so the long haves + short have-nots can coexist and
+# the preipo ramp runs its own book). Default funding split mirrors the v2 config notes: ~90%
+# across the Lion two-speed engine (long ~60% / short ~30% — the modest net-long tilt) and ~10%
+# to the preipo satellite. Fund only long+short to drop the pre-IPO sleeve.
+instances:
+  - name: long
+    runtime: long/runtime.yaml
+    wallet_env: CUB_LONG_WALLET
+    funding_share: 0.55
+  - name: short
+    runtime: short/runtime.yaml
+    wallet_env: CUB_SHORT_WALLET
+    funding_share: 0.35
+  - name: preipo
+    runtime: preipo/runtime.yaml
+    wallet_env: CUB_PREIPO_WALLET
+    funding_share: 0.10

--- a/strategies/eel/long/runtime.yaml
+++ b/strategies/eel/long/runtime.yaml
@@ -1,0 +1,131 @@
+# ── EEL · LONG book ("POWER") — long the AI-power complex on Hyperliquid XYZ ──
+name: eel-long
+group: eel
+version: 3.0.0
+description: >
+  EEL LONG (POWER book) — Electrons vs Hydrocarbons energy-pair thesis fund (Runtime 3.0
+  port of v2 Eel v1.0). The LONG leg of an energy-sector-neutral pair. This book LONGS the
+  AI-power complex on Hyperliquid XYZ — uranium (URNM), gas-fired power (NATGAS), the grid
+  metal (COPPER), on-site fuel cells (BE), rare-earth (USAR) — the electrons AI datacenters
+  need — but only when ABSOLUTE trend confirms (4h structure not bearish + positive own
+  momentum), with an RSI blow-off guard. Cross-sectional relative strength tilts size/ranking
+  but never benches a genuinely-trending name. Per-name size scales with account value and a
+  conviction weight (URNM 1.2x, COPPER 1.1x, BE 0.6x). Pairs with the SHORT crude-oil book
+  (short/runtime.yaml) on a separate wallet; both legs are energy, so an energy-wide move
+  washes out and the P&L is the electrons-vs-hydrocarbons spread. Commodities trade ~24/7.
+
+strategy:
+  wallet: "${EEL_LONG_WALLET}"
+  # ── FUNDING DEFAULT: slight long-power tilt (~55/45 long:short) ── the split is an
+  # OPERATOR decision (config _hedge_note in v2) set by the power/oil wallet funding; this
+  # power book defaults a touch larger (slots 4, margin_pct 18) than the oil book.
+  slots: 4
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: eel_long_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — energy-trend cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map + per-tick result
+    inputs:
+      leg: "long"
+      # ── VALIDATED thematic POWER universe (live HL xyz board, authoring time) ──
+      # All 5 names present on the live HL xyz board, none delisted (validated 2026-06-29).
+      universe: ["xyz:URNM", "xyz:NATGAS", "xyz:COPPER", "xyz:BE", "xyz:USAR"]
+      sizingWeights:
+        URNM: 1.2          # uranium — the purest AI-power play
+        COPPER: 1.1        # the electrification / grid metal
+        NATGAS: 1.0
+        USAR: 0.7          # smaller-cap rare-earth
+        BE: 0.6            # speculative fuel-cell
+        _default: 1.0
+      minScore: 5
+      marginPct: 18          # PERCENT of withdrawable (0,100]; per-name = marginPct × sizingWeight; runtime sizes the $
+      maxLeverage: 5         # strict clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 4
+      rankPoolSize: 12       # small power complex — score all of it each tick
+      rsThresholdPct: 3.0
+      rsiOverbought: 82      # blow-off guard — don't chase an overbought leader
+      volFloorPctOfMedian: 0.2
+      minUniverseForMedianGate: 5   # small-list bypass (Mongoose-short fix) — don't median-gate a tiny curated list
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      weight: { type: number, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: eel_long_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # the scan already applied the power universe + 4h/1h absolute-trend gate + RS tiebreaker + conviction size + venue clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [eel_long_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: eel_long_signals
+
+# ── EXIT (DSL — moderate; let energy winners run, cut reversers; ported verbatim from v2) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10080          # 7d — energy/power trends persist; let winners run
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h — cut a name that peaked then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 960            # 16h — recycle a position going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 20,  lock_hw_pct: 40 }   # first LOCK — reachable
+        - { trigger_pct: 35,  lock_hw_pct: 60 }
+        - { trigger_pct: 60,  lock_hw_pct: 78 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6                # basket rotation as power-complex leadership shifts
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600                # v2 cooldown_minutes 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 14400     # v2 per_asset_cooldown_minutes 240

--- a/strategies/eel/long/scanners/scan.py
+++ b/strategies/eel/long/scanners/scan.py
@@ -1,0 +1,349 @@
+"""EEL — supervised scanner (shared verbatim by both books).
+
+Direction-parametrized: the `long` instance passes leg=LONG (long the AI-power complex —
+uranium / gas-fired power / grid copper / fuel cells / rare-earth); the `short` instance
+passes leg=SHORT (short crude oil — Brent + WTI). A faithful Runtime 3.0 port of the v2
+eel-producer.py — the curated thematic universe build, the ABSOLUTE-trend gate (RS as a
+tiebreaker), and the per-group conviction sizing are preserved exactly. Read-only,
+single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin; dual-DEX
+     equity via max(), never sum())
+  2. build the live universe: the curated thematic whitelist (config.universe — haves for
+     the long leg, have-nots for the short leg) intersected with the live instrument board +
+     a relative-to-market liquidity floor (NO hardcoded $; small-list median-gate BYPASS so
+     a tiny curated list never collapses to 1 — the Mongoose-short fix)
+  3. cross-sectional relative-strength rank over the thematic universe (own 24h - universe
+     mean), take the top (long) / bottom (short) rankPoolSize
+  4. score each pooled name with the v2 ABSOLUTE-trend gate (RS tiebreaker), dedup held +
+     recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT, runtime sizes) = base marginPct ×
+     per-group conviction weight, + a per-name venue-clamped leverage; the runtime owns
+     slots, dedup, execution, DSL.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (asia-ai NASDAQ-bug class). The universe was
+validated against the live HL xyz board at authoring time (all 7 names present, none
+delisted); the per-asset guard is the runtime backstop for a name that delists or goes thin
+between authoring and a live tick.
+
+FIDELITY NOTES vs eel-producer.py v1.0.0:
+  - v2 was a long-lived producer_daemon driven by EEL_LEG env into one of two books; this
+    port is two supervised scan() instances (long/, short/) selected by inputs.leg. The
+    per-tick decision logic (universe → RS rank → score_thematic gate → conviction sizing →
+    fund-cap) is identical.
+  - v2 marginPct was a FRACTION (long 0.18, short 0.15) used as account_value*marginPct.
+    This port takes marginPct as a PERCENT (18 / 15) and emits a top-level marginPct =
+    base_pct × sizing_weight; the runtime sizes (marginPct/100)*withdrawable. A defensive
+    <=1.0 -> ×100 guard catches a pasted v2 fraction. The per-group sizing WEIGHTS and the
+    [0.1,3.0] clamp are verbatim.
+  - v2 push_signal() emitted score min(score/9.0, 1.0) on the wire; the 3.0 scaffold owns the
+    wire envelope, so the raw integer score rides on data{} (NORM_DIV kept in scoring for
+    reference only).
+  - DROPPED: nothing order-lifecycle — v2 Eel had no cancel_order / resting-order purge; the
+    only mutation path was push_signal (now the scaffold's job). v2 record_signal() /
+    was_recently_signaled() JSON cache -> ctx.state dedup map (same TTL semantics).
+  - v2 recent-signal TTL was 180s; preserved via recentSignalTtlSeconds.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[eel.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts and
+    makes every size 2x). Free margin = equity - committed margin. Includes the v2 read-
+    sanity guard (margin in use but empty positions -> corrupt read, skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an
+    # EMPTY positions list is a corrupt read — sizing or held-dedup off that re-enters held
+    # names (pyramiding). Skip the tick.
+    if used > 1.0 and not positions:
+        print("[eel.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return ─────────────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, vol (dayNtlVlm), ret24h}. Skips delisted. Verbatim v2
+    get_universe_meta() + ret_24h() + day_vol() folded together."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns
+    ([], []) and the universe loop skips it (asia-ai per-asset read-guard)."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    if isinstance(resp, dict) and resp.get("success") is False:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map, vol_floor_pct, min_universe_for_gate):
+    """The curated thematic whitelist intersected with the live board + a relative liquidity
+    floor (>= vol_floor_pct of the whitelist's median 24h vol; NO hardcoded $). Verbatim v2
+    build_universe() — INCLUDING the small-list BYPASS: below min_universe_for_gate live
+    names, skip the median gate entirely (on a tiny curated list it drops an intentionally-
+    thinner name and can collapse the universe to 1, bricking the book — the Mongoose-short
+    fix, 2026-06-22). The curation IS the liquidity decision below the threshold."""
+    cand = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue                                        # not on the live board — drop
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        cand.append((name, vol))
+    if not cand:
+        return []
+    if len(cand) < int(min_universe_for_gate):              # v2-quirk: small-list bypass
+        return [n for n, _ in cand]
+    vols = sorted(v for _, v in cand)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in cand if v >= floor]
+
+
+def _norm_pct(p):
+    """Defensive marginPct guard (dire/koala): a value <=1.0 is a pasted v2 FRACTION
+    (0.18) — multiply by 100 to recover the PERCENT (18). A value already in (1,100] is
+    treated as a percent as-is."""
+    p = float(p)
+    return p * 100.0 if 0 < p <= 1.0 else p
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    whitelist = inputs.get("universe", [])
+    sizing_weights = inputs.get("sizingWeights", {"_default": 1.0})
+    min_score = float(inputs.get("minScore", 5))
+    base_margin_pct = _norm_pct(inputs.get("marginPct", 18))   # PERCENT of withdrawable (0,100]
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 4))
+    rank_pool = int(inputs.get("rankPoolSize", 12))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    min_universe_for_gate = int(inputs.get("minUniverseForMedianGate", 5))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if (ctx.state is not None and len(ctx.state) > 0) else {}
+    signaled = {k: v for k, v in (last.get("signaled") or {}).items()
+                if isinstance(v, (int, float)) and (now - v) < (ttl * 4)}  # prune at 4x TTL (v2)
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[eel.scan] WARNING: state append failed; next tick may re-emit a "
+                  f"suppressed signal: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist({"ts": now, "leg": leg, "emitted": False, "note": "no account value / corrupt read"})
+        return []                                            # no value / corrupt read — skip tick
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist({"ts": now, "leg": leg, "emitted": False, "held": held, "note": "slots full"})
+        return []                                            # book full — runtime also caps via slots
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map, vol_floor_pct, min_universe_for_gate)
+
+    # ── Cross-sectional relative-strength rank over the thematic universe (v2-quirk: used as
+    #    a score tiebreaker; absolute trend is the gate inside score_thematic) ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = meta.get("ret24h") if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 1:                                          # v2-quirk: thematic universe too thin
+        _persist({"ts": now, "leg": leg, "scanned": len(universe), "emitted": False,
+                  "note": "WAITING — thematic universe too thin to evaluate"})
+        print(f"[eel.scan] leg={leg} WAITING — thematic universe too thin "
+              f"(scanned={len(universe)})", file=sys.stderr)
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=(leg == "long"))     # haves-up first (long) / have-nots-down first (short)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        last_sig = signaled.get(name.upper())
+        if last_sig is not None and (now - last_sig) < ttl:  # signal-dedup
+            continue
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_thematic(name, c1, c4, excess, own, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist({"ts": now, "leg": leg, "scanned": len(universe), "ranked_pool": len(pool),
+                  "candidates": 0, "emitted": False, "mean_rs_24h": round(mean_rs, 2),
+                  "held": held, "note": f"WAITING — no name cleared min score {min_score:.0f}"})
+        print(f"[eel.scan] leg={leg} WAITING — no name cleared min score {min_score:.0f}; "
+              f"scanned={len(universe)} pool={len(pool)} held={held}", file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: never emit more than the wallet can actually FUND. An open slot with no free
+    # margin re-emits an un-fillable order every tick (insufficient-funds spam). free margin
+    # is decremented per emit as (marginPct/100)*accountValue × weight × 1.1 fee headroom —
+    # a mixed-size basket (URNM big, BE small) never emits an un-fundable order.
+    out = []
+    emitted = []
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], sizing_weights)
+        margin_pct = base_margin_pct * weight                # PERCENT × conviction weight
+        margin_usd = (margin_pct / 100.0) * account_value    # for the fund-cap check only
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # v2-quirk: per-name venue clamp
+        if margin_pct <= 0 or leverage <= 0:
+            continue
+        if margin_usd * 1.1 > free_margin:                   # 1.1 = fee/slippage headroom
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": round(margin_pct, 4),               # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                            # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "weight": round(weight, 3),
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+            },
+        })
+        emitted.append({"coin": th["coin"], "score": th["score"], "leverage": leverage,
+                        "marginPct": round(margin_pct, 2), "weight": round(weight, 2)})
+        open_slots -= 1
+        free_margin -= margin_usd * 1.1
+        signaled[th["coin"].upper()] = now
+
+    _persist({"ts": now, "leg": leg, "scanned": len(universe), "ranked_pool": len(pool),
+              "candidates": len(candidates), "emitted": bool(out), "signals": emitted,
+              "mean_rs_24h": round(mean_rs, 2), "held": held})
+    print(f"[eel.scan] leg={leg} {'EMIT' if out else 'WAITING'} scanned={len(universe)} "
+          f"pool={len(pool)} candidates={len(candidates)} emitted={len(out)} "
+          f"mean_rs={mean_rs:.2f} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/eel/long/scanners/scoring.py
+++ b/strategies/eel/long/scanners/scoring.py
@@ -1,0 +1,213 @@
+"""EEL — pure thematic-trend thesis math (no I/O, no MCP, no clock). Shared verbatim by
+both books; direction is passed in (`leg` = "long" for the AI-power complex, "short" for
+crude oil). A faithful port of the v2 eel-producer.py score_thematic() — the gates + the
+point weights + the per-group sizing-weight resolution are copied EXACTLY (marked
+`# v2-quirk` where the v2 behaviour is load-bearing and must not be redesigned).
+
+UNLIKE a pure cross-sectional book (cougar): Eel's universe is THEMATIC — every name is
+already a thesis pick (a "have" / "have-not"). So the HARD GATE is ABSOLUTE trend (long a
+have only while it is actually trending up; short a have-not only while it is rolling over),
+and cross-sectional excess vs the leg-universe mean is a SCORE MODIFIER / tiebreaker that
+tilts size + ranking but NEVER benches a genuinely-trending name. Unit-testable on plain
+candle lists."""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score.
+# The 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and
+# only expose NORM_DIV for callers wanting the v2-equivalent normalised score.
+NORM_DIV = 9.0
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_thematic(asset, candles_1h, candles_4h, excess, own24h, leg, inputs):
+    """Thematic-trend score for one name, given its excess return vs the leg-universe mean
+    (`excess`) and its own 24h return (`own24h`). Returns a thesis dict or None. The point
+    weights + skip gates are copied VERBATIM from the v2 eel-producer score_thematic() — do
+    NOT redesign.
+
+    leg == "long":  long an AI-power "have"  — gate: never long a confirmed 4h downtrend
+    leg == "short": short a crude "have-not" — gate: never short a confirmed 4h uptrend,
+                    capitulation guard (never short an exhausted bottom).
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if leg == "long":
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":                             # v2-quirk
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)  # v2-quirk
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")        # noted, NOT penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 82))
+        if rsi > rsi_ob:                                     # v2-quirk: blow-off guard
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":                             # v2-quirk
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")        # noted, NOT penalized
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:                                     # v2-quirk: capitulation guard
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+def _bare(asset):
+    """Bare ticker for sizing-weight lookups: 'xyz:URNM' -> 'URNM'. Verbatim v2 _bare()."""
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+def sizing_weight(asset, sizing_weights):
+    """Per-group conviction multiplier (URNM 1.2x, COPPER 1.1x, BE 0.6x, …). Keyed by bare
+    ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim v2 sizing_weight()."""
+    if not isinstance(sizing_weights, dict):
+        sizing_weights = {"_default": 1.0}
+    try:
+        w = float(sizing_weights.get(_bare(asset), sizing_weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: XYZ commodities cap
+    at the venue (COPPER 20x, URNM/NATGAS/BE/USAR 10x, BRENTOIL/CL 20x) — over-leveraging a
+    name is a venue reject, so this clamp is load-bearing. Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/eel/short/runtime.yaml
+++ b/strategies/eel/short/runtime.yaml
@@ -1,0 +1,126 @@
+# ── EEL · SHORT book ("OIL") — short crude oil on Hyperliquid XYZ (the hedge leg) ──
+name: eel-short
+group: eel
+version: 3.0.0
+description: >
+  EEL SHORT (OIL book) — Electrons vs Hydrocarbons energy-pair thesis fund (Runtime 3.0 port
+  of v2 Eel v1.0). The SHORT leg (the hedge) of an energy-sector-neutral pair. This book
+  SHORTS crude oil on Hyperliquid XYZ (Brent + WTI) — the legacy transport fuel losing
+  relative ground to the electrification/AI-power demand the long book rides — but only when
+  ABSOLUTE trend confirms (4h structure not bullish + negative own momentum), with a
+  CAPITULATION guard so it never shorts an exhausted oil bottom. Cross-sectional relative
+  weakness tilts size/ranking but never benches a genuinely-rolling-over name. Pairs with the
+  LONG power book (long/runtime.yaml) on a separate wallet; both legs are energy, so an
+  energy-wide move washes out and the P&L is the electrons-vs-hydrocarbons spread.
+  Commodities trade ~24/7.
+
+strategy:
+  wallet: "${EEL_SHORT_WALLET}"
+  # ── FUNDING DEFAULT: slight long-power tilt (~55/45 long:short) ── this oil book defaults
+  # smaller (slots 2, margin_pct 15, 4x cap) than the power book since the thesis is
+  # directionally pro-power and an oil supply-shock spike is violent.
+  slots: 2
+  default_leverage: 4
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: eel_short_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — energy-trend cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map + per-tick result
+    inputs:
+      leg: "short"
+      # ── VALIDATED crude-oil universe (live HL xyz board, authoring time) ──
+      # Both crude benchmarks present on the live HL xyz board, none delisted (validated 2026-06-29).
+      universe: ["xyz:BRENTOIL", "xyz:CL"]
+      sizingWeights:
+        _default: 1.0        # both crude benchmarks equal-weight
+      minScore: 5
+      marginPct: 15          # PERCENT of withdrawable (0,100]; per-name = marginPct × sizingWeight; runtime sizes the $
+      maxLeverage: 4         # strict clamp (an oil supply-shock spike is violent), then each name's HL venue max
+      maxSlots: 2
+      rankPoolSize: 8
+      rsThresholdPct: 3.0
+      rsiOversold: 18        # capitulation guard — never short an exhausted oil bottom
+      volFloorPctOfMedian: 0.2
+      minUniverseForMedianGate: 5   # small-list bypass (Mongoose-short fix) — don't median-gate a tiny curated list
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      weight: { type: number, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: eel_short_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # the scan already applied the crude universe + 4h/1h absolute-downtrend gate + capitulation guard + RS tiebreaker + conviction size + venue clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [eel_short_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: eel_short_signals
+
+# ── EXIT (DSL — tighter than the power book; short theses decay faster, oil spikes are violent; ported verbatim from v2) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 7200           # 5d — shorter than the power book
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h — cut a short that bottomed then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 720            # 12h — recycle a short going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                  # tighter than power book — oil-spike protection
+      retrace_threshold: 7
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 18,  lock_hw_pct: 45 }   # first LOCK — reachable
+        - { trigger_pct: 35,  lock_hw_pct: 65 }
+        - { trigger_pct: 60,  lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 4
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 5400                # v2 cooldown_minutes 90
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 18000     # v2 per_asset_cooldown_minutes 300

--- a/strategies/eel/short/scanners/scan.py
+++ b/strategies/eel/short/scanners/scan.py
@@ -1,0 +1,349 @@
+"""EEL — supervised scanner (shared verbatim by both books).
+
+Direction-parametrized: the `long` instance passes leg=LONG (long the AI-power complex —
+uranium / gas-fired power / grid copper / fuel cells / rare-earth); the `short` instance
+passes leg=SHORT (short crude oil — Brent + WTI). A faithful Runtime 3.0 port of the v2
+eel-producer.py — the curated thematic universe build, the ABSOLUTE-trend gate (RS as a
+tiebreaker), and the per-group conviction sizing are preserved exactly. Read-only,
+single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin; dual-DEX
+     equity via max(), never sum())
+  2. build the live universe: the curated thematic whitelist (config.universe — haves for
+     the long leg, have-nots for the short leg) intersected with the live instrument board +
+     a relative-to-market liquidity floor (NO hardcoded $; small-list median-gate BYPASS so
+     a tiny curated list never collapses to 1 — the Mongoose-short fix)
+  3. cross-sectional relative-strength rank over the thematic universe (own 24h - universe
+     mean), take the top (long) / bottom (short) rankPoolSize
+  4. score each pooled name with the v2 ABSOLUTE-trend gate (RS tiebreaker), dedup held +
+     recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT, runtime sizes) = base marginPct ×
+     per-group conviction weight, + a per-name venue-clamped leverage; the runtime owns
+     slots, dedup, execution, DSL.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (asia-ai NASDAQ-bug class). The universe was
+validated against the live HL xyz board at authoring time (all 7 names present, none
+delisted); the per-asset guard is the runtime backstop for a name that delists or goes thin
+between authoring and a live tick.
+
+FIDELITY NOTES vs eel-producer.py v1.0.0:
+  - v2 was a long-lived producer_daemon driven by EEL_LEG env into one of two books; this
+    port is two supervised scan() instances (long/, short/) selected by inputs.leg. The
+    per-tick decision logic (universe → RS rank → score_thematic gate → conviction sizing →
+    fund-cap) is identical.
+  - v2 marginPct was a FRACTION (long 0.18, short 0.15) used as account_value*marginPct.
+    This port takes marginPct as a PERCENT (18 / 15) and emits a top-level marginPct =
+    base_pct × sizing_weight; the runtime sizes (marginPct/100)*withdrawable. A defensive
+    <=1.0 -> ×100 guard catches a pasted v2 fraction. The per-group sizing WEIGHTS and the
+    [0.1,3.0] clamp are verbatim.
+  - v2 push_signal() emitted score min(score/9.0, 1.0) on the wire; the 3.0 scaffold owns the
+    wire envelope, so the raw integer score rides on data{} (NORM_DIV kept in scoring for
+    reference only).
+  - DROPPED: nothing order-lifecycle — v2 Eel had no cancel_order / resting-order purge; the
+    only mutation path was push_signal (now the scaffold's job). v2 record_signal() /
+    was_recently_signaled() JSON cache -> ctx.state dedup map (same TTL semantics).
+  - v2 recent-signal TTL was 180s; preserved via recentSignalTtlSeconds.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[eel.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts and
+    makes every size 2x). Free margin = equity - committed margin. Includes the v2 read-
+    sanity guard (margin in use but empty positions -> corrupt read, skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return 0.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an
+    # EMPTY positions list is a corrupt read — sizing or held-dedup off that re-enters held
+    # names (pyramiding). Skip the tick.
+    if used > 1.0 and not positions:
+        print("[eel.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return ─────────────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, vol (dayNtlVlm), ret24h}. Skips delisted. Verbatim v2
+    get_universe_meta() + ret_24h() + day_vol() folded together."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns
+    ([], []) and the universe loop skips it (asia-ai per-asset read-guard)."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    if isinstance(resp, dict) and resp.get("success") is False:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map, vol_floor_pct, min_universe_for_gate):
+    """The curated thematic whitelist intersected with the live board + a relative liquidity
+    floor (>= vol_floor_pct of the whitelist's median 24h vol; NO hardcoded $). Verbatim v2
+    build_universe() — INCLUDING the small-list BYPASS: below min_universe_for_gate live
+    names, skip the median gate entirely (on a tiny curated list it drops an intentionally-
+    thinner name and can collapse the universe to 1, bricking the book — the Mongoose-short
+    fix, 2026-06-22). The curation IS the liquidity decision below the threshold."""
+    cand = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue                                        # not on the live board — drop
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        cand.append((name, vol))
+    if not cand:
+        return []
+    if len(cand) < int(min_universe_for_gate):              # v2-quirk: small-list bypass
+        return [n for n, _ in cand]
+    vols = sorted(v for _, v in cand)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in cand if v >= floor]
+
+
+def _norm_pct(p):
+    """Defensive marginPct guard (dire/koala): a value <=1.0 is a pasted v2 FRACTION
+    (0.18) — multiply by 100 to recover the PERCENT (18). A value already in (1,100] is
+    treated as a percent as-is."""
+    p = float(p)
+    return p * 100.0 if 0 < p <= 1.0 else p
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    whitelist = inputs.get("universe", [])
+    sizing_weights = inputs.get("sizingWeights", {"_default": 1.0})
+    min_score = float(inputs.get("minScore", 5))
+    base_margin_pct = _norm_pct(inputs.get("marginPct", 18))   # PERCENT of withdrawable (0,100]
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 4))
+    rank_pool = int(inputs.get("rankPoolSize", 12))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    min_universe_for_gate = int(inputs.get("minUniverseForMedianGate", 5))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if (ctx.state is not None and len(ctx.state) > 0) else {}
+    signaled = {k: v for k, v in (last.get("signaled") or {}).items()
+                if isinstance(v, (int, float)) and (now - v) < (ttl * 4)}  # prune at 4x TTL (v2)
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[eel.scan] WARNING: state append failed; next tick may re-emit a "
+                  f"suppressed signal: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist({"ts": now, "leg": leg, "emitted": False, "note": "no account value / corrupt read"})
+        return []                                            # no value / corrupt read — skip tick
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist({"ts": now, "leg": leg, "emitted": False, "held": held, "note": "slots full"})
+        return []                                            # book full — runtime also caps via slots
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map, vol_floor_pct, min_universe_for_gate)
+
+    # ── Cross-sectional relative-strength rank over the thematic universe (v2-quirk: used as
+    #    a score tiebreaker; absolute trend is the gate inside score_thematic) ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = meta.get("ret24h") if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 1:                                          # v2-quirk: thematic universe too thin
+        _persist({"ts": now, "leg": leg, "scanned": len(universe), "emitted": False,
+                  "note": "WAITING — thematic universe too thin to evaluate"})
+        print(f"[eel.scan] leg={leg} WAITING — thematic universe too thin "
+              f"(scanned={len(universe)})", file=sys.stderr)
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=(leg == "long"))     # haves-up first (long) / have-nots-down first (short)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        last_sig = signaled.get(name.upper())
+        if last_sig is not None and (now - last_sig) < ttl:  # signal-dedup
+            continue
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_thematic(name, c1, c4, excess, own, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist({"ts": now, "leg": leg, "scanned": len(universe), "ranked_pool": len(pool),
+                  "candidates": 0, "emitted": False, "mean_rs_24h": round(mean_rs, 2),
+                  "held": held, "note": f"WAITING — no name cleared min score {min_score:.0f}"})
+        print(f"[eel.scan] leg={leg} WAITING — no name cleared min score {min_score:.0f}; "
+              f"scanned={len(universe)} pool={len(pool)} held={held}", file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: never emit more than the wallet can actually FUND. An open slot with no free
+    # margin re-emits an un-fillable order every tick (insufficient-funds spam). free margin
+    # is decremented per emit as (marginPct/100)*accountValue × weight × 1.1 fee headroom —
+    # a mixed-size basket (URNM big, BE small) never emits an un-fundable order.
+    out = []
+    emitted = []
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], sizing_weights)
+        margin_pct = base_margin_pct * weight                # PERCENT × conviction weight
+        margin_usd = (margin_pct / 100.0) * account_value    # for the fund-cap check only
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # v2-quirk: per-name venue clamp
+        if margin_pct <= 0 or leverage <= 0:
+            continue
+        if margin_usd * 1.1 > free_margin:                   # 1.1 = fee/slippage headroom
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": round(margin_pct, 4),               # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                            # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "weight": round(weight, 3),
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+            },
+        })
+        emitted.append({"coin": th["coin"], "score": th["score"], "leverage": leverage,
+                        "marginPct": round(margin_pct, 2), "weight": round(weight, 2)})
+        open_slots -= 1
+        free_margin -= margin_usd * 1.1
+        signaled[th["coin"].upper()] = now
+
+    _persist({"ts": now, "leg": leg, "scanned": len(universe), "ranked_pool": len(pool),
+              "candidates": len(candidates), "emitted": bool(out), "signals": emitted,
+              "mean_rs_24h": round(mean_rs, 2), "held": held})
+    print(f"[eel.scan] leg={leg} {'EMIT' if out else 'WAITING'} scanned={len(universe)} "
+          f"pool={len(pool)} candidates={len(candidates)} emitted={len(out)} "
+          f"mean_rs={mean_rs:.2f} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/eel/short/scanners/scoring.py
+++ b/strategies/eel/short/scanners/scoring.py
@@ -1,0 +1,213 @@
+"""EEL — pure thematic-trend thesis math (no I/O, no MCP, no clock). Shared verbatim by
+both books; direction is passed in (`leg` = "long" for the AI-power complex, "short" for
+crude oil). A faithful port of the v2 eel-producer.py score_thematic() — the gates + the
+point weights + the per-group sizing-weight resolution are copied EXACTLY (marked
+`# v2-quirk` where the v2 behaviour is load-bearing and must not be redesigned).
+
+UNLIKE a pure cross-sectional book (cougar): Eel's universe is THEMATIC — every name is
+already a thesis pick (a "have" / "have-not"). So the HARD GATE is ABSOLUTE trend (long a
+have only while it is actually trending up; short a have-not only while it is rolling over),
+and cross-sectional excess vs the leg-universe mean is a SCORE MODIFIER / tiebreaker that
+tilts size + ranking but NEVER benches a genuinely-trending name. Unit-testable on plain
+candle lists."""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score.
+# The 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and
+# only expose NORM_DIV for callers wanting the v2-equivalent normalised score.
+NORM_DIV = 9.0
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_thematic(asset, candles_1h, candles_4h, excess, own24h, leg, inputs):
+    """Thematic-trend score for one name, given its excess return vs the leg-universe mean
+    (`excess`) and its own 24h return (`own24h`). Returns a thesis dict or None. The point
+    weights + skip gates are copied VERBATIM from the v2 eel-producer score_thematic() — do
+    NOT redesign.
+
+    leg == "long":  long an AI-power "have"  — gate: never long a confirmed 4h downtrend
+    leg == "short": short a crude "have-not" — gate: never short a confirmed 4h uptrend,
+                    capitulation guard (never short an exhausted bottom).
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if leg == "long":
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":                             # v2-quirk
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)  # v2-quirk
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")        # noted, NOT penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 82))
+        if rsi > rsi_ob:                                     # v2-quirk: blow-off guard
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":                             # v2-quirk
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")        # noted, NOT penalized
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:                                     # v2-quirk: capitulation guard
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+def _bare(asset):
+    """Bare ticker for sizing-weight lookups: 'xyz:URNM' -> 'URNM'. Verbatim v2 _bare()."""
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+def sizing_weight(asset, sizing_weights):
+    """Per-group conviction multiplier (URNM 1.2x, COPPER 1.1x, BE 0.6x, …). Keyed by bare
+    ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim v2 sizing_weight()."""
+    if not isinstance(sizing_weights, dict):
+        sizing_weights = {"_default": 1.0}
+    try:
+        w = float(sizing_weights.get(_bare(asset), sizing_weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: XYZ commodities cap
+    at the venue (COPPER 20x, URNM/NATGAS/BE/USAR 10x, BRENTOIL/CL 20x) — over-leveraging a
+    name is a venue reject, so this clamp is load-bearing. Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/eel/strategy.yaml
+++ b/strategies/eel/strategy.yaml
@@ -1,0 +1,47 @@
+# Eel — Electrons vs Hydrocarbons energy-pair thesis fund. A two-instance PACKAGE: this
+# manifest + two self-contained runtime.yaml books (long "power" / short "oil" on SEPARATE
+# wallets, so the long power complex and the short crude book coexist) + per-instance
+# scanners/. A faithful Runtime 3.0 port of the v2 Eel v1.0 producer — the curated thematic
+# universe + ABSOLUTE-trend gate (RS tiebreaker) + per-group conviction sizing is preserved
+# exactly. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: eel
+version: "1.0.0"
+
+catalog:
+  name: "Eel — Electrons vs Hydrocarbons"
+  emoji: "⚡"
+  tagline: "Bets AI datacenters are a structural new source of electricity demand: LONGS the AI-power complex on Hyperliquid XYZ (uranium, gas-fired power, grid copper, fuel cells, rare-earth) and SHORTS crude oil — both trend-confirmed, on two separate wallets — so the pair is energy-sector-neutral and harvests the electrons-vs-barrels spread."
+  belief_plain: "Buys the things that make electricity for AI datacenters (uranium, natural gas, copper, fuel cells, rare-earth) and shorts crude oil at the same time, on two separate wallets, so it makes money on power BEATING oil rather than on energy going up or down."
+  thesis: "AI datacenter electricity demand is a structural new bid for the power complex, while crude oil is the legacy transport fuel barely levered to AI. Both legs are energy, so a broad energy move washes out and the P&L is the dispersion — power outperforming oil. Each book only acts when ABSOLUTE trend confirms (long power on a non-bearish 4h; short oil on a non-bullish 4h, with a capitulation guard), with cross-sectional relative strength as a size/rank tiebreaker. Commodities trade ~24/7 on Hyperliquid, so the book never waits for a market open."
+  group: multi-asset-whitelist
+  archetype: structural_neutral   # energy-sector-neutral L/S pair — paid on dispersion, not direction
+  sub_style: pairs_rv             # relative-value pair (power complex vs crude oil)
+  asset_classes: [commodities]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 6
+  min_budget: 400
+  assets: ["xyz:URNM", "xyz:NATGAS", "xyz:COPPER", "xyz:BE", "xyz:USAR", "xyz:BRENTOIL", "xyz:CL"]
+  tags: [energy, power, uranium, natgas, copper, crude-oil, ai-datacenter, long-short, market-neutral, dispersion, xyz, commodities]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: long
+    runtime: long/runtime.yaml
+    wallet_env: EEL_LONG_WALLET
+    funding_share: 0.55
+  - name: short
+    runtime: short/runtime.yaml
+    wallet_env: EEL_SHORT_WALLET
+    funding_share: 0.45

--- a/strategies/elephant/fade/runtime.yaml
+++ b/strategies/elephant/fade/runtime.yaml
@@ -1,0 +1,120 @@
+# ── ELEPHANT · FADE book — global-macro mean-reversion (Runtime 3.0 port of v2 Elephant v1.0, ELEPHANT_LEG=fade) ──
+name: elephant-fade
+group: elephant
+version: 3.0.0
+description: >
+  ELEPHANT FADE — global-macro mean-reversion book (Runtime 3.0 port of v2 Elephant v1.0).
+  One of two macro books. Fades short-TF over-extensions on the cross-asset macro complex
+  (XYZ equity indices / metals / energy / FX + BTC) back toward the mean: it picks the
+  more-extreme side (oversold->LONG, overbought->SHORT) from 1h RSI extreme + stretch from
+  the 20-bar 1h MA, with a 4h regime filter (knife guard: +1 fading WITH the higher-TF bias,
+  -2 against a strong macro trend) so it never fades a strong macro trend. BOTH directions.
+  Pairs with the TREND book (trend/runtime.yaml) on a separate, larger-funded wallet — a
+  name in a macro uptrend can still print a short-term overbought fade. The edge is GLOBAL
+  MACRO over-extension reverting to regime. Macro whitelist intersected with the live board
+  each tick; per-name venue leverage clamp; strict 5x. XYZ trades 24/7 — no market-hours gating.
+
+strategy:
+  wallet: "${ELEPHANT_FADE_WALLET}"
+  slots: 3
+  default_leverage: 5                       # fallback; scan emits per-name venue-clamped 5x
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: elephant_fade_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                    # v2 tickSeconds
+    timeout_seconds: 180                     # v2 tick_timeout; universe-level per-asset reads
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 100             # recent-signals dedup map + per-tick result history
+    inputs:
+      # ── Macro whitelist (config.allowedAssets). XYZ indices / metals / energy / FX + BTC.
+      #    Validated against the live HL meta at authoring time (2026-06-29): all 18 names live. ──
+      allowedAssets: ["BTC", "xyz:SP500", "xyz:XYZ100", "xyz:JP225", "xyz:KR200", "xyz:NIFTY", "xyz:IBOV", "xyz:GOLD", "xyz:SILVER", "xyz:PLATINUM", "xyz:COPPER", "xyz:BRENTOIL", "xyz:CL", "xyz:NATGAS", "xyz:EUR", "xyz:JPY", "xyz:GBP", "xyz:DXY"]
+      minScore: 4                            # v2 fade minScore
+      marginPct: 15                          # PERCENT of withdrawable (0,100); v2 0.15 fraction x100
+      maxLeverage: 5                         # strict clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 3
+      rsiOversold: 30
+      rsiOverbought: 70
+      stretchThresholdPct: 1.0               # macro stretch from the 20-bar 1h MA
+      recentSignalTtlSeconds: 180            # v2 RECENT_SIGNAL_TTL_SEC race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      stretchPct: { type: number, required: false }
+      rsi: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: elephant_fade_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                      # the scan already applied RSI/stretch scoring + knife guard + clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [elephant_fade_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: elephant_fade_signals
+
+# ── EXIT (DSL — tight fast-capture mean-reversion; ported VERBATIM from v2 runtime-fade.yaml) ──
+# A reversion resolves fast or the thesis failed: tight phase1, lock the snapback quickly,
+# stall-cuts ON, 2d hard_timeout. First phase2 LOCK is at 4% -> 35% (reachable on a snapback).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 2880             # 2d
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 240              # 4h
+      min_value: 1.5
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 480              # 8h
+    phase1:
+      enabled: true
+      max_loss_pct: 8.0
+      retrace_threshold: 5
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 4, lock_hw_pct: 35 }
+        - { trigger_pct: 8, lock_hw_pct: 55 }
+        - { trigger_pct: 15, lock_hw_pct: 70 }
+        - { trigger_pct: 28, lock_hw_pct: 85 }
+
+risk:
+  data_retention_seconds: 345600            # v2 data_retention_hours 96 -> 96*3600 = 345600
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 12                  # mean-reversion turns over faster
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 5
+    cooldown_seconds: 2700                   # v2 cooldown_minutes 45
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 7200         # v2 per_asset_cooldown_minutes 120

--- a/strategies/elephant/fade/scanners/scan.py
+++ b/strategies/elephant/fade/scanners/scan.py
@@ -1,0 +1,278 @@
+"""ELEPHANT FADE book — supervised scanner (Runtime 3.0 port of the v2 elephant-producer.py
+FADE leg, ELEPHANT_LEG=fade).
+
+Global-macro mean-reversion book over the cross-asset macro complex (XYZ equity indices /
+metals / energy / FX + BTC). Per tick it:
+  1. reads the wallet clearinghouse (account value + held names + free margin),
+  2. builds the live universe: the curated macro whitelist intersected with the live
+     instrument board (names not live are skipped — v2 build_universe),
+  3. scores every non-held, non-recently-signaled name with the pure scoring.score_fade
+     (picks the more-extreme side: oversold->LONG / overbought->SHORT from 1h RSI extreme +
+     stretch from the 20-bar 1h MA, with a 4h regime knife guard so it never fades a strong
+     macro trend),
+  4. emits the top candidates up to open slots AND what free margin can FUND, as a top-level
+     marginPct INTENT (PERCENT) + a per-name venue-clamped leverage.
+
+Read-only + single-pass. No daemon, no push_signal, no create_position, no order-lifecycle
+mutation — the runtime sizes the dollars, owns slots/cooldowns/risk gates, and trails the DSL.
+
+FIDELITY NOTES vs elephant-producer.py v1.0.0 (ELEPHANT_LEG=fade):
+  - SET of scored assets, scoring weights/gates, the more-extreme-side selection, the RSI/
+    stretch tiers, the 4h knife guard (+1 with-bias / -2 against a strong trend), minScore (4),
+    marginPct (0.15 fraction -> 15 PERCENT), maxLeverage (5), maxSlots (3), venue leverage
+    clamp, and the 180s recent-signals race-dedup TTL are all preserved EXACTLY.
+  - v2 marginPct was a FRACTION (0.15) used as account_value * marginPct -> marginUsd. This
+    port emits `marginPct` PERCENT (15) at the top level; the runtime sizes
+    (marginPct/100)*withdrawable. The defensive "<=1.0 means a pasted fraction, x100" guard
+    is applied in scan().
+  - The fade scoring needs NO 24h momentum (unlike the trend book) — it uses only 1h/4h
+    candles. market_list_instruments is still read for the per-name venue leverage clamp +
+    the universe intersection (same as v2 get_universe_meta). FLAGGED: this means a fade tick
+    still does one instrument-board read even though ret24h is unused — matches v2, which
+    always read get_universe_meta() regardless of leg.
+  - DROPPED v2 order-lifecycle / mutation behaviour: the v2 producer called push_signal()
+    (a POST) + a JSON recent-signals cache; scan() is read-only and returns plain dicts. The
+    recent-signals cache moves to ctx.state (same TTL/prune semantics). The free-margin
+    affordability cap is preserved (pure arithmetic over a read, not a mutation). Nothing
+    else mutated in v2 (no cancel_order / resting-order purge), so nothing else was dropped.
+  - v2 emitted up to min(open_slots, affordable) candidates; preserved.
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 _MACRO_WHITELIST (config.allowedAssets overrides). Validated against the live HL meta at
+# authoring time (2026-06-29): every name present on the main (BTC) / xyz boards.
+_MACRO_WHITELIST_DEFAULT = [
+    "BTC",
+    "xyz:SP500", "xyz:XYZ100", "xyz:JP225", "xyz:KR200", "xyz:NIFTY", "xyz:IBOV",
+    "xyz:GOLD", "xyz:SILVER", "xyz:PLATINUM", "xyz:COPPER",
+    "xyz:BRENTOIL", "xyz:CL", "xyz:NATGAS",
+    "xyz:EUR", "xyz:JPY", "xyz:GBP", "xyz:DXY",
+]
+_DEFAULT_TTL = 180   # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup (3x ALO open fill window)
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick (the contract rolls any uncaught exception back to []). Returns None
+    on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[elephant.fade.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk). Free margin = equity -
+    committed margin. Ported verbatim from v2 cfg.get_positions, including the read-sanity
+    guard (margin in use + empty positions -> corrupt read -> skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an
+    # EMPTY positions list is a corrupt read — sizing or held-dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        print("[elephant.fade.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage}. Skips delisted. Verbatim v2 get_universe_meta() — the fade
+    book uses this only for the per-name venue leverage clamp + the universe intersection
+    (ret24h is unused by the fade thesis)."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        entry = {"max_leverage": inst.get("max_leverage", inst.get("maxLeverage"))}
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns
+    ([], []) and the universe loop skips it. Verbatim v2 fetch_candles intervals."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    if isinstance(resp, dict) and resp.get("success") is False:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map):
+    """Macro whitelist intersected with the live instrument board so dead/unavailable names
+    are skipped. Verbatim v2 build_universe()."""
+    out = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        if meta_map.get(name) or meta_map.get(name.upper()):
+            out.append(name)
+    return out
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    whitelist = inputs.get("allowedAssets", _MACRO_WHITELIST_DEFAULT)
+    min_score = int(inputs.get("minScore", 4))
+    margin_pct = float(inputs.get("marginPct", 15))          # PERCENT of withdrawable (0,100]
+    # defensive: a stale config may carry the v2 FRACTION (0.15). <=1.0 means a pasted
+    # fraction -> x100. (dire/koala guard.)
+    if 0 < margin_pct <= 1.0:
+        margin_pct *= 100.0
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 3))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[elephant.fade.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist()
+        return []                                            # no value / corrupt read — skip tick
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist()
+        print(f"[elephant.fade.scan] WAITING — slots full held={held}", file=sys.stderr)
+        return []                                            # book full — runtime also caps via slots
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map)
+
+    candidates = []
+    scanned = 0
+    for name in universe:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup (race-window)
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue
+        scanned += 1
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 22 or len(c4) < 6:
+            continue
+        thesis = scoring.score_fade(name, c1, c4, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist()
+        print(f"[elephant.fade.scan] WAITING — no macro name cleared min score {min_score}; "
+              f"scanned={scanned} held={held} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: never emit more than the wallet can actually FUND. Per-name margin =
+    # (marginPct/100)*accountValue; 1.1 = fee/slippage headroom.
+    per_name_margin = (margin_pct / 100.0) * account_value
+    affordable = int(free_margin / (per_name_margin * 1.1)) if per_name_margin > 0 else 0
+    to_emit = candidates[:max(0, min(open_slots, affordable))]
+
+    out = []
+    for th in to_emit:
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # v2-quirk: per-name venue clamp
+        if leverage <= 0:
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": th["direction"],
+            "marginPct": margin_pct,                           # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                              # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": th["direction"],
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "stretchPct": round(th.get("stretchPct", 0), 3),
+                "rsi": round(th.get("rsi", 0), 1),
+                "heldAssets": held,
+            },
+        })
+        recent[th["coin"].upper()] = now
+
+    _persist()
+    if out:
+        top = out[0]
+        print(f"[elephant.fade.scan] EMIT {len(out)} (top {top['asset']} {top['direction']} "
+              f"{top['leverage']}x marginPct={margin_pct:.1f}%) scanned={scanned} "
+              f"candidates={len(candidates)} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    else:
+        print(f"[elephant.fade.scan] WAITING — candidates={len(candidates)} but none fundable/clamped; "
+              f"free_margin={free_margin:.2f} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/elephant/fade/scanners/scoring.py
+++ b/strategies/elephant/fade/scanners/scoring.py
@@ -1,0 +1,184 @@
+"""ELEPHANT FADE book — pure macro mean-reversion thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 elephant-producer.py score_fade() — the RSI-extreme +
+stretch-from-MA over-extension scoring, the 4h regime knife guard, the point weights, and
+the skip gates are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing
+and must not be redesigned). Unit-testable on plain candle lists. The runtime owns
+sizing/execution/DSL; this only scores.
+
+The FADE book fades short-TF over-extensions on the cross-asset macro complex (XYZ equity
+indices / metals / energy / FX + BTC) back toward the mean. It picks the MORE-extreme side
+(oversold -> LONG, overbought -> SHORT) from 1h RSI extreme + stretch from the 20-bar 1h MA,
+with a 4h regime filter (knife guard) so it never fades a strong macro trend. BOTH directions.
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score
+# (NORM_DIV = 9.0, max raw ~7 for fade). The 3.0 scaffold owns the wire envelope, so we keep
+# the raw integer score on data{} and only expose NORM_DIV for parity.
+NORM_DIV = 9.0
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2.
+    Used by the fade book ONLY as the 4h regime knife guard (never fade a strong trend)."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def simple_ma(closes, period):
+    """Simple moving average over the last `period` closes (or all, if fewer). Verbatim v2."""
+    if not closes:
+        return 0
+    window = closes[-period:] if len(closes) >= period else closes
+    return sum(window) / len(window)
+
+
+def score_fade(asset, candles_1h, candles_4h, inputs):
+    """Macro mean-reversion (fade) score for one asset. Returns a thesis dict or None.
+    The point weights, the more-extreme-side selection, and the 4h knife guard are copied
+    VERBATIM from the v2 elephant-producer.py score_fade() — do NOT redesign.
+
+    Picks the more-extreme side: oversold -> LONG, overbought -> SHORT, from 1h RSI extreme
+    + stretch from the 20-bar 1h MA. 4h regime: +1 fading WITH the higher-TF bias, -2 against
+    a strong macro trend (knife guard).
+    """
+    if len(candles_1h) < 22 or len(candles_4h) < 6:         # v2-quirk: 20-bar MA + 4h regime warmup
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    ma = simple_ma(closes1, 20)
+    stretch = ((price - ma) / ma * 100) if ma > 0 else 0
+    rsi = calc_rsi(closes1)
+    trend4, _ = trend_structure(candles_4h)
+    rsi_os = float(inputs.get("rsiOversold", 30))
+    rsi_ob = float(inputs.get("rsiOverbought", 70))
+    st = float(inputs.get("stretchThresholdPct", 1.0))
+
+    # v2-quirk: pick the more-extreme side; magnitudes blend normalised RSI excess + stretch.
+    oversold_mag = max(rsi_os - rsi, 0) / max(rsi_os, 1) + max(-stretch, 0) / st
+    overbought_mag = max(rsi - rsi_ob, 0) / max(100 - rsi_ob, 1) + max(stretch, 0) / st
+    if oversold_mag <= 0 and overbought_mag <= 0:
+        return None
+    direction = "LONG" if oversold_mag >= overbought_mag else "SHORT"
+
+    score = 0
+    reasons = []
+    if direction == "LONG":
+        if rsi <= 20:
+            score += 3
+            reasons.append(f"rsi_{rsi:.0f}_deep_os")
+        elif rsi <= 25:
+            score += 2
+            reasons.append(f"rsi_{rsi:.0f}_os")
+        elif rsi <= rsi_os:
+            score += 1
+            reasons.append(f"rsi_{rsi:.0f}_os")
+        if -stretch >= 2 * st:
+            score += 2
+            reasons.append(f"stretch_{stretch:+.2f}%")
+        elif -stretch >= st:
+            score += 1
+            reasons.append(f"stretch_{stretch:+.2f}%")
+        # v2-quirk: regime knife guard — never fade a strong macro downtrend (knife guard).
+        if trend4 == "BULLISH":
+            score += 1
+            reasons.append("macro_uptrend_dip")
+        elif trend4 == "BEARISH":
+            score -= 2
+            reasons.append("macro_downtrend_knife")
+    else:
+        if rsi >= 80:
+            score += 3
+            reasons.append(f"rsi_{rsi:.0f}_deep_ob")
+        elif rsi >= 75:
+            score += 2
+            reasons.append(f"rsi_{rsi:.0f}_ob")
+        elif rsi >= rsi_ob:
+            score += 1
+            reasons.append(f"rsi_{rsi:.0f}_ob")
+        if stretch >= 2 * st:
+            score += 2
+            reasons.append(f"stretch_{stretch:+.2f}%")
+        elif stretch >= st:
+            score += 1
+            reasons.append(f"stretch_{stretch:+.2f}%")
+        if trend4 == "BEARISH":
+            score += 1
+            reasons.append("macro_downtrend_rip")
+        elif trend4 == "BULLISH":
+            score -= 2
+            reasons.append("macro_uptrend_knife")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "stretchPct": stretch,
+    }
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: indices / metals /
+    FX cap LOW at the venue, so over-leveraging a name is a venue reject — this clamp is
+    load-bearing, not cosmetic. Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/elephant/strategy.yaml
+++ b/strategies/elephant/strategy.yaml
@@ -1,0 +1,48 @@
+# Elephant — global-macro hedge fund. A two-instance PACKAGE: this manifest + two
+# self-contained runtime.yaml books (trend / fade on SEPARATE wallets, so a name in a
+# macro uptrend can still print a short-term overbought fade) + per-instance scanners/.
+# A faithful Runtime 3.0 port of the v2 Elephant v1.0 cross-asset macro complex —
+# equity indices, precious metals, energy, FX (all on XYZ) plus BTC as the macro risk
+# asset. The TREND book rides the medium-term multi-timeframe macro trend (both
+# directions); the FADE book fades short-TF macro over-extensions back to regime (both
+# directions, with a 4h knife guard). Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: elephant
+version: "1.0.0"
+
+catalog:
+  name: "Elephant — Global-Macro Hedge Fund"
+  emoji: "🐘"
+  tagline: "Trades the cross-asset macro complex — equity indices, precious metals, energy, FX (all on XYZ) plus BTC — on two books and two wallets: the TREND book rides the durable multi-timeframe macro trend (both directions); the FADE book fades short-TF over-extensions back to regime (both directions, with a knife guard). The edge is GLOBAL MACRO — the complex moves on regime, not crypto noise."
+  belief_plain: "Trades the big global markets — stock indices, gold/silver/copper, oil and gas, the major currencies, and Bitcoin. One book rides the slow, durable trends (buying things going up, shorting things going down); a second book on a separate wallet bets on stretched moves snapping back. It only fades a snap-back when the bigger trend isn't fighting it."
+  thesis: "Crypto-only funds all crowd the same coins; the cross-asset macro complex (indices / metals / energy / FX) moves on macro regime — oil on geopolitics, indices on the AI-equity bid, metals on risk-off — and is uncorrelated with crypto noise. Running a trend book AND a mean-reversion book on the same macro whitelist, on two wallets, harvests both the durable direction and the over-extensions without the two conflicting. These markets trade 24/7 on Hyperliquid XYZ, so the fund never has to wait for a market open."
+  group: macro
+  archetype: trend_following      # package-level: the dominant (60%-funded) book is the directional macro trend engine; the FADE book is contrarian_fade (see fade/runtime.yaml)
+  sub_style: basket               # curated macro whitelist intersected with the live board
+  asset_classes: [indices, commodities, btc_eth]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 3
+  min_budget: 400
+  assets: ["BTC", "xyz:SP500", "xyz:XYZ100", "xyz:JP225", "xyz:KR200", "xyz:NIFTY", "xyz:IBOV", "xyz:GOLD", "xyz:SILVER", "xyz:PLATINUM", "xyz:COPPER", "xyz:BRENTOIL", "xyz:CL", "xyz:NATGAS", "xyz:EUR", "xyz:JPY", "xyz:GBP", "xyz:DXY"]
+  tags: [macro, global-macro, cross-asset, indices, metals, energy, fx, btc, xyz, trend, mean-reversion, contrarian-fade, two-book, long-short]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: trend
+    runtime: trend/runtime.yaml
+    wallet_env: ELEPHANT_TREND_WALLET
+    funding_share: 0.6
+  - name: fade
+    runtime: fade/runtime.yaml
+    wallet_env: ELEPHANT_FADE_WALLET
+    funding_share: 0.4

--- a/strategies/elephant/trend/runtime.yaml
+++ b/strategies/elephant/trend/runtime.yaml
@@ -1,0 +1,121 @@
+# ── ELEPHANT · TREND book — global-macro trend (Runtime 3.0 port of v2 Elephant v1.0, ELEPHANT_LEG=trend) ──
+name: elephant-trend
+group: elephant
+version: 3.0.0
+description: >
+  ELEPHANT TREND — global-macro trend book (Runtime 3.0 port of v2 Elephant v1.0). One of
+  two macro books. Scores the cross-asset macro complex (XYZ equity indices / metals /
+  energy / FX + BTC) on its medium-term multi-timeframe trend — LONG clean uptrends, SHORT
+  clean downtrends. The 4h structure is the macro backbone (BULLISH->LONG, BEARISH->SHORT,
+  NEUTRAL->skip), confirmed by 1h structure + 24h momentum + RSI room. BOTH directions.
+  Pairs with the FADE book (fade/runtime.yaml) on a separate, larger-funded wallet. The edge
+  is GLOBAL MACRO: the complex moves on macro regime, and macro trends (oil on geopolitics,
+  indices on the AI-equity bid, metals on risk-off) are slow and clean. Macro whitelist
+  intersected with the live board each tick; per-name venue leverage clamp; strict 5x.
+  XYZ trades 24/7 — no market-hours gating.
+
+strategy:
+  wallet: "${ELEPHANT_TREND_WALLET}"
+  slots: 3
+  default_leverage: 5                       # fallback; scan emits per-name venue-clamped 5x
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: elephant_trend_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                    # v2 tickSeconds — macro is slow
+    timeout_seconds: 180                     # v2 tick_timeout; universe-level per-asset reads
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 100             # recent-signals dedup map + per-tick result history
+    inputs:
+      # ── Macro whitelist (config.allowedAssets). XYZ indices / metals / energy / FX + BTC.
+      #    Validated against the live HL meta at authoring time (2026-06-29): all 18 names live. ──
+      allowedAssets: ["BTC", "xyz:SP500", "xyz:XYZ100", "xyz:JP225", "xyz:KR200", "xyz:NIFTY", "xyz:IBOV", "xyz:GOLD", "xyz:SILVER", "xyz:PLATINUM", "xyz:COPPER", "xyz:BRENTOIL", "xyz:CL", "xyz:NATGAS", "xyz:EUR", "xyz:JPY", "xyz:GBP", "xyz:DXY"]
+      minScore: 5                            # v2 trend minScore
+      marginPct: 18                          # PERCENT of withdrawable (0,100); v2 0.18 fraction x100
+      maxLeverage: 5                         # strict clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 3
+      momThresholdPct: 1.5                   # 24h move for momentum confirmation (macro is slow)
+      rsiOverbought: 75
+      rsiOversold: 25
+      recentSignalTtlSeconds: 180            # v2 RECENT_SIGNAL_TTL_SEC race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      own24h: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: elephant_trend_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                      # the scan already applied 4h/1h scoring + clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [elephant_trend_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: elephant_trend_signals
+
+# ── EXIT (DSL — wide let-macro-trends-run; ported VERBATIM from v2 runtime-trend.yaml) ──
+# Macro trends are slow and persistent, so ride them: wide phase1, ALL time cuts OFF, and
+# only a 7d hard_timeout staleness backstop. First phase2 tier (12% -> lock 0) primes the
+# trail; first LOCK is at 25% -> 45% (reachable on a real macro trend).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10080            # 7d staleness cap
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 720
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 1440
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 12, lock_hw_pct: 0 }
+        - { trigger_pct: 25, lock_hw_pct: 45 }
+        - { trigger_pct: 45, lock_hw_pct: 65 }
+        - { trigger_pct: 75, lock_hw_pct: 80 }
+        - { trigger_pct: 120, lock_hw_pct: 90 }
+
+risk:
+  data_retention_seconds: 604800            # v2 data_retention_hours 168 -> 168*3600 = 604800 (= 7d max)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 4                   # macro trends are slow -> few new entries/day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 5400                   # v2 cooldown_minutes 90
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 21600        # v2 per_asset_cooldown_minutes 360

--- a/strategies/elephant/trend/scanners/scan.py
+++ b/strategies/elephant/trend/scanners/scan.py
@@ -1,0 +1,288 @@
+"""ELEPHANT TREND book — supervised scanner (Runtime 3.0 port of the v2 elephant-producer.py
+TREND leg, ELEPHANT_LEG=trend).
+
+Global-macro trend book over the cross-asset macro complex (XYZ equity indices / metals /
+energy / FX + BTC). Per tick it:
+  1. reads the wallet clearinghouse (account value + held names + free margin),
+  2. builds the live universe: the curated macro whitelist intersected with the live
+     instrument board (names not live are skipped — v2 build_universe),
+  3. scores every non-held, non-recently-signaled name with the pure scoring.score_trend
+     (4h backbone, 1h confirm, 24h momentum, RSI room),
+  4. emits the top candidates up to open slots AND what free margin can FUND, as a
+     top-level marginPct INTENT (PERCENT) + a per-name venue-clamped leverage.
+
+Read-only + single-pass. No daemon, no push_signal, no create_position, no order-lifecycle
+mutation — the runtime sizes the dollars, owns slots/cooldowns/risk gates, and trails the DSL.
+
+FIDELITY NOTES vs elephant-producer.py v1.0.0 (ELEPHANT_LEG=trend):
+  - SET of scored assets, scoring weights/gates, 4h-backbone direction, momentum/RSI tiers,
+    minScore (5), marginPct (0.18 fraction -> 18 PERCENT), maxLeverage (5), maxSlots (3),
+    venue leverage clamp, and the 180s recent-signals race-dedup TTL are all preserved EXACTLY.
+  - v2 marginPct was a FRACTION (0.18) used as account_value * marginPct -> marginUsd. This
+    port emits `marginPct` PERCENT (18) at the top level; the runtime sizes
+    (marginPct/100)*withdrawable. The defensive "<=1.0 means a pasted fraction, x100" guard
+    is applied in scan() so a stale fractional config still sizes correctly.
+  - v2 `own24h` (24h % return) came from ret_24h(meta) using the instrument-board context
+    (markPx vs prevDayPx) from market_list_instruments. This port reads ret24h from the same
+    market_list_instruments meta — IDENTICAL source. (v2 only ever read momentum from meta,
+    never from the per-asset asset_context, so this matches.)
+  - DROPPED v2 order-lifecycle / mutation behaviour: the v2 producer called push_signal()
+    (a POST) and recorded signals to a JSON cache; scan() is read-only and returns plain
+    dicts. The recent-signals cache moves to ctx.state (same TTL/prune semantics). The free
+    margin "affordability cap" (never emit more entries than the wallet can fund) is preserved
+    because it is pure arithmetic over a read, not a mutation. FLAGGED: nothing else mutated
+    in v2 (no cancel_order / resting-order purge), so nothing else was dropped.
+  - v2 emitted up to min(open_slots, affordable) candidates; preserved. The runtime's slots
+    ceiling is the backstop.
+"""
+
+import sys
+import time
+
+import scoring
+
+# v2 _MACRO_WHITELIST (config.allowedAssets overrides). XYZ indices / metals / energy / FX
+# + BTC as the macro risk asset. Validated against the live HL meta at authoring time
+# (2026-06-29): every name present on the main (BTC) / xyz boards.
+_MACRO_WHITELIST_DEFAULT = [
+    "BTC",
+    "xyz:SP500", "xyz:XYZ100", "xyz:JP225", "xyz:KR200", "xyz:NIFTY", "xyz:IBOV",
+    "xyz:GOLD", "xyz:SILVER", "xyz:PLATINUM", "xyz:COPPER",
+    "xyz:BRENTOIL", "xyz:CL", "xyz:NATGAS",
+    "xyz:EUR", "xyz:JPY", "xyz:GBP", "xyz:DXY",
+]
+_DEFAULT_TTL = 180   # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup (3x ALO open fill window)
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick (the contract rolls any uncaught exception back to []). Returns None
+    on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[elephant.trend.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts and
+    makes every size 2x). Free margin = equity - committed margin. Ported verbatim from v2
+    cfg.get_positions, including the read-sanity guard (margin in use + empty positions ->
+    corrupt read -> skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an
+    # EMPTY positions list is a corrupt read — sizing or held-dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        print("[elephant.trend.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, ret24h}. Skips delisted. Verbatim v2 get_universe_meta()
+    folded with ret_24h(): ret24h = (markPx - prevDayPx)/prevDayPx * 100 from the instrument
+    context — IDENTICAL to the v2 momentum source for the trend book."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns
+    ([], []) and the universe loop skips it. Verbatim v2 fetch_candles intervals."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    if isinstance(resp, dict) and resp.get("success") is False:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map):
+    """Macro whitelist intersected with the live instrument board so dead/unavailable names
+    are skipped. Verbatim v2 build_universe()."""
+    out = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        if meta_map.get(name) or meta_map.get(name.upper()):
+            out.append(name)
+    return out
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    whitelist = inputs.get("allowedAssets", _MACRO_WHITELIST_DEFAULT)
+    min_score = int(inputs.get("minScore", 5))
+    margin_pct = float(inputs.get("marginPct", 18))          # PERCENT of withdrawable (0,100]
+    # defensive: a stale config may carry the v2 FRACTION (0.18). <=1.0 means a pasted
+    # fraction -> x100. (dire/koala guard.)
+    if 0 < margin_pct <= 1.0:
+        margin_pct *= 100.0
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 3))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[elephant.trend.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        _persist()
+        return []                                            # no value / corrupt read — skip tick
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist()
+        print(f"[elephant.trend.scan] WAITING — slots full held={held}", file=sys.stderr)
+        return []                                            # book full — runtime also caps via slots
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map)
+
+    candidates = []
+    scanned = 0
+    for name in universe:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup (race-window)
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue
+        scanned += 1
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_trend(name, c1, c4, meta.get("ret24h"), inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist()
+        print(f"[elephant.trend.scan] WAITING — no macro name cleared min score {min_score}; "
+              f"scanned={scanned} held={held} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: never emit more than the wallet can actually FUND. An open slot with no free
+    # margin re-emits an un-fillable order every tick (insufficient-funds spam). Per-name
+    # margin = (marginPct/100)*accountValue; 1.1 = fee/slippage headroom.
+    per_name_margin = (margin_pct / 100.0) * account_value
+    affordable = int(free_margin / (per_name_margin * 1.1)) if per_name_margin > 0 else 0
+    to_emit = candidates[:max(0, min(open_slots, affordable))]
+
+    out = []
+    for th in to_emit:
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # v2-quirk: per-name venue clamp
+        if leverage <= 0:
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": th["direction"],
+            "marginPct": margin_pct,                           # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                              # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": th["direction"],
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "own24h": round(th.get("own24h", 0), 2),
+                "heldAssets": held,
+            },
+        })
+        recent[th["coin"].upper()] = now
+
+    _persist()
+    if out:
+        top = out[0]
+        print(f"[elephant.trend.scan] EMIT {len(out)} (top {top['asset']} {top['direction']} "
+              f"{top['leverage']}x marginPct={margin_pct:.1f}%) scanned={scanned} "
+              f"candidates={len(candidates)} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    else:
+        print(f"[elephant.trend.scan] WAITING — candidates={len(candidates)} but none fundable/clamped; "
+              f"free_margin={free_margin:.2f} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/elephant/trend/scanners/scoring.py
+++ b/strategies/elephant/trend/scanners/scoring.py
@@ -1,0 +1,158 @@
+"""ELEPHANT TREND book — pure macro-trend thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 elephant-producer.py score_trend() — the 4h-backbone
+multi-timeframe trend scoring, the point weights, and the skip gates are copied EXACTLY
+(marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be redesigned).
+Unit-testable on plain candle lists. The runtime owns sizing/execution/DSL; this only scores.
+
+The TREND book rides the medium-term macro trend on the cross-asset macro complex (XYZ
+equity indices / metals / energy / FX + BTC). The 4h structure IS the macro backbone —
+BULLISH -> LONG, BEARISH -> SHORT, NEUTRAL -> skip (no clean trend) — confirmed by 1h
+structure, 24h momentum, and RSI room. BOTH directions.
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score
+# (NORM_DIV = 9.0, max raw ~8 for trend). The 3.0 scaffold owns the wire envelope, so we
+# keep the raw integer score on data{} and only expose NORM_DIV for parity if a caller
+# wants the v2-equivalent normalised score.
+NORM_DIV = 9.0
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_trend(asset, candles_1h, candles_4h, own24h, inputs):
+    """Macro multi-timeframe trend score for one asset. Returns a thesis dict or None.
+    The point weights + skip gates are copied VERBATIM from the v2 elephant-producer.py
+    score_trend() — do NOT redesign.
+
+    own24h = the asset's 24h return (%) from the instrument context (ret_24h in v2).
+    The 4h structure sets the direction; a NEUTRAL 4h macro = no clean trend -> None.
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:          # v2-quirk: trend warmup floors
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    own = own24h if own24h is not None else 0.0
+    mom = float(inputs.get("momThresholdPct", 1.5))
+    rsi_ob = float(inputs.get("rsiOverbought", 75))
+    rsi_os = float(inputs.get("rsiOversold", 25))
+
+    # v2-quirk: the 4h structure IS the macro trend; a NEUTRAL macro = no clean trend.
+    if trend4 == "BULLISH":
+        direction = "LONG"
+    elif trend4 == "BEARISH":
+        direction = "SHORT"
+    else:
+        return None
+
+    score = 3
+    reasons = [f"4h_{trend4.lower()}_{s4:.0%}"]
+
+    if (direction == "LONG" and trend1 == "BULLISH") or (direction == "SHORT" and trend1 == "BEARISH"):
+        score += 2
+        reasons.append(f"1h_confirm_{s1:.0%}")
+    elif (direction == "LONG" and trend1 == "BEARISH") or (direction == "SHORT" and trend1 == "BULLISH"):
+        score -= 1
+        reasons.append("1h_against")
+
+    if direction == "LONG":
+        if own >= mom:
+            score += 2
+            reasons.append(f"mom_{own:+.1f}%")
+        elif own >= 0:
+            score += 1
+            reasons.append(f"mom_{own:+.1f}%")
+        if rsi < rsi_ob:
+            score += 1
+            reasons.append(f"rsi_room_{rsi:.0f}")
+    else:
+        if own <= -mom:
+            score += 2
+            reasons.append(f"mom_{own:+.1f}%")
+        elif own <= 0:
+            score += 1
+            reasons.append(f"mom_{own:+.1f}%")
+        if rsi > rsi_os:
+            score += 1
+            reasons.append(f"rsi_room_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "own24h": own,
+    }
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: indices / metals /
+    FX cap LOW at the venue, so over-leveraging a name is a venue reject — this clamp is
+    load-bearing, not cosmetic. Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/lion/long/runtime.yaml
+++ b/strategies/lion/long/runtime.yaml
@@ -1,0 +1,141 @@
+# ── LION · LONG "haves" book — long the structural winners of a two-speed (K-shaped) world ──
+name: lion-long
+group: lion
+version: 3.0.0
+description: >
+  LION LONG ("haves" book) — two-speed-market (K-shaped) cross-asset long/short fund
+  (Runtime 3.0 port of v2 Lion v1.0.0). This book LONGS the structural winners of a
+  K-shaped world: the AI complex on Hyperliquid XYZ (NVDA, AMD, MRVL, TSM, ASML, ARM,
+  AVGO, CRWV, PLTR, ORCL, …) PLUS the crypto winners (HYPE large, SOL modest) — but only
+  when ABSOLUTE trend confirms (4h structure not bearish + positive own momentum), with
+  an RSI blow-off guard. Cross-sectional relative strength tilts size/ranking but NEVER
+  benches a genuinely-trending winner. Per-name size = marginPct(18) × conviction weight
+  (HYPE 1.5×, SOL 0.6×, AI equities 1.0×), capped at 25%. Pairs with the SHORT "have-nots"
+  book on a SEPARATE wallet; the P&L is the DISPERSION between the two speeds, not market
+  direction. Tokenized equities trade 24/7 on Hyperliquid — no market-hours gating.
+
+strategy:
+  wallet: "${LION_LONG_WALLET}"
+  # ── NET-EXPOSURE DEFAULT: modest NET-LONG tilt (~60/40) ──
+  # Net exposure is an OPERATOR decision (set by the long/short wallet funding split +
+  # per-leg knobs), NOT a runtime-enforced field. This book defaults larger (slots 5,
+  # margin_pct 18, 5x) than the short book to express the directional AI/HYPE conviction.
+  slots: 5
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: lion_long_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — two-speed cross-asset cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map + per-tick observability
+    inputs:
+      leg: "long"
+      # ── Curated thematic "haves" universe (validated against the live HL board) ──
+      # AI chips / memory / infra / software/hyperscalers + frontier compute + crypto
+      # winners. All 29 names confirmed live (HL meta main + xyz, 2026-06-29). New AI
+      # listings auto-join once added here and live on the board.
+      universe: ["xyz:NVDA", "xyz:AMD", "xyz:MRVL", "xyz:ARM", "xyz:AVGO", "xyz:INTC", "xyz:TSM", "xyz:ASML", "xyz:CBRS", "xyz:MU", "xyz:SMSN", "xyz:SKHX", "xyz:SNDK", "xyz:CRWV", "xyz:NBIS", "xyz:DELL", "xyz:LITE", "xyz:GOOGL", "xyz:MSFT", "xyz:META", "xyz:AMZN", "xyz:ORCL", "xyz:PLTR", "xyz:NOW", "xyz:IBM", "xyz:SPCX", "xyz:QNT", "HYPE", "SOL"]
+      sizingWeights:
+        HYPE: 1.5
+        SOL: 0.6
+        SPCX: 0.6
+        QNT: 0.5
+        CBRS: 0.7
+        NBIS: 0.7
+        _default: 1.0
+      minScore: 5
+      marginPctBase: 18      # PERCENT of withdrawable (0,100]; per-name = marginPctBase × conviction weight
+      marginPctCap: 25       # fleet <=25% per-position cap (binds HYPE: 18×1.5=27 -> 25)
+      maxLeverage: 5         # strict clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 5
+      rankPoolSize: 30       # large AI universe — score the whole complex each tick
+      rsThresholdPct: 3.0
+      rsiOverbought: 82      # blow-off guard — don't chase an overbought winner
+      volFloorPctOfMedian: 0.2
+      minUniverseForMedianGate: 5
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+      weight: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: lion_long_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # the scan already applied the thematic universe, the 4h/1h
+                                          # absolute-trend gate, the RS tiebreaker, conviction sizing,
+                                          # the 5x clamp + venue clamp, and held/recent dedup (v2 LLM
+                                          # gate was pass-through)
+    scanners: [lion_long_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: lion_long_signals
+
+# ── EXIT (DSL — moderate; let two-speed winners run, cut reversers; ported verbatim) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10080          # 7d — the AI trend persists; let winners run
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h — cut a winner that peaked then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 960            # 16h — recycle a position going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 16.0                  # slightly wider than equity-only (HYPE vol in basket)
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 20,  lock_hw_pct: 40 }   # first LOCK — reachable
+        - { trigger_pct: 35,  lock_hw_pct: 60 }
+        - { trigger_pct: 60,  lock_hw_pct: 78 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6                # basket rotation as leadership shifts
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600                # v2 cooldown_minutes 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 14400     # v2 per_asset_cooldown_minutes 240

--- a/strategies/lion/long/scanners/scan.py
+++ b/strategies/lion/long/scanners/scan.py
@@ -1,0 +1,369 @@
+"""LION — supervised scanner (Runtime 3.0 port of the v2 lion-producer.py).
+
+Two-Speed-Market (K-shaped) cross-asset long/short. ONE scan.py serves BOTH books;
+the runtime instance passes `leg` ("long" = the "haves" book, longs the AI complex +
+crypto winners; "short" = the "have-nots" book, shorts the broad U.S. market via SP500
++ laggard alts). A faithful port — the curated thematic universe, the ABSOLUTE-trend
+hard gate, the relative-strength TIEBREAKER, the per-group conviction sizing, the
+venue-leverage clamp, the affordability cap, and the held/recent dedup are preserved.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin; the
+     'main' + 'xyz' sections are TWO VIEWS of ONE cross-margined wallet — max() not sum)
+  2. build the curated thematic universe (inputs.universe — haves for long / have-nots
+     for short) intersected with the live board + a relative liquidity floor (NO $ floor;
+     SKIPPED for small curated lists, per v2 Mongoose-2026-06-22 fix)
+  3. cross-sectional relative-strength rank (own 24h return - the leg-universe mean),
+     take the top (long) / bottom (short) rankPoolSize
+  4. score each pooled name through pure scoring.score_thematic (ABSOLUTE trend is the
+     gate; excess is a bonus), dedup held + recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT = marginPctBase * conviction-weight,
+     capped at marginPctCap) + a per-name venue-clamped leverage; the runtime owns
+     slots, dedup, execution, DSL.
+
+Read-only + single-pass. NO daemon, NO push_signal, NO create_position — the runtime
+sizes the dollars, owns cooldowns/risk gates/slots, and trails the DSL exit.
+
+FIDELITY NOTES vs lion-producer.py v1.0.0:
+  - v2 conviction sizing emitted marginUsd = account_value * marginPct(FRACTION 0.18) *
+    sizingWeight. The Runtime 3.0 runtime sizes from a top-level PERCENT in (0,100], so
+    this port emits marginPct = marginPctBase(PERCENT 18) * sizingWeight, capped at
+    marginPctCap (25, the fleet <=25% per-position rule). Same fraction of equity, same
+    conviction multiplier — the cap binds only the highest-weight name (HYPE 18*1.5=27 ->
+    25). A defensive guard converts a marginPctBase <= 1 (an operator who pasted the v2
+    fraction 0.18) into a PERCENT (*100) and logs it. FLAGGED.
+  - v2 LEG was an env var (LION_LEG) read once at import; the Runtime 3.0 port passes
+    `leg` via runtime.yaml inputs (one shared scan.py, two instances). Same two books.
+  - v2 emitted ALL gated, affordable candidates up to open_slots; preserved (emit-all,
+    runtime applies the slots ceiling). The per-candidate AFFORDABILITY cap (never emit
+    an order the wallet can't FUND, with 1.1 fee headroom) is ported verbatim — but per
+    NAME since each carries a different conviction weight -> different marginPct.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=180) -> ctx.state dedup map (same
+    TTL semantics, race-window held-asset suppression).
+  - v2 get_positions read-sanity guard (margin/notional IN USE but EMPTY positions =
+    corrupt read -> skip tick to avoid pyramiding / mis-sizing) is ported verbatim.
+  - DROPPED (Runtime 3.0 read-only boundary): the v2 had NO order-lifecycle management
+    (no cancel_order / resting-order purge), so nothing to drop there. The v2 LLM entry
+    gate was an explicit pass-through ("honor the signal unless malformed"); the Runtime
+    3.0 action is decision_mode: rule — the scan IS the decision, so the pass-through LLM
+    step is correctly dropped. FLAGGED.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+_MIN_UNIVERSE_FOR_MEDIAN_GATE = 5   # v2 minUniverseForMedianGate default (Mongoose fix)
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick. Returns None on failure so the caller's degrade path applies
+    (asia-ai NASDAQ-bug class — one bad name must not kill the universe tick)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad read must not kill the universe tick
+        print(f"[lion.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts
+    and makes every size 2x). Lion holds BOTH xyz equities and main-DEX crypto on one
+    wallet, so both sections routinely carry positions. Free margin = equity - committed
+    margin. Verbatim v2 get_positions() + the read-sanity guard."""
+    if not getattr(ctx, "wallet", None):
+        return 0.0, [], 0.0
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but
+    # an EMPTY positions list is a corrupt read — sizing or held-dedup off that re-enters
+    # held names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return ─────────────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, vol, ret24h}. Skips delisted. Verbatim v2 get_universe_meta()
+    + ret_24h() + day_vol() folded together. Keys under BOTH the raw name and its upper
+    form so a 'xyz:NVDA' whitelist entry resolves against a 'XYZ:NVDA' live board name."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        name = inst.get("name") or ctxd.get("coin")
+        if not name:
+            continue
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _meta_for(meta_map, name):
+    """Resolve a whitelist name against the live board, tolerating the xyz:/XYZ: case
+    skew (v2 whitelist uses 'xyz:NVDA'; the live board returns 'XYZ:NVDA')."""
+    return meta_map.get(name) or meta_map.get(name.upper())
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns
+    ([], []) and the universe loop skips it (asia-ai per-asset read-guard). Verbatim v2
+    fetch_candles()."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate):
+    """The curated thematic whitelist (haves for the long leg / have-nots for the short
+    leg) intersected with the live board + a relative liquidity floor. Verbatim v2
+    build_universe(): a SMALL curated list (< min_for_gate live names) SKIPS the
+    median-vol gate — on a tiny list it drops an intentionally-thinner name and can
+    collapse the universe to 1, bricking the book (v2 Mongoose short, 2026-06-22). Below
+    the threshold, keep every live (vol>0) name — the curation IS the liquidity decision."""
+    cand = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        meta = _meta_for(meta_map, name)
+        if not meta:
+            continue                                        # not on the live board — drop
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        cand.append((name, vol))
+    if not cand:
+        return []
+    if len(cand) < int(min_for_gate):
+        return [n for n, _ in cand]
+    vols = sorted(v for _, v in cand)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in cand if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    whitelist = inputs.get("universe", [])
+    sizing_weights = inputs.get("sizingWeights") or (
+        scoring.HAVES_WEIGHTS if leg == "long" else scoring.HAVE_NOTS_WEIGHTS)
+    min_score = int(inputs.get("minScore", 5))
+
+    # marginPct is a PERCENT in (0,100]. FLAGGED: defensively convert a value <= 1 (an
+    # operator who pasted the v2 FRACTION 0.18) into a PERCENT so it never silently sizes
+    # ~100x small (the runtime sizes (marginPct/100)*withdrawable).
+    margin_pct_base = float(inputs.get("marginPctBase", 18 if leg == "long" else 15))
+    if margin_pct_base <= 1.0:
+        print(f"[lion.scan] WARN marginPctBase={margin_pct_base} looks like a v2 FRACTION; "
+              f"converting to PERCENT ({margin_pct_base * 100})", file=sys.stderr)
+        margin_pct_base *= 100.0
+    margin_pct_cap = float(inputs.get("marginPctCap", 25))   # fleet <=25% per-position rule
+
+    max_lev = int(inputs.get("maxLeverage", 5 if leg == "long" else 4))
+    max_slots = int(inputs.get("maxSlots", 5 if leg == "long" else 4))
+    rank_pool = int(inputs.get("rankPoolSize", 30 if leg == "long" else 16))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    min_for_gate = int(inputs.get("minUniverseForMedianGate", _MIN_UNIVERSE_FOR_MEDIAN_GATE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist(result=None):
+        if ctx.state is None:
+            return
+        rec = {"recent": recent}
+        if result is not None:
+            rec["result"] = result
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[lion.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        print(f"[lion.scan] leg={leg} WAITING — no account value / corrupt read", file=sys.stderr)
+        _persist({"ts": now, "leg": leg, "emitted": 0, "gate": "no_value"})
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        print(f"[lion.scan] leg={leg} slots full ({len(held)}/{max_slots}) — DSL manages exit",
+              file=sys.stderr)
+        _persist({"ts": now, "leg": leg, "emitted": 0, "gate": "slots_full", "held": held})
+        return []
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate)
+
+    # ── Cross-sectional relative strength over the thematic universe (score tiebreaker;
+    #    absolute trend is the gate inside scoring.score_thematic). Verbatim v2. ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = _meta_for(meta_map, name)
+        own = meta.get("ret24h") if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 1:                                          # v2-quirk: thematic universe too thin
+        print(f"[lion.scan] leg={leg} WAITING — thematic universe too thin "
+              f"(scanned {len(universe)})", file=sys.stderr)
+        _persist({"ts": now, "leg": leg, "emitted": 0, "gate": "thin_universe",
+                  "scanned": len(universe)})
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=(leg == "long"))     # leaders first (long) / laggards first (short)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup (race window)
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_thematic(name, c1, c4, own, excess, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        print(f"[lion.scan] leg={leg} WAITING — no name cleared min_score={min_score} "
+              f"(scanned {len(universe)}, pool {len(pool)}, mean_rs={mean_rs:.2f})",
+              file=sys.stderr)
+        _persist({"ts": now, "leg": leg, "emitted": 0, "gate": "no_candidate",
+                  "scanned": len(universe), "pool": len(pool),
+                  "mean_rs": round(mean_rs, 2), "min_score": min_score})
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # Emit best-scoring first, sizing each by its conviction weight, capping to what the
+    # wallet can actually FUND. v2-quirk: free margin decremented per commit so a mixed
+    # basket of different-weight names never emits an un-fundable order (which would
+    # re-emit an insufficient-funds create every tick). 1.1 = fee/slippage headroom.
+    out = []
+    fm = free_margin
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], sizing_weights)
+        margin_pct = round(min(margin_pct_base * weight, margin_pct_cap), 4)
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)   # per-name venue clamp
+        if margin_pct <= 0 or leverage <= 0:
+            continue
+        # affordability cap in USD terms: per-name margin = (margin_pct/100)*account_value
+        per_name_margin = (margin_pct / 100.0) * account_value
+        if per_name_margin * 1.1 > fm:
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": margin_pct,                            # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                               # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+                "weight": round(weight, 2),
+                "heldAssets": held,
+            },
+        })
+        recent[th["coin"].upper()] = now
+        open_slots -= 1
+        fm -= per_name_margin * 1.1
+
+    _persist({"ts": now, "leg": leg, "emitted": len(out),
+              "gate": "pass" if out else "unaffordable",
+              "scanned": len(universe), "pool": len(pool),
+              "candidates": len(candidates), "mean_rs": round(mean_rs, 2),
+              "held": held})
+    verb = "EMIT" if out else "WAITING"
+    print(f"[lion.scan] {verb} leg={leg} scanned={len(universe)} pool={len(pool)} "
+          f"candidates={len(candidates)} emitted={len(out)} mean_rs={mean_rs:.2f} "
+          f"elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/lion/long/scanners/scoring.py
+++ b/strategies/lion/long/scanners/scoring.py
@@ -1,0 +1,240 @@
+"""LION — pure two-speed (K-shaped) thematic thesis math (no I/O, no MCP, no clock).
+
+Shared VERBATIM by both books; direction is passed in via `leg` ("long" for the
+"haves" book, "short" for the "have-nots" book). A faithful port of the v2
+lion-producer.py scoring — the ABSOLUTE-trend hard gate, the relative-strength
+TIEBREAKER (bonus only, never a disqualifier), the point weights, the per-group
+conviction sizing weights, and the venue-leverage clamp are copied EXACTLY
+(marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be
+redesigned). Unit-testable on plain candle lists.
+
+KEY DIFFERENCE vs cougar (do NOT confuse them): Lion's universe is THEMATIC — every
+name is already a thesis pick (a "have" or a "have-not"). So the HARD GATE is
+ABSOLUTE 4h trend (never long a confirmed downtrend / never short a confirmed
+uptrend), and cross-sectional excess is a SCORE MODIFIER (tilts size + ranking)
+that NEVER benches a genuinely-trending winner. Cougar, by contrast, DISQUALIFIES
+the wrong-sign excess. The point weights also differ (Lion 4h_bullish=+3 with a
++1 neutral fallback; Cougar 4h_bullish=+2 with no neutral fallback). Ported per
+the v2 lion-producer score_thematic() exactly.
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire
+# score. The Runtime 3.0 scaffold owns the wire envelope, so we keep the raw integer
+# score on data{} and only expose NORM_DIV if a caller wants the v2-equivalent value.
+NORM_DIV = 9.0
+
+# Per-group sizing weights (conviction, NOT dollars) — verbatim v2 defaults. The
+# producer (scan.py) overrides via inputs.sizingWeights; "_default" is the fallback.
+HAVES_WEIGHTS = {
+    "HYPE": 1.5,    # highest-conviction crypto winner
+    "SOL": 0.6,     # modest crypto growth
+    "SPCX": 0.6,    # frontier (xAI) but pre-IPO / 5x-capped / volatile -> smaller
+    "QNT": 0.5,     # quantum, most speculative -> smallest
+    "CBRS": 0.7,    # smaller-cap AI-chip
+    "NBIS": 0.7,    # smaller-cap AI-cloud
+    "_default": 1.0,  # core AI complex (megacap chips + hyperscalers) at full slot
+}
+HAVE_NOTS_WEIGHTS = {"SP500": 1.2, "_default": 0.7}
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def bare(asset):
+    """Bare ticker for sizing-weight + dedup lookups: 'xyz:NVDA' -> 'NVDA'.
+    Verbatim v2 _bare()."""
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2.
+
+    v2-quirk: the BULLISH/BEARISH gate is `>= total * 0.6` where total = lookback - 1,
+    counting STRICT (>) higher-lows / lower-highs. Strength = higher_lows/total
+    (BULLISH) or lower_highs/total (BEARISH). Reproduced exactly."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Trailing-window simple-average RSI. Verbatim v2 calc_rsi (gains[-period:])."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_thematic(asset, candles_1h, candles_4h, own24h, excess, leg, inputs):
+    """Two-speed thematic score for one name. ABSOLUTE trend is the GATE; relative
+    strength (`excess` = own 24h return minus the leg-universe mean) is a TIEBREAKER.
+    Returns a thesis dict or None. The point weights + gates are copied VERBATIM from
+    the v2 lion-producer score_thematic() — do NOT redesign.
+
+    leg == "long":  long a "have" only while its 4h trend is not BEARISH (hard gate);
+                    relative strength is a bonus that never disqualifies a trending have.
+    leg == "short": short a "have-not" only while its 4h trend is not BULLISH (hard gate);
+                    relative weakness is a bonus.
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if leg == "long":
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")        # noted, not penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 82))
+        if rsi > rsi_ob:
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")        # noted, not penalized
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+def sizing_weight(asset, weights):
+    """Per-group conviction multiplier (HYPE large, SOL modest, SP500 core).
+    Keyed by bare ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim
+    v2 sizing_weight()."""
+    if not isinstance(weights, dict):
+        weights = HAVES_WEIGHTS
+    try:
+        w = float(weights.get(bare(asset), weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp desired leverage to the asset's HL venue max. v2-quirk: cross-asset names
+    cap LOW at the venue (SPCX 5x, equities vary) — over-leveraging is a venue reject,
+    so this clamp is load-bearing, not cosmetic. Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/lion/short/runtime.yaml
+++ b/strategies/lion/short/runtime.yaml
@@ -1,0 +1,137 @@
+# ── LION · SHORT "have-nots" book — short the laggards of a two-speed (K-shaped) world ──
+name: lion-short
+group: lion
+version: 3.0.0
+description: >
+  LION SHORT ("have-nots" book) — two-speed-market (K-shaped) cross-asset long/short fund
+  (Runtime 3.0 port of v2 Lion v1.0.0). This book SHORTS the laggards of a K-shaped world:
+  the broad U.S. market via the SP500 index product (the "economy suffers" core) PLUS a
+  curated, gated basket of laggard crypto majors/alts (the "rest of crypto struggles" bet)
+  — but only when ABSOLUTE trend confirms (4h structure not bullish + negative momentum),
+  with a CAPITULATION guard so it never shorts an exhausted bottom. Cross-sectional relative
+  weakness tilts size/ranking. Per-name size = marginPct(15) × conviction weight (SP500
+  1.2× core, alts 0.7×), capped at 25%. Pairs with the LONG "haves" book on a SEPARATE
+  wallet. Longing AI names while shorting SP500 (which contains them) isolates the
+  AI-vs-broad-market spread by design. Tokenized equities trade 24/7 — no market-hours gating.
+
+strategy:
+  wallet: "${LION_SHORT_WALLET}"
+  # ── NET-EXPOSURE DEFAULT: modest NET-LONG tilt (~60/40) ──
+  # Net exposure is an OPERATOR decision (set by the long/short wallet funding split +
+  # per-leg knobs), NOT a runtime-enforced field. This book defaults smaller (slots 4,
+  # margin_pct 15, 4x cap) than the long book to express the directional AI/HYPE conviction
+  # and to respect that short squeezes are violent.
+  slots: 4
+  default_leverage: 4
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: lion_short_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — two-speed cross-asset cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map + per-tick observability
+    inputs:
+      leg: "short"
+      # ── Curated thematic "have-nots" universe (validated against the live HL board) ──
+      # The broad U.S. market (SP500 index) + a curated basket of laggard crypto
+      # majors/alts. All 10 names confirmed live (HL meta main + xyz, 2026-06-29). BTC is
+      # deliberately omitted (too reflexive to short cleanly) — add only with intent.
+      universe: ["xyz:SP500", "ETH", "XRP", "DOGE", "AVAX", "LINK", "ADA", "LTC", "NEAR", "APT"]
+      sizingWeights:
+        SP500: 1.2
+        _default: 0.7
+      minScore: 5
+      marginPctBase: 15      # PERCENT of withdrawable (0,100]; per-name = marginPctBase × conviction weight
+      marginPctCap: 25       # fleet <=25% per-position cap (SP500: 15×1.2=18, never binds here)
+      maxLeverage: 4         # strict clamp (short squeezes are violent), then HL venue max
+      maxSlots: 4
+      rankPoolSize: 16
+      rsThresholdPct: 3.0
+      rsiOversold: 18        # capitulation guard — never short an exhausted bottom
+      volFloorPctOfMedian: 0.2
+      minUniverseForMedianGate: 5
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+      weight: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: lion_short_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # the scan already applied the thematic universe, the 4h/1h
+                                          # absolute-downtrend gate, the capitulation guard, the RS
+                                          # tiebreaker, conviction sizing, the 4x clamp + venue clamp,
+                                          # and held/recent dedup (v2 LLM gate was pass-through)
+    scanners: [lion_short_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: lion_short_signals
+
+# ── EXIT (DSL — tighter; short theses decay faster, squeezes are violent; ported verbatim) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 7200           # 5d — shorter than the long book
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h — cut a short that bottomed then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 720            # 12h — recycle a short going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                  # tighter than long book — squeeze protection
+      retrace_threshold: 7
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 18,  lock_hw_pct: 45 }   # first LOCK — reachable
+        - { trigger_pct: 35,  lock_hw_pct: 65 }
+        - { trigger_pct: 60,  lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 5
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 5400                # v2 cooldown_minutes 90
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 18000     # v2 per_asset_cooldown_minutes 300

--- a/strategies/lion/short/scanners/scan.py
+++ b/strategies/lion/short/scanners/scan.py
@@ -1,0 +1,369 @@
+"""LION — supervised scanner (Runtime 3.0 port of the v2 lion-producer.py).
+
+Two-Speed-Market (K-shaped) cross-asset long/short. ONE scan.py serves BOTH books;
+the runtime instance passes `leg` ("long" = the "haves" book, longs the AI complex +
+crypto winners; "short" = the "have-nots" book, shorts the broad U.S. market via SP500
++ laggard alts). A faithful port — the curated thematic universe, the ABSOLUTE-trend
+hard gate, the relative-strength TIEBREAKER, the per-group conviction sizing, the
+venue-leverage clamp, the affordability cap, and the held/recent dedup are preserved.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin; the
+     'main' + 'xyz' sections are TWO VIEWS of ONE cross-margined wallet — max() not sum)
+  2. build the curated thematic universe (inputs.universe — haves for long / have-nots
+     for short) intersected with the live board + a relative liquidity floor (NO $ floor;
+     SKIPPED for small curated lists, per v2 Mongoose-2026-06-22 fix)
+  3. cross-sectional relative-strength rank (own 24h return - the leg-universe mean),
+     take the top (long) / bottom (short) rankPoolSize
+  4. score each pooled name through pure scoring.score_thematic (ABSOLUTE trend is the
+     gate; excess is a bonus), dedup held + recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT = marginPctBase * conviction-weight,
+     capped at marginPctCap) + a per-name venue-clamped leverage; the runtime owns
+     slots, dedup, execution, DSL.
+
+Read-only + single-pass. NO daemon, NO push_signal, NO create_position — the runtime
+sizes the dollars, owns cooldowns/risk gates/slots, and trails the DSL exit.
+
+FIDELITY NOTES vs lion-producer.py v1.0.0:
+  - v2 conviction sizing emitted marginUsd = account_value * marginPct(FRACTION 0.18) *
+    sizingWeight. The Runtime 3.0 runtime sizes from a top-level PERCENT in (0,100], so
+    this port emits marginPct = marginPctBase(PERCENT 18) * sizingWeight, capped at
+    marginPctCap (25, the fleet <=25% per-position rule). Same fraction of equity, same
+    conviction multiplier — the cap binds only the highest-weight name (HYPE 18*1.5=27 ->
+    25). A defensive guard converts a marginPctBase <= 1 (an operator who pasted the v2
+    fraction 0.18) into a PERCENT (*100) and logs it. FLAGGED.
+  - v2 LEG was an env var (LION_LEG) read once at import; the Runtime 3.0 port passes
+    `leg` via runtime.yaml inputs (one shared scan.py, two instances). Same two books.
+  - v2 emitted ALL gated, affordable candidates up to open_slots; preserved (emit-all,
+    runtime applies the slots ceiling). The per-candidate AFFORDABILITY cap (never emit
+    an order the wallet can't FUND, with 1.1 fee headroom) is ported verbatim — but per
+    NAME since each carries a different conviction weight -> different marginPct.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=180) -> ctx.state dedup map (same
+    TTL semantics, race-window held-asset suppression).
+  - v2 get_positions read-sanity guard (margin/notional IN USE but EMPTY positions =
+    corrupt read -> skip tick to avoid pyramiding / mis-sizing) is ported verbatim.
+  - DROPPED (Runtime 3.0 read-only boundary): the v2 had NO order-lifecycle management
+    (no cancel_order / resting-order purge), so nothing to drop there. The v2 LLM entry
+    gate was an explicit pass-through ("honor the signal unless malformed"); the Runtime
+    3.0 action is decision_mode: rule — the scan IS the decision, so the pass-through LLM
+    step is correctly dropped. FLAGGED.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+_MIN_UNIVERSE_FOR_MEDIAN_GATE = 5   # v2 minUniverseForMedianGate default (Mongoose fix)
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick. Returns None on failure so the caller's degrade path applies
+    (asia-ai NASDAQ-bug class — one bad name must not kill the universe tick)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad read must not kill the universe tick
+        print(f"[lion.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts
+    and makes every size 2x). Lion holds BOTH xyz equities and main-DEX crypto on one
+    wallet, so both sections routinely carry positions. Free margin = equity - committed
+    margin. Verbatim v2 get_positions() + the read-sanity guard."""
+    if not getattr(ctx, "wallet", None):
+        return 0.0, [], 0.0
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but
+    # an EMPTY positions list is a corrupt read — sizing or held-dedup off that re-enters
+    # held names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return ─────────────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, vol, ret24h}. Skips delisted. Verbatim v2 get_universe_meta()
+    + ret_24h() + day_vol() folded together. Keys under BOTH the raw name and its upper
+    form so a 'xyz:NVDA' whitelist entry resolves against a 'XYZ:NVDA' live board name."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        name = inst.get("name") or ctxd.get("coin")
+        if not name:
+            continue
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _meta_for(meta_map, name):
+    """Resolve a whitelist name against the live board, tolerating the xyz:/XYZ: case
+    skew (v2 whitelist uses 'xyz:NVDA'; the live board returns 'XYZ:NVDA')."""
+    return meta_map.get(name) or meta_map.get(name.upper())
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns
+    ([], []) and the universe loop skips it (asia-ai per-asset read-guard). Verbatim v2
+    fetch_candles()."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate):
+    """The curated thematic whitelist (haves for the long leg / have-nots for the short
+    leg) intersected with the live board + a relative liquidity floor. Verbatim v2
+    build_universe(): a SMALL curated list (< min_for_gate live names) SKIPS the
+    median-vol gate — on a tiny list it drops an intentionally-thinner name and can
+    collapse the universe to 1, bricking the book (v2 Mongoose short, 2026-06-22). Below
+    the threshold, keep every live (vol>0) name — the curation IS the liquidity decision."""
+    cand = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        meta = _meta_for(meta_map, name)
+        if not meta:
+            continue                                        # not on the live board — drop
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        cand.append((name, vol))
+    if not cand:
+        return []
+    if len(cand) < int(min_for_gate):
+        return [n for n, _ in cand]
+    vols = sorted(v for _, v in cand)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in cand if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    whitelist = inputs.get("universe", [])
+    sizing_weights = inputs.get("sizingWeights") or (
+        scoring.HAVES_WEIGHTS if leg == "long" else scoring.HAVE_NOTS_WEIGHTS)
+    min_score = int(inputs.get("minScore", 5))
+
+    # marginPct is a PERCENT in (0,100]. FLAGGED: defensively convert a value <= 1 (an
+    # operator who pasted the v2 FRACTION 0.18) into a PERCENT so it never silently sizes
+    # ~100x small (the runtime sizes (marginPct/100)*withdrawable).
+    margin_pct_base = float(inputs.get("marginPctBase", 18 if leg == "long" else 15))
+    if margin_pct_base <= 1.0:
+        print(f"[lion.scan] WARN marginPctBase={margin_pct_base} looks like a v2 FRACTION; "
+              f"converting to PERCENT ({margin_pct_base * 100})", file=sys.stderr)
+        margin_pct_base *= 100.0
+    margin_pct_cap = float(inputs.get("marginPctCap", 25))   # fleet <=25% per-position rule
+
+    max_lev = int(inputs.get("maxLeverage", 5 if leg == "long" else 4))
+    max_slots = int(inputs.get("maxSlots", 5 if leg == "long" else 4))
+    rank_pool = int(inputs.get("rankPoolSize", 30 if leg == "long" else 16))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    min_for_gate = int(inputs.get("minUniverseForMedianGate", _MIN_UNIVERSE_FOR_MEDIAN_GATE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist(result=None):
+        if ctx.state is None:
+            return
+        rec = {"recent": recent}
+        if result is not None:
+            rec["result"] = result
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[lion.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        print(f"[lion.scan] leg={leg} WAITING — no account value / corrupt read", file=sys.stderr)
+        _persist({"ts": now, "leg": leg, "emitted": 0, "gate": "no_value"})
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        print(f"[lion.scan] leg={leg} slots full ({len(held)}/{max_slots}) — DSL manages exit",
+              file=sys.stderr)
+        _persist({"ts": now, "leg": leg, "emitted": 0, "gate": "slots_full", "held": held})
+        return []
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate)
+
+    # ── Cross-sectional relative strength over the thematic universe (score tiebreaker;
+    #    absolute trend is the gate inside scoring.score_thematic). Verbatim v2. ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = _meta_for(meta_map, name)
+        own = meta.get("ret24h") if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 1:                                          # v2-quirk: thematic universe too thin
+        print(f"[lion.scan] leg={leg} WAITING — thematic universe too thin "
+              f"(scanned {len(universe)})", file=sys.stderr)
+        _persist({"ts": now, "leg": leg, "emitted": 0, "gate": "thin_universe",
+                  "scanned": len(universe)})
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=(leg == "long"))     # leaders first (long) / laggards first (short)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup (race window)
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_thematic(name, c1, c4, own, excess, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        print(f"[lion.scan] leg={leg} WAITING — no name cleared min_score={min_score} "
+              f"(scanned {len(universe)}, pool {len(pool)}, mean_rs={mean_rs:.2f})",
+              file=sys.stderr)
+        _persist({"ts": now, "leg": leg, "emitted": 0, "gate": "no_candidate",
+                  "scanned": len(universe), "pool": len(pool),
+                  "mean_rs": round(mean_rs, 2), "min_score": min_score})
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # Emit best-scoring first, sizing each by its conviction weight, capping to what the
+    # wallet can actually FUND. v2-quirk: free margin decremented per commit so a mixed
+    # basket of different-weight names never emits an un-fundable order (which would
+    # re-emit an insufficient-funds create every tick). 1.1 = fee/slippage headroom.
+    out = []
+    fm = free_margin
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], sizing_weights)
+        margin_pct = round(min(margin_pct_base * weight, margin_pct_cap), 4)
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)   # per-name venue clamp
+        if margin_pct <= 0 or leverage <= 0:
+            continue
+        # affordability cap in USD terms: per-name margin = (margin_pct/100)*account_value
+        per_name_margin = (margin_pct / 100.0) * account_value
+        if per_name_margin * 1.1 > fm:
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": margin_pct,                            # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                               # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+                "weight": round(weight, 2),
+                "heldAssets": held,
+            },
+        })
+        recent[th["coin"].upper()] = now
+        open_slots -= 1
+        fm -= per_name_margin * 1.1
+
+    _persist({"ts": now, "leg": leg, "emitted": len(out),
+              "gate": "pass" if out else "unaffordable",
+              "scanned": len(universe), "pool": len(pool),
+              "candidates": len(candidates), "mean_rs": round(mean_rs, 2),
+              "held": held})
+    verb = "EMIT" if out else "WAITING"
+    print(f"[lion.scan] {verb} leg={leg} scanned={len(universe)} pool={len(pool)} "
+          f"candidates={len(candidates)} emitted={len(out)} mean_rs={mean_rs:.2f} "
+          f"elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/lion/short/scanners/scoring.py
+++ b/strategies/lion/short/scanners/scoring.py
@@ -1,0 +1,240 @@
+"""LION — pure two-speed (K-shaped) thematic thesis math (no I/O, no MCP, no clock).
+
+Shared VERBATIM by both books; direction is passed in via `leg` ("long" for the
+"haves" book, "short" for the "have-nots" book). A faithful port of the v2
+lion-producer.py scoring — the ABSOLUTE-trend hard gate, the relative-strength
+TIEBREAKER (bonus only, never a disqualifier), the point weights, the per-group
+conviction sizing weights, and the venue-leverage clamp are copied EXACTLY
+(marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be
+redesigned). Unit-testable on plain candle lists.
+
+KEY DIFFERENCE vs cougar (do NOT confuse them): Lion's universe is THEMATIC — every
+name is already a thesis pick (a "have" or a "have-not"). So the HARD GATE is
+ABSOLUTE 4h trend (never long a confirmed downtrend / never short a confirmed
+uptrend), and cross-sectional excess is a SCORE MODIFIER (tilts size + ranking)
+that NEVER benches a genuinely-trending winner. Cougar, by contrast, DISQUALIFIES
+the wrong-sign excess. The point weights also differ (Lion 4h_bullish=+3 with a
++1 neutral fallback; Cougar 4h_bullish=+2 with no neutral fallback). Ported per
+the v2 lion-producer score_thematic() exactly.
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire
+# score. The Runtime 3.0 scaffold owns the wire envelope, so we keep the raw integer
+# score on data{} and only expose NORM_DIV if a caller wants the v2-equivalent value.
+NORM_DIV = 9.0
+
+# Per-group sizing weights (conviction, NOT dollars) — verbatim v2 defaults. The
+# producer (scan.py) overrides via inputs.sizingWeights; "_default" is the fallback.
+HAVES_WEIGHTS = {
+    "HYPE": 1.5,    # highest-conviction crypto winner
+    "SOL": 0.6,     # modest crypto growth
+    "SPCX": 0.6,    # frontier (xAI) but pre-IPO / 5x-capped / volatile -> smaller
+    "QNT": 0.5,     # quantum, most speculative -> smallest
+    "CBRS": 0.7,    # smaller-cap AI-chip
+    "NBIS": 0.7,    # smaller-cap AI-cloud
+    "_default": 1.0,  # core AI complex (megacap chips + hyperscalers) at full slot
+}
+HAVE_NOTS_WEIGHTS = {"SP500": 1.2, "_default": 0.7}
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def bare(asset):
+    """Bare ticker for sizing-weight + dedup lookups: 'xyz:NVDA' -> 'NVDA'.
+    Verbatim v2 _bare()."""
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2.
+
+    v2-quirk: the BULLISH/BEARISH gate is `>= total * 0.6` where total = lookback - 1,
+    counting STRICT (>) higher-lows / lower-highs. Strength = higher_lows/total
+    (BULLISH) or lower_highs/total (BEARISH). Reproduced exactly."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Trailing-window simple-average RSI. Verbatim v2 calc_rsi (gains[-period:])."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_thematic(asset, candles_1h, candles_4h, own24h, excess, leg, inputs):
+    """Two-speed thematic score for one name. ABSOLUTE trend is the GATE; relative
+    strength (`excess` = own 24h return minus the leg-universe mean) is a TIEBREAKER.
+    Returns a thesis dict or None. The point weights + gates are copied VERBATIM from
+    the v2 lion-producer score_thematic() — do NOT redesign.
+
+    leg == "long":  long a "have" only while its 4h trend is not BEARISH (hard gate);
+                    relative strength is a bonus that never disqualifies a trending have.
+    leg == "short": short a "have-not" only while its 4h trend is not BULLISH (hard gate);
+                    relative weakness is a bonus.
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if leg == "long":
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")        # noted, not penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 82))
+        if rsi > rsi_ob:
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")        # noted, not penalized
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+def sizing_weight(asset, weights):
+    """Per-group conviction multiplier (HYPE large, SOL modest, SP500 core).
+    Keyed by bare ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim
+    v2 sizing_weight()."""
+    if not isinstance(weights, dict):
+        weights = HAVES_WEIGHTS
+    try:
+        w = float(weights.get(bare(asset), weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp desired leverage to the asset's HL venue max. v2-quirk: cross-asset names
+    cap LOW at the venue (SPCX 5x, equities vary) — over-leveraging is a venue reject,
+    so this clamp is load-bearing, not cosmetic. Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/lion/strategy.yaml
+++ b/strategies/lion/strategy.yaml
@@ -1,0 +1,48 @@
+# Lion — Two-Speed-Market (K-shaped) cross-asset long/short hedge fund. A two-instance
+# PACKAGE: this manifest + two self-contained runtime.yaml books (long "haves" / short
+# "have-nots" on SEPARATE wallets, so the AI winners and the laggard shorts can coexist on
+# a net-long tilt) + per-instance scanners/. A faithful Runtime 3.0 port of the v2 Lion
+# v1.0.0 thematic dispersion engine spanning tokenized U.S. equities (Hyperliquid XYZ) +
+# main-DEX crypto on one cross-margined wallet per book. Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: lion
+version: "1.0.0"
+
+catalog:
+  name: "Lion — Two-Speed-Market Cross-Asset L/S"
+  emoji: "🦁"
+  tagline: "Bets on a K-shaped divergence: LONGS the structural winners (the AI complex on Hyperliquid XYZ + the crypto winners HYPE/SOL) on the 'haves' wallet, and SHORTS the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) on the 'have-nots' wallet. Both trend-confirmed on absolute structure, with relative strength as a tiebreaker and per-name conviction sizing (HYPE big, SOL small, SP500 core). The edge is the DISPERSION between the two speeds, not market direction."
+  belief_plain: "Buys the booming AI stocks and crypto winners while shorting the broad stock market and the alts losing ground, each on its own wallet — so it makes money on the GAP between the world's fast lane and slow lane rather than on the market going up or down. It only buys names actually trending up and only shorts names actually rolling over, and bets bigger on its highest-conviction picks."
+  thesis: "The world is splitting into two speeds: the AI complex and HYPE/SOL keep booming while the broad U.S. economy and the rest of crypto struggle. Express it as one thematic long/short book — long the haves, short the have-nots — and the P&L is the dispersion between the two, not the market's direction. The hard gate is ABSOLUTE trend (never long a downtrend, never short an uptrend, even for a thesis name); cross-sectional relative strength only tilts size and ranking. Net exposure is the operator's dial (default modest net-long), set by how much capital each wallet holds."
+  group: multi-asset-whitelist
+  archetype: trend_following     # both legs ride ABSOLUTE-trend-confirmed thematic names; net-long tilt (not market-neutral)
+  sub_style: rotation            # holds the strongest of a curated basket per leg; rotates as leadership shifts
+  asset_classes: [xyz_equities, major_alts, indices]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 9                   # 5 long + 4 short across the two books
+  min_budget: 400
+  assets: ["xyz:NVDA", "xyz:AMD", "xyz:MRVL", "xyz:ARM", "xyz:AVGO", "xyz:INTC", "xyz:TSM", "xyz:ASML", "xyz:CBRS", "xyz:MU", "xyz:SMSN", "xyz:SKHX", "xyz:SNDK", "xyz:CRWV", "xyz:NBIS", "xyz:DELL", "xyz:LITE", "xyz:GOOGL", "xyz:MSFT", "xyz:META", "xyz:AMZN", "xyz:ORCL", "xyz:PLTR", "xyz:NOW", "xyz:IBM", "xyz:SPCX", "xyz:QNT", "HYPE", "SOL", "xyz:SP500", "ETH", "XRP", "DOGE", "AVAX", "LINK", "ADA", "LTC", "NEAR", "APT"]
+  tags: [k-shaped, two-speed, ai-complex, long-short, cross-asset, dispersion, conviction-sizing, hedge-fund, xyz, hype]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: long
+    runtime: long/runtime.yaml
+    wallet_env: LION_LONG_WALLET
+    funding_share: 0.6           # modest net-long tilt (~60/40); operator's dial
+  - name: short
+    runtime: short/runtime.yaml
+    wallet_env: LION_SHORT_WALLET
+    funding_share: 0.4

--- a/strategies/mongoose/long/runtime.yaml
+++ b/strategies/mongoose/long/runtime.yaml
@@ -1,0 +1,134 @@
+# ── MONGOOSE · ON-CHAIN (LONG) book — long the on-chain financial rails ──
+name: mongoose-long
+group: mongoose
+version: 3.0.0
+description: >
+  MONGOOSE ON-CHAIN (LONG) — On-Chain Finance vs Legacy thesis fund (Runtime 3.0 port of
+  v2 Mongoose v1.0.0). This book LONGS the on-chain financial rails — HYPE (the venue),
+  CRCL (Circle/stablecoins), COIN (Coinbase), HOOD (Robinhood), MSTR + PURRDAT (crypto
+  treasuries) — the disruptors eating legacy finance, but only when ABSOLUTE trend confirms
+  (4h structure not bearish + positive momentum), with an RSI blow-off guard. Cross-sectional
+  relative strength tilts size/ranking but never benches a genuinely-trending name. Per-name
+  size scales with account value AND a conviction weight (HYPE 1.3x, CRCL 1.2x; MSTR/PURRDAT
+  sized down). Pairs with the SHORT legacy book on a separate wallet; the P&L is the
+  disruptor-vs-incumbent spread. LONG only.
+
+strategy:
+  wallet: "${MONGOOSE_LONG_WALLET}"
+  slots: 5
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: mongoose_long_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — on-chain-finance basket cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map + per-tick result
+    inputs:
+      leg: "long"
+      # ── VALIDATED on-chain-finance universe (live HL board — main + xyz — authoring time) ──
+      # HYPE on the main DEX; the rest are xyz: (HIP-3) equities. All 6 confirmed live on the
+      # HL meta at authoring time (curl type:meta + type:meta dex:xyz). The per-asset read-guard
+      # is the backstop if any goes thin/delists between authoring and a live tick.
+      universe: ["HYPE", "xyz:CRCL", "xyz:COIN", "xyz:HOOD", "xyz:MSTR", "xyz:PURRDAT"]
+      # Per-NAME conviction sizing weights (multiply the marginPct intent). Bare tickers;
+      # '_default' fallback; clamped [0.1, 3.0] in scoring.sizing_weight.
+      sizingWeights:
+        HYPE: 1.3            # the on-chain venue + token — the core of the thesis
+        CRCL: 1.2            # stablecoin leader — the clearest on-chain-finance winner
+        COIN: 1.0
+        HOOD: 1.0
+        MSTR: 0.7            # levered BTC proxy — double-count risk, sized down
+        PURRDAT: 0.6         # small / levered HYPE proxy
+        _default: 1.0
+      minScore: 5
+      marginPct: 18          # PERCENT of withdrawable (0,100]; runtime sizes (marginPct/100 * weight)*withdrawable
+      maxLeverage: 5         # strict clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 5
+      rankPoolSize: 12       # small on-chain-finance basket — score it all each tick
+      rsThresholdPct: 3.0
+      rsiOverbought: 84      # blow-off guard — crypto-finance equities run hot; loosen
+      volFloorPctOfMedian: 0.2
+      minUniverseForMedianGate: 5   # curated small list -> keep all live names (curation IS the liquidity call)
+      minNotionalPctOfEquity: 0.01
+      venueMinNotionalUsd: 10       # HL physical minimum order value
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      weight: { type: number, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: mongoose_long_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # the scan already applied the curated universe, the absolute-trend gate, the RS tiebreaker, conviction sizing, the leverage clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [mongoose_long_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: mongoose_long_signals
+
+# ── EXIT (DSL — moderate; let the disruptors run, cut reversers; ported VERBATIM from v2) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10080          # 7d — the trend persists; let winners run
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 480            # 8h — cut a winner that peaked then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 960            # 16h — recycle a position going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 16.0                  # slightly wider than equity-only (HYPE vol in basket)
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10,  lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 20,  lock_hw_pct: 40 }   # first LOCK — reachable
+        - { trigger_pct: 35,  lock_hw_pct: 60 }
+        - { trigger_pct: 60,  lock_hw_pct: 78 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6                # basket rotation as leadership shifts
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600                # v2 cooldown_minutes 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 14400     # v2 per_asset_cooldown_minutes 240

--- a/strategies/mongoose/long/scanners/scan.py
+++ b/strategies/mongoose/long/scanners/scan.py
@@ -1,0 +1,366 @@
+"""MONGOOSE — supervised scanner (shared verbatim by both books).
+
+Direction-parametrized: the `long` instance passes leg=LONG (long the on-chain financial
+rails — HYPE + CRCL + COIN + HOOD + MSTR + PURRDAT); the `short` instance passes leg=SHORT
+(short legacy finance + broad financial-beta — BX + SP500). A faithful Runtime 3.0 port of
+the v2 mongoose-producer.py — the curated thematic universe build + absolute-trend scoring +
+cross-sectional relative-strength tiebreaker + per-name conviction sizing is preserved
+exactly. Read-only, single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin)
+  2. build the curated thematic universe: config.universe intersected with the live board +
+     a relative-to-market liquidity floor — BUT skip the median gate on a SMALL CURATED list
+     (< minUniverseForMedianGate), where the curation IS the liquidity decision (v2-quirk)
+  3. rank the universe by 24h relative strength (own 24h return - the universe mean), take the
+     top (long) / bottom (short) rankPoolSize. Cross-sectional excess is a TIEBREAKER only —
+     a 1-name universe still trades (excess vs mean = 0; scored on its own absolute trend)
+  4. score each pooled name with the v2 absolute-trend gate, dedup held + recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT, conviction-weighted, the runtime sizes the $)
+     + a per-name venue-clamped leverage; the runtime owns slots, dedup, execution, DSL.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (asia-ai NASDAQ-bug class). The universe was
+validated against the live HL board (main + xyz) at authoring time; the per-asset guard is the
+runtime backstop for a name that delists or goes thin between authoring and a live tick.
+
+FIDELITY NOTES vs mongoose-producer.py v1.0.0:
+  - v2 stored marginPct as a FRACTION (0.18 long / 0.15 short) and emitted an absolute
+    marginUsd = account_value * marginPct * sizingWeights[name]. This port follows the
+    Runtime 3.0 contract: it emits a top-level `marginPct` PERCENT intent = (marginPct
+    fraction * 100) * sizingWeights[name], and the runtime sizes (marginPct/100)*withdrawable.
+    The per-name conviction weighting is identical; only the unit (fraction->percent) and the
+    sizing owner (producer->runtime) changed. A defensive guard converts an inputs.marginPct
+    that was pasted as a fraction (<=1.0) by x100.
+  - v2's affordability cap decremented a running free_margin and applied a 1.1 fee/slippage
+    headroom per emit so a mixed-size basket never emits an un-fundable order. Preserved: the
+    per-name weighted margin is checked against a running free_margin (1.1 headroom) and the
+    venue-min-notional floor; un-fundable / sub-min names are skipped, not emitted.
+  - DROPPED (v2 had NONE of these, but for the record): no order-lifecycle management
+    (cancel_order / resting-order purge) existed in the v2 producer, so nothing to drop.
+  - v2 push_signal() POSTed each emit and recorded a per-leg recent-signals.json dedup cache;
+    here that becomes the ctx.state dedup map (same TTL semantics) and the runtime POSTs.
+  - v2 emitted min(score/9.0, 1.0) as the [0,1] wire score; the 3.0 scaffold owns the wire
+    envelope, so the raw integer score rides on data{} instead.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll back
+    the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[mongoose.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is taken
+    ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts and makes
+    every size 2x). Mongoose holds both xyz equities AND main-DEX crypto on the same wallet, so
+    both sections routinely carry positions; iterate both. Free margin = equity - committed
+    margin. Verbatim v2 cfg.get_positions (incl. the read-sanity guard)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return -1.0, [], 0.0                         # call failed -> non-positive => skip tick
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return -1.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch, June 2026): a corrupt read can report
+    # margin/notional IN USE while returning an EMPTY positions list — sizing or held-dedup off
+    # that re-enters held names (pyramiding) and mis-sizes. Skip the tick (non-positive value).
+    if used > 1.0 and not positions:
+        print("[mongoose.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return -1.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return ─────────────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, vol, ret24h}. Skips delisted. Verbatim v2 get_universe_meta() +
+    ret_24h() + day_vol() folded together. Names are keyed both raw and uppercased; the live
+    XYZ board already returns the 'xyz:' prefix, so the curated 'xyz:CRCL' etc. match directly."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns ([],[])
+    and the universe loop skips it (asia-ai per-asset read-guard)."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    if isinstance(resp, dict) and resp.get("success") is False:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate):
+    """The curated thematic whitelist intersected with the live board + a relative liquidity
+    floor (>= vol_floor_pct of the whitelist's median 24h vol; NO hardcoded $). Verbatim v2
+    build_universe(), INCLUDING the curated-list exception: on a SMALL list
+    (< minUniverseForMedianGate) the median gate is HARMFUL (it drops an intentionally-included
+    but thinner name e.g. xyz:BX vs xyz:SP500 -> universe collapses to 1 -> the book never
+    trades), so every live (vol>0) name is kept — the curation IS the liquidity decision."""
+    cand = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue                                        # not on the live board — drop
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        cand.append((name, vol))
+    if not cand:
+        return []
+    if len(cand) < int(min_for_gate):                       # v2-quirk: curated small list — keep all live
+        return [n for n, _ in cand]
+    vols = sorted(v for _, v in cand)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in cand if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    whitelist = inputs.get("universe", [])
+    min_score = int(inputs.get("minScore", 5))
+
+    # marginPct INTENT (PERCENT of withdrawable, (0,100]). v2 stored a FRACTION (0.18); the
+    # defensive guard treats a pasted <=1.0 as a fraction and x100 (dire/koala pattern).
+    margin_pct = float(inputs.get("marginPct", 18))
+    if margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 5))
+    rank_pool = int(inputs.get("rankPoolSize", 12))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    min_for_gate = int(inputs.get("minUniverseForMedianGate", 5))
+    min_notional_pct = float(inputs.get("minNotionalPctOfEquity", 0.01))
+    venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist(result=None):
+        if ctx.state is None:
+            return
+        try:
+            rec = {"recent": recent}
+            if result is not None:
+                rec["result"] = result
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[mongoose.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        # Either a genuinely empty account OR a corrupt clearinghouse read — never size or dedup
+        # off a bad read (that pyramided a name to 61% of book in v2 on 2026-06-22). Skip tick.
+        _persist({"ts": now, "leg": leg, "emitted": 0,
+                  "note": "skip — non-positive / inconsistent clearinghouse read"})
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist({"ts": now, "leg": leg, "emitted": 0, "held": held, "note": "slots full"})
+        print(f"[mongoose.scan] leg={leg} WAITING — slots full ({len(held)}/{max_slots})",
+              file=sys.stderr)
+        return []
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate)
+
+    # ── Cross-sectional relative strength over the thematic universe (a score TIEBREAKER;
+    #    absolute trend is the gate inside score_thematic) ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = meta.get("ret24h") if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 1:
+        # v2-quirk: excess vs the mean is a TIEBREAKER, not a gate — a 1-name universe still
+        # trades (excess = 0; scored on its own absolute trend). Only a truly EMPTY universe
+        # aborts (v2 fix: was len < 2, which bricked a 1-name book).
+        _persist({"ts": now, "leg": leg, "scanned": len(universe), "emitted": 0,
+                  "note": "WAITING — no live names in the thematic universe"})
+        print(f"[mongoose.scan] leg={leg} WAITING — empty thematic universe (scanned={len(universe)})",
+              file=sys.stderr)
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=(leg == "long"))     # leaders first (long) / laggards first (short)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_thematic(name, c1, c4, excess, own, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist({"ts": now, "leg": leg, "scanned": len(universe), "pool": len(pool),
+                  "candidates": 0, "emitted": 0, "mean_rs": round(mean_rs, 2), "held": held,
+                  "note": f"WAITING — no name cleared min score {min_score}"})
+        print(f"[mongoose.scan] leg={leg} WAITING — no name cleared min score {min_score}; "
+              f"scanned={len(universe)} pool={len(pool)} held={held}", file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: emit best-scoring first, each sized by its conviction weight, capped to what the
+    # wallet can actually FUND. free_margin decrements as we commit (1.1 fee/slippage headroom)
+    # so a mixed basket of different-sized names never emits an un-fundable order (which would
+    # re-emit an insufficient-funds create_position every tick). Sub-min-notional names skipped.
+    min_notional = max(account_value * min_notional_pct, venue_min_notional)
+
+    out = []
+    emitted = []
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], leg, inputs)
+        name_margin_pct = round(margin_pct * weight, 4)      # PERCENT, conviction-weighted
+        margin_usd = (name_margin_pct / 100.0) * account_value
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # v2-quirk: per-name venue clamp
+        if name_margin_pct <= 0 or leverage <= 0:
+            continue
+        notional = margin_usd * leverage
+        if notional < min_notional:                          # below HL venue minimum order value
+            continue
+        if margin_usd * 1.1 > free_margin:                   # 1.1 = fee/slippage headroom
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": name_margin_pct,                    # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                            # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "weight": weight,
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+            },
+        })
+        recent[th["coin"].upper()] = now
+        free_margin -= margin_usd * 1.1
+        open_slots -= 1
+        emitted.append({"coin": th["coin"], "score": th["score"], "lev": leverage,
+                        "marginPct": name_margin_pct, "weight": weight,
+                        "excess": round(th.get("excess", 0), 2)})
+
+    _persist({"ts": now, "leg": leg, "scanned": len(universe), "pool": len(pool),
+              "candidates": len(candidates), "emitted": len(out), "mean_rs": round(mean_rs, 2),
+              "held": held, "emits": emitted})
+    if out:
+        print(f"[mongoose.scan] leg={leg} EMIT {len(out)} | scanned={len(universe)} "
+              f"pool={len(pool)} candidates={len(candidates)} mean_rs={mean_rs:.2f} "
+              f"elapsed={time.time() - run_start:.2f}s | {emitted}", file=sys.stderr)
+    else:
+        print(f"[mongoose.scan] leg={leg} WAITING — candidates unfundable/sub-min; "
+              f"scanned={len(universe)} candidates={len(candidates)} "
+              f"elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/mongoose/long/scanners/scoring.py
+++ b/strategies/mongoose/long/scanners/scoring.py
@@ -1,0 +1,234 @@
+"""MONGOOSE — pure thematic thesis math (no I/O, no MCP, no clock). Shared verbatim by both
+books; direction is passed in (`leg` = "long" for the on-chain rails book, "short" for the
+legacy hedge book). A faithful port of the v2 mongoose-producer.py scoring — the gates + the
+point weights + the per-name conviction sizing weights are copied EXACTLY (marked `# v2-quirk`
+where the v2 behaviour is load-bearing and must not be redesigned). Unit-testable on plain
+candle lists.
+
+THE THESIS (v2 score_thematic): unlike a pure cross-sectional book (Cougar), Mongoose's
+universe is THEMATIC — every name is already a thesis pick (a "have" or a "have-not"). So the
+HARD GATE is ABSOLUTE trend (long a have only while it is actually trending up; short a
+have-not only while it is actually rolling over). Cross-sectional excess (vs the leg-universe
+mean) is a SCORE MODIFIER / TIEBREAKER, not a disqualifier — it tilts size and ranking toward
+the strongest leaders / weakest laggards without benching a genuinely-trending winner.
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score.
+# The 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and only
+# expose NORM_DIV if a caller wants the v2-equivalent normalised score.
+NORM_DIV = 9.0
+
+# v2 per-group sizing-weight fallbacks (mongoose_config defaults). The runtime config's
+# sizingWeights override these; "_default" is the per-leg fallback. Kept here as the in-scoring
+# defaults so the pure math has no I/O dependency.
+_HAVES_WEIGHTS = {
+    "HYPE": 1.3,    # the on-chain venue + token — the core of the thesis
+    "CRCL": 1.2,    # stablecoin leader — the clearest on-chain-finance winner
+    "COIN": 1.0,
+    "HOOD": 1.0,
+    "MSTR": 0.7,    # levered BTC proxy — double-count risk, sized down
+    "PURRDAT": 0.6,  # small / levered HYPE proxy
+    "_default": 1.0,
+}
+_HAVE_NOTS_WEIGHTS = {"SP500": 1.2, "BX": 0.8, "_default": 1.0}
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def _bare(asset):
+    """Bare ticker for sizing-weight lookups: 'xyz:CRCL' -> 'CRCL'. Verbatim v2 _bare()."""
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_thematic(asset, candles_1h, candles_4h, excess, own24h, leg, inputs):
+    """Thematic absolute-trend score for one curated name, given its excess return vs the
+    leg-universe mean (`excess`) and its own 24h return (`own24h`). Returns a thesis dict or
+    None. The point weights + skip gates are copied VERBATIM from the v2 mongoose-producer
+    score_thematic() — do NOT redesign.
+
+    leg == "long":  long an on-chain rail while it is trending up (HARD GATE: never long a
+                    confirmed 4h downtrend); excess is a bonus tiebreaker, never disqualifies.
+    leg == "short": short a legacy incumbent while it is rolling over (HARD GATE: never short
+                    a confirmed 4h uptrend); capitulation guard so it never shorts an exhausted
+                    bottom.
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if leg == "long":
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")  # noted, not penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 84))
+        if rsi > rsi_ob:                                    # v2-quirk: blow-off guard (don't chase)
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:                                    # v2-quirk: capitulation guard
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+def sizing_weight(asset, leg, inputs):
+    """Per-group conviction multiplier (HYPE 1.3x large, PURRDAT 0.6x small; SP500 1.2x core).
+    Keyed by BARE ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim v2
+    sizing_weight(). The runtime config's sizingWeights override the per-leg defaults."""
+    default = _HAVES_WEIGHTS if leg == "long" else _HAVE_NOTS_WEIGHTS
+    weights = inputs.get("sizingWeights") or default
+    if not isinstance(weights, dict):
+        weights = default
+    try:
+        w = float(weights.get(_bare(asset), weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: each name caps at its
+    venue max (over-leveraging is a venue reject), so this clamp is load-bearing, not cosmetic.
+    Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/mongoose/short/runtime.yaml
+++ b/strategies/mongoose/short/runtime.yaml
@@ -1,0 +1,129 @@
+# ── MONGOOSE · LEGACY (SHORT) book — short legacy finance + broad financial-beta (the hedge) ──
+name: mongoose-short
+group: mongoose
+version: 3.0.0
+description: >
+  MONGOOSE LEGACY (SHORT) — On-Chain Finance vs Legacy thesis fund (Runtime 3.0 port of v2
+  Mongoose v1.0.0). The SHORT leg (the hedge). This book SHORTS legacy finance + broad
+  financial-beta — BX (Blackstone) + SP500 — the incumbents being disrupted by on-chain
+  finance, but only when ABSOLUTE trend confirms (4h structure not bullish + negative
+  momentum), with a CAPITULATION guard so it never shorts an exhausted bottom. Pairs with the
+  LONG on-chain book on a separate wallet; the P&L is the disruptor-vs-incumbent spread. NOTE:
+  a CROSS-SECTOR hedge with a thin short universe (few pure legacy-finance names list on the
+  venue), so it leans on the broad index — looser than a same-sector pair, nets down market
+  beta. SHORT only. Runs tighter than the long book (lower leverage, tighter max-loss, faster
+  stall-cuts) — short squeezes are violent.
+
+strategy:
+  wallet: "${MONGOOSE_SHORT_WALLET}"
+  slots: 2
+  default_leverage: 4
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: mongoose_short_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map + per-tick result
+    inputs:
+      leg: "short"
+      # ── VALIDATED legacy-finance universe (live HL xyz board, authoring time) ──
+      # Both confirmed live on the HL meta (curl type:meta dex:xyz). Deliberately THIN — few
+      # pure legacy-finance names list yet, so the hedge leans on SP500 (broad financial-beta)
+      # plus the one liquid legacy name (BX). Add more incumbents as they list to sharpen the pair.
+      universe: ["xyz:BX", "xyz:SP500"]
+      sizingWeights:
+        SP500: 1.2           # broad financial-beta (the incumbent market) — the core of the hedge
+        BX: 0.8              # Blackstone — legacy alternative-asset finance
+        _default: 1.0
+      minScore: 5
+      marginPct: 15          # PERCENT of withdrawable (0,100]; runtime sizes (marginPct/100 * weight)*withdrawable
+      maxLeverage: 4         # strict 4x clamp (short squeezes are violent), then each name's HL venue max
+      maxSlots: 2
+      rankPoolSize: 8        # v2 config override (config JSON wins over the producer _DEFAULTS)
+      rsThresholdPct: 3.0
+      rsiOversold: 18        # capitulation guard — never short an exhausted bottom
+      volFloorPctOfMedian: 0.2
+      minUniverseForMedianGate: 5   # curated 2-name list -> keep both live names (median gate would collapse it to 1)
+      minNotionalPctOfEquity: 0.01
+      venueMinNotionalUsd: 10       # HL physical minimum order value
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      weight: { type: number, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: mongoose_short_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # the scan already applied the curated universe, the absolute-downtrend gate, the capitulation guard, conviction sizing, the 4x clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [mongoose_short_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: mongoose_short_signals
+
+# ── EXIT (DSL — tighter; short theses decay faster, squeezes are violent; ported VERBATIM from v2) ──
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 7200           # 5d — shorter than the long book
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h — cut a short that bottomed then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 720            # 12h — recycle a short going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                  # tighter than long book — squeeze protection
+      retrace_threshold: 7
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 18,  lock_hw_pct: 45 }   # first LOCK — reachable
+        - { trigger_pct: 35,  lock_hw_pct: 65 }
+        - { trigger_pct: 60,  lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 604800       # 168h (was data_retention_hours: 168)
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 5
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 5400                # v2 cooldown_minutes 90
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 18000     # v2 per_asset_cooldown_minutes 300

--- a/strategies/mongoose/short/scanners/scan.py
+++ b/strategies/mongoose/short/scanners/scan.py
@@ -1,0 +1,366 @@
+"""MONGOOSE — supervised scanner (shared verbatim by both books).
+
+Direction-parametrized: the `long` instance passes leg=LONG (long the on-chain financial
+rails — HYPE + CRCL + COIN + HOOD + MSTR + PURRDAT); the `short` instance passes leg=SHORT
+(short legacy finance + broad financial-beta — BX + SP500). A faithful Runtime 3.0 port of
+the v2 mongoose-producer.py — the curated thematic universe build + absolute-trend scoring +
+cross-sectional relative-strength tiebreaker + per-name conviction sizing is preserved
+exactly. Read-only, single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin)
+  2. build the curated thematic universe: config.universe intersected with the live board +
+     a relative-to-market liquidity floor — BUT skip the median gate on a SMALL CURATED list
+     (< minUniverseForMedianGate), where the curation IS the liquidity decision (v2-quirk)
+  3. rank the universe by 24h relative strength (own 24h return - the universe mean), take the
+     top (long) / bottom (short) rankPoolSize. Cross-sectional excess is a TIEBREAKER only —
+     a 1-name universe still trades (excess vs mean = 0; scored on its own absolute trend)
+  4. score each pooled name with the v2 absolute-trend gate, dedup held + recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT, conviction-weighted, the runtime sizes the $)
+     + a per-name venue-clamped leverage; the runtime owns slots, dedup, execution, DSL.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (asia-ai NASDAQ-bug class). The universe was
+validated against the live HL board (main + xyz) at authoring time; the per-asset guard is the
+runtime backstop for a name that delists or goes thin between authoring and a live tick.
+
+FIDELITY NOTES vs mongoose-producer.py v1.0.0:
+  - v2 stored marginPct as a FRACTION (0.18 long / 0.15 short) and emitted an absolute
+    marginUsd = account_value * marginPct * sizingWeights[name]. This port follows the
+    Runtime 3.0 contract: it emits a top-level `marginPct` PERCENT intent = (marginPct
+    fraction * 100) * sizingWeights[name], and the runtime sizes (marginPct/100)*withdrawable.
+    The per-name conviction weighting is identical; only the unit (fraction->percent) and the
+    sizing owner (producer->runtime) changed. A defensive guard converts an inputs.marginPct
+    that was pasted as a fraction (<=1.0) by x100.
+  - v2's affordability cap decremented a running free_margin and applied a 1.1 fee/slippage
+    headroom per emit so a mixed-size basket never emits an un-fundable order. Preserved: the
+    per-name weighted margin is checked against a running free_margin (1.1 headroom) and the
+    venue-min-notional floor; un-fundable / sub-min names are skipped, not emitted.
+  - DROPPED (v2 had NONE of these, but for the record): no order-lifecycle management
+    (cancel_order / resting-order purge) existed in the v2 producer, so nothing to drop.
+  - v2 push_signal() POSTed each emit and recorded a per-leg recent-signals.json dedup cache;
+    here that becomes the ctx.state dedup map (same TTL semantics) and the runtime POSTs.
+  - v2 emitted min(score/9.0, 1.0) as the [0,1] wire score; the 3.0 scaffold owns the wire
+    envelope, so the raw integer score rides on data{} instead.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll back
+    the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[mongoose.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is taken
+    ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts and makes
+    every size 2x). Mongoose holds both xyz equities AND main-DEX crypto on the same wallet, so
+    both sections routinely carry positions; iterate both. Free margin = equity - committed
+    margin. Verbatim v2 cfg.get_positions (incl. the read-sanity guard)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return -1.0, [], 0.0                         # call failed -> non-positive => skip tick
+    data = _unwrap(ch)
+    if not isinstance(data, dict):
+        return -1.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch, June 2026): a corrupt read can report
+    # margin/notional IN USE while returning an EMPTY positions list — sizing or held-dedup off
+    # that re-enters held names (pyramiding) and mis-sizes. Skip the tick (non-positive value).
+    if used > 1.0 and not positions:
+        print("[mongoose.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return -1.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return ─────────────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, vol, ret24h}. Skips delisted. Verbatim v2 get_universe_meta() +
+    ret_24h() + day_vol() folded together. Names are keyed both raw and uppercased; the live
+    XYZ board already returns the 'xyz:' prefix, so the curated 'xyz:CRCL' etc. match directly."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset, dex-routed for xyz. Guarded — a bad name returns ([],[])
+    and the universe loop skips it (asia-ai per-asset read-guard)."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    if isinstance(resp, dict) and resp.get("success") is False:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate):
+    """The curated thematic whitelist intersected with the live board + a relative liquidity
+    floor (>= vol_floor_pct of the whitelist's median 24h vol; NO hardcoded $). Verbatim v2
+    build_universe(), INCLUDING the curated-list exception: on a SMALL list
+    (< minUniverseForMedianGate) the median gate is HARMFUL (it drops an intentionally-included
+    but thinner name e.g. xyz:BX vs xyz:SP500 -> universe collapses to 1 -> the book never
+    trades), so every live (vol>0) name is kept — the curation IS the liquidity decision."""
+    cand = []
+    for name in whitelist:
+        if not isinstance(name, str):
+            continue
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        if not meta:
+            continue                                        # not on the live board — drop
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        cand.append((name, vol))
+    if not cand:
+        return []
+    if len(cand) < int(min_for_gate):                       # v2-quirk: curated small list — keep all live
+        return [n for n, _ in cand]
+    vols = sorted(v for _, v in cand)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in cand if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    whitelist = inputs.get("universe", [])
+    min_score = int(inputs.get("minScore", 5))
+
+    # marginPct INTENT (PERCENT of withdrawable, (0,100]). v2 stored a FRACTION (0.18); the
+    # defensive guard treats a pasted <=1.0 as a fraction and x100 (dire/koala pattern).
+    margin_pct = float(inputs.get("marginPct", 18))
+    if margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 5))
+    rank_pool = int(inputs.get("rankPoolSize", 12))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    min_for_gate = int(inputs.get("minUniverseForMedianGate", 5))
+    min_notional_pct = float(inputs.get("minNotionalPctOfEquity", 0.01))
+    venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist(result=None):
+        if ctx.state is None:
+            return
+        try:
+            rec = {"recent": recent}
+            if result is not None:
+                rec["result"] = result
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[mongoose.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        # Either a genuinely empty account OR a corrupt clearinghouse read — never size or dedup
+        # off a bad read (that pyramided a name to 61% of book in v2 on 2026-06-22). Skip tick.
+        _persist({"ts": now, "leg": leg, "emitted": 0,
+                  "note": "skip — non-positive / inconsistent clearinghouse read"})
+        return []
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        _persist({"ts": now, "leg": leg, "emitted": 0, "held": held, "note": "slots full"})
+        print(f"[mongoose.scan] leg={leg} WAITING — slots full ({len(held)}/{max_slots})",
+              file=sys.stderr)
+        return []
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(whitelist, meta_map, vol_floor_pct, min_for_gate)
+
+    # ── Cross-sectional relative strength over the thematic universe (a score TIEBREAKER;
+    #    absolute trend is the gate inside score_thematic) ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = meta.get("ret24h") if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 1:
+        # v2-quirk: excess vs the mean is a TIEBREAKER, not a gate — a 1-name universe still
+        # trades (excess = 0; scored on its own absolute trend). Only a truly EMPTY universe
+        # aborts (v2 fix: was len < 2, which bricked a 1-name book).
+        _persist({"ts": now, "leg": leg, "scanned": len(universe), "emitted": 0,
+                  "note": "WAITING — no live names in the thematic universe"})
+        print(f"[mongoose.scan] leg={leg} WAITING — empty thematic universe (scanned={len(universe)})",
+              file=sys.stderr)
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=(leg == "long"))     # leaders first (long) / laggards first (short)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_thematic(name, c1, c4, excess, own, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        _persist({"ts": now, "leg": leg, "scanned": len(universe), "pool": len(pool),
+                  "candidates": 0, "emitted": 0, "mean_rs": round(mean_rs, 2), "held": held,
+                  "note": f"WAITING — no name cleared min score {min_score}"})
+        print(f"[mongoose.scan] leg={leg} WAITING — no name cleared min score {min_score}; "
+              f"scanned={len(universe)} pool={len(pool)} held={held}", file=sys.stderr)
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: emit best-scoring first, each sized by its conviction weight, capped to what the
+    # wallet can actually FUND. free_margin decrements as we commit (1.1 fee/slippage headroom)
+    # so a mixed basket of different-sized names never emits an un-fundable order (which would
+    # re-emit an insufficient-funds create_position every tick). Sub-min-notional names skipped.
+    min_notional = max(account_value * min_notional_pct, venue_min_notional)
+
+    out = []
+    emitted = []
+    for th in candidates:
+        if open_slots <= 0:
+            break
+        weight = scoring.sizing_weight(th["coin"], leg, inputs)
+        name_margin_pct = round(margin_pct * weight, 4)      # PERCENT, conviction-weighted
+        margin_usd = (name_margin_pct / 100.0) * account_value
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # v2-quirk: per-name venue clamp
+        if name_margin_pct <= 0 or leverage <= 0:
+            continue
+        notional = margin_usd * leverage
+        if notional < min_notional:                          # below HL venue minimum order value
+            continue
+        if margin_usd * 1.1 > free_margin:                   # 1.1 = fee/slippage headroom
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": name_margin_pct,                    # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                            # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "weight": weight,
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+            },
+        })
+        recent[th["coin"].upper()] = now
+        free_margin -= margin_usd * 1.1
+        open_slots -= 1
+        emitted.append({"coin": th["coin"], "score": th["score"], "lev": leverage,
+                        "marginPct": name_margin_pct, "weight": weight,
+                        "excess": round(th.get("excess", 0), 2)})
+
+    _persist({"ts": now, "leg": leg, "scanned": len(universe), "pool": len(pool),
+              "candidates": len(candidates), "emitted": len(out), "mean_rs": round(mean_rs, 2),
+              "held": held, "emits": emitted})
+    if out:
+        print(f"[mongoose.scan] leg={leg} EMIT {len(out)} | scanned={len(universe)} "
+              f"pool={len(pool)} candidates={len(candidates)} mean_rs={mean_rs:.2f} "
+              f"elapsed={time.time() - run_start:.2f}s | {emitted}", file=sys.stderr)
+    else:
+        print(f"[mongoose.scan] leg={leg} WAITING — candidates unfundable/sub-min; "
+              f"scanned={len(universe)} candidates={len(candidates)} "
+              f"elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/mongoose/short/scanners/scoring.py
+++ b/strategies/mongoose/short/scanners/scoring.py
@@ -1,0 +1,234 @@
+"""MONGOOSE — pure thematic thesis math (no I/O, no MCP, no clock). Shared verbatim by both
+books; direction is passed in (`leg` = "long" for the on-chain rails book, "short" for the
+legacy hedge book). A faithful port of the v2 mongoose-producer.py scoring — the gates + the
+point weights + the per-name conviction sizing weights are copied EXACTLY (marked `# v2-quirk`
+where the v2 behaviour is load-bearing and must not be redesigned). Unit-testable on plain
+candle lists.
+
+THE THESIS (v2 score_thematic): unlike a pure cross-sectional book (Cougar), Mongoose's
+universe is THEMATIC — every name is already a thesis pick (a "have" or a "have-not"). So the
+HARD GATE is ABSOLUTE trend (long a have only while it is actually trending up; short a
+have-not only while it is actually rolling over). Cross-sectional excess (vs the leg-universe
+mean) is a SCORE MODIFIER / TIEBREAKER, not a disqualifier — it tilts size and ranking toward
+the strongest leaders / weakest laggards without benching a genuinely-trending winner.
+"""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score.
+# The 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and only
+# expose NORM_DIV if a caller wants the v2-equivalent normalised score.
+NORM_DIV = 9.0
+
+# v2 per-group sizing-weight fallbacks (mongoose_config defaults). The runtime config's
+# sizingWeights override these; "_default" is the per-leg fallback. Kept here as the in-scoring
+# defaults so the pure math has no I/O dependency.
+_HAVES_WEIGHTS = {
+    "HYPE": 1.3,    # the on-chain venue + token — the core of the thesis
+    "CRCL": 1.2,    # stablecoin leader — the clearest on-chain-finance winner
+    "COIN": 1.0,
+    "HOOD": 1.0,
+    "MSTR": 0.7,    # levered BTC proxy — double-count risk, sized down
+    "PURRDAT": 0.6,  # small / levered HYPE proxy
+    "_default": 1.0,
+}
+_HAVE_NOTS_WEIGHTS = {"SP500": 1.2, "BX": 0.8, "_default": 1.0}
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def _bare(asset):
+    """Bare ticker for sizing-weight lookups: 'xyz:CRCL' -> 'CRCL'. Verbatim v2 _bare()."""
+    a = str(asset or "")
+    return (a.split(":", 1)[1] if ":" in a else a).upper()
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_thematic(asset, candles_1h, candles_4h, excess, own24h, leg, inputs):
+    """Thematic absolute-trend score for one curated name, given its excess return vs the
+    leg-universe mean (`excess`) and its own 24h return (`own24h`). Returns a thesis dict or
+    None. The point weights + skip gates are copied VERBATIM from the v2 mongoose-producer
+    score_thematic() — do NOT redesign.
+
+    leg == "long":  long an on-chain rail while it is trending up (HARD GATE: never long a
+                    confirmed 4h downtrend); excess is a bonus tiebreaker, never disqualifies.
+    leg == "short": short a legacy incumbent while it is rolling over (HARD GATE: never short
+                    a confirmed 4h uptrend); capitulation guard so it never shorts an exhausted
+                    bottom.
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if leg == "long":
+        # ── HARD GATE: never long a confirmed downtrend ──
+        if trend4 == "BEARISH":
+            return None
+        if trend4 == "BULLISH":
+            score += 3
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        # absolute momentum
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        # relative strength = TIEBREAKER (bonus only; never disqualifies a have)
+        if excess >= 2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess < -rs_thresh:
+            reasons.append(f"rs_lag_{excess:+.1f}%")  # noted, not penalized
+        rsi_ob = float(inputs.get("rsiOverbought", 84))
+        if rsi > rsi_ob:                                    # v2-quirk: blow-off guard (don't chase)
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        # ── HARD GATE: never short a confirmed uptrend ──
+        if trend4 == "BULLISH":
+            return None
+        if trend4 == "BEARISH":
+            score += 3
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        else:
+            score += 1
+            reasons.append("4h_neutral")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        if excess <= -2 * rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess > rs_thresh:
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        rsi_os = float(inputs.get("rsiOversold", 18))
+        if rsi < rsi_os:                                    # v2-quirk: capitulation guard
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+def sizing_weight(asset, leg, inputs):
+    """Per-group conviction multiplier (HYPE 1.3x large, PURRDAT 0.6x small; SP500 1.2x core).
+    Keyed by BARE ticker; falls back to '_default'. Clamped to [0.1, 3.0]. Verbatim v2
+    sizing_weight(). The runtime config's sizingWeights override the per-leg defaults."""
+    default = _HAVES_WEIGHTS if leg == "long" else _HAVE_NOTS_WEIGHTS
+    weights = inputs.get("sizingWeights") or default
+    if not isinstance(weights, dict):
+        weights = default
+    try:
+        w = float(weights.get(_bare(asset), weights.get("_default", 1.0)))
+    except (TypeError, ValueError):
+        w = 1.0
+    return max(0.1, min(3.0, w))
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: each name caps at its
+    venue max (over-leveraging is a venue reject), so this clamp is load-bearing, not cosmetic.
+    Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/mongoose/strategy.yaml
+++ b/strategies/mongoose/strategy.yaml
@@ -1,0 +1,53 @@
+# Mongoose — On-Chain Finance vs Legacy hedge fund. A two-instance PACKAGE: this manifest
+# + two self-contained runtime.yaml books (long / short on SEPARATE wallets, so the on-chain
+# longs and the legacy shorts can coexist) + per-instance scanners/. A faithful Runtime 3.0
+# port of the v2 Mongoose v1.0.0 — ONE producer (mongoose-producer.py) driven by MONGOOSE_LEG
+# into two books, each scoring its OWN curated thematic universe on ABSOLUTE trend with
+# cross-sectional relative strength as a tiebreaker, per-name conviction sizing weights.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: mongoose
+version: "1.0.0"
+
+catalog:
+  name: "Mongoose — On-Chain Finance vs Legacy"
+  emoji: "🪙"
+  tagline: "Bets money is migrating on-chain: LONGS the on-chain financial rails (HYPE the venue + Circle/CRCL + Coinbase/COIN + Robinhood/HOOD + BTC treasuries MSTR/PURRDAT) on one wallet and SHORTS legacy finance + broad financial-beta (Blackstone/BX + SP500) on another — both trend-confirmed on absolute 4h/1h structure — so the P&L is the disruptor-vs-incumbent spread."
+  belief_plain: "Buys the companies and tokens that are pulling finance on-chain (the crypto exchange, the stablecoin issuer, the BTC treasuries) and at the same time shorts the old-finance incumbents and the broad market, on two separate wallets. It only buys names that are actually trending up and only shorts names actually rolling over, and it bets bigger on its highest-conviction picks (HYPE and Circle)."
+  thesis: "Money is migrating on-chain — stablecoins, crypto exchanges and BTC treasuries are eating legacy financial rails. You want to own the disruptors and short the incumbents so the return is the GAP between them, not the direction of the market. HONEST CAVEAT: the hedge is cross-sector and the short universe is thin (few pure legacy-finance names list on the venue yet), so the short leg leans on the broad index — it nets down market beta rather than perfectly isolating the pair, and the long book is the strong, high-conviction side."
+  group: multi-asset-whitelist
+  archetype: structural_neutral   # long disruptors / short incumbents — a (loose, cross-sector) spread pair
+  sub_style: pairs_rv             # relative-value: the disruptor-vs-incumbent spread is the edge
+  asset_classes: [xyz_equities, indices, major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 7                    # long book 5 + short book 2
+  min_budget: 400                 # two wallets, ~$200 floor each
+  assets: ["HYPE", "xyz:CRCL", "xyz:COIN", "xyz:HOOD", "xyz:MSTR", "xyz:PURRDAT", "xyz:BX", "xyz:SP500"]
+  tags: [on-chain-finance, hedge-fund, long-short, disruptor-vs-incumbent, hype, stablecoins, crypto-treasuries, conviction-sizing, xyz, thematic]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+# ── FUNDING SPLIT DEFAULT: net-long tilt (the thesis is bullish the disruptors) ──
+# The split is an OPERATOR funding dial (sums to 1.0), set across the two wallets — NOT a
+# runtime-enforced field. The on-chain (long) book defaults larger (5 slots / 18% / 5x) than
+# the legacy (short) hedge book (2 slots / 15% / 4x). Fund 50/50 for a tighter (still
+# cross-sector) hedge. See config _hedge_note in the v2 source.
+instances:
+  - name: long
+    runtime: long/runtime.yaml          # -> runtime name mongoose-long, group mongoose
+    wallet_env: MONGOOSE_LONG_WALLET     # bound as ${MONGOOSE_LONG_WALLET} in long/runtime.yaml
+    funding_share: 0.65
+  - name: short
+    runtime: short/runtime.yaml         # -> runtime name mongoose-short, group mongoose
+    wallet_env: MONGOOSE_SHORT_WALLET
+    funding_share: 0.35

--- a/strategies/octopus/long/runtime.yaml
+++ b/strategies/octopus/long/runtime.yaml
@@ -1,0 +1,121 @@
+# ── OCTOPUS · LONG book — long the relative-strength LEADERS of the live crypto cross-section ──
+name: octopus-long
+group: octopus
+version: 3.0.0
+description: >
+  OCTOPUS LONG — market-neutral crypto long/short dispersion fund (Runtime 3.0 port of v2
+  Octopus v1.0). This book ranks the LIVE liquid main-DEX crypto cross-section (top
+  universeMaxNames by 24h volume, then a relative liquidity floor — NO fixed whitelist) by
+  24h RELATIVE STRENGTH (excess return vs the universe mean) and LONGS the strongest names —
+  but only when absolute trend confirms (4h structure bullish + positive own momentum), with
+  an RSI blow-off guard, so it never longs a least-bad laggard in a crash. Pairs with the
+  SHORT book on a separate, equally-funded wallet; the two net to ~beta-neutral. The edge is
+  CRYPTO DISPERSION (leaders minus laggards), not market direction.
+
+strategy:
+  wallet: "${OCTOPUS_LONG_WALLET}"
+  slots: 4
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: octopus_long_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — crypto dispersion cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map + per-tick result observability
+    inputs:
+      leg: "long"
+      # ── Universe is the LIVE liquid main-DEX crypto board (no fixed whitelist) ──
+      # XYZ equities excluded (Octopus ranks crypto dispersion). Top universeMaxNames by
+      # 24h volume, then a relative-to-market liquidity floor (NO hardcoded $).
+      minScore: 5
+      marginPct: 20          # PERCENT of withdrawable (0,100]; runtime sizes (marginPct/100)*withdrawable. v2 fraction 0.20 -> 20
+      maxLeverage: 5         # strict clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 4
+      universeMaxNames: 40   # cap the cross-section to the most-liquid majors
+      rankPoolSize: 12       # top-N by RS that get candles pulled for confirmation
+      rsThresholdPct: 3.0
+      rsiOverbought: 80      # blow-off guard — don't chase an overbought leader
+      volFloorPctOfMedian: 0.2
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: octopus_long_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # the scan already applied RS rank + trend + clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [octopus_long_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: octopus_long_signals
+
+# ── EXIT (DSL — moderate dispersion management, crypto rhythm; ported VERBATIM from v2) ──
+# A dispersion leg rides a relative trend. Cut reversers, lock profit as the relative move
+# extends, and exit stalled positions (the spread mean-reverted). Stall-cuts are ON — a
+# dispersion position that stops working should be recycled into a fresher leader.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760           # 4d staleness cap
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h — cut a leader that peaked then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 720            # 12h — recycle a position going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 14.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 18,  lock_hw_pct: 40 }   # first LOCK — reachable on a real dispersion winner
+        - { trigger_pct: 35,  lock_hw_pct: 60 }
+        - { trigger_pct: 60,  lock_hw_pct: 78 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 432000        # v2 data_retention_hours 120 (x3600)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6                # basket rotation as leadership shifts
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600                # v2 cooldown_minutes 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true  # dispersion winners spike then settle; don't let a closed leader's peak halt next-day entries while net green
+    per_asset_cooldown_seconds: 10800     # v2 per_asset_cooldown_minutes 180

--- a/strategies/octopus/long/scanners/scan.py
+++ b/strategies/octopus/long/scanners/scan.py
@@ -1,0 +1,337 @@
+"""OCTOPUS — supervised scanner (shared verbatim by both books).
+
+Direction-parametrized: the `long` instance passes leg=LONG (long the relative-strength
+LEADERS of the live crypto cross-section); the `short` instance passes leg=SHORT (short the
+LAGGARDS). A faithful Runtime 3.0 port of the v2 octopus-producer.py — the cross-sectional
+relative-strength rank + dispersion scoring is preserved exactly. Read-only, single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin)
+  2. build the live universe: ALL main-DEX crypto perps (XYZ excluded), capped to the top
+     universeMaxNames by 24h volume, then a relative-to-market liquidity floor (NO hardcoded
+     $) — names with 24h vol < volFloorPctOfMedian x the cohort median are dropped
+  3. rank the universe by 24h relative strength (own 24h return - the universe mean), take
+     the top (long) / bottom (short) rankPoolSize names
+  4. pull 1h+4h candles for ONLY the pooled names, score with the v2 dispersion gates, dedup
+     held + recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT, the runtime sizes) + a per-name
+     venue-clamped leverage; the runtime owns slots, dedup, execution, DSL.
+
+FIDELITY NOTES vs octopus-producer.py v1.0.0:
+  - v2 ran one long-lived producer_daemon driven by OCTOPUS_LEG; here the leg is an `inputs`
+    field (long/runtime.yaml -> leg=long, short/runtime.yaml -> leg=short). One shared
+    scan.py + scoring.py, two runtime instances.
+  - v2 stored marginPct as a FRACTION (0.20) and computed margin_usd = account_value *
+    marginPct, then emitted the absolute USD. Runtime 3.0 sizes from a PERCENT intent, so
+    this port carries marginPct=20 (PERCENT) in runtime.yaml and emits a top-level
+    `marginPct`; the runtime sizes (marginPct/100)*withdrawable. A defensive guard converts
+    a value <= 1.0 (an operator who pasted the v2 fraction 0.20) to a PERCENT (*100). FLAGGED.
+  - v2's per-tick `affordable` cap (never emit more entries than free margin can FUND) is
+    preserved verbatim — an open slot with no free margin would otherwise re-emit an
+    un-fillable order every tick (insufficient-funds spam).
+  - v2 push_signal + record_signal -> ctx.state dedup map (same 180s TTL semantics, 4x-TTL
+    prune via the recent-window filter).
+  - The v2 LLM entry gate was an explicit pass-through ("honor the signal unless malformed").
+    The Runtime 3.0 action is decision_mode: rule — the scan IS the decision — so the
+    pass-through LLM step is correctly dropped. The scan already applied the RS rank, 4h/1h
+    trend confirmation, the venue leverage clamp, and held-asset/race dedup.
+  - DROPPED (read-only scan cannot mutate): nothing — the v2 producer had no order-lifecycle
+    management (no cancel_order / has_resting_orders / stale-order purge). Pure emit path.
+  - v2's unused first-seen / recent-signals JSON files collapse into ctx.state.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (asia-ai NASDAQ-bug class). Per the scan
+contract, ANY uncaught exception rolls the whole tick back to [] — one bad read would
+silently kill all emits."""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[octopus.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts
+    and makes every size 2x). Free margin = equity - committed margin."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an
+    # EMPTY positions list is a corrupt read — sizing or held-dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return ─────────────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, vol, ret24h}. Skips delisted. Verbatim v2 get_universe_meta()
+    + ret_24h() + day_vol() folded together (markPx/prevDayPx/dayNtlVlm from the board)."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset. Guarded — a bad name returns ([], []) and the universe
+    loop skips it (asia-ai per-asset read-guard)."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(meta_map, max_names, vol_floor_pct):
+    """Resolve the live liquid main-DEX crypto cross-section to rank this tick. Verbatim v2
+    build_universe(): a name qualifies if it is a main-DEX perp (NO xyz: prefix), survives
+    the top-`max_names`-by-24h-volume cap, and is in the liquid cohort (24h vol >=
+    vol_floor_pct of the top-N median — relative-to-market, NO hardcoded $ floor). XYZ
+    equities are excluded (Octopus ranks crypto dispersion; XYZ has no clean peer group)."""
+    seen, pool = set(), []
+    for name, meta in meta_map.items():
+        if not isinstance(name, str) or name.lower().startswith("xyz:"):
+            continue
+        key = name.upper()
+        if key != name:
+            continue                                         # skip the .upper() alias dup-key
+        if key in seen:
+            continue
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        seen.add(key)
+        pool.append((name, vol))
+    pool.sort(key=lambda x: x[1], reverse=True)
+    pool = pool[:max_names]
+    if not pool:
+        return []
+    # Relative-to-market liquidity gate (NO hardcoded $): keep only names whose 24h volume is
+    # >= vol_floor_pct of the top-N cohort's median. The top-N cap already restricts to the
+    # most-liquid majors; this drops the anomalously thin tail. Budget-independent.
+    vols = sorted(v for _, v in pool)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in pool if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    min_score = int(inputs.get("minScore", 5))
+
+    # marginPct is a PERCENT in (0,100]. FLAGGED: defensively convert a value <= 1.0 (an
+    # operator who pasted the v2 FRACTION 0.20) into a PERCENT so it never silently sizes
+    # ~100x small (resolve-margin sizes (marginPct/100)*withdrawable).
+    margin_pct = float(inputs.get("marginPct", 20))
+    if margin_pct <= 1.0:
+        print(f"[octopus.scan] marginPct={margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
+
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 4))
+    max_names = int(inputs.get("universeMaxNames", 40))
+    rank_pool = int(inputs.get("rankPoolSize", 12))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist(result=None):
+        if ctx.state is None:
+            return
+        rec = {"recent": recent}
+        if result is not None:
+            rec["signaled"] = result.get("emitted", 0)
+            rec["result"] = result
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[octopus.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        print(f"[octopus.scan] leg={leg} WAITING — no account value / corrupt read",
+              file=sys.stderr)
+        _persist({"emitted": 0, "gate": "no_account_value"})
+        return []                                            # no value / corrupt read — skip tick
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        print(f"[octopus.scan] leg={leg} WAITING — slots full ({len(held)}/{max_slots})",
+              file=sys.stderr)
+        _persist({"emitted": 0, "gate": "slots_full", "held": sorted(held_set)})
+        return []                                            # book full — runtime also caps via slots
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(meta_map, max_names, vol_floor_pct)
+
+    # ── Cross-sectional relative-strength rank (one pass, no candle fetch) (v2-quirk) ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = meta.get("ret24h") if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 5:                                          # v2-quirk: too thin to rank a cross-section
+        print(f"[octopus.scan] leg={leg} WAITING — cross-section too thin to rank "
+              f"({len(rs)} ranked, scanned {len(universe)})", file=sys.stderr)
+        _persist({"emitted": 0, "gate": "thin_cross_section", "scanned": len(universe)})
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=(leg == "long"))     # leaders first (long) / laggards first (short)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup race window
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_dispersion(name, c1, c4, excess, own, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        print(f"[octopus.scan] leg={leg} WAITING — no name cleared min score {min_score} "
+              f"(scanned {len(universe)}, pool {len(pool)}, mean_rs {mean_rs:.2f})",
+              file=sys.stderr)
+        _persist({"emitted": 0, "gate": "no_candidate", "scanned": len(universe),
+                  "pool": len(pool), "mean_rs": round(mean_rs, 2)})
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: never emit more than the wallet can actually FUND. An open slot with no free
+    # margin re-emits an un-fillable order every tick (insufficient-funds spam). free margin
+    # is sized as (marginPct/100)*accountValue per name + 1.1 fee/slippage headroom.
+    per_name_margin = (margin_pct / 100.0) * account_value
+    affordable = int(free_margin / (per_name_margin * 1.1)) if per_name_margin > 0 else 0
+    to_emit = candidates[:max(0, min(open_slots, affordable))]
+
+    out = []
+    for th in to_emit:
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # v2-quirk: per-name venue clamp
+        if leverage <= 0:
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": margin_pct,                           # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                              # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+            },
+        })
+        recent[th["coin"].upper()] = now
+
+    _persist({"emitted": len(out), "gate": "emit", "scanned": len(universe),
+              "pool": len(pool), "candidates": len(candidates),
+              "mean_rs": round(mean_rs, 2),
+              "coins": [o["asset"] for o in out]})
+    print(f"[octopus.scan] leg={leg} {'EMIT' if out else 'WAITING'} scanned={len(universe)} "
+          f"pool={len(pool)} candidates={len(candidates)} emitted={len(out)} "
+          f"mean_rs={mean_rs:.2f} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/octopus/long/scanners/scoring.py
+++ b/strategies/octopus/long/scanners/scoring.py
@@ -1,0 +1,183 @@
+"""OCTOPUS — pure dispersion thesis math (no I/O, no MCP, no clock). Shared verbatim by
+both books; direction is passed in (`leg` = "long" for the leaders book, "short" for the
+laggards book). A faithful port of the v2 octopus-producer.py scoring — the gates + the
+point weights are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing
+and must not be redesigned). Unit-testable on plain candle lists."""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score.
+# The 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and
+# only use NORM_DIV if a caller wants the v2-equivalent normalised score.
+NORM_DIV = 9.0
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_dispersion(asset, candles_1h, candles_4h, excess, own24h, leg, inputs):
+    """Cross-sectional dispersion score for one crypto perp, given its excess return vs the
+    universe mean (`excess`) and its own 24h return (`own24h`). Returns a thesis dict or
+    None. The point weights + skip gates are copied VERBATIM from the v2 octopus-producer
+    score_dispersion() — do NOT redesign.
+
+    leg == "long":  long the relative-strength LEADERS  (positive excess + bullish trend)
+    leg == "short": short the relative-strength LAGGARDS (negative excess + bearish trend)
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if leg == "long":
+        if excess < 0:                                      # v2-quirk: must be a relative LEADER
+            return None
+        if excess >= 2 * rs_thresh:
+            score += 3
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        else:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        if trend4 == "BEARISH":                             # v2-quirk: never long a 4h downtrend
+            return None
+        if trend4 == "BULLISH":
+            score += 2
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        rsi_ob = float(inputs.get("rsiOverbought", 80))
+        if rsi > rsi_ob:                                    # v2-quirk: blow-off guard (don't chase)
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        if excess > 0:                                      # v2-quirk: must be a relative LAGGARD
+            return None
+        if excess <= -2 * rs_thresh:
+            score += 3
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        else:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        if trend4 == "BULLISH":                             # v2-quirk: never short a 4h uptrend
+            return None
+        if trend4 == "BEARISH":
+            score += 2
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        rsi_os = float(inputs.get("rsiOversold", 20))
+        if rsi < rsi_os:                                    # v2-quirk: capitulation guard
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: over-leveraging a
+    name above its venue cap is a venue reject, so this clamp is load-bearing, not cosmetic.
+    Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/octopus/short/runtime.yaml
+++ b/strategies/octopus/short/runtime.yaml
@@ -1,0 +1,122 @@
+# ── OCTOPUS · SHORT book — short the relative-strength LAGGARDS of the live crypto cross-section ──
+name: octopus-short
+group: octopus
+version: 3.0.0
+description: >
+  OCTOPUS SHORT — market-neutral crypto long/short dispersion fund (Runtime 3.0 port of v2
+  Octopus v1.0). This book ranks the LIVE liquid main-DEX crypto cross-section (top
+  universeMaxNames by 24h volume, then a relative liquidity floor — NO fixed whitelist) by
+  24h RELATIVE WEAKNESS (negative excess return vs the universe mean) and SHORTS the weakest
+  names — but only when absolute trend confirms (4h structure bearish + negative own
+  momentum), with an RSI capitulation guard, so it never shorts a relative outperformer
+  that's still rising. Pairs with the LONG book on a separate, equally-funded wallet; the two
+  net to ~beta-neutral. The edge is CRYPTO DISPERSION (leaders minus laggards), not market
+  direction. In an alts-crushed regime this book gravitates to the carnage.
+
+strategy:
+  wallet: "${OCTOPUS_SHORT_WALLET}"
+  slots: 4
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: octopus_short_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                 # v2 tickSeconds — crypto dispersion cadence
+    timeout_seconds: 180
+    default_signal_validity_seconds: 900
+    state_history_max_count: 50           # signal-dedup map + per-tick result observability
+    inputs:
+      leg: "short"
+      # ── Universe is the LIVE liquid main-DEX crypto board (no fixed whitelist) ──
+      # XYZ equities excluded (Octopus ranks crypto dispersion). Top universeMaxNames by
+      # 24h volume, then a relative-to-market liquidity floor (NO hardcoded $).
+      minScore: 5
+      marginPct: 20          # PERCENT of withdrawable (0,100]; runtime sizes (marginPct/100)*withdrawable. v2 fraction 0.20 -> 20
+      maxLeverage: 5         # strict clamp, then each name's HL venue max (per-name, in-scan)
+      maxSlots: 4
+      universeMaxNames: 40   # cap the cross-section to the most-liquid majors
+      rankPoolSize: 12       # bottom-N by RS that get candles pulled for confirmation
+      rsThresholdPct: 3.0
+      rsiOversold: 20        # capitulation guard — don't short an oversold bottom
+      volFloorPctOfMedian: 0.2
+      recentSignalTtlSeconds: 180
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      trend4h: { type: string, required: false }
+      excess: { type: number, required: false }
+      own24h: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: octopus_short_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                   # the scan already applied RS rank + trend + clamp + dedup (v2 LLM gate was pass-through)
+    scanners: [octopus_short_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: octopus_short_signals
+
+# ── EXIT (DSL — moderate dispersion management, crypto rhythm; ported VERBATIM from v2) ──
+# A dispersion leg rides a relative trend. Cut squeezes, lock profit as the relative move
+# extends, and exit stalled positions (the spread mean-reverted). Stall-cuts are ON — a
+# short that stops working should be recycled into a fresher laggard.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760           # 4d staleness cap
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 360            # 6h — cut a laggard-short that peaked then stalled
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 720            # 12h — recycle a position going nowhere
+    phase1:
+      enabled: true
+      max_loss_pct: 14.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,   lock_hw_pct: 0 }    # priming tier (arms the trail; no lock yet)
+        - { trigger_pct: 18,  lock_hw_pct: 40 }   # first LOCK — reachable on a real dispersion winner
+        - { trigger_pct: 35,  lock_hw_pct: 60 }
+        - { trigger_pct: 60,  lock_hw_pct: 78 }
+        - { trigger_pct: 100, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 432000        # v2 data_retention_hours 120 (x3600)
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 6                # basket rotation as weakness shifts
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600                # v2 cooldown_minutes 60
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true  # dispersion winners spike then settle; don't let a closed laggard-short's peak halt next-day entries while net green
+    per_asset_cooldown_seconds: 10800     # v2 per_asset_cooldown_minutes 180

--- a/strategies/octopus/short/scanners/scan.py
+++ b/strategies/octopus/short/scanners/scan.py
@@ -1,0 +1,337 @@
+"""OCTOPUS — supervised scanner (shared verbatim by both books).
+
+Direction-parametrized: the `long` instance passes leg=LONG (long the relative-strength
+LEADERS of the live crypto cross-section); the `short` instance passes leg=SHORT (short the
+LAGGARDS). A faithful Runtime 3.0 port of the v2 octopus-producer.py — the cross-sectional
+relative-strength rank + dispersion scoring is preserved exactly. Read-only, single-pass.
+
+Per tick:
+  1. read the wallet clearinghouse (account value + held names + free margin)
+  2. build the live universe: ALL main-DEX crypto perps (XYZ excluded), capped to the top
+     universeMaxNames by 24h volume, then a relative-to-market liquidity floor (NO hardcoded
+     $) — names with 24h vol < volFloorPctOfMedian x the cohort median are dropped
+  3. rank the universe by 24h relative strength (own 24h return - the universe mean), take
+     the top (long) / bottom (short) rankPoolSize names
+  4. pull 1h+4h candles for ONLY the pooled names, score with the v2 dispersion gates, dedup
+     held + recently-signalled
+  5. emit a top-level marginPct INTENT (PERCENT, the runtime sizes) + a per-name
+     venue-clamped leverage; the runtime owns slots, dedup, execution, DSL.
+
+FIDELITY NOTES vs octopus-producer.py v1.0.0:
+  - v2 ran one long-lived producer_daemon driven by OCTOPUS_LEG; here the leg is an `inputs`
+    field (long/runtime.yaml -> leg=long, short/runtime.yaml -> leg=short). One shared
+    scan.py + scoring.py, two runtime instances.
+  - v2 stored marginPct as a FRACTION (0.20) and computed margin_usd = account_value *
+    marginPct, then emitted the absolute USD. Runtime 3.0 sizes from a PERCENT intent, so
+    this port carries marginPct=20 (PERCENT) in runtime.yaml and emits a top-level
+    `marginPct`; the runtime sizes (marginPct/100)*withdrawable. A defensive guard converts
+    a value <= 1.0 (an operator who pasted the v2 fraction 0.20) to a PERCENT (*100). FLAGGED.
+  - v2's per-tick `affordable` cap (never emit more entries than free margin can FUND) is
+    preserved verbatim — an open slot with no free margin would otherwise re-emit an
+    un-fillable order every tick (insufficient-funds spam).
+  - v2 push_signal + record_signal -> ctx.state dedup map (same 180s TTL semantics, 4x-TTL
+    prune via the recent-window filter).
+  - The v2 LLM entry gate was an explicit pass-through ("honor the signal unless malformed").
+    The Runtime 3.0 action is decision_mode: rule — the scan IS the decision — so the
+    pass-through LLM step is correctly dropped. The scan already applied the RS rank, 4h/1h
+    trend confirmation, the venue leverage clamp, and held-asset/race dedup.
+  - DROPPED (read-only scan cannot mutate): nothing — the v2 producer had no order-lifecycle
+    management (no cancel_order / has_resting_orders / stale-order purge). Pure emit path.
+  - v2's unused first-seen / recent-signals JSON files collapse into ctx.state.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped so one bad/illiquid/fake name skips
+without rolling back the whole universe tick (asia-ai NASDAQ-bug class). Per the scan
+contract, ANY uncaught exception rolls the whole tick back to [] — one bad read would
+silently kill all emits."""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_TTL = 180   # 3m: match v2 RECENT_SIGNAL_TTL_SEC — don't re-fire a name in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must NOT roll
+    back the whole tick. Returns None on failure so the caller's degrade path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[octopus.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
+
+
+# ── account / positions ──────────────────────────────────────────────────────
+
+def _get_positions(ctx):
+    """Returns (account_value, [position dicts], free_margin). The 'main' and 'xyz'
+    clearinghouse sections are TWO VIEWS of ONE cross-margined wallet — accountValue is
+    taken ONCE via max() across sections, NEVER summed (v2-quirk: summing double-counts
+    and makes every size 2x). Free margin = equity - committed margin."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, [], 0.0
+    data = _unwrap(ch)
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {}) if isinstance(data, dict) else {}
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = float(pos.get("szi", 0) or 0)
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": float(pos.get("marginUsed", 0) or 0),
+            })
+    # v2-quirk read-sanity guard (funding/$0 glitch 2026-06): margin/notional IN USE but an
+    # EMPTY positions list is a corrupt read — sizing or held-dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
+
+
+# ── live instrument board: venue leverage + 24h vol + 24h return ─────────────
+
+def _get_universe_meta(ctx):
+    """name -> {max_leverage, vol, ret24h}. Skips delisted. Verbatim v2 get_universe_meta()
+    + ret_24h() + day_vol() folded together (markPx/prevDayPx/dayNtlVlm from the board)."""
+    resp = _read(ctx, "market_list_instruments", {})
+    out = {}
+    if not resp:
+        return out
+    insts = _unwrap(resp)
+    if isinstance(insts, dict):
+        insts = insts.get("instruments", [])
+    for inst in insts or []:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        try:
+            mark = float(ctxd.get("markPx", 0) or 0)
+            prev = float(ctxd.get("prevDayPx", 0) or 0)
+        except (TypeError, ValueError):
+            mark = prev = 0.0
+        ret24 = ((mark - prev) / prev * 100.0) if (prev > 0 and mark > 0) else None
+        try:
+            vol = float(ctxd.get("dayNtlVlm", 0) or 0)
+        except (TypeError, ValueError):
+            vol = 0.0
+        entry = {
+            "max_leverage": inst.get("max_leverage", inst.get("maxLeverage")),
+            "ret24h": ret24,
+            "vol": vol,
+        }
+        out[name] = entry
+        out[name.upper()] = entry
+    return out
+
+
+def _fetch_candles(ctx, asset):
+    """1h + 4h candles for ONE asset. Guarded — a bad name returns ([], []) and the universe
+    loop skips it (asia-ai per-asset read-guard)."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "dex": _dex_for(asset),
+        "include_funding": False,
+        "include_order_book": False,
+    })
+    if not resp:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _build_universe(meta_map, max_names, vol_floor_pct):
+    """Resolve the live liquid main-DEX crypto cross-section to rank this tick. Verbatim v2
+    build_universe(): a name qualifies if it is a main-DEX perp (NO xyz: prefix), survives
+    the top-`max_names`-by-24h-volume cap, and is in the liquid cohort (24h vol >=
+    vol_floor_pct of the top-N median — relative-to-market, NO hardcoded $ floor). XYZ
+    equities are excluded (Octopus ranks crypto dispersion; XYZ has no clean peer group)."""
+    seen, pool = set(), []
+    for name, meta in meta_map.items():
+        if not isinstance(name, str) or name.lower().startswith("xyz:"):
+            continue
+        key = name.upper()
+        if key != name:
+            continue                                         # skip the .upper() alias dup-key
+        if key in seen:
+            continue
+        vol = meta.get("vol", 0.0)
+        if vol <= 0:
+            continue
+        seen.add(key)
+        pool.append((name, vol))
+    pool.sort(key=lambda x: x[1], reverse=True)
+    pool = pool[:max_names]
+    if not pool:
+        return []
+    # Relative-to-market liquidity gate (NO hardcoded $): keep only names whose 24h volume is
+    # >= vol_floor_pct of the top-N cohort's median. The top-N cap already restricts to the
+    # most-liquid majors; this drops the anomalously thin tail. Budget-independent.
+    vols = sorted(v for _, v in pool)
+    median = vols[len(vols) // 2]
+    floor = vol_floor_pct * median
+    return [n for n, v in pool if v >= floor]
+
+
+def scan(inputs, ctx):
+    run_start = time.time()
+    leg = (inputs.get("leg", "long") or "long").strip().lower()
+    direction = "LONG" if leg == "long" else "SHORT"
+    min_score = int(inputs.get("minScore", 5))
+
+    # marginPct is a PERCENT in (0,100]. FLAGGED: defensively convert a value <= 1.0 (an
+    # operator who pasted the v2 FRACTION 0.20) into a PERCENT so it never silently sizes
+    # ~100x small (resolve-margin sizes (marginPct/100)*withdrawable).
+    margin_pct = float(inputs.get("marginPct", 20))
+    if margin_pct <= 1.0:
+        print(f"[octopus.scan] marginPct={margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
+
+    max_lev = int(inputs.get("maxLeverage", 5))
+    max_slots = int(inputs.get("maxSlots", 4))
+    max_names = int(inputs.get("universeMaxNames", 40))
+    rank_pool = int(inputs.get("rankPoolSize", 12))
+    vol_floor_pct = float(inputs.get("volFloorPctOfMedian", 0.2))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    now = time.time()
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist(result=None):
+        if ctx.state is None:
+            return
+        rec = {"recent": recent}
+        if result is not None:
+            rec["signaled"] = result.get("emitted", 0)
+            rec["result"] = result
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[octopus.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    account_value, positions, free_margin = _get_positions(ctx)
+    if account_value <= 0:
+        print(f"[octopus.scan] leg={leg} WAITING — no account value / corrupt read",
+              file=sys.stderr)
+        _persist({"emitted": 0, "gate": "no_account_value"})
+        return []                                            # no value / corrupt read — skip tick
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
+
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        print(f"[octopus.scan] leg={leg} WAITING — slots full ({len(held)}/{max_slots})",
+              file=sys.stderr)
+        _persist({"emitted": 0, "gate": "slots_full", "held": sorted(held_set)})
+        return []                                            # book full — runtime also caps via slots
+
+    meta_map = _get_universe_meta(ctx)
+    universe = _build_universe(meta_map, max_names, vol_floor_pct)
+
+    # ── Cross-sectional relative-strength rank (one pass, no candle fetch) (v2-quirk) ──
+    rs = []  # (name, own_24h, meta)
+    for name in universe:
+        meta = meta_map.get(name) or meta_map.get(name.upper())
+        own = meta.get("ret24h") if meta else None
+        if own is None:
+            continue
+        rs.append((name, own, meta))
+    if len(rs) < 5:                                          # v2-quirk: too thin to rank a cross-section
+        print(f"[octopus.scan] leg={leg} WAITING — cross-section too thin to rank "
+              f"({len(rs)} ranked, scanned {len(universe)})", file=sys.stderr)
+        _persist({"emitted": 0, "gate": "thin_cross_section", "scanned": len(universe)})
+        return []
+
+    mean_rs = sum(r[1] for r in rs) / len(rs)
+    rs.sort(key=lambda x: x[1], reverse=(leg == "long"))     # leaders first (long) / laggards first (short)
+    pool = rs[:rank_pool]
+
+    candidates = []
+    for name, own, meta in pool:
+        if name.upper() in held_set:
+            continue
+        if recent.get(name.upper()) is not None and (now - recent[name.upper()]) < ttl:
+            continue                                         # signal-dedup race window
+        excess = own - mean_rs
+        c1, c4 = _fetch_candles(ctx, name)                   # per-asset read-guarded
+        if len(c1) < 8 or len(c4) < 6:
+            continue
+        thesis = scoring.score_dispersion(name, c1, c4, excess, own, leg, inputs)
+        if thesis and thesis["score"] >= min_score:
+            thesis["_meta"] = meta
+            candidates.append(thesis)
+
+    if not candidates:
+        print(f"[octopus.scan] leg={leg} WAITING — no name cleared min score {min_score} "
+              f"(scanned {len(universe)}, pool {len(pool)}, mean_rs {mean_rs:.2f})",
+              file=sys.stderr)
+        _persist({"emitted": 0, "gate": "no_candidate", "scanned": len(universe),
+                  "pool": len(pool), "mean_rs": round(mean_rs, 2)})
+        return []
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+
+    # v2-quirk: never emit more than the wallet can actually FUND. An open slot with no free
+    # margin re-emits an un-fillable order every tick (insufficient-funds spam). free margin
+    # is sized as (marginPct/100)*accountValue per name + 1.1 fee/slippage headroom.
+    per_name_margin = (margin_pct / 100.0) * account_value
+    affordable = int(free_margin / (per_name_margin * 1.1)) if per_name_margin > 0 else 0
+    to_emit = candidates[:max(0, min(open_slots, affordable))]
+
+    out = []
+    for th in to_emit:
+        venue_max = (th.get("_meta") or {}).get("max_leverage")
+        leverage = scoring.clamp_leverage(max_lev, venue_max)  # v2-quirk: per-name venue clamp
+        if leverage <= 0:
+            continue
+        out.append({
+            "asset": th["coin"],
+            "direction": direction,
+            "marginPct": margin_pct,                           # PERCENT intent — runtime sizes the $
+            "leverage": leverage,                              # already venue-clamped
+            "data": {
+                "score": th["score"],
+                "direction": direction,
+                "reasons": th["reasons"][:6],
+                "trend4h": th.get("trend4h"),
+                "excess": round(th.get("excess", 0), 2),
+                "own24h": round(th.get("own24h", 0), 2),
+            },
+        })
+        recent[th["coin"].upper()] = now
+
+    _persist({"emitted": len(out), "gate": "emit", "scanned": len(universe),
+              "pool": len(pool), "candidates": len(candidates),
+              "mean_rs": round(mean_rs, 2),
+              "coins": [o["asset"] for o in out]})
+    print(f"[octopus.scan] leg={leg} {'EMIT' if out else 'WAITING'} scanned={len(universe)} "
+          f"pool={len(pool)} candidates={len(candidates)} emitted={len(out)} "
+          f"mean_rs={mean_rs:.2f} elapsed={time.time() - run_start:.2f}s", file=sys.stderr)
+    return out

--- a/strategies/octopus/short/scanners/scoring.py
+++ b/strategies/octopus/short/scanners/scoring.py
@@ -1,0 +1,183 @@
+"""OCTOPUS — pure dispersion thesis math (no I/O, no MCP, no clock). Shared verbatim by
+both books; direction is passed in (`leg` = "long" for the leaders book, "short" for the
+laggards book). A faithful port of the v2 octopus-producer.py scoring — the gates + the
+point weights are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing
+and must not be redesigned). Unit-testable on plain candle lists."""
+
+# v2-quirk: wire-score normaliser. v2 emitted min(score/9.0, 1.0) as the [0,1] wire score.
+# The 3.0 scaffold owns the wire envelope, so we keep the raw integer score on data{} and
+# only use NORM_DIV if a caller wants the v2-equivalent normalised score.
+NORM_DIV = 9.0
+
+
+def _close(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return float(c[4])                                  # [t,o,h,l,c,v] -> close
+    if isinstance(c, dict):
+        return float(c.get("close", c.get("c", 0)) or 0)
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 3:
+        return float(c[2])                                  # [t,o,h,l,c,v] -> high
+    if isinstance(c, dict):
+        return float(c.get("high", c.get("h", 0)) or 0)
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, (list, tuple)) and len(c) >= 4:
+        return float(c[3])                                  # [t,o,h,l,c,v] -> low
+    if isinstance(c, dict):
+        return float(c.get("low", c.get("l", 0)) or 0)
+    return 0.0
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows / lower-highs structure over the last `lookback` candles. Verbatim v2."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def calc_rsi(closes, period=14):
+    """Wilder-less simple-average RSI. Verbatim v2."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def score_dispersion(asset, candles_1h, candles_4h, excess, own24h, leg, inputs):
+    """Cross-sectional dispersion score for one crypto perp, given its excess return vs the
+    universe mean (`excess`) and its own 24h return (`own24h`). Returns a thesis dict or
+    None. The point weights + skip gates are copied VERBATIM from the v2 octopus-producer
+    score_dispersion() — do NOT redesign.
+
+    leg == "long":  long the relative-strength LEADERS  (positive excess + bullish trend)
+    leg == "short": short the relative-strength LAGGARDS (negative excess + bearish trend)
+    """
+    if len(candles_1h) < 8 or len(candles_4h) < 6:
+        return None
+    closes1 = [_close(c) for c in candles_1h]
+    price = closes1[-1]
+    own = own24h if own24h is not None else 0.0
+
+    trend4, s4 = trend_structure(candles_4h)
+    trend1, s1 = trend_structure(candles_1h)
+    rsi = calc_rsi(closes1)
+    rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
+
+    score = 0
+    reasons = []
+
+    if leg == "long":
+        if excess < 0:                                      # v2-quirk: must be a relative LEADER
+            return None
+        if excess >= 2 * rs_thresh:
+            score += 3
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        elif excess >= rs_thresh:
+            score += 2
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        else:
+            score += 1
+            reasons.append(f"rs_lead_{excess:+.1f}%")
+        if trend4 == "BEARISH":                             # v2-quirk: never long a 4h downtrend
+            return None
+        if trend4 == "BULLISH":
+            score += 2
+            reasons.append(f"4h_bullish_{s4:.0%}")
+        if trend1 == "BULLISH":
+            score += 1
+            reasons.append(f"1h_bullish_{s1:.0%}")
+        elif trend1 == "BEARISH":
+            score -= 1
+            reasons.append("1h_bearish")
+        if own >= 0:
+            score += 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        rsi_ob = float(inputs.get("rsiOverbought", 80))
+        if rsi > rsi_ob:                                    # v2-quirk: blow-off guard (don't chase)
+            score -= 2
+            reasons.append(f"rsi_blowoff_{rsi:.0f}")
+    else:  # short
+        if excess > 0:                                      # v2-quirk: must be a relative LAGGARD
+            return None
+        if excess <= -2 * rs_thresh:
+            score += 3
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        elif excess <= -rs_thresh:
+            score += 2
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        else:
+            score += 1
+            reasons.append(f"rs_lag_{excess:+.1f}%")
+        if trend4 == "BULLISH":                             # v2-quirk: never short a 4h uptrend
+            return None
+        if trend4 == "BEARISH":
+            score += 2
+            reasons.append(f"4h_bearish_{s4:.0%}")
+        if trend1 == "BEARISH":
+            score += 1
+            reasons.append(f"1h_bearish_{s1:.0%}")
+        elif trend1 == "BULLISH":
+            score -= 1
+            reasons.append("1h_bullish")
+        if own <= 0:
+            score += 1
+            reasons.append(f"abs_dn_{own:+.1f}%")
+        else:
+            score -= 1
+            reasons.append(f"abs_up_{own:+.1f}%")
+        rsi_os = float(inputs.get("rsiOversold", 20))
+        if rsi < rsi_os:                                    # v2-quirk: capitulation guard
+            score -= 2
+            reasons.append(f"rsi_capitulation_{rsi:.0f}")
+
+    return {
+        "coin": asset,
+        "direction": "LONG" if leg == "long" else "SHORT",
+        "score": score,
+        "reasons": reasons,
+        "price": price,
+        "rsi": rsi,
+        "trend4h": trend4,
+        "trend1h": trend1,
+        "excess": excess,
+        "own24h": own,
+    }
+
+
+def clamp_leverage(desired, venue_max):
+    """Clamp the desired leverage to the asset's HL venue max. v2-quirk: over-leveraging a
+    name above its venue cap is a venue reject, so this clamp is load-bearing, not cosmetic.
+    Verbatim v2 clamp_leverage()."""
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))

--- a/strategies/octopus/strategy.yaml
+++ b/strategies/octopus/strategy.yaml
@@ -1,0 +1,46 @@
+# Octopus — market-neutral crypto long/short dispersion fund. A two-instance PACKAGE: this
+# manifest + two self-contained runtime.yaml books (long / short on SEPARATE wallets, so the
+# long leaders and short laggards can coexist) + shared scanners/. A faithful Runtime 3.0 port
+# of the v2 Octopus v1.0 cross-sectional relative-strength engine over the LIVE liquid main-DEX
+# crypto universe on Hyperliquid (no fixed whitelist — the board is ranked every tick).
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: octopus
+version: "1.0.0"
+
+catalog:
+  name: "Octopus — Market-Neutral Crypto Long/Short"
+  emoji: "🐙"
+  tagline: "Ranks the live liquid main-DEX crypto cross-section by 24h relative strength every tick, then LONGS the strongest names (long book) and SHORTS the weakest (short book) — both trend-confirmed — on two equally-funded wallets so the pair is ~market-neutral and harvests crypto dispersion."
+  belief_plain: "Buys the strongest crypto coins and shorts the weakest at the same time, on two separate wallets, so it makes money on the GAP between winners and losers instead of betting on the whole market going up or down."
+  thesis: "The edge is dispersion, not direction. In a HYPE-dominates / alts-crushed regime the long book gravitates to the leaders and the short book to the carnage, and the two equally-funded notionals offset market beta — so the return is driven by the spread between strong and weak names. The universe is the live liquid board, not a fixed list, so it always ranks whatever is actually trading and liquid right now."
+  group: multi-asset-universe
+  archetype: structural_neutral   # market-neutral L/S — net beta ~0 by construction
+  sub_style: pairs_rv             # cross-sectional relative-value (leaders vs laggards dispersion)
+  asset_classes: [universe_crypto]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 8
+  min_budget: 400
+  tags: [crypto, hedge-fund, long-short, market-neutral, dispersion, relative-strength, universe, cross-sectional]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: long
+    runtime: long/runtime.yaml
+    wallet_env: OCTOPUS_LONG_WALLET
+    funding_share: 0.5
+  - name: short
+    runtime: short/runtime.yaml
+    wallet_env: OCTOPUS_SHORT_WALLET
+    funding_share: 0.5


### PR DESCRIPTION
Wave 4 of the v2→3.0 migration (56→66). 10 multi-instance hedge-fund-style agents (21 instances): debasement/energy/on-chain L/S pairs, funding-carry harvest/payout, cross-asset CTA, K-shaped two-speed + pre-IPO (cub = 3 sleeves), vol-breakout, global-macro trend/fade, crypto dispersion.

Each instance: read-guarded MCP (incl. `market_list_instruments`), marginUsd→marginPct (vol-parity + conviction-weighted), HL-meta-validated tickers, `data_retention_seconds` in range, canonical taxonomy, distinct `wallet_env`, no `__init__.py`. Leg-parametrized shared scan/scoring (cougar pattern). Fidelity diffs 0-mismatch (caracal 3000, elephant 4000/leg). All 66 packages pass the modernized validator.