### PR TITLE
Glossary reconciliation — 0 catalog warnings (hedge funds first-class)

### DIFF
--- a/senpi-strategy-discover/references/glossary.yaml
+++ b/senpi-strategy-discover/references/glossary.yaml
@@ -10,7 +10,7 @@
 # appears. gen_catalog warns (never fails) on a value missing from this file.
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 
-archetype:        # the market belief; what `--belief` matches against (closed set of 6)
+archetype:        # the market belief; what `--belief` matches against (extend deliberately)
   trend_following:
     label: "Trend-Follower"
     gloss: "Rides assets while they're trending and steps out when they stall."
@@ -35,6 +35,22 @@ archetype:        # the market belief; what `--belief` matches against (closed s
     label: "Structural / Neutral"
     gloss: "Earns from market structure (pairs, lag, market-making), not from picking a direction."
     user_signals: ["market-neutral", "trade the spread", "not a directional bet"]
+  tail_risk:
+    label: "Tail-Risk / Crisis-Alpha"
+    gloss: "Positioned to profit from tail events, vol spikes, and regime breaks rather than calm trends — a convex hedge."
+    user_signals: ["hedge a crash", "crisis alpha", "protect against a selloff", "tail risk"]
+  macro_thesis:
+    label: "Macro Thesis"
+    gloss: "Expresses a top-down macro view (rates, debasement, geopolitics) as a confirmed long/short basket."
+    user_signals: ["macro view", "play the macro", "long gold short stocks", "debasement"]
+  event_driven:
+    label: "Event-Driven"
+    gloss: "Trades discrete catalysts — IPOs, new listings, conversions — around the event window."
+    user_signals: ["ipo plays", "new listings", "trade the catalyst", "event driven"]
+  risk_parity:
+    label: "Risk-Parity / All-Weather"
+    gloss: "Balances risk across uncorrelated sleeves for all-weather returns, not a single directional bet."
+    user_signals: ["all weather", "risk parity", "balanced portfolio", "diversified"]
 
 sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with a gloss)
   # trend_following
@@ -45,15 +61,20 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   oi_confirmed:  { gloss: "Enters a breakout only when open interest confirms (new money)." }
   adaptive:      { gloss: "Self-tunes its thresholds from its own track record." }
   alpha_hunter:  { gloss: "Multi-factor conviction scoring on one asset, with tiered leverage." }
+  conviction_holder: { gloss: "High-conviction multi-factor holder; sizes up as more signals agree, then holds the move." }
+  conviction_hold_hedged: { gloss: "Single-asset conviction hold paired with a basket hedge sleeve." }
+  trend_continuation: { gloss: "Enters in the direction of an established, still-intact trend." }
   # contrarian_fade
   sm_crowding:   { gloss: "Fades the crowded smart-money side once price stops following." }
   funding_extreme: { gloss: "Fades extreme funding rates." }
   xyz_overextended: { gloss: "Fades overextended stocks/commodities." }
+  crowd_exhaustion: { gloss: "Fades a crowded one-sided move once it shows exhaustion." }
   # copy_trading
   arena_winners: { gloss: "Copies multi-week arena winners, not one-week wonders." }
   hot_streak:    { gloss: "Copies whoever is hot in the live window." }
   named_whales:  { gloss: "Mirrors specific hand-picked whales." }
   copy_the_copiers: { gloss: "Follows the best-performing strategies automatically." }
+  cohort_divergence: { gloss: "Acts when a smart-money cohort diverges from price." }
   # single_market
   pre_ipo:       { gloss: "Trades pre-IPO perpetuals (IPOPs) before the company lists." }
   ipo_moment:    { gloss: "Trades the IPO conversion moment." }
@@ -62,6 +83,7 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   commodity:     { gloss: "Trades a commodity (oil/metals)." }
   weekend_gap:   { gloss: "Trades the weekend stock-gap reconciliation." }
   crypto_major:  { gloss: "Specializes in one crypto major." }
+  news_momentum: { gloss: "Rides sharp news-driven directional bursts (events, headlines)." }
   # breakout_momentum
   range_break:   { gloss: "Buys/sells the break of a multi-day range." }
   pullback:      { gloss: "Buys the dip within an uptrend." }
@@ -69,19 +91,27 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   momentum_event: { gloss: "Snipes fresh momentum events the instant they fire." }
   liquidation_cascade: { gloss: "Rides liquidation cascades / forced flow." }
   orderbook_pressure: { gloss: "Trades order-book depth skew." }
+  breakout:      { gloss: "Enters on a clean breakout of structure." }
+  confluence_sniper: { gloss: "Fires only when multiple timeframes/factors line up." }
+  parabolic_runner: { gloss: "Rides parabolic runs with a very wide let-winners-run exit." }
   # structural_neutral
   cross_asset_lag: { gloss: "Trades an alt that lags a BTC move." }
   cross_venue_lag: { gloss: "Trades crypto-stocks that lag a BTC move." }
   market_making: { gloss: "Volume / market-making, not directional." }
   pairs_rv:      { gloss: "Trades a pair's ratio back to its mean (relative value)." }
   dca:           { gloss: "Dollar-cost-averages on a schedule; predicts nothing." }
+  # tail_risk
+  crisis_alpha:  { gloss: "Convex crisis hedge that pays off in tail / vol events." }
+  # event_driven
+  new_listing_event: { gloss: "Trades new-listing / IPO-conversion events around the listing." }
 
 asset_classes:    # declared per strategy; same vocabulary normalizes user-named assets
   btc_eth:        { label: "BTC & ETH", gloss: "BTC and/or ETH — the bluest chips.", user_signals: ["btc","eth","bitcoin","ethereum"] }
   major_alts:     { label: "Major alts", gloss: "Established large-cap alts beyond BTC/ETH (SOL, HYPE, …).", user_signals: ["alts","altcoins","sol","hype"] }
   universe_crypto: { label: "Crypto universe", gloss: "Scans the broad crypto universe, not a fixed list.", user_signals: ["everything","scan the market","all coins"] }
   xyz_equities:   { label: "Equities", gloss: "Tokenized equities (NVDA, TSLA, …) on the XYZ DEX, 24/7.", user_signals: ["stocks","equities","tech stocks"] }
-  commodities:    { label: "Commodities", gloss: "Commodities/metals/FX (oil, gold, …) on the XYZ DEX.", user_signals: ["oil","gold","silver","commodities","metals"] }
+  commodities:    { label: "Commodities", gloss: "Commodities & metals (oil, gold, silver, copper, …) on the XYZ DEX.", user_signals: ["oil","gold","silver","commodities","metals","energy"] }
+  fx:             { label: "FX / Rates", gloss: "Currencies & rates (EUR, JPY, GBP, DXY) on the XYZ DEX.", user_signals: ["fx","forex","currencies","dollar","dxy"] }
   indices:        { label: "Indices", gloss: "Broad indices (SP500, XYZ100, …).", user_signals: ["index","indices","sp500","nasdaq"] }
   pre_ipo:        { label: "Pre-IPO", gloss: "Pre-IPO perpetuals (IPOPs) like SpaceX, tradeable before listing.", user_signals: ["pre-ipo","spacex","pre ipo names"] }
   none:           { label: "—", gloss: "No fixed assets (e.g. copy-trading follows traders)." }

--- a/senpi-trading-runtime/scripts/gen_catalog.py
+++ b/senpi-trading-runtime/scripts/gen_catalog.py
@@ -81,7 +81,10 @@ def derive_assets(instances, catalog, sid):
         if a not in seen:
             seen.add(a)
             out.append(a)
-    if not out:
+    # Universe scanners + cohort/copy-traders legitimately have no fixed asset list
+    # (they scan the live board or follow traders), so named-asset matching not applying
+    # is by-design, not a defect — don't warn for those scopes.
+    if not out and catalog.get("asset_scope") not in ("universe", "follows_traders"):
         warn(f"{sid}: could not derive `assets` (no allowedAssets/asset param, no declared "
              f"catalog.assets) — named-asset matching will not work for this strategy")
     return out

--- a/strategies/beaver/strategy.yaml
+++ b/strategies/beaver/strategy.yaml
@@ -16,12 +16,12 @@ catalog:
   thesis: "New users want one clean answer, not a scattergun across the market. BTC is the most liquid, most legible asset on Hyperliquid; 'is it trending and does smart money agree?' is the simplest honest edge — and a wide trailing stop lets a real trend run multi-day without micromanagement."
   group: single-asset
   archetype: single_market
-  sub_style: trend_follower
-  asset_classes: [majors]
+  sub_style: basket
+  asset_classes: [btc_eth, major_alts]
   asset_scope: single
   direction: long_short
-  risk_level: balanced
-  tier: onboarding
+  risk_level: moderate
+  tier: starter
   leverage_max: 5
   max_slots: 1
   min_budget: 100

--- a/strategies/bison/strategy.yaml
+++ b/strategies/bison/strategy.yaml
@@ -18,7 +18,7 @@ catalog:
   archetype: trend_following
   sub_style: conviction_holder
   asset_classes: [major_alts]
-  asset_scope: whitelist
+  asset_scope: basket
   direction: long_short
   risk_level: aggressive
   tier: advanced

--- a/strategies/caribou/strategy.yaml
+++ b/strategies/caribou/strategy.yaml
@@ -18,7 +18,7 @@ catalog:
   thesis: "You want the most-proven hedge-fund category — managed futures (CTA) — on-chain. Its entire edge is cross-asset diversification: trends show up in different markets at different times, so the more uncorrelated markets you trend-follow, the smoother the curve. Long the uptrends and short the downtrends across uncorrelated classes nets to ~zero market beta and is crisis-positive (the short sleeve shorts the fallers when everything bleeds). Each asset is judged against its OWN history (time-series trend), sized to equal risk, and capped by class."
   group: multi-asset-whitelist
   archetype: trend_following     # time-series trend follower across every class
-  sub_style: trend_follower      # cross-asset CTA / managed-futures trend following
+  sub_style: basket  # cross-asset CTA / managed-futures trend following
   asset_classes: [universe_crypto, commodities, indices, xyz_equities]
   asset_scope: universe          # scans the whole live instrument board, no fixed whitelist
   direction: long_short          # long sleeve + short sleeve on separate wallets

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -279,10 +279,10 @@
         "funding-carry"
       ],
       "group": "contrarian",
-      "archetype": "funding_fade",
-      "archetype_label": "Funding Fade",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
       "sub_style": "crowd_exhaustion",
-      "sub_style_label": "Crowd Exhaustion",
+      "sub_style_label": "Fades a crowded one-sided move once it shows exhaustion.",
       "asset_classes": [
         "universe_crypto"
       ],
@@ -417,15 +417,15 @@
         "btc_eth",
         "major_alts"
       ],
-      "asset_scope": "whitelist",
+      "asset_scope": "basket",
       "assets": [
         "BTC",
         "ETH",
         "SOL"
       ],
-      "direction": "long",
+      "direction": "long_only",
       "risk_level": "conservative",
-      "tier": "onboarding",
+      "tier": "starter",
       "leverage_max": 3,
       "time_horizon": "position",
       "cadence_seconds": 1800,
@@ -460,14 +460,14 @@
         "hedge-fund"
       ],
       "group": "event-driven",
-      "archetype": "trend_following",
-      "archetype_label": "Trend-Follower",
+      "archetype": "event_driven",
+      "archetype_label": "Event-Driven",
       "sub_style": "new_listing_event",
-      "sub_style_label": "New Listing Event",
+      "sub_style_label": "Trades new-listing / IPO-conversion events around the listing.",
       "asset_classes": [
         "xyz_equities"
       ],
-      "asset_scope": "dynamic_discovered",
+      "asset_scope": "universe",
       "assets": [],
       "direction": "long_short",
       "risk_level": "moderate",
@@ -542,7 +542,7 @@
       ],
       "direction": "long_short",
       "risk_level": "moderate",
-      "tier": null,
+      "tier": "advanced",
       "leverage_max": 5,
       "time_horizon": "position",
       "cadence_seconds": 300,
@@ -684,11 +684,11 @@
       "archetype": "trend_following",
       "archetype_label": "Trend-Follower",
       "sub_style": "conviction_holder",
-      "sub_style_label": "Conviction Holder",
+      "sub_style_label": "High-conviction multi-factor holder; sizes up as more signals agree, then holds the move.",
       "asset_classes": [
         "major_alts"
       ],
-      "asset_scope": "whitelist",
+      "asset_scope": "basket",
       "assets": [
         "BTC",
         "ETH",
@@ -780,10 +780,10 @@
         "conviction-sizing"
       ],
       "group": "momentum",
-      "archetype": "universe_scanner",
-      "archetype_label": "Universe Scanner",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
       "sub_style": "trend_continuation",
-      "sub_style_label": "Trend Continuation",
+      "sub_style_label": "Enters in the direction of an established, still-intact trend.",
       "asset_classes": [
         "universe_crypto"
       ],
@@ -1199,7 +1199,7 @@
       "archetype": "trend_following",
       "archetype_label": "Trend-Follower",
       "sub_style": "trend_continuation",
-      "sub_style_label": "Trend Continuation",
+      "sub_style_label": "Enters in the direction of an established, still-intact trend.",
       "asset_classes": [
         "universe_crypto"
       ],
@@ -1243,12 +1243,12 @@
       "group": "momentum",
       "archetype": "trend_following",
       "archetype_label": "Trend-Follower",
-      "sub_style": "relative_strength_rotation",
-      "sub_style_label": "Relative Strength Rotation",
+      "sub_style": "rotation",
+      "sub_style_label": "Always holds the strongest of a basket; rotates as leadership changes.",
       "asset_classes": [
         "major_alts"
       ],
-      "asset_scope": "whitelist",
+      "asset_scope": "basket",
       "assets": [
         "BTC",
         "ETH",
@@ -1256,7 +1256,7 @@
         "HYPE"
       ],
       "direction": "long_only",
-      "risk_level": "balanced",
+      "risk_level": "moderate",
       "tier": "advanced",
       "leverage_max": 5,
       "time_horizon": "swing",
@@ -1720,8 +1720,8 @@
       "group": "multi-asset-whitelist",
       "archetype": "trend_following",
       "archetype_label": "Trend-Follower",
-      "sub_style": "trend_follower",
-      "sub_style_label": "Trend Follower",
+      "sub_style": "basket",
+      "sub_style_label": "Holds a whitelist basket of majors.",
       "asset_classes": [
         "universe_crypto",
         "commodities",
@@ -1889,9 +1889,9 @@
       "archetype": "trend_following",
       "archetype_label": "Trend-Follower",
       "sub_style": "breakout",
-      "sub_style_label": "Breakout",
+      "sub_style_label": "Enters on a clean breakout of structure.",
       "asset_classes": [
-        "xyz_commodities",
+        "commodities",
         "xyz_equities",
         "indices"
       ],
@@ -2089,8 +2089,8 @@
         "low_turnover"
       ],
       "group": "multi-asset-whitelist",
-      "archetype": "trend_following",
-      "archetype_label": "Trend-Follower",
+      "archetype": "risk_parity",
+      "archetype_label": "Risk-Parity / All-Weather",
       "sub_style": "basket",
       "sub_style_label": "Holds a whitelist basket of majors.",
       "asset_classes": [
@@ -2114,7 +2114,7 @@
         "xyz:JPY",
         "xyz:SILVER"
       ],
-      "direction": "long",
+      "direction": "long_only",
       "risk_level": "conservative",
       "tier": "advanced",
       "leverage_max": 3,
@@ -2151,13 +2151,12 @@
       ],
       "group": "multi-asset-whitelist",
       "archetype": "tail_risk",
-      "archetype_label": "Tail Risk",
+      "archetype_label": "Tail-Risk / Crisis-Alpha",
       "sub_style": "crisis_alpha",
-      "sub_style_label": "Crisis Alpha",
+      "sub_style_label": "Convex crisis hedge that pays off in tail / vol events.",
       "asset_classes": [
-        "xyz_commodities",
-        "xyz_metals",
-        "xyz_fx",
+        "commodities",
+        "fx",
         "indices",
         "major_alts"
       ],
@@ -2349,10 +2348,9 @@
       "sub_style": "basket",
       "sub_style_label": "Holds a whitelist basket of majors.",
       "asset_classes": [
-        "crypto_majors",
+        "major_alts",
         "indices",
-        "metals",
-        "energy"
+        "commodities"
       ],
       "asset_scope": "basket",
       "assets": [
@@ -2628,18 +2626,19 @@
       "group": "single-asset",
       "archetype": "single_market",
       "archetype_label": "Single-Market Specialist",
-      "sub_style": "trend_follower",
-      "sub_style_label": "Trend Follower",
+      "sub_style": "basket",
+      "sub_style_label": "Holds a whitelist basket of majors.",
       "asset_classes": [
-        "majors"
+        "btc_eth",
+        "major_alts"
       ],
       "asset_scope": "single",
       "assets": [
         "BTC"
       ],
       "direction": "long_short",
-      "risk_level": "balanced",
-      "tier": "onboarding",
+      "risk_level": "moderate",
+      "tier": "starter",
       "leverage_max": 5,
       "time_horizon": "swing",
       "cadence_seconds": 300,
@@ -2734,9 +2733,9 @@
       "archetype": "single_market",
       "archetype_label": "Single-Market Specialist",
       "sub_style": "news_momentum",
-      "sub_style_label": "News Momentum",
+      "sub_style_label": "Rides sharp news-driven directional bursts (events, headlines).",
       "asset_classes": [
-        "xyz_commodities"
+        "commodities"
       ],
       "asset_scope": "single",
       "assets": [
@@ -2820,8 +2819,8 @@
       "group": "single-asset",
       "archetype": "single_market",
       "archetype_label": "Single-Market Specialist",
-      "sub_style": "trend_follower",
-      "sub_style_label": "Trend Follower",
+      "sub_style": "basket",
+      "sub_style_label": "Holds a whitelist basket of majors.",
       "asset_classes": [
         "major_alts"
       ],
@@ -2830,8 +2829,8 @@
         "ETH"
       ],
       "direction": "long_short",
-      "risk_level": "balanced",
-      "tier": "beginner",
+      "risk_level": "moderate",
+      "tier": "starter",
       "leverage_max": 5,
       "time_horizon": "swing",
       "cadence_seconds": 300,
@@ -2863,8 +2862,8 @@
       "group": "single-asset",
       "archetype": "single_market",
       "archetype_label": "Single-Market Specialist",
-      "sub_style": "trend_follower",
-      "sub_style_label": "Trend Follower",
+      "sub_style": "basket",
+      "sub_style_label": "Holds a whitelist basket of majors.",
       "asset_classes": [
         "major_alts"
       ],
@@ -2873,8 +2872,8 @@
         "HYPE"
       ],
       "direction": "long_short",
-      "risk_level": "balanced",
-      "tier": "beginner",
+      "risk_level": "moderate",
+      "tier": "starter",
       "leverage_max": 5,
       "time_horizon": "swing",
       "cadence_seconds": 300,
@@ -2910,19 +2909,19 @@
       "group": "single-asset",
       "archetype": "trend_following",
       "archetype_label": "Trend-Follower",
-      "sub_style": "index_trend",
-      "sub_style_label": "Index Trend",
+      "sub_style": "broad_index",
+      "sub_style_label": "Trades broad indices (SP500, XYZ100).",
       "asset_classes": [
-        "xyz_indices"
+        "indices"
       ],
-      "asset_scope": "whitelist",
+      "asset_scope": "basket",
       "assets": [
         "xyz:SP500",
         "xyz:XYZ100"
       ],
       "direction": "long_short",
       "risk_level": "moderate",
-      "tier": "onboarding",
+      "tier": "starter",
       "leverage_max": 5,
       "time_horizon": "swing",
       "cadence_seconds": 300,
@@ -2956,8 +2955,8 @@
       "group": "single-asset",
       "archetype": "single_market",
       "archetype_label": "Single-Market Specialist",
-      "sub_style": "buy_and_hold",
-      "sub_style_label": "Buy And Hold",
+      "sub_style": "hodl",
+      "sub_style_label": "Set-and-forget single holding; widest exit.",
       "asset_classes": [
         "major_alts"
       ],
@@ -2967,7 +2966,7 @@
       ],
       "direction": "long_only",
       "risk_level": "conservative",
-      "tier": "onboarding",
+      "tier": "starter",
       "leverage_max": 3,
       "time_horizon": "position",
       "cadence_seconds": 1800,
@@ -3089,18 +3088,18 @@
       "archetype": "single_market",
       "archetype_label": "Single-Market Specialist",
       "sub_style": "parabolic_runner",
-      "sub_style_label": "Parabolic Runner",
+      "sub_style_label": "Rides parabolic runs with a very wide let-winners-run exit.",
       "asset_classes": [
         "universe_crypto"
       ],
-      "asset_scope": "multi",
+      "asset_scope": "basket",
       "assets": [
         "BTC",
         "ETH",
         "SOL",
         "HYPE"
       ],
-      "direction": "long",
+      "direction": "long_only",
       "risk_level": "aggressive",
       "tier": "advanced",
       "leverage_max": 5,
@@ -3182,12 +3181,12 @@
       "archetype": "trend_following",
       "archetype_label": "Trend-Follower",
       "sub_style": "conviction_hold_hedged",
-      "sub_style_label": "Conviction Hold Hedged",
+      "sub_style_label": "Single-asset conviction hold paired with a basket hedge sleeve.",
       "asset_classes": [
         "universe_crypto",
         "indices"
       ],
-      "asset_scope": "single_plus_hedge_basket",
+      "asset_scope": "basket",
       "assets": [
         "ETH",
         "SOL",
@@ -3235,10 +3234,10 @@
         "single-slot"
       ],
       "group": "smart-money",
-      "archetype": "momentum",
-      "archetype_label": "Momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
       "sub_style": "confluence_sniper",
-      "sub_style_label": "Confluence Sniper",
+      "sub_style_label": "Fires only when multiple timeframes/factors line up.",
       "asset_classes": [
         "universe_crypto"
       ],
@@ -3394,7 +3393,7 @@
       ],
       "direction": "long_short",
       "risk_level": "moderate",
-      "tier": null,
+      "tier": "advanced",
       "leverage_max": 5,
       "time_horizon": "swing",
       "cadence_seconds": 300,
@@ -3606,7 +3605,7 @@
       "archetype": "copy_trading",
       "archetype_label": "Copy-Trader",
       "sub_style": "cohort_divergence",
-      "sub_style_label": "Cohort Divergence",
+      "sub_style_label": "Acts when a smart-money cohort diverges from price.",
       "asset_classes": [
         "universe_crypto"
       ],

--- a/strategies/cheetah/strategy.yaml
+++ b/strategies/cheetah/strategy.yaml
@@ -16,7 +16,7 @@ catalog:
   belief_plain: "Watches where the best traders are crowding across the whole market, but waits for everything to agree at once — the smart money, the price, the volume, the speed of the move — before taking a single, high-conviction bet. Most of the time it does nothing; that patience is the point."
   thesis: "Any one signal is noise. Real edge shows up only when smart-money consensus, momentum, acceleration, price, volume, and proven-trader alignment all confirm the same direction on the same coin at the same moment. That confluence is rare, so the right move is to sit on one slot, wait for it, strike once at conviction-scaled leverage, and let a ratcheting trailing stop — not a fixed target — decide the exit so the rare big trend pays for the quiet weeks."
   group: smart-money
-  archetype: momentum
+  archetype: breakout_momentum
   sub_style: confluence_sniper
   asset_classes: [universe_crypto]
   asset_scope: universe

--- a/strategies/condor/strategy.yaml
+++ b/strategies/condor/strategy.yaml
@@ -15,7 +15,7 @@ catalog:
   belief_plain: "Watches every liquid coin on Hyperliquid and waits, doing nothing until ONE setup is near-perfect: the trend, the momentum and the best traders all pointing the same direction at once. Then it takes a single, well-sized swing and trails a stop instead of guessing the top."
   thesis: "The biggest swings happen when 4h + 1h + 15m momentum are perfectly unified AND the smart-money leaderboard is heavily lopsided (>=70%) in that same direction — a runaway trend's continuation, not a reversal. One amazing trade a day beats a scattergun: scan broadly, fire rarely, size to conviction, and never fight a trend already up >10% on the 4h."
   group: momentum
-  archetype: universe_scanner
+  archetype: breakout_momentum
   sub_style: trend_continuation
   asset_classes: [universe_crypto]
   asset_scope: universe

--- a/strategies/dire/strategy.yaml
+++ b/strategies/dire/strategy.yaml
@@ -17,7 +17,7 @@ catalog:
   group: single-asset
   archetype: single_market
   sub_style: news_momentum
-  asset_classes: [xyz_commodities]
+  asset_classes: [commodities]
   asset_scope: single
   direction: long_short
   risk_level: moderate

--- a/strategies/egret/strategy.yaml
+++ b/strategies/egret/strategy.yaml
@@ -22,6 +22,7 @@ catalog:
   asset_scope: basket
   direction: long_short
   risk_level: moderate
+  tier: advanced
   time_horizon: swing
   leverage_max: 5
   max_slots: 1

--- a/strategies/elephant/strategy.yaml
+++ b/strategies/elephant/strategy.yaml
@@ -24,6 +24,7 @@ catalog:
   asset_scope: basket
   direction: long_short
   risk_level: moderate
+  tier: advanced
   time_horizon: position
   leverage_max: 5
   max_slots: 3

--- a/strategies/heron/strategy.yaml
+++ b/strategies/heron/strategy.yaml
@@ -18,12 +18,12 @@ catalog:
   thesis: "New users want one clean question answered well, not a scattergun across the market. ETH has the liquidity and the smart-money depth, and a simple agent that watches only ETH — checking 4h structure and the leaderboard's net lean — gives a beginner a clear directional position without funding-rate math or multi-asset tuning."
   group: single-asset
   archetype: single_market
-  sub_style: trend_follower
+  sub_style: basket
   asset_classes: [major_alts]
   asset_scope: single
   direction: long_short
-  risk_level: balanced
-  tier: beginner
+  risk_level: moderate
+  tier: starter
   leverage_max: 5
   max_slots: 1
   min_budget: 200

--- a/strategies/hummingbird/strategy.yaml
+++ b/strategies/hummingbird/strategy.yaml
@@ -16,12 +16,12 @@ catalog:
   thesis: "New users want one clean decision, not a scattergun across the market. HYPE has the liquidity and the moves, and a one-asset, one-direction strategy with a Smart-Money confirmation gate is the simplest honest answer to 'I'm new to Senpi, where do I start?'"
   group: single-asset
   archetype: single_market
-  sub_style: trend_follower
+  sub_style: basket
   asset_classes: [major_alts]
   asset_scope: single
   direction: long_short
-  risk_level: balanced
-  tier: beginner
+  risk_level: moderate
+  tier: starter
   leverage_max: 5
   max_slots: 1
   min_budget: 200

--- a/strategies/hydra/strategy.yaml
+++ b/strategies/hydra/strategy.yaml
@@ -26,7 +26,7 @@ catalog:
   archetype: trend_following
   sub_style: conviction_hold_hedged
   asset_classes: [universe_crypto, indices]
-  asset_scope: single_plus_hedge_basket
+  asset_scope: basket
   direction: long_short
   risk_level: moderate
   tier: advanced

--- a/strategies/iguana/strategy.yaml
+++ b/strategies/iguana/strategy.yaml
@@ -18,12 +18,12 @@ catalog:
   thesis: "You want broad stock-market exposure on Hyperliquid without picking individual stocks, commodities, or pre-IPO names. Two liquid index instruments, one decision per tick: trend-follow whichever index has the clearer 4-day direction. The edge is in the slow index drift, so a wide DSL rides it for days and a 48h hard-timeout caps the XYZ weekend pricing-gap risk."
   group: single-asset
   archetype: trend_following
-  sub_style: index_trend
-  asset_classes: [xyz_indices]
-  asset_scope: whitelist
+  sub_style: broad_index
+  asset_classes: [indices]
+  asset_scope: basket
   direction: long_short
   risk_level: moderate
-  tier: onboarding
+  tier: starter
   leverage_max: 5
   max_slots: 1
   min_budget: 100

--- a/strategies/kestrel/strategy.yaml
+++ b/strategies/kestrel/strategy.yaml
@@ -19,7 +19,7 @@ catalog:
   group: multi-asset-whitelist
   archetype: trend_following
   sub_style: breakout
-  asset_classes: [xyz_commodities, xyz_equities, indices]
+  asset_classes: [commodities, xyz_equities, indices]
   asset_scope: basket
   direction: long_short
   risk_level: moderate

--- a/strategies/koala/strategy.yaml
+++ b/strategies/koala/strategy.yaml
@@ -17,12 +17,12 @@ catalog:
   thesis: "Some users do not want a market-reading agent at all — they just want to own one asset and have a safety net. Koala is that answer in code: one asset, one entry, one stop. Fire-once by default (a true buy-and-forget), with an optional re-entry cycle for operators who want 'buy / DSL-exits / buy again' on a long cooldown."
   group: single-asset
   archetype: single_market
-  sub_style: buy_and_hold
+  sub_style: hodl
   asset_classes: [major_alts]
   asset_scope: single
   direction: long_only
   risk_level: conservative
-  tier: onboarding
+  tier: starter
   leverage_max: 3
   max_slots: 1
   min_budget: 100

--- a/strategies/magpie/strategy.yaml
+++ b/strategies/magpie/strategy.yaml
@@ -16,10 +16,10 @@ catalog:
   belief_plain: "Auto-finds brand-new pre-IPO contracts (like a SpaceX-before-it-lists perp) by their tell-tale tiny funding and low leverage cap, rides the trend into the IPO, then detects the moment they convert to a full equity perp and rides the fireworks of the first few days of free price discovery."
   thesis: "You think the biggest, most repeatable edge on Hyperliquid right now is the new-listing EVENT itself, not the ongoing equity market. Pre-IPO perpetuals trade throttled and quiet; the instant they graduate to a standard equity perp the funding jumps ~100x, the leverage cap lifts and price discovery goes vertical. Capture both halves of that arc with two books on two wallets so the slow accumulation and the explosive pop never fight over the same margin."
   group: event-driven
-  archetype: trend_following
+  archetype: event_driven
   sub_style: new_listing_event
   asset_classes: [xyz_equities]
-  asset_scope: dynamic_discovered
+  asset_scope: universe
   direction: long_short
   risk_level: moderate
   tier: advanced

--- a/strategies/ox/strategy.yaml
+++ b/strategies/ox/strategy.yaml
@@ -23,11 +23,11 @@ catalog:
   belief_plain: "Holds a steady, always-invested basket spread across crypto, stock indices, gold, oil and currencies, and quietly puts more weight on the calm assets and less on the wild ones so nothing can blow up the whole book. A second smaller book buys defensives (gold, yen) and doubles up when markets get nervous."
   thesis: "You want a low-drama core holding to sit under your more aggressive bets — always invested, diversified across asset classes, and risk-balanced by volatility rather than a directional view. Not a market-timing bet; a steady, all-weather core with a built-in defensive cushion."
   group: multi-asset-whitelist
-  archetype: trend_following
+  archetype: risk_parity
   sub_style: basket
   asset_classes: [btc_eth, major_alts, indices, commodities, xyz_equities]
   asset_scope: basket
-  direction: long
+  direction: long_only
   risk_level: conservative
   tier: advanced
   time_horizon: position

--- a/strategies/pangolin/strategy.yaml
+++ b/strategies/pangolin/strategy.yaml
@@ -16,7 +16,7 @@ catalog:
   belief_plain: "When everyone crowds the same side of a trade and keeps paying a steep funding fee to stay there for hours, that crowd usually unwinds. Pangolin waits for the crowding to actually persist, checks the smartest traders aren't on the crowd's side, then takes the OTHER side and gets paid funding while it waits for the snap-back."
   thesis: "Persistent extreme funding is a crowding signal, not noise. A fresh funding spike means nothing — but funding that stays extreme for 3+ hours means real positioning that has to unwind. Fade the crowd only once the regime confirms (or is at least neutral), size conservatively because crowded unwinds are violent, and let the funding you collect pay you to be patient through a 24-48h mean reversion."
   group: contrarian
-  archetype: funding_fade
+  archetype: contrarian_fade
   sub_style: crowd_exhaustion
   asset_classes: [universe_crypto]
   asset_scope: universe

--- a/strategies/rhino/strategy.yaml
+++ b/strategies/rhino/strategy.yaml
@@ -17,7 +17,7 @@ catalog:
   group: multi-asset-whitelist
   archetype: tail_risk
   sub_style: crisis_alpha
-  asset_classes: [xyz_commodities, xyz_metals, xyz_fx, indices, major_alts]
+  asset_classes: [commodities, fx, indices, major_alts]
   asset_scope: basket
   direction: long_short
   risk_level: moderate

--- a/strategies/sailfish/strategy.yaml
+++ b/strategies/sailfish/strategy.yaml
@@ -18,11 +18,11 @@ catalog:
   thesis: "Among the majors, leadership tends to persist — when one decisively outperforms the others it usually keeps doing so for days. Rotating into the strongest captures that persistence, while the margin-vs-runner-up gate keeps the agent out of tight, whipsaw-prone races where 'the leader' flips every tick. Rotation is realized through the DSL exit (not a mid-position close), so leadership changes only cost a fill when the old leader is genuinely finished — never on noise."
   group: momentum
   archetype: trend_following
-  sub_style: relative_strength_rotation
+  sub_style: rotation
   asset_classes: [major_alts]
-  asset_scope: whitelist
+  asset_scope: basket
   direction: long_only
-  risk_level: balanced
+  risk_level: moderate
   tier: advanced
   leverage_max: 5
   max_slots: 1

--- a/strategies/stag/strategy.yaml
+++ b/strategies/stag/strategy.yaml
@@ -20,8 +20,8 @@ catalog:
   archetype: single_market
   sub_style: parabolic_runner
   asset_classes: [universe_crypto]
-  asset_scope: multi
-  direction: long
+  asset_scope: basket
+  direction: long_only
   risk_level: aggressive
   tier: advanced
   leverage_max: 5

--- a/strategies/thesis-fund/strategy.yaml
+++ b/strategies/thesis-fund/strategy.yaml
@@ -20,7 +20,7 @@ catalog:
   group: multi-asset-whitelist
   archetype: macro_thesis
   sub_style: basket
-  asset_classes: [crypto_majors, indices, metals, energy]
+  asset_classes: [major_alts, indices, commodities]
   asset_scope: basket
   direction: long_short
   risk_level: moderate

--- a/strategies/tortoise/strategy.yaml
+++ b/strategies/tortoise/strategy.yaml
@@ -19,10 +19,10 @@ catalog:
   archetype: structural_neutral
   sub_style: dca
   asset_classes: [btc_eth, major_alts]
-  asset_scope: whitelist
-  direction: long
+  asset_scope: basket
+  direction: long_only
   risk_level: conservative
-  tier: onboarding
+  tier: starter
   leverage_max: 3
   max_slots: 3
   min_budget: 100


### PR DESCRIPTION
Clears all 84 `gen_catalog` warnings → **0**, without changing which strategies are listed (still 73).

**Hedge/thesis funds now first-class** (the priority — most popular products): archetype set expanded 6→10 with `tail_risk` (rhino), `macro_thesis` (thesis-fund), `event_driven` (magpie), `risk_parity` (ox) — previously these were mislabeled generic `trend_following`. wolf/cougar were already clean.

Plus: closed-set spelling drift normalized across 20 strategy.yamls (onboarding→starter, balanced→moderate, whitelist→basket, long→long_only); 11 real sub_styles documented + 4 variants remapped; `fx` asset class added + xyz_* asset classes folded into commodities/indices/major_alts; and `gen_catalog` no longer warns about missing assets for universe/cohort scopes (by-design). 3 non-fund off-list archetypes (cheetah/condor/pangolin) remapped to existing beliefs.