### PR TITLE
feat(barnacle): rebuild as autonomous accumulation/decoupler (no operator calendar)

### DIFF
--- a/senpi-strategy-discover/references/glossary.yaml
+++ b/senpi-strategy-discover/references/glossary.yaml
@@ -64,6 +64,7 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   conviction_holder: { gloss: "High-conviction multi-factor holder; sizes up as more signals agree, then holds the move." }
   conviction_hold_hedged: { gloss: "Single-asset conviction hold paired with a basket hedge sleeve." }
   trend_continuation: { gloss: "Enters in the direction of an established, still-intact trend." }
+  accumulation: { gloss: "Detects persistent institutional accumulation — relative-strength decoupling from the market on rising volume with shallow, bought dips — from the tape, no catalyst feed needed." }
   # contrarian_fade
   sm_crowding:   { gloss: "Fades the crowded smart-money side once price stops following." }
   funding_extreme: { gloss: "Fades extreme funding rates." }
@@ -105,7 +106,6 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   crisis_alpha:  { gloss: "Convex crisis hedge that pays off in tail / vol events." }
   # event_driven
   new_listing_event: { gloss: "Trades new-listing / IPO-conversion events around the listing." }
-  index_inclusion: { gloss: "Front-runs index additions/deletions for the forced passive-fund flow into the rebalance effective date." }
 
 asset_classes:    # declared per strategy; same vocabulary normalizes user-named assets
   btc_eth:        { label: "BTC & ETH", gloss: "BTC and/or ETH — the bluest chips.", user_signals: ["btc","eth","bitcoin","ethereum"] }

--- a/strategies/barnacle/main/runtime.yaml
+++ b/strategies/barnacle/main/runtime.yaml
@@ -1,36 +1,41 @@
-# ── BARNACLE · single instance — index-inclusion / passive-flow front-runner ──
-# NET-NEW Runtime 3.0 strategy (NOT a port). Thesis: when a stock is announced for
-# ADD to a major index (S&P 500 / Nasdaq-100 / Russell), index funds are FORCED to
-# buy it by the rebalance effective date — a predictable passive-buying wave that
-# lifts price INTO the date. Barnacle rides that anticipatory flow on Hyperliquid XYZ
-# equity perps from detection up to ~the effective date, then EXITS before the
-# rebalance (sell into the inclusion; the pop often fades once forced buying
-# completes). DELETE events mirror as SHORTS (forced selling into the date).
+# ── BARNACLE · single instance — autonomous stealth-accumulation / decoupler ──
+# AUTONOMOUS detector — NO operator calendar, NO event feed. Index inclusions, M&A
+# targets, and catalyst run-ups all leave the SAME fingerprint visible in the tape
+# WITHOUT knowing the catalyst: a name DECOUPLING from the broad market on
+# persistent, rising volume with shallow (bought) dips — relentless accumulation,
+# not a one-bar spike. Barnacle detects that footprint from market data alone and
+# rides it; the DSL owns the exit (no event date needed). LONG up-accumulation,
+# SHORT down-distribution.
 #
-# CONFIG-DRIVEN UNIVERSE: there is no MCP feed for index-rebalance events, so the
-# operator supplies them in scanners.inputs.events as {asset, effectiveDate, side,
-# index}. The default events list is an EXAMPLE — replace it with the live schedule.
-# The scan trades ONLY the names in inputs.events. xyz: prefix mandatory (HIP-3 DEX).
+# Universe = the LIVE Hyperliquid xyz board (market_list_instruments(dex="xyz")),
+# filtered to liquid names (24h notional volume >= minVolUsd) with the broad-market
+# benchmark (xyz:XYZ100) excluded. Per tick: read the benchmark once, score every
+# non-held candidate's decoupling footprint, emit the top 1-2 by score. xyz: prefix
+# mandatory for the HIP-3 DEX. benchmarkAsset xyz:XYZ100 validated live vs HL xyz
+# meta 2026-06-30 (max_leverage 30, not delisted, dayNtlVlm ~$361M); fallback
+# xyz:SP500 also validated live (max_leverage 50).
 name: barnacle-main
 group: barnacle
 version: 1.0.0
 description: >
-  BARNACLE — index-inclusion / passive-flow front-runner on Hyperliquid XYZ equity
-  perps. Config-driven event universe (inputs.events: {asset, effectiveDate, side
-  add|delete, index}) — there is no MCP feed for index rebalances, the operator
-  supplies the schedule. Per tick it computes hours-to-effective-date for each
-  in-window event, rides ADDs LONG / DELETEs SHORT when the passive-anticipation
-  signature confirms (4h trend in-direction + rising 4h volume), sizes marginPct
-  scaled UP by proximity to the date (base 12% -> max 20%), leverage 4x (clamped
-  [1,5] + venue max). It STOPS emitting once within exitBufferHours (24h) of the
-  date — sell into the inclusion before the rebalance completes. DSL is the exit:
-  time-bounded hard_timeout covers the event window (~6d), Phase 1 12% max_loss,
-  Phase 2 first lock reachable (+8%). Net-new — sub_style index_inclusion.
+  BARNACLE — autonomous stealth-accumulation / decoupler on Hyperliquid XYZ
+  equity/commodity/index perps. NO operator calendar: it detects the catalyst
+  FOOTPRINT directly from market data — a name decoupling from the broad xyz
+  market (excess return vs xyz:XYZ100) on persistent rising 4h volume with shallow
+  (bought) dips, a relentless-accumulation grind rather than a one-bar spike. Per
+  tick it scans the live liquid xyz board, reads the benchmark once, and scores
+  each name: +excess tier (|name return - benchmark| >= 3%, sign sets direction),
+  +volume persistence, +shallow-dip grind, +4h/1h trend structure, +/- smart-money
+  nudge; floor minScore 5. Emits the top 1-2 by score. LONG up-accumulation, SHORT
+  down-distribution. Flat 15% margin / 4x (clamped [1,5] + venue max). DSL is the
+  ONLY exit — trend-following let-winners-run ladder (first lock at +10%),
+  hard_timeout 48h (equity perps have a weekend pricing gap). Net-new — sub_style
+  accumulation.
 
 strategy:
   wallet: "${BARNACLE_WALLET}"
-  slots: 3                                 # a few concurrent index events at once
-  margin_pct: 12                           # baseline %; scan emits the proximity-scaled marginPct per signal
+  slots: 3                                 # a few concurrent decouplers at once
+  margin_pct: 15                           # baseline %; scan emits the flat marginPct per signal
   default_leverage: 4                      # fallback; scan emits 4x (clamped [1,5] + venue max) per signal
   trading_risk: moderate
   enabled: true
@@ -43,37 +48,42 @@ scanners:
     type: external_scanner
     path: ./scanners
     entrypoint: scan.py
-    interval_seconds: 900                  # 15 min — event windows are days long; no need for fast cadence
-    timeout_seconds: 180                   # ~1 read/event + account read
-    default_signal_validity_seconds: 1800  # 2x tick; a fresh re-score arrives next tick
-    state_history_max_count: 50            # dedup map + per-tick scan-results history
+    interval_seconds: 600                  # 10 min — accumulation footprints build over days; no fast cadence
+    timeout_seconds: 180                   # account + 1 universe read + 1 benchmark + ~1 read/candidate + SM
+    default_signal_validity_seconds: 1200  # 2x tick; a fresh re-score arrives next tick
+    state_history_max_count: 100           # dedup map + per-tick scan-results history
     inputs:
-      # EXAMPLE events — operators REPLACE this with the live rebalance schedule.
-      # asset must be a live HL xyz instrument; effectiveDate is ISO date / ISO
-      # datetime / epoch; side is "add" (LONG) or "delete" (SHORT). xyz:SPCX
-      # validated live vs HL xyz meta 2026-06-30 (max_leverage 20, not delisted).
-      events:
-        - { asset: "xyz:SPCX", effectiveDate: "2026-07-07", side: "add", index: "russell+ndx100" }
       dex: "xyz"                           # HIP-3 DEX — xyz: prefix mandatory
-      exitBufferHours: 24                  # stop emitting (sell into the inclusion) this long before the date
-      windowHours: 168                     # 7d tradeable anticipation window before the date
-      marginPctBase: 12                    # PERCENT of withdrawable (0,100] at window start
-      marginPctMax: 20                     # PERCENT near the exit buffer (proximity-scaled UP)
-      leverage: 4                          # clamped to [1,5] and to the instrument venue max
-      minVolTrendPct: 10                   # 4h volume-trend floor for the anticipation confirmation
-      recentSignalTtlSeconds: 1800         # 30m signal-dedup (don't re-fire while in flight)
+      benchmarkAsset: "xyz:XYZ100"         # broad-xyz market index (validated live vs HL xyz meta 2026-06-30)
+      fallbackBenchmarkAsset: "xyz:SP500"  # used only if the primary benchmark read fails/short (validated live)
+      minVolUsd: 5000000                   # 24h notional-volume liquidity floor (drops thin/delisted tail)
+      universeMaxNames: 50                 # cap candidate set by 24h volume (cost bound)
+      minScore: 5                          # floor for an emit
+      excessBars: 24                       # 24 * 4h = ~4 days for the decoupling/benchmark window
+      minExcessPct: 3                      # |name return - benchmark return| floor — the decoupling must exist
+      minVolTrendPct: 10                   # 4h volume-persistence floor (rising, not flat)
+      shallowDipMaxPct: 4                  # deepest adverse pullback this shallow => bought dips (grind bonus)
+      dipLookbackBars: 24                  # window for the deepest-dip scan (matches excessBars)
+      marginPct: 15                        # PERCENT of withdrawable (0,100]; flat per signal
+      leverage: 4                          # clamped to [1,5] and to the instrument venue max in scan.py
+      maxEmit: 2                           # emit the top 1-2 by score per tick
+      recentSignalTtlSeconds: 240          # 4min signal-dedup (don't re-fire a name in flight)
     signal_data_schema:
-      side: { type: string }
-      index: { type: string, required: false }
+      score: { type: number }
+      leverage: { type: number }
       direction: { type: string }
-      leverage: { type: number, required: false }
-      hoursToEffective: { type: number, required: false }
-      effectiveEpoch: { type: number, required: false }
+      reasons: { type: array, required: false }
+      excess: { type: number, required: false }
+      nameRet: { type: number, required: false }
+      benchmarkRet: { type: number, required: false }
+      benchmark: { type: string, required: false }
       trend4h: { type: string, required: false }
       trend4hStrength: { type: number, required: false }
       trend1h: { type: string, required: false }
       volTrend4hPct: { type: number, required: false }
-      reasons: { type: array, required: false }
+      deepestDipPct: { type: number, required: false }
+      smDirection: { type: string, required: false }
+      smPct: { type: number, required: false }
       heldAssets: { type: array, required: false }
 
 actions:
@@ -83,28 +93,31 @@ actions:
     scanners: [position_tracker]
   - name: barnacle_main_entry
     action_type: OPEN_POSITION
-    decision_mode: rule                    # the scan already applied every gate (in-window + confirm + dedup)
+    decision_mode: rule                    # the scan already applied every gate (decoupling + footprint + dedup)
     scanners: [barnacle_main_signals]
     params:
       order_type: FEE_OPTIMIZED_LIMIT
       fee_optimized_limit_options:
-        ensure_execution_as_taker: true    # anticipation entries must fill — maker-only rests unfilled (CREATE_ORDER_RESTING)
+        ensure_execution_as_taker: true    # accumulation entries must fill — maker-only rests unfilled (CREATE_ORDER_RESTING)
         execution_timeout_seconds: 30
     context:
       - type: signal
         scanner: barnacle_main_signals
 
-# ── EXIT (DSL — TIME-BOUNDED for a bounded event window) ──────────────────────
-# Unlike the crypto single-asset family (hard_timeout OFF), Barnacle's edge is a
-# CALENDAR event with a known expiry: the rebalance effective date. The position
-# should never camp past the event window, so hard_timeout is ENABLED at ~6d
-# (8640 min) — it covers the full tradeable window (windowHours 168 = 7d) minus
-# the exit buffer, a backstop in case the scan's exit-buffer cutoff is somehow not
-# reached (e.g. event removed from config mid-hold). Phase 1 max_loss 12%; Phase 2
-# FIRST lock reachable at +8% (forced-flow pops are modest and fade post-rebalance,
-# so lock gains early). weak_peak_cut KEPT (self-limiting thesis-validity check):
-# if the anticipation pop never materializes, cut. order_type FEE_OPTIMIZED_LIMIT,
-# taker fallback on (closes MUST happen). interval_seconds 60.
+# ── EXIT (DSL — trend-following let-winners-run, equity shape) ─────────────────
+# Barnacle rides a relentless GRIND, so the DSL must let winners run (bobcat equity
+# shape): Phase 1 ~15% max_loss + retrace; Phase 2 wide ladder with the FIRST lock
+# REACHABLE at +10% ROE (lock gains as the grind extends, but let it breathe).
+# hard_timeout ENABLED at 48h (2880 min) — INTENTIONAL for equities: the
+# post-Friday-close -> pre-Sunday-reopen window is where internal-oracle drift
+# accumulates without external price discovery, so positions must not camp through
+# the full weekend gap. (This differs from the crypto single-asset family where
+# hard_timeout is OFF; equity/index perps justify it via the weekend pricing gap.)
+# weak_peak_cut KEPT (self-limiting thesis-validity check): if the accumulation pop
+# never materializes, cut. dead_weight_cut DISABLED (a multi-day grind tolerates
+# flat windows). order_type FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST
+# happen). interval_seconds 60 (REDUCE_ONLY-spam mitigation when runtime position
+# state lags HL).
 exit:
   engine: dsl
   interval_seconds: 60
@@ -114,41 +127,42 @@ exit:
     execution_timeout_seconds: 30
   dsl_preset:
     hard_timeout:
-      enabled: true                        # event window is bounded — never camp past the rebalance
-      interval_in_minutes: 8640            # ~6d (windowHours 168 minus the 24h exit buffer), a backstop
+      enabled: true                        # 48h cap — equity/index perps have a weekend pricing gap
+      interval_in_minutes: 2880
     weak_peak_cut:
-      enabled: true                        # self-limiting: cut if the anticipation pop never appears
+      enabled: true                        # self-limiting: cut if the accumulation pop never appears
       interval_in_minutes: 90
       min_value: 3.0
     dead_weight_cut:
-      enabled: false                       # DISABLED — a multi-day anticipation ramp tolerates flat windows
+      enabled: false                       # DISABLED — a multi-day grind tolerates flat windows
       interval_in_minutes: 60
     phase1:
       enabled: true
-      max_loss_pct: 12.0                    # modest floor — passive-flow theses don't justify deep drawdown
+      max_loss_pct: 15.0                    # protective floor for a moderate-risk equity grind
       retrace_threshold: 8
       consecutive_breaches_required: 1
     phase2:
       enabled: true
-      tiers:                               # FIRST lock REACHABLE at +8% — forced-flow pops are modest + fade
-        - { trigger_pct: 8,  lock_hw_pct: 0  }
-        - { trigger_pct: 14, lock_hw_pct: 35 }
-        - { trigger_pct: 22, lock_hw_pct: 50 }
-        - { trigger_pct: 35, lock_hw_pct: 65 }
-        - { trigger_pct: 55, lock_hw_pct: 80 }
+      tiers:                               # wide-by-design; FIRST lock REACHABLE at +10% ROE (ride the grind)
+        - { trigger_pct: 10,  lock_hw_pct: 0  }
+        - { trigger_pct: 20,  lock_hw_pct: 25 }
+        - { trigger_pct: 30,  lock_hw_pct: 40 }
+        - { trigger_pct: 50,  lock_hw_pct: 60 }
+        - { trigger_pct: 75,  lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
 
 # ── RISK guard rails (all durations in SECONDS) ──
 risk:
   data_retention_seconds: 259200           # 72h (in [3600,604800])
   guard_rails:
-    daily_loss_limit_pct: 12
-    max_entries_per_day: 3                  # index events are infrequent; turns over slowly
+    daily_loss_limit_pct: 15
+    max_entries_per_day: 4                  # decouplers are infrequent; turns over slowly
     bypass_max_entries_per_day_on_profit: false
     max_consecutive_losses: 3
     cooldown_seconds: 3600                  # post-loss cooldown 60m
-    drawdown_halt_pct: 18
+    drawdown_halt_pct: 20
     drawdown_reset_on_day_rollover: false
-    per_asset_cooldown_seconds: 21600       # 6h — one event per name, don't re-enter the same inclusion
+    per_asset_cooldown_seconds: 14400       # 4h — don't re-enter the same name immediately
 
 notifications:
   dsl_lifecycle: true

--- a/strategies/barnacle/main/scanners/scan.py
+++ b/strategies/barnacle/main/scanners/scan.py
@@ -1,28 +1,33 @@
-"""BARNACLE — supervised scanner (net-new Runtime 3.0 index-inclusion front-runner).
+"""BARNACLE — supervised scanner (autonomous "stealth accumulation / decoupler").
 
-Config-driven EVENT universe — there is NO MCP feed for index-rebalance events, so
-the operator supplies them in `inputs.events` as a list of:
-    {asset, effectiveDate (ISO date / ISO datetime / epoch), side: "add"|"delete", index}
-The scan trades ONLY the names in `inputs.events`. The default events list is an
-EXAMPLE operators replace with the live rebalance schedule.
+Index inclusions, M&A targets, and catalyst run-ups all leave the SAME fingerprint
+in the tape WITHOUT knowing the catalyst: a name DECOUPLING from the broad market
+on persistent, rising volume with shallow (bought) dips — relentless accumulation,
+not a one-bar spike. Barnacle detects that footprint from market data ALONE — no
+operator calendar, no event feed — and rides it. The DSL owns the exit (no event
+date needed). LONG up-accumulation, SHORT down-distribution.
 
-Per tick it:
-  - reads account state + held positions (dual-DEX equity via max(), never sum()),
-  - for each well-formed, not-yet-past, not-held, not-recently-signaled event whose
-    asset resolves on HL xyz: reads market_get_asset_data (dex="xyz", READ-GUARDED),
-    computes hours-to-effective-date,
-  - ADD -> LONG / DELETE -> SHORT (direction comes from the EVENT side, not price),
-  - emits ONLY while `now < effectiveDate - exitBufferHours` (default 24h) AND the
-    passive-anticipation signature confirms (4h trend in-direction + rising volume),
-  - sizes marginPct scaled UP by proximity to the date (closer = larger, base ->
-    max), leverage clamped to [1,5] and to the instrument venue max,
-  - once `now >= effectiveDate - exitBufferHours` it emits NOTHING for that event —
-    "sell into the inclusion": the DSL/exit owns the close before the rebalance.
+Per tick (read-only, single-pass):
+  1. Account read (clearinghouse, dual-DEX equity via max(), read-sanity guard).
+  2. Universe = the LIVE xyz board (market_list_instruments(dex="xyz")), filtered
+     to liquid names (dayNtlVlm >= minVolUsd, not delisted) and excluding the
+     benchmark itself.
+  3. Benchmark: read the broad-xyz market (benchmarkAsset, default xyz:XYZ100)
+     4h candles ONCE -> benchmark return over the excess lookback.
+  4. For each non-held, non-recently-signaled candidate: pull 1h+4h candles and
+     score the footprint via the pure scoring.build_thesis (excess vs benchmark,
+     volume persistence, shallow-dip grind, 4h/1h trend, smart-money nudge).
+  5. Emit the TOP 1-2 by score at/above minScore. Held + recent-signal dedup via
+     ctx.state (TTL).
 
-Read-only + single-pass — emits a `marginPct` intent (PERCENT) + `leverage`; the
-runtime sizes the dollars, owns cooldowns/risk gates, and trails the DSL exit. No
-daemon, no push_signal, no create_position. Every ctx.senpi_mcp.call_tool is
-read-guarded (degrade, never crash the whole tick).
+EVERY ctx.senpi_mcp.call_tool is READ-GUARDED — one bad/illiquid/fake name (or a
+flaky benchmark/account/leaderboard read) skips without rolling back the whole
+universe tick (per the scan contract, ANY uncaught exception rolls the entire tick
+back to []). No daemon, no push_signal, no create_position — the runtime sizes the
+dollars, owns cooldowns/slots/risk gates, and trails the DSL exit.
+
+Sizing: emits a top-level `marginPct` INTENT (PERCENT in (0,100]) plus a per-name
+venue-clamped `leverage`; the runtime sizes (marginPct/100) * withdrawable.
 """
 
 import sys
@@ -30,48 +35,55 @@ import time
 
 import scoring
 
+# defaults (also declared in runtime.yaml inputs)
+_DEFAULT_BENCHMARK = "xyz:XYZ100"   # broad-xyz market index (validated live in HL xyz meta)
+_DEFAULT_FALLBACK_BENCHMARK = "xyz:SP500"  # if the primary benchmark read fails/empty
+_DEFAULT_MIN_VOL_USD = 5_000_000    # 24h notional-volume liquidity floor
+_DEFAULT_MIN_SCORE = 5
+_DEFAULT_MARGIN_PCT = 15            # PERCENT of withdrawable (0,100]
+_DEFAULT_LEVERAGE = 4              # clamped to [1,5] + venue max
+_DEFAULT_MAX_EMIT = 2              # emit the top 1-2 by score
+_DEFAULT_TTL = 240                # 4min race-window dedup
+_DEFAULT_EXCESS_BARS = 24          # ~24 * 4h = 4 days for the excess/benchmark window
 
-# net-new defaults (an EXAMPLE events list — operators replace with the live schedule)
-_DEFAULT_EVENTS = [
-    {"asset": "xyz:SPCX", "effectiveDate": "2026-07-07",
-     "side": "add", "index": "russell+ndx100"},  # validated live vs HL xyz meta 2026-06-30
-]
-_DEFAULT_EXIT_BUFFER_HOURS = 24      # stop emitting (sell into the inclusion) this long before the date
-_DEFAULT_WINDOW_HOURS = 168          # 7d tradeable anticipation window before the date
-_DEFAULT_MARGIN_BASE = 12            # PERCENT at window start
-_DEFAULT_MARGIN_MAX = 20             # PERCENT near the exit buffer
-_DEFAULT_LEVERAGE = 4                # clamped to [1,5] and venue max
-_DEFAULT_MIN_VOL_TREND = 10          # 4h volume-trend floor for confirmation
-_DEFAULT_RECENT_TTL = 1800           # 30m signal-dedup (don't re-fire while in flight)
-_LEV_MIN = 1
-_LEV_MAX = 5
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission/illiquid error on ONE read must
+    NOT roll back the whole tick. Returns None on failure so the caller's degrade
+    path applies."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — one bad name must not kill the universe tick
+        print(f"[barnacle.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _unwrap(resp):
+    return resp.get("data", resp) if isinstance(resp, dict) else resp
 
 
 def _dex_for(asset, inputs):
     dex = inputs.get("dex")
     if dex is not None:
         return dex
-    return "xyz" if asset.lower().startswith("xyz:") else ""
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
 
+
+# ── account / positions (dual-DEX, read-sanity guard — like bison) ─────────────
 
 def _get_account(ctx):
     """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
-
     READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
     main/xyz (two views of ONE cross-margined wallet — summing double-counts the
     shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
     enumerated across both sections. Includes the read-sanity guard (margin in use
-    + empty positions -> skip tick) to avoid re-entering held names off a corrupt
-    clearinghouse read."""
-    try:
-        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
-                                     {"strategy_wallet": ctx.wallet})
-    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
-        print(f"[barnacle.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+    but empty positions -> corrupt read -> skip tick)."""
+    if not getattr(ctx, "wallet", None):
         return 0.0, []
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
     if not ch:
         return 0.0, []
-    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    data = _unwrap(ch)
     if not isinstance(data, dict):
         return 0.0, []
 
@@ -88,11 +100,12 @@ def _get_account(ctx):
             if szi == 0:
                 continue
             positions.append({"coin": pos.get("coin", ""),
-                              "margin": scoring._f(pos.get("marginUsed", 0))})
+                              "direction": "LONG" if szi > 0 else "SHORT"})
 
-    # read-sanity guard: a corrupt clearinghouse read can report margin/notional IN
-    # USE while returning an EMPTY positions list; sizing or running the held-asset
-    # dedup off that re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    # read-sanity guard (funding/$0 glitch 2026-06): a corrupt clearinghouse read
+    # can report margin/notional IN USE while returning an EMPTY positions list;
+    # sizing or the held-dedup off that re-enters held names (pyramiding) and
+    # mis-sizes. Skip the tick.
     _use = 0.0
     for _sec in ("main", "xyz"):
         _s = data.get(_sec, {}) if isinstance(data, dict) else {}
@@ -106,42 +119,134 @@ def _get_account(ctx):
     return account_value, positions
 
 
-def _asset_data(ctx, coin, dex):
-    """{candles_1h, candles_4h, venue_max} for `coin` or None. READ-GUARDED.
-    A failed read (transient/permission/not-listed) returns None -> the event is
-    skipped this tick rather than crashing the whole scan."""
-    try:
-        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
-            "asset": coin,
-            "candle_intervals": ["1h", "4h"],
-            "include_funding": False,
-            "include_order_book": False,
-            "dex": dex,
+# ── live xyz instrument board: the universe ────────────────────────────────────
+
+def _get_universe(ctx, inputs, benchmark_asset):
+    """The live liquid xyz board to scan this tick. READ-GUARDED.
+    A name qualifies if it is on the xyz DEX, NOT delisted, has 24h notional
+    volume >= minVolUsd, and is NOT the benchmark itself. Returns a list of
+    {coin, vol, venue_max}."""
+    min_vol = float(inputs.get("minVolUsd", _DEFAULT_MIN_VOL_USD))
+    dex = inputs.get("dex", "xyz")
+    resp = _read(ctx, "market_list_instruments", {"dex": dex})
+    if not resp:
+        return []
+    data = _unwrap(resp)
+    insts = data.get("instruments", data) if isinstance(data, dict) else data
+    if not isinstance(insts, list):
+        return []
+
+    bench_u = str(benchmark_asset).upper()
+    out, seen = [], set()
+    for inst in insts:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        nu = str(name).upper()
+        if nu == bench_u or nu in seen:
+            continue
+        ctxd = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        vol = scoring._f(ctxd.get("dayNtlVlm", inst.get("dayNtlVlm", 0)))
+        if vol < min_vol:
+            continue
+        seen.add(nu)
+        out.append({
+            "coin": name,
+            "vol": vol,
+            "venue_max": inst.get("max_leverage", inst.get("maxLeverage")),
         })
-    except Exception as exc:  # noqa: BLE001
-        print(f"[barnacle.scan] market_get_asset_data({coin}) read failed: {exc!r}", file=sys.stderr)
+    out.sort(key=lambda x: -x["vol"])
+    return out
+
+
+def _benchmark_return(ctx, inputs, asset, excess_bars):
+    """Benchmark return over `excess_bars` of 4h candles, or None. READ-GUARDED."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["4h"],
+        "include_funding": False,
+        "include_order_book": False,
+        "dex": _dex_for(asset, inputs),
+    })
+    if not resp:
         return None
-    if not md:
+    if isinstance(resp, dict) and resp.get("success") is False:
         return None
-    if isinstance(md, dict) and md.get("success") is False:
-        return None
-    d = md.get("data", md) if isinstance(md, dict) else md
+    d = _unwrap(resp)
     if not isinstance(d, dict):
         return None
-    candles = d.get("candles", {}) or {}
-    # venue max leverage if the read surfaces it (asset_context / top-level); else None
-    venue_max = None
-    actx = d.get("asset_context", d) if isinstance(d, dict) else {}
-    if isinstance(actx, dict):
-        venue_max = actx.get("max_leverage", d.get("max_leverage"))
-    return {
-        "candles_1h": candles.get("1h", []) or [],
-        "candles_4h": candles.get("4h", []) or [],
-        "venue_max": venue_max,
-    }
+    candles = (d.get("candles", {}) or {}).get("4h", []) or []
+    return scoring.window_return(candles, excess_bars)
 
 
-# ── ctx.state: recent-signal dedup ──
+def _fetch_candles(ctx, asset, inputs):
+    """1h + 4h candles for ONE asset, or ([], []). READ-GUARDED."""
+    resp = _read(ctx, "market_get_asset_data", {
+        "asset": asset,
+        "candle_intervals": ["1h", "4h"],
+        "include_funding": False,
+        "include_order_book": False,
+        "dex": _dex_for(asset, inputs),
+    })
+    if not resp:
+        return [], []
+    if isinstance(resp, dict) and resp.get("success") is False:
+        return [], []
+    d = _unwrap(resp)
+    candles = (d.get("candles", {}) or {}) if isinstance(d, dict) else {}
+    return candles.get("1h", []) or [], candles.get("4h", []) or []
+
+
+def _get_sm_direction(ctx, coin):
+    """Net smart-money lean for `coin` from leaderboard_get_markets. Returns
+    (direction, tilt_pct) or (None, 0.0). READ-GUARDED -> a read error degrades to
+    (None, 0.0), which the scorer treats as a NEUTRAL nudge (no gate). Token match
+    is case-insensitive. long_ratio >= 55 -> LONG; <= 45 -> SHORT; else NEUTRAL."""
+    raw = _read(ctx, "leaderboard_get_markets", {})
+    if not raw or (isinstance(raw, dict) and raw.get("success") is False):
+        return None, 0.0
+    markets = _unwrap(raw)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets.get("leaderboard", markets))
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return None, 0.0
+
+    # xyz instruments carry the 'xyz:' prefix; the leaderboard tokens may be bare
+    # (e.g. NVDA). Match against both the full name and the bare suffix.
+    target = coin.upper()
+    bare = target.split(":", 1)[1] if ":" in target else target
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if token not in (target, bare):
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100.0
+    if long_ratio >= 55:
+        return "LONG", long_ratio
+    if long_ratio <= 45:
+        return "SHORT", 100 - long_ratio
+    return "NEUTRAL", 50.0
+
+
+# ── ctx.state: recent-signal dedup ─────────────────────────────────────────────
 
 def _load_signaled(ctx):
     if ctx.state is None or len(ctx.state) == 0:
@@ -152,7 +257,6 @@ def _load_signaled(ctx):
 
 
 def _prune_signaled(signaled, ttl, now):
-    """Drop entries older than 4x TTL (fleet-standard bound)."""
     cutoff = now - (ttl * 4)
     return {k: v for k, v in signaled.items() if v >= cutoff}
 
@@ -166,153 +270,141 @@ def _was_recently_signaled(signaled, coin, ttl, now):
 
 def scan(inputs, ctx):
     now = time.time()
-    events = inputs.get("events", _DEFAULT_EVENTS)
-    exit_buffer_h = float(inputs.get("exitBufferHours", _DEFAULT_EXIT_BUFFER_HOURS))
-    window_h = float(inputs.get("windowHours", _DEFAULT_WINDOW_HOURS))
-    margin_base = float(inputs.get("marginPctBase", _DEFAULT_MARGIN_BASE))
-    margin_max = float(inputs.get("marginPctMax", _DEFAULT_MARGIN_MAX))
+    benchmark = str(inputs.get("benchmarkAsset", _DEFAULT_BENCHMARK))
+    fallback_benchmark = str(inputs.get("fallbackBenchmarkAsset", _DEFAULT_FALLBACK_BENCHMARK))
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    excess_bars = int(inputs.get("excessBars", _DEFAULT_EXCESS_BARS))
     lev_cfg = int(inputs.get("leverage", _DEFAULT_LEVERAGE))
-    min_vol_trend = float(inputs.get("minVolTrendPct", _DEFAULT_MIN_VOL_TREND))
-    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+    max_emit = int(inputs.get("maxEmit", _DEFAULT_MAX_EMIT))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    universe_max_names = int(inputs.get("universeMaxNames", 50))
 
-    # marginPct PERCENT in (0,100]. Defensive fraction guard (fleet pattern): a
-    # value <= 1.0 is a pasted FRACTION (e.g. 0.12) -> *100.
-    if margin_base <= 1.0:
-        margin_base *= 100
-    if margin_max <= 1.0:
-        margin_max *= 100
+    # marginPct: PERCENT in (0,100]. Defensive fraction guard (dire/koala pattern):
+    # a value <= 1.0 is a pasted FRACTION (e.g. 0.15) -> *100 -> 15.
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        print(f"[barnacle.scan] marginPct={margin_pct} looks like a fraction; "
+              f"converting to PERCENT ({margin_pct * 100})", file=sys.stderr)
+        margin_pct = margin_pct * 100.0
 
-    if not isinstance(events, list) or not events:
-        print("[barnacle.scan] WAITING — no events in inputs.events (operator supplies "
-              "the rebalance schedule)", file=sys.stderr)
-        if ctx.state is not None:
-            try:
-                ctx.state.append({"signaled": _load_signaled(ctx),
-                                  "result": {"ts": now, "emitted": False, "note": "no events configured"}})
-            except Exception as exc:  # noqa: BLE001
-                print(f"[barnacle.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
-        return []
+    def _persist(result=None, signaled=None):
+        if ctx.state is None:
+            return
+        rec = {}
+        if signaled is not None:
+            rec["signaled"] = signaled
+        if result is not None:
+            rec["result"] = result
+        try:
+            ctx.state.append(rec)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[barnacle.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
 
+    # 1) account
     account_value, positions = _get_account(ctx)
     if account_value <= 0:
+        print("[barnacle.scan] WAITING — no account value / corrupt read", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_account_value"})
         return []
-    held_assets = [p["coin"] for p in positions if p.get("coin")]
-    held_set = {h.upper() for h in held_assets}
+    held = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held}
 
     signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
 
+    # 2) universe (live xyz board, liquid, benchmark excluded)
+    universe = _get_universe(ctx, inputs, benchmark)
+    if not universe:
+        print("[barnacle.scan] market_list_instruments(xyz) empty/failed — no signal", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_universe"}, signaled)
+        return []
+    universe = universe[:universe_max_names]
+
+    # 3) benchmark return ONCE (broad-xyz decoupling reference), with fallback
+    benchmark_ret = _benchmark_return(ctx, inputs, benchmark, excess_bars)
+    used_benchmark = benchmark
+    if benchmark_ret is None and fallback_benchmark and fallback_benchmark != benchmark:
+        print(f"[barnacle.scan] benchmark {benchmark} read failed/short — "
+              f"falling back to {fallback_benchmark}", file=sys.stderr)
+        benchmark_ret = _benchmark_return(ctx, inputs, fallback_benchmark, excess_bars)
+        used_benchmark = fallback_benchmark
+    if benchmark_ret is None:
+        print("[barnacle.scan] WAITING — no benchmark return (broad-xyz read failed)", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_benchmark"}, signaled)
+        return []
+
+    # 4) score every eligible candidate (held + recently-signaled filtered BEFORE
+    #    the per-asset MCP fetch)
     candidates = []
     scanned = 0
-    skipped = 0
-    for raw_ev in events:
-        ev = scoring.normalize_event(raw_ev)
-        if ev is None:
-            skipped += 1
-            print(f"[barnacle.scan] SKIP malformed event {raw_ev!r}", file=sys.stderr)
-            continue
-
-        coin = ev["asset"]
+    for u in universe:
+        coin = u["coin"]
         cu = coin.upper()
-        eff = ev["effectiveEpoch"]
-        side = ev["side"]
-        direction = scoring.direction_for_side(side)
-        hours_to_eff = (eff - now) / 3600.0
-
-        # past-date -> the rebalance has happened; nothing to front-run
-        if hours_to_eff <= 0:
-            skipped += 1
-            print(f"[barnacle.scan] SKIP past-date event {coin} (effective {eff:.0f}, "
-                  f"{hours_to_eff:.1f}h)", file=sys.stderr)
-            continue
-
-        # SELL INTO THE INCLUSION: once inside the exit buffer, emit nothing for this
-        # event — the DSL/exit owns the close before the rebalance completes.
-        if hours_to_eff <= exit_buffer_h:
-            print(f"[barnacle.scan] HOLD/EXIT-WINDOW {coin} {direction} — within exit buffer "
-                  f"({hours_to_eff:.1f}h <= {exit_buffer_h:.0f}h); no new entry", file=sys.stderr)
-            continue
-
-        # outside the tradeable anticipation window -> too early
-        if hours_to_eff > window_h:
-            print(f"[barnacle.scan] EARLY {coin} {direction} — {hours_to_eff:.1f}h to date "
-                  f"(> window {window_h:.0f}h)", file=sys.stderr)
-            continue
-
         if cu in held_set:
             continue
         if _was_recently_signaled(signaled, coin, ttl, now):
             continue
-
         scanned += 1
-        md = _asset_data(ctx, coin, _dex_for(coin, inputs))
-        if not md:
+        c1, c4 = _fetch_candles(ctx, coin, inputs)
+        if len(c4) < excess_bars + 1 or len(c1) < 6:
             continue
+        sm = _get_sm_direction(ctx, coin)
+        th = scoring.build_thesis(coin, c1, c4, benchmark_ret, sm, inputs)
+        if th and th["score"] >= min_score:
+            th["_venue_max"] = u.get("venue_max")
+            candidates.append(th)
 
-        ok, reasons, detail = scoring.anticipation_confirms(
-            direction, md["candles_4h"], md["candles_1h"], min_vol_trend)
-        if not ok:
-            print(f"[barnacle.scan] NO-CONFIRM {coin} {direction} — {reasons}", file=sys.stderr)
+    if not candidates:
+        print(f"[barnacle.scan] WAITING — no decoupler footprint >= minScore {min_score:.0f} "
+              f"(scanned {scanned}/{len(universe)}, bench {used_benchmark} {benchmark_ret:+.1f}%) "
+              f"held={held}", file=sys.stderr)
+        _persist({"ts": now, "emitted": False, "gate": "no_candidate", "scanned": scanned,
+                  "benchmark": used_benchmark, "benchmark_ret": round(benchmark_ret, 3),
+                  "held": held}, signaled)
+        return []
+
+    # 5) emit the top 1-2 by score
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    to_emit = candidates[:max(1, max_emit)]
+
+    out, emitted_coins = [], []
+    for th in to_emit:
+        leverage = scoring.clamp_leverage(lev_cfg, th.get("_venue_max"), lo=1, hi=5)
+        if leverage <= 0:
             continue
-
-        margin_pct = scoring.proximity_margin_pct(
-            hours_to_eff, exit_buffer_h, margin_base, margin_max, window_h)
-        leverage = scoring.clamp_leverage(lev_cfg, _LEV_MIN, _LEV_MAX, md.get("venue_max"))
-
-        candidates.append({
-            "coin": coin, "direction": direction, "side": side,
-            "index": ev["index"], "effectiveEpoch": eff,
-            "hoursToEffective": round(hours_to_eff, 2),
-            "marginPct": round(margin_pct, 4), "leverage": leverage,
-            "reasons": reasons, "detail": detail,
+        signaled[th["coin"].upper()] = now
+        emitted_coins.append(th["coin"])
+        out.append({
+            "asset": th["coin"],
+            "direction": th["direction"],
+            "marginPct": margin_pct,           # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,              # venue-clamped to [1,5] + instrument max
+            "data": {
+                "score": th["score"],
+                "leverage": leverage,
+                "direction": th["direction"],
+                "reasons": th["reasons"][:8],
+                "excess": th["excess"],
+                "nameRet": th["name_ret"],
+                "benchmarkRet": th["benchmark_ret"],
+                "benchmark": used_benchmark,
+                "trend4h": th["trend_4h"],
+                "trend4hStrength": th["trend_4h_strength"],
+                "trend1h": th["trend_1h"],
+                "volTrend4hPct": th["vol_trend"],
+                "deepestDipPct": th["deepest_dip"],
+                "smDirection": th["sm_direction"] or "NEUTRAL",
+                "smPct": th["sm_pct"],
+                "heldAssets": held,
+            },
         })
 
-    out = []
-    if not candidates:
-        result = {"ts": now, "scanned": scanned, "skipped": skipped, "emitted": False,
-                  "held": held_assets, "note": "WAITING (no confirmed in-window event)"}
-        print(f"[barnacle.scan] WAITING — no confirmed in-window index event; "
-              f"scanned={scanned} skipped={skipped} held={held_assets}", file=sys.stderr)
-    else:
-        # emit the MOST IMMINENT confirmed event (smallest hours-to-date = strongest
-        # forced-flow proximity). One signal/tick keeps the book focused.
-        candidates.sort(key=lambda c: c["hoursToEffective"])
-        best = candidates[0]
-        signaled[best["coin"].upper()] = now
-        result = {"ts": now, "scanned": scanned, "skipped": skipped, "emitted": True,
-                  "coin": best["coin"], "direction": best["direction"], "side": best["side"],
-                  "index": best["index"], "hoursToEffective": best["hoursToEffective"],
-                  "marginPct": best["marginPct"], "leverage": best["leverage"],
-                  "held": held_assets, "reasons": best["reasons"]}
-        print(f"[barnacle.scan] EMIT {best['coin']} {best['direction']} ({best['side']} "
-              f"{best['index']}) {best['leverage']}x marginPct={best['marginPct']:.2f}% "
-              f"{best['hoursToEffective']:.1f}h-to-date | {best['reasons']}", file=sys.stderr)
-        out = [{
-            "asset": best["coin"],
-            "direction": best["direction"],
-            "marginPct": best["marginPct"],   # PERCENT in (0,100] — runtime sizes (marginPct/100)*withdrawable
-            "leverage": best["leverage"],     # clamped [1,5] + venue max; runtime applies it
-            "data": {
-                "side": best["side"],
-                "index": best["index"],
-                "direction": best["direction"],
-                "leverage": best["leverage"],
-                "hoursToEffective": best["hoursToEffective"],
-                "effectiveEpoch": best["effectiveEpoch"],
-                "trend4h": best["detail"].get("trend4h"),
-                "trend4hStrength": best["detail"].get("trend4hStrength"),
-                "trend1h": best["detail"].get("trend1h"),
-                "volTrend4hPct": best["detail"].get("volTrend4hPct"),
-                "reasons": best["reasons"],
-                "heldAssets": held_assets,
-            },
-        }]
-
-    # ── persist dedup map + this tick's result EVERY tick; bounded by
-    #    state_history_max_count. Read back via ctx.state.recent(n). ──
-    if ctx.state is not None:
-        try:
-            ctx.state.append({"signaled": signaled, "result": result})
-        except Exception as exc:  # noqa: BLE001
-            print(f"[barnacle.scan] WARNING: state append failed; next tick may re-emit "
-                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    result = {"ts": now, "emitted": len(out), "gate": "emit", "scanned": scanned,
+              "benchmark": used_benchmark, "benchmark_ret": round(benchmark_ret, 3),
+              "candidates": len(candidates), "coins": emitted_coins,
+              "marginPct": round(margin_pct, 4), "held": held}
+    print(f"[barnacle.scan] EMIT {emitted_coins} (scanned {scanned}, "
+          f"bench {used_benchmark} {benchmark_ret:+.1f}%, marginPct {margin_pct:.1f}%) | "
+          f"top {to_emit[0]['coin']} {to_emit[0]['direction']} score={to_emit[0]['score']} "
+          f"{to_emit[0]['reasons'][:5]}", file=sys.stderr)
+    _persist(result, signaled)
     return out

--- a/strategies/barnacle/main/scanners/scoring.py
+++ b/strategies/barnacle/main/scanners/scoring.py
@@ -1,28 +1,36 @@
-"""BARNACLE — pure thesis math (no I/O, no MCP, no clock).
+"""BARNACLE — pure footprint math (no I/O, no MCP, no clock).
 
-Index-inclusion / passive-flow front-runner. NOT a port — this is a net-new
-Runtime 3.0 strategy. The math is original but the candle-accessor + trend +
-volume helpers follow the fleet gold-template idiom (bison/bobcat scoring.py) so a
-fidelity harness can diff structurally.
+Autonomous "stealth accumulation / decoupler" detector. Index inclusions, M&A
+targets, and catalyst run-ups all leave the SAME fingerprint in the tape WITHOUT
+knowing the catalyst: a name DECOUPLING from the broad market on persistent,
+rising volume with shallow (bought) dips — relentless accumulation, not a
+one-bar spike. This module scores that footprint from market data alone:
 
-THESIS. When a stock is announced for ADD to a major index (S&P 500 / Nasdaq-100 /
-Russell), index funds are FORCED to buy it by the rebalance effective date — a
-predictable passive-buying wave that lifts price INTO the date. Barnacle rides that
-anticipatory flow from detection up to ~the effective date and exits BEFORE the
-rebalance (the scan stops emitting once inside the exit buffer; the DSL/exit owns
-the close). DELETE events mirror as SHORTS (forced selling into the date).
+  - EXCESS RETURN  — name return minus the broad-xyz benchmark return over the
+                     lookback (~3-5 days of 4h bars). |excess| sets conviction;
+                     its SIGN sets direction (up -> LONG accumulation, down ->
+                     SHORT distribution).
+  - VOLUME PERSISTENCE — 4h volume rising STEADILY across the window (recent-half
+                     vs earlier-half average), not a single spike. This is the
+                     "relentless" tell.
+  - SHALLOW-DIP / GRIND — within the move, the largest adverse pullback is
+                     SHALLOW (dips are bought). A volatile breakout has deep
+                     retraces; accumulation grinds. This is the accumulation
+                     signature vs a noisy spike.
+  - TREND STRUCTURE (4h) — strict higher-lows (long) / lower-highs (short),
+                     bobcat's trend_structure (verbatim).
+  - SMART-MONEY lean — a +/- score NUDGE (fetched by the caller, passed in),
+                     never a hard gate.
 
-Every function here is pure and unit-testable on plain candle lists + plain event
-dicts. The scan layer (scan.py) supplies the wall clock, the account/held read,
-the per-asset candle read, and the ctx.state dedup. Direction comes from the EVENT
-side (add->LONG, delete->SHORT), NOT from price — the confirmation signature only
-gates WHETHER to ride and the proximity scaler only sizes it.
-"""
+This is a SCORED detector, not a pure gate: the only hard requirements are
+(a) sufficient candle history, (b) |excess| >= minExcessPct (the decoupling
+exists), and (c) a resolvable direction. Everything else is a score contributor.
+The minScore floor is applied by the CALLER (scan.py).
 
-import sys
+Multi-asset, single-pass, unit-testable on plain candle lists."""
 
 
-# ── numeric + candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
 
 def _f(v, d=0.0):
     try:
@@ -63,12 +71,29 @@ def _vol(c):
     return 0.0
 
 
-# ── indicators (fleet-idiom: same trend_structure / volume_trend as bison/bobcat) ──
+# ── indicators ───────────────────────────────────────────────────────────────
+
+def window_return(candles, n_bars):
+    """% change of close over the last n_bars (close[-1] vs close[-(n_bars+1)]).
+    Used for both the name return and the benchmark return over the SAME bar
+    count so the excess is apples-to-apples. Returns None on insufficient history
+    or a non-positive base."""
+    if len(candles) < n_bars + 1:
+        return None
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    if old <= 0:
+        return None
+    return ((new - old) / old) * 100.0
+
 
 def trend_structure(candles, lookback=6):
-    """Higher lows = BULLISH, lower highs = BEARISH. Fleet-standard structure read
-    (strict > counting, >= total*0.6 gate; total = lookback-1). Strength is the
-    matching count / total; NEUTRAL -> 0.0."""
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim from bobcat.
+
+    Thresholds use strict (>) for higher-lows / lower-highs counting; the
+    BULLISH/BEARISH gate is `>= total * 0.6` where total = lookback - 1. Strength
+    returned is higher_lows/total (BULLISH) or lower_highs/total (BEARISH);
+    NEUTRAL returns 0.0."""
     if len(candles) < lookback:
         return "NEUTRAL", 0.0
     lows = [_low(c) for c in candles[-lookback:]]
@@ -83,8 +108,11 @@ def trend_structure(candles, lookback=6):
     return "NEUTRAL", 0.0
 
 
-def volume_trend(candles, lookback=6):
-    """Recent-half vs earlier-half average volume, % change. Fleet-standard."""
+def volume_persistence(candles, lookback=6):
+    """Recent-half vs earlier-half average 4h volume, % change — the SAME
+    construction as bison/bobcat volume_trend, used here as the "rising on
+    persistent volume" tell. A steady accumulation campaign shows recent-half
+    volume materially above the earlier half. Returns 0 on insufficient history."""
     if len(candles) < lookback + 2:
         return 0.0
     vols = [_vol(c) for c in candles[-(lookback + 2):]]
@@ -93,175 +121,173 @@ def volume_trend(candles, lookback=6):
         return 0.0
     recent = sum(vols[-half:]) / half
     earlier = sum(vols[:half]) / half
-    if earlier == 0:
+    if earlier <= 0:
         return 0.0
-    return ((recent - earlier) / earlier) * 100
+    return ((recent - earlier) / earlier) * 100.0
 
 
-# ── event parsing ──
+def deepest_dip_pct(candles, direction, lookback):
+    """The largest ADVERSE pullback (against `direction`) within the lookback
+    window, as a positive % of the running extreme. A grind/accumulation has a
+    SHALLOW deepest dip (dips bought); a volatile breakout has a deep one.
 
-def parse_effective_epoch(value):
-    """Coerce an event's `effectiveDate` to an epoch (seconds). Accepts:
-      - an ISO date "YYYY-MM-DD" (interpreted as 00:00:00 UTC of that day, the
-        rebalance effective open — see THESIS: forced buying completes by the
-        open of the effective date),
-      - an ISO datetime "YYYY-MM-DDTHH:MM:SS[Z]",
-      - an int/float/epoch-string (seconds since epoch).
-    Returns a float epoch, or None if it cannot be parsed (caller skips the event).
-    Pure: no wall clock is read here."""
-    if value is None:
-        return None
-    # numeric epoch (int/float, or a string of digits)
-    if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
-        s = value.strip()
-        if not s:
-            return None
-        # bare epoch string
-        try:
-            if s.replace(".", "", 1).isdigit():
-                return float(s)
-        except (TypeError, ValueError):
-            pass
-        # ISO date / datetime -> UTC epoch
-        from datetime import datetime, timezone
-        iso = s.replace("Z", "+00:00")
-        for fmt_try in (None,):  # use fromisoformat once; fall through on failure
-            try:
-                dt = datetime.fromisoformat(iso)
-                if dt.tzinfo is None:
-                    dt = dt.replace(tzinfo=timezone.utc)
-                return dt.timestamp()
-            except ValueError:
-                break
-        # last resort: plain date
-        try:
-            dt = datetime.strptime(s, "%Y-%m-%d").replace(tzinfo=timezone.utc)
-            return dt.timestamp()
-        except ValueError:
-            return None
-    return None
+    LONG  — track the running peak close; the dip is how far the bar's LOW fell
+            below the running peak. Return the max such drop.
+    SHORT — mirror: track the running trough close; the dip is how far the bar's
+            HIGH rose above the running trough.
+
+    Returns a non-negative percent (0 = no adverse excursion). Insufficient
+    history -> a large sentinel (999.0) so the shallow-dip bonus never fires on
+    too-short data."""
+    if len(candles) < lookback:
+        return 999.0
+    window = candles[-lookback:]
+    worst = 0.0
+    if direction == "LONG":
+        peak = _close(window[0])
+        for c in window:
+            cl = _close(c)
+            if cl > peak:
+                peak = cl
+            lo = _low(c)
+            if peak > 0 and lo > 0:
+                drop = (peak - lo) / peak * 100.0
+                if drop > worst:
+                    worst = drop
+    else:  # SHORT
+        trough = _close(window[0])
+        for c in window:
+            cl = _close(c)
+            if cl > 0 and (trough <= 0 or cl < trough):
+                trough = cl
+            hi = _high(c)
+            if trough > 0 and hi > 0:
+                rise = (hi - trough) / trough * 100.0
+                if rise > worst:
+                    worst = rise
+    return worst
 
 
-def normalize_event(ev):
-    """Validate + normalize one config event dict. Returns a normalized dict
-      {asset, effectiveEpoch, side ('add'|'delete'), index} or None if malformed.
-    A malformed event (missing asset, unparseable date, unknown side) -> None so
-    the caller can skip-with-note. Pure."""
-    if not isinstance(ev, dict):
+# ── the footprint thesis (decoupling detector) ────────────────────────────────
+
+def build_thesis(coin, candles_1h, candles_4h, benchmark_ret, sm, inputs):
+    """Score the stealth-accumulation footprint. Returns a thesis dict (with
+    `score`) or None.
+
+    None is returned ONLY when:
+      - insufficient candle history (len(c4h) < excessBars+1, or < 6, or
+        len(c1h) < 6), OR
+      - the decoupling is too small (|excess| < minExcessPct), OR
+      - name/benchmark return cannot be computed.
+
+    The minScore floor is applied by the CALLER (scan.py).
+
+    `benchmark_ret` is the broad-xyz benchmark return over the SAME bar count
+    (excessBars of 4h candles), fetched once by the caller. `sm` is the
+    smart-money lean tuple (direction, tilt_pct) or (None, 0.0) — a NUDGE, never
+    a gate."""
+    excess_bars = int(inputs.get("excessBars", 24))          # ~24 * 4h = 4 days
+    min_excess = float(inputs.get("minExcessPct", 3.0))
+    min_vol_trend = float(inputs.get("minVolTrendPct", 10.0))
+    shallow_dip_max = float(inputs.get("shallowDipMaxPct", 4.0))
+    dip_lookback = int(inputs.get("dipLookbackBars", excess_bars))
+
+    if len(candles_4h) < excess_bars + 1 or len(candles_4h) < 6 or len(candles_1h) < 6:
         return None
-    asset = ev.get("asset")
-    if not asset or not isinstance(asset, str):
+
+    name_ret = window_return(candles_4h, excess_bars)
+    if name_ret is None or benchmark_ret is None:
         return None
-    side = str(ev.get("side", "add")).strip().lower()
-    if side not in ("add", "delete"):
+
+    # ── EXCESS RETURN: the decoupling. Sign -> direction; magnitude -> conviction.
+    excess = name_ret - benchmark_ret
+    if abs(excess) < min_excess:
         return None
-    eff = parse_effective_epoch(ev.get("effectiveDate"))
-    if eff is None:
-        return None
+    direction = "LONG" if excess > 0 else "SHORT"
+
+    t4, s4 = trend_structure(candles_4h)
+    t1, _ = trend_structure(candles_1h)
+    vol_trend = volume_persistence(candles_4h)
+    dip = deepest_dip_pct(candles_4h, direction, dip_lookback)
+    sm_dir, sm_pct = sm if sm else (None, 0.0)
+
+    score = 0
+    reasons = [f"excess_{excess:+.1f}%_vs_bench_{benchmark_ret:+.1f}%"]
+
+    # ── EXCESS tier (the core signal): +2 base for clearing minExcess, +1 strong,
+    #    +1 very strong. Decoupling magnitude IS the conviction.
+    abs_ex = abs(excess)
+    score += 2
+    if abs_ex >= min_excess * 2:
+        score += 1
+        reasons.append(f"strong_decouple_{abs_ex:.1f}%")
+    if abs_ex >= min_excess * 3:
+        score += 1
+        reasons.append(f"very_strong_decouple_{abs_ex:.1f}%")
+
+    # ── VOLUME PERSISTENCE: +2 if 4h volume is rising steadily across the window
+    #    (the "relentless accumulation" tell vs a flat/declining tape).
+    if vol_trend >= min_vol_trend:
+        score += 2
+        reasons.append(f"vol_persistent_{vol_trend:+.0f}%")
+    elif vol_trend <= -min_vol_trend:
+        score -= 1
+        reasons.append(f"vol_fading_{vol_trend:+.0f}%")
+
+    # ── SHALLOW-DIP / GRIND: +2 if the deepest adverse pullback is shallow (dips
+    #    bought = accumulation). A deep dip means a volatile breakout, not a grind.
+    if dip <= shallow_dip_max:
+        score += 2
+        reasons.append(f"shallow_dip_{dip:.1f}%")
+    elif dip >= shallow_dip_max * 2.5:
+        score -= 1
+        reasons.append(f"choppy_dip_{dip:.1f}%")
+
+    # ── TREND STRUCTURE (4h) in the excess direction: +2 confirm / -1 opposing.
+    if t4 != "NEUTRAL":
+        if (direction == "LONG" and t4 == "BULLISH") or (direction == "SHORT" and t4 == "BEARISH"):
+            score += 2
+            reasons.append(f"4h_{t4.lower()}_{s4:.0%}")
+        else:
+            score -= 1
+            reasons.append(f"4h_opposing_{t4.lower()}")
+
+    # ── 1H trend agreement: +1 confirm.
+    if (direction == "LONG" and t1 == "BULLISH") or (direction == "SHORT" and t1 == "BEARISH"):
+        score += 1
+        reasons.append(f"1h_confirms_{t1.lower()}")
+
+    # ── SMART-MONEY nudge (+1 / -1), never a gate.
+    if sm_dir in ("LONG", "SHORT"):
+        if sm_dir == direction:
+            score += 1
+            reasons.append(f"sm_aligned_{_f(sm_pct):.0f}%")
+        else:
+            score -= 1
+            reasons.append(f"sm_opposing_{sm_dir}")
+
     return {
-        "asset": asset.strip(),
-        "effectiveEpoch": eff,
-        "side": side,
-        "index": str(ev.get("index", "")).strip(),
+        "coin": coin, "direction": direction, "score": score, "reasons": reasons,
+        "excess": round(excess, 3), "name_ret": round(name_ret, 3),
+        "benchmark_ret": round(benchmark_ret, 3),
+        "trend_4h": t4, "trend_4h_strength": round(s4, 4), "trend_1h": t1,
+        "vol_trend": round(vol_trend, 2), "deepest_dip": round(dip, 3),
+        "sm_direction": sm_dir, "sm_pct": round(_f(sm_pct), 2),
     }
 
 
-def direction_for_side(side):
-    """add -> LONG (forced buying), delete -> SHORT (forced selling)."""
-    return "LONG" if side == "add" else "SHORT"
+# ── leverage clamp (venue-aware) ──────────────────────────────────────────────
 
-
-# ── proximity-scaled margin (closer to the effective date = larger conviction) ──
-
-def proximity_margin_pct(hours_to_effective, exit_buffer_hours, base_pct, max_pct,
-                         window_hours):
-    """Scale margin PERCENT UP by proximity to the effective date.
-
-    At the START of the tradeable window (now == effectiveDate - window_hours) the
-    forced-flow thesis is youngest -> size at `base_pct`. As `now` approaches the
-    exit buffer (now -> effectiveDate - exit_buffer_hours) the passive wave is most
-    imminent -> size scales linearly toward `max_pct`. Clamped to [base, max].
-
-    `hours_to_effective` is (effectiveEpoch - now)/3600 (POSITIVE before the date).
-    The tradeable proximity band runs from window_hours down to exit_buffer_hours.
-    Returns a PERCENT in (0, 100]. Pure."""
-    base_pct = float(base_pct)
-    max_pct = float(max_pct)
-    if max_pct < base_pct:
-        max_pct = base_pct
-    span = float(window_hours) - float(exit_buffer_hours)   # width of the ramp band
-    if span <= 0:
-        return max_pct
-    # progress 0.0 at window start -> 1.0 at the exit buffer edge
-    elapsed = float(window_hours) - float(hours_to_effective)
-    progress = elapsed / span
-    if progress < 0.0:
-        progress = 0.0
-    if progress > 1.0:
-        progress = 1.0
-    return base_pct + (max_pct - base_pct) * progress
-
-
-def clamp_leverage(requested, lo=1, hi=5, venue_max=None):
-    """Clamp leverage to [lo, hi], then to the instrument's venue max if given.
-    Mirrors the fleet leverage-clamp idiom. Pure."""
-    try:
-        lev = int(requested)
-    except (TypeError, ValueError):
-        lev = lo
+def clamp_leverage(desired, venue_max, lo=1, hi=5):
+    """Clamp `desired` into [lo, hi] then to the instrument's venue max (if known
+    and positive). Returns an int >= lo. Mirrors the octopus/dire venue clamp."""
+    lev = int(desired)
     lev = max(lo, min(lev, hi))
-    if venue_max is not None:
+    if venue_max:
         try:
             vm = int(venue_max)
             if vm > 0:
                 lev = min(lev, vm)
         except (TypeError, ValueError):
             pass
-    return lev
-
-
-# ── confirmation signature: does passive-anticipation flow actually show up? ──
-
-def anticipation_confirms(direction, candles_4h, candles_1h, min_vol_trend):
-    """Confirm the passive-anticipation SIGNATURE before riding an event.
-
-    The forced-flow thesis is only worth riding if the market is already moving the
-    expected way INTO the date: a 4h trend in the event's direction AND rising 4h
-    volume (passive desks accumulating). 1h is a softer confirm used for the reason
-    string only. Returns (ok: bool, reasons: list[str], detail: dict). Pure.
-
-    For an ADD (LONG) we want BULLISH 4h structure + rising volume; for a DELETE
-    (SHORT) we want BEARISH 4h structure + rising volume (distribution)."""
-    reasons = []
-    detail = {}
-    if len(candles_4h) < 6:
-        return False, ["insufficient_4h_history"], detail
-
-    t4, s4 = trend_structure(candles_4h)
-    t1, _ = trend_structure(candles_1h) if len(candles_1h) >= 6 else ("NEUTRAL", 0.0)
-    vt4 = volume_trend(candles_4h)
-    detail = {"trend4h": t4, "trend4hStrength": round(s4, 4),
-              "trend1h": t1, "volTrend4hPct": round(vt4, 2)}
-
-    want = "BULLISH" if direction == "LONG" else "BEARISH"
-    if t4 != want:
-        reasons.append(f"4h_not_{want.lower()}_{t4.lower()}")
-        return False, reasons, detail
-    reasons.append(f"4h_{t4.lower()}_{s4:.0%}")
-
-    if vt4 < float(min_vol_trend):
-        reasons.append(f"vol_flat_{vt4:+.0f}%")
-        return False, reasons, detail
-    reasons.append(f"vol_rising_{vt4:+.0f}%")
-
-    if (direction == "LONG" and t1 == "BULLISH") or (direction == "SHORT" and t1 == "BEARISH"):
-        reasons.append(f"1h_confirms_{t1.lower()}")
-
-    return True, reasons, detail
-
-
-def _note(msg):
-    """One-line stderr note helper (kept here so scan stays terse)."""
-    print(f"[barnacle.scoring] {msg}", file=sys.stderr)
+    return max(lo, lev)

--- a/strategies/barnacle/strategy.yaml
+++ b/strategies/barnacle/strategy.yaml
@@ -1,28 +1,28 @@
-# Barnacle — Index-inclusion / passive-flow front-runner. A single-instance PACKAGE:
+# Barnacle — autonomous stealth-accumulation / decoupler. A single-instance PACKAGE:
 # this manifest + one self-contained runtime.yaml + scanners/. A NET-NEW Runtime 3.0
-# strategy (NOT a port). Thesis: when a stock is announced for ADD to a major index
-# (S&P 500 / Nasdaq-100 / Russell), index funds are FORCED to buy it by the rebalance
-# effective date — a predictable passive-buying wave that lifts price INTO the date.
-# Barnacle rides that flow on Hyperliquid XYZ equity perps and EXITS before the
-# rebalance (the pop fades once forced buying completes); DELETE events mirror as
-# shorts. The universe is CONFIG-DRIVEN (inputs.events) — there is no MCP feed for
-# index rebalances. Install/teardown via senpi-strategy-ops.
+# strategy (NOT a port). Thesis: index inclusions, M&A targets, and catalyst run-ups
+# all leave the SAME fingerprint visible in the tape WITHOUT knowing the catalyst — a
+# name DECOUPLING from the broad market on persistent, rising volume with shallow
+# (bought) dips, i.e. relentless accumulation rather than a one-bar spike. Barnacle
+# detects that footprint AUTONOMOUSLY from market data (no operator calendar, no event
+# feed) across the live Hyperliquid xyz board and rides it; the DSL owns the exit. LONG
+# up-accumulation, SHORT down-distribution. Install/teardown via senpi-strategy-ops.
 schema_version: 1
 
 id: barnacle
 version: "1.0.0"
 
 catalog:
-  name: "Barnacle — Index-Inclusion Front-Runner"
+  name: "Barnacle — Stealth Accumulation Detector"
   emoji: "🦪"
-  tagline: "Front-runs index-rebalance flow on Hyperliquid XYZ equity perps: when a stock is announced for addition to the S&P 500 / Nasdaq-100 / Russell, index funds are FORCED to buy it by the effective date — Barnacle rides that predictable passive-buying wave into the date and sells into the inclusion before the rebalance completes. Index deletions mirror as shorts."
-  belief_plain: "When a company is announced for addition to a big index like the S&P 500, every index fund has to buy it before a set date — that forced buying reliably lifts the price into the date. Barnacle gets in early on the stock (as a perp on Hyperliquid XYZ), rides the run-up, and gets out just before the rebalance, because the pop usually fades once the forced buying is done. Index removals work the same way in reverse, as shorts. You give it the list of upcoming index changes; it trades only those names."
-  thesis: "Index-inclusion is one of the most-documented predictable flows in equities: passive funds tracking the S&P 500 / Nasdaq-100 / Russell MUST buy an added name by the rebalance effective date, regardless of price, producing an anticipatory run-up that front-runners capture and that fades after the forced buying completes. Hyperliquid XYZ lists these equities as leveraged perps, so the flow is tradeable both directions (additions long, deletions short). There is no market data feed for index events, so the universe is operator-supplied (inputs.events); the agent only trades the configured names, only inside the anticipation window, only when the passive-flow signature confirms, and it deliberately exits BEFORE the effective date rather than holding through the rebalance."
-  group: event-driven
-  archetype: event_driven
-  sub_style: index_inclusion
-  asset_classes: [xyz_equities]
-  asset_scope: basket
+  tagline: "An autonomous decoupler on Hyperliquid XYZ equity/commodity/index perps: it finds names quietly DECOUPLING from the broad market — outperforming the xyz index on persistent rising volume with shallow, bought dips (relentless accumulation, not a one-bar spike) — and rides the grind. No calendar, no event feed: the catalyst footprint is read straight from the tape. LONG up-accumulation, SHORT down-distribution; a wide DSL ratchet lets winners run."
+  belief_plain: "Big catalysts — a stock getting added to an index, a buyout brewing, a sector run-up — all leave the same tell in the chart before anyone needs to know the news: the name starts beating the broad market on steady, rising volume, and every dip gets bought instead of selling off. That is accumulation, and Barnacle hunts for it automatically across the stocks, commodities and indices on Hyperliquid XYZ. It doesn't need you to feed it a calendar — it reads the footprint itself, goes long the quiet climbers (or short the quiet bleeders), and trails a stop so a real move can run for days."
+  thesis: "You don't need to know WHY a name is being accumulated to trade the accumulation. Index inclusions, M&A targets, and catalyst run-ups share one observable signature: the name decouples from its benchmark (positive excess return vs the broad xyz market) on PERSISTENT rising volume, and the largest pullback within the move stays shallow because the dips are bought — a grind, not a volatile breakout. Barnacle measures exactly that footprint from market data: excess return vs xyz:XYZ100 sets direction and conviction, 4h volume persistence and a shallow-deepest-dip confirm it's accumulation not noise, 4h/1h trend structure confirms the path, and a smart-money lean nudges the score. Because the edge is read from the tape rather than an event date, the agent needs no operator calendar and the DSL owns the exit — a wide let-winners-run ratchet rides the grind, with a 48h cap so equity/index perps don't camp through the weekend pricing gap."
+  group: momentum
+  archetype: trend_following
+  sub_style: accumulation
+  asset_classes: [xyz_equities, commodities, indices]
+  asset_scope: universe
   direction: long_short
   risk_level: moderate
   tier: advanced
@@ -30,8 +30,8 @@ catalog:
   leverage_max: 5
   max_slots: 3
   min_budget: 200
-  assets: ["xyz:SPCX"]
-  tags: [index-inclusion, index-rebalance, passive-flow, front-running, sp500, nasdaq100, russell, event-driven, xyz, equities, long-short, calendar]
+  assets: []
+  tags: [accumulation, decoupler, relative-strength, excess-return, smart-money, volume-persistence, xyz, equities, commodities, indices, trend-following, long-short, autonomous, universe]
 
 requires:
   runtime: ">=3.0.0"

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -439,55 +439,6 @@
       "sort_order": 1
     },
     {
-      "id": "barnacle",
-      "name": "Barnacle — Index-Inclusion Front-Runner",
-      "emoji": "🦪",
-      "tagline": "Front-runs index-rebalance flow on Hyperliquid XYZ equity perps: when a stock is announced for addition to the S&P 500 / Nasdaq-100 / Russell, index funds are FORCED to buy it by the effective date — Barnacle rides that predictable passive-buying wave into the date and sells into the inclusion before the rebalance completes. Index deletions mirror as shorts.",
-      "belief_plain": "When a company is announced for addition to a big index like the S&P 500, every index fund has to buy it before a set date — that forced buying reliably lifts the price into the date. Barnacle gets in early on the stock (as a perp on Hyperliquid XYZ), rides the run-up, and gets out just before the rebalance, because the pop usually fades once the forced buying is done. Index removals work the same way in reverse, as shorts. You give it the list of upcoming index changes; it trades only those names.",
-      "version": "1.0.0",
-      "thesis": "Index-inclusion is one of the most-documented predictable flows in equities: passive funds tracking the S&P 500 / Nasdaq-100 / Russell MUST buy an added name by the rebalance effective date, regardless of price, producing an anticipatory run-up that front-runners capture and that fades after the forced buying completes. Hyperliquid XYZ lists these equities as leveraged perps, so the flow is tradeable both directions (additions long, deletions short). There is no market data feed for index events, so the universe is operator-supplied (inputs.events); the agent only trades the configured names, only inside the anticipation window, only when the passive-flow signature confirms, and it deliberately exits BEFORE the effective date rather than holding through the rebalance.",
-      "tags": [
-        "index-inclusion",
-        "index-rebalance",
-        "passive-flow",
-        "front-running",
-        "sp500",
-        "nasdaq100",
-        "russell",
-        "event-driven",
-        "xyz",
-        "equities",
-        "long-short",
-        "calendar"
-      ],
-      "group": "event-driven",
-      "archetype": "event_driven",
-      "archetype_label": "Event-Driven",
-      "sub_style": "index_inclusion",
-      "sub_style_label": "Front-runs index additions/deletions for the forced passive-fund flow into the rebalance effective date.",
-      "asset_classes": [
-        "xyz_equities"
-      ],
-      "asset_scope": "basket",
-      "assets": [
-        "xyz:SPCX"
-      ],
-      "direction": "long_short",
-      "risk_level": "moderate",
-      "tier": "advanced",
-      "leverage_max": 5,
-      "time_horizon": "swing",
-      "cadence_seconds": 900,
-      "min_budget": 200,
-      "instance_count": 1,
-      "funding_split": [
-        1.0
-      ],
-      "max_slots": 3,
-      "branch": "strategy-v2",
-      "sort_order": 1
-    },
-    {
       "id": "magpie",
       "name": "Magpie — IPO / New-Listing Event Fund",
       "emoji": "🐦",
@@ -532,7 +483,7 @@
       ],
       "max_slots": 6,
       "branch": "strategy-v2",
-      "sort_order": 2
+      "sort_order": 1
     },
     {
       "id": "elephant",
@@ -711,6 +662,57 @@
       "sort_order": 1
     },
     {
+      "id": "barnacle",
+      "name": "Barnacle — Stealth Accumulation Detector",
+      "emoji": "🦪",
+      "tagline": "An autonomous decoupler on Hyperliquid XYZ equity/commodity/index perps: it finds names quietly DECOUPLING from the broad market — outperforming the xyz index on persistent rising volume with shallow, bought dips (relentless accumulation, not a one-bar spike) — and rides the grind. No calendar, no event feed: the catalyst footprint is read straight from the tape. LONG up-accumulation, SHORT down-distribution; a wide DSL ratchet lets winners run.",
+      "belief_plain": "Big catalysts — a stock getting added to an index, a buyout brewing, a sector run-up — all leave the same tell in the chart before anyone needs to know the news: the name starts beating the broad market on steady, rising volume, and every dip gets bought instead of selling off. That is accumulation, and Barnacle hunts for it automatically across the stocks, commodities and indices on Hyperliquid XYZ. It doesn't need you to feed it a calendar — it reads the footprint itself, goes long the quiet climbers (or short the quiet bleeders), and trails a stop so a real move can run for days.",
+      "version": "1.0.0",
+      "thesis": "You don't need to know WHY a name is being accumulated to trade the accumulation. Index inclusions, M&A targets, and catalyst run-ups share one observable signature: the name decouples from its benchmark (positive excess return vs the broad xyz market) on PERSISTENT rising volume, and the largest pullback within the move stays shallow because the dips are bought — a grind, not a volatile breakout. Barnacle measures exactly that footprint from market data: excess return vs xyz:XYZ100 sets direction and conviction, 4h volume persistence and a shallow-deepest-dip confirm it's accumulation not noise, 4h/1h trend structure confirms the path, and a smart-money lean nudges the score. Because the edge is read from the tape rather than an event date, the agent needs no operator calendar and the DSL owns the exit — a wide let-winners-run ratchet rides the grind, with a 48h cap so equity/index perps don't camp through the weekend pricing gap.",
+      "tags": [
+        "accumulation",
+        "decoupler",
+        "relative-strength",
+        "excess-return",
+        "smart-money",
+        "volume-persistence",
+        "xyz",
+        "equities",
+        "commodities",
+        "indices",
+        "trend-following",
+        "long-short",
+        "autonomous",
+        "universe"
+      ],
+      "group": "momentum",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "accumulation",
+      "sub_style_label": "Detects persistent institutional accumulation — relative-strength decoupling from the market on rising volume with shallow, bought dips — from the tape, no catalyst feed needed.",
+      "asset_classes": [
+        "xyz_equities",
+        "commodities",
+        "indices"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "strategy-v2",
+      "sort_order": 2
+    },
+    {
       "id": "bison",
       "name": "Bison — Conviction Momentum Holder",
       "emoji": "🦬",
@@ -756,7 +758,7 @@
       ],
       "max_slots": 3,
       "branch": "strategy-v2",
-      "sort_order": 2
+      "sort_order": 3
     },
     {
       "id": "caracal",
@@ -809,7 +811,7 @@
       ],
       "max_slots": 6,
       "branch": "strategy-v2",
-      "sort_order": 3
+      "sort_order": 4
     },
     {
       "id": "condor",
@@ -851,7 +853,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "falcon",
@@ -894,7 +896,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "hedgehog",
@@ -943,7 +945,7 @@
       ],
       "max_slots": 3,
       "branch": "strategy-v2",
-      "sort_order": 6
+      "sort_order": 7
     },
     {
       "id": "hornet",
@@ -1010,7 +1012,7 @@
       ],
       "max_slots": 3,
       "branch": "strategy-v2",
-      "sort_order": 7
+      "sort_order": 8
     },
     {
       "id": "lemur",
@@ -1056,7 +1058,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 8
+      "sort_order": 9
     },
     {
       "id": "lynx",
@@ -1107,7 +1109,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "meerkat",
@@ -1151,7 +1153,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "orca",
@@ -1194,7 +1196,7 @@
       ],
       "max_slots": 3,
       "branch": "strategy-v2",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "otter",
@@ -1238,7 +1240,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "piranha",
@@ -1290,7 +1292,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "python",
@@ -1334,7 +1336,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "sailfish",
@@ -1384,7 +1386,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 15
+      "sort_order": 16
     },
     {
       "id": "salamander",
@@ -1434,7 +1436,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 16
+      "sort_order": 17
     },
     {
       "id": "sheep",
@@ -1487,7 +1489,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 17
+      "sort_order": 18
     },
     {
       "id": "jaguar",


### PR DESCRIPTION
Replaces the just-merged v1 barnacle, which needed the operator to hand-feed the index-rebalance calendar (`inputs.events`) — not genuinely autonomous, because the `scan()` runtime has **no news/calendar feed**, only market data.

**v2 detects the footprint instead of the headline.** Index inclusions, M&A targets, and catalyst run-ups all leave the same tape-readable fingerprint: a name **decoupling from the broad market (`xyz:XYZ100`) on persistent rising volume with shallow, bought dips** — relentless accumulation, not a one-bar spike. Barnacle now scans the live xyz board (`market_list_instruments`), scores that footprint, and rides it (the DSL owns the exit). LONG up-accumulation, SHORT down-distribution. It would have caught SPCX on the data alone — no calendar.

- archetype `event_driven`/`index_inclusion` → `trend_following`/`accumulation` (new sub_style; the now-unused `index_inclusion` removed from the glossary).
- `asset_scope: universe`, read-guarded MCP (incl. `market_list_instruments`), marginPct percent, benchmark `xyz:XYZ100` HL-validated, equity let-winners-run DSL (48h hard_timeout).
- catalog 75 / 0 warnings; all 75 pass the validator.

Ready to merge to replace v1.
