### PR TITLE
Runtime 3.0 Wave 5 (7 cohort/follower + special) -> 73 strategies (migration complete)

### DIFF
--- a/strategies/albatross/main/runtime.yaml
+++ b/strategies/albatross/main/runtime.yaml
@@ -1,0 +1,148 @@
+# ── ALBATROSS · single instance — multi-week Arena conviction mirror ──────────
+# Runtime 3.0 port of the v2 Albatross (SKILL.md v1.0.0). Builds a top-N pool of
+# Arena leaders by a composite conviction score across the last 4 weekly
+# leaderboards + the current month, then mirrors each NEW position a pooled leader
+# opens. Derived universe (assets come from the leaders). DSL-only exits — wide
+# ladder, 96h hard-timeout cap. Faithful port of the v2 producer thesis — see
+# scanners/scoring.py (pool math reproduced verbatim, v2-quirks flagged in scan.py).
+#
+# REQUIRES USER-SCOPE AUTH TOKEN. strategy_list + discovery_get_trader_state gate
+# on user identity — a service token cannot resolve other users' wallets/positions.
+# Operators must provide a Privy-issued Senpi user token via SENPI_AUTH_TOKEN.
+name: albatross-main
+group: albatross
+version: 3.0.0
+description: >
+  ALBATROSS — multi-week Arena conviction mirror. Pulls the last 4 Arena weekly
+  leaderboards + the current monthly leaderboard, scores each trader by a composite
+  that rewards persistence and penalizes weekly variance
+  (0.3 monthly_roe + 0.7 mean(weekly_roe) - 0.5 stdev(weekly_roe)), and mirrors each
+  NEW position the top-N pool opens. A steady +22%/week-for-4-weeks trader beats an
+  identical-mean trader who got there on one +98% week. Pool refreshes every 4h
+  (cached in ctx.state). Asset+direction copied from the leader; leverage capped at
+  5x; fixed 15% margin. DSL is the only exit (wide ratchet, 96h cap) — we don't have
+  visibility into the leader's exit logic. Faithful port of v2 Albatross v1.0.x.
+
+strategy:
+  wallet: "${ALBATROSS_WALLET}"
+  slots: 3                                  # v2 runtime slots 3
+  margin_pct: 15                            # baseline %; scan emits a fixed 15% marginPct INTENT per signal
+  default_leverage: 5                       # fallback; scan emits leverage capped at 5x per signal
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: albatross_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                   # v2 producer cadence (5 min)
+    timeout_seconds: 180                    # v2 tick_timeout=180; pool refresh = 5 arena reads, then ~2/leader
+    default_signal_validity_seconds: 600    # 2x tick; rule action, a fresh diff arrives next tick
+    state_history_max_count: 24             # holds the pool cache + per-leader snapshots + dedup map
+    inputs:
+      leaderPoolSize: 5                     # v2 leaderPoolSize / DEFAULT_POOL_SIZE
+      leaderRefreshHours: 4                 # v2 leaderRefreshHours (pool cache TTL)
+      minWeeksTraded: 3                     # v2 minWeeksTraded (persistence floor)
+      minWeeklyVolumeUsd: 50000             # v2 minWeeklyVolumeUsd (no toy accounts)
+      convictionWeights:
+        monthlyRoe: 0.3                     # v2 convictionWeights.monthlyRoe
+        weeklyRoeMean: 0.7                  # v2 convictionWeights.weeklyRoeMean
+        weeklyRoeStdevPenalty: 0.5         # v2 convictionWeights.weeklyRoeStdevPenalty
+      excludeXHandles: ["betashop"]         # v2 excludeXHandles (no Senpi-fleet self-mirror)
+      marginPct: 15                         # PERCENT of withdrawable (0,100] — v2 stored 0.15 FRACTION; ported x100
+      leverage: 5                           # capped at 5x in scan.py (MAX_LEVERAGE) — we don't follow into 25x
+      recentSignalTtlSeconds: 240           # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      signalKind: { type: string, required: false }
+      leaderUsername: { type: string, required: false }
+      leaderXHandle: { type: string, required: false }
+      leaderConvictionScore: { type: number, required: false }
+      leaderWeeksTraded: { type: number, required: false }
+      leaderWeeklyRoeMean: { type: number, required: false }
+      leaderMonthlyRoe: { type: number, required: false }
+      leaderEntryPrice: { type: number, required: false }
+      leaderLeverage: { type: number, required: false }
+      reasons: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: albatross_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [albatross_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true     # a confirmed mirror must fill — maker-only can rest unfilled (CREATE_ORDER_RESTING)
+        execution_timeout_seconds: 30       # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: albatross_main_signals
+
+# ── EXIT (DSL — ported VERBATIM from v2 runtime.yaml) ─────────────────────────
+# Mirrored trades inherit direction from the source leader; we don't know when
+# they'll close, so we run our OWN DSL. Phase 1 max_loss 20% = catastrophic floor.
+# Phase 2 wide ladder (FIRST lock reachable at +10% ROE) so winning mirrors ride.
+# weak_peak_cut KEPT (self-limiting thesis-validity check). hard_timeout 96h (4d)
+# caps the slot since we lack visibility into the leader's exit rules.
+# order_type FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST happen).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30           # v2: maker attempt kept comfortably under the server connection window
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760             # v2: 96h (4d) cap
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 90               # v2 weak_peak_cut
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                        # v2: disabled
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0                     # v2 phase1 floor
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                # v2 wide ladder; FIRST lock reachable at +10% ROE
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200            # 72h (was data_retention_hours 72)
+  guard_rails:
+    daily_loss_limit_pct: 15                # v2 daily_loss_limit_pct
+    max_entries_per_day: 5                  # v2 max_entries_per_day (multiple leaders fire)
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4               # v2 max_consecutive_losses
+    cooldown_seconds: 1800                  # v2 cooldown_minutes 30 -> 1800s
+    drawdown_halt_pct: 20                   # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false   # v2: no grace
+    per_asset_cooldown_seconds: 7200        # v2 per_asset_cooldown_minutes 120 -> 7200s (2h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/albatross/main/scanners/scan.py
+++ b/strategies/albatross/main/scanners/scan.py
@@ -1,0 +1,390 @@
+"""ALBATROSS — supervised scanner (Runtime 3.0 port of the v2 Arena conviction mirror).
+
+Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - refreshes the conviction-weighted LEADER POOL (cached in ctx.state with a
+    leaderRefreshHours TTL; 4 weekly + 1 monthly arena_leaderboard reads only on
+    refresh), degrading to the cached pool whenever a refresh read fails — a cohort
+    read failure NEVER crashes the tick and NEVER empties an existing pool,
+  - for each pooled leader: resolves strategy wallets (strategy_list), pulls current
+    positions (discovery_get_trader_state), and diffs against the per-leader snapshot
+    in ctx.state to detect NEW positions,
+  - emits one MIRROR signal per new position: asset+direction COPIED from the leader,
+    a fixed conviction-pool marginPct INTENT (PERCENT) + capped leverage, top-level.
+
+Read-only + single-pass. No daemon, no push_signal, no create_position, no cancel_order.
+Derived universe — the assets come from the leaders' positions, not a fixed list.
+The runtime sizes the dollars, owns slots/cooldowns/risk gates, and trails the DSL exit.
+
+FIDELITY NOTES vs albatross-producer.py v1.0.1:
+  - SIZING: v2 stored marginPct=0.15 as a FRACTION and computed marginUsd =
+    accountValue * 0.15 in the producer. This port emits `marginPct` as a PERCENT
+    (15) at the TOP level and lets the runtime size (marginPct/100)*withdrawable.
+    A defensive guard treats any inputs.marginPct <= 1.0 as a pasted fraction and
+    x100s it. The SIZE is identical for the default config; only WHO multiplies
+    moves to the runtime (per the 3.0 contract).
+  - DEDUP: v2 recent-signals.json (TTL 240s, key `<COIN>:<DIRECTION>`) -> ctx.state
+    `signaled` map, same TTL + 4xTTL prune semantics.
+  - POOL CACHE: v2 state/leader-pool.json (leaderRefreshHours TTL) -> ctx.state
+    `pool` record (refreshed_at + leaders). Same TTL; degrade-to-cache on refresh
+    read failure is preserved (v2 compute_conviction_pool returned [] on a failed
+    week read; this port instead KEEPS the prior cached pool, matching the gold
+    cohort peers — a strictly safer degrade that never blanks a live pool).
+  - PER-LEADER SNAPSHOTS: v2 state/leader-positions/<uid>.json -> ctx.state
+    `leader_snapshots` map (uid -> list of position keys). Same diff semantics.
+  - DROPPED (v2 -> 3.0): the producer's push_signal + record-on-disk are gone (the
+    runtime ingests scan()'s return). v2 had NO order-lifecycle mutations to drop.
+    The producer's `_get_current_week_number` + explicit per-week-number fetch
+    collapses to "pull the current week + the 3 prior periods" via period_number
+    offsets when available; if the API doesn't expose periodNumber we fall back to
+    the default current-period weekly read repeated is avoided — we degrade to the
+    single current-week snapshot (weeks_traded floor then naturally blocks until
+    more weekly history accrues). FLAGGED.
+  - leverage clamped to MAX_LEVERAGE (5) verbatim; betashop xHandle excluded by
+    default (config.excludeXHandles).
+"""
+
+import sys
+import time
+
+import scoring
+
+VERSION = "1.0.0"
+
+_MAX_LEVERAGE = 5            # v2 MAX_LEVERAGE
+_DEFAULT_LEVERAGE = 5        # v2 DEFAULT_LEVERAGE
+_DEFAULT_RECENT_TTL = 240    # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+_DEFAULT_POOL_SIZE = 5       # v2 DEFAULT_POOL_SIZE
+_DEFAULT_REFRESH_HOURS = 4   # v2 DEFAULT_REFRESH_HOURS
+_DEFAULT_MIN_WEEKS = 3       # v2 DEFAULT_MIN_WEEKS_TRADED
+_DEFAULT_MIN_WEEKLY_VOL = 50000  # v2 DEFAULT_MIN_WEEKLY_VOL_USD
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll back
+    the whole tick (the contract turns any propagated exception into an empty tick).
+    Returns None on failure so the existing degrade paths apply (pool -> cached pool;
+    a failed per-leader read -> that leader is skipped this tick)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[albatross.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _entries(resp):
+    """arena_leaderboard -> entries list, defensively unwrapping data/leaderboard."""
+    if not resp:
+        return []
+    if isinstance(resp, dict) and resp.get("success") is False:
+        return []
+    data = resp.get("data", resp) if isinstance(resp, dict) else resp
+    lb = data.get("leaderboard", data) if isinstance(data, dict) else data
+    if isinstance(lb, dict):
+        ents = lb.get("entries", [])
+    elif isinstance(lb, list):
+        ents = lb
+    else:
+        ents = []
+    return ents if isinstance(ents, list) else []
+
+
+def _period_number(resp):
+    if not resp:
+        return None
+    data = resp.get("data", resp) if isinstance(resp, dict) else resp
+    lb = data.get("leaderboard", data) if isinstance(data, dict) else data
+    if isinstance(lb, dict):
+        return lb.get("periodNumber")
+    return None
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across main/xyz
+    (two views of ONE cross-margined wallet — summing double-counts shared free
+    balance -> 2x sizing). assetPositions are per-sub-DEX so enumerated across both.
+    Ported verbatim from v2 cfg.get_positions, incl. the read-sanity guard (margin
+    in use + empty positions -> skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+            })
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; running held-asset dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[albatross.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _refresh_pool(ctx, inputs, now):
+    """Pull the current week + 3 prior weekly leaderboards + the current month, and
+    compose the conviction pool via scoring.build_pool. READ-GUARDED throughout;
+    if NO weekly snapshot can be read the caller keeps the cached pool."""
+    # Resolve the current week's period number from a small qualified read.
+    cur_resp = _read(ctx, "arena_leaderboard",
+                     {"period_type": "WEEK", "qualified": True, "limit": 50})
+    current_week = _period_number(cur_resp)
+
+    week_lists = []
+    cur_entries = _entries(cur_resp)
+    if cur_entries:
+        week_lists.append(cur_entries)
+
+    if current_week is not None:
+        # Pull the 3 prior weeks by explicit period_number (verbatim v2 offset loop).
+        for offset in range(1, 4):
+            wk = current_week - offset
+            if wk <= 0:
+                continue
+            resp = _read(ctx, "arena_leaderboard",
+                         {"period_type": "WEEK", "qualified": True, "limit": 50,
+                          "period_number": wk})
+            ents = _entries(resp)
+            if ents:
+                week_lists.append(ents)
+    else:
+        # FLAGGED degrade: API didn't expose periodNumber. We only have the current
+        # week; weeks_traded floor then blocks until more weekly history accrues
+        # across future refreshes (no double-counting the same week).
+        print("[albatross.scan] periodNumber unavailable — pool from current week only "
+              "(weeks_traded floor will gate until more history)", file=sys.stderr)
+
+    if not week_lists:
+        return None  # signal "no usable weekly read" -> caller keeps cached pool
+
+    month_resp = _read(ctx, "arena_leaderboard",
+                       {"period_type": "MONTH", "qualified": True, "limit": 50})
+    month_entries = _entries(month_resp)
+
+    leaders = scoring.build_pool(week_lists, month_entries, inputs)
+    return {"refreshed_at": now, "leaders": leaders, "weeks_pulled": len(week_lists)}
+
+
+def _get_pool(ctx, inputs, now, cached_pool):
+    """Return (pool_record, refreshed_bool). Serves the cached pool while fresh;
+    on a stale cache attempts a refresh; on a failed refresh DEGRADES to the cached
+    pool (never blanks a live pool) per the gold cohort pattern."""
+    refresh_hours = scoring._f(inputs.get("leaderRefreshHours", _DEFAULT_REFRESH_HOURS),
+                               _DEFAULT_REFRESH_HOURS)
+    if (cached_pool and cached_pool.get("leaders")
+            and (now - cached_pool.get("refreshed_at", 0)) < refresh_hours * 3600):
+        return cached_pool, False
+    fresh = _refresh_pool(ctx, inputs, now)
+    if fresh is None:
+        # refresh read failed entirely — keep whatever we had
+        return (cached_pool or {"refreshed_at": 0, "leaders": []}), False
+    return fresh, True
+
+
+def _leader_wallets(ctx, senpi_user_id):
+    """senpiUserId -> [strategy wallet addresses]. READ-GUARDED (verbatim v2)."""
+    raw = _read(ctx, "strategy_list",
+                {"userIds": [senpi_user_id], "status": ["ACTIVE"]})
+    if not raw:
+        return []
+    data = raw.get("data", raw) if isinstance(raw, dict) else raw
+    strategies = data.get("strategies", data) if isinstance(data, dict) else data
+    if not isinstance(strategies, list):
+        return []
+    return [s.get("strategyWalletAddress") for s in strategies
+            if isinstance(s, dict) and s.get("strategyWalletAddress")]
+
+
+def _leader_positions(ctx, wallets):
+    """Current open positions across all of a leader's strategy wallets. READ-GUARDED."""
+    if not wallets:
+        return []
+    raw = _read(ctx, "discovery_get_trader_state",
+                {"trader_addresses": wallets, "latest": True})
+    if not raw:
+        return []
+    data = raw.get("data", raw) if isinstance(raw, dict) else raw
+    states = data.get("traders", data) if isinstance(data, dict) else data
+    if not isinstance(states, list):
+        return []
+    return scoring.normalize_positions(states)
+
+
+# ── ctx.state: pool cache + per-leader snapshots + recent-signal dedup ──
+
+def _load_state(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}, {}, {}
+    last = ctx.state.last() or {}
+    pool = last.get("pool", {}) if isinstance(last.get("pool"), dict) else {}
+    snaps = last.get("leader_snapshots", {}) if isinstance(last.get("leader_snapshots"), dict) else {}
+    signaled = last.get("signaled", {}) if isinstance(last.get("signaled"), dict) else {}
+    return dict(pool), dict(snaps), dict(signaled)
+
+
+def _prune_signaled(signaled, ttl, now):
+    cutoff = now - (ttl * 4)  # verbatim v2 record_signal prune window
+    return {k: v for k, v in signaled.items() if scoring._f(v, 0) >= cutoff}
+
+
+def _was_recently_signaled(signaled, key, ttl, now):
+    last = signaled.get(key.upper())
+    if last is None:
+        return False
+    return (now - scoring._f(last, 0)) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL), _DEFAULT_RECENT_TTL)
+
+    # marginPct INTENT as a PERCENT in (0,100]. Defensive: a value <= 1.0 is a
+    # pasted v2 FRACTION (v2 stored 0.15) -> x100 (-> 15). (dire/koala guard.)
+    margin_pct = scoring._f(inputs.get("marginPct", 15), 15.0)
+    if margin_pct <= 1.0:
+        margin_pct = margin_pct * 100.0
+
+    leverage = min(int(inputs.get("leverage", _DEFAULT_LEVERAGE)), _MAX_LEVERAGE)
+
+    # config bundle passed to the pure pool builder
+    pool_cfg = {
+        "convictionWeights": inputs.get("convictionWeights", {
+            "monthlyRoe": 0.3, "weeklyRoeMean": 0.7, "weeklyRoeStdevPenalty": 0.5}),
+        "minWeeksTraded": int(inputs.get("minWeeksTraded", _DEFAULT_MIN_WEEKS)),
+        "minWeeklyVolumeUsd": scoring._f(inputs.get("minWeeklyVolumeUsd", _DEFAULT_MIN_WEEKLY_VOL),
+                                         _DEFAULT_MIN_WEEKLY_VOL),
+        "excludeXHandles": inputs.get("excludeXHandles", ["betashop"]),
+        "leaderPoolSize": int(inputs.get("leaderPoolSize", _DEFAULT_POOL_SIZE)),
+    }
+
+    account_value, positions = _get_account(ctx)
+    cached_pool, leader_snapshots, signaled = _load_state(ctx)
+    signaled = _prune_signaled(signaled, ttl, now)
+
+    def _persist(pool_rec, result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({
+                "pool": pool_rec,
+                "leader_snapshots": leader_snapshots,
+                "signaled": signaled,
+                "result": result,
+            })
+        except Exception as exc:  # noqa: BLE001
+            print(f"[albatross.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+
+    if account_value <= 0:
+        result = {"ts": now, "emitted": False, "note": "no account value"}
+        _persist(cached_pool, result)
+        print("[albatross.scan] WAITING — no account value", file=sys.stderr)
+        return []
+
+    held_set = {p["coin"].upper() for p in positions if p.get("coin")}
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+
+    pool_rec, refreshed = _get_pool(ctx, pool_cfg, now, cached_pool)
+    leaders = pool_rec.get("leaders", []) if isinstance(pool_rec, dict) else []
+
+    if not leaders:
+        result = {"ts": now, "emitted": False, "pool_size": 0,
+                  "note": "no qualifying leaders (conviction>0, >=min weeks)"}
+        _persist(pool_rec, result)
+        print(f"[albatross.scan] WAITING — empty leader pool (refreshed={refreshed})",
+              file=sys.stderr)
+        return []
+
+    out = []
+    pushed = []
+    for leader in leaders:
+        uid = leader.get("senpiUserId")
+        if not uid:
+            continue
+        wallets = _leader_wallets(ctx, uid)
+        if not wallets:
+            continue
+        current = _leader_positions(ctx, wallets)
+        last_keys = set(leader_snapshots.get(str(uid), []))
+        new_positions = scoring.detect_new(current, last_keys)
+        # Update this leader's snapshot every tick regardless (verbatim v2 semantics).
+        leader_snapshots[str(uid)] = [scoring.position_key(p) for p in current]
+
+        for pos in new_positions:
+            coin = pos["coin"]
+            direction = pos["direction"]
+            if coin.upper() in held_set:           # don't re-mirror a name we already hold
+                continue
+            dedup_key = f"{coin}:{direction}"
+            if _was_recently_signaled(signaled, dedup_key, ttl, now):
+                continue
+            out.append({
+                "asset": coin,
+                "direction": direction,
+                "marginPct": round(margin_pct, 4),   # PERCENT in (0,100] — runtime sizes the dollars
+                "leverage": leverage,                # <= MAX_LEVERAGE; runtime applies it
+                "data": {
+                    "score": scoring.wire_score(leader.get("conviction_score")),
+                    "direction": direction,
+                    "signalKind": "ARENA_MIRROR",
+                    "leaderUsername": leader.get("username"),
+                    "leaderXHandle": leader.get("xHandle"),
+                    "leaderConvictionScore": scoring._f(leader.get("conviction_score"), 0.0),
+                    "leaderWeeksTraded": int(leader.get("weeks_traded") or 0),
+                    "leaderWeeklyRoeMean": scoring._f(leader.get("weekly_mean_roe"), 0.0),
+                    "leaderMonthlyRoe": scoring._f(leader.get("monthly_roe"), 0.0),
+                    "leaderEntryPrice": scoring._f(pos.get("entryPx"), 0.0),
+                    "leaderLeverage": scoring._f(pos.get("leverage"), 0.0),
+                    "reasons": [
+                        f"mirror {coin} {direction} from {leader.get('username')}",
+                        f"conviction {leader.get('conviction_score')}",
+                        f"weekly mean {leader.get('weekly_mean_roe')} over {leader.get('weeks_traded')} wks",
+                        f"monthly {leader.get('monthly_roe')}",
+                    ],
+                    "heldAssets": held_assets,
+                },
+            })
+            signaled[dedup_key.upper()] = now
+            pushed.append({"coin": coin, "direction": direction,
+                           "from": leader.get("username"),
+                           "conviction": leader.get("conviction_score")})
+
+    result = {"ts": now, "emitted": bool(out), "pool_size": len(leaders),
+              "signals": len(out), "pushed": pushed, "held": held_assets,
+              "pool_refreshed": refreshed}
+    _persist(pool_rec, result)
+
+    if out:
+        print(f"[albatross.scan] EMIT {len(out)} mirror(s) from pool of {len(leaders)} "
+              f"leaders: {[p['coin'] + ' ' + p['direction'] for p in pushed]}", file=sys.stderr)
+    else:
+        print(f"[albatross.scan] WAITING — no new leader positions; pool={len(leaders)} "
+              f"held={held_assets} (refreshed={refreshed})", file=sys.stderr)
+    return out

--- a/strategies/albatross/main/scanners/scoring.py
+++ b/strategies/albatross/main/scanners/scoring.py
@@ -1,0 +1,183 @@
+"""ALBATROSS — pure multi-week Arena conviction math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Albatross v1.0.x producer
+(albatross-producer.py). Given the raw arena_leaderboard entry lists already
+fetched by scan.py (4 weekly snapshots + 1 monthly), this composes the
+per-trader conviction pool VERBATIM so a fidelity harness can diff it against
+the v2 producer on the same snapshot.
+
+The thesis: the Senpi Arena resets weekly, so single-week mirroring is a
+survivor-bias trap. Score each trader by a composite that rewards multi-week
+persistence and penalizes weekly variance:
+
+    conviction = 0.3 * monthly_roe
+               + 0.7 * mean(weekly_roe across last 4 weeks)
+               - 0.5 * pstdev(weekly_roe)
+
+Filter to conviction > 0, weeks_traded >= minWeeksTraded, each appearance's
+notionalVolume >= minWeeklyVolumeUsd, xHandle not excluded. Top-N by conviction.
+The pool is the cohort; scan.py then diffs each pooled leader's open positions
+tick-over-tick and mirrors NEW ones.
+"""
+
+import statistics
+
+
+def _f(x, default=0.0):
+    try:
+        if x is None:
+            return default
+        return float(x)
+    except (TypeError, ValueError):
+        return default
+
+
+# ── conviction-weighted leader pool (verbatim compute_conviction_pool) ──
+
+def build_pool(week_entry_lists, month_entries, config):
+    """Compose the top-N conviction pool.
+
+    week_entry_lists: list of arena_leaderboard `entries` lists, one per week
+        (current + last 3). Each entry is a raw leaderboard dict.
+    month_entries: the current-month arena_leaderboard `entries` list.
+    config: inputs dict (weights, floors, exclude set, pool size).
+
+    Returns a list of leader dicts, best conviction first, capped to pool_size.
+    Pure: callers pass the already-fetched leaderboard rows; no clock/MCP here.
+    """
+    weights = config.get("convictionWeights", {}) or {}
+    w_monthly = _f(weights.get("monthlyRoe", 0.3), 0.3)
+    w_weekly_mean = _f(weights.get("weeklyRoeMean", 0.7), 0.7)
+    w_stdev_penalty = _f(weights.get("weeklyRoeStdevPenalty", 0.5), 0.5)
+    min_weeks_traded = int(config.get("minWeeksTraded", 3))
+    min_weekly_vol = _f(config.get("minWeeklyVolumeUsd", 50000), 50000.0)
+    excluded_handles = {str(h).lower() for h in config.get("excludeXHandles", ["betashop"])}
+    pool_size = int(config.get("leaderPoolSize", 5))
+
+    # Aggregate per senpiUserId across the weekly snapshots. Each snapshot is a
+    # distinct week, so a uid appearing in k snapshots = traded k of the 4 weeks.
+    # (v2 keyed weekly_roe_by_week by week_num; here each list is one week, so
+    # we accumulate a roe per appearance — identical math, snapshot-indexed.)
+    by_uid = {}
+    for week_idx, entries in enumerate(week_entry_lists):
+        if not isinstance(entries, list):
+            continue
+        for e in entries:
+            if not isinstance(e, dict):
+                continue
+            uid = e.get("senpiUserId")
+            if not uid:
+                continue
+            handle = str(e.get("xHandle") or "").lower()
+            if handle in excluded_handles:
+                continue
+            vol = _f(e.get("notionalVolume", 0))
+            if vol < min_weekly_vol:
+                continue
+            roe = _f(e.get("roePct", 0))
+            snap = by_uid.setdefault(uid, {
+                "senpiUserId": uid,
+                "username": e.get("senpiUserName"),
+                "xHandle": e.get("xHandle"),
+                "weekly_roe_by_week": {},
+                "totalPnl": _f(e.get("totalPnl", 0)),
+                "currentBalance": _f(e.get("currentBalance", 0)),
+            })
+            snap["weekly_roe_by_week"][str(week_idx)] = roe
+
+    monthly_roe_by_uid = {
+        e.get("senpiUserId"): _f(e.get("roePct", 0))
+        for e in (month_entries or [])
+        if isinstance(e, dict) and e.get("senpiUserId")
+    }
+
+    candidates = []
+    for uid, snap in by_uid.items():
+        weekly_roes = list(snap["weekly_roe_by_week"].values())
+        if len(weekly_roes) < min_weeks_traded:
+            continue
+        weekly_mean = statistics.mean(weekly_roes)
+        weekly_std = statistics.pstdev(weekly_roes) if len(weekly_roes) > 1 else 0
+        monthly_roe = monthly_roe_by_uid.get(uid, 0.0)
+        conviction = (
+            w_monthly * monthly_roe
+            + w_weekly_mean * weekly_mean
+            - w_stdev_penalty * weekly_std
+        )
+        if conviction <= 0:
+            continue
+        candidates.append({
+            "senpiUserId": uid,
+            "username": snap["username"],
+            "xHandle": snap["xHandle"],
+            "totalPnl": snap["totalPnl"],
+            "currentBalance": snap["currentBalance"],
+            "weekly_roe": weekly_roes,
+            "weekly_mean_roe": round(weekly_mean, 3),
+            "weekly_stdev_roe": round(weekly_std, 3),
+            "monthly_roe": round(monthly_roe, 3),
+            "conviction_score": round(conviction, 3),
+            "weeks_traded": len(weekly_roes),
+        })
+
+    candidates.sort(key=lambda c: c["conviction_score"], reverse=True)
+    return candidates[:pool_size]
+
+
+# ── leader position normalisation + new-position diff ──
+
+def normalize_positions(states):
+    """Flatten discovery_get_trader_state `traders` into mirror-able positions.
+
+    Verbatim port of v2 fetch_leader_positions' inner loop: one row per non-zero
+    open position, direction from szi sign, leverage unwrapped from the nested
+    {value:..} shape the API sometimes returns.
+    """
+    positions = []
+    for state in states or []:
+        if not isinstance(state, dict):
+            continue
+        for pos in state.get("openPositions", []) or []:
+            if not isinstance(pos, dict):
+                continue
+            coin = pos.get("coin") or pos.get("asset")
+            szi = _f(pos.get("szi", 0))
+            if not coin or szi == 0:
+                continue
+            lev_raw = pos.get("leverage")
+            if isinstance(lev_raw, dict):
+                lev = _f(lev_raw.get("value", 1), 1.0)
+            else:
+                lev = _f(lev_raw, 1.0)
+            positions.append({
+                "wallet": state.get("traderAddress"),
+                "coin": coin,
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "size": abs(szi),
+                "entryPx": _f(pos.get("entryPx", 0)),
+                "leverage": lev,
+            })
+    return positions
+
+
+def position_key(p):
+    """Dedup key for a leader position: `<COIN>:<DIRECTION>` (verbatim v2)."""
+    return f"{p.get('coin')}:{p.get('direction')}"
+
+
+def detect_new(current_positions, last_keys):
+    """Positions present now but absent from the last snapshot's key set.
+
+    `last_keys` is a set of position_key()s from the previous tick. Verbatim port
+    of v2 detect_new_positions (which read the snapshot off disk; here scan.py
+    carries it in ctx.state)."""
+    last = set(last_keys or [])
+    return [p for p in current_positions if position_key(p) not in last]
+
+
+# ── sizing + wire score ──
+
+def wire_score(conviction_score):
+    """Normalise the composite conviction into the [0,1] wire score the v2
+    producer emitted: min(conviction / 50, 1.0). Carried on data{} only."""
+    return round(min(_f(conviction_score) / 50.0, 1.0), 4)

--- a/strategies/albatross/strategy.yaml
+++ b/strategies/albatross/strategy.yaml
@@ -1,0 +1,44 @@
+# Albatross — multi-week Arena conviction copy-trader. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of
+# the v2 Albatross (SKILL.md v1.0.0): builds a top-N pool of Arena leaders by a composite
+# conviction score (0.3 monthly_roe + 0.7 mean(weekly_roe) - 0.5 stdev(weekly_roe)) across
+# the last 4 weekly leaderboards + the current month, then mirrors each NEW position a
+# pooled leader opens. Derived universe (assets come from the leaders, not a fixed list).
+# DSL-only exits. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: albatross
+version: "1.0.0"
+
+catalog:
+  name: "Albatross — Multi-week Arena Conviction Mirror"
+  emoji: "🐦‍⬛"
+  tagline: "Mirrors trades from Senpi Arena participants whose ROE has been consistently strong across the last 4 weekly periods AND the current month — a composite conviction score (0.3 monthly + 0.7 weekly_mean - 0.5 weekly_stdev) picks the persistent winners over the one-week wonders, and the producer mirrors each new position they open."
+  belief_plain: "The Arena resets every Thursday, so a trader can top the board with one lucky +98% week and three flat ones. Albatross looks back over four weeks plus the month and copies the traders who have been steadily winning the whole time, not the ones who got lucky once — then it opens what they open and rides it on its own wide stop."
+  thesis: "Single-week Arena mirroring is a survivor-bias trap: it copies whoever spiked, who is then most likely to mean-revert. Selecting on a multi-week composite that rewards persistence and penalizes weekly variance corrects for that — a steady +22%/week-for-4-weeks trader scores far above an identical-mean trader who got there on one +98% week. You copy the proven hand, cap their leverage, size fixed, and exit on your own DSL because you can't see when they will."
+  group: copy-trading
+  archetype: copy_trading
+  sub_style: arena_winners
+  asset_classes: [universe_crypto]
+  asset_scope: follows_traders
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 3
+  min_budget: 200
+  assets: []
+  tags: [arena, copy-trading, multi-week, conviction, mirror, long-short, persistence]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: ALBATROSS_WALLET
+    funding_share: 1.0

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -304,6 +304,91 @@
       "sort_order": 4
     },
     {
+      "id": "albatross",
+      "name": "Albatross — Multi-week Arena Conviction Mirror",
+      "emoji": "🐦‍⬛",
+      "tagline": "Mirrors trades from Senpi Arena participants whose ROE has been consistently strong across the last 4 weekly periods AND the current month — a composite conviction score (0.3 monthly + 0.7 weekly_mean - 0.5 weekly_stdev) picks the persistent winners over the one-week wonders, and the producer mirrors each new position they open.",
+      "belief_plain": "The Arena resets every Thursday, so a trader can top the board with one lucky +98% week and three flat ones. Albatross looks back over four weeks plus the month and copies the traders who have been steadily winning the whole time, not the ones who got lucky once — then it opens what they open and rides it on its own wide stop.",
+      "version": "1.0.0",
+      "thesis": "Single-week Arena mirroring is a survivor-bias trap: it copies whoever spiked, who is then most likely to mean-revert. Selecting on a multi-week composite that rewards persistence and penalizes weekly variance corrects for that — a steady +22%/week-for-4-weeks trader scores far above an identical-mean trader who got there on one +98% week. You copy the proven hand, cap their leverage, size fixed, and exit on your own DSL because you can't see when they will.",
+      "tags": [
+        "arena",
+        "copy-trading",
+        "multi-week",
+        "conviction",
+        "mirror",
+        "long-short",
+        "persistence"
+      ],
+      "group": "copy-trading",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "arena_winners",
+      "sub_style_label": "Copies multi-week arena winners, not one-week wonders.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
+      "id": "jackal",
+      "name": "Jackal — The Smart Stalker",
+      "emoji": "🐺",
+      "tagline": "Maintains a daily-refreshed pool of the top-ROI Hyperliquid traders (win-rate + age + 30d-ROI filtered, quality-scored toward tail-winner trend-followers), watches for the moment a pool member opens a fresh position, and mirrors only the freshest entries (< 10 min old) when pool consensus and independent TA confirm — sized to the source trader's quality and ridden on its own wide DSL.",
+      "belief_plain": "Keeps a shortlist of the most profitable traders on Hyperliquid and refreshes it every day. The instant one of them opens a new trade, Jackal copies that trade in the same direction — but only if the entry is brand new, other shortlisted traders are leaning the same way, and the chart agrees. It bets a bit more behind the highest-quality traders and then trails a wide stop so a good copy can run for days.",
+      "version": "1.0.0",
+      "thesis": "High-quality traders telegraph alpha, but naive copy-trading loses because winners regress, signals lag, and style mismatches amplify risk. Jackal only copies the freshest entries (< 10 min, before the alpha is public) from a pool ranked toward tail-winner trend-followers (ROI 35% / gain-to-pain 25% / age 15% / win-rate 10% — deliberately NOT high-win-rate scalpers), and confirms each copy with pool consensus + independent multi-timeframe TA + funding regime before sizing to the source's quality and riding its OWN DSL rather than the source trader's.",
+      "tags": [
+        "copy-trading",
+        "smart-money",
+        "trader-pool",
+        "consensus",
+        "fresh-entry",
+        "quality-score",
+        "long-short",
+        "let-winners-run"
+      ],
+      "group": "copy-trading",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "hot_streak",
+      "sub_style_label": "Copies whoever is hot in the live window.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "scalp",
+      "cadence_seconds": 60,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 2
+    },
+    {
       "id": "tortoise",
       "name": "Tortoise — DCA Scheduler",
       "emoji": "🐢",
@@ -468,6 +553,61 @@
         0.4
       ],
       "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
+      "id": "turbine",
+      "name": "Turbine — Volume / Market-Making Engine",
+      "emoji": "🌪️",
+      "tagline": "A two-wallet volume engine: it rotates funding-fade entries across a tight liquid universe to generate notional volume at minimum fee cost (builder-fee recycling), not to take a directional view — one wallet churns fast, the other lets the rare winner run.",
+      "belief_plain": "This isn't a bet on prices going up or down. It opens and closes a steady stream of small, balanced positions across a handful of the deepest, tightest-spread markets (BTC/ETH/SOL/HYPE plus oil, gold, and the S&P 500 on the XYZ DEX) to rack up trading volume as cheaply as possible. It leans against crowded funding (shorts the crowded-long side, longs the crowded-short side) so the average position is roughly neutral. One wallet force-cuts every position on a 10-minute clock for pure volume; the second wallet runs the exact same entries but gives the occasional real move room to ratchet up before exiting.",
+      "version": "3.2.2",
+      "thesis": "Volume itself is the product: high notional throughput on Hyperliquid recycles builder fees, and on a tight, deep universe the maker-rebate math can net out roughly breakeven-to-slightly-positive before the volume reward. Concentrating on the few markets with the tightest spreads (XYZ books weighted 80%) keeps the per-$1M cost low. Funding-fade direction selection keeps the book structurally neutral rather than exposed. Splitting into a fast-rotation wallet and a patient-DSL wallet captures the asymmetry that pure rotation gives up — most positions exit flat either way, but the ~5% that catch a real directional move ride to a much larger realized PnL on the runners wallet instead of being force-cut at 10 minutes.",
+      "tags": [
+        "volume",
+        "market-making",
+        "builder-fee",
+        "funding-fade",
+        "two-wallet",
+        "rotation",
+        "structural-neutral",
+        "maker"
+      ],
+      "group": "market-neutral",
+      "archetype": "structural_neutral",
+      "archetype_label": "Structural / Neutral",
+      "sub_style": "market_making",
+      "sub_style_label": "Volume / market-making, not directional.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "commodities",
+        "indices"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE",
+        "xyz:BRENTOIL",
+        "xyz:GOLD",
+        "xyz:SP500"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "scalp",
+      "cadence_seconds": 60,
+      "min_budget": 200,
+      "instance_count": 2,
+      "funding_split": [
+        0.675,
+        0.325
+      ],
+      "max_slots": 9,
       "branch": "strategy-v2",
       "sort_order": 1
     },
@@ -1353,6 +1493,52 @@
       "sort_order": 1
     },
     {
+      "id": "mantis",
+      "name": "Mantis — Cross-Asset Catchup Hunter",
+      "emoji": "🦎",
+      "tagline": "Watches BTC's 4-hour move via market_get_cross_asset_flows and strikes the highest-confidence correlated alt that historically follows BTC but hasn't caught up yet — entering the alt in BTC's direction, sized to the tool's confidence score, with a stop that trails the catchup.",
+      "belief_plain": "When Bitcoin makes a big 4-hour move, certain alts that usually follow it lag behind for a while before catching up. Mantis spots those laggards (only the ones that follow Bitcoin reliably, with smart money already starting to rotate in) and buys the gap, betting it closes — bigger when it's more confident, with a stop that trails the move.",
+      "version": "1.0.0",
+      "thesis": "The edge is a statistical lag, not a directional view: alts with an 85%+ historical follow-rate and tight timing variance tend to catch up to a confirmed leader move within their typical lag window. Restricting the leader to BTC (the only asset with pre-computed lag data) and requiring smart-money rotation plus a meaningful gap keeps it to high-probability catchups; sizing scales with the tool's confidence, and a dynamic timeout calibrated to each alt's lag distribution backstops trades where the catchup never materialises.",
+      "tags": [
+        "crypto",
+        "cross-asset",
+        "lag",
+        "catchup",
+        "slipstream",
+        "btc-leader",
+        "smart-money",
+        "conviction-margin",
+        "statistical-edge"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "structural_neutral",
+      "archetype_label": "Structural / Neutral",
+      "sub_style": "cross_asset_lag",
+      "sub_style_label": "Trades an alt that lags a BTC move.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [
+        "BTC"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 8,
+      "time_horizon": "swing",
+      "cadence_seconds": 60,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
       "id": "octopus",
       "name": "Octopus — Market-Neutral Crypto Long/Short",
       "emoji": "🐙",
@@ -1394,7 +1580,7 @@
       ],
       "max_slots": 8,
       "branch": "strategy-v2",
-      "sort_order": 1
+      "sort_order": 2
     },
     {
       "id": "asia-ai",
@@ -3074,6 +3260,48 @@
       "sort_order": 1
     },
     {
+      "id": "cuckoo",
+      "name": "Cuckoo — Copy-the-Copiers",
+      "emoji": "🐦",
+      "tagline": "Auto-discovers the platform's top-performing strategies, then trades the asset + direction they agree on most — performance-weighted, so a stronger strategy gets more say (capped so one outlier can't dominate).",
+      "belief_plain": "Lets the best strategies on the platform do the work. Every few minutes it finds the top performers, looks at what they're holding right now, and copies whatever the most (and best) of them are piling into together — going long what they're long and short what they're short.",
+      "version": "1.0.0",
+      "thesis": "Following one trader or one leaderboard is one layer; Cuckoo is a layer above it. The strategies it follows are themselves copy/algo/trader-following strategies, so it captures the consensus of the consensus. When the best strategies independently pile into the same asset+direction, that agreement is a strong, self-cleaning signal — underperformers fall out of the top-N automatically, so the pool refreshes toward whatever is working.",
+      "tags": [
+        "copy-trading",
+        "copy-the-copiers",
+        "meta-strategy",
+        "consensus",
+        "performance-weighted",
+        "follows-strategies",
+        "let-winners-run"
+      ],
+      "group": "smart-money",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "copy_the_copiers",
+      "sub_style_label": "Follows the best-performing strategies automatically.",
+      "asset_classes": [
+        "none"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 2
+    },
+    {
       "id": "dog",
       "name": "Dog — Contrarian Pup (SM Exhaustion Fader)",
       "emoji": "🐕",
@@ -3124,7 +3352,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 2
+      "sort_order": 3
     },
     {
       "id": "egret",
@@ -3177,7 +3405,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 3
+      "sort_order": 4
     },
     {
       "id": "marlin",
@@ -3228,7 +3456,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "raptor",
@@ -3269,7 +3497,49 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 5
+      "sort_order": 6
+    },
+    {
+      "id": "remora",
+      "name": "Remora — Whale Single-Position Mirror",
+      "emoji": "🐟",
+      "tagline": "Rides a small, hand-picked set of whale traders the way a remora fish rides a shark: each tick it takes each whale's highest-conviction open position and mirrors the strongest, leaning hardest when several whales pile into the same trade (consensus) or when a whale is ELITE/RELIABLE tier.",
+      "belief_plain": "You name a few whale traders you trust. Remora watches their open positions, finds each one's biggest bet, and copies the single strongest one — betting bigger when several of your whales are in the same trade and one of them has an elite track record. Then it trails a wide stop so the trade can run.",
+      "version": "1.0.0",
+      "thesis": "The broad trader-followers scan a leaderboard and synthesize an opaque pick. Remora is the opposite: YOU choose whom to ride. Mirroring one whale's single highest-conviction position keeps your exposure tracking specific traders you trust, and the consensus multiplier means it leans hardest exactly when those whales independently agree — one whale can be wrong, three agreeing is a much stronger signal. Whales hold winners, so the exit lets the mirror run and only caps staleness.",
+      "tags": [
+        "whale",
+        "mirror",
+        "copy-trading",
+        "named-whales",
+        "consensus",
+        "let-winners-run",
+        "follows-traders"
+      ],
+      "group": "smart-money",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "named_whales",
+      "sub_style_label": "Mirrors specific hand-picked whales.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 7
     },
     {
       "id": "roach",
@@ -3313,7 +3583,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 6
+      "sort_order": 8
     },
     {
       "id": "whalehunter",
@@ -3356,7 +3626,54 @@
       ],
       "max_slots": 6,
       "branch": "strategy-v2",
-      "sort_order": 7
+      "sort_order": 9
+    },
+    {
+      "id": "osprey",
+      "name": "Osprey — Cross-Venue Lag (Crypto -> XYZ Equity)",
+      "emoji": "🦅",
+      "tagline": "When BTC moves hard, crypto-correlated equities on Hyperliquid XYZ (Coinbase, MicroStrategy) follow late: Osprey self-computes each proxy's catch-up gap (leader move x its beta minus the move it has actually made), and when a proxy still owes a gap in the leader's direction it enters the proxy that way and lets a wide DSL ride the catch-up.",
+      "belief_plain": "When Bitcoin makes a big move, the crypto-flavored stocks on the XYZ exchange (Coinbase, MicroStrategy) usually move the same way — but a beat late, because they are priced on a different venue. Osprey works out how far behind each one is and bets it catches up, then trails a wide stop so the catch-up can run for a day or two.",
+      "version": "1.0.0",
+      "thesis": "A crypto-correlated equity has a known beta to BTC (COIN ~1.8x, MSTR ~2.5x), so a BTC move implies an expected proxy move. But XYZ pricing trails spot crypto around its reference windows, so the proxy's actual move lags — a measurable, tradeable gap. Trading the lag (not the leader) means entering in the leader's confirmed direction only when the proxy still owes catch-up, which sidesteps the chase-the-leader failure mode and lets the structural pricing lag, not a directional guess, be the edge.",
+      "tags": [
+        "xyz",
+        "coin",
+        "mstr",
+        "cross-venue-lag",
+        "cross-asset-lag",
+        "btc-proxy",
+        "crypto-equities",
+        "catch-up",
+        "let-winners-run"
+      ],
+      "group": "structural",
+      "archetype": "structural_neutral",
+      "archetype_label": "Structural / Neutral",
+      "sub_style": "cross_venue_lag",
+      "sub_style_label": "Trades crypto-stocks that lag a BTC move.",
+      "asset_classes": [
+        "xyz_equities"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:COIN",
+        "xyz:MSTR"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "strategy-v2",
+      "sort_order": 1
     },
     {
       "id": "raccoon",

--- a/strategies/cuckoo/main/runtime.yaml
+++ b/strategies/cuckoo/main/runtime.yaml
@@ -1,0 +1,139 @@
+# ── CUCKOO · single instance — copy-the-copiers meta-strategy follower ────────
+# Runtime 3.0 port of the v2 Cuckoo (SKILL.md v1.0.0 / producer v1.0.1).
+# Auto-discovers the top strategies by realized performance
+# (discovery_get_top_strategies), builds a performance-weighted consensus across
+# their positions (leaderboard_get_trader_positions), and follows the single
+# highest weighted-consensus (asset, direction) that >= minStrategies agree on.
+# Derived universe (coins come from the followed strategies' positions). Producer
+# enters only — DSL owns exits (let-winners-run + 96h staleness cap). Faithful
+# port of the v2 thesis — see scanners/scoring.py (math reproduced verbatim).
+name: cuckoo-main
+group: cuckoo
+version: 3.0.0
+description: >
+  CUCKOO — copy-the-copiers meta-strategy follower. Auto-discovers the top
+  strategies by realized performance (discovery_get_top_strategies), pulls each
+  one's current positions, and trades the asset + direction the top performers
+  agree on most — PERFORMANCE-WEIGHTED, so a stronger strategy gets more say
+  (capped at weightCap so one outlier can't dominate). Because the strategies it
+  follows are themselves copy/algo strategies, Cuckoo copies the copiers. Entry
+  requires >= minStrategies top strategies in agreement at/above minScore; emits
+  the single best weighted-consensus candidate per tick. DSL is the ONLY exit —
+  let-winners-run preset (wide ladder, first lock at +10% ROE) with time-cuts off
+  except a 96h hard_timeout staleness cap (the consensus EXIT is not yet mirrored).
+  Faithful port of the v2 Cuckoo v1.0.0 thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${CUCKOO_WALLET}"
+  slots: 1                                # v2 slots 1 (emits the single best consensus)
+  margin_pct: 15                          # baseline %; scan emits marginPct per signal (v2 0.15 fraction ×100)
+  default_leverage: 4                     # v2 DEFAULT_LEVERAGE; scan emits 1-10x per signal
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: cuckoo_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 600                  # v2 producer cadence (10 min — consensus drifts slowly)
+    timeout_seconds: 240                   # v2 tick_timeout=240; up to ~1 read/strategy + account
+    default_signal_validity_seconds: 1200  # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 24            # cohort cache + dedup map + per-tick scan-results history
+    inputs:
+      topN: 12                             # v2 DEFAULT_TOP_N — how many top strategies to follow
+      minStrategies: 2                     # v2 DEFAULT_MIN_STRATEGIES — min agreeing to enter
+      minNotionalUsd: 2000                 # v2 DEFAULT_MIN_NOTIONAL_USD — per-position notional floor for a vote
+      weightCap: 3.0                       # v2 DEFAULT_WEIGHT_CAP — max per-strategy weight (outlier guard)
+      highWeight: 6.0                      # v2 DEFAULT_HIGH_WEIGHT — aggregate weight that earns the bonus point
+      minScore: 4                          # v2 DEFAULT_MIN_SCORE — consensus-score floor
+      marginPct: 15                        # PERCENT of withdrawable (0,100] (v2 0.15 fraction ×100)
+      leverage: 4                          # v2 DEFAULT_LEVERAGE; clamped to <= 10 (MAX_LEVERAGE) in scan.py
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      strategyCount: { type: number, required: false }
+      consensusWeight: { type: number, required: false }
+      strategiesFollowed: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: cuckoo_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan applied every filter (v2 LLM gate was pass-through — "Honor the signal")
+    scanners: [cuckoo_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # follow the live consensus now — a maker order that rests (CREATE_ORDER_RESTING) drifts from the top strategies' exposure
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: cuckoo_main_signals
+
+# ── EXIT (DSL — let-winners-run preset, ported VERBATIM from v2) ──────────────
+# The top strategies hold conviction positions, so let the consensus run: wide
+# ladder (T0 +10% / lock 0 — reachable, first lock NOT > +40%), max_loss 18%,
+# time-cuts OFF except a 96h hard_timeout staleness cap (Cuckoo re-evaluates the
+# consensus each tick but does not yet MIRROR an EXIT, so the timeout prevents
+# holding a stale consensus forever). NO weak_peak_cut. order_type
+# FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST happen).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760            # 96h — staleness cap (consensus EXIT not yet mirrored)
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # first lock at +10% ROE (reachable)
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 45 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+        - { trigger_pct: 90, lock_hw_pct: 88 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 345600           # 96h (was data_retention_hours 96); within [3600, 604800]
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 daily_loss_limit_pct
+    max_entries_per_day: 3                  # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 5400                 # v2 cooldown_minutes 90 -> 5400s
+    drawdown_halt_pct: 22                  # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 28800      # v2 per_asset_cooldown_minutes 480 -> 28800s (8h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/cuckoo/main/scanners/scan.py
+++ b/strategies/cuckoo/main/scanners/scan.py
@@ -1,0 +1,324 @@
+"""CUCKOO — supervised scanner (Runtime 3.0 port of the v2 copy-the-copiers meta-follower).
+
+Copy-the-Copiers / COHORT. Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - auto-discovers the top `topN` strategies by realized performance
+    (discovery_get_top_strategies) — READ-GUARDED, falls back to the last cached
+    cohort if the discovery read fails/returns empty (never crashes the tick),
+  - pulls each top strategy's current positions (leaderboard_get_trader_positions),
+  - builds a PERFORMANCE-WEIGHTED consensus across (asset, direction) votes
+    (pure `scoring.gather_entries` / `tally_consensus` / `consensus_score`),
+  - emits the SINGLE highest weighted-consensus candidate that >= minStrategies
+    top strategies agree on, at/above minScore (v2 main() emitted only `best`).
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`;
+the runtime sizes the dollars, owns slots/cooldowns/risk gates, and trails the DSL
+exit. No daemon, no push_signal, no create_position. Derived universe — the coins
+come from the followed strategies' positions, not a fixed list.
+
+FIDELITY NOTES vs cuckoo-producer.py v1.0.1:
+  - v2 sized margin from marginPct=0.15 (a FRACTION) * account_value -> marginUsd.
+    This port emits `marginPct` as a PERCENT in (0,100] (×100 -> 15) at the top
+    level; the runtime sizes (marginPct/100)*withdrawable. Includes the defensive
+    "<=1.0 means a pasted fraction, ×100" guard (dire/koala pattern). The 0.15
+    sizing is otherwise identical.
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1 signal/tick.
+  - v2 recent-signals JSON cache (RECENT_SIGNAL_TTL_SEC=240) -> ctx.state dedup
+    map (same 4x-TTL prune + was_recently_signaled semantics).
+  - COHORT->CACHE->DEGRADE: v2 returned a "WAITING" status and emitted nothing
+    when discovery_get_top_strategies returned empty. This port instead falls
+    back to the last cached strategy list in ctx.state (whalehunter/spider
+    pattern), so a single transient discovery hiccup doesn't blank the consensus.
+    If there is no cache yet, it degrades to [] exactly like v2's no-strategies path.
+  - DROPPED v2 order-lifecycle/mutation: the v2 producer's `push_signal` (a POST
+    via SenpiClient) and `record_signal` disk write are gone — scan() is read-only;
+    the runtime owns signal intake/dedup/execution. Cross-tick dedup is kept in
+    ctx.state. FLAGGED in the port report.
+  - v2 fetched discovery_get_top_strategies(limit=top_n) and
+    leaderboard_get_trader_positions(trader_id=wallet); both are reads, both
+    READ-GUARDED here. The defensive multi-key shape unwrap is reproduced verbatim.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v2 producer defaults (cuckoo-producer.py / cuckoo-config.json)
+_DEFAULT_TOP_N = 12              # how many top strategies to follow
+_DEFAULT_MIN_STRATEGIES = 2     # require at least this many agreeing
+_DEFAULT_MIN_NOTIONAL_USD = 2000
+_DEFAULT_WEIGHT_CAP = 3.0       # max per-strategy weight (outlier guard)
+_DEFAULT_HIGH_WEIGHT = 6.0      # aggregate weight that earns the bonus point
+_DEFAULT_MIN_SCORE = 4
+_DEFAULT_MARGIN_PCT = 15.0      # PERCENT of withdrawable (v2 0.15 fraction ×100)
+_DEFAULT_LEVERAGE = 4
+_MAX_LEVERAGE = 10              # v2 MAX_LEVERAGE (hardcoded clamp)
+_DEFAULT_RECENT_TTL = 240       # v2 RECENT_SIGNAL_TTL_SEC — race-window dedup
+_CACHE_VERSION = 1             # bump if cohort-BUILDING logic changes (busts stale cache)
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll back
+    the whole tick (per the contract, ANY exception rolls the tick back to []).
+    Returns None on failure so the degrade paths apply (cohort -> cached; a failed
+    per-strategy positions read -> that strategy contributes no votes this tick)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[cuckoo.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring.safe_float(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring.safe_float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "direction": "LONG" if szi > 0 else "SHORT"})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; running the held-asset dedup off that re-enters held
+    # names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring.safe_float(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring.safe_float(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[cuckoo.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _fetch_top_strategies(ctx, top_n):
+    """[{wallet, roi}] for the top strategies by performance. READ-GUARDED.
+    Defensive multi-key unwrap of the discovery response (verbatim from v2)."""
+    raw = _read(ctx, "discovery_get_top_strategies", {"limit": top_n})
+    if not raw:
+        return []
+    d = raw.get("data", raw) if isinstance(raw, dict) else raw
+    items = d
+    if isinstance(d, dict):
+        items = d.get("strategies", d.get("top_strategies", d.get("results", [])))
+    if not isinstance(items, list):
+        return []
+    out = []
+    for it in items[:top_n]:
+        if not isinstance(it, dict):
+            continue
+        wallet = (
+            it.get("strategyWalletAddress")
+            or it.get("strategy_wallet")
+            or it.get("wallet")
+            or it.get("trader_id")
+            or it.get("address")
+        )
+        if not wallet:
+            continue
+        roi = scoring.safe_float(
+            it.get("roi", it.get("roe", it.get("totalPnlPct", it.get("totalPnl", 0))))
+        )
+        out.append({"wallet": str(wallet), "roi": roi})
+    return out
+
+
+def _fetch_strategy_positions(ctx, wallet):
+    """Positions for one strategy, unwrapping the nested data.positions.positions
+    shape (same as Remora/Spider). READ-GUARDED -> [] on failure."""
+    raw = _read(ctx, "leaderboard_get_trader_positions", {"trader_id": wallet})
+    if not raw:
+        return []
+    if not isinstance(raw, dict):
+        return raw if isinstance(raw, list) else []
+    d = raw.get("data", raw)
+    if isinstance(d, list):
+        return d
+    if not isinstance(d, dict):
+        return []
+    rp = d.get("positions", d.get("top_positions", []))
+    if isinstance(rp, list):
+        return rp
+    if isinstance(rp, dict):
+        nested = rp.get("positions", [])
+        return nested if isinstance(nested, list) else []
+    return []
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(last):
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def _normalize_margin_pct(raw):
+    """marginPct must be a PERCENT in (0,100]. A pasted v2 fraction (<=1.0) is
+    converted ×100 (dire/koala defensive guard)."""
+    mp = float(raw)
+    if mp <= 1.0:
+        mp = mp * 100.0
+    return mp
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    top_n = int(inputs.get("topN", _DEFAULT_TOP_N))
+    min_strategies = int(inputs.get("minStrategies", _DEFAULT_MIN_STRATEGIES))
+    min_notional = float(inputs.get("minNotionalUsd", _DEFAULT_MIN_NOTIONAL_USD))
+    cap = float(inputs.get("weightCap", _DEFAULT_WEIGHT_CAP))
+    high_weight = float(inputs.get("highWeight", _DEFAULT_HIGH_WEIGHT))
+    min_score = int(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    base_margin_pct = _normalize_margin_pct(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    leverage = min(int(inputs.get("leverage", _DEFAULT_LEVERAGE)), _MAX_LEVERAGE)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    last = (ctx.state.last() or {}) if ctx.state is not None else {}
+    signaled = _prune_signaled(_load_signaled(last), ttl, now)
+    cached_cohort = last.get("cohort", {}) if isinstance(last.get("cohort"), dict) else {}
+
+    account_value, positions = _get_account(ctx)
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    def _persist(cohort):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"signaled": signaled, "cohort": cohort, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[cuckoo.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal or refetch the cohort: {exc!r}", file=sys.stderr)
+
+    if account_value <= 0:
+        result = {"ts": now, "emitted": False, "note": "no account value", "held": held_assets}
+        print("[cuckoo.scan] WAITING — no account value", file=sys.stderr)
+        _persist(cached_cohort)
+        return []
+
+    # ── auto-discover top strategies; COHORT->CACHE->DEGRADE ──
+    strategies = _fetch_top_strategies(ctx, top_n)
+    if strategies:
+        cohort = {"refreshed_at": now, "cache_version": _CACHE_VERSION, "strategies": strategies}
+    else:
+        cohort = cached_cohort if cached_cohort.get("cache_version") == _CACHE_VERSION else {}
+        strategies = cohort.get("strategies", [])
+        if strategies:
+            print(f"[cuckoo.scan] discovery empty — using cached cohort ({len(strategies)} strategies)",
+                  file=sys.stderr)
+
+    if not strategies:
+        result = {"ts": now, "emitted": False,
+                  "note": "WAITING — no top strategies (discovery empty, no cache)",
+                  "held": held_assets}
+        print("[cuckoo.scan] WAITING — discovery_get_top_strategies returned no strategies "
+              "and no cohort cache", file=sys.stderr)
+        _persist(cohort)
+        return []
+
+    # ── pull each strategy's positions (read-guarded), build weighted consensus ──
+    positions_by_wallet = {s["wallet"]: _fetch_strategy_positions(ctx, s["wallet"])
+                           for s in strategies}
+    entries = scoring.gather_entries(strategies, positions_by_wallet, min_notional, cap)
+    consensus = scoring.tally_consensus(entries)
+
+    scored = []
+    for cand in consensus.values():
+        if cand["count"] < min_strategies:
+            continue
+        if cand["asset"].upper() in held_set:
+            continue
+        if _was_recently_signaled(signaled, cand["asset"], ttl, now):
+            continue
+        score = scoring.consensus_score(cand["count"], cand["weight"], high_weight)
+        if score >= min_score:
+            reasons = [
+                f"{cand['asset']}_{cand['direction']}",
+                f"top_strategies_{cand['count']}",
+                f"weighted_{cand['weight']:.1f}",
+            ]
+            scored.append((score, reasons, cand))
+
+    out = []
+    if not scored:
+        result = {"ts": now, "emitted": False,
+                  "note": f"WAITING — no asset held by >= {min_strategies} top strategies",
+                  "strategiesFollowed": len(strategies),
+                  "candidatesSeen": len(consensus), "held": held_assets}
+        print(f"[cuckoo.scan] WAITING — no >= {min_strategies}-strategy consensus; "
+              f"strategies={len(strategies)} candidates={len(consensus)} held={held_assets}",
+              file=sys.stderr)
+        _persist(cohort)
+        return out
+
+    # v2 emitted exactly the single best: sort by (score, weight, count) desc.
+    scored.sort(key=lambda t: (t[0], t[2]["weight"], t[2]["count"]), reverse=True)
+    best_score, best_reasons, best = scored[0]
+
+    signaled[best["asset"].upper()] = now
+    result = {"ts": now, "emitted": True, "coin": best["asset"], "direction": best["direction"],
+              "score": best_score, "strategyCount": best["count"],
+              "consensusWeight": round(best["weight"], 2), "leverage": leverage,
+              "marginPct": round(base_margin_pct, 4), "strategiesFollowed": len(strategies),
+              "held": held_assets, "reasons": best_reasons}
+    print(f"[cuckoo.scan] EMIT {best['asset']} {best['direction']} score={best_score} "
+          f"{leverage}x marginPct={base_margin_pct:.2f}% count={best['count']} "
+          f"weight={best['weight']:.1f}", file=sys.stderr)
+    out = [{
+        "asset": best["asset"],
+        "direction": best["direction"],
+        "marginPct": base_margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+        "leverage": leverage,                  # 1..10; runtime applies it
+        "data": {
+            "score": best_score,
+            "leverage": leverage,
+            "direction": best["direction"],
+            "reasons": best_reasons,
+            "strategyCount": best["count"],
+            "consensusWeight": round(best["weight"], 2),
+            "strategiesFollowed": len(strategies),
+            "heldAssets": held_assets,
+        },
+    }]
+
+    _persist(cohort)
+    return out

--- a/strategies/cuckoo/main/scanners/scoring.py
+++ b/strategies/cuckoo/main/scanners/scoring.py
@@ -1,0 +1,145 @@
+"""CUCKOO — pure meta-consensus math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Cuckoo producer's pure functions
+(cuckoo-producer.py v1.0.1 — `performance_weight`, `mirror_direction`,
+`position_asset`, `position_notional`, `tally_consensus`, `consensus_score`).
+The math is reproduced VERBATIM so a fidelity harness can diff this against the
+v2 producer on the same snapshot. scan.py does the reads (top-strategies +
+per-strategy positions) and hands plain lists/dicts to these functions.
+
+Thesis (copy-the-copiers / copy_trading · copy_the_copiers):
+  Each top strategy casts ONE vote per (asset, direction) it holds above
+  minNotionalUsd, weighted by performance_weight(roi) = clamp(1 + roi/50,
+  0.5, weightCap). Votes are tallied into weighted (asset, direction)
+  candidates; entry requires >= minStrategies agreeing. A stronger strategy
+  gets more say (capped so one outlier can't dominate)."""
+
+
+# v2 producer constants (cuckoo-producer.py)
+DEFAULT_WEIGHT_CAP = 3.0       # max per-strategy weight (outlier guard)
+DEFAULT_HIGH_WEIGHT = 6.0      # aggregate weight that earns the bonus point
+
+
+def safe_float(v, default=0.0):
+    """Verbatim from v2 safe_float."""
+    try:
+        return float(v if v is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def performance_weight(roi_pct, cap=DEFAULT_WEIGHT_CAP):
+    """Map a strategy's ROI% to a follow weight in [0.5, cap]. A flat strategy
+    weighs 1.0; a +100% strategy hits the cap; a losing strategy floors at
+    0.5 (it still counts a little, but barely). Verbatim from v2."""
+    w = 1.0 + (safe_float(roi_pct) / 50.0)
+    if w < 0.5:
+        return 0.5
+    if w > cap:
+        return cap
+    return w
+
+
+def mirror_direction(pos):
+    """LONG / SHORT for a position (explicit direction/side field, else szi
+    sign). None if undeterminable. Verbatim from v2."""
+    if not isinstance(pos, dict):
+        return None
+    d = str(pos.get("direction", pos.get("side", ""))).upper()
+    if d in ("LONG", "SHORT"):
+        return d
+    szi = safe_float(pos.get("szi", pos.get("size", 0)))
+    if szi > 0:
+        return "LONG"
+    if szi < 0:
+        return "SHORT"
+    return None
+
+
+def position_asset(pos):
+    """Asset symbol for a position (multi-key fallback). Verbatim from v2.
+
+    Preserves the symbol as returned by the upstream strategy's position
+    (e.g. an `xyz:` prefix survives). Case is uppercased, matching v2."""
+    if not isinstance(pos, dict):
+        return ""
+    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", ""))))).upper()
+
+
+def position_notional(pos):
+    """USD notional for a position (size*entry, else marginUsed, else size).
+    Verbatim from v2."""
+    if not isinstance(pos, dict):
+        return 0.0
+    size = abs(safe_float(pos.get("szi", pos.get("size", 0))))
+    entry = safe_float(pos.get("entryPx", pos.get("entryPrice", pos.get("entry", 0))))
+    notional = size * entry
+    if notional > 0:
+        return notional
+    margin = abs(safe_float(pos.get("marginUsed", pos.get("margin", 0))))
+    return margin if margin > 0 else size
+
+
+def tally_consensus(entries):
+    """Aggregate per-strategy votes into weighted (asset, direction) candidates.
+    `entries` = list of {"asset","direction","weight"}. Returns a dict keyed by
+    (asset, direction) -> {"asset","direction","count","weight"}. Verbatim."""
+    agg = {}
+    for e in entries:
+        asset = str(e.get("asset", "")).upper()
+        direction = e.get("direction")
+        if not asset or direction not in ("LONG", "SHORT"):
+            continue
+        weight = safe_float(e.get("weight"), 1.0)
+        key = (asset, direction)
+        rec = agg.setdefault(key, {"asset": asset, "direction": direction, "count": 0, "weight": 0.0})
+        rec["count"] += 1
+        rec["weight"] += weight
+    return agg
+
+
+def consensus_score(count, total_weight, high_weight=DEFAULT_HIGH_WEIGHT):
+    """Score a weighted-consensus candidate (max ~6). Verbatim from v2.
+
+      +2 held by at least one top strategy
+      +3 if 4+ strategies agree, +2 if 3, +1 if 2
+      +1 if aggregate weight >= high_weight"""
+    score = 2  # held by at least one top strategy
+    if count >= 4:
+        score += 3
+    elif count >= 3:
+        score += 2
+    elif count == 2:
+        score += 1
+    if total_weight >= high_weight:
+        score += 1
+    return score
+
+
+def gather_entries(strategies, positions_by_wallet, min_notional, cap):
+    """One weighted vote per (strategy, asset, direction) for every qualifying
+    position the top strategies hold. Port of v2 gather_entries — but the MCP
+    fetch is hoisted into scan.py (read-guarded there) and the already-fetched
+    positions are passed in via `positions_by_wallet` (wallet -> [positions]).
+
+    `strategies` = [{"wallet", "roi"}]. Returns the entries list for
+    tally_consensus()."""
+    entries = []
+    for strat in strategies:
+        wallet = strat["wallet"]
+        weight = performance_weight(strat["roi"], cap)
+        positions = positions_by_wallet.get(wallet, [])
+        seen = set()  # dedupe within a strategy: one vote per asset+direction
+        for pos in positions:
+            asset = position_asset(pos)
+            direction = mirror_direction(pos)
+            if not asset or direction is None:
+                continue
+            if position_notional(pos) < min_notional:
+                continue
+            key = (asset, direction)
+            if key in seen:
+                continue
+            seen.add(key)
+            entries.append({"asset": asset, "direction": direction, "weight": weight})
+    return entries

--- a/strategies/cuckoo/strategy.yaml
+++ b/strategies/cuckoo/strategy.yaml
@@ -1,0 +1,45 @@
+# Cuckoo — copy-the-copiers meta-strategy follower. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port
+# of the v2 Cuckoo (SKILL.md v1.0.0 / producer v1.0.1): auto-discovers the top
+# strategies by realized performance (discovery_get_top_strategies), builds a
+# performance-weighted consensus across their positions, and follows the asset+direction
+# they agree on most. Let-winners-run DSL with a 96h staleness cap. Derived universe —
+# coins come from the followed strategies' positions, not a fixed list.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: cuckoo
+version: "1.0.0"
+
+catalog:
+  name: "Cuckoo — Copy-the-Copiers"
+  emoji: "🐦"
+  tagline: "Auto-discovers the platform's top-performing strategies, then trades the asset + direction they agree on most — performance-weighted, so a stronger strategy gets more say (capped so one outlier can't dominate)."
+  belief_plain: "Lets the best strategies on the platform do the work. Every few minutes it finds the top performers, looks at what they're holding right now, and copies whatever the most (and best) of them are piling into together — going long what they're long and short what they're short."
+  thesis: "Following one trader or one leaderboard is one layer; Cuckoo is a layer above it. The strategies it follows are themselves copy/algo/trader-following strategies, so it captures the consensus of the consensus. When the best strategies independently pile into the same asset+direction, that agreement is a strong, self-cleaning signal — underperformers fall out of the top-N automatically, so the pool refreshes toward whatever is working."
+  group: smart-money
+  archetype: copy_trading
+  sub_style: copy_the_copiers
+  asset_classes: [none]
+  asset_scope: follows_traders
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 10
+  max_slots: 1
+  min_budget: 200
+  assets: []
+  tags: [copy-trading, copy-the-copiers, meta-strategy, consensus, performance-weighted, follows-strategies, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: CUCKOO_WALLET
+    funding_share: 1.0

--- a/strategies/jackal/main/runtime.yaml
+++ b/strategies/jackal/main/runtime.yaml
@@ -1,0 +1,160 @@
+# ── JACKAL · single instance — the Smart Stalker (copy-trader / trader-follower) ──
+# Runtime 3.0 port of the v2 Jackal v3.0.1 producer thesis. Maintains a daily-refreshed,
+# quality-scored pool of top-ROI Hyperliquid traders (discovery_get_top_traders), watches
+# for FRESH pool-member entries (< 10 min old) via a per-trader position diff, enriches
+# with pool consensus + multi-timeframe TA + funding regime + BTC macro, and mirrors the
+# entry with its OWN wide DSL. Faithful port of the v2 producer thesis — see
+# scanners/scoring.py (math reproduced verbatim, v2 quirks flagged). The v2 LLM gate
+# (decision_mode: llm, min_confidence 7) is replaced by decision_mode: rule: the producer
+# already applied every hard filter, and the v2 prompt's soft skip-conditions are
+# reproduced as deterministic rule gates inside scan.py (applySoftGates).
+name: jackal-main
+group: jackal
+version: 3.0.0
+description: >
+  JACKAL — the Smart Stalker. A copy-trader that keeps a daily-refreshed pool of the
+  top-ROI Hyperliquid traders (win-rate + age + 30d-ROI filtered, quality-scored toward
+  tail-winner trend-followers: ROI 35% / gain-to-pain 25% / age 15% / win-rate 10%),
+  detects the moment a pool member opens a FRESH position (< 10 min old), confirms it
+  with pool consensus + independent 15m/1h/4h TA + funding regime, and mirrors the entry
+  in the same direction with our OWN wide DSL. Long/short, derived universe (coins come
+  from what pool members enter). Faithful port of the v2 Jackal v3.0.1 thesis — all
+  pool/scoring/diff logic verbatim; LLM gate -> deterministic rule gates.
+
+strategy:
+  wallet: "${JACKAL_WALLET}"
+  slots: 2                                 # v2 strategy.slots 2
+  margin_pct: 30                           # v2 strategy.margin_pct 30 (flat; scan emits the per-signal marginPct)
+  default_leverage: 5                      # v2 strategy.default_leverage 5; scan emits std/max-clamped leverage
+  trading_risk: moderate                   # v2 strategy.trading_risk moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: jackal_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 60                    # v2 producer_daemon 60s tick
+    timeout_seconds: 120                    # v2 tick_timeout=120; pool fetch + per-member state + per-candidate TA
+    default_signal_validity_seconds: 120    # 2x tick; fresh-entry alpha decays fast, a re-detect re-fires
+    state_history_max_count: 24             # cohort cache + last-seen baseline + dedup map + per-tick result
+    inputs:
+      # ── pool (discovery_get_top_traders, cached ~24h) ──
+      poolSize: 25                          # v2 POOL_SIZE
+      poolMinWinRate: 0.50                  # v2 POOL_MIN_WIN_RATE (note: v2 compared vs a 0-100 % field, see scoring)
+      poolMinRoi30d: 10.0                   # v2 POOL_MIN_ROI_30D (%)
+      poolMinTraderAgeDays: 14              # v2 POOL_MIN_TRADER_AGE_DAYS
+      poolFetchLimit: 60                    # v2 overfetch-then-filter limit
+      poolRefreshHours: 24                  # v2 refresh_pool daily cadence
+      # ── fresh-entry detection ──
+      maxEntryAgeSeconds: 600               # v2 MAX_ENTRY_AGE_SECONDS (10 min)
+      recentSignalTtlSeconds: 600           # signal-dedup window (don't re-fire a coin+dir while in flight)
+      applySoftGates: true                  # reproduce v2 LLM hard-skip conditions as rule gates
+      qualityFloor: 55                      # v2 prompt: sourceQualityScore < 55 -> skip
+      # ── sizing ──
+      marginPct: 30                         # PERCENT of withdrawable (0,100]; flat = v2 sizing (runtime sized off margin_pct: 30)
+      maxMarginPct: 30                      # cap == base => flat (no producer-side conviction scaling, as v2)
+      qualityMarginScale: 0.0               # 0 => faithful flat; >0 opts into quality-scaled margin
+      stdLeverage: 5                        # v2 default_leverage 5
+      maxLeverage: 5                        # venue/strategy clamp
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      sourceTraderAddress: { type: string }
+      sourceTraderUserId: { type: string, required: false }
+      sourceTraderUsername: { type: string, required: false }
+      sourceQualityScore: { type: number }
+      sourceWinRate: { type: number, required: false }
+      sourceRoi30d: { type: number, required: false }
+      sourceConsecutiveWins: { type: number, required: false }
+      entryTimestamp: { type: number }
+      sourceLeverage: { type: number, required: false }
+      sizeUsd: { type: number, required: false }
+      entryPrice: { type: number, required: false }
+      poolConsensusCount: { type: number }
+      poolConsensusAssetCount: { type: number }
+      trend4h: { type: string, required: false }
+      trend1h: { type: string, required: false }
+      trend15m: { type: string, required: false }
+      priceChange4hPct: { type: number, required: false }
+      fundingRegime: { type: string, required: false }
+      fundingAnnualizedPct: { type: number, required: false }
+      btcMacroDirection: { type: string, required: false }
+      btcMacro24hPct: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: jackal_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # scan applied every filter (v2 LLM gate was a pass-through rubber-stamp;
+                                            # its soft skip-conditions are reproduced as rule gates in scan.py)
+    scanners: [jackal_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true     # v2 entry ensure_execution_as_taker: true
+        execution_timeout_seconds: 60       # v2.0.6 entry execution_timeout_seconds 60 (maker fill window)
+    context:
+      - type: signal
+        scanner: jackal_main_signals
+
+# ── EXIT (DSL — ported VERBATIM from v2 runtime.yaml) ─────────────────────────
+# Jackal's thesis is patience — consensus signals take time to develop. Wide Phase 1
+# (22% max_loss), loose-but-REACHABLE early Phase 2 locks (first lock at +6% ROE, NOT
+# +40%). Hard timeout 72h lets multi-day holds breathe. weak_peak_cut 4h @ 3% (self-
+# limiting). dead_weight_cut DISABLED (Jackal is patient; no time-based loss cuts).
+exit:
+  engine: dsl
+  interval_seconds: 30                       # v2 exit.interval_seconds 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true          # closes MUST happen — taker fallback (v2)
+    execution_timeout_seconds: 60            # v2.0.6 exit execution_timeout_seconds 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                          # v2: enabled
+      interval_in_minutes: 4320              # v2: 72h
+    weak_peak_cut:
+      enabled: true                          # v2: enabled
+      interval_in_minutes: 240               # v2: 4h of stale peak before cut
+      min_value: 3.0                         # v2: 3.0
+    dead_weight_cut:
+      enabled: false                         # v2: disabled — Jackal is patient
+      interval_in_minutes: 240
+    phase1:
+      enabled: true
+      max_loss_pct: 22.0                      # v2: 22%
+      retrace_threshold: 10                   # v2: 10
+      consecutive_breaches_required: 1        # v2: 1
+    phase2:
+      enabled: true
+      tiers:                                  # ported verbatim (first lock at +6% ROE — reachable)
+        - { trigger_pct: 6,   lock_hw_pct: 20 }
+        - { trigger_pct: 14,  lock_hw_pct: 40 }
+        - { trigger_pct: 28,  lock_hw_pct: 62 }
+        - { trigger_pct: 50,  lock_hw_pct: 80 }
+        - { trigger_pct: 100, lock_hw_pct: 94 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200             # v2 data_retention_hours 72 -> 72*3600 (within [3600, 604800])
+  guard_rails:
+    daily_loss_limit_pct: 5                   # v2 daily_loss_limit_pct 5
+    max_entries_per_day: 4                    # v2 max_entries_per_day 4
+    bypass_max_entries_per_day_on_profit: false  # v2: false
+    max_consecutive_losses: 3                 # v2 max_consecutive_losses 3
+    cooldown_seconds: 7200                    # v2 cooldown_minutes 120 -> 7200s
+    drawdown_halt_pct: 20                     # v2 drawdown_halt_pct 20
+    drawdown_reset_on_day_rollover: false     # v2: false
+    per_asset_cooldown_seconds: 14400         # v2 per_asset_cooldown_minutes 240 -> 14400s
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/jackal/main/scanners/scan.py
+++ b/strategies/jackal/main/scanners/scan.py
@@ -1,0 +1,352 @@
+"""JACKAL — supervised scanner (Runtime 3.0 port of the v2 Jackal Smart-Stalker producer).
+
+TRADER-FOLLOWER / COHORT copy-trader. Per tick it:
+  - refreshes a quality-scored trader pool from discovery_get_top_traders (cached ~24h
+    in ctx.state; on a failed refresh it DEGRADES to the stale cohort cache, never crashes),
+  - fetches every pool member's current open positions (discovery_get_trader_state, batched),
+  - diffs against last-tick's per-trader baseline to detect FRESH new entries (< 10 min old),
+  - enriches each candidate with pool consensus + per-asset multi-timeframe TA + funding
+    regime (market_get_funding_regime, neutral on fail) + asset funding + BTC 24h macro,
+  - emits ONE marginPct intent per fresh entry (the runtime sizes, owns slots/dedup/risk,
+    and trails the DSL exit).
+
+Read-only + single-pass. Derived universe — coins come from what pool members enter, not a
+fixed list. Every ctx.senpi_mcp.call_tool is wrapped in try/except -> degrade (stale cohort
+cache / skip member / neutral regime / UNKNOWN TA), so one bad read never rolls the whole
+tick back to []. No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs jackal-producer.py v3.0.1:
+  - v2 was a 60s producer_daemon pushing signals via SenpiClient.push_signal(); this is a
+    single-pass scan() emitting plain dicts the runtime sizes/executes. No HTTP POST, no
+    daemon loop, no reentrancy lock (the runtime supervises ticks).
+  - v2 emitted `score = quality_score/100` (0..1 confidence) and the runtime sized every
+    entry from a FLAT margin_pct: 30 (NO producer-side conviction scaling). This port emits
+    `marginPct` TOP-LEVEL at the same flat base (scoring.margin_pct_for, qualityMarginScale
+    default 0 => flat) — v2 sizing preserved exactly. quality_score is still carried on
+    data{} as sourceQualityScore (and as `score`).
+  - v2 LLM gate (decision_mode: llm, min_confidence 7) is replaced by decision_mode: rule
+    in the runtime.yaml. The producer already applied every HARD filter (pool quality floors,
+    fresh-entry window, direction derivation); the v2 LLM prompt's SOFT checks (consensus>0,
+    TA-not-all-UNKNOWN, funding-not-fighting, quality>=55) are reproduced as RULE gates here
+    (scan-level skips) so behaviour matches the gated v2 without an LLM in the loop. FLAGGED.
+  - v2 cohort cache (state/pool.json, daily) + last-seen baseline (state/last-seen.json) ->
+    ctx.state records. The v2 baseline-seed guard is preserved VERBATIM: on an EMPTY baseline
+    (first tick / state reset) emit 0 signals and just seed, so existing positions are never
+    re-detected as "new" on startup (the v2.0.3 live bug).
+  - Dropped: nothing order-lifecycle (the v2 producer had no cancel_order / order purge —
+    it never managed orders, only emitted signals). Nothing to drop.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+
+import sys
+import time
+
+import scoring
+
+
+CACHE_VERSION = 1            # bump if pool-BUILDING logic changes (busts a stale cache)
+_DEFAULT_RECENT_TTL = 600    # 10m signal-dedup: don't re-fire a coin+dir while a signal is in flight
+_DEFAULT_MAX_ENTRY_AGE = 600  # v2 MAX_ENTRY_AGE_SECONDS — only mirror entries < 10 min old
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll the whole
+    tick back to []. Returns None on failure so the existing degrade paths apply (cohort
+    falls back to its daily cache; a failed member-state batch is skipped; TA -> UNKNOWN)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[jackal.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _unwrap_list(resp, *keys):
+    """Unwrap the discovery list document: resp -> resp.data -> resp.data.<key> -> list."""
+    if not resp:
+        return []
+    raw = resp.get("data", resp) if isinstance(resp, dict) else resp
+    if isinstance(raw, dict):
+        for k in keys:
+            if isinstance(raw.get(k), list):
+                return raw[k]
+        # fall through: a single-key dict wrapping the list
+        for v in raw.values():
+            if isinstance(v, list):
+                return v
+        return []
+    return raw if isinstance(raw, list) else []
+
+
+# ── trader pool: refresh from discovery_get_top_traders, cached ~24h in ctx.state ──
+
+def _refresh_pool(ctx, cached, inputs, now):
+    """Return the active trader pool. Fresh cache (< refresh_h) is reused with NO fetch.
+    On a stale/missing cache, fetch + filter + rank (scoring.build_pool). On a FAILED
+    refresh, DEGRADE to the stale cache (v2 refresh_pool fallback). Cached in ctx.state."""
+    refresh_h = float(inputs.get("poolRefreshHours", 24))
+    fetch_limit = int(inputs.get("poolFetchLimit", 60))   # v2 overfetch then filter
+    if (cached.get("traders") and cached.get("cache_version") == CACHE_VERSION
+            and (now - cached.get("refreshed_at", 0)) / 3600 < refresh_h):
+        return cached                                     # fresh cache — no fetch
+
+    resp = _read(ctx, "discovery_get_top_traders", {
+        "time_frame": "MONTHLY",
+        "sort_by": "RETURN_ON_INVESTMENT",
+        "limit": fetch_limit,
+    })
+    raw = _unwrap_list(resp, "traders", "data")
+    if not raw:
+        return cached                                     # failed refresh — keep old cache (degrade)
+
+    top = scoring.build_pool(raw, inputs)
+    if not top:
+        return cached                                     # filtered to empty — keep old cache
+    return {"refreshed_at": now, "cache_version": CACHE_VERSION,
+            "size": len(top), "traders": top}
+
+
+def _fetch_pool_positions(ctx, pool):
+    """{addr -> [open_position dicts]} for every pool member (discovery_get_trader_state,
+    batched by 50). A failed batch is skipped (those members just look unchanged)."""
+    addresses = [t["address"] for t in pool]
+    by_addr = {}
+    for i in range(0, len(addresses), 50):
+        resp = _read(ctx, "discovery_get_trader_state",
+                     {"trader_addresses": addresses[i:i + 50]})
+        for t in _unwrap_list(resp, "traders"):
+            if not isinstance(t, dict):
+                continue
+            addr = (t.get("address") or "").lower()
+            if not addr:
+                continue
+            by_addr[addr] = t.get("openPositions") or t.get("open_positions") or []
+    return by_addr
+
+
+def _fetch_funding_regime(ctx):
+    """Market-wide funding regime once per tick, or None (neutral on fail). v2 fetch_funding_regime."""
+    resp = _read(ctx, "market_get_funding_regime", {})
+    if not resp:
+        return None
+    data = resp.get("data", resp) if isinstance(resp, dict) else resp
+    return data.get("regime") if isinstance(data, dict) else None
+
+
+def _dex_for(coin):
+    return "xyz" if str(coin).lower().startswith("xyz:") else ""
+
+
+def _enrich_ta(ctx, coin, funding_regime):
+    """Per-candidate 15m/1h/4h trend + asset funding for `coin`. Degrades to UNKNOWN/None
+    on a failed read (v2 enrich_with_ta swallowed exceptions to a None-filled dict)."""
+    out = {"trend_4h": None, "trend_1h": None, "trend_15m": None,
+           "price_change_4h_pct": None, "funding_regime": funding_regime,
+           "funding_annualized_pct": None}
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": coin,
+        "candle_intervals": ["15m", "1h", "4h"],
+        "include_funding": True,
+        "include_order_book": False,
+        "dex": _dex_for(coin),
+    })
+    if not resp:
+        return out
+    data = resp.get("data", resp) if isinstance(resp, dict) else resp
+    if not isinstance(data, dict):
+        return out
+    candles = data.get("candles", {}) or {}
+    out["price_change_4h_pct"] = scoring.trend_pct(candles.get("4h"))
+    out["trend_4h"] = scoring.trend_label(out["price_change_4h_pct"])
+    out["trend_1h"] = scoring.trend_label(scoring.trend_pct(candles.get("1h")))
+    out["trend_15m"] = scoring.trend_label(scoring.trend_pct(candles.get("15m")))
+    ac = data.get("asset_context") or data.get("assetContext") or {}
+    if isinstance(ac, dict) and ac.get("funding") is not None:
+        out["funding_annualized_pct"] = scoring.annualize_funding(ac.get("funding"))
+    return out
+
+
+def _fetch_btc_macro(ctx):
+    """BTC 24h direction/pct from 1h candles, or (None, None). v2 fetch_btc_macro."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": "BTC",
+        "candle_intervals": ["1h"],
+        "include_funding": False,
+        "include_order_book": False,
+        "dex": "",
+    })
+    if not resp:
+        return None, None
+    data = resp.get("data", resp) if isinstance(resp, dict) else resp
+    candles_1h = (data.get("candles", {}) or {}).get("1h", []) if isinstance(data, dict) else []
+    return scoring.macro_pct(candles_1h)
+
+
+# ── soft gates (port of the v2 LLM decision_prompt hard-skip conditions, as RULES) ──
+
+def _passes_soft_gates(c, ta, inputs):
+    """Reproduce the v2 LLM gate's HARD SKIP conditions as deterministic rule gates
+    (no LLM in the 3.0 loop). Returns (ok, reason).
+      - sourceQualityScore < qualityFloor (55)            -> skip
+      - poolConsensusCount == 0 AND all TA UNKNOWN/contra -> skip (no independent confirm)
+      - all of trend4h/1h/15m UNKNOWN                      -> skip (no data)
+      - fundingRegime actively fights direction           -> skip (SHORT into SHORT_CROWDED, etc.)
+    """
+    floor = float(inputs.get("qualityFloor", 55))
+    q = scoring._f(c["trader"].get("quality_score"), default=0.0)
+    if q < floor:
+        return False, f"quality<{floor:.0f}"
+
+    labels = [ta.get("trend_4h"), ta.get("trend_1h"), ta.get("trend_15m")]
+    known = [x for x in labels if x not in (None, "UNKNOWN")]
+    if not known:
+        return False, "TA_all_unknown"
+
+    want = "BULLISH" if c["direction"] == "LONG" else "BEARISH"
+    confirms = any(x == want for x in known)
+    if c["pool_consensus_count"] == 0 and not confirms:
+        return False, "solo_no_TA_confirm"
+
+    regime = (ta.get("funding_regime") or "").upper()
+    if c["direction"] == "SHORT" and "SHORT_CROWDED" in regime:
+        return False, "regime_fights_short"
+    if c["direction"] == "LONG" and "LONG_CROWDED" in regime:
+        return False, "regime_fights_long"
+    return True, "ok"
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    max_entry_age = float(inputs.get("maxEntryAgeSeconds", _DEFAULT_MAX_ENTRY_AGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+    std_lev = int(inputs.get("stdLeverage", 5))
+    max_lev = int(inputs.get("maxLeverage", 5))
+    soft_gates = bool(inputs.get("applySoftGates", True))
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    last_seen = {k.lower(): v for k, v in (last.get("last_seen") or {}).items()
+                 if isinstance(v, list)}
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    pool = _refresh_pool(ctx, last.get("cohorts", {}), inputs, now)
+    traders = pool.get("traders", [])
+
+    # current positions for every pool member
+    current_positions = _fetch_pool_positions(ctx, traders) if traders else {}
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({
+                "cohorts": pool,
+                "last_seen": current_positions,   # next-tick baseline
+                "recent": recent,
+                "result": result,
+            })
+        except Exception as exc:  # noqa: BLE001
+            print(f"[jackal.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+
+    if not traders:
+        result = {"ts": now, "pool_size": 0, "emitted": 0, "note": "WAITING (no pool)"}
+        print("[jackal.scan] WAITING — empty trader pool (cohort refresh/cache empty)",
+              file=sys.stderr)
+        _persist(result)
+        return []
+
+    # v2.0.4 baseline-seed guard (preserved VERBATIM): on an EMPTY baseline (first tick
+    # ever / state reset), DO NOT treat every current pool-member position as "new" —
+    # that would emit signals for all existing positions on startup (the v2.0.3 live bug).
+    # Emit 0, just seed the baseline; the NEXT tick can safely diff.
+    if not last_seen:
+        result = {"ts": now, "pool_size": len(traders), "emitted": 0,
+                  "note": "WAITING (baseline seed)"}
+        print(f"[jackal.scan] WAITING — baseline seed (pool={len(traders)}, "
+              f"{len(current_positions)} members snapshotted); no diff on first tick",
+              file=sys.stderr)
+        _persist(result)
+        return []
+
+    candidates = scoring.detect_new_entries(traders, current_positions, last_seen,
+                                            now, max_entry_age)
+    candidates = scoring.enrich_with_consensus(candidates, current_positions)
+
+    if not candidates:
+        result = {"ts": now, "pool_size": len(traders), "emitted": 0,
+                  "note": "WAITING (no fresh entries)"}
+        print(f"[jackal.scan] WAITING — no fresh pool-member entries "
+              f"(pool={len(traders)})", file=sys.stderr)
+        _persist(result)
+        return []
+
+    # shared per-tick context (v2.0.3: fetch ONCE per run, not per candidate)
+    btc_dir, btc_pct = _fetch_btc_macro(ctx)
+    funding_regime = _fetch_funding_regime(ctx)
+    leverage = min(std_lev, max_lev)
+
+    out = []
+    emitted = 0
+    for c in candidates:
+        cu = c["coin"].upper()
+        dk = f"{cu}|{c['direction']}"
+        if recent.get(dk) is not None and (now - recent[dk]) < ttl:   # signal-dedup
+            continue
+
+        ta = _enrich_ta(ctx, c["coin"], funding_regime)
+        if soft_gates:
+            ok, why = _passes_soft_gates(c, ta, inputs)
+            if not ok:
+                print(f"[jackal.scan] SKIP {c['coin']} {c['direction']} ({why})",
+                      file=sys.stderr)
+                continue
+
+        trader = c["trader"]
+        q = scoring._f(trader.get("quality_score"), default=0.0)
+        margin_pct = scoring.margin_pct_for(q, inputs)
+        out.append({
+            "asset": c["coin"],
+            "direction": c["direction"],
+            "marginPct": margin_pct,           # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,              # std; runtime clamps to venue max
+            "data": {
+                "score": scoring.confidence_score(q),   # 0..1 confidence (v2 push_signal score)
+                "direction": c["direction"],
+                "sourceTraderAddress": trader["address"],
+                "sourceTraderUserId": str(trader.get("user_id") or ""),
+                "sourceTraderUsername": str(trader.get("username") or ""),
+                "sourceQualityScore": q,
+                "sourceWinRate": scoring._f(trader.get("win_rate"), default=0.0),
+                "sourceRoi30d": scoring._f(trader.get("roi_30d"), default=0.0),
+                "sourceConsecutiveWins": int(scoring._f(trader.get("consecutive_wins"), default=0)),
+                "entryTimestamp": c["entry_ts"],
+                "sourceLeverage": c["leverage"],
+                "sizeUsd": c["size_usd"],
+                "entryPrice": c["entry_price"],
+                "poolConsensusCount": c["pool_consensus_count"],
+                "poolConsensusAssetCount": c["pool_consensus_asset_count"],
+                "trend4h": ta["trend_4h"] or "UNKNOWN",
+                "trend1h": ta["trend_1h"] or "UNKNOWN",
+                "trend15m": ta["trend_15m"] or "UNKNOWN",
+                "priceChange4hPct": ta["price_change_4h_pct"] if ta["price_change_4h_pct"] is not None else 0,
+                "fundingRegime": ta["funding_regime"] or "UNKNOWN",
+                "fundingAnnualizedPct": ta["funding_annualized_pct"] if ta["funding_annualized_pct"] is not None else 0,
+                "btcMacroDirection": btc_dir or "UNKNOWN",
+                "btcMacro24hPct": btc_pct if btc_pct is not None else 0,
+            },
+        })
+        recent[dk] = now
+        emitted += 1
+        print(f"[jackal.scan] EMIT {c['coin']} {c['direction']} q={q:.1f} "
+              f"consensus={c['pool_consensus_count']} {leverage}x marginPct={margin_pct:.2f}% "
+              f"src={trader['address'][:8]}", file=sys.stderr)
+
+    if emitted == 0:
+        print(f"[jackal.scan] WAITING — {len(candidates)} fresh entries, none passed "
+              f"dedup/soft-gates (pool={len(traders)})", file=sys.stderr)
+
+    result = {"ts": now, "pool_size": len(traders),
+              "candidates": len(candidates), "emitted": emitted,
+              "btc_macro": [btc_dir, btc_pct], "funding_regime": funding_regime}
+    _persist(result)
+    return out

--- a/strategies/jackal/main/scanners/scoring.py
+++ b/strategies/jackal/main/scanners/scoring.py
@@ -1,0 +1,308 @@
+"""JACKAL — pure copy-trade scoring math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Jackal v3.0.1 producer (jackal-producer.py).
+Given trader/position/candle dicts already fetched by scan.py, this module reproduces
+VERBATIM the v2 producer's:
+  - trader-pool quality filter + composite quality score (_compute_quality_score, v2.0.6)
+  - new-entry diff key derivation (coin, LONG/SHORT-from-szi)
+  - pool-consensus aggregation (same coin+direction; same-asset-any-direction)
+  - per-asset trend labels (open->close % over a candle window) + funding annualization
+so a fidelity harness can diff it against the v2 producer on the same snapshot.
+
+The v2 producer pushed `score = quality_score / 100` (0..1 confidence) and let the
+runtime size each entry from a FLAT `margin_pct: 30`. Jackal applied NO producer-side
+conviction scaling, so this port emits a FLAT base marginPct by default
+(qualityMarginScale defaults to 0 => no scale) to preserve v2 sizing exactly; the knob
+is exposed for operators but defaults to faithful flat behaviour.
+
+Pure / single-pass / unit-testable on plain dicts. All clock/MCP lives in scan.py.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+
+
+def _f(x, *keys, default=0.0):
+    """Float from x. If keys given, x is a dict and we try each key in order
+    (first non-None wins). Mirrors the v2 producer's camelCase/snake_case fallbacks."""
+    if keys:
+        if not isinstance(x, dict):
+            return default
+        for k in keys:
+            if x.get(k) is not None:
+                try:
+                    return float(x[k])
+                except (TypeError, ValueError):
+                    continue
+        return default
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return default
+
+
+# ── trader pool: filter floors + quality score (ported verbatim from v2) ──
+
+def pool_field_win_rate(t):
+    # v2: discovery_get_top_traders returns winRate as a 0-100 PERCENTAGE (already, not a fraction).
+    return _f(t, "win_rate", "winRate", default=0.0)
+
+
+def pool_field_roi(t):
+    # v2.0.4: MCP returns returnOnInvestment (camelCase); keep all fallbacks.
+    return _f(t, "return_on_investment", "roi", "returnOnInvestment", default=0.0)
+
+
+def pool_field_age_days(t):
+    # v2.0.4: MCP returns traderAgeSeconds (not days); convert. Keep snake/camel fallbacks.
+    direct = _f(t, "trader_age_days", "traderAgeDays", default=0.0)
+    if direct > 0:
+        return direct
+    secs = _f(t, "traderAgeSeconds", "trader_age_seconds", default=0.0)
+    return secs / 86400.0 if secs > 0 else 0.0
+
+
+def compute_quality_score(trader):
+    """Composite quality score 0-100, ported VERBATIM from v2.0.6 _compute_quality_score.
+
+    Weighting reflects Jackal's actual edge — tail-winner trend-followers (low win-rate,
+    huge winners), NOT high-win-rate scalpers:
+      - ROI            50 pts cap (reward big-winner distributions; 150%+ -> full)
+      - gain-to-pain   25 pts cap (risk-adjusted pnl, the real quality signal; g/p>=5 -> full)
+      - age            15 pts cap (survivorship buffer; 90+ days -> full)
+      - win rate       10 pts cap (CEILING not requirement; 60%+ -> full)
+    NOTE: winRate is treated as a 0-100 PERCENTAGE here (v2.0.6 bug fix — the prior
+    `win_rate * 100` mis-pegged every trader at the cap)."""
+    win_rate = pool_field_win_rate(trader)            # already 0-100 %
+    roi_30d = pool_field_roi(trader)
+    age_days = pool_field_age_days(trader)
+    gain_to_pain = _f(trader, "gain_to_pain_ratio", "gainToPainRatio", default=0.0)
+
+    score = 0.0
+    score += min(roi_30d / 150.0 * 50, 50)            # 50 pts for 150%+ ROI
+    score += min(gain_to_pain / 5.0 * 25, 25)         # 25 pts for g/p >= 5
+    score += min(age_days / 90.0 * 15, 15)            # 15 pts for 90+ day age
+    score += min(win_rate / 60.0 * 10, 10)            # 10 pts for 60%+ winrate (ceiling)
+    return round(score, 2)
+
+
+def build_pool(raw_traders, inputs):
+    """Filter + quality-score + rank the raw discovery_get_top_traders list.
+    Ported verbatim from v2 refresh_pool: win_rate/roi/age floors, top-N by quality.
+    Returns a list of pool-member dicts (the producer's `traders` cache shape)."""
+    min_win_rate = float(inputs.get("poolMinWinRate", 0.50))
+    min_roi_30d = float(inputs.get("poolMinRoi30d", 10.0))
+    min_age_days = float(inputs.get("poolMinTraderAgeDays", 14))
+    pool_size = int(inputs.get("poolSize", 25))
+
+    # v2 floor compared win_rate against POOL_MIN_WIN_RATE=0.50 while win_rate is a
+    # 0-100 percentage — i.e. the v2 floor was effectively winRate >= 0.50% (a no-op
+    # for any real trader). Reproduced VERBATIM (do not "fix" to *100 in the port).
+    filtered = []
+    for t in raw_traders:
+        if not isinstance(t, dict):
+            continue
+        win_rate = pool_field_win_rate(t)
+        roi_30d = pool_field_roi(t)
+        age_days = pool_field_age_days(t)
+        address = t.get("address") or t.get("trader_address")
+        if not address:
+            continue
+        if win_rate < min_win_rate:
+            continue
+        if roi_30d < min_roi_30d:
+            continue
+        if age_days < min_age_days:
+            continue
+        filtered.append({
+            "address": address.lower(),
+            "user_id": t.get("user_id") or t.get("userId"),
+            "username": t.get("username") or t.get("userName"),
+            "quality_score": compute_quality_score(t),
+            "win_rate": win_rate,
+            "roi_30d": roi_30d,
+            "trader_age_days": age_days,
+            "consecutive_wins": int(_f(t, "consecutive_wins", "consecutiveWins", default=0)),
+        })
+    filtered.sort(key=lambda x: x["quality_score"], reverse=True)
+    return filtered[:pool_size]
+
+
+# ── position diff + direction derivation (ported verbatim from v2) ──
+
+def derive_key(p):
+    """(coin, LONG/SHORT-from-szi-sign) or (coin, None). Ported verbatim from v2
+    detect_new_entries._derive_key — MCP positions carry no explicit direction key."""
+    coin = p.get("coin") or p.get("asset")
+    szi = _f(p, "szi", "size", default=0.0)
+    direction = "LONG" if szi > 0 else ("SHORT" if szi < 0 else None)
+    return (coin, direction)
+
+
+def detect_new_entries(pool, current_positions, last_seen, now, max_entry_age_seconds):
+    """Diff current vs last-seen positions per pool member; return candidate dicts for
+    anything that newly appeared (coin+direction not in prev) AND whose entry is within
+    max_entry_age_seconds. Ported verbatim from v2 detect_new_entries."""
+    candidates = []
+    for trader in pool:
+        addr = trader["address"]
+        cur = current_positions.get(addr, [])
+        prev = last_seen.get(addr, [])
+        prev_keys = {derive_key(p) for p in prev if isinstance(p, dict)}
+
+        for pos in cur:
+            if not isinstance(pos, dict):
+                continue
+            coin = pos.get("coin") or pos.get("asset")
+            if not coin:
+                continue
+            szi = _f(pos, "szi", "size", default=0.0)
+            direction = "LONG" if szi > 0 else ("SHORT" if szi < 0 else None)
+            if not direction:
+                continue
+            key = (coin, direction)
+            if key in prev_keys:
+                continue  # not new
+
+            # v2.0.4: MCP returns startTime (not openedAtTs/openTime).
+            entry_ts = _f(pos, "openedAtTs", "openTime", "startTime", default=0.0)
+            if entry_ts > 0 and (now - entry_ts) > max_entry_age_seconds:
+                continue
+
+            candidates.append({
+                "trader": trader,
+                "coin": coin,
+                "direction": direction,
+                "entry_price": _f(pos, "entryPx", "entry_price", default=0.0),
+                "leverage": _leverage_of(pos),
+                "size_usd": abs(_f(pos, "positionValue", "notional", default=0.0)),
+                "entry_ts": entry_ts or now,
+            })
+    return candidates
+
+
+def _leverage_of(pos):
+    lev = pos.get("leverage")
+    if isinstance(lev, dict):
+        return _f(lev, "value", default=0.0)
+    return _f(lev, default=0.0)
+
+
+# ── pool consensus (ported verbatim from v2 enrich_with_consensus) ──
+
+def enrich_with_consensus(candidates, current_positions):
+    """For each candidate, count other pool members in the SAME coin+direction
+    (poolConsensusCount, excluding self) and same-asset-any-direction
+    (poolConsensusAssetCount, excluding self). Ported verbatim from v2."""
+    by_key = {}
+    for addr, positions in current_positions.items():
+        for pos in positions or []:
+            if not isinstance(pos, dict):
+                continue
+            coin = pos.get("coin") or pos.get("asset")
+            szi = _f(pos, "szi", "size", default=0.0)
+            direction = "LONG" if szi > 0 else ("SHORT" if szi < 0 else None)
+            if not coin or not direction:
+                continue
+            by_key.setdefault((coin, direction), set()).add(addr)
+
+    for c in candidates:
+        key = (c["coin"], c["direction"])
+        consensus_set = by_key.get(key, set()) - {c["trader"]["address"]}
+        c["pool_consensus_count"] = len(consensus_set)
+
+        asset_addrs = set()
+        for (coin, _), addrs in by_key.items():
+            if coin == c["coin"]:
+                asset_addrs.update(addrs)
+        asset_addrs.discard(c["trader"]["address"])
+        c["pool_consensus_asset_count"] = len(asset_addrs)
+    return candidates
+
+
+# ── per-asset TA (open->close % trend) + funding (ported verbatim from v2) ──
+
+def trend_pct(candles):
+    """% change open(first)->close(last) over a candle window. Verbatim from v2 _trend_pct."""
+    if not candles or not isinstance(candles, list) or len(candles) < 2:
+        return None
+    try:
+        open_price = _f(candles[0], "open", "o", default=0.0)
+        close_price = _f(candles[-1], "close", "c", default=0.0)
+        if open_price <= 0:
+            return None
+        return round((close_price - open_price) / open_price * 100, 3)
+    except (TypeError, ValueError):
+        return None
+
+
+def trend_label(pct):
+    """BULLISH/BEARISH/NEUTRAL from a % change. Verbatim from v2 _trend_label
+    (>= 0.3 BULLISH, <= -0.3 BEARISH, else NEUTRAL)."""
+    if pct is None:
+        return None
+    if pct >= 0.3:
+        return "BULLISH"
+    if pct <= -0.3:
+        return "BEARISH"
+    return "NEUTRAL"
+
+
+def annualize_funding(hourly_funding):
+    """HL funding is HOURLY -> annualize x24x365 (x8760), as %. Verbatim from v2 v3.0.1
+    (the v3.0.1 fix: was x3x365, 8x too low). Returns None on bad input."""
+    if hourly_funding is None:
+        return None
+    try:
+        return round(float(hourly_funding) * 8760 * 100, 2)
+    except (TypeError, ValueError):
+        return None
+
+
+def macro_pct(candles_1h):
+    """BTC 24h % from the last 24 1h candles (open[0]->close[-1]). Verbatim from v2
+    fetch_btc_macro. Returns (direction, pct) or (None, None)."""
+    if not candles_1h or len(candles_1h) < 24:
+        return None, None
+    try:
+        window = candles_1h[-24:]
+        open0 = _f(window[0], "open", "o", default=0.0)
+        closeN = _f(window[-1], "close", "c", default=0.0)
+        if open0 <= 0:
+            return None, None
+        pct = (closeN - open0) / open0 * 100
+        return ("UP" if pct > 0 else "DOWN"), round(pct, 2)
+    except (TypeError, ValueError):
+        return None, None
+
+
+# ── sizing (top-level marginPct) ──
+
+def confidence_score(quality_score):
+    """v2 pushed score = quality_score / 100 as the 0..1 confidence. Preserved."""
+    return round(float(quality_score) / 100.0, 4)
+
+
+def margin_pct_for(quality_score, inputs):
+    """marginPct INTENT as a PERCENT of withdrawable in (0,100] (runtime sizes
+    (marginPct/100)*withdrawable).
+
+    v2 applied NO producer-side conviction scaling — the runtime sized every entry
+    from a flat margin_pct: 30. To preserve that EXACTLY, qualityMarginScale defaults
+    to 0 (flat base). When an operator opts in (>0), margin scales up to maxMarginPct
+    by quality above a 55 floor (the v2.0.6 LLM-gate trust floor). Defaults reproduce
+    v2 flat sizing.
+
+    Defensive fraction guard (dire/koala pattern): a base/cap pasted as a fraction
+    (<= 1.0, e.g. 0.30) is multiplied x100 to a percent."""
+    base = float(inputs.get("marginPct", 30))
+    if base <= 1.0:                       # pasted fraction (0.30) -> percent (30)
+        base *= 100.0
+    cap = float(inputs.get("maxMarginPct", base))
+    if cap <= 1.0:
+        cap *= 100.0
+    scale_per_pt = float(inputs.get("qualityMarginScale", 0.0))   # 0 => faithful flat
+    if scale_per_pt <= 0:
+        return round(min(base, cap), 4)
+    floor = float(inputs.get("qualityFloor", 55))
+    bonus = max(0.0, float(quality_score) - floor) * scale_per_pt
+    return round(min(base * (1.0 + bonus), cap), 4)

--- a/strategies/jackal/strategy.yaml
+++ b/strategies/jackal/strategy.yaml
@@ -1,0 +1,44 @@
+# Jackal — the Smart Stalker: a copy-trader that watches a quality-scored pool of top
+# Hyperliquid traders and mirrors their FRESH entries (< 10 min old) with its own DSL.
+# A single-instance PACKAGE: this manifest + one self-contained runtime.yaml + scanners/.
+# A faithful Runtime 3.0 port of the v2 Jackal v3.0.1 producer thesis (TRADER-FOLLOWER /
+# COHORT): discovery_get_top_traders cohort cached ~24h, diff per-trader open positions
+# for new entries, enrich with pool consensus + per-asset TA + funding regime + BTC macro,
+# emit the fresh entry sized by the source trader's quality score. Read-guarded everywhere
+# (stale cohort cache / neutral regime, never crash). Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: jackal
+version: "1.0.0"
+
+catalog:
+  name: "Jackal — The Smart Stalker"
+  emoji: "🐺"
+  tagline: "Maintains a daily-refreshed pool of the top-ROI Hyperliquid traders (win-rate + age + 30d-ROI filtered, quality-scored toward tail-winner trend-followers), watches for the moment a pool member opens a fresh position, and mirrors only the freshest entries (< 10 min old) when pool consensus and independent TA confirm — sized to the source trader's quality and ridden on its own wide DSL."
+  belief_plain: "Keeps a shortlist of the most profitable traders on Hyperliquid and refreshes it every day. The instant one of them opens a new trade, Jackal copies that trade in the same direction — but only if the entry is brand new, other shortlisted traders are leaning the same way, and the chart agrees. It bets a bit more behind the highest-quality traders and then trails a wide stop so a good copy can run for days."
+  thesis: "High-quality traders telegraph alpha, but naive copy-trading loses because winners regress, signals lag, and style mismatches amplify risk. Jackal only copies the freshest entries (< 10 min, before the alpha is public) from a pool ranked toward tail-winner trend-followers (ROI 35% / gain-to-pain 25% / age 15% / win-rate 10% — deliberately NOT high-win-rate scalpers), and confirms each copy with pool consensus + independent multi-timeframe TA + funding regime before sizing to the source's quality and riding its OWN DSL rather than the source trader's."
+  group: copy-trading
+  archetype: copy_trading
+  sub_style: hot_streak
+  asset_classes: [universe_crypto]
+  asset_scope: follows_traders
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 5
+  max_slots: 2
+  min_budget: 200
+  assets: []
+  tags: [copy-trading, smart-money, trader-pool, consensus, fresh-entry, quality-score, long-short, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: JACKAL_WALLET
+    funding_share: 1.0

--- a/strategies/mantis/main/runtime.yaml
+++ b/strategies/mantis/main/runtime.yaml
@@ -1,0 +1,147 @@
+# ── MANTIS · single instance — cross-asset lag / catchup hunter ───────────────
+# Runtime 3.0 port of the v2 Mantis Slipstream (SKILL.md v6.0.0 / producer v6.0.1).
+# CROSS-ASSET LAG archetype: monitors market_get_cross_asset_flows (BTC-only
+# pre-computed lag data), strikes the highest-confidence correlated alt that
+# lags a confirmed BTC 4h move, in the direction the leader moved, sized by the
+# tool's confidence score (conviction tiers). DSL-only exit (the v2 producer-side
+# leader-reversal veto is a MUTATION read-only scan() cannot perform — DROPPED;
+# see scanners/scan.py FIDELITY NOTES). Entry filters/tiers verbatim from v2.
+name: mantis-main
+group: mantis
+version: 6.0.0
+description: >
+  MANTIS — Slipstream cross-asset catchup hunter. Every tick it reads
+  market_get_cross_asset_flows for each leader (BTC — the only asset with
+  pre-computed lag data), surfacing correlated alts that historically follow the
+  leader's 4h move but haven't responded yet. Filters laggards by follow_rate
+  >= 0.85, confidence >= 0.75, |gap| >= 1.5%, sm_starting_to_rotate true,
+  lag_stddev <= 90min; picks the highest-confidence non-held alt; emits ONE strike
+  in the leader's direction, sized by conviction tier (confidence 0.92+ -> 75%
+  margin/8x, 0.85+ -> 50%/7x, 0.75+ -> 25%/5x). Dynamic hard_timeout (avg_lag x
+  1.5, clamped [30,240]min) is surfaced in signal data; the DSL exit (240min
+  ceiling + Phase1/Phase2 ladder + weak_peak_cut) owns exits. Faithful port of
+  the v2 Mantis v6.0.0 thesis (filters/tiers/direction/timeout verbatim).
+
+strategy:
+  wallet: "${MANTIS_WALLET}"
+  slots: 2                                # v2 MAX_CONCURRENT_POSITIONS / runtime.yaml slots 2
+  margin_pct: 25                          # baseline %; scan emits the conviction-tier marginPct per signal
+  default_leverage: 5                     # fallback; scan emits 5/7/8x per confidence tier
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: mantis_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 60                   # v2 producer_daemon interval_seconds=60
+    timeout_seconds: 90                    # v2 tick_timeout=90
+    default_signal_validity_seconds: 120   # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      leaderUniverse: ["BTC"]              # only BTC has pre-computed lag data (v1 cross-asset flow tool)
+      minFollowRate: 0.85                  # v2 MIN_FOLLOW_RATE
+      minConfidence: 0.75                  # v2 MIN_CONFIDENCE
+      minGapPct: 1.5                       # v2 MIN_GAP_PCT (abs)
+      requireSmRotation: true              # v2 REQUIRE_SM_ROTATION
+      maxLagStddevMinutes: 90              # v2 MAX_LAG_STDDEV_MINUTES
+      maxLeverage: 8                       # v2 MAX_LEVERAGE
+      hardTimeoutLagMultiplier: 1.5        # v2 HARD_TIMEOUT_LAG_MULTIPLIER
+      hardTimeoutFloorMinutes: 30          # v2 HARD_TIMEOUT_FLOOR_MINUTES
+      hardTimeoutCeilingMinutes: 240       # v2 HARD_TIMEOUT_CEILING_MINUTES
+      sizingTiers:                         # v2 SIZING_TIERS (margin_pct PERCENT, conviction-scaled)
+        - { confidence_min: 0.92, margin_pct: 75, leverage: 8 }
+        - { confidence_min: 0.85, margin_pct: 50, leverage: 7 }
+        - { confidence_min: 0.75, margin_pct: 25, leverage: 5 }
+      recentSignalTtlSeconds: 240          # race-window dedup (runtime per_asset_cooldown is authoritative)
+    signal_data_schema:
+      score: { type: number }                                # 0..1 confidence
+      leverage: { type: number }
+      direction: { type: string }
+      hardTimeoutMinutes: { type: number, required: false }
+      gapPct: { type: number, required: false }
+      followRate: { type: number, required: false }
+      avgLagMinutes: { type: number, required: false }
+      lagStddevMinutes: { type: number, required: false }
+      smStartingToRotate: { type: boolean, required: false }
+      leaderAsset: { type: string, required: false }
+      leaderMovePct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: mantis_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [mantis_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # taker fallback guarantees fill + DSL attach (catchups are time-sensitive)
+        execution_timeout_seconds: 60      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: mantis_main_signals
+
+# ── EXIT (DSL — preserved VERBATIM from v2 runtime.yaml dsl_preset) ────────────
+# v2 Mantis had THREE exit layers: (1) producer-side leader-reversal veto
+# [DROPPED — close_position is a mutation read-only scan() cannot perform; the
+# runtime cannot model "close if a separate asset's 4h move reverses"], (2)
+# dynamic per-trade hard_timeout [surfaced in signal data.hardTimeoutMinutes for
+# observability], (3) the DSL preset below. With the veto + dynamic timeout
+# dropped/advisory, the DSL preset is now the PRIMARY exit authority. Ported
+# verbatim; first Phase-2 lock at +5% ROE (reachable — NOT >+40%). order_type
+# FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST happen).
+exit:
+  engine: dsl
+  interval_seconds: 30                     # v2 exit.interval_seconds 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 60          # v2 exit execution_timeout_seconds
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # v2: 240min absolute ceiling (the catchup either happens or it doesn't)
+      interval_in_minutes: 240
+    weak_peak_cut:
+      enabled: true                        # v2: 20min / 1.5% min_value
+      interval_in_minutes: 20
+      min_value: 1.5
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                    # v2 phase1.max_loss_pct
+      retrace_threshold: 5                  # v2 phase1.retrace_threshold
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # v2 phase2.tiers — first lock at +5% ROE (reachable)
+        - { trigger_pct: 5,  lock_hw_pct: 30 }
+        - { trigger_pct: 10, lock_hw_pct: 60 }
+        - { trigger_pct: 15, lock_hw_pct: 75 }
+        - { trigger_pct: 25, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime.yaml; hours/minutes -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # v2 data_retention_hours 72 -> 72*3600 (in [3600,604800])
+  guard_rails:
+    daily_loss_limit_pct: 10               # v2 daily_loss_limit_pct
+    max_entries_per_day: 6                 # v2 max_entries_per_day / MAX_DAILY_ENTRIES
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 3600                 # v2 cooldown_minutes 60 -> 3600s (post-loss)
+    drawdown_halt_pct: 20                  # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400      # v2 per_asset_cooldown_minutes 240 -> 14400s (4h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/mantis/main/scanners/scan.py
+++ b/strategies/mantis/main/scanners/scan.py
@@ -1,0 +1,272 @@
+"""MANTIS — supervised scanner (Runtime 3.0 port of the v2 Mantis Slipstream).
+
+CROSS-ASSET LAG / catchup hunter. Its SIGNATURE read is
+`market_get_cross_asset_flows`: for each leader (BTC only — the only asset with
+pre-computed lag data) the tool returns the leader's 4h move + a list of
+correlated alts ("laggards") that historically follow but haven't moved yet, each
+with PRE-COMPUTED scores (follow_rate, confidence, gap_pct, avg_lag_minutes,
+lag_stddev_minutes, sm_starting_to_rotate). Per tick scan():
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - walks each leader's flows, filters laggards by the verbatim entry filters,
+  - picks the highest-confidence non-held laggard,
+  - emits ONE signal sized by the conviction tier (margin PERCENT + leverage),
+    in the direction the leader moved.
+
+Read-only + single-pass — emits a `marginPct` (PERCENT, conviction-tiered) +
+`leverage` at the top level; the runtime sizes the dollars, owns cooldowns/risk
+gates, and trails the DSL exit. No daemon, no push_signal, no create_position.
+
+FIDELITY NOTES vs the v2 producer (mantis-producer.py v6.0.1 / mantis_config.py v6.0.0):
+  - SIGNATURE READ: `market_get_cross_asset_flows(leader_asset=<leader>)`. The v2
+    config calls it with kwarg `leader_asset`; ported verbatim as the args dict
+    {"leader_asset": leader}. READ-GUARDED: any exception (tool absent during
+    warmup, BTC-only lag data, transport error) degrades to "no candidates" and
+    the tick emits nothing — never crashes the tick (per the contract, ANY
+    exception rolls the whole tick to []). Warmup / empty-laggards is the tool's
+    documented normal state and is handled as a clean WAITING.
+  - DROPPED (v2 -> Runtime 3.0): the LEADER-REVERSAL VETO. v2 re-called the flow
+    tool per open position and, when the leader had reversed >1% from entry,
+    called `close_position` DIRECTLY (a producer-authoritative mutation the
+    runtime "cannot express"). In Runtime 3.0 scan() is READ-ONLY:
+    `close_position` raises PermissionError and would roll the whole tick to [].
+    The veto MATH is preserved in scoring.leader_reversed (documented + testable)
+    but is NOT executed here. The runtime's DSL exit (hard_timeout 240 ceiling +
+    Phase1/Phase2 retrace ladder + weak_peak_cut) is the exit authority; the v2
+    dynamic per-trade hard_timeout is surfaced in signal data.hardTimeoutMinutes
+    for observability/future runtime consumption. FLAGGED in the port report.
+  - DROPPED (v2 -> Runtime 3.0): position-metadata.json + entry-log.jsonl state
+    files. position-metadata existed ONLY to feed the (now-dropped) veto pass;
+    entry-log was observability only. Cross-tick dedup uses ctx.state instead.
+  - SIZING: v2 build_strike computed marginUsd = account_value*(margin_pct/100).
+    This port emits the conviction-tier margin PERCENT (75/50/25) directly; the
+    runtime sizes (marginPct/100)*withdrawable. Tier cutoffs + leverage clamp +
+    direction + dynamic hard_timeout are VERBATIM (see scoring.py).
+  - DEDUP: v2 skipped any laggard already in open positions (no-double-up) +
+    relied on runtime guard_rails per_asset_cooldown. Preserved: held-asset skip
+    BEFORE emit + a ctx.state recent-signal TTL dedup (race-window guard).
+  - v2 emitted exactly one strike per tick (highest confidence). Preserved:
+    scan() emits <= 1 signal/tick.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v2 config defaults (mantis_config.py) — overridable via runtime inputs
+_LEADER_UNIVERSE_DEFAULT = ["BTC"]   # only BTC has pre-computed lag data (v1 tool)
+_DEFAULT_RECENT_TTL = 240            # race-window dedup (informational; runtime cooldown is authoritative)
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[mantis.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; running the held-asset dedup off that re-enters
+    # held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[mantis.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _get_flows(ctx, leader):
+    """Cross-asset flows for one leader. SIGNATURE READ. READ-GUARDED.
+
+    Returns the unwrapped flow dict ({leader/leader_move_pct, laggards}) or None.
+    None on: transport error, tool-absent-during-warmup, BTC-only lag data
+    yielding an empty/None payload, or success:false. Degrades to None so the
+    caller treats this leader as having no candidates — never crashes the tick."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("market_get_cross_asset_flows",
+                                      {"leader_asset": leader})
+    except Exception as exc:  # noqa: BLE001 — warmup / BTC-only / transport: degrade, never crash
+        print(f"[mantis.scan] cross_asset_flows({leader}) read failed "
+              f"(degrade to no-candidates): {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    if isinstance(raw, dict) and raw.get("success") is False:
+        return None
+    return scoring.unwrap_flow_response(raw)
+
+
+def _gather_candidates(ctx, inputs, leaders):
+    """Walk each leader's flows; return filtered laggards (each tagged with its
+    leader asset + leader move), sorted by confidence desc. Verbatim port of
+    producer.gather_candidates. Each per-leader read is independently guarded."""
+    candidates = []
+    for leader in leaders:
+        flow = _get_flows(ctx, leader)
+        if not flow:
+            print(f"[mantis.scan] no flow data for leader={leader} "
+                  f"(warmup/empty/degraded)", file=sys.stderr)
+            continue
+        leader_move_pct = scoring.leader_move_from_flow(flow)
+        laggards = flow.get("laggards", []) or []
+        if not laggards:
+            # empty laggards = leader hasn't moved enough; documented-normal state
+            print(f"[mantis.scan] empty laggards for leader={leader} "
+                  f"(move={leader_move_pct:+.2f}%)", file=sys.stderr)
+            continue
+        for laggard in laggards:
+            if not isinstance(laggard, dict):
+                continue
+            if not scoring.passes_entry_filters(laggard, inputs):
+                continue
+            tagged = dict(laggard)
+            tagged["_leader_asset"] = leader
+            tagged["_leader_move_pct"] = leader_move_pct
+            candidates.append(tagged)
+    candidates.sort(key=lambda x: scoring._f(x.get("confidence")), reverse=True)
+    return candidates
+
+
+# ── ctx.state: recent-signal dedup (race-window guard) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    leaders = inputs.get("leaderUniverse", _LEADER_UNIVERSE_DEFAULT)
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        # No account value (read degraded / read-sanity guard tripped / zero equity) -> hold.
+        print("[mantis.scan] WAITING — no account value (read degraded or zero equity)",
+              file=sys.stderr)
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # SIGNATURE READ + filter (each per-leader flow read is independently guarded)
+    candidates = _gather_candidates(ctx, inputs, leaders)
+
+    out = []
+    # walk by confidence; skip any already open OR recently signaled (no-double-up)
+    pick = None
+    for c in candidates:
+        asset = (c.get("asset") or "").upper()
+        if not asset:
+            continue
+        if asset in held_set:
+            continue
+        if _was_recently_signaled(signaled, asset, ttl, now):
+            continue
+        pick = c
+        break
+
+    if not pick:
+        result = {"ts": now, "emitted": False, "candidates": len(candidates),
+                  "held": held_assets, "leaders": list(leaders),
+                  "note": "no_qualifying_laggards" if not candidates else "all_qualifying_held_or_signaled"}
+        print(f"[mantis.scan] WAITING — no qualifying laggard "
+              f"(candidates={len(candidates)} held={held_assets})", file=sys.stderr)
+    else:
+        strike = scoring.build_strike(pick, inputs)
+        margin_pct = strike["margin_pct"]
+        leverage = strike["leverage"]
+        asset = strike["asset"]
+
+        signaled[asset.upper()] = now
+        result = {"ts": now, "emitted": True, "asset": asset,
+                  "direction": strike["direction"], "confidence": strike["confidence"],
+                  "leverage": leverage, "marginPct": round(margin_pct, 4),
+                  "leaderAsset": strike["leader_asset"],
+                  "leaderMovePct": strike["leader_move_pct"],
+                  "gapPct": strike["gap_pct"], "held": held_assets}
+        print(f"[mantis.scan] EMIT {asset} {strike['direction']} conf={strike['confidence']:.2f} "
+              f"{leverage}x marginPct={margin_pct:.2f}% | leader {strike['leader_asset']} "
+              f"{strike['leader_move_pct']:+.2f}% gap {strike['gap_pct']:+.2f}%", file=sys.stderr)
+        out = [{
+            "asset": asset,
+            "direction": strike["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # 5/7/8 by confidence tier; runtime applies it
+            "data": {
+                "score": strike["confidence"],          # 0..1 confidence is Mantis's score
+                "leverage": leverage,
+                "direction": strike["direction"],
+                "hardTimeoutMinutes": strike["hard_timeout_minutes"],
+                "gapPct": strike["gap_pct"],
+                "followRate": strike["follow_rate"],
+                "avgLagMinutes": strike["avg_lag_minutes"],
+                "lagStddevMinutes": strike["lag_stddev_minutes"],
+                "smStartingToRotate": strike["sm_starting_to_rotate"],
+                "leaderAsset": strike["leader_asset"],
+                "leaderMovePct": strike["leader_move_pct"],
+                "heldAssets": held_assets,
+                "reasons": strike["reasons"],
+            },
+        }]
+
+    # persist dedup map + this tick's result every tick (bounded by
+    # state_history_max_count); read back via ctx.state.last()/recent(n)
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[mantis.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/mantis/main/scanners/scoring.py
+++ b/strategies/mantis/main/scanners/scoring.py
@@ -1,0 +1,195 @@
+"""MANTIS — pure thesis math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Mantis producer's Slipstream logic
+(mantis-producer.py v6.0.1 + mantis_config.py v6.0.0). Mantis is a CROSS-ASSET
+LAG / catchup hunter: it does NOT compute its own indicators — the
+`market_get_cross_asset_flows` MCP tool returns PRE-COMPUTED per-laggard scores
+(follow_rate, confidence, gap_pct, avg_lag_minutes, lag_stddev_minutes,
+sm_starting_to_rotate). This module holds the PURE decision math applied on top
+of those tool fields: the entry filters, the conviction sizing tiers, the
+leader-follow direction, and the dynamic hard-timeout clamp. The flow-response
+unwrap + the MCP reads live in scan.py (so this module stays pure and testable).
+
+All thresholds/tiers reproduced VERBATIM from mantis_config.py; behaviour-
+preserving quirks flagged `# v2-quirk`.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# ── v2 config defaults (mantis_config.py) — overridable via runtime inputs ──
+DEFAULT_MIN_FOLLOW_RATE = 0.85
+DEFAULT_MIN_CONFIDENCE = 0.75
+DEFAULT_MIN_GAP_PCT = 1.5
+DEFAULT_REQUIRE_SM_ROTATION = True
+DEFAULT_MAX_LAG_STDDEV_MINUTES = 90
+
+# Sizing tiers — conviction-scaled off the tool's confidence score.
+# margin_pct is a PERCENT in (0,100]. VERBATIM from cfg.SIZING_TIERS.
+DEFAULT_SIZING_TIERS = [
+    {"confidence_min": 0.92, "margin_pct": 75, "leverage": 8},
+    {"confidence_min": 0.85, "margin_pct": 50, "leverage": 7},
+    {"confidence_min": 0.75, "margin_pct": 25, "leverage": 5},
+]
+DEFAULT_MAX_LEVERAGE = 8
+
+DEFAULT_HARD_TIMEOUT_LAG_MULTIPLIER = 1.5
+DEFAULT_HARD_TIMEOUT_FLOOR_MINUTES = 30
+DEFAULT_HARD_TIMEOUT_CEILING_MINUTES = 240
+DEFAULT_LEADER_REVERSAL_VETO_PCT = 1.0
+
+
+def unwrap_flow_response(result):
+    """MCP returns {success: bool, data: {...}}. Unwrap to inner dict.
+    VERBATIM port of producer._unwrap_flow_response. Returns dict or None."""
+    if not result or not isinstance(result, dict):
+        return None
+    if "data" in result and isinstance(result["data"], dict):
+        return result["data"]
+    if "leader" in result or "laggards" in result:
+        return result
+    return None
+
+
+def leader_move_from_flow(flow_data):
+    """Read the leader's current 4h move from an unwrapped flow dict.
+
+    v2-quirk: producer reads `data['leader']['move_pct']` (a `leader` BLOCK with a
+    `move_pct` field). The cross-asset-flow-guide documents the alternate shape
+    with TOP-LEVEL `leader_move_pct`. We honour the producer's primary path first
+    (leader block) then fall back to the top-level field, so either tool shape
+    yields the same number. Returns float (0.0 if absent)."""
+    if not isinstance(flow_data, dict):
+        return 0.0
+    leader_block = flow_data.get("leader") or {}
+    if isinstance(leader_block, dict) and "move_pct" in leader_block:
+        return _f(leader_block.get("move_pct"))
+    return _f(flow_data.get("leader_move_pct"))
+
+
+def passes_entry_filters(laggard, inputs):
+    """All filters must pass — VERBATIM from producer.passes_entry_filters.
+
+    follow_rate >= MIN_FOLLOW_RATE; confidence >= MIN_CONFIDENCE;
+    |gap_pct| >= MIN_GAP_PCT; (REQUIRE_SM_ROTATION -> sm_starting_to_rotate true);
+    0 < lag_stddev_minutes <= MAX_LAG_STDDEV_MINUTES."""
+    min_follow = float(inputs.get("minFollowRate", DEFAULT_MIN_FOLLOW_RATE))
+    min_conf = float(inputs.get("minConfidence", DEFAULT_MIN_CONFIDENCE))
+    min_gap = float(inputs.get("minGapPct", DEFAULT_MIN_GAP_PCT))
+    require_sm = bool(inputs.get("requireSmRotation", DEFAULT_REQUIRE_SM_ROTATION))
+    max_lag_std = float(inputs.get("maxLagStddevMinutes", DEFAULT_MAX_LAG_STDDEV_MINUTES))
+
+    if _f(laggard.get("follow_rate")) < min_follow:
+        return False
+    if _f(laggard.get("confidence")) < min_conf:
+        return False
+    if abs(_f(laggard.get("gap_pct"))) < min_gap:
+        return False
+    if require_sm and not laggard.get("sm_starting_to_rotate"):
+        return False
+    lag_stddev = _f(laggard.get("lag_stddev_minutes"))
+    if lag_stddev <= 0 or lag_stddev > max_lag_std:
+        return False
+    return True
+
+
+def sizing_tier_for(confidence, tiers):
+    """Pick highest tier the confidence qualifies for.
+    VERBATIM from producer.sizing_tier_for: walks tiers in order (descending
+    confidence_min), returns the first whose floor is cleared, else the last."""
+    conf = _f(confidence)
+    for tier in tiers:
+        if conf >= _f(tier.get("confidence_min")):
+            return tier
+    return tiers[-1]
+
+
+def direction_from_leader_move(leader_move_pct):
+    """Follow the leader: positive move -> LONG laggard, negative -> SHORT.
+    VERBATIM from producer.direction_from_leader_move."""
+    return "LONG" if _f(leader_move_pct) >= 0 else "SHORT"
+
+
+def compute_hard_timeout(avg_lag_minutes, inputs):
+    """Dynamic hard_timeout = avg_lag_minutes * multiplier, clamped to
+    [floor, ceiling]. VERBATIM from producer.compute_hard_timeout."""
+    mult = float(inputs.get("hardTimeoutLagMultiplier", DEFAULT_HARD_TIMEOUT_LAG_MULTIPLIER))
+    floor = float(inputs.get("hardTimeoutFloorMinutes", DEFAULT_HARD_TIMEOUT_FLOOR_MINUTES))
+    ceil = float(inputs.get("hardTimeoutCeilingMinutes", DEFAULT_HARD_TIMEOUT_CEILING_MINUTES))
+    minutes = max(1.0, _f(avg_lag_minutes, 60.0)) * mult
+    minutes = max(floor, min(ceil, minutes))
+    return int(minutes)
+
+
+def leader_reversed(leader_pct_at_entry, current_leader_move_pct, veto_pct):
+    """True if the leader has reversed by more than veto_pct from its move at
+    entry time. Direction matters. VERBATIM from producer.leader_reversed.
+
+    NOTE: This predicate is preserved for fidelity/reference (the v2 leader-
+    reversal veto thesis). In Runtime 3.0 the veto's ACTION (close_position) is a
+    MUTATION that read-only scan() cannot perform — see scan.py FIDELITY NOTES.
+    The math is kept here so the thesis stays documented + unit-testable."""
+    delta = _f(current_leader_move_pct) - _f(leader_pct_at_entry)
+    if _f(leader_pct_at_entry) >= 0:
+        return delta < -_f(veto_pct)
+    return delta > _f(veto_pct)
+
+
+def build_strike(candidate, inputs):
+    """Build the strike dict from a filtered laggard + its attached leader fields.
+
+    Mirrors producer.build_strike, but emits a margin PERCENT (not marginUsd) —
+    the Runtime 3.0 runtime sizes the dollars from (marginPct/100)*withdrawable.
+    The TIER margin_pct values + leverage clamp + direction + dynamic hard_timeout
+    are all VERBATIM. `candidate` must carry `_leader_asset` + `_leader_move_pct`
+    (attached by scan.gather_candidates)."""
+    max_lev = int(inputs.get("maxLeverage", DEFAULT_MAX_LEVERAGE))
+    tiers = inputs.get("sizingTiers", DEFAULT_SIZING_TIERS)
+
+    confidence = _f(candidate.get("confidence"))
+    tier = sizing_tier_for(confidence, tiers)
+    margin_pct = _f(tier.get("margin_pct"))
+    # v2-quirk: if an operator pastes a v2 FRACTION (e.g. 0.75) into a tier's
+    # margin_pct, convert to PERCENT so it never silently sizes ~100x small
+    # (runtime sizes (marginPct/100)*withdrawable). Tier defaults are already
+    # PERCENTs (75/50/25) so this is a defensive no-op for the shipped config.
+    if 0 < margin_pct <= 1.0:
+        margin_pct = margin_pct * 100.0
+    leverage = min(int(_f(tier.get("leverage"))), max_lev)
+
+    leader_move_pct = _f(candidate.get("_leader_move_pct"))
+    direction = direction_from_leader_move(leader_move_pct)
+    avg_lag = _f(candidate.get("avg_lag_minutes"), 60)
+    hard_timeout = compute_hard_timeout(avg_lag, inputs)
+
+    return {
+        "asset": candidate.get("asset"),
+        "direction": direction,
+        "leverage": leverage,
+        "margin_pct": margin_pct,
+        "hard_timeout_minutes": hard_timeout,
+        "confidence": confidence,
+        "gap_pct": _f(candidate.get("gap_pct")),
+        "follow_rate": _f(candidate.get("follow_rate")),
+        "avg_lag_minutes": avg_lag,
+        "lag_stddev_minutes": _f(candidate.get("lag_stddev_minutes")),
+        "sm_starting_to_rotate": bool(candidate.get("sm_starting_to_rotate")),
+        "leader_asset": candidate.get("_leader_asset"),
+        "leader_move_pct": leader_move_pct,
+        "reasons": [
+            "SLIPSTREAM {} follows {}".format(
+                candidate.get("asset"), candidate.get("_leader_asset")),
+            "leader_move {:+.2f}% in 4h".format(leader_move_pct),
+            "gap {:+.2f}% behind".format(_f(candidate.get("gap_pct"))),
+            "follow_rate {:.0%}".format(_f(candidate.get("follow_rate"))),
+            "avg_lag {:.0f}+/-{:.0f}min".format(
+                avg_lag, _f(candidate.get("lag_stddev_minutes"))),
+            "confidence {:.2f}".format(confidence),
+            "sizing_tier margin_pct={:.0f}% lev={}x".format(margin_pct, leverage),
+        ],
+    }

--- a/strategies/mantis/strategy.yaml
+++ b/strategies/mantis/strategy.yaml
@@ -1,0 +1,44 @@
+# Mantis — cross-asset lag / catchup hunter. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0
+# port of the v2 Mantis Slipstream (SKILL.md v6.0.0): monitors
+# market_get_cross_asset_flows (BTC-only pre-computed lag data), strikes the
+# highest-confidence correlated alt that lags a confirmed BTC 4h move, sized by
+# the tool's confidence score (conviction tiers), DSL-only exits.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: mantis
+version: "1.0.0"
+
+catalog:
+  name: "Mantis — Cross-Asset Catchup Hunter"
+  emoji: "🦎"
+  tagline: "Watches BTC's 4-hour move via market_get_cross_asset_flows and strikes the highest-confidence correlated alt that historically follows BTC but hasn't caught up yet — entering the alt in BTC's direction, sized to the tool's confidence score, with a stop that trails the catchup."
+  belief_plain: "When Bitcoin makes a big 4-hour move, certain alts that usually follow it lag behind for a while before catching up. Mantis spots those laggards (only the ones that follow Bitcoin reliably, with smart money already starting to rotate in) and buys the gap, betting it closes — bigger when it's more confident, with a stop that trails the move."
+  thesis: "The edge is a statistical lag, not a directional view: alts with an 85%+ historical follow-rate and tight timing variance tend to catch up to a confirmed leader move within their typical lag window. Restricting the leader to BTC (the only asset with pre-computed lag data) and requiring smart-money rotation plus a meaningful gap keeps it to high-probability catchups; sizing scales with the tool's confidence, and a dynamic timeout calibrated to each alt's lag distribution backstops trades where the catchup never materialises."
+  group: multi-asset-universe
+  archetype: structural_neutral   # earns from a cross-asset lag relationship, not a directional bet
+  sub_style: cross_asset_lag      # trades an alt that lags a BTC move
+  asset_classes: [universe_crypto]
+  asset_scope: universe           # laggards are surfaced dynamically by the flow tool — no fixed list
+  direction: long_short           # follows the leader's sign: +BTC -> LONG alt, -BTC -> SHORT alt
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 8
+  max_slots: 2
+  min_budget: 200
+  assets: ["BTC"]                 # BTC is the leader (signal source); the traded laggards are dynamic
+  tags: [crypto, cross-asset, lag, catchup, slipstream, btc-leader, smart-money, conviction-margin, statistical-edge]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: MANTIS_WALLET
+    funding_share: 1.0

--- a/strategies/osprey/main/runtime.yaml
+++ b/strategies/osprey/main/runtime.yaml
@@ -1,0 +1,152 @@
+# ── OSPREY · single instance — cross-venue lag (crypto leader -> XYZ equity) ──
+# Runtime 3.0 port of the v2 Osprey (SKILL.md v1.0.0 / producer v1.0.1). When a
+# crypto leader (BTC) makes a strong move, crypto-correlated XYZ equities
+# (xyz:COIN/xyz:MSTR) tend to FOLLOW but on a different venue, with a lag. Osprey
+# self-computes each proxy's catch-up gap (leader move x beta - proxy move) from
+# 1h candles and trades the proxy in the leader's direction when it still owes a
+# gap. Let-winners-run DSL (a catch-up move can extend across XYZ pricing windows).
+# Faithful port of the v2 producer thesis — see scanners/scoring.py (math verbatim).
+name: osprey-main
+group: osprey
+version: 3.0.0
+description: >
+  OSPREY — cross-VENUE lag catcher (crypto leader -> XYZ equity proxy). Each tick
+  measures the leader's (BTC's) move over moveLookbackBars 1h candles; if
+  |move| >= minLeaderMovePct it scores each proxy's catch-up gap
+  (leader move x beta - the proxy's own move). When |gap| >= minGapPct AND the gap
+  shares the leader's sign (the proxy still owes catch-up in the leader's
+  direction), it trades the proxy in that direction. Smart-money on the proxy
+  (leaderboard_get_markets) is a SCORE BONUS, not a gate (SM is sparse on XYZ
+  equities). market_get_cross_asset_flows is read (read-guarded) as an independent
+  confirmation of the leader move only — it never gates. Default proxies
+  xyz:COIN (beta 1.8) / xyz:MSTR (beta 2.5), operator-tunable. DSL is the ONLY
+  exit: let-winners-run preset (wide ladder, T0 +10% / lock 0, max_loss 18%,
+  time-cuts OFF except a 96h hard_timeout). Faithful port of the v2 Osprey v1.0.0.
+
+strategy:
+  wallet: "${OSPREY_WALLET}"
+  slots: 1                                # v2 emitted exactly one signal (best); single slot
+  margin_pct: 15                          # baseline %; scan emits marginPct (PERCENT) per signal
+  default_leverage: 4                     # fallback; scan emits clamped <=10x per signal
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: osprey_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # v2 producer cadence (5 min)
+    timeout_seconds: 180                   # v2 tick_timeout=180; leader + per-proxy candles + sm + flows + account
+    default_signal_validity_seconds: 600   # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      leader: "BTC"                        # v2 leader (main DEX) — validated live on HL meta 2026-06-29
+      proxies:                             # v2 DEFAULT_PROXIES — operator-tunable crypto-correlated XYZ equities
+        - { proxy: "xyz:COIN", beta: 1.8 } # validated live on HL xyz meta 2026-06-29
+        - { proxy: "xyz:MSTR", beta: 2.5 } # validated live on HL xyz meta 2026-06-29
+      moveLookbackBars: 4                  # v2 moveLookbackBars — 1h bars for the recent-move window (both legs)
+      minLeaderMovePct: 2.0                # v2 minLeaderMovePct — leader must move at least this %
+      minGapPct: 2.0                       # v2 minGapPct — proxy must still owe at least this % of catch-up
+      strongGapPct: 5.0                    # v2 strongGapPct — |gap| >= this -> +2 score
+      smTiltMinPct: 55                     # v2 smTiltMinPct — SM confirm bonus floor
+      smStrongTiltPct: 70                  # v2 smStrongTiltPct — SM strong bonus
+      minScore: 4                          # v2 minScore floor
+      marginPct: 15                        # PERCENT of withdrawable (0,100] (v2 fraction 0.15 -> 15%)
+      leverage: 4                          # v2 leverage; clamped to <=10 (MAX_LEVERAGE) in scan.py
+      recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      leader: { type: string, required: false }
+      leaderMovePct: { type: number, required: false }
+      proxyMovePct: { type: number, required: false }
+      gapPct: { type: number, required: false }
+      beta: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      volumeTrendPct: { type: number, required: false }
+      leaderConfirmed: { type: boolean, required: false }
+      leaderFlowDir: { type: string, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: osprey_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [osprey_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # enter while the gap is open — a maker order that rests
+                                           # (CREATE_ORDER_RESTING) misses the catch-up
+        execution_timeout_seconds: 30      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: osprey_main_signals
+
+# ── EXIT (DSL — let-winners-run preset, preserved VERBATIM from v2) ───────────
+# A catch-up move can extend well past the modeled gap once the proxy starts
+# tracking the leader. Let it run: wide ladder (T0 +10% / lock 0), max_loss 18%,
+# time-cuts OFF except a long hard_timeout. NO weak_peak_cut — XYZ proxies can
+# develop slowly across pricing windows. First Phase-2 lock at +10% ROE (REACHABLE,
+# not +40%+) — no unreachable-DSL concern. interval_seconds 60 (REDUCE_ONLY-spam
+# mitigation when runtime position state lags HL).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 5760            # 96h — the lag can take days to close across XYZ pricing windows
+    weak_peak_cut:
+      enabled: false                       # v2: DISABLED — XYZ proxies develop slowly
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                       # v2: DISABLED
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # wide-by-design; FIRST lock at +10% ROE (reachable)
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 45 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+        - { trigger_pct: 90, lock_hw_pct: 88 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # 72h (was data_retention_hours 72)
+  guard_rails:
+    daily_loss_limit_pct: 15               # v2 daily_loss_limit_pct
+    max_entries_per_day: 3                  # v2 max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3              # v2 max_consecutive_losses
+    cooldown_seconds: 5400                 # v2 cooldown_minutes 90 -> 5400s
+    drawdown_halt_pct: 22                  # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 21600      # v2 per_asset_cooldown_minutes 360 -> 21600s (6h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/osprey/main/scanners/scan.py
+++ b/strategies/osprey/main/scanners/scan.py
@@ -1,0 +1,380 @@
+"""OSPREY — supervised scanner (Runtime 3.0 port of the v2 Osprey cross-venue lag).
+
+Cross-VENUE lag catcher: when a crypto leader (BTC) makes a strong move,
+crypto-correlated XYZ equities (COIN/MSTR) tend to FOLLOW but on a different
+venue, with a lag. Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - measures the LEADER's move over `moveLookbackBars` 1h candles; if |move| is
+    below `minLeaderMovePct`, no lag to trade -> WAITING,
+  - for each non-held, non-recently-signaled proxy: fetches its 1h candles,
+    self-computes the catch-up gap (leader_move x beta - proxy_move) and scores
+    it via the pure `scoring.build_thesis`,
+  - emits the SINGLE highest-scoring candidate at/above `minScore` (v2 main()
+    emitted only `best`), sized by `marginPct` (PERCENT) + `leverage`.
+
+Read-only + single-pass. No daemon, no push_signal, no create_position. The
+runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit.
+
+FIDELITY NOTES vs the v2 producer (osprey-producer.py v1.0.1 + osprey_config.py):
+  - Thesis math is BYTE-FOR-BYTE the v2 thesis: self-computed leader move +
+    per-proxy catch-up gap from 1h candles (scoring.move_pct / catchup_gap /
+    lag_direction / volume_trend, all verbatim). Smart-money on the proxy
+    (leaderboard_get_markets) is a SCORE BONUS, not a gate (verbatim).
+  - ARCHETYPE SIGNATURE READ — market_get_cross_asset_flows: the cross-asset-lag
+    archetype's signature read. v2 Osprey did NOT call it (it self-computes the
+    gap from candles, because cross_asset_flows only surfaces CRYPTO laggards and
+    only BTC has lag data — XYZ equity proxies cannot be surfaced by it). This
+    port reads it ONCE per tick, FULLY READ-GUARDED, purely as an INDEPENDENT
+    CONFIRMATION of the leader move (RULE 1). It NEVER alters score or gating —
+    so the v2 scoring/emit is preserved EXACTLY. On warmup / empty laggards /
+    error it degrades to neutral and the tick proceeds on the self-computed
+    leader move alone (the v2 path). The confirmation is surfaced in
+    observability + data{leaderConfirmed,leaderFlowDir}. FLAGGED: this is an
+    ADDED read vs v2 (a no-op on the decision), present to honor the archetype's
+    documented signature read with the required warmup/BTC-only read-guard.
+  - v2 conviction-scaled margin used marginPct=0.15 (a FRACTION) * account_value
+    -> marginUsd. This port emits `marginPct` (PERCENT) and the runtime sizes
+    (marginPct/100)*withdrawable. Defensive guard: a value <= 1.0 is treated as a
+    pasted v2 fraction and converted x100 (dire/koala pattern).
+  - DROPPED v2 order-lifecycle: none. v2 Osprey had NO cancel_order /
+    has_resting_orders / stale-order purge — the producer NEVER closed (DSL owns
+    exits), so there is no mutation to drop. The runtime's reconciliation owns
+    order lifecycle as usual.
+  - v2 emitted exactly one signal (best). Preserved: scan() emits <= 1/tick.
+  - v2 recent-signals JSON cache -> ctx.state dedup map (same TTL semantics).
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# v2 defaults (osprey-producer.py / osprey-config.json)
+_DEFAULT_LEADER = "BTC"
+_DEFAULT_PROXIES = [
+    {"proxy": "xyz:COIN", "beta": 1.8},
+    {"proxy": "xyz:MSTR", "beta": 2.5},
+]
+_DEFAULT_MOVE_LOOKBACK = 4            # 1h bars — the "recent move" window for both legs
+_DEFAULT_MIN_LEADER_MOVE = 2.0       # leader must move at least this % to matter
+_DEFAULT_MIN_SCORE = 4               # v2 DEFAULT_MIN_SCORE
+_DEFAULT_MARGIN_PCT = 15.0           # PERCENT of withdrawable (v2 fraction 0.15 -> 15%)
+_DEFAULT_LEVERAGE = 4                # v2 DEFAULT_LEVERAGE
+_MAX_LEVERAGE = 10                   # v2 MAX_LEVERAGE (hardcoded cap)
+_DEFAULT_RECENT_TTL = 240            # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[osprey.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)), abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[osprey.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _fetch_candles(ctx, asset):
+    """1h candles for `asset` or [] (READ-GUARDED). Ported from v2 fetch_candles
+    (1h only, no funding, no order book)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": asset,
+            "candle_intervals": ["1h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": _dex_for(asset),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[osprey.scan] market_get_asset_data({asset}) read failed: {exc!r}", file=sys.stderr)
+        return []
+    if not md:
+        return []
+    if isinstance(md, dict) and md.get("success") is False:
+        return []
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return []
+    candles = d.get("candles", {}) or {}
+    return candles.get("1h", []) if isinstance(candles, dict) else []
+
+
+def _get_sm_direction(ctx, asset):
+    """Net smart-money lean for `asset` from leaderboard_get_markets.
+    Returns (direction, pct) or (None, 0.0). READ-GUARDED. Ported verbatim from
+    v2 fetch_sm_direction: long_ratio >= 50 -> LONG else SHORT (NEUTRAL/50 when
+    found but flat). SM is a SCORE BONUS on XYZ equities, never a gate."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — smart-money is a bonus; never crash the tick
+        print(f"[osprey.scan] leaderboard_get_markets read failed (smart-money -> neutral): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw:
+        return None, 0.0
+    data = raw.get("data", raw) if isinstance(raw, dict) else raw
+    markets = data.get("markets", data) if isinstance(data, dict) else data
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != asset.upper():
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    return ("LONG", long_ratio) if long_ratio >= 50 else ("SHORT", 100 - long_ratio)
+
+
+def _get_leader_flow(ctx, leader, min_leader_move):
+    """ARCHETYPE SIGNATURE READ — market_get_cross_asset_flows.
+
+    READ-GUARDED + DEGRADE-TO-NEUTRAL. This is the cross-asset-lag archetype's
+    signature read; here it serves ONLY as an INDEPENDENT confirmation of the
+    leader move (RULE 1). It NEVER alters score or gating (the v2 thesis self-
+    computes the leader move + gap from candles), so the v2 decision is exact.
+
+    The tool has a daily-cron WARMUP and only BTC has lag data; on warmup / empty
+    / non-BTC / any error it returns (False, 'NONE') and the tick proceeds on the
+    self-computed leader move alone. Returns (confirmed: bool, flow_dir: str)."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("market_get_cross_asset_flows", {
+            "leader_asset": leader,
+            "min_move_pct": min_leader_move,
+            "window": "4h",
+        })
+    except Exception as exc:  # noqa: BLE001 — warmup/BTC-only/transient — degrade to neutral
+        print(f"[osprey.scan] cross_asset_flows read failed (leader confirm -> neutral): {exc!r}",
+              file=sys.stderr)
+        return False, "NONE"
+    if not raw:
+        return False, "NONE"
+    data = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if not isinstance(data, dict):
+        return False, "NONE"
+    # Leader-move block shape varies; probe the documented "leader" summary.
+    leader_blk = data.get("leader", data.get("leader_move", {}))
+    if not isinstance(leader_blk, dict):
+        return False, "NONE"
+    mag = abs(scoring._f(leader_blk.get("move_pct", leader_blk.get("magnitude", 0))))
+    flow_dir = str(leader_blk.get("direction", "")).upper() or "NONE"
+    confirmed = mag >= float(min_leader_move) and flow_dir in ("LONG", "SHORT", "UP", "DOWN")
+    return confirmed, flow_dir
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    leader = str(inputs.get("leader", _DEFAULT_LEADER) or _DEFAULT_LEADER)
+    proxies = inputs.get("proxies", _DEFAULT_PROXIES)
+    lookback = int(inputs.get("moveLookbackBars", _DEFAULT_MOVE_LOOKBACK))
+    min_leader = float(inputs.get("minLeaderMovePct", _DEFAULT_MIN_LEADER_MOVE))
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    lev_default = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    # marginPct is a PERCENT in (0,100]. FLAGGED: defensively convert a value <= 1
+    # (an operator who pasted the v2 FRACTION 0.15) into a PERCENT so it never
+    # silently sizes ~100x small (the runtime sizes (marginPct/100)*withdrawable).
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        print(f"[osprey.scan] marginPct={margin_pct} looks like a v2 fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
+
+    # leverage clamp: min(default, MAX_LEVERAGE) — verbatim from v2 main()
+    leverage = min(lev_default, _MAX_LEVERAGE)
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── RULE 1: the leader must move first (self-computed from candles) ──
+    leader_candles = _fetch_candles(ctx, leader)
+    leader_closes = [scoring._close(c) for c in leader_candles]
+    leader_move = scoring.move_pct(leader_closes, lookback)
+
+    if leader_move is None or abs(leader_move) < min_leader:
+        result = {"ts": now, "emitted": False, "held": held_assets,
+                  "leaderMovePct": round(leader_move, 2) if leader_move is not None else None,
+                  "note": f"WAITING — leader {leader} move below {min_leader}% threshold"}
+        print(f"[osprey.scan] WAITING — leader {leader} move "
+              f"{leader_move if leader_move is not None else 'n/a'} below {min_leader}%; "
+              f"held={held_assets}", file=sys.stderr)
+        _persist(ctx, signaled, result)
+        return []
+
+    # ARCHETYPE SIGNATURE READ (confirmation-only; never gates — see _get_leader_flow)
+    leader_confirmed, leader_flow_dir = _get_leader_flow(ctx, leader, min_leader)
+
+    # ── score each proxy's catch-up gap (held + recently-signaled filtered
+    #    BEFORE the per-asset MCP fetch, as in v2 main()) ──
+    candidates = []
+    scanned = 0
+    for proxy_cfg in proxies:
+        proxy = str(proxy_cfg.get("proxy", "")).strip()
+        if not proxy:
+            continue
+        pu = proxy.upper()
+        if pu in held_set:
+            continue
+        if _was_recently_signaled(signaled, proxy, ttl, now):
+            continue
+        scanned += 1
+        proxy_candles = _fetch_candles(ctx, proxy)
+        if len(proxy_candles) <= lookback:
+            continue
+        proxy_closes = [scoring._close(c) for c in proxy_candles]
+        sm = _get_sm_direction(ctx, proxy)
+        th = scoring.build_thesis(proxy_cfg, leader_move, proxy_closes, proxy_candles, sm, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "emitted": False, "scanned": scanned, "held": held_assets,
+                  "leaderMovePct": round(leader_move, 2), "leaderConfirmed": leader_confirmed,
+                  "note": f"WAITING — {leader} moved {leader_move:+.1f}% but no proxy owes a catch-up gap"}
+        print(f"[osprey.scan] WAITING — {leader} moved {leader_move:+.1f}% but no proxy gap "
+              f">= floor; scanned={scanned} held={held_assets}", file=sys.stderr)
+    else:
+        # v2 sort: (score, |gap|) descending; emit exactly the single best.
+        candidates.sort(key=lambda c: (c["score"], abs(c["gap_pct"])), reverse=True)
+        best = candidates[0]
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "emitted": True, "scanned": scanned, "held": held_assets,
+                  "coin": best["coin"], "direction": best["direction"], "score": best["score"],
+                  "leverage": leverage, "marginPct": round(margin_pct, 4),
+                  "leaderMovePct": round(leader_move, 2), "gapPct": best["gap_pct"],
+                  "leaderConfirmed": leader_confirmed, "reasons": best["reasons"]}
+        print(f"[osprey.scan] EMIT {best['coin']} {best['direction']} score={best['score']} "
+              f"{leverage}x marginPct={margin_pct:.2f}% gap={best['gap_pct']:+.1f}% "
+              f"leader={leader_move:+.1f}% | {best['reasons'][:5]}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # 1..10; runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best["reasons"],
+                "leader": leader,
+                "leaderMovePct": best.get("leader_move_pct") or 0.0,
+                "proxyMovePct": best.get("proxy_move_pct") or 0.0,
+                "gapPct": best.get("gap_pct") or 0.0,
+                "beta": best.get("beta") or 0.0,
+                "smDirection": best.get("sm_direction") or "NONE",
+                "smTiltPct": best.get("sm_tilt_pct") or 0.0,
+                "volumeTrendPct": best.get("volume_trend_pct") or 0.0,
+                "leaderConfirmed": leader_confirmed,
+                "leaderFlowDir": leader_flow_dir,
+                "heldAssets": held_assets,
+            },
+        }]
+
+    _persist(ctx, signaled, result)
+    return out
+
+
+def _persist(ctx, signaled, result):
+    """Append the dedup map + this tick's result every tick; bounded by
+    state_history_max_count. Read back via ctx.state.recent(n)."""
+    if ctx.state is None:
+        return
+    try:
+        ctx.state.append({"signaled": signaled, "result": result})
+    except Exception as exc:  # noqa: BLE001
+        print(f"[osprey.scan] WARNING: state append failed; next tick may re-emit "
+              f"a suppressed signal: {exc!r}", file=sys.stderr)

--- a/strategies/osprey/main/scanners/scoring.py
+++ b/strategies/osprey/main/scanners/scoring.py
@@ -1,0 +1,173 @@
+"""OSPREY — pure cross-venue lag math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Osprey producer's pure functions
+(osprey-producer.py v1.0.1 + osprey_config.py). The math/indexing is reproduced
+VERBATIM so a fidelity harness can diff this against the v2 producer on the same
+market snapshot. Behaviour-preserving quirks from v2 are kept and flagged
+`# v2-quirk`.
+
+THESIS (cross-VENUE lag): when a crypto leader (BTC) makes a strong move,
+crypto-correlated XYZ equities (COIN/MSTR) tend to follow but on a different
+venue with a lag. Each tick measures, per proxy:
+
+    expected_move = leader_move_pct * proxy_beta
+    gap           = expected_move - proxy_actual_move
+
+A gap in the LEADER'S direction (same sign) means the proxy still owes catch-up
+-> trade the proxy in the leader's direction. An overshot proxy (gap flips
+sign) is skipped — the catch-up is already done.
+
+`sm` (smart-money lean on the proxy) is fetched by the caller and passed in, so
+this module stays pure. The proxy candles (for the volume-trend bonus) are also
+passed in by the caller as plain lists.
+"""
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read via _f(c, "close", "c") / _f(c, "volume", "v"); the list branch is
+# defensive and never fires on dict candles, so it does not change v2 behaviour.
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ═══════════════════════════════════════════════════════════════
+# Pure cross-venue lag math (ported verbatim from v2 osprey-producer.py)
+# ═══════════════════════════════════════════════════════════════
+
+def move_pct(closes, lookback):
+    """% change of the latest close vs the close `lookback` bars ago.
+    None if insufficient data or the reference price is non-positive.
+    Verbatim from v2 move_pct."""
+    if not closes or len(closes) <= lookback:
+        return None
+    ref = closes[-(lookback + 1)]
+    latest = closes[-1]
+    if ref is None or ref <= 0:
+        return None
+    return ((latest - ref) / ref) * 100.0
+
+
+def catchup_gap(leader_move, proxy_move, beta):
+    """How much of the expected catch-up move the proxy still owes.
+    expected = leader_move * beta; gap = expected - actual. Verbatim from v2."""
+    return (leader_move * beta) - proxy_move
+
+
+def lag_direction(leader_move, gap, min_leader_move, min_gap):
+    """Direction to trade the proxy so it profits from closing the gap.
+    None unless the leader moved enough AND the proxy still owes a gap in the
+    LEADER'S direction (same sign). An overshot proxy (gap flips sign) is
+    skipped — the catch-up is already done. Verbatim from v2 lag_direction."""
+    if leader_move is None or gap is None:
+        return None
+    if abs(leader_move) < min_leader_move:
+        return None
+    if abs(gap) < min_gap:
+        return None
+    if (leader_move > 0) != (gap > 0):   # gap must share the leader's sign
+        return None
+    return "LONG" if gap > 0 else "SHORT"
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-half vs earlier-half average volume, % change. Verbatim from v2
+    volume_trend (default lookback 6)."""
+    if len(candles) < lookback:
+        return 0.0
+    vols = [_vol(c) for c in candles[-lookback:]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier <= 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# Thesis builder — one proxy (ported verbatim from v2 build_thesis)
+# ═══════════════════════════════════════════════════════════════
+
+def build_thesis(proxy_cfg, leader_move, proxy_closes, proxy_candles, sm, inputs):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned when:
+      - the proxy has no measurable move (insufficient candle history), OR
+      - lag_direction resolves no direction (leader didn't move enough, the gap
+        is below threshold, or the proxy overshot / already caught up).
+    minScore is NOT applied here — the caller (scan.py) gates on thesis['score'].
+
+    `sm` is the smart-money tuple (direction, pct) or (None, 0.0) — the caller
+    fetches it (leaderboard_get_markets). SM on XYZ equities is sparse, so SM is
+    a SCORE BONUS, not a gate (verbatim from v2)."""
+    proxy = proxy_cfg["proxy"]
+    beta = float(proxy_cfg.get("beta", 1.0))
+    lookback = int(inputs.get("moveLookbackBars", 4))
+    min_leader = float(inputs.get("minLeaderMovePct", 2.0))
+    min_gap = float(inputs.get("minGapPct", 2.0))
+    strong_gap = float(inputs.get("strongGapPct", 5.0))
+    sm_min = float(inputs.get("smTiltMinPct", 55))
+    sm_strong = float(inputs.get("smStrongTiltPct", 70))
+
+    proxy_move = move_pct(proxy_closes, lookback)
+    if proxy_move is None:
+        return None
+    gap = catchup_gap(leader_move, proxy_move, beta)
+    direction = lag_direction(leader_move, gap, min_leader, min_gap)
+    if direction is None:
+        return None
+
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    vol_trend = volume_trend(proxy_candles)
+
+    score = 0
+    reasons = [f"leader_{leader_move:+.1f}%", f"{proxy}_lag_{proxy_move:+.1f}%", f"gap_{gap:+.1f}%"]
+    score += 2  # leader moved + proxy owes a gap in the leader's direction (gate)
+    if abs(gap) >= strong_gap:
+        score += 2
+        reasons.append(f"gap_strong_{gap:+.1f}%")
+    # SM is often sparse on XYZ equities — agreement is a bonus, not a gate.
+    if sm_dir == direction and sm_tilt >= sm_min:
+        score += 1
+        reasons.append(f"sm_confirms_{sm_tilt:.0f}%")
+        if sm_tilt >= sm_strong:
+            score += 1
+            reasons.append("sm_strong")
+    if vol_trend > 15:
+        score += 1
+        reasons.append(f"vol_rising_{vol_trend:+.0f}%")
+
+    return {
+        "coin": proxy,
+        "direction": direction,
+        "score": score,
+        "reasons": reasons,
+        "leader_move_pct": round(leader_move, 2),
+        "proxy_move_pct": round(proxy_move, 2),
+        "gap_pct": round(gap, 2),
+        "beta": beta,
+        "sm_direction": sm_dir if sm_dir else "NONE",
+        "sm_tilt_pct": _f(sm_tilt),
+        "volume_trend_pct": round(vol_trend, 2),
+    }

--- a/strategies/osprey/strategy.yaml
+++ b/strategies/osprey/strategy.yaml
@@ -1,0 +1,44 @@
+# Osprey — cross-venue lag catcher (crypto leader -> XYZ equity proxy). A single-
+# instance PACKAGE: this manifest + one self-contained runtime.yaml + scanners/. A
+# faithful Runtime 3.0 port of the v2 Osprey (SKILL.md v1.0.0 / producer v1.0.1):
+# when a crypto leader (BTC) makes a strong move, crypto-correlated equities on
+# Hyperliquid XYZ (COIN/MSTR) tend to follow with a lag; Osprey self-computes each
+# proxy's catch-up gap (leader move x beta - proxy move) from 1h candles and trades
+# the proxy in the leader's direction when it still owes a gap. Let-winners-run DSL.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: osprey
+version: "1.0.0"
+
+catalog:
+  name: "Osprey — Cross-Venue Lag (Crypto -> XYZ Equity)"
+  emoji: "🦅"
+  tagline: "When BTC moves hard, crypto-correlated equities on Hyperliquid XYZ (Coinbase, MicroStrategy) follow late: Osprey self-computes each proxy's catch-up gap (leader move x its beta minus the move it has actually made), and when a proxy still owes a gap in the leader's direction it enters the proxy that way and lets a wide DSL ride the catch-up."
+  belief_plain: "When Bitcoin makes a big move, the crypto-flavored stocks on the XYZ exchange (Coinbase, MicroStrategy) usually move the same way — but a beat late, because they are priced on a different venue. Osprey works out how far behind each one is and bets it catches up, then trails a wide stop so the catch-up can run for a day or two."
+  thesis: "A crypto-correlated equity has a known beta to BTC (COIN ~1.8x, MSTR ~2.5x), so a BTC move implies an expected proxy move. But XYZ pricing trails spot crypto around its reference windows, so the proxy's actual move lags — a measurable, tradeable gap. Trading the lag (not the leader) means entering in the leader's confirmed direction only when the proxy still owes catch-up, which sidesteps the chase-the-leader failure mode and lets the structural pricing lag, not a directional guess, be the edge."
+  group: structural
+  archetype: structural_neutral
+  sub_style: cross_venue_lag
+  asset_classes: [xyz_equities]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 10
+  max_slots: 1
+  min_budget: 200
+  assets: ["xyz:COIN", "xyz:MSTR"]
+  tags: [xyz, coin, mstr, cross-venue-lag, cross-asset-lag, btc-proxy, crypto-equities, catch-up, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: OSPREY_WALLET
+    funding_share: 1.0

--- a/strategies/remora/main/runtime.yaml
+++ b/strategies/remora/main/runtime.yaml
@@ -1,0 +1,143 @@
+# ── REMORA · single instance — whale single-position mirror ───────────────────
+# Runtime 3.0 port of the v2 Remora (SKILL.md v1.0.0 / remora-producer.py v1.0.1).
+# TRADER-FOLLOWER: mirrors a small, hand-picked set of whale traders (NOT a
+# leaderboard universe). Each tick pulls each whale's open positions, takes their
+# highest-conviction (largest-notional) position, aggregates across whales into
+# (asset, direction) candidates, and emits the strongest — boosting score when
+# multiple whales agree (consensus) and when a whale is ELITE/RELIABLE tier.
+# Let-winners-run DSL with a 120h hard_timeout staleness cap (whales hold winners;
+# the whale-exit mirror is a future enhancement). Faithful port — see
+# scanners/scoring.py (mirror math reproduced verbatim).
+name: remora-main
+group: remora
+version: 1.0.0
+description: >
+  REMORA — whale single-position mirror. Rides a small, hand-picked set of whale
+  traders: each tick it pulls each whale's open positions (leaderboard_get_trader_positions),
+  takes their highest-conviction (largest-notional) position above minNotionalUsd,
+  aggregates across whales into (asset, direction) candidates, scores by consensus
+  (how many whales agree) + whale quality (discovery_get_trader_state ELITE/RELIABLE/
+  PROFITABLE tier when useWhaleQuality), and mirrors the strongest — sized by
+  Remora's own marginPct (default 15%), leverage clamped to 10x. Distinct from the
+  broad trader-followers (Raptor/Jackal/Spider) that scan a leaderboard universe;
+  Remora mirrors whales YOU choose (set inputs.whales). Producer enters only — the
+  DSL owns exits: let-winners-run preset (wide ladder, first lock at +10% ROE,
+  max_loss 18%) with a 120h hard_timeout staleness cap. Faithful port of the v2
+  Remora v1.0.0 thesis (all scoring/thresholds verbatim).
+
+strategy:
+  wallet: "${REMORA_WALLET}"
+  slots: 1                                  # v2 mirror emits exactly one best candidate
+  margin_pct: 15                            # baseline %; scan emits the marginPct intent per signal
+  default_leverage: 4                       # v2 DEFAULT_LEVERAGE; scan emits leverage (clamped <=10x)
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: remora_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 600                    # v2 producer cadence (10 min — whale positions change slowly)
+    timeout_seconds: 240                     # v2 tick_timeout=240; up to ~2 reads/whale + account
+    default_signal_validity_seconds: 1200    # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 50              # dedup map + per-tick scan-results history
+    inputs:
+      whales: []                             # SET to your hand-picked trader_ids/wallets, e.g.
+                                             #   [ { trader_id: "0x..." }, { trader_id: "0x..." } ]
+                                             # v2 config.whales default was placeholder; empty -> WAITING
+      useWhaleQuality: true                  # v2 config.useWhaleQuality — ELITE/RELIABLE/PROFITABLE bonus
+      minNotionalUsd: 5000                   # v2 DEFAULT_MIN_NOTIONAL_USD — skip dust positions
+      minScore: 4                            # v2 DEFAULT_MIN_SCORE — producer floor
+      marginPct: 15                          # PERCENT of withdrawable (0,100]; v2 stored fraction 0.15 -> 15%
+      leverage: 4                            # v2 config.leverage default; clamped to <=10x in scan.py
+      recentSignalTtlSeconds: 240            # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      whaleCount: { type: number, required: false }
+      maxNotionalUsd: { type: number, required: false }
+      eliteTier: { type: boolean, required: false }
+      whales: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: remora_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                      # the scan already applied every filter (v2 LLM gate was pass-through)
+    scanners: [remora_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true      # mirror the whale's live exposure now — a maker order that rests
+                                             # (CREATE_ORDER_RESTING) drifts from the whale's entry
+        execution_timeout_seconds: 30        # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: remora_signals
+
+# ── EXIT (DSL — let-winners-run preset, ported VERBATIM from v2 runtime.yaml) ──
+# Whales hold winners, so let the mirror run: wide ladder (T0 +10% / lock 0),
+# max_loss 18%, time-cuts OFF except a hard_timeout staleness cap (Remora does
+# not yet mirror the whale's EXIT, so the 120h timeout prevents holding a stale
+# mirror indefinitely — a whale-exit mirror is a future enhancement). NO
+# weak_peak_cut. First Phase-2 lock at +10% ROE (reachable — not the >+40%
+# unreachable pattern).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true          # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 7200              # 120h (5d) — staleness cap, since the whale's exit is not yet mirrored
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 45 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+        - { trigger_pct: 90, lock_hw_pct: 88 }
+
+# ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 345600             # 96h (was data_retention_hours 96); in [3600, 604800], no clamp
+  guard_rails:
+    daily_loss_limit_pct: 15                 # v2 risk.daily_loss_limit_pct
+    max_entries_per_day: 3                   # v2 risk.max_entries_per_day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3                # v2 risk.max_consecutive_losses
+    cooldown_seconds: 5400                   # v2 cooldown_minutes 90 -> 5400s
+    drawdown_halt_pct: 22                    # v2 risk.drawdown_halt_pct
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 28800        # v2 per_asset_cooldown_minutes 480 -> 28800s (8h)
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/remora/main/scanners/scan.py
+++ b/strategies/remora/main/scanners/scan.py
@@ -1,0 +1,299 @@
+"""REMORA — supervised scanner (Runtime 3.0 port of the v2 Remora whale mirror).
+
+TRADER-FOLLOWER archetype: mirrors a small, hand-picked set of whale traders
+(NOT a leaderboard universe). Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - for each configured whale, pulls their open positions
+    (leaderboard_get_trader_positions — the producer signature) and takes their
+    single largest-notional position above minNotionalUsd,
+  - optionally validates whale quality (discovery_get_trader_state ELITE /
+    RELIABLE / PROFITABLE tier) as a scoring bonus,
+  - aggregates across whales into (asset, direction) candidates (consensus is the
+    edge multiplier), scores via the pure `scoring` module, and emits the SINGLE
+    highest-scoring candidate at/above minScore (v2 main() emitted only `best`),
+    sized by Remora's OWN marginPct + leverage clamp.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`;
+the runtime sizes the dollars, owns cooldowns/risk gates/dedup, and trails the
+DSL exit. No daemon, no push_signal, no create_position.
+
+READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped try/except -> degrade (skip
+that whale / neutral tier / skip the tick), NEVER propagate. Per the scan
+contract ANY exception rolls the whole tick back to [], so one bad whale read
+would silently kill all emits — guarded so a single flaky whale just drops out.
+
+FIDELITY NOTES vs the v2 producer (remora-producer.py v1.0.1):
+  - v2 stored margin as a FRACTION (config.marginPct = 0.15) and multiplied by
+    account_value to get a marginUsd, then emitted marginUsd. This port emits
+    `marginPct` (PERCENT in (0,100]) at the top level; the runtime sizes
+    (marginPct/100)*withdrawable. The default 0.15 -> 15 PERCENT. A defensive
+    "<=1.0 means a pasted fraction, x100" guard preserves either input form.
+  - v2 emitted exactly one signal (best, highest score, tie-break by consensus
+    count then max_notional). Preserved: scan() emits <= 1 signal/tick with the
+    SAME sort key.
+  - v2's recent-signals.json race-window dedup cache -> ctx.state dedup map (same
+    TTL semantics: TTL=240s, prune at 4x TTL). The on-chain held-asset filter is
+    preserved verbatim (held names are skipped before scoring).
+  - v2 leverage clamp `min(int(config.leverage), MAX_LEVERAGE)` preserved.
+  - v2 read-sanity guard (margin in use + empty positions -> skip tick) ported
+    verbatim from cfg.get_positions.
+  - DROPPED: nothing — the v2 producer is enter-only (no cancel_order /
+    has_resting_orders / stale-order purge to drop). The DSL owns exits; a
+    whale-exit mirror remains a future enhancement (as in v2).
+  - No fixed universe to validate against HL meta: Remora has NO whitelist — the
+    assets it mirrors are whatever the configured whales hold, resolved live each
+    tick. (config.whales is the operator's hand-picked trader set, default empty.)
+"""
+
+import sys
+import time
+
+import scoring
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''.
+    Defensive — only matters if a whale holds an xyz: position."""
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Ported verbatim from v2 cfg.get_positions,
+    including the read-sanity guard (margin in use + empty positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[remora.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring.safe_float(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring.safe_float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", "")})
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported verbatim from v2): a
+    # corrupt clearinghouse read can report margin/notional IN USE while returning
+    # an EMPTY positions list; sizing or running the held-asset dedup off that
+    # re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring.safe_float(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring.safe_float(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[remora.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _fetch_whale_positions(ctx, trader_id):
+    """List of position dicts for one whale (leaderboard_get_trader_positions),
+    unwrapping the nested data.positions.positions shape. READ-GUARDED -> []
+    on any failure (the whale just drops out of this tick). Verbatim unwrap from
+    v2 fetch_whale_positions."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_trader_positions",
+                                      {"trader_id": trader_id})
+    except Exception as exc:  # noqa: BLE001 — one flaky whale must not kill the tick
+        print(f"[remora.scan] leaderboard_get_trader_positions({str(trader_id)[:10]}) "
+              f"read failed (whale skipped): {exc!r}", file=sys.stderr)
+        return []
+    if not raw:
+        return []
+    if not isinstance(raw, dict):
+        return raw if isinstance(raw, list) else []
+    d = raw.get("data", raw)
+    if isinstance(d, list):
+        return d
+    if not isinstance(d, dict):
+        return []
+    rp = d.get("positions", d.get("top_positions", []))
+    if isinstance(rp, list):
+        return rp
+    if isinstance(rp, dict):  # nested one level deeper (observed shape)
+        nested = rp.get("positions", [])
+        return nested if isinstance(nested, list) else []
+    return []
+
+
+def _fetch_whale_tier(ctx, trader_id):
+    """ELITE / RELIABLE / etc. for one whale, or None if unavailable.
+    READ-GUARDED -> None (quality bonus simply not awarded). Verbatim parse from
+    v2 fetch_whale_tier."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("discovery_get_trader_state",
+                                      {"trader_id": trader_id})
+    except Exception as exc:  # noqa: BLE001 — quality is a bonus; never crash the tick
+        print(f"[remora.scan] discovery_get_trader_state({str(trader_id)[:10]}) "
+              f"read failed (tier -> none): {exc!r}", file=sys.stderr)
+        return None
+    if not raw or not isinstance(raw, dict):
+        return None
+    d = raw.get("data", raw)
+    if not isinstance(d, dict):
+        return None
+    tier = d.get("tier", d.get("classification", d.get("rating")))
+    return str(tier).upper() if tier else None
+
+
+# ── ctx.state: recent-signal dedup (port of v2 recent-signals.json) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def _normalize_whale_id(whale):
+    """A whale entry can be a dict {trader_id|wallet} or a bare string (v2
+    gather_candidates accepted both)."""
+    if isinstance(whale, dict):
+        return whale.get("trader_id") or whale.get("wallet") or ""
+    return whale or ""
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    whales_cfg = inputs.get("whales", [])
+    use_tier = bool(inputs.get("useWhaleQuality", True))
+    min_notional = float(inputs.get("minNotionalUsd", scoring.DEFAULT_MIN_NOTIONAL_USD))
+    min_score = int(inputs.get("minScore", scoring.DEFAULT_MIN_SCORE))
+    leverage = min(int(inputs.get("leverage", scoring.DEFAULT_LEVERAGE)), scoring.MAX_LEVERAGE)
+    ttl = float(inputs.get("recentSignalTtlSeconds", 240))
+
+    # marginPct intent (PERCENT in (0,100]). v2 stored a FRACTION (0.15); the
+    # defensive guard converts a pasted fraction (<=1.0) to a percent (x100).
+    margin_pct = float(inputs.get("marginPct", 15))
+    if margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    if not whales_cfg:
+        print("[remora.scan] WAITING — no whales configured (set inputs.whales)", file=sys.stderr)
+        if ctx.state is not None:
+            try:
+                ctx.state.append({"signaled": {}, "result": {"ts": now, "emitted": False,
+                                                             "note": "no_whales_configured"}})
+            except Exception as exc:  # noqa: BLE001
+                print(f"[remora.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+        return []
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── per-whale: fetch positions, take the top, validate tier (READ-GUARDED) ──
+    whale_tops = []
+    for whale in whales_cfg:
+        trader_id = _normalize_whale_id(whale)
+        if not trader_id:
+            continue
+        whale_positions = _fetch_whale_positions(ctx, trader_id)
+        top = scoring.top_position(whale_positions, min_notional)
+        if not top:
+            continue
+        tier = _fetch_whale_tier(ctx, trader_id) if use_tier else None
+        whale_tops.append((trader_id, top, tier))
+
+    # ── aggregate into (asset, direction) candidates + score (pure) ──
+    candidates = scoring.aggregate_candidates(whale_tops, use_tier)
+    scored = []
+    for cand in candidates:
+        if cand["asset"].upper() in held_set:                 # on-chain held-asset filter
+            continue
+        if _was_recently_signaled(signaled, cand["asset"], ttl, now):
+            continue
+        score, reasons = scoring.score_candidate(cand)
+        if score >= min_score:
+            scored.append((score, reasons, cand))
+
+    out = []
+    if not scored:
+        result = {"ts": now, "emitted": False, "whales_tracked": len(whales_cfg),
+                  "candidates_seen": len(candidates), "held": held_assets,
+                  "note": f"WAITING (min score {min_score})"}
+        print(f"[remora.scan] WAITING — no qualifying whale position to mirror "
+              f"(min score {min_score}); whales={len(whales_cfg)} "
+              f"candidates={len(candidates)} held={held_assets}", file=sys.stderr)
+    else:
+        # v2 sort: highest score, tie-break by consensus count then max_notional.
+        scored.sort(key=lambda t: (t[0], t[2]["count"], t[2]["max_notional"]), reverse=True)
+        best_score, best_reasons, best = scored[0]
+
+        signaled[best["asset"].upper()] = now
+        result = {"ts": now, "emitted": True, "coin": best["asset"],
+                  "direction": best["direction"], "score": best_score,
+                  "whaleCount": best["count"], "maxNotionalUsd": round(best["max_notional"], 2),
+                  "eliteTier": bool(best.get("quality")), "leverage": leverage,
+                  "marginPct": round(margin_pct, 4), "held": held_assets,
+                  "reasons": best_reasons}
+        print(f"[remora.scan] EMIT {best['asset']} {best['direction']} score={best_score} "
+              f"whales={best['count']} maxNotional=${best['max_notional']:,.0f} "
+              f"{leverage}x marginPct={margin_pct:.2f}% | {best_reasons[:5]}", file=sys.stderr)
+        out = [{
+            "asset": best["asset"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # clamped to <= MAX_LEVERAGE; runtime applies it
+            "data": {
+                "score": best_score,
+                "leverage": leverage,
+                "direction": best["direction"],
+                "reasons": best_reasons,
+                "whaleCount": best["count"],
+                "maxNotionalUsd": round(best["max_notional"], 2),
+                "eliteTier": bool(best.get("quality")),
+                "whales": best.get("whales", []),
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + this tick's result every tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[remora.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/remora/main/scanners/scoring.py
+++ b/strategies/remora/main/scanners/scoring.py
@@ -1,0 +1,151 @@
+"""REMORA — pure whale-mirror math (no I/O, no MCP, no clock).
+
+A faithful Runtime 3.0 port of the v2 Remora producer's pure mirror logic
+(remora-producer.py v1.0.1). Every function here is reproduced VERBATIM from the
+v2 producer so a fidelity harness can diff this against v2 on the same whale
+position snapshot. These are the functions v2 unit-tested in tests/test_signal.py:
+position_notional, mirror_direction, position_asset, top_position,
+consensus_bonus, plus the candidate aggregation/scoring.
+
+Remora rides a small, hand-picked set of whale traders: take each whale's
+highest-conviction (largest-notional) open position, aggregate across whales into
+(asset, direction) candidates, and score by consensus (how many whales agree) +
+whale quality. The MCP fetches (whale positions, whale tier) are done by the
+caller (scan.py) and passed in, so this module stays pure and unit-testable.
+"""
+
+# Whale-quality tiers that earn the discovery_get_trader_state bonus
+# (verbatim from v2 QUALITY_TIERS).
+QUALITY_TIERS = {"ELITE", "RELIABLE", "PROFITABLE"}
+
+# v2 producer constants (remora-producer.py).
+MAX_LEVERAGE = 10
+DEFAULT_LEVERAGE = 4
+DEFAULT_MIN_SCORE = 4
+DEFAULT_MIN_NOTIONAL_USD = 5000   # ignore dust positions
+
+
+def safe_float(v, default=0.0):
+    """Verbatim from v2 safe_float."""
+    try:
+        return float(v if v is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def position_notional(pos):
+    """USD notional of a position for conviction ranking: size x entry,
+    falling back to marginUsed, then to raw size. Verbatim from v2."""
+    if not isinstance(pos, dict):
+        return 0.0
+    size = abs(safe_float(pos.get("szi", pos.get("size", 0))))
+    entry = safe_float(pos.get("entryPx", pos.get("entryPrice", pos.get("entry", 0))))
+    notional = size * entry
+    if notional > 0:
+        return notional
+    margin = abs(safe_float(pos.get("marginUsed", pos.get("margin", 0))))
+    return margin if margin > 0 else size
+
+
+def mirror_direction(pos):
+    """LONG / SHORT for a position (explicit direction/side field, else szi
+    sign). None if undeterminable. Verbatim from v2."""
+    if not isinstance(pos, dict):
+        return None
+    d = str(pos.get("direction", pos.get("side", ""))).upper()
+    if d in ("LONG", "SHORT"):
+        return d
+    szi = safe_float(pos.get("szi", pos.get("size", 0)))
+    if szi > 0:
+        return "LONG"
+    if szi < 0:
+        return "SHORT"
+    return None
+
+
+def position_asset(pos):
+    """Verbatim from v2."""
+    if not isinstance(pos, dict):
+        return ""
+    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", ""))))).upper()
+
+
+def top_position(positions, min_notional=0.0):
+    """The single largest-notional position with a determinable direction and
+    notional >= min_notional. None if the whale holds nothing qualifying.
+    Verbatim from v2."""
+    best, best_n = None, -1.0
+    for p in positions or []:
+        if not isinstance(p, dict):
+            continue
+        if mirror_direction(p) is None or not position_asset(p):
+            continue
+        n = position_notional(p)
+        if n < min_notional:
+            continue
+        if n > best_n:
+            best_n, best = n, p
+    return best
+
+
+def consensus_bonus(count):
+    """Score bonus for how many whales independently hold the same
+    asset+direction. 3+ whales is a strong consensus. Verbatim from v2."""
+    if count >= 3:
+        return 3
+    if count == 2:
+        return 2
+    return 0
+
+
+def aggregate_candidates(whale_tops, use_tier):
+    """Aggregate per-whale (top_position, tier) tuples into (asset, direction)
+    candidates with consensus count + max notional + whale quality.
+
+    `whale_tops` is a list of (trader_id, top_position_dict_or_None,
+    tier_str_or_None) tuples — the caller (scan.py) does the MCP fetches and
+    passes the resolved tops here so this module stays pure. Reproduces the
+    aggregation body of v2 gather_candidates() verbatim."""
+    agg = {}
+    for trader_id, top, tier in whale_tops:
+        if not top:
+            continue
+        asset = position_asset(top)
+        direction = mirror_direction(top)
+        notional = position_notional(top)
+        if not asset or direction is None:
+            continue
+        key = (asset, direction)
+        entry = agg.setdefault(key, {
+            "asset": asset, "direction": direction,
+            "count": 0, "max_notional": 0.0, "quality": False,
+            "whales": [],
+        })
+        entry["count"] += 1
+        entry["max_notional"] = max(entry["max_notional"], notional)
+        if use_tier and tier in QUALITY_TIERS:
+            entry["quality"] = True
+        entry["whales"].append(str(trader_id)[:10])
+    return list(agg.values())
+
+
+def score_candidate(cand):
+    """(score, reasons) for an aggregated candidate. Verbatim from v2
+    score_candidate: +3 base (a tracked whale's top conviction position),
+    +consensus_bonus (2 whales -> +2, 3+ -> +3), +1 if any agreeing whale is
+    ELITE/RELIABLE/PROFITABLE tier."""
+    count = cand["count"]
+    score = 3  # a tracked whale's top conviction position
+    reasons = [
+        f"{cand['asset']}_{cand['direction']}",
+        f"whales_{count}",
+        f"notional_${cand['max_notional']:,.0f}",
+    ]
+    cb = consensus_bonus(count)
+    if cb:
+        score += cb
+        reasons.append(f"consensus_{count}_whales")
+    if cand.get("quality"):
+        score += 1
+        reasons.append("elite_tier")
+    return score, reasons

--- a/strategies/remora/strategy.yaml
+++ b/strategies/remora/strategy.yaml
@@ -1,0 +1,44 @@
+# Remora — whale single-position mirror. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2
+# Remora (SKILL.md v1.0.0): mirrors a small, hand-picked set of whale traders — takes
+# each whale's highest-conviction (largest-notional) open position, aggregates across
+# whales into (asset, direction) candidates, scores by consensus + whale quality, and
+# mirrors the strongest. Let-winners-run DSL with a 120h staleness cap. No fixed
+# universe — the assets come from whatever the configured whales hold. Install/teardown
+# via senpi-strategy-ops.
+schema_version: 1
+
+id: remora
+version: "1.0.0"
+
+catalog:
+  name: "Remora — Whale Single-Position Mirror"
+  emoji: "🐟"
+  tagline: "Rides a small, hand-picked set of whale traders the way a remora fish rides a shark: each tick it takes each whale's highest-conviction open position and mirrors the strongest, leaning hardest when several whales pile into the same trade (consensus) or when a whale is ELITE/RELIABLE tier."
+  belief_plain: "You name a few whale traders you trust. Remora watches their open positions, finds each one's biggest bet, and copies the single strongest one — betting bigger when several of your whales are in the same trade and one of them has an elite track record. Then it trails a wide stop so the trade can run."
+  thesis: "The broad trader-followers scan a leaderboard and synthesize an opaque pick. Remora is the opposite: YOU choose whom to ride. Mirroring one whale's single highest-conviction position keeps your exposure tracking specific traders you trust, and the consensus multiplier means it leans hardest exactly when those whales independently agree — one whale can be wrong, three agreeing is a much stronger signal. Whales hold winners, so the exit lets the mirror run and only caps staleness."
+  group: smart-money
+  archetype: copy_trading
+  sub_style: named_whales
+  asset_classes: [universe_crypto]
+  asset_scope: follows_traders
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 10
+  max_slots: 1
+  min_budget: 100
+  assets: []
+  tags: [whale, mirror, copy-trading, named-whales, consensus, let-winners-run, follows-traders]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: REMORA_WALLET
+    funding_share: 1.0

--- a/strategies/turbine/runners/runtime.yaml
+++ b/strategies/turbine/runners/runtime.yaml
@@ -1,0 +1,146 @@
+# ── TURBINE · RUNNERS wallet — volume rotation with patient DSL exits ──
+# Runtime 3.0 port of the v2 Turbine RUNNERS runtime (turbine-runners-tracker, producer
+# v3.2.2). The runners wallet receives the SAME funding-fade volume-rotation alpha as
+# the volume wallet (same universe BTC/ETH/SOL/HYPE + xyz:BRENTOIL/GOLD/SP500, same
+# direction selection) — the ONLY difference is the DSL exit profile: patient, with a
+# 240-min hard_timeout and a Phase 2 ratchet (T0 5%/0, T1 10%/35, T2 20%/55, T3 35%/75,
+# T4 50%/85) so the ~5% of entries that catch a real directional move ride to a much
+# larger realized PnL instead of being force-cut at 10 min. Faithful port — see scan.py.
+#
+# Top-level `version` is package/skill metadata (NOT the runtime schema version, which
+# is the runtime engine's own boundary). Keeping it at the skill semver 3.2.2.
+name: turbine-runners
+group: turbine
+version: 3.2.2
+description: >
+  TURBINE RUNNERS — volume rotation with patient DSL exits on a tight liquid universe
+  (BTC/ETH/SOL/HYPE + xyz:BRENTOIL/GOLD/SP500). Receives the SAME funding-fade volume-
+  rotation signals as the volume wallet but exits them patiently: most positions still
+  exit early (Phase 1 max_loss 30% or weak_peak_cut), but the ~5% that land on a real
+  directional move ratchet through T0/T1/T2/T3/T4 to +20-50% margin ROE instead of being
+  force-cut at the volume wallet's 10-min hard_timeout. 2 slots, 5x, spread-gated maker
+  entries, 80% XYZ weighting, auto-downsize. Faithful port of the v2 Turbine v3.2.2.
+
+strategy:
+  wallet: "${TURBINE_RUNNERS_WALLET}"
+  slots: 2                                 # v2 slots.runners
+  margin_pct: 50                           # PERCENT of withdrawable per slot; scan emits per-signal
+                                           # marginPct. v2 sized a FIXED $1300/slot on a $2600 budget
+                                           # (50%); marginPct approximates that fixed-USD intent.
+  default_leverage: 5                      # v2 leverage.runners
+  trading_risk: moderate                   # v2 trading_risk "balanced" -> moderate (canonical)
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: turbine_runners_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 60                    # v2 producer_daemon interval_seconds=60
+    timeout_seconds: 45                     # v2 tick_timeout=45
+    default_signal_validity_seconds: 120    # 2x tick; rotation re-scores every tick
+    state_history_max_count: 100            # rotation index + prev-held + post-close cooldown
+    inputs:
+      volumeXyz: ["xyz:BRENTOIL", "xyz:GOLD", "xyz:SP500"]  # v2 VOLUME_XYZ (xyz:SPX -> live xyz:SP500)
+      volumeMain: ["BTC", "ETH", "SOL", "HYPE"]             # v2 VOLUME_MAIN
+      slots: 2                              # v2 slots.runners (auto-downsize ceiling)
+      marginPct: 50                         # PERCENT in (0,100] per slot ($1300 of v2 $2600 budget)
+      marginUsdEquiv: 1300                  # v2 margin.runners fixed $/slot — drives auto-downsize math
+      leverage: 5                           # v2 leverage.runners
+      xyzWeight: 0.80                       # v2 xyzWeight
+      spreadMainBps: 3                      # v2 spread.mainBps
+      spreadXyzBps: 10                      # v2 spread.xyzBps
+      postCloseCooldownSeconds: 90          # v2 pick_rotation_asset post-close cooldown
+      cycleMin: 10                          # v2 cycle.volumeDefaultMin (informational on payload)
+    signal_data_schema:
+      thesis: { type: string }             # funding_fade_long | funding_fade_short | alternate_neutral
+      leverage: { type: number }
+      marginPct: { type: number }
+      fundingRegime: { type: string, required: false }
+      fundingAnnualizedPct: { type: number, required: false }
+      spreadBps: { type: number, required: false }
+      slotIndex: { type: number, required: false }
+      isXyz: { type: boolean, required: false }
+      cycleMin: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: turbine_runners_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # v2 LLM gate was a pure pass-through
+    scanners: [turbine_runners_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false    # v2 runners entry: maker-first
+        execution_timeout_seconds: 180      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: turbine_runners_signals
+
+# ── EXIT (DSL — preserved VERBATIM from v2 runtime-runners.yaml) ──
+# RUNNERS wallet: same volume rotation, but a patient DSL gives winners breathing room.
+#   hard_timeout 240min (4h absolute cap; rarely hit)
+#   weak_peak_cut 90min @ 3% min  — if peak ROE never above 3% in 90min, thesis is dead
+#   dead_weight_cut 120min        — flat for 2h = thesis not unfolding
+#   phase1 max_loss 30%           — 6% adverse price move at 5x
+#   phase2 ratchet T0 5%/0, T1 10%/35, T2 20%/55, T3 35%/75, T4 50%/85
+# FIDELITY NOTE: first Phase-2 lock trigger is +5% ROE (reachable on realistic winners),
+# NOT the unreachable >+40% pattern — no flag needed.
+exit:
+  engine: dsl
+  interval_seconds: 30                      # v2 exit.interval_seconds
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true         # v2 runners exit: taker fallback (lock-ins MUST happen)
+    execution_timeout_seconds: 60           # v2 exit execution_timeout_seconds
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 240              # v2: 4h absolute cap
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 90               # v2
+      min_value: 3.0                        # v2
+    dead_weight_cut:
+      enabled: true
+      interval_in_minutes: 120              # v2
+    phase1:
+      enabled: true
+      max_loss_pct: 30.0                     # v2
+      retrace_threshold: 8                   # v2
+      consecutive_breaches_required: 1       # v2
+    phase2:
+      enabled: true
+      tiers:                                 # v2: T0..T4 ratchet (let winners run)
+        - { trigger_pct: 5,  lock_hw_pct: 0  }
+        - { trigger_pct: 10, lock_hw_pct: 35 }
+        - { trigger_pct: 20, lock_hw_pct: 55 }
+        - { trigger_pct: 35, lock_hw_pct: 75 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
+
+# ── RISK guard rails (from v2 runtime-runners.yaml; minutes -> seconds) ──
+risk:
+  data_retention_seconds: 259200            # v2 data_retention_hours 72 -> 259200s
+  guard_rails:
+    daily_loss_limit_pct: 25                # v2
+    max_entries_per_day: 50                 # v2: far lower than volume (patient wallet)
+    bypass_max_entries_per_day_on_profit: true
+    max_consecutive_losses: 6               # v2
+    cooldown_seconds: 300                   # v2 cooldown_minutes 5 -> 300s
+    drawdown_halt_pct: 25                   # v2
+    drawdown_reset_on_day_rollover: false   # v2 (Roach lesson: do NOT reset on rollover)
+    per_asset_cooldown_seconds: 600         # v2 per_asset_cooldown_minutes 10 -> 600s
+
+notifications:
+  dsl_lifecycle: true                       # v2: runners are notify-on (fewer, bigger positions)
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/turbine/runners/scanners/scan.py
+++ b/strategies/turbine/runners/scanners/scan.py
@@ -1,0 +1,277 @@
+"""TURBINE RUNNERS — supervised scanner (Runtime 3.0 port of the v2 Turbine RUNNERS wallet).
+
+The runners wallet receives the SAME funding-fade volume-rotation alpha as the volume
+wallet (same scoring, same universe BTC/ETH/SOL/HYPE + xyz:BRENTOIL/GOLD/SP500, same
+direction selection). The ONLY difference from the volume instance is the DSL exit
+profile (patient: 240-min hard_timeout + Phase 2 ratchet, see runtime.yaml) and the
+per-slot sizing (fewer, larger slots). Turbine is a VOLUME / MARKET-MAKING engine, NOT a
+directional strategy — the runners wallet's value is the ~5% of entries that catch a
+real directional move and ratchet to a much larger realized PnL instead of being
+force-cut at 10 minutes. Per tick it:
+
+  - reads account value + open positions + resting orders (read-guarded, dual-DEX),
+  - computes held_keys (positions + non-reduce-only resting orders = slot occupiers),
+  - applies auto-downsize: effective_slots = min(config max, account_value / margin_usd),
+  - fills the free slots by rotation (pick_rotation_asset), gating each pick on the
+    spread book (parse_asset_data) and choosing direction by funding fade,
+  - emits one volume-rotation signal per free slot.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`; the
+runtime sizes the dollars, owns cooldowns/risk gates/slot accounting, and runs the
+patient DSL exit. No daemon, no push_signal, no create_position, no cancel_order.
+
+FIDELITY NOTES vs the v2 producer (turbine-producer.py / turbine_config.py v3.2.2):
+  - SINGLE WALLET PER SCANNER. The v2 producer was ONE daemon managing BOTH wallets in
+    one main() tick. Runtime 3.0 binds one runtime per wallet, so the two wallets are
+    split into two instances (volume/ + runners/), each its own scan() bound to its own
+    ctx.wallet. This instance is the RUNNERS wallet. The v2 producer used a SEPARATE
+    per-wallet rotation index so the two wallets desync naturally (cleaner volume
+    distribution across the universe); that desync is preserved because each instance
+    keeps its own ctx.state rotIdx and seeds its rng independently.
+  - STALE-ORDER SWEEP DROPPED (MUTATION). The v2 producer called
+    sweep_stale_resting_orders() -> cancel_order (a MUTATION) before computing held_keys.
+    cancel_order raises PermissionError under the read-only scan() boundary, so it is
+    dropped — the runtime's reconciliation + execution_timeout_seconds owns order
+    lifecycle. FLAGGED: held_keys may transiently over-count an orphaned resting order
+    until the runtime cancels it (conservatively under-emits; never over-emits).
+  - FIXED-USD MARGIN -> marginPct. The v2 producer sized a FIXED USD margin per slot
+    ($1300 runners) regardless of account value. Runtime 3.0 sizes marginPct/100 *
+    withdrawable, so this port emits `marginPct` (PERCENT, default 50% = $1300/$2600 v2
+    budget). The auto-downsize SLOT logic is preserved verbatim using `marginUsdEquiv`
+    (the dollar margin the percent represents) for the affordable count. marginUsd is
+    NOT emitted (spec 4.4: marginPct percent, top-level).
+  - PER-WALLET STATE FILES -> ctx.state (rotation-index / prev-held / last-closed).
+    Runners had no cycle-stats file (that was volume-only); the runners cycleMin is just
+    the static default echoed onto the payload for telemetry parity.
+  - EMIT-ALL. Preserved — one signal per free slot; the runtime owns the slot ceiling.
+"""
+
+import random
+import sys
+import time
+
+import scoring
+
+
+# v2 defaults (turbine-config.json / turbine-producer.py v3.2.2). Same universe as the
+# volume wallet; xyz:SP500 is the live HL symbol (v2 hardcoded the stale "xyz:SPX" which
+# does NOT exist on HL — corrected here, see report).
+_VOLUME_XYZ_DEFAULT = ["xyz:BRENTOIL", "xyz:GOLD", "xyz:SP500"]
+_VOLUME_MAIN_DEFAULT = ["BTC", "ETH", "SOL", "HYPE"]
+_POST_CLOSE_COOLDOWN_SEC = 90        # v2 pick_rotation_asset post-close cooldown
+_DEFAULT_CYCLE_MIN = 10              # v2 cycle.volumeDefaultMin (informational on payload)
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account_and_held(ctx):
+    """(account_value, held_keys:set, n_positions, n_resting) — READ-GUARDED.
+
+    Dual-DEX equity collapse via max() across main/xyz (two views of ONE cross-margined
+    wallet; summing double-counts the shared free balance -> 2x sizing). held_keys =
+    open positions + non-reduce-only, non-trigger resting orders (every non-reduce-only
+    resting order is a slot occupier, v2.0.4 ghost-trade fix)."""
+    account_value = 0.0
+    held_keys = set()
+    n_positions = 0
+    n_resting = 0
+
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[turbine.runners.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, set(), 0, 0
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, set(), 0, 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            coin = pos.get("coin", "")
+            if coin:
+                held_keys.add(scoring.normalize_coin_key(coin))
+                n_positions += 1
+
+    try:
+        oo = ctx.senpi_mcp.call_tool("strategy_get_open_orders",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — degrade: count only positions as held
+        print(f"[turbine.runners.scan] open-orders read failed (count positions only): {exc!r}",
+              file=sys.stderr)
+        oo = None
+    orders = []
+    if oo:
+        od = oo.get("data", oo) if isinstance(oo, dict) else oo
+        if isinstance(od, dict):
+            od = od.get("orders", od.get("openOrders", []))
+        if isinstance(od, list):
+            orders = od
+    for o in orders:
+        if not isinstance(o, dict):
+            continue
+        if o.get("reduceOnly") or o.get("isTrigger"):
+            continue
+        coin = o.get("coin") or o.get("asset", "")
+        if not coin:
+            continue
+        held_keys.add(scoring.normalize_coin_key(coin))
+        n_resting += 1
+
+    return account_value, held_keys, n_positions, n_resting
+
+
+def _effective_slots(account_value, max_slots, margin_usd_equiv):
+    """Auto-downsize: min(config max, account_value / margin_per_slot floored).
+    Verbatim from v2 effective_slots — graceful slot reduction as the wallet bleeds."""
+    if account_value <= 0 or margin_usd_equiv <= 0:
+        return 0
+    affordable = int(account_value / margin_usd_equiv)
+    return max(0, min(max_slots, affordable))
+
+
+# ── ctx.state: rotation index + prev-held (close detection) + post-close cooldown ──
+
+def _load_state(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return 0, set(), {}
+    last = ctx.state.last() or {}
+    rot_idx = int(last.get("rotIdx", 0)) if isinstance(last.get("rotIdx"), (int, float)) else 0
+    prev_held = set(last.get("prevHeld", [])) if isinstance(last.get("prevHeld"), list) else set()
+    last_closed = dict(last.get("lastClosed", {})) if isinstance(last.get("lastClosed"), dict) else {}
+    return rot_idx, prev_held, last_closed
+
+
+def _prune_last_closed(last_closed, now, cooldown_seconds):
+    cutoff = now - (cooldown_seconds * 4)
+    return {k: v for k, v in last_closed.items()
+            if isinstance(v, dict) and scoring._f(v.get("ts", 0)) >= cutoff}
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    xyz_pool = list(inputs.get("volumeXyz", _VOLUME_XYZ_DEFAULT))
+    main_pool = list(inputs.get("volumeMain", _VOLUME_MAIN_DEFAULT))
+    max_slots = int(inputs.get("slots", 2))
+    margin_pct = float(inputs.get("marginPct", 50.0))      # PERCENT in (0,100]
+    margin_usd_equiv = float(inputs.get("marginUsdEquiv", 1300.0))  # v2 fixed $/slot (downsize math)
+    leverage = float(inputs.get("leverage", 5))
+    xyz_weight = float(inputs.get("xyzWeight", 0.80))
+    spread_main_bps = float(inputs.get("spreadMainBps", 3))
+    spread_xyz_bps = float(inputs.get("spreadXyzBps", 10))
+    cooldown = float(inputs.get("postCloseCooldownSeconds", _POST_CLOSE_COOLDOWN_SEC))
+    cycle_min = float(inputs.get("cycleMin", _DEFAULT_CYCLE_MIN))
+    seed = inputs.get("rotationSeed")  # optional; deterministic rotation for tests
+
+    # Defensive fraction->percent guard (spec 4.4 / dire/koala): a pasted FRACTION
+    # (e.g. 0.50) means 50%, so x100. A legitimate percent is always > 1.0.
+    if 0 < margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    account_value, held_keys, n_positions, n_resting = _get_account_and_held(ctx)
+    if account_value <= 0:
+        print("[turbine.runners.scan] WAITING — cannot read account value; skip tick",
+              file=sys.stderr)
+        return []
+
+    rot_idx, prev_held, last_closed = _load_state(ctx)
+
+    closed_this_tick = sorted(prev_held - held_keys)
+    for k in closed_this_tick:
+        last_closed[k] = {"ts": now}
+    last_closed = _prune_last_closed(last_closed, now, cooldown)
+
+    eff_slots = _effective_slots(account_value, max_slots, margin_usd_equiv)
+    free_slots = max(0, eff_slots - len(held_keys))
+
+    rng = random.Random(seed) if seed is not None else random.Random()
+
+    emitted = []
+    out = []
+    working_held = set(held_keys)
+    for _slot in range(free_slots):
+        asset, rot_idx = scoring.pick_rotation_asset(
+            rot_idx, xyz_weight, working_held, last_closed, now,
+            xyz_pool, main_pool, rng, cooldown_seconds=cooldown,
+        )
+        if asset is None:
+            break
+        try:
+            resp = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+                "asset": asset,
+                "candle_intervals": [],
+                "include_funding": True,
+                "include_order_book": True,
+                "dex": _dex_for(asset),
+            })
+        except Exception as exc:  # noqa: BLE001 — skip this asset, keep filling other slots
+            print(f"[turbine.runners.scan] market_get_asset_data({asset}) read failed: {exc!r}",
+                  file=sys.stderr)
+            continue
+        ad = scoring.parse_asset_data(resp)
+        if ad is None:
+            continue
+        max_spread = spread_xyz_bps if scoring.is_xyz(asset) else spread_main_bps
+        if ad["spread_bps"] > max_spread:
+            continue
+        direction, thesis = scoring.choose_direction(ad["funding_regime"], rng)
+
+        slot_index = len(out)
+        out.append({
+            "asset": asset,
+            "direction": direction,
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes dollars
+            "leverage": leverage,
+            "data": {
+                "thesis": thesis,
+                "leverage": leverage,
+                "marginPct": margin_pct,
+                "fundingRegime": ad["funding_regime"],
+                "fundingAnnualizedPct": ad["funding_annualized_pct"],
+                "spreadBps": ad["spread_bps"],
+                "slotIndex": slot_index,
+                "isXyz": scoring.is_xyz(asset),
+                "cycleMin": cycle_min,
+            },
+        })
+        emitted.append({"asset": asset, "direction": direction, "thesis": thesis})
+        working_held.add(scoring.normalize_coin_key(asset))
+
+    if out:
+        print(f"[turbine.runners.scan] EMIT {len(out)} vol-rotation | "
+              f"acct={account_value:.0f} slots eff={eff_slots} held={len(held_keys)} "
+              f"free={free_slots} | {[e['asset'] + ':' + e['direction'] for e in emitted]}",
+              file=sys.stderr)
+    else:
+        print(f"[turbine.runners.scan] WAITING — no free slot fills | acct={account_value:.0f} "
+              f"slots eff={eff_slots} held={len(held_keys)} free={free_slots}",
+              file=sys.stderr)
+
+    result = {
+        "ts": now, "acct": round(account_value, 2),
+        "slotsEff": eff_slots, "held": len(held_keys), "free": free_slots,
+        "positions": n_positions, "resting": n_resting,
+        "emitted": emitted, "closed": closed_this_tick,
+    }
+    if ctx.state is not None:
+        try:
+            ctx.state.append({
+                "rotIdx": rot_idx,
+                "prevHeld": sorted(held_keys),
+                "lastClosed": last_closed,
+                "result": result,
+            })
+        except Exception as exc:  # noqa: BLE001
+            print(f"[turbine.runners.scan] WARNING: state append failed; rotation/cooldown "
+                  f"state may reset next tick: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/turbine/runners/scanners/scoring.py
+++ b/strategies/turbine/runners/scanners/scoring.py
@@ -1,0 +1,151 @@
+"""TURBINE RUNNERS — pure volume-rotation math (no I/O, no MCP, no clock-as-side-effect).
+
+IDENTICAL to the volume instance's scoring.py — the runners wallet receives the SAME
+funding-fade volume-rotation alpha as the volume wallet (same scoring, same universe,
+same direction selection). The ONLY difference between the two instances is the DSL exit
+profile (runtime.yaml) and the per-slot sizing inputs; the alpha is shared. Kept as a
+sibling module per the package layout (no shared import across instance dirs).
+
+A faithful Runtime 3.0 port of the v2 Turbine producer's volume-rotation logic
+(turbine-producer.py v3.2.2). Turbine is a VOLUME / MARKET-MAKING engine, NOT a
+directional scorer: there is no "score" — every gated candidate is emitted to churn
+notional volume for builder-fee recycling. The "thesis" here is just:
+
+  1. funding-fade DIRECTION selection (choose_direction)        — keeps the book neutral
+  2. spread parsing from an order book (parse_asset_data)       — the only entry gate
+  3. deterministic rotation-asset selection (pick_rotation_asset)
+
+Reproduced VERBATIM from the v2 producer so a fidelity harness can diff this against
+turbine-producer.py on the same market snapshot. Behaviour-preserving quirks are kept
+and flagged `# v2-quirk`. This module is pure (no MCP, no file I/O); the caller
+(scan.py) fetches order-book/funding via ctx.senpi_mcp and passes plain dicts in.
+
+The randomness in the v2 producer (random.random() XYZ/main pool pick, random.choice
+LONG/SHORT on a neutral funding regime) is preserved — it is core to the volume engine
+spreading evenly across the universe. The caller seeds `rng` so the pool/coin-flip
+choices stay test-reproducible while remaining stochastic in production.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def is_xyz(asset):
+    return bool(asset) and asset.startswith("xyz:")
+
+
+def normalize_coin_key(coin):
+    """Canonicalize a coin string for held-slot dedup sets.
+
+    v3.2.2: preserve the xyz: prefix so main:HYPE and xyz:HYPE are DISTINCT slot
+    occupiers (the v3.2.1 bug stripped the prefix, collapsing them and undercounting
+    slots -> over-emit). Lowercase the prefix, uppercase the symbol. Ported verbatim
+    from cfg.normalize_coin_key."""
+    if not coin:
+        return ""
+    s = coin.strip()
+    if ":" in s:
+        prefix, _, symbol = s.partition(":")
+        return f"{prefix.lower()}:{symbol.upper()}"
+    return s.upper()
+
+
+def choose_direction(regime, rng):
+    """Funding fade. Crowded longs -> SHORT, crowded shorts -> LONG, flat -> coin-flip.
+
+    Verbatim from v2 choose_direction. `rng` is the caller's random.Random so the
+    neutral-regime coin-flip is reproducible in tests but stochastic in production
+    (the v2 producer used the module-global `random`)."""
+    r = (regime or "").upper()
+    if r in ("LONG_CROWDED", "LONG_HEAVY"):
+        return "SHORT", "funding_fade_short"
+    if r in ("SHORT_CROWDED", "SHORT_HEAVY"):
+        return "LONG", "funding_fade_long"
+    return rng.choice(["LONG", "SHORT"]), "alternate_neutral"
+
+
+def parse_asset_data(resp):
+    """Extract {bid, ask, mid, spread_bps, funding_regime, funding_annualized_pct}
+    from a market_get_asset_data response, or None if the book is unusable.
+
+    Ported VERBATIM from the v2 producer's query_asset_data parsing (the MCP call
+    itself lives in scan.py to keep this module pure). Returns None on any missing /
+    malformed level so the caller skips the asset (degrade, never crash)."""
+    if not resp or not isinstance(resp, dict):
+        return None
+    ad = resp.get("data", resp)
+    if not isinstance(ad, dict):
+        return None
+    ob = ad.get("order_book") or ad.get("orderBook") or {}
+    levels = ob.get("levels", []) if isinstance(ob, dict) else []
+    if not isinstance(levels, list) or len(levels) < 2:
+        return None
+    bids, asks = levels[0], levels[1]
+    if not bids or not asks:
+        return None
+
+    def _lvl_px(lvl):
+        if isinstance(lvl, dict):
+            return _f(lvl.get("px", lvl.get("price", 0)))
+        if isinstance(lvl, list) and lvl:
+            return _f(lvl[0])
+        return 0.0
+
+    bid = _lvl_px(bids[0])
+    ask = _lvl_px(asks[0])
+    if bid <= 0 or ask <= 0:
+        return None
+    mid = (bid + ask) / 2.0
+    spread_bps = ((ask - bid) / mid) * 10000 if mid > 0 else 999
+
+    funding_regime = (ad.get("funding_regime") or ad.get("fundingRegime") or "UNKNOWN").upper()
+    funding_annualized_pct = _f(
+        ad.get("funding_annualized_pct") or ad.get("fundingAnnualizedPct") or 0
+    )
+    return {
+        "bid": bid,
+        "ask": ask,
+        "mid": mid,
+        "spread_bps": round(spread_bps, 3),
+        "funding_regime": funding_regime,
+        "funding_annualized_pct": funding_annualized_pct,
+    }
+
+
+def pick_rotation_asset(rot_idx, xyz_weight, held_set, last_closed, now,
+                        xyz_pool, main_pool, rng, cooldown_seconds=90):
+    """Pick the next rotation asset. Probabilistic XYZ/main pool weighting +
+    deterministic rotation index inside each pool. Skips held names + post-close
+    cooldown. Returns (asset|None, new_rot_idx).
+
+    Ported VERBATIM from the v2 producer's pick_rotation_asset. `last_closed` is the
+    dedup map {coin_key: epoch_seconds_closed}; `now` is the caller's wall clock (the
+    v2 producer read time.time() inline — passed in here to keep this module pure)."""
+    use_xyz = rng.random() < xyz_weight
+    pool = xyz_pool if use_xyz else main_pool
+
+    def _scan_pool(pool, rot_idx):
+        n = len(pool)
+        for _ in range(n):
+            candidate = pool[rot_idx % n]
+            rot_idx = (rot_idx + 1) % n
+            coin_key = normalize_coin_key(candidate)
+            if coin_key in held_set:
+                continue
+            last = last_closed.get(coin_key, {})
+            if last and (now - _f(last.get("ts", 0))) < cooldown_seconds:
+                continue
+            return candidate, rot_idx
+        return None, rot_idx
+
+    asset, rot_idx = _scan_pool(pool, rot_idx)
+    if asset is not None:
+        return asset, rot_idx
+    # Fall back to the other pool (v2 behaviour: if the chosen pool is fully
+    # held/cooled, try the other before giving up).
+    other = main_pool if use_xyz else xyz_pool
+    return _scan_pool(other, rot_idx)

--- a/strategies/turbine/strategy.yaml
+++ b/strategies/turbine/strategy.yaml
@@ -1,0 +1,47 @@
+# Turbine — two-wallet VOLUME / market-making engine. A multi-instance PACKAGE: this
+# manifest + two self-contained runtime.yaml files (volume + runners) + scanners/. A
+# faithful Runtime 3.0 port of the v2 Turbine (turbine-producer.py v3.2.2): the same
+# funding-fade volume-rotation alpha is emitted to BOTH wallets; the wallet boundary
+# only selects the DSL exit profile. NOT a directional strategy — it churns notional
+# volume for builder-fee recycling. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: turbine
+version: "3.2.2"
+
+catalog:
+  name: "Turbine — Volume / Market-Making Engine"
+  emoji: "🌪️"
+  tagline: "A two-wallet volume engine: it rotates funding-fade entries across a tight liquid universe to generate notional volume at minimum fee cost (builder-fee recycling), not to take a directional view — one wallet churns fast, the other lets the rare winner run."
+  belief_plain: "This isn't a bet on prices going up or down. It opens and closes a steady stream of small, balanced positions across a handful of the deepest, tightest-spread markets (BTC/ETH/SOL/HYPE plus oil, gold, and the S&P 500 on the XYZ DEX) to rack up trading volume as cheaply as possible. It leans against crowded funding (shorts the crowded-long side, longs the crowded-short side) so the average position is roughly neutral. One wallet force-cuts every position on a 10-minute clock for pure volume; the second wallet runs the exact same entries but gives the occasional real move room to ratchet up before exiting."
+  thesis: "Volume itself is the product: high notional throughput on Hyperliquid recycles builder fees, and on a tight, deep universe the maker-rebate math can net out roughly breakeven-to-slightly-positive before the volume reward. Concentrating on the few markets with the tightest spreads (XYZ books weighted 80%) keeps the per-$1M cost low. Funding-fade direction selection keeps the book structurally neutral rather than exposed. Splitting into a fast-rotation wallet and a patient-DSL wallet captures the asymmetry that pure rotation gives up — most positions exit flat either way, but the ~5% that catch a real directional move ride to a much larger realized PnL on the runners wallet instead of being force-cut at 10 minutes."
+  group: market-neutral
+  archetype: structural_neutral
+  sub_style: market_making
+  asset_classes: [btc_eth, major_alts, commodities, indices]
+  asset_scope: basket
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  time_horizon: scalp
+  leverage_max: 5
+  max_slots: 9                 # volume 7 + runners 2
+  min_budget: 200              # two wallets, $100 floor each
+  assets: ["BTC", "ETH", "SOL", "HYPE", "xyz:BRENTOIL", "xyz:GOLD", "xyz:SP500"]
+  tags: [volume, market-making, builder-fee, funding-fade, two-wallet, rotation, structural-neutral, maker]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: volume
+    runtime: volume/runtime.yaml      # → runtime turbine-volume, group turbine
+    wallet_env: TURBINE_VOLUME_WALLET
+    funding_share: 0.675              # v2 budget split: $5400 vol / ($5400 + $2600) ≈ 0.675
+  - name: runners
+    runtime: runners/runtime.yaml     # → runtime turbine-runners, group turbine
+    wallet_env: TURBINE_RUNNERS_WALLET
+    funding_share: 0.325              # $2600 runners / $8000 total ≈ 0.325

--- a/strategies/turbine/volume/runtime.yaml
+++ b/strategies/turbine/volume/runtime.yaml
@@ -1,0 +1,133 @@
+# ── TURBINE · VOLUME wallet — volume / market-making engine (fast rotation) ──
+# Runtime 3.0 port of the v2 Turbine VOLUME runtime (turbine-volume-tracker, producer
+# v3.2.2). Turbine is a VOLUME engine, NOT a directional strategy: it rotates funding-
+# fade entries across a tight liquid universe (BTC/ETH/SOL/HYPE + xyz:BRENTOIL/GOLD/
+# SP500) to churn notional volume for builder-fee recycling at minimum fee cost. This
+# wallet force-cuts EVERY position on a 10-min hard_timeout (pure rotation cadence,
+# no Phase 2). Faithful port of the v2 producer thesis — see scanners/scan.py.
+name: turbine-volume
+group: turbine
+version: 3.2.2
+description: >
+  TURBINE VOLUME — volume / market-making engine on a tight liquid universe
+  (BTC/ETH/SOL/HYPE + xyz:BRENTOIL/GOLD/SP500). Rotates funding-fade entries across
+  free slots to generate notional Hyperliquid volume for builder-fee recycling; NOT a
+  directional bet (funding fade keeps the book structurally neutral). 7 slots, 5x,
+  spread-gated maker entries (3 bps main / 10 bps XYZ), 80% XYZ pool weighting,
+  auto-downsize on tight margin. DSL force-cuts every position on a 10-min hard_timeout
+  (pure rotation; no Phase 2). Faithful port of the v2 Turbine v3.2.2 volume thesis.
+
+strategy:
+  wallet: "${TURBINE_VOLUME_WALLET}"
+  slots: 7                                 # v2 slots.volume
+  margin_pct: 13                           # PERCENT of withdrawable per slot; scan emits per-signal
+                                           # marginPct. v2 sized a FIXED $700/slot on a $5400 budget
+                                           # (~13%); marginPct approximates that fixed-USD intent.
+  default_leverage: 5                      # v2 leverage.volume
+  trading_risk: aggressive                 # v2 trading_risk
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: turbine_volume_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 60                    # v2 producer_daemon interval_seconds=60
+    timeout_seconds: 45                     # v2 tick_timeout=45 (account + per-slot order-book reads)
+    default_signal_validity_seconds: 120    # 2x tick; rotation re-scores every tick
+    state_history_max_count: 100            # rotation index + prev-held + post-close cooldown
+    inputs:
+      volumeXyz: ["xyz:BRENTOIL", "xyz:GOLD", "xyz:SP500"]  # v2 VOLUME_XYZ (xyz:SPX -> live xyz:SP500)
+      volumeMain: ["BTC", "ETH", "SOL", "HYPE"]             # v2 VOLUME_MAIN
+      slots: 7                              # v2 slots.volume (auto-downsize ceiling)
+      marginPct: 13                         # PERCENT in (0,100] per slot (~$700 of v2 $5400 budget)
+      marginUsdEquiv: 700                   # v2 margin.volume fixed $/slot — drives auto-downsize math
+      leverage: 5                           # v2 leverage.volume
+      xyzWeight: 0.80                       # v2 xyzWeight (80% XYZ pool weighting)
+      spreadMainBps: 3                      # v2 spread.mainBps
+      spreadXyzBps: 10                      # v2 spread.xyzBps
+      postCloseCooldownSeconds: 90          # v2 pick_rotation_asset post-close cooldown
+      cycleMin: 10                          # v2 cycle.volumeDefaultMin (informational on payload)
+    signal_data_schema:
+      thesis: { type: string }             # funding_fade_long | funding_fade_short | alternate_neutral
+      leverage: { type: number }
+      marginPct: { type: number }
+      fundingRegime: { type: string, required: false }
+      fundingAnnualizedPct: { type: number, required: false }
+      spreadBps: { type: number, required: false }
+      slotIndex: { type: number, required: false }
+      isXyz: { type: boolean, required: false }
+      cycleMin: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: turbine_volume_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # v2 LLM gate was a pure pass-through (producer applied every filter)
+    scanners: [turbine_volume_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT       # v2 volume entry: maker-first (cost discipline)
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false    # v2 volume: maker-only entries; HL charges only on fills
+        execution_timeout_seconds: 180      # v2 entry execution_timeout_seconds
+    context:
+      - type: signal
+        scanner: turbine_volume_signals
+
+# ── EXIT (DSL — preserved VERBATIM from v2 runtime-volume.yaml) ──
+# VOLUME wallet: pure rotation. hard_timeout 10min force-closes every position on the
+# clock; NO Phase 2 (winners are NOT let run on this wallet — that is the runners
+# wallet's job). Phase 1 max_loss 50% = catastrophic-only floor (the 10-min clock is
+# the real exit). order_type FEE_OPTIMIZED_LIMIT maker-first; exit timeout 60s.
+exit:
+  engine: dsl
+  interval_seconds: 30                      # v2 exit.interval_seconds
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: false        # v2 volume exit: maker-first
+    execution_timeout_seconds: 60           # v2 exit execution_timeout_seconds
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 10               # v2: force-close every position on the 10-min clock
+    weak_peak_cut:
+      enabled: false                        # v2: disabled on volume wallet
+      interval_in_minutes: 60
+      min_value: 1.0
+    dead_weight_cut:
+      enabled: false                        # v2: disabled on volume wallet
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 50.0                     # v2: catastrophic-only (clock is the real exit)
+      retrace_threshold: 30
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: false                         # v2: NO Phase 2 on volume (pure rotation)
+      tiers: []                              # required key even when phase2 disabled
+
+# ── RISK guard rails (from v2 runtime-volume.yaml; minutes -> seconds) ──
+risk:
+  data_retention_seconds: 259200            # v2 data_retention_hours 72 -> 259200s
+  guard_rails:
+    daily_loss_limit_pct: 50                # v2: wide — volume engine bleeds at cost-of-volume rate
+    max_entries_per_day: 1500               # v2: high-turnover volume engine
+    bypass_max_entries_per_day_on_profit: true
+    max_consecutive_losses: 30              # v2: tolerant — flat positions are expected
+    cooldown_seconds: 60                    # v2 cooldown_minutes 1 -> 60s
+    drawdown_halt_pct: 50                   # v2 drawdown_halt_pct
+    drawdown_reset_on_day_rollover: true    # v2
+    per_asset_cooldown_seconds: 0           # v2 per_asset_cooldown_minutes 0 (rapid re-rotation)
+
+notifications:
+  dsl_lifecycle: false                      # v2: quiet (high-frequency volume engine)
+  dsl_notify_sl_updates: false
+  action_lifecycle: false

--- a/strategies/turbine/volume/scanners/scan.py
+++ b/strategies/turbine/volume/scanners/scan.py
@@ -1,0 +1,299 @@
+"""TURBINE VOLUME — supervised scanner (Runtime 3.0 port of the v2 Turbine VOLUME wallet).
+
+Turbine is a VOLUME / MARKET-MAKING engine, NOT a directional strategy. This scanner
+churns notional volume for builder-fee recycling by rotating funding-fade entries across
+a tight, deep liquid universe (BTC/ETH/SOL/HYPE + xyz:BRENTOIL/GOLD/SP500). There is no
+"score" — every gated candidate is emitted; the VOLUME wallet's DSL force-cuts every
+position on a 10-minute clock (pure rotation cadence). Per tick it:
+
+  - reads account value + open positions + resting orders (read-guarded, dual-DEX),
+  - computes held_keys (positions + non-reduce-only resting orders = slot occupiers),
+  - applies auto-downsize: effective_slots = min(config max, account_value / margin_usd),
+  - fills the free slots by rotation (pick_rotation_asset), gating each pick on the
+    spread book (parse_asset_data) and choosing direction by funding fade,
+  - emits one volume-rotation signal per free slot.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`; the
+runtime sizes the dollars, owns cooldowns/risk gates/slot accounting, and runs the DSL
+exit. No daemon, no push_signal, no create_position, no cancel_order.
+
+FIDELITY NOTES vs the v2 producer (turbine-producer.py / turbine_config.py v3.2.2):
+  - SINGLE WALLET PER SCANNER. The v2 producer was ONE daemon managing BOTH wallets
+    (volume + runners) in one main() tick. Runtime 3.0 binds one runtime per wallet,
+    so the two wallets are split into two instances (volume/ + runners/), each its own
+    scan() bound to its own ctx.wallet. This instance is the VOLUME wallet. The
+    runners wallet is the sibling runners/ instance — same rotation alpha, patient DSL.
+  - STALE-ORDER SWEEP DROPPED (MUTATION). The v2 producer called
+    sweep_stale_resting_orders() -> cancel_order (a MUTATION) before computing held_keys
+    to clear orphaned ALOs left by previous runtime swaps. cancel_order raises
+    PermissionError under the read-only scan() boundary, so it is dropped — the runtime's
+    own reconciliation + execution_timeout_seconds owns order lifecycle now. FLAGGED:
+    held_keys may transiently over-count an orphaned resting order until the runtime
+    cancels it, conservatively under-emitting (safe direction: never over-emits).
+  - FIXED-USD MARGIN -> marginPct. The v2 producer sized a FIXED USD margin per slot
+    ($700 volume) regardless of account value (auto-downsize only reduced the slot
+    COUNT, never the per-slot dollars). Runtime 3.0 sizes marginPct/100 * withdrawable,
+    so this port emits `marginPct` (PERCENT, default ~13% = $700/$5400 v2 budget). The
+    fixed-USD per-slot intent is approximated by a percent of equity; operators tune
+    `marginPct` to hit the same dollar notional. marginUsd is NOT emitted (spec 4.4:
+    marginPct percent, top-level). The auto-downsize SLOT logic is preserved verbatim
+    using `marginUsdEquiv` (the dollar margin the percent represents) for the affordable
+    count, so slot accounting matches v2.
+  - PER-WALLET STATE FILES -> ctx.state. The v2 producer kept rotation-index.json,
+    prev-held.json, last-closed.json, cycle-stats.json in SKILL_DIR/state/<hash>/. All
+    move into ctx.state: {rotIdx, prevHeld[], lastClosed{coin:ts}, result{}}. cycle-stats
+    fill-rate fallback -> see cycle-length note below.
+  - CYCLE-LENGTH FALLBACK DROPPED (informational only). The v2 producer adjusted the
+    advertised `cycleMin` (10 -> 12 min) from a rolling maker fill-rate window. That value
+    was purely informational telemetry on the signal payload (the runtime's hard_timeout,
+    not the producer, controls the actual rotation cadence). The runtime can't observe per-
+    entry maker fill rate from scan(), so cycleMin is emitted as the static default. The
+    real 10-min rotation cadence lives in runtime.yaml exit.dsl_preset.hard_timeout. FLAGGED.
+  - EMIT-ALL. The v2 producer filled all free slots opportunistically; preserved — scan()
+    emits one signal per free slot (the runtime owns the slot ceiling either way).
+"""
+
+import random
+import sys
+import time
+
+import scoring
+
+
+# v2 defaults (turbine-config.json / turbine-producer.py v3.2.2). The volume universe
+# is the tight, deep, tight-spread set; xyz:SP500 is the live HL symbol (v2 hardcoded
+# the stale "xyz:SPX" which does NOT exist on HL — corrected here, see report).
+_VOLUME_XYZ_DEFAULT = ["xyz:BRENTOIL", "xyz:GOLD", "xyz:SP500"]
+_VOLUME_MAIN_DEFAULT = ["BTC", "ETH", "SOL", "HYPE"]
+_POST_CLOSE_COOLDOWN_SEC = 90        # v2 pick_rotation_asset post-close cooldown
+_DEFAULT_CYCLE_MIN = 10              # v2 cycle.volumeDefaultMin (informational on payload)
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''."""
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account_and_held(ctx):
+    """(account_value, held_keys:set, n_positions, n_resting) — READ-GUARDED.
+
+    Dual-DEX equity collapse via max() across main/xyz (two views of ONE cross-margined
+    wallet; summing double-counts the shared free balance -> 2x sizing). held_keys =
+    open positions + non-reduce-only, non-trigger resting orders (every non-reduce-only
+    resting order is a slot occupier, v2.0.4 ghost-trade fix). Ported from
+    cfg.get_open_positions + cfg.get_resting_orders + cfg.get_account_value, merged into
+    one clearinghouse read + one open-orders read."""
+    account_value = 0.0
+    held_keys = set()
+    n_positions = 0
+    n_resting = 0
+
+    # ── clearinghouse: account value + open positions ──
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[turbine.volume.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, set(), 0, 0
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, set(), 0, 0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            coin = pos.get("coin", "")
+            if coin:
+                held_keys.add(scoring.normalize_coin_key(coin))
+                n_positions += 1
+
+    # ── open orders: resting non-reduce-only, non-trigger = slot occupiers ──
+    try:
+        oo = ctx.senpi_mcp.call_tool("strategy_get_open_orders",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — degrade: count only positions as held
+        print(f"[turbine.volume.scan] open-orders read failed (count positions only): {exc!r}",
+              file=sys.stderr)
+        oo = None
+    orders = []
+    if oo:
+        od = oo.get("data", oo) if isinstance(oo, dict) else oo
+        if isinstance(od, dict):
+            od = od.get("orders", od.get("openOrders", []))
+        if isinstance(od, list):
+            orders = od
+    for o in orders:
+        if not isinstance(o, dict):
+            continue
+        if o.get("reduceOnly") or o.get("isTrigger"):
+            continue
+        coin = o.get("coin") or o.get("asset", "")
+        if not coin:
+            continue
+        held_keys.add(scoring.normalize_coin_key(coin))
+        n_resting += 1
+
+    return account_value, held_keys, n_positions, n_resting
+
+
+def _effective_slots(account_value, max_slots, margin_usd_equiv):
+    """Auto-downsize: how many slots can the wallet actually open right now?
+    min(config max, account_value / margin_per_slot floored). Verbatim from v2
+    effective_slots. Handles cost-of-volume bleed gracefully (no insufficient_margin
+    rejections). `margin_usd_equiv` is the dollar margin the emitted marginPct
+    represents, so this affordable count matches the v2 fixed-USD logic."""
+    if account_value <= 0 or margin_usd_equiv <= 0:
+        return 0
+    affordable = int(account_value / margin_usd_equiv)
+    return max(0, min(max_slots, affordable))
+
+
+# ── ctx.state: rotation index + prev-held (close detection) + post-close cooldown ──
+
+def _load_state(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return 0, set(), {}
+    last = ctx.state.last() or {}
+    rot_idx = int(last.get("rotIdx", 0)) if isinstance(last.get("rotIdx"), (int, float)) else 0
+    prev_held = set(last.get("prevHeld", [])) if isinstance(last.get("prevHeld"), list) else set()
+    last_closed = dict(last.get("lastClosed", {})) if isinstance(last.get("lastClosed"), dict) else {}
+    return rot_idx, prev_held, last_closed
+
+
+def _prune_last_closed(last_closed, now, cooldown_seconds):
+    """Drop close timestamps older than 4x the cooldown (bounded growth)."""
+    cutoff = now - (cooldown_seconds * 4)
+    return {k: v for k, v in last_closed.items()
+            if isinstance(v, dict) and scoring._f(v.get("ts", 0)) >= cutoff}
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    xyz_pool = list(inputs.get("volumeXyz", _VOLUME_XYZ_DEFAULT))
+    main_pool = list(inputs.get("volumeMain", _VOLUME_MAIN_DEFAULT))
+    max_slots = int(inputs.get("slots", 7))
+    margin_pct = float(inputs.get("marginPct", 13.0))      # PERCENT in (0,100]
+    margin_usd_equiv = float(inputs.get("marginUsdEquiv", 700.0))  # v2 fixed $/slot (downsize math)
+    leverage = float(inputs.get("leverage", 5))
+    xyz_weight = float(inputs.get("xyzWeight", 0.80))
+    spread_main_bps = float(inputs.get("spreadMainBps", 3))
+    spread_xyz_bps = float(inputs.get("spreadXyzBps", 10))
+    cooldown = float(inputs.get("postCloseCooldownSeconds", _POST_CLOSE_COOLDOWN_SEC))
+    cycle_min = float(inputs.get("cycleMin", _DEFAULT_CYCLE_MIN))
+    seed = inputs.get("rotationSeed")  # optional; deterministic rotation for tests
+
+    # Defensive fraction->percent guard (spec 4.4 / dire/koala pattern): a pasted
+    # FRACTION (e.g. 0.13) means 13%, so x100. A legitimate percent is always > 1.0.
+    if 0 < margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    account_value, held_keys, n_positions, n_resting = _get_account_and_held(ctx)
+    if account_value <= 0:
+        print("[turbine.volume.scan] WAITING — cannot read account value; skip tick",
+              file=sys.stderr)
+        return []
+
+    rot_idx, prev_held, last_closed = _load_state(ctx)
+
+    # Close detection -> post-close cooldown (v2 prev-held diff). Names that were held
+    # last tick but aren't now just closed; stamp them so rotation skips them briefly.
+    closed_this_tick = sorted(prev_held - held_keys)
+    for k in closed_this_tick:
+        last_closed[k] = {"ts": now}
+    last_closed = _prune_last_closed(last_closed, now, cooldown)
+
+    # Auto-downsize -> free slots.
+    eff_slots = _effective_slots(account_value, max_slots, margin_usd_equiv)
+    free_slots = max(0, eff_slots - len(held_keys))
+
+    rng = random.Random(seed) if seed is not None else random.Random()
+
+    # ── fill free slots by rotation (the volume engine) ──
+    emitted = []
+    out = []
+    # working held set so two picks in one tick don't collide on the same coin
+    working_held = set(held_keys)
+    for _slot in range(free_slots):
+        asset, rot_idx = scoring.pick_rotation_asset(
+            rot_idx, xyz_weight, working_held, last_closed, now,
+            xyz_pool, main_pool, rng, cooldown_seconds=cooldown,
+        )
+        if asset is None:
+            break  # whole universe held / cooled — nothing to emit
+        # spread gate (the only entry gate) — read the order book for this asset
+        try:
+            resp = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+                "asset": asset,
+                "candle_intervals": [],
+                "include_funding": True,
+                "include_order_book": True,
+                "dex": _dex_for(asset),
+            })
+        except Exception as exc:  # noqa: BLE001 — skip this asset, keep filling other slots
+            print(f"[turbine.volume.scan] market_get_asset_data({asset}) read failed: {exc!r}",
+                  file=sys.stderr)
+            continue
+        ad = scoring.parse_asset_data(resp)
+        if ad is None:
+            continue
+        max_spread = spread_xyz_bps if scoring.is_xyz(asset) else spread_main_bps
+        if ad["spread_bps"] > max_spread:
+            continue  # too wide — would not net out on cost
+        direction, thesis = scoring.choose_direction(ad["funding_regime"], rng)
+
+        slot_index = len(out)
+        out.append({
+            "asset": asset,
+            "direction": direction,
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes dollars
+            "leverage": leverage,
+            "data": {
+                "thesis": thesis,
+                "leverage": leverage,
+                "marginPct": margin_pct,
+                "fundingRegime": ad["funding_regime"],
+                "fundingAnnualizedPct": ad["funding_annualized_pct"],
+                "spreadBps": ad["spread_bps"],
+                "slotIndex": slot_index,
+                "isXyz": scoring.is_xyz(asset),
+                "cycleMin": cycle_min,
+            },
+        })
+        emitted.append({"asset": asset, "direction": direction, "thesis": thesis})
+        working_held.add(scoring.normalize_coin_key(asset))
+
+    # ── observability: one-line stderr + per-tick result into ctx.state ──
+    if out:
+        print(f"[turbine.volume.scan] EMIT {len(out)} vol-rotation | "
+              f"acct={account_value:.0f} slots eff={eff_slots} held={len(held_keys)} "
+              f"free={free_slots} | {[e['asset'] + ':' + e['direction'] for e in emitted]}",
+              file=sys.stderr)
+    else:
+        print(f"[turbine.volume.scan] WAITING — no free slot fills | acct={account_value:.0f} "
+              f"slots eff={eff_slots} held={len(held_keys)} free={free_slots}",
+              file=sys.stderr)
+
+    result = {
+        "ts": now, "acct": round(account_value, 2),
+        "slotsEff": eff_slots, "held": len(held_keys), "free": free_slots,
+        "positions": n_positions, "resting": n_resting,
+        "emitted": emitted, "closed": closed_this_tick,
+    }
+    if ctx.state is not None:
+        try:
+            ctx.state.append({
+                "rotIdx": rot_idx,
+                "prevHeld": sorted(held_keys),
+                "lastClosed": last_closed,
+                "result": result,
+            })
+        except Exception as exc:  # noqa: BLE001
+            print(f"[turbine.volume.scan] WARNING: state append failed; rotation/cooldown "
+                  f"state may reset next tick: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/turbine/volume/scanners/scoring.py
+++ b/strategies/turbine/volume/scanners/scoring.py
@@ -1,0 +1,145 @@
+"""TURBINE VOLUME — pure volume-rotation math (no I/O, no MCP, no clock-as-side-effect).
+
+A faithful Runtime 3.0 port of the v2 Turbine producer's volume-rotation logic
+(turbine-producer.py v3.2.2). Turbine is a VOLUME / MARKET-MAKING engine, NOT a
+directional scorer: there is no "score" — every gated candidate is emitted to churn
+notional volume for builder-fee recycling. The "thesis" here is just:
+
+  1. funding-fade DIRECTION selection (choose_direction)        — keeps the book neutral
+  2. spread parsing from an order book (parse_asset_data)       — the only entry gate
+  3. deterministic rotation-asset selection (pick_rotation_asset)
+
+Reproduced VERBATIM from the v2 producer so a fidelity harness can diff this against
+turbine-producer.py on the same market snapshot. Behaviour-preserving quirks are kept
+and flagged `# v2-quirk`. This module is pure (no MCP, no file I/O); the caller
+(scan.py) fetches order-book/funding via ctx.senpi_mcp and passes plain dicts in.
+
+The randomness in the v2 producer (random.random() XYZ/main pool pick, random.choice
+LONG/SHORT on a neutral funding regime) is preserved — it is core to the volume engine
+spreading evenly across the universe. The caller seeds `rng` so the pool/coin-flip
+choices stay test-reproducible while remaining stochastic in production.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def is_xyz(asset):
+    return bool(asset) and asset.startswith("xyz:")
+
+
+def normalize_coin_key(coin):
+    """Canonicalize a coin string for held-slot dedup sets.
+
+    v3.2.2: preserve the xyz: prefix so main:HYPE and xyz:HYPE are DISTINCT slot
+    occupiers (the v3.2.1 bug stripped the prefix, collapsing them and undercounting
+    slots -> over-emit). Lowercase the prefix, uppercase the symbol. Ported verbatim
+    from cfg.normalize_coin_key."""
+    if not coin:
+        return ""
+    s = coin.strip()
+    if ":" in s:
+        prefix, _, symbol = s.partition(":")
+        return f"{prefix.lower()}:{symbol.upper()}"
+    return s.upper()
+
+
+def choose_direction(regime, rng):
+    """Funding fade. Crowded longs -> SHORT, crowded shorts -> LONG, flat -> coin-flip.
+
+    Verbatim from v2 choose_direction. `rng` is the caller's random.Random so the
+    neutral-regime coin-flip is reproducible in tests but stochastic in production
+    (the v2 producer used the module-global `random`)."""
+    r = (regime or "").upper()
+    if r in ("LONG_CROWDED", "LONG_HEAVY"):
+        return "SHORT", "funding_fade_short"
+    if r in ("SHORT_CROWDED", "SHORT_HEAVY"):
+        return "LONG", "funding_fade_long"
+    return rng.choice(["LONG", "SHORT"]), "alternate_neutral"
+
+
+def parse_asset_data(resp):
+    """Extract {bid, ask, mid, spread_bps, funding_regime, funding_annualized_pct}
+    from a market_get_asset_data response, or None if the book is unusable.
+
+    Ported VERBATIM from the v2 producer's query_asset_data parsing (the MCP call
+    itself lives in scan.py to keep this module pure). Returns None on any missing /
+    malformed level so the caller skips the asset (degrade, never crash)."""
+    if not resp or not isinstance(resp, dict):
+        return None
+    ad = resp.get("data", resp)
+    if not isinstance(ad, dict):
+        return None
+    ob = ad.get("order_book") or ad.get("orderBook") or {}
+    levels = ob.get("levels", []) if isinstance(ob, dict) else []
+    if not isinstance(levels, list) or len(levels) < 2:
+        return None
+    bids, asks = levels[0], levels[1]
+    if not bids or not asks:
+        return None
+
+    def _lvl_px(lvl):
+        if isinstance(lvl, dict):
+            return _f(lvl.get("px", lvl.get("price", 0)))
+        if isinstance(lvl, list) and lvl:
+            return _f(lvl[0])
+        return 0.0
+
+    bid = _lvl_px(bids[0])
+    ask = _lvl_px(asks[0])
+    if bid <= 0 or ask <= 0:
+        return None
+    mid = (bid + ask) / 2.0
+    spread_bps = ((ask - bid) / mid) * 10000 if mid > 0 else 999
+
+    funding_regime = (ad.get("funding_regime") or ad.get("fundingRegime") or "UNKNOWN").upper()
+    funding_annualized_pct = _f(
+        ad.get("funding_annualized_pct") or ad.get("fundingAnnualizedPct") or 0
+    )
+    return {
+        "bid": bid,
+        "ask": ask,
+        "mid": mid,
+        "spread_bps": round(spread_bps, 3),
+        "funding_regime": funding_regime,
+        "funding_annualized_pct": funding_annualized_pct,
+    }
+
+
+def pick_rotation_asset(rot_idx, xyz_weight, held_set, last_closed, now,
+                        xyz_pool, main_pool, rng, cooldown_seconds=90):
+    """Pick the next rotation asset. Probabilistic XYZ/main pool weighting +
+    deterministic rotation index inside each pool. Skips held names + post-close
+    cooldown. Returns (asset|None, new_rot_idx).
+
+    Ported VERBATIM from the v2 producer's pick_rotation_asset. `last_closed` is the
+    dedup map {coin_key: epoch_seconds_closed}; `now` is the caller's wall clock (the
+    v2 producer read time.time() inline — passed in here to keep this module pure)."""
+    use_xyz = rng.random() < xyz_weight
+    pool = xyz_pool if use_xyz else main_pool
+
+    def _scan_pool(pool, rot_idx):
+        n = len(pool)
+        for _ in range(n):
+            candidate = pool[rot_idx % n]
+            rot_idx = (rot_idx + 1) % n
+            coin_key = normalize_coin_key(candidate)
+            if coin_key in held_set:
+                continue
+            last = last_closed.get(coin_key, {})
+            if last and (now - _f(last.get("ts", 0))) < cooldown_seconds:
+                continue
+            return candidate, rot_idx
+        return None, rot_idx
+
+    asset, rot_idx = _scan_pool(pool, rot_idx)
+    if asset is not None:
+        return asset, rot_idx
+    # Fall back to the other pool (v2 behaviour: if the chosen pool is fully
+    # held/cooled, try the other before giving up).
+    other = main_pool if use_xyz else xyz_pool
+    return _scan_pool(other, rot_idx)


### PR DESCRIPTION
Final wave of the v2→3.0 migration (66→73). 4 copy-traders (albatross/cuckoo/jackal/remora), 2 cross-asset-lag (osprey/mantis), and the two-wallet volume engine turbine (volume + runners instances).

**This completes the migration — all 73 strategies are now on the supervised `scan()` model.** Each: read-guarded MCP, marginPct percent, canonical taxonomy, no `__init__.py`, all 73 pass the modernized validator. turbine fits `scan()` cleanly (emit-all, the scan-contract's own example); stale `xyz:SPX→xyz:SP500` fixed.

⚠️ **Pre-live review item:** three agents dropped v2 mutation-based exits that `scan()` can't perform (bald-eagle `cancel_order` sweep, mantis `close_position` leader-reversal veto, turbine stale-order sweep) — runtime reconciliation/DSL must cover those. Glossary reconciliation remains a separate fleet-wide pass.