### PR TITLE
fix(discover): named-asset broaden no longer mis-buckets non-crypto tickers

### DIFF
--- a/senpi-strategy-discover/scripts/discover.py
+++ b/senpi-strategy-discover/scripts/discover.py
@@ -168,13 +168,22 @@ def asset_matches(named, assets):
     return False
 
 
+# Crypto majors the fleet trades by name — used only to infer a class for the named-asset broaden
+# fallback. A ticker not here (a stock like NVDA passed without the xyz: prefix, or an unknown coin)
+# broadens to NO class constraint rather than being wrongly forced into the crypto bucket.
+_CRYPTO_NAMED = {"BTC", "ETH", "SOL", "HYPE", "XRP", "DOGE", "AVAX", "LINK", "ADA",
+                 "LTC", "NEAR", "APT", "UNI", "AAVE", "SUI", "TON", "OP", "ARB"}
+
+
 def infer_class_for_named(named):
     n = named.upper().replace("XYZ:", "")
     if named.upper().startswith("XYZ:"):
-        return None  # xyz domain but sub-class unknown; broaden = no class constraint
+        return None  # xyz domain, sub-class unknown -> no class constraint
     if n in ("BTC", "ETH"):
         return "btc_eth"
-    return "major_alts"
+    if n in _CRYPTO_NAMED:
+        return "major_alts"
+    return None  # unknown ticker (often an equity passed without xyz:) -> don't force a crypto class
 
 
 # ---------------------------------------------------------------- matcher (pure: filter + return all)

--- a/senpi-strategy-discover/tests/test_discover.py
+++ b/senpi-strategy-discover/tests/test_discover.py
@@ -221,10 +221,18 @@ def test_intent_echo():
     check("echo has no soft keys", not any(k in e for k in ("risk", "belief", "horizon")), e)
 
 
+def test_infer_class():
+    # the named-asset broaden fallback must not force a non-crypto ticker into the crypto bucket
+    check("infer BTC -> btc_eth", discover.infer_class_for_named("BTC") == "btc_eth")
+    check("infer SOL -> major_alts", discover.infer_class_for_named("SOL") == "major_alts")
+    check("infer NVDA -> None (not mis-bucketed as crypto)", discover.infer_class_for_named("NVDA") is None)
+    check("infer xyz:GOLD -> None (xyz, sub-class unknown)", discover.infer_class_for_named("xyz:GOLD") is None)
+
+
 if __name__ == "__main__":
     for fn in [test_normalizer, test_return_all, test_soft_surface, test_asset_class_crossdomain,
                test_named_asset, test_direction, test_exclude, test_ordering, test_caveats,
-               test_degrade, test_failopen, test_intent_echo]:
+               test_degrade, test_failopen, test_intent_echo, test_infer_class]:
         try:
             fn()
         except Exception as e:  # noqa


### PR DESCRIPTION
## Problem
`infer_class_for_named()` (the named-asset broaden fallback) returned `major_alts` for every non-BTC/ETH ticker — so an equity passed without the `xyz:` prefix (e.g. `NVDA`) would broaden a query into the **crypto** bucket, surfacing the wrong domain.

## Fix
- Only known crypto majors (`_CRYPTO_NAMED`) infer `major_alts`; `BTC`/`ETH` → `btc_eth`; `xyz:*` → no constraint (unchanged).
- An unknown ticker → **no class constraint** (broaden wide, never a wrong-domain cut) — consistent with the engine's 'a bad cut hides the answer, a full list never does' principle.
- Adds `test_infer_class`.

Lowest-severity of the three (the broaden path is rarely hit, especially once #411 lands), but it removes a latent wrong-domain bug. **Not merged.**