### PR TITLE
fix(discover): named-asset queries no longer exclude universe scanners

### DIFF
--- a/senpi-strategy-discover/scripts/discover.py
+++ b/senpi-strategy-discover/scripts/discover.py
@@ -177,6 +177,19 @@ def infer_class_for_named(named):
     return "major_alts"
 
 
+def _record_trades_named(r, named):
+    """True if record r could trade ticker `named` — by an explicit fixed-asset match OR as an
+    in-domain universe scanner. A broad scanner (asset_scope 'universe') ships no fixed `assets`
+    list but WILL trade any name in its domain (a crypto-universe scanner trades SOL; an xyz-universe
+    scanner trades NVDA), so naming a ticker must NOT exclude it."""
+    if asset_matches(named, r.get("assets")):
+        return True
+    if r.get("asset_scope") == "universe":
+        ndom = {"xyz"} if str(named).upper().startswith("XYZ:") else {"crypto"}
+        return bool(ndom & domain_of(r.get("asset_classes") or []))
+    return False
+
+
 # ---------------------------------------------------------------- matcher (pure: filter + return all)
 def _hard_reject(r, intent):
     """The ONLY narrowing — reject on an explicitly-stated, unambiguous constraint. Nothing soft."""
@@ -186,7 +199,7 @@ def _hard_reject(r, intent):
         if ud and sd and ud.isdisjoint(sd):
             return True
     named = [v for k, v in intent["assets"] if k == "named"]
-    if named and not any(asset_matches(n, r.get("assets")) for n in named):
+    if named and not any(_record_trades_named(r, n) for n in named):
         if not intent.get("_broadened_classes"):
             return True
         if not (set(intent["_broadened_classes"]) & set(r.get("asset_classes") or [])):
@@ -220,7 +233,7 @@ def _asset_match(r, intent):
     acs = set(r.get("asset_classes") or [])
     if user_classes and (set(user_classes) & acs):
         n += 1
-    if named and any(asset_matches(x, r.get("assets")) for x in named):
+    if named and any(_record_trades_named(r, x) for x in named):
         n += 1
     return n
 
@@ -239,6 +252,9 @@ def _caveats(r, intent):
         cav.append(f"Splits across {r['instance_count']} wallets ({split}); your assets may sit mainly in one leg.")
     if intent["budget"] is not None and intent["budget"] < (r.get("min_budget") or 0):
         cav.append(f"Needs ~${int(r['min_budget'])} to start; you mentioned ${int(intent['budget'])}.")
+    named_tickers = [v for k, v in intent["assets"] if k == "named"]
+    if named_tickers and r.get("asset_scope") == "universe":
+        cav.append(f"Scans the whole universe — trades {', '.join(named_tickers)} among many names, not exclusively.")
     return cav
 
 

--- a/senpi-strategy-discover/tests/test_discover.py
+++ b/senpi-strategy-discover/tests/test_discover.py
@@ -188,10 +188,13 @@ def test_caveats():
 
 
 def test_degrade():
-    # named asset nobody trades -> broaden to class
+    # named crypto ticker with no fixed-asset specialist -> universe scanners cover it directly
+    # (a broad crypto scanner trades any crypto name, so the broaden fallback isn't needed)
     r = run(assets="DOGE")
-    check("DOGE broadened (widened named_asset)", "named_asset" in r["meta"].get("widened", []), r["meta"])
-    check("DOGE broaden -> alt strategies survive", "kodiak" in ids(r), ids(r))
+    check("DOGE -> non-empty (covered by universe scanners)", r["candidates"] != [], ids(r))
+    check("DOGE -> a universe-scope scanner is present",
+          any(c.get("asset_scope") == "universe" for c in r["candidates"]), ids(r))
+    check("DOGE -> no broaden needed", "named_asset" not in r["meta"].get("widened", []), r["meta"])
 
     # genuinely impossible (crypto user, exclude crypto AND copy) -> build-custom only
     r2 = run(assets="btc_eth", exclude="crypto,copy_trading")


### PR DESCRIPTION
## Problem
`--assets SOL` returned 27 survivors but **0 universe scanners** — octopus/python/otter/condor/owl were all hard-rejected because their `assets` list is empty (dynamic universe). The broad scanners that would actually trade SOL never reached the ranker; the broaden-to-class fallback only fires when survivors is *empty*, so it didn't help.

## Fix
- `_record_trades_named(r, named)`: a record matches a named ticker by explicit fixed-asset match **or** as an in-domain universe scanner (`asset_scope: universe` covers any name in its domain). Cross-domain stays excluded (a crypto-only scanner is *not* returned for NVDA).
- Honest caveat on those cards: *"Scans the whole universe — trades {ticker} among many names, not exclusively."*
- `test_degrade` updated: DOGE is now covered directly by universe scanners (no broaden needed).

After: `--assets SOL` → 42 survivors incl. octopus/python/otter/condor/owl, fixed SOL specialists still present; `--assets NVDA` → caracal (xyz-universe) present, crypto-only scanners correctly absent. **Not merged.**