### PR TITLE
feat: hornet (semis supply-chain) + barnacle (index-inclusion) — 73 -> 75

### DIFF
--- a/senpi-strategy-discover/references/glossary.yaml
+++ b/senpi-strategy-discover/references/glossary.yaml
@@ -94,6 +94,7 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   breakout:      { gloss: "Enters on a clean breakout of structure." }
   confluence_sniper: { gloss: "Fires only when multiple timeframes/factors line up." }
   parabolic_runner: { gloss: "Rides parabolic runs with a very wide let-winners-run exit." }
+  sector_momentum: { gloss: "Rides a whole sector / supply chain only when its breadth confirms; won't chase a lone name." }
   # structural_neutral
   cross_asset_lag: { gloss: "Trades an alt that lags a BTC move." }
   cross_venue_lag: { gloss: "Trades crypto-stocks that lag a BTC move." }
@@ -104,6 +105,7 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   crisis_alpha:  { gloss: "Convex crisis hedge that pays off in tail / vol events." }
   # event_driven
   new_listing_event: { gloss: "Trades new-listing / IPO-conversion events around the listing." }
+  index_inclusion: { gloss: "Front-runs index additions/deletions for the forced passive-fund flow into the rebalance effective date." }
 
 asset_classes:    # declared per strategy; same vocabulary normalizes user-named assets
   btc_eth:        { label: "BTC & ETH", gloss: "BTC and/or ETH — the bluest chips.", user_signals: ["btc","eth","bitcoin","ethereum"] }

--- a/strategies/barnacle/main/runtime.yaml
+++ b/strategies/barnacle/main/runtime.yaml
@@ -1,0 +1,156 @@
+# ── BARNACLE · single instance — index-inclusion / passive-flow front-runner ──
+# NET-NEW Runtime 3.0 strategy (NOT a port). Thesis: when a stock is announced for
+# ADD to a major index (S&P 500 / Nasdaq-100 / Russell), index funds are FORCED to
+# buy it by the rebalance effective date — a predictable passive-buying wave that
+# lifts price INTO the date. Barnacle rides that anticipatory flow on Hyperliquid XYZ
+# equity perps from detection up to ~the effective date, then EXITS before the
+# rebalance (sell into the inclusion; the pop often fades once forced buying
+# completes). DELETE events mirror as SHORTS (forced selling into the date).
+#
+# CONFIG-DRIVEN UNIVERSE: there is no MCP feed for index-rebalance events, so the
+# operator supplies them in scanners.inputs.events as {asset, effectiveDate, side,
+# index}. The default events list is an EXAMPLE — replace it with the live schedule.
+# The scan trades ONLY the names in inputs.events. xyz: prefix mandatory (HIP-3 DEX).
+name: barnacle-main
+group: barnacle
+version: 1.0.0
+description: >
+  BARNACLE — index-inclusion / passive-flow front-runner on Hyperliquid XYZ equity
+  perps. Config-driven event universe (inputs.events: {asset, effectiveDate, side
+  add|delete, index}) — there is no MCP feed for index rebalances, the operator
+  supplies the schedule. Per tick it computes hours-to-effective-date for each
+  in-window event, rides ADDs LONG / DELETEs SHORT when the passive-anticipation
+  signature confirms (4h trend in-direction + rising 4h volume), sizes marginPct
+  scaled UP by proximity to the date (base 12% -> max 20%), leverage 4x (clamped
+  [1,5] + venue max). It STOPS emitting once within exitBufferHours (24h) of the
+  date — sell into the inclusion before the rebalance completes. DSL is the exit:
+  time-bounded hard_timeout covers the event window (~6d), Phase 1 12% max_loss,
+  Phase 2 first lock reachable (+8%). Net-new — sub_style index_inclusion.
+
+strategy:
+  wallet: "${BARNACLE_WALLET}"
+  slots: 3                                 # a few concurrent index events at once
+  margin_pct: 12                           # baseline %; scan emits the proximity-scaled marginPct per signal
+  default_leverage: 4                      # fallback; scan emits 4x (clamped [1,5] + venue max) per signal
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: barnacle_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900                  # 15 min — event windows are days long; no need for fast cadence
+    timeout_seconds: 180                   # ~1 read/event + account read
+    default_signal_validity_seconds: 1800  # 2x tick; a fresh re-score arrives next tick
+    state_history_max_count: 50            # dedup map + per-tick scan-results history
+    inputs:
+      # EXAMPLE events — operators REPLACE this with the live rebalance schedule.
+      # asset must be a live HL xyz instrument; effectiveDate is ISO date / ISO
+      # datetime / epoch; side is "add" (LONG) or "delete" (SHORT). xyz:SPCX
+      # validated live vs HL xyz meta 2026-06-30 (max_leverage 20, not delisted).
+      events:
+        - { asset: "xyz:SPCX", effectiveDate: "2026-07-07", side: "add", index: "russell+ndx100" }
+      dex: "xyz"                           # HIP-3 DEX — xyz: prefix mandatory
+      exitBufferHours: 24                  # stop emitting (sell into the inclusion) this long before the date
+      windowHours: 168                     # 7d tradeable anticipation window before the date
+      marginPctBase: 12                    # PERCENT of withdrawable (0,100] at window start
+      marginPctMax: 20                     # PERCENT near the exit buffer (proximity-scaled UP)
+      leverage: 4                          # clamped to [1,5] and to the instrument venue max
+      minVolTrendPct: 10                   # 4h volume-trend floor for the anticipation confirmation
+      recentSignalTtlSeconds: 1800         # 30m signal-dedup (don't re-fire while in flight)
+    signal_data_schema:
+      side: { type: string }
+      index: { type: string, required: false }
+      direction: { type: string }
+      leverage: { type: number, required: false }
+      hoursToEffective: { type: number, required: false }
+      effectiveEpoch: { type: number, required: false }
+      trend4h: { type: string, required: false }
+      trend4hStrength: { type: number, required: false }
+      trend1h: { type: string, required: false }
+      volTrend4hPct: { type: number, required: false }
+      reasons: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: barnacle_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every gate (in-window + confirm + dedup)
+    scanners: [barnacle_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # anticipation entries must fill — maker-only rests unfilled (CREATE_ORDER_RESTING)
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: barnacle_main_signals
+
+# ── EXIT (DSL — TIME-BOUNDED for a bounded event window) ──────────────────────
+# Unlike the crypto single-asset family (hard_timeout OFF), Barnacle's edge is a
+# CALENDAR event with a known expiry: the rebalance effective date. The position
+# should never camp past the event window, so hard_timeout is ENABLED at ~6d
+# (8640 min) — it covers the full tradeable window (windowHours 168 = 7d) minus
+# the exit buffer, a backstop in case the scan's exit-buffer cutoff is somehow not
+# reached (e.g. event removed from config mid-hold). Phase 1 max_loss 12%; Phase 2
+# FIRST lock reachable at +8% (forced-flow pops are modest and fade post-rebalance,
+# so lock gains early). weak_peak_cut KEPT (self-limiting thesis-validity check):
+# if the anticipation pop never materializes, cut. order_type FEE_OPTIMIZED_LIMIT,
+# taker fallback on (closes MUST happen). interval_seconds 60.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # exit closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # event window is bounded — never camp past the rebalance
+      interval_in_minutes: 8640            # ~6d (windowHours 168 minus the 24h exit buffer), a backstop
+    weak_peak_cut:
+      enabled: true                        # self-limiting: cut if the anticipation pop never appears
+      interval_in_minutes: 90
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                       # DISABLED — a multi-day anticipation ramp tolerates flat windows
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                    # modest floor — passive-flow theses don't justify deep drawdown
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # FIRST lock REACHABLE at +8% — forced-flow pops are modest + fade
+        - { trigger_pct: 8,  lock_hw_pct: 0  }
+        - { trigger_pct: 14, lock_hw_pct: 35 }
+        - { trigger_pct: 22, lock_hw_pct: 50 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 80 }
+
+# ── RISK guard rails (all durations in SECONDS) ──
+risk:
+  data_retention_seconds: 259200           # 72h (in [3600,604800])
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 3                  # index events are infrequent; turns over slowly
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 3600                  # post-loss cooldown 60m
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 21600       # 6h — one event per name, don't re-enter the same inclusion
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/barnacle/main/scanners/scan.py
+++ b/strategies/barnacle/main/scanners/scan.py
@@ -1,0 +1,318 @@
+"""BARNACLE — supervised scanner (net-new Runtime 3.0 index-inclusion front-runner).
+
+Config-driven EVENT universe — there is NO MCP feed for index-rebalance events, so
+the operator supplies them in `inputs.events` as a list of:
+    {asset, effectiveDate (ISO date / ISO datetime / epoch), side: "add"|"delete", index}
+The scan trades ONLY the names in `inputs.events`. The default events list is an
+EXAMPLE operators replace with the live rebalance schedule.
+
+Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum()),
+  - for each well-formed, not-yet-past, not-held, not-recently-signaled event whose
+    asset resolves on HL xyz: reads market_get_asset_data (dex="xyz", READ-GUARDED),
+    computes hours-to-effective-date,
+  - ADD -> LONG / DELETE -> SHORT (direction comes from the EVENT side, not price),
+  - emits ONLY while `now < effectiveDate - exitBufferHours` (default 24h) AND the
+    passive-anticipation signature confirms (4h trend in-direction + rising volume),
+  - sizes marginPct scaled UP by proximity to the date (closer = larger, base ->
+    max), leverage clamped to [1,5] and to the instrument venue max,
+  - once `now >= effectiveDate - exitBufferHours` it emits NOTHING for that event —
+    "sell into the inclusion": the DSL/exit owns the close before the rebalance.
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) + `leverage`; the
+runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit. No
+daemon, no push_signal, no create_position. Every ctx.senpi_mcp.call_tool is
+read-guarded (degrade, never crash the whole tick).
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# net-new defaults (an EXAMPLE events list — operators replace with the live schedule)
+_DEFAULT_EVENTS = [
+    {"asset": "xyz:SPCX", "effectiveDate": "2026-07-07",
+     "side": "add", "index": "russell+ndx100"},  # validated live vs HL xyz meta 2026-06-30
+]
+_DEFAULT_EXIT_BUFFER_HOURS = 24      # stop emitting (sell into the inclusion) this long before the date
+_DEFAULT_WINDOW_HOURS = 168          # 7d tradeable anticipation window before the date
+_DEFAULT_MARGIN_BASE = 12            # PERCENT at window start
+_DEFAULT_MARGIN_MAX = 20             # PERCENT near the exit buffer
+_DEFAULT_LEVERAGE = 4                # clamped to [1,5] and venue max
+_DEFAULT_MIN_VOL_TREND = 10          # 4h volume-trend floor for confirmation
+_DEFAULT_RECENT_TTL = 1800           # 30m signal-dedup (don't re-fire while in flight)
+_LEV_MIN = 1
+_LEV_MAX = 5
+
+
+def _dex_for(asset, inputs):
+    dex = inputs.get("dex")
+    if dex is not None:
+        return dex
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Includes the read-sanity guard (margin in use
+    + empty positions -> skip tick) to avoid re-entering held names off a corrupt
+    clearinghouse read."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[barnacle.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) or {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard: a corrupt clearinghouse read can report margin/notional IN
+    # USE while returning an EMPTY positions list; sizing or running the held-asset
+    # dedup off that re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[barnacle.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _asset_data(ctx, coin, dex):
+    """{candles_1h, candles_4h, venue_max} for `coin` or None. READ-GUARDED.
+    A failed read (transient/permission/not-listed) returns None -> the event is
+    skipped this tick rather than crashing the whole scan."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["1h", "4h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": dex,
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[barnacle.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    # venue max leverage if the read surfaces it (asset_context / top-level); else None
+    venue_max = None
+    actx = d.get("asset_context", d) if isinstance(d, dict) else {}
+    if isinstance(actx, dict):
+        venue_max = actx.get("max_leverage", d.get("max_leverage"))
+    return {
+        "candles_1h": candles.get("1h", []) or [],
+        "candles_4h": candles.get("4h", []) or [],
+        "venue_max": venue_max,
+    }
+
+
+# ── ctx.state: recent-signal dedup ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (fleet-standard bound)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    events = inputs.get("events", _DEFAULT_EVENTS)
+    exit_buffer_h = float(inputs.get("exitBufferHours", _DEFAULT_EXIT_BUFFER_HOURS))
+    window_h = float(inputs.get("windowHours", _DEFAULT_WINDOW_HOURS))
+    margin_base = float(inputs.get("marginPctBase", _DEFAULT_MARGIN_BASE))
+    margin_max = float(inputs.get("marginPctMax", _DEFAULT_MARGIN_MAX))
+    lev_cfg = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    min_vol_trend = float(inputs.get("minVolTrendPct", _DEFAULT_MIN_VOL_TREND))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    # marginPct PERCENT in (0,100]. Defensive fraction guard (fleet pattern): a
+    # value <= 1.0 is a pasted FRACTION (e.g. 0.12) -> *100.
+    if margin_base <= 1.0:
+        margin_base *= 100
+    if margin_max <= 1.0:
+        margin_max *= 100
+
+    if not isinstance(events, list) or not events:
+        print("[barnacle.scan] WAITING — no events in inputs.events (operator supplies "
+              "the rebalance schedule)", file=sys.stderr)
+        if ctx.state is not None:
+            try:
+                ctx.state.append({"signaled": _load_signaled(ctx),
+                                  "result": {"ts": now, "emitted": False, "note": "no events configured"}})
+            except Exception as exc:  # noqa: BLE001
+                print(f"[barnacle.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+        return []
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    candidates = []
+    scanned = 0
+    skipped = 0
+    for raw_ev in events:
+        ev = scoring.normalize_event(raw_ev)
+        if ev is None:
+            skipped += 1
+            print(f"[barnacle.scan] SKIP malformed event {raw_ev!r}", file=sys.stderr)
+            continue
+
+        coin = ev["asset"]
+        cu = coin.upper()
+        eff = ev["effectiveEpoch"]
+        side = ev["side"]
+        direction = scoring.direction_for_side(side)
+        hours_to_eff = (eff - now) / 3600.0
+
+        # past-date -> the rebalance has happened; nothing to front-run
+        if hours_to_eff <= 0:
+            skipped += 1
+            print(f"[barnacle.scan] SKIP past-date event {coin} (effective {eff:.0f}, "
+                  f"{hours_to_eff:.1f}h)", file=sys.stderr)
+            continue
+
+        # SELL INTO THE INCLUSION: once inside the exit buffer, emit nothing for this
+        # event — the DSL/exit owns the close before the rebalance completes.
+        if hours_to_eff <= exit_buffer_h:
+            print(f"[barnacle.scan] HOLD/EXIT-WINDOW {coin} {direction} — within exit buffer "
+                  f"({hours_to_eff:.1f}h <= {exit_buffer_h:.0f}h); no new entry", file=sys.stderr)
+            continue
+
+        # outside the tradeable anticipation window -> too early
+        if hours_to_eff > window_h:
+            print(f"[barnacle.scan] EARLY {coin} {direction} — {hours_to_eff:.1f}h to date "
+                  f"(> window {window_h:.0f}h)", file=sys.stderr)
+            continue
+
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+
+        scanned += 1
+        md = _asset_data(ctx, coin, _dex_for(coin, inputs))
+        if not md:
+            continue
+
+        ok, reasons, detail = scoring.anticipation_confirms(
+            direction, md["candles_4h"], md["candles_1h"], min_vol_trend)
+        if not ok:
+            print(f"[barnacle.scan] NO-CONFIRM {coin} {direction} — {reasons}", file=sys.stderr)
+            continue
+
+        margin_pct = scoring.proximity_margin_pct(
+            hours_to_eff, exit_buffer_h, margin_base, margin_max, window_h)
+        leverage = scoring.clamp_leverage(lev_cfg, _LEV_MIN, _LEV_MAX, md.get("venue_max"))
+
+        candidates.append({
+            "coin": coin, "direction": direction, "side": side,
+            "index": ev["index"], "effectiveEpoch": eff,
+            "hoursToEffective": round(hours_to_eff, 2),
+            "marginPct": round(margin_pct, 4), "leverage": leverage,
+            "reasons": reasons, "detail": detail,
+        })
+
+    out = []
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "skipped": skipped, "emitted": False,
+                  "held": held_assets, "note": "WAITING (no confirmed in-window event)"}
+        print(f"[barnacle.scan] WAITING — no confirmed in-window index event; "
+              f"scanned={scanned} skipped={skipped} held={held_assets}", file=sys.stderr)
+    else:
+        # emit the MOST IMMINENT confirmed event (smallest hours-to-date = strongest
+        # forced-flow proximity). One signal/tick keeps the book focused.
+        candidates.sort(key=lambda c: c["hoursToEffective"])
+        best = candidates[0]
+        signaled[best["coin"].upper()] = now
+        result = {"ts": now, "scanned": scanned, "skipped": skipped, "emitted": True,
+                  "coin": best["coin"], "direction": best["direction"], "side": best["side"],
+                  "index": best["index"], "hoursToEffective": best["hoursToEffective"],
+                  "marginPct": best["marginPct"], "leverage": best["leverage"],
+                  "held": held_assets, "reasons": best["reasons"]}
+        print(f"[barnacle.scan] EMIT {best['coin']} {best['direction']} ({best['side']} "
+              f"{best['index']}) {best['leverage']}x marginPct={best['marginPct']:.2f}% "
+              f"{best['hoursToEffective']:.1f}h-to-date | {best['reasons']}", file=sys.stderr)
+        out = [{
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": best["marginPct"],   # PERCENT in (0,100] — runtime sizes (marginPct/100)*withdrawable
+            "leverage": best["leverage"],     # clamped [1,5] + venue max; runtime applies it
+            "data": {
+                "side": best["side"],
+                "index": best["index"],
+                "direction": best["direction"],
+                "leverage": best["leverage"],
+                "hoursToEffective": best["hoursToEffective"],
+                "effectiveEpoch": best["effectiveEpoch"],
+                "trend4h": best["detail"].get("trend4h"),
+                "trend4hStrength": best["detail"].get("trend4hStrength"),
+                "trend1h": best["detail"].get("trend1h"),
+                "volTrend4hPct": best["detail"].get("volTrend4hPct"),
+                "reasons": best["reasons"],
+                "heldAssets": held_assets,
+            },
+        }]
+
+    # ── persist dedup map + this tick's result EVERY tick; bounded by
+    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[barnacle.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/barnacle/main/scanners/scoring.py
+++ b/strategies/barnacle/main/scanners/scoring.py
@@ -1,0 +1,267 @@
+"""BARNACLE — pure thesis math (no I/O, no MCP, no clock).
+
+Index-inclusion / passive-flow front-runner. NOT a port — this is a net-new
+Runtime 3.0 strategy. The math is original but the candle-accessor + trend +
+volume helpers follow the fleet gold-template idiom (bison/bobcat scoring.py) so a
+fidelity harness can diff structurally.
+
+THESIS. When a stock is announced for ADD to a major index (S&P 500 / Nasdaq-100 /
+Russell), index funds are FORCED to buy it by the rebalance effective date — a
+predictable passive-buying wave that lifts price INTO the date. Barnacle rides that
+anticipatory flow from detection up to ~the effective date and exits BEFORE the
+rebalance (the scan stops emitting once inside the exit buffer; the DSL/exit owns
+the close). DELETE events mirror as SHORTS (forced selling into the date).
+
+Every function here is pure and unit-testable on plain candle lists + plain event
+dicts. The scan layer (scan.py) supplies the wall clock, the account/held read,
+the per-asset candle read, and the ctx.state dedup. Direction comes from the EVENT
+side (add->LONG, delete->SHORT), NOT from price — the confirmation signature only
+gates WHETHER to ride and the proximity scaler only sizes it.
+"""
+
+import sys
+
+
+# ── numeric + candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── indicators (fleet-idiom: same trend_structure / volume_trend as bison/bobcat) ──
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Fleet-standard structure read
+    (strict > counting, >= total*0.6 gate; total = lookback-1). Strength is the
+    matching count / total; NEUTRAL -> 0.0."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-half vs earlier-half average volume, % change. Fleet-standard."""
+    if len(candles) < lookback + 2:
+        return 0.0
+    vols = [_vol(c) for c in candles[-(lookback + 2):]]
+    half = lookback // 2
+    if half <= 0:
+        return 0.0
+    recent = sum(vols[-half:]) / half
+    earlier = sum(vols[:half]) / half
+    if earlier == 0:
+        return 0.0
+    return ((recent - earlier) / earlier) * 100
+
+
+# ── event parsing ──
+
+def parse_effective_epoch(value):
+    """Coerce an event's `effectiveDate` to an epoch (seconds). Accepts:
+      - an ISO date "YYYY-MM-DD" (interpreted as 00:00:00 UTC of that day, the
+        rebalance effective open — see THESIS: forced buying completes by the
+        open of the effective date),
+      - an ISO datetime "YYYY-MM-DDTHH:MM:SS[Z]",
+      - an int/float/epoch-string (seconds since epoch).
+    Returns a float epoch, or None if it cannot be parsed (caller skips the event).
+    Pure: no wall clock is read here."""
+    if value is None:
+        return None
+    # numeric epoch (int/float, or a string of digits)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        # bare epoch string
+        try:
+            if s.replace(".", "", 1).isdigit():
+                return float(s)
+        except (TypeError, ValueError):
+            pass
+        # ISO date / datetime -> UTC epoch
+        from datetime import datetime, timezone
+        iso = s.replace("Z", "+00:00")
+        for fmt_try in (None,):  # use fromisoformat once; fall through on failure
+            try:
+                dt = datetime.fromisoformat(iso)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt.timestamp()
+            except ValueError:
+                break
+        # last resort: plain date
+        try:
+            dt = datetime.strptime(s, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def normalize_event(ev):
+    """Validate + normalize one config event dict. Returns a normalized dict
+      {asset, effectiveEpoch, side ('add'|'delete'), index} or None if malformed.
+    A malformed event (missing asset, unparseable date, unknown side) -> None so
+    the caller can skip-with-note. Pure."""
+    if not isinstance(ev, dict):
+        return None
+    asset = ev.get("asset")
+    if not asset or not isinstance(asset, str):
+        return None
+    side = str(ev.get("side", "add")).strip().lower()
+    if side not in ("add", "delete"):
+        return None
+    eff = parse_effective_epoch(ev.get("effectiveDate"))
+    if eff is None:
+        return None
+    return {
+        "asset": asset.strip(),
+        "effectiveEpoch": eff,
+        "side": side,
+        "index": str(ev.get("index", "")).strip(),
+    }
+
+
+def direction_for_side(side):
+    """add -> LONG (forced buying), delete -> SHORT (forced selling)."""
+    return "LONG" if side == "add" else "SHORT"
+
+
+# ── proximity-scaled margin (closer to the effective date = larger conviction) ──
+
+def proximity_margin_pct(hours_to_effective, exit_buffer_hours, base_pct, max_pct,
+                         window_hours):
+    """Scale margin PERCENT UP by proximity to the effective date.
+
+    At the START of the tradeable window (now == effectiveDate - window_hours) the
+    forced-flow thesis is youngest -> size at `base_pct`. As `now` approaches the
+    exit buffer (now -> effectiveDate - exit_buffer_hours) the passive wave is most
+    imminent -> size scales linearly toward `max_pct`. Clamped to [base, max].
+
+    `hours_to_effective` is (effectiveEpoch - now)/3600 (POSITIVE before the date).
+    The tradeable proximity band runs from window_hours down to exit_buffer_hours.
+    Returns a PERCENT in (0, 100]. Pure."""
+    base_pct = float(base_pct)
+    max_pct = float(max_pct)
+    if max_pct < base_pct:
+        max_pct = base_pct
+    span = float(window_hours) - float(exit_buffer_hours)   # width of the ramp band
+    if span <= 0:
+        return max_pct
+    # progress 0.0 at window start -> 1.0 at the exit buffer edge
+    elapsed = float(window_hours) - float(hours_to_effective)
+    progress = elapsed / span
+    if progress < 0.0:
+        progress = 0.0
+    if progress > 1.0:
+        progress = 1.0
+    return base_pct + (max_pct - base_pct) * progress
+
+
+def clamp_leverage(requested, lo=1, hi=5, venue_max=None):
+    """Clamp leverage to [lo, hi], then to the instrument's venue max if given.
+    Mirrors the fleet leverage-clamp idiom. Pure."""
+    try:
+        lev = int(requested)
+    except (TypeError, ValueError):
+        lev = lo
+    lev = max(lo, min(lev, hi))
+    if venue_max is not None:
+        try:
+            vm = int(venue_max)
+            if vm > 0:
+                lev = min(lev, vm)
+        except (TypeError, ValueError):
+            pass
+    return lev
+
+
+# ── confirmation signature: does passive-anticipation flow actually show up? ──
+
+def anticipation_confirms(direction, candles_4h, candles_1h, min_vol_trend):
+    """Confirm the passive-anticipation SIGNATURE before riding an event.
+
+    The forced-flow thesis is only worth riding if the market is already moving the
+    expected way INTO the date: a 4h trend in the event's direction AND rising 4h
+    volume (passive desks accumulating). 1h is a softer confirm used for the reason
+    string only. Returns (ok: bool, reasons: list[str], detail: dict). Pure.
+
+    For an ADD (LONG) we want BULLISH 4h structure + rising volume; for a DELETE
+    (SHORT) we want BEARISH 4h structure + rising volume (distribution)."""
+    reasons = []
+    detail = {}
+    if len(candles_4h) < 6:
+        return False, ["insufficient_4h_history"], detail
+
+    t4, s4 = trend_structure(candles_4h)
+    t1, _ = trend_structure(candles_1h) if len(candles_1h) >= 6 else ("NEUTRAL", 0.0)
+    vt4 = volume_trend(candles_4h)
+    detail = {"trend4h": t4, "trend4hStrength": round(s4, 4),
+              "trend1h": t1, "volTrend4hPct": round(vt4, 2)}
+
+    want = "BULLISH" if direction == "LONG" else "BEARISH"
+    if t4 != want:
+        reasons.append(f"4h_not_{want.lower()}_{t4.lower()}")
+        return False, reasons, detail
+    reasons.append(f"4h_{t4.lower()}_{s4:.0%}")
+
+    if vt4 < float(min_vol_trend):
+        reasons.append(f"vol_flat_{vt4:+.0f}%")
+        return False, reasons, detail
+    reasons.append(f"vol_rising_{vt4:+.0f}%")
+
+    if (direction == "LONG" and t1 == "BULLISH") or (direction == "SHORT" and t1 == "BEARISH"):
+        reasons.append(f"1h_confirms_{t1.lower()}")
+
+    return True, reasons, detail
+
+
+def _note(msg):
+    """One-line stderr note helper (kept here so scan stays terse)."""
+    print(f"[barnacle.scoring] {msg}", file=sys.stderr)

--- a/strategies/barnacle/strategy.yaml
+++ b/strategies/barnacle/strategy.yaml
@@ -1,0 +1,46 @@
+# Barnacle — Index-inclusion / passive-flow front-runner. A single-instance PACKAGE:
+# this manifest + one self-contained runtime.yaml + scanners/. A NET-NEW Runtime 3.0
+# strategy (NOT a port). Thesis: when a stock is announced for ADD to a major index
+# (S&P 500 / Nasdaq-100 / Russell), index funds are FORCED to buy it by the rebalance
+# effective date — a predictable passive-buying wave that lifts price INTO the date.
+# Barnacle rides that flow on Hyperliquid XYZ equity perps and EXITS before the
+# rebalance (the pop fades once forced buying completes); DELETE events mirror as
+# shorts. The universe is CONFIG-DRIVEN (inputs.events) — there is no MCP feed for
+# index rebalances. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: barnacle
+version: "1.0.0"
+
+catalog:
+  name: "Barnacle — Index-Inclusion Front-Runner"
+  emoji: "🦪"
+  tagline: "Front-runs index-rebalance flow on Hyperliquid XYZ equity perps: when a stock is announced for addition to the S&P 500 / Nasdaq-100 / Russell, index funds are FORCED to buy it by the effective date — Barnacle rides that predictable passive-buying wave into the date and sells into the inclusion before the rebalance completes. Index deletions mirror as shorts."
+  belief_plain: "When a company is announced for addition to a big index like the S&P 500, every index fund has to buy it before a set date — that forced buying reliably lifts the price into the date. Barnacle gets in early on the stock (as a perp on Hyperliquid XYZ), rides the run-up, and gets out just before the rebalance, because the pop usually fades once the forced buying is done. Index removals work the same way in reverse, as shorts. You give it the list of upcoming index changes; it trades only those names."
+  thesis: "Index-inclusion is one of the most-documented predictable flows in equities: passive funds tracking the S&P 500 / Nasdaq-100 / Russell MUST buy an added name by the rebalance effective date, regardless of price, producing an anticipatory run-up that front-runners capture and that fades after the forced buying completes. Hyperliquid XYZ lists these equities as leveraged perps, so the flow is tradeable both directions (additions long, deletions short). There is no market data feed for index events, so the universe is operator-supplied (inputs.events); the agent only trades the configured names, only inside the anticipation window, only when the passive-flow signature confirms, and it deliberately exits BEFORE the effective date rather than holding through the rebalance."
+  group: event-driven
+  archetype: event_driven
+  sub_style: index_inclusion
+  asset_classes: [xyz_equities]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 3
+  min_budget: 200
+  assets: ["xyz:SPCX"]
+  tags: [index-inclusion, index-rebalance, passive-flow, front-running, sp500, nasdaq100, russell, event-driven, xyz, equities, long-short, calendar]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: BARNACLE_WALLET
+    funding_share: 1.0

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -439,6 +439,55 @@
       "sort_order": 1
     },
     {
+      "id": "barnacle",
+      "name": "Barnacle — Index-Inclusion Front-Runner",
+      "emoji": "🦪",
+      "tagline": "Front-runs index-rebalance flow on Hyperliquid XYZ equity perps: when a stock is announced for addition to the S&P 500 / Nasdaq-100 / Russell, index funds are FORCED to buy it by the effective date — Barnacle rides that predictable passive-buying wave into the date and sells into the inclusion before the rebalance completes. Index deletions mirror as shorts.",
+      "belief_plain": "When a company is announced for addition to a big index like the S&P 500, every index fund has to buy it before a set date — that forced buying reliably lifts the price into the date. Barnacle gets in early on the stock (as a perp on Hyperliquid XYZ), rides the run-up, and gets out just before the rebalance, because the pop usually fades once the forced buying is done. Index removals work the same way in reverse, as shorts. You give it the list of upcoming index changes; it trades only those names.",
+      "version": "1.0.0",
+      "thesis": "Index-inclusion is one of the most-documented predictable flows in equities: passive funds tracking the S&P 500 / Nasdaq-100 / Russell MUST buy an added name by the rebalance effective date, regardless of price, producing an anticipatory run-up that front-runners capture and that fades after the forced buying completes. Hyperliquid XYZ lists these equities as leveraged perps, so the flow is tradeable both directions (additions long, deletions short). There is no market data feed for index events, so the universe is operator-supplied (inputs.events); the agent only trades the configured names, only inside the anticipation window, only when the passive-flow signature confirms, and it deliberately exits BEFORE the effective date rather than holding through the rebalance.",
+      "tags": [
+        "index-inclusion",
+        "index-rebalance",
+        "passive-flow",
+        "front-running",
+        "sp500",
+        "nasdaq100",
+        "russell",
+        "event-driven",
+        "xyz",
+        "equities",
+        "long-short",
+        "calendar"
+      ],
+      "group": "event-driven",
+      "archetype": "event_driven",
+      "archetype_label": "Event-Driven",
+      "sub_style": "index_inclusion",
+      "sub_style_label": "Front-runs index additions/deletions for the forced passive-fund flow into the rebalance effective date.",
+      "asset_classes": [
+        "xyz_equities"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:SPCX"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 900,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 1
+    },
+    {
       "id": "magpie",
       "name": "Magpie — IPO / New-Listing Event Fund",
       "emoji": "🐦",
@@ -483,7 +532,7 @@
       ],
       "max_slots": 6,
       "branch": "strategy-v2",
-      "sort_order": 1
+      "sort_order": 2
     },
     {
       "id": "elephant",
@@ -897,6 +946,73 @@
       "sort_order": 6
     },
     {
+      "id": "hornet",
+      "name": "Hornet — Semiconductor Supply-Chain Momentum",
+      "emoji": "🐝",
+      "tagline": "A semiconductor / AI-capex supply-chain momentum basket on Hyperliquid XYZ (equipment ASML/AMAT/MRVL, logic NVDA/AMD/AVGO/TSM/QCOM/ARM/INTC/SMH, memory MU/SNDK/SMSN/SKHX/WDC): it only trades when the whole chain confirms as a complex — a sector-breadth gate flips it long-only when most names trend up and short-only when the chain rolls over — then rides the strongest 1-2 names, with an extra edge when the equipment makers lead the move. Flat 18% margin / 4x, wide DSL ratchet capped at 48h so it never camps through the weekend pricing gap.",
+      "belief_plain": "Trades the semiconductor supply chain — the chip designers, the memory makers, and the equipment companies that build the factories — as perps on Hyperliquid XYZ, 23/5. AI spending bids the whole chain together, so Hornet refuses to trade single names in isolation: it first checks whether the sector as a whole is trending up or down, and only then takes the strongest 1-2 names in that direction. It pays special attention when the equipment makers move first, since that tends to lead the cycle. It trails a wide stop so a real move can run, but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
+      "version": "1.0.0",
+      "thesis": "AI capex doesn't bid one chip name — it bids the entire semiconductor supply chain: equipment makers (ASML, AMAT, MRVL), logic/compute (NVDA, AMD, AVGO, TSM, QCOM, ARM, INTC, SMH), and memory (MU, SNDK, SMSN, SKHX, WDC). A per-name momentum agent can get chopped up taking a single semi that's moving on idiosyncratic news against a flat sector. Hornet's edge is that it requires the chain to confirm as a complex first — a sector-breadth gate (the fraction of the universe whose 4h trend is bullish) flips the agent long-only above 0.55 and short-only below 0.35, and emits nothing in the chop band between. Within an open gate it rides the strongest 1-2 names and adds conviction when the equipment sub-group leads (capex tools bid first, then logic and memory — the classic early-cycle gradient). The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap where drift accumulates without external price discovery.",
+      "tags": [
+        "semiconductors",
+        "ai-capex",
+        "supply-chain",
+        "sector-breadth",
+        "equities",
+        "xyz",
+        "nvda",
+        "asml",
+        "tsm",
+        "momentum",
+        "smart-money",
+        "basket",
+        "long-short",
+        "advanced",
+        "23-5"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "sector_momentum",
+      "sub_style_label": "Rides a whole sector / supply chain only when its breadth confirms; won't chase a lone name.",
+      "asset_classes": [
+        "xyz_equities"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:ASML",
+        "xyz:AMAT",
+        "xyz:MRVL",
+        "xyz:NVDA",
+        "xyz:AMD",
+        "xyz:AVGO",
+        "xyz:TSM",
+        "xyz:QCOM",
+        "xyz:ARM",
+        "xyz:INTC",
+        "xyz:SMH",
+        "xyz:MU",
+        "xyz:SNDK",
+        "xyz:SMSN",
+        "xyz:SKHX",
+        "xyz:WDC"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 7
+    },
+    {
       "id": "lemur",
       "name": "Lemur — Pre-IPO Perpetual Trend Follower",
       "emoji": "🦤",
@@ -940,7 +1056,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 7
+      "sort_order": 8
     },
     {
       "id": "lynx",
@@ -991,7 +1107,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 8
+      "sort_order": 9
     },
     {
       "id": "meerkat",
@@ -1035,7 +1151,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "orca",
@@ -1078,7 +1194,7 @@
       ],
       "max_slots": 3,
       "branch": "strategy-v2",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "otter",
@@ -1122,7 +1238,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "piranha",
@@ -1174,7 +1290,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "python",
@@ -1218,7 +1334,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "sailfish",
@@ -1268,7 +1384,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "salamander",
@@ -1318,7 +1434,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 15
+      "sort_order": 16
     },
     {
       "id": "sheep",
@@ -1371,7 +1487,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 16
+      "sort_order": 17
     },
     {
       "id": "jaguar",

--- a/strategies/hornet/main/runtime.yaml
+++ b/strategies/hornet/main/runtime.yaml
@@ -1,0 +1,170 @@
+# ── HORNET · single instance — semiconductor / AI-capex supply-chain momentum ──
+# Net-new Runtime 3.0 strategy (NOT a port). A 16-name semis basket on Hyperliquid
+# XYZ (HIP-3 DEX) grouped into supply-chain sub-groups (equipment / logic / memory).
+# THE EDGE: requires the SECTOR to confirm as a COMPLEX before taking any name —
+# "the chain bids together or not at all." A cross-asset BREADTH GATE (fraction of
+# the universe whose 4h trend is bullish) decides LONG-only / SHORT-only / WAIT;
+# only then are names scored in the gate direction. Flat 18% margin / 4x. DSL exits
+# — Phase 1 15% max_loss, Phase 2 wide ladder, hard_timeout 48h (equity perps have
+# a weekend pricing gap). Every market read passes dex="xyz".
+name: hornet-main
+group: hornet
+version: 1.0.0
+description: >
+  HORNET — semiconductor / AI-capex supply-chain momentum on Hyperliquid XYZ. A
+  16-name semis basket grouped into equipment (ASML/AMAT/MRVL), logic (NVDA/AMD/
+  AVGO/TSM/QCOM/ARM/INTC/SMH) and memory (MU/SNDK/SMSN/SKHX/WDC). The edge over a
+  per-name momentum agent: it requires the sector to confirm as a complex first.
+  Each tick it computes sector breadth (fraction of the universe whose 4h trend is
+  bullish) and applies a breadth gate: breadth >= 0.55 -> only LONGs eligible;
+  breadth <= 0.35 -> only SHORTs eligible; chop in between -> emit nothing. Eligible
+  names are scored in the gate direction (base 3 + 4h trend + 1h confirm + |momentum|
+  tier + smart-money agreement + a supply-chain-gradient bonus when the equipment
+  sub-group leads — early-cycle confirmation); floor minScore 5. Emits the top 1-2.
+  Flat sizing 18% margin / 4x. DSL is the ONLY exit — Phase 1 15% max_loss, Phase 2
+  wide ladder (first lock at +10% ROE), hard_timeout 48h (equity perps reconcile
+  against an internal oracle over the Fri-Sun gap where drift accumulates).
+
+strategy:
+  wallet: "${HORNET_WALLET}"
+  slots: 3
+  margin_pct: 18                          # baseline %; scan emits the flat marginPct per signal
+  default_leverage: 4                     # fallback; scan emits 4x (clamped [1,5]) per signal
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: hornet_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # 5-min cadence
+    timeout_seconds: 240                   # ~1 candle read/name (16) + per-candidate SM + account
+    default_signal_validity_seconds: 600   # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
+    inputs:
+      universe: ["xyz:ASML", "xyz:AMAT", "xyz:MRVL", "xyz:NVDA", "xyz:AMD", "xyz:AVGO", "xyz:TSM", "xyz:QCOM", "xyz:ARM", "xyz:INTC", "xyz:SMH", "xyz:MU", "xyz:SNDK", "xyz:SMSN", "xyz:SKHX", "xyz:WDC"]  # validated live vs HL xyz meta 2026-06-30
+      subGroups:                           # name -> supply-chain sub-group (drives the gradient bonus)
+        "xyz:ASML": equipment
+        "xyz:AMAT": equipment
+        "xyz:MRVL": equipment
+        "xyz:NVDA": logic
+        "xyz:AMD": logic
+        "xyz:AVGO": logic
+        "xyz:TSM": logic
+        "xyz:QCOM": logic
+        "xyz:ARM": logic
+        "xyz:INTC": logic
+        "xyz:SMH": logic
+        "xyz:MU": memory
+        "xyz:SNDK": memory
+        "xyz:SMSN": memory
+        "xyz:SKHX": memory
+        "xyz:WDC": memory
+      dex: "xyz"                           # HIP-3 DEX — xyz: prefix mandatory on every read
+      minScore: 5                          # per-name score floor
+      longBreadthPct: 0.55                 # breadth >= -> LONG-only eligible (the core gate)
+      shortBreadthPct: 0.35                # breadth <= -> SHORT-only eligible
+      momStrongPct: 1.0                    # |1h momentum| tier: strong (+2)
+      momModeratePct: 0.5                  # |1h momentum| tier: moderate (+1)
+      marginPctBase: 18                    # PERCENT of withdrawable (0,100]; flat
+      leverage: 4                          # clamped to [1,5] in scan.py
+      maxEmit: 2                           # emit the top 1-2 by score
+      recentSignalTtlSeconds: 240          # race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      subGroup: { type: string, required: false }
+      reasons: { type: array, required: false }
+      sectorBreadth: { type: number, required: false }
+      gateDir: { type: string, required: false }
+      equipmentLeading: { type: boolean, required: false }
+      trend4h: { type: string, required: false }
+      trend4hStrength: { type: number, required: false }
+      trend1h: { type: string, required: false }
+      momentum1hPct: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: hornet_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied breadth gate + scoring + dedup
+    scanners: [hornet_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # momentum entries must fill — maker-only rests unfilled (CREATE_ORDER_RESTING)
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: hornet_main_signals
+
+# ── EXIT (DSL — the ONLY exit) ────────────────────────────────────────────────
+# Equity two-phase shape (matches bobcat): Phase 1 max_loss 15% + retrace 8; Phase 2
+# wide-by-design ladder (T0 +10%/lock 0 through T5 +100%/lock 85) so a real sector
+# move rides multi-day; weak_peak_cut + dead_weight_cut DISABLED. hard_timeout ENABLED
+# at 48h (2880 min) — INTENTIONAL for equities: the post-Friday-close -> pre-Sunday-
+# reopen window is where internal-oracle drift accumulates without external price
+# discovery, so positions must not camp through the full gap.
+# order_type FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST happen). interval 60s
+# (REDUCE_ONLY-spam mitigation when runtime position state lags HL).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # exit closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 30
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # 48h cap — equities have weekend pricing gaps
+      interval_in_minutes: 2880
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # wide-by-design; FIRST lock at +10% ROE
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (minutes/hours -> seconds) ──
+risk:
+  data_retention_seconds: 259200           # 72h (in [3600,604800])
+  guard_rails:
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 4
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 3600                  # 60m post-loss cooldown
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400       # 4h per-asset cooldown
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/hornet/main/scanners/scan.py
+++ b/strategies/hornet/main/scanners/scan.py
@@ -1,0 +1,411 @@
+"""HORNET — supervised scanner (net-new Runtime 3.0 strategy).
+
+Semiconductor / AI-capex supply-chain momentum on Hyperliquid XYZ (HIP-3 DEX).
+A 16-name semis basket grouped into three supply-chain sub-groups:
+  equipment  — xyz:ASML, xyz:AMAT, xyz:MRVL
+  logic      — xyz:NVDA, xyz:AMD, xyz:AVGO, xyz:TSM, xyz:QCOM, xyz:ARM, xyz:INTC, xyz:SMH
+  memory     — xyz:MU, xyz:SNDK, xyz:SMSN, xyz:SKHX, xyz:WDC
+
+THE EDGE — the chain bids together or not at all. Per tick Hornet:
+  1. reads account state + held positions (dual-DEX equity via max(), never sum(),
+     with the fleet-standard read-sanity guard),
+  2. reads each universe name's 4h+1h candles (READ-GUARDED — a name that fails to
+     read is simply skipped, both from breadth and from scoring),
+  3. computes SECTOR BREADTH = fraction of the universe whose 4h trend is bullish
+     (strict higher-lows, bobcat/scoring.trend_structure),
+  4. applies the BREADTH GATE (the core edge):
+        breadth >= longBreadthPct  (default 0.55) -> only LONGs eligible
+        breadth <= shortBreadthPct (default 0.35) -> only SHORTs eligible
+        otherwise (chop)                          -> emit NOTHING (WAITING),
+  5. scores each eligible name in the breadth direction (base 3 + 4h-trend +
+     1h-confirm + |momentum| tier + smart-money agreement + supply-chain-gradient
+     bonus), floors via minScore,
+  6. emits the TOP 1-2 by score, with held-asset + recent-signal dedup via ctx.state
+     (240s TTL).
+
+Read-only + single-pass — emits `marginPct` (PERCENT) + `leverage` intents; the
+runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit. No
+daemon, no push_signal, no create_position.
+
+XYZ notes (xyz-equity DEX handling, matching bobcat):
+  - every asset is xyz:NAME and EVERY market read passes dex="xyz" (the prefix is
+    mandatory for the HIP-3 DEX),
+  - 23/5 trading; the 48h hard_timeout (runtime.yaml) caps holds across the weekend
+    pricing gap. No scan-level market-hours gate.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# ── universe + sub-group tags (validated live vs HL xyz meta 2026-06-30) ──
+# Sub-group tags drive the supply-chain-gradient bonus. Config-overridable via
+# inputs.universe (a flat list of xyz: tickers); inputs.subGroups (optional) can
+# override the name->group map. Anything not in the map defaults to "logic".
+_DEFAULT_UNIVERSE = [
+    # equipment
+    "xyz:ASML", "xyz:AMAT", "xyz:MRVL",
+    # logic
+    "xyz:NVDA", "xyz:AMD", "xyz:AVGO", "xyz:TSM", "xyz:QCOM", "xyz:ARM", "xyz:INTC", "xyz:SMH",
+    # memory
+    "xyz:MU", "xyz:SNDK", "xyz:SMSN", "xyz:SKHX", "xyz:WDC",
+]
+_DEFAULT_SUB_GROUPS = {
+    "xyz:ASML": "equipment", "xyz:AMAT": "equipment", "xyz:MRVL": "equipment",
+    "xyz:NVDA": "logic", "xyz:AMD": "logic", "xyz:AVGO": "logic", "xyz:TSM": "logic",
+    "xyz:QCOM": "logic", "xyz:ARM": "logic", "xyz:INTC": "logic", "xyz:SMH": "logic",
+    "xyz:MU": "memory", "xyz:SNDK": "memory", "xyz:SMSN": "memory",
+    "xyz:SKHX": "memory", "xyz:WDC": "memory",
+}
+
+_DEFAULT_MIN_SCORE = 5
+_DEFAULT_LONG_BREADTH = 0.55       # breadth >= this -> LONG-only eligible
+_DEFAULT_SHORT_BREADTH = 0.35      # breadth <= this -> SHORT-only eligible
+_DEFAULT_MARGIN_PCT = 18           # flat marginPct base (PERCENT)
+_DEFAULT_LEVERAGE = 4
+_MIN_LEVERAGE = 1
+_MAX_LEVERAGE = 5
+_DEFAULT_MAX_EMIT = 2              # emit the top 1-2 by score
+_DEFAULT_RECENT_TTL = 240         # race-window dedup (seconds)
+
+
+def _dex_for(asset, inputs):
+    """XYZ (HIP-3) names must pass dex="xyz"; this whole universe is xyz."""
+    dex = inputs.get("dex")
+    if dex is not None:
+        return dex
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
+    enumerated across both sections. Includes the fleet-standard read-sanity guard
+    (margin in use + empty positions -> skip tick) to avoid re-entering held names."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[hornet.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) or {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring._f(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring._f(pos.get("marginUsed", 0))})
+
+    # read-sanity guard (funding/$0 glitch family): a corrupt clearinghouse read
+    # can report margin/notional IN USE while returning an EMPTY positions list;
+    # sizing or running held-asset dedup off that re-enters held names (pyramiding)
+    # and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring._f(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring._f(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[hornet.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _get_sm_direction(ctx, coin):
+    """Net smart-money lean for `coin` from leaderboard_get_markets. Returns
+    (direction, tilt_pct) or (None, 0.0). READ-GUARDED -> degrades to neutral
+    on failure (smart-money is a score CONTRIBUTOR here, never a hard gate).
+
+    Thresholds (bobcat-consistent): long_ratio >= 50 -> (LONG, long_ratio); else
+    -> (SHORT, 100 - long_ratio); total <= 0 -> (NEUTRAL, 50.0); not-found ->
+    (None, 0.0). Token match is case-insensitive on the full xyz: name."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("leaderboard_get_markets", {})
+    except Exception as exc:  # noqa: BLE001 — never crash the tick; degrade to neutral
+        print(f"[hornet.scan] leaderboard_get_markets read failed (smart-money -> neutral): {exc!r}",
+              file=sys.stderr)
+        return None, 0.0
+    if not raw or (isinstance(raw, dict) and raw.get("success") is False):
+        return None, 0.0
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    long_pct, short_pct, found = 0.0, 0.0, False
+    cu = coin.upper()
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token != cu:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100
+    if long_ratio >= 50:
+        return "LONG", long_ratio
+    return "SHORT", 100 - long_ratio
+
+
+def _asset_data(ctx, coin, dex):
+    """{candles_1h, candles_4h} for `coin` or None. READ-GUARDED — a name that
+    fails to read is dropped from BOTH breadth and scoring (so a flaky read can
+    only soften the gate, never fabricate a signal)."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin,
+            "candle_intervals": ["1h", "4h"],
+            "include_funding": False,
+            "include_order_book": False,
+            "dex": dex,
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[hornet.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    return {"candles_1h": candles.get("1h", []) or [], "candles_4h": candles.get("4h", []) or []}
+
+
+# ── ctx.state: recent-signal dedup ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(coin.upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    universe = inputs.get("universe", _DEFAULT_UNIVERSE)
+    sub_groups = inputs.get("subGroups", _DEFAULT_SUB_GROUPS)
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    long_breadth = float(inputs.get("longBreadthPct", _DEFAULT_LONG_BREADTH))
+    short_breadth = float(inputs.get("shortBreadthPct", _DEFAULT_SHORT_BREADTH))
+    lev_cfg = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
+    max_emit = int(inputs.get("maxEmit", _DEFAULT_MAX_EMIT))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    # marginPct: PERCENT in (0,100]. Defensive fraction guard (bobcat/dire/koala
+    # pattern): a value <= 1.0 is a pasted FRACTION (e.g. 0.18) -> *100 -> 18.
+    margin_pct = float(inputs.get("marginPctBase", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        margin_pct = margin_pct * 100
+
+    # leverage: clamp to [1,5].
+    leverage = min(lev_cfg, _MAX_LEVERAGE)
+    leverage = max(leverage, _MIN_LEVERAGE)
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── read every name's candles ONCE (READ-GUARDED). Breadth and scoring both
+    #    consume this single map; a name that fails to read is absent from both. ──
+    trends = {}     # coin -> (trend_4h, market_dict)
+    scanned = 0
+    for coin in universe:
+        if not coin:
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin, _dex_for(coin, inputs))
+        if not md:
+            continue
+        t4, _ = scoring.trend_structure(md["candles_4h"])
+        trends[coin] = (t4, md)
+
+    if not trends:
+        result = {"ts": now, "scanned": scanned, "emitted": False,
+                  "held": held_assets, "note": "WAITING (no readable names)"}
+        print(f"[hornet.scan] WAITING — no readable universe names; scanned={scanned}",
+              file=sys.stderr)
+        _persist(ctx, signaled, result)
+        return []
+
+    n_read = len(trends)
+
+    # ── SECTOR BREADTH = fraction of READABLE names whose 4h trend is bullish ──
+    n_bull = sum(1 for (t4, _) in trends.values() if t4 == "BULLISH")
+    n_bear = sum(1 for (t4, _) in trends.values() if t4 == "BEARISH")
+    breadth = n_bull / n_read if n_read else 0.0
+
+    # ── BREADTH GATE (the core edge): the chain bids together or not at all ──
+    if breadth >= long_breadth:
+        gate_dir = "LONG"
+    elif breadth <= short_breadth:
+        gate_dir = "SHORT"
+    else:
+        gate_dir = None  # chop — emit nothing this tick
+
+    # ── supply-chain gradient: is the EQUIPMENT sub-group leading the complex? ──
+    # "leading" = the equipment sub-group's directional breadth (in the gate
+    # direction) is STRICTLY GREATER than the whole-universe directional breadth —
+    # i.e. capex tools are bidding/rolling ahead of logic+memory. Early-cycle
+    # confirmation -> +1 per name (applied in scoring.build_thesis).
+    equipment_leading = False
+    if gate_dir is not None:
+        eq_total, eq_match = 0, 0
+        for coin, (t4, _) in trends.items():
+            if sub_groups.get(coin) != "equipment":
+                continue
+            eq_total += 1
+            if (gate_dir == "LONG" and t4 == "BULLISH") or (gate_dir == "SHORT" and t4 == "BEARISH"):
+                eq_match += 1
+        if eq_total > 0:
+            eq_breadth = eq_match / eq_total
+            whole_dir_breadth = (n_bull / n_read) if gate_dir == "LONG" else (n_bear / n_read)
+            equipment_leading = eq_breadth > whole_dir_breadth
+
+    out = []
+    if gate_dir is None:
+        result = {"ts": now, "scanned": scanned, "readable": n_read,
+                  "breadth": round(breadth, 3), "emitted": False, "held": held_assets,
+                  "note": f"WAITING (breadth {breadth:.2f} in chop band "
+                          f"[{short_breadth:.2f},{long_breadth:.2f}])"}
+        print(f"[hornet.scan] WAITING — sector breadth {breadth:.2f} in chop band "
+              f"[{short_breadth:.2f},{long_breadth:.2f}]; bull={n_bull} bear={n_bear} "
+              f"read={n_read} held={held_assets}", file=sys.stderr)
+        _persist(ctx, signaled, result)
+        return out
+
+    # ── score each eligible name in the gate direction (held + recently-signaled
+    #    filtered out; smart-money fetched per candidate, read-guarded) ──
+    candidates = []
+    for coin, (t4, md) in trends.items():
+        cu = coin.upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        sm = _get_sm_direction(ctx, coin)
+        th = scoring.build_thesis(
+            coin, sub_groups.get(coin, "logic"),
+            md["candles_1h"], md["candles_4h"], gate_dir,
+            sm, equipment_leading, inputs,
+        )
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    if not candidates:
+        result = {"ts": now, "scanned": scanned, "readable": n_read,
+                  "breadth": round(breadth, 3), "gateDir": gate_dir,
+                  "emitted": False, "held": held_assets,
+                  "note": f"WAITING (gate {gate_dir} open, no name >= min score {min_score:.0f})"}
+        print(f"[hornet.scan] WAITING — breadth gate {gate_dir} OPEN (breadth {breadth:.2f}) "
+              f"but no name cleared min score {min_score:.0f}; read={n_read} "
+              f"equipment_leading={equipment_leading} held={held_assets}", file=sys.stderr)
+        _persist(ctx, signaled, result)
+        return out
+
+    # ── emit the top 1-2 by score ──
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    chosen = candidates[:max(1, max_emit)]
+
+    for best in chosen:
+        signaled[best["coin"].upper()] = now
+        out.append({
+            "asset": best["coin"],
+            "direction": best["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes (marginPct/100)*withdrawable
+            "leverage": leverage,             # flat, clamped [1,5]; runtime applies it
+            "data": {
+                "score": best["score"],
+                "leverage": leverage,
+                "direction": best["direction"],
+                "subGroup": best["sub_group"],
+                "reasons": best["reasons"],
+                "sectorBreadth": round(breadth, 4),
+                "gateDir": gate_dir,
+                "equipmentLeading": best["equipment_leading"],
+                "trend4h": best["trend_4h"],
+                "trend4hStrength": best["trend_4h_strength"],
+                "trend1h": best["trend_1h"],
+                "momentum1hPct": best["momentum_1h"],
+                "smDirection": best["sm_direction"] or "NEUTRAL",
+                "smTiltPct": best["sm_tilt_pct"],
+                "heldAssets": held_assets,
+            },
+        })
+
+    emitted = [(c["coin"], c["direction"], c["score"]) for c in chosen]
+    result = {"ts": now, "scanned": scanned, "readable": n_read,
+              "breadth": round(breadth, 3), "gateDir": gate_dir,
+              "equipmentLeading": equipment_leading, "emitted": True,
+              "emit": emitted, "held": held_assets}
+    print(f"[hornet.scan] EMIT {gate_dir} x{len(chosen)} (breadth {breadth:.2f}, "
+          f"equipment_leading={equipment_leading}) {emitted} marginPct={margin_pct:.2f}% "
+          f"{leverage}x held={held_assets}", file=sys.stderr)
+    _persist(ctx, signaled, result)
+    return out
+
+
+def _persist(ctx, signaled, result):
+    """Persist dedup map + this tick's result EVERY tick; bounded by
+    state_history_max_count. Read back via ctx.state.recent(n)."""
+    if ctx.state is None:
+        return
+    try:
+        ctx.state.append({"signaled": signaled, "result": result})
+    except Exception as exc:  # noqa: BLE001
+        print(f"[hornet.scan] WARNING: state append failed; next tick may re-emit "
+              f"a suppressed signal: {exc!r}", file=sys.stderr)

--- a/strategies/hornet/main/scanners/scoring.py
+++ b/strategies/hornet/main/scanners/scoring.py
@@ -1,0 +1,179 @@
+"""HORNET — pure thesis math (no I/O, no MCP, no clock).
+
+Net-new Runtime 3.0 strategy: semiconductor / AI-capex supply-chain momentum.
+Thesis: AI capex bids the WHOLE semiconductor supply chain. Hornet's edge over a
+per-name momentum agent (bobcat) is that it requires the SECTOR to confirm as a
+complex before taking ANY name — "the chain bids together or not at all." The
+cross-asset BREADTH GATE lives in scan.py (it is a property of the whole universe,
+not of one candle list). This module stays pure: it holds the per-name candle
+indicators (trend structure, momentum) and the per-name scorer, both unit-testable
+on plain candle lists.
+
+Structurally Hornet is a HYBRID of the two gold templates:
+  - it reuses bobcat's `trend_structure` (strict higher-lows / lower-highs, the
+    `>= total * 0.6` BULLISH/BEARISH gate) so sector-breadth (computed in scan.py
+    by counting bullish 4h trends across the universe) and the per-name 4h-trend
+    score use ONE consistent definition;
+  - like bison, the per-name signals are SCORE CONTRIBUTORS, not hard gates — the
+    direction is already fixed by the breadth gate (scan.py decides LONG-only or
+    SHORT-only this tick), so build_thesis scores conviction FOR that direction and
+    floors via the caller's minScore.
+
+The supply-chain-gradient bonus (+1 when the EQUIPMENT sub-group is leading the
+complex — early-cycle confirmation) is also a cross-group property, so scan.py
+computes the boolean and passes it in; build_thesis just applies the +1.
+"""
+
+
+# ── candle accessors (dual-key dict {high|h}/{low|l}/{close|c}; HL xyz candles
+#    use the short keys o/c/h/l/v — see market_get_asset_data response shape) ──
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _ck(c, primary, alt=None, default=0.0):
+    """Read `primary`, fall back to `alt`, coerce to float. Mirrors bobcat's
+    candle field accessor so the trend math is byte-for-byte consistent with the
+    breadth computation in scan.py."""
+    if not isinstance(c, dict):
+        return default
+    val = c.get(primary)
+    if val is None and alt:
+        val = c.get(alt)
+    return _f(val if val is not None else default, default)
+
+
+def _close(c):
+    return _ck(c, "close", "c")
+
+
+# ── indicators ──
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH (bobcat-consistent).
+
+    Strict (>) for higher-lows / lower-highs counting; the BULLISH/BEARISH gate is
+    `>= total * 0.6` where total = lookback - 1. Strength returned is
+    higher_lows/total (BULLISH) or lower_highs/total (BEARISH); NEUTRAL -> 0.0.
+    This is the SAME definition scan.py uses to count sector breadth, so a name
+    that contributes to bullish breadth also scores its 4h-trend component."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_ck(c, "low", "l") for c in candles[-lookback:]]
+    highs = [_ck(c, "high", "h") for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def price_momentum(candles, n_bars=1):
+    """% change over the last n_bars closes (bison-consistent)."""
+    if len(candles) < n_bars + 1:
+        return 0.0
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    if old == 0:
+        return 0.0
+    return ((new - old) / old) * 100
+
+
+# ── the per-name thesis (direction fixed by the breadth gate; this scores
+#    conviction FOR that direction) ──
+
+def build_thesis(coin, sub_group, candles_1h, candles_4h, direction,
+                 sm, equipment_leading, inputs):
+    """Score one eligible name in the breadth-gate direction. Returns a thesis
+    dict (with `score`) or None.
+
+    None is returned ONLY when there is insufficient candle history
+    (len(c4h) < 6 or len(c1h) < 6). Unlike bobcat there is no per-name trend GATE
+    here: the breadth gate in scan.py has already decided the direction for the
+    whole complex, so a name can be taken even if its own 4h trend lags slightly —
+    the gradient bonus + 1h confirmation differentiate conviction. minScore is
+    applied by the CALLER (scan.py).
+
+    Args:
+      coin              the xyz: ticker.
+      sub_group         "equipment" | "logic" | "memory" (informational + reasons).
+      direction         "LONG" or "SHORT" — fixed by the breadth gate this tick.
+      sm                smart-money tuple (dir, tilt_pct) or (None, 0.0) — fetched
+                        by the caller; degrades to neutral on read failure.
+      equipment_leading bool — True if the EQUIPMENT sub-group breadth is leading
+                        the complex (early-cycle confirmation -> +1).
+
+    Score components (base 3 + contributors; floor minScore in scan.py):
+      base                            +3
+      4h trend agrees with direction  +4  (4h opposing -> -1)
+      1h confirms direction           +1
+      |1h momentum| tier              +2 (strong) / +1 (moderate)
+      smart-money agrees              +2 (aligned) / -2 (opposing)
+      supply-chain gradient           +1 (equipment sub-group leading)
+    """
+    if len(candles_4h) < 6 or len(candles_1h) < 6:
+        return None
+
+    mom_strong = float(inputs.get("momStrongPct", 1.0))
+    mom_moderate = float(inputs.get("momModeratePct", 0.5))
+
+    t4, s4 = trend_structure(candles_4h)
+    t1, _ = trend_structure(candles_1h)
+    mom_1h = price_momentum(candles_1h, 2)
+
+    score = 3
+    reasons = [f"{sub_group}:{coin}"]
+
+    # 4h trend strength (the core per-name conviction; +4 agree / -1 oppose)
+    if t4 != "NEUTRAL":
+        if (direction == "LONG" and t4 == "BULLISH") or (direction == "SHORT" and t4 == "BEARISH"):
+            score += 4
+            reasons.append(f"4h_{t4.lower()}_{s4:.0%}")
+        else:
+            score -= 1
+            reasons.append(f"4h_opposing_{t4.lower()}")
+
+    # 1h confirmation (+1)
+    if (direction == "LONG" and t1 == "BULLISH") or (direction == "SHORT" and t1 == "BEARISH"):
+        score += 1
+        reasons.append(f"1h_confirms_{t1.lower()}")
+
+    # |1h momentum| tier (+2 strong / +1 moderate), sign must match direction
+    signed = mom_1h if direction == "LONG" else -mom_1h
+    if signed >= mom_strong:
+        score += 2
+        reasons.append(f"1h_strong_momentum_{mom_1h:+.2f}%")
+    elif signed >= mom_moderate:
+        score += 1
+        reasons.append(f"1h_momentum_{mom_1h:+.2f}%")
+
+    # smart-money agreement (+2 aligned / -2 opposing)
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    if sm_dir == direction:
+        score += 2
+        reasons.append(f"sm_aligned_{_f(sm_tilt):.0f}%")
+    elif sm_dir in ("LONG", "SHORT") and sm_dir != direction:
+        score -= 2
+        reasons.append(f"sm_opposing_{sm_dir}")
+
+    # supply-chain gradient bonus (+1) — equipment leading the complex is the
+    # classic early-cycle confirmation: capex tools bid first, then logic/memory.
+    if equipment_leading:
+        score += 1
+        reasons.append("equipment_leading")
+
+    return {
+        "coin": coin, "sub_group": sub_group, "direction": direction,
+        "score": score, "reasons": reasons,
+        "trend_4h": t4, "trend_4h_strength": round(s4, 4), "trend_1h": t1,
+        "momentum_1h": round(mom_1h, 3),
+        "sm_direction": sm_dir, "sm_tilt_pct": round(_f(sm_tilt), 2),
+        "equipment_leading": bool(equipment_leading),
+    }

--- a/strategies/hornet/strategy.yaml
+++ b/strategies/hornet/strategy.yaml
@@ -1,0 +1,46 @@
+# Hornet — semiconductor / AI-capex supply-chain momentum. A single-instance
+# PACKAGE: this manifest + one self-contained runtime.yaml + scanners/. NET-NEW
+# Runtime 3.0 strategy (not a port). A 16-name semis basket on Hyperliquid XYZ
+# (HIP-3 DEX) grouped into supply-chain sub-groups (equipment / logic / memory).
+# THE EDGE: it requires the sector to confirm as a COMPLEX before taking any name —
+# a cross-asset breadth gate decides LONG-only / SHORT-only / WAIT, then scores names
+# in the gate direction with a supply-chain-gradient bonus when equipment leads.
+# Flat 18% margin / 4x, DSL exits with a 48h hard_timeout (equities have weekend
+# pricing gaps). Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: hornet
+version: "1.0.0"
+
+catalog:
+  name: "Hornet — Semiconductor Supply-Chain Momentum"
+  emoji: "🐝"
+  tagline: "A semiconductor / AI-capex supply-chain momentum basket on Hyperliquid XYZ (equipment ASML/AMAT/MRVL, logic NVDA/AMD/AVGO/TSM/QCOM/ARM/INTC/SMH, memory MU/SNDK/SMSN/SKHX/WDC): it only trades when the whole chain confirms as a complex — a sector-breadth gate flips it long-only when most names trend up and short-only when the chain rolls over — then rides the strongest 1-2 names, with an extra edge when the equipment makers lead the move. Flat 18% margin / 4x, wide DSL ratchet capped at 48h so it never camps through the weekend pricing gap."
+  belief_plain: "Trades the semiconductor supply chain — the chip designers, the memory makers, and the equipment companies that build the factories — as perps on Hyperliquid XYZ, 23/5. AI spending bids the whole chain together, so Hornet refuses to trade single names in isolation: it first checks whether the sector as a whole is trending up or down, and only then takes the strongest 1-2 names in that direction. It pays special attention when the equipment makers move first, since that tends to lead the cycle. It trails a wide stop so a real move can run, but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price."
+  thesis: "AI capex doesn't bid one chip name — it bids the entire semiconductor supply chain: equipment makers (ASML, AMAT, MRVL), logic/compute (NVDA, AMD, AVGO, TSM, QCOM, ARM, INTC, SMH), and memory (MU, SNDK, SMSN, SKHX, WDC). A per-name momentum agent can get chopped up taking a single semi that's moving on idiosyncratic news against a flat sector. Hornet's edge is that it requires the chain to confirm as a complex first — a sector-breadth gate (the fraction of the universe whose 4h trend is bullish) flips the agent long-only above 0.55 and short-only below 0.35, and emits nothing in the chop band between. Within an open gate it rides the strongest 1-2 names and adds conviction when the equipment sub-group leads (capex tools bid first, then logic and memory — the classic early-cycle gradient). The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap where drift accumulates without external price discovery."
+  group: momentum
+  archetype: breakout_momentum
+  sub_style: sector_momentum
+  asset_classes: [xyz_equities]
+  asset_scope: basket
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 3
+  min_budget: 200
+  assets: ["xyz:ASML", "xyz:AMAT", "xyz:MRVL", "xyz:NVDA", "xyz:AMD", "xyz:AVGO", "xyz:TSM", "xyz:QCOM", "xyz:ARM", "xyz:INTC", "xyz:SMH", "xyz:MU", "xyz:SNDK", "xyz:SMSN", "xyz:SKHX", "xyz:WDC"]
+  tags: [semiconductors, ai-capex, supply-chain, sector-breadth, equities, xyz, nvda, asml, tsm, momentum, smart-money, basket, long-short, advanced, 23-5]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: HORNET_WALLET
+    funding_share: 1.0


### PR DESCRIPTION
Two net-new Runtime 3.0 agents built to the current **risk-on rotation / AI-capex** regime, filling the **two zero-coverage gaps** the cross-asset read surfaced (the fleet had 0 strategies for either).

### 🐝 hornet — Semiconductor / AI-capex supply-chain momentum
Longs the strongest semis names **only when sector breadth confirms** (fraction of the 16-name equipment→logic→memory complex in a 4h uptrend ≥ 0.55 → long-only; ≤ 0.35 → short-only; chop → no trade). That breadth gate is its edge over bobcat, which scores each big-tech name independently. Score adds a supply-chain-gradient bonus when equipment leads (early-cycle). `breakout_momentum` / `sector_momentum` (new sub_style). 16 xyz semis, all HL-meta-validated.

### 🐚 barnacle — Index-inclusion / passive-flow front-runner
Rides the forced passive-fund buying into an index addition's effective date, **sells into the rebalance**; mirrors deletions as shorts. Config-driven (`inputs.events = [{asset, effectiveDate, side, index}]`) since there's no MCP feed for index events; margin scales up by proximity to the date, emits nothing inside the exit buffer. Default example **SPCX** (Russell + Nasdaq-100, eff. Jul 7). `event_driven` / `index_inclusion` (new sub_style) — joins magpie in the thin event-driven archetype.

Both: read-guarded MCP, marginPct percent, equity DSL (48h / time-bounded hard_timeout), no `__init__.py`. Two sub_styles added to `glossary.yaml`; **catalog 75 / 0 warnings; all 75 pass the validator.** Not merged — for your review.