### PR TITLE
feat: stingray + oxpecker + hyena (smart-money rotation agents) — 75 -> 78

### DIFF
--- a/senpi-strategy-discover/references/glossary.yaml
+++ b/senpi-strategy-discover/references/glossary.yaml
@@ -70,12 +70,15 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   funding_extreme: { gloss: "Fades extreme funding rates." }
   xyz_overextended: { gloss: "Fades overextended stocks/commodities." }
   crowd_exhaustion: { gloss: "Fades a crowded one-sided move once it shows exhaustion." }
+  risk_off_rotation: { gloss: "Shorts the crypto block when smart money rotates out and longs are crowded — a risk-off hedge." }
   # copy_trading
   arena_winners: { gloss: "Copies multi-week arena winners, not one-week wonders." }
   hot_streak:    { gloss: "Copies whoever is hot in the live window." }
   named_whales:  { gloss: "Mirrors specific hand-picked whales." }
   copy_the_copiers: { gloss: "Follows the best-performing strategies automatically." }
   cohort_divergence: { gloss: "Acts when a smart-money cohort diverges from price." }
+  sm_rotation: { gloss: "Follows where smart money is rotating across asset classes — long the crowded-into, short the fled." }
+  elite_conviction: { gloss: "Mirrors only top-tier (elite/reliable) traders' concentrated, high-conviction positions." }
   # single_market
   pre_ipo:       { gloss: "Trades pre-IPO perpetuals (IPOPs) before the company lists." }
   ipo_moment:    { gloss: "Trades the IPO conversion moment." }

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -3525,6 +3525,68 @@
       "sort_order": 4
     },
     {
+      "id": "hyena",
+      "name": "Hyena — Risk-Off Crypto Short (Hedge Sleeve)",
+      "emoji": "🐺",
+      "tagline": "A short-only crypto defense sleeve on majors (BTC/ETH/SOL/HYPE) plus crypto-proxy equities (xyz:MSTR/COIN/CRCL): shorts the block ONLY when risk-off confirms — the market-wide funding regime is LONG_CROWDED (crowded longs = squeeze fuel), smart money is rotating OUT of the name, and the 4h trend is breaking down. Conservative 4x, tight short-side DSL, 30h cap because squeezes resolve fast. CAVEAT: this is a hedge that pairs with long crypto exposure — it idles and emits nothing whenever risk-off conditions are not met.",
+      "belief_plain": "Most of the time the safe trade on crypto is no trade. But when the best traders are all crowded long, smart money starts rotating out, and price begins rolling over together, that crowded long is fuel for a squeeze to the downside. Hyena bets against that exhausted crowd — short only — on Bitcoin, Ether, Solana, HYPE, and the crypto-proxy stocks MicroStrategy, Coinbase and Circle. It is a defense sleeve you run alongside your long crypto bets to cushion a downturn; when the risk-off picture is not there, it does nothing and waits.",
+      "version": "1.0.0",
+      "thesis": "The fleet has no dedicated short-biased crypto agent — every directional engine is long-or-long/short, so there is no clean defensive sleeve for a risk-off turn. Hyena fills that gap. It treats the market-wide funding regime as a master gate: it only opens new shorts when funding shows the crowd is one-sided LONG (LONG_CROWDED), because a crowded long is the squeeze that a short monetizes. On top of that gate it requires, per name, that smart money is net-SHORT (rotating out) AND that the 4h structure is making lower highs (price confirming the unwind). All three must agree, so it sits idle in normal markets and only acts on genuine risk-off confluence. It is short_only by design — a hedge meant to be paired with long crypto exposure, sized conservatively (15% margin, 4x) with a tight short-side DSL and a 30h hold cap because short squeezes resolve fast.",
+      "tags": [
+        "short-only",
+        "hedge",
+        "risk-off",
+        "defense",
+        "funding-regime",
+        "smart-money",
+        "rotation",
+        "contrarian",
+        "crypto-proxy",
+        "btc",
+        "eth",
+        "sol",
+        "hype",
+        "mstr",
+        "coin",
+        "crcl",
+        "idles-when-uncertain"
+      ],
+      "group": "smart-money",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "risk_off_rotation",
+      "sub_style_label": "Shorts the crypto block when smart money rotates out and longs are crowded — a risk-off hedge.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE",
+        "xyz:MSTR",
+        "xyz:COIN",
+        "xyz:CRCL"
+      ],
+      "direction": "short_only",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 5
+    },
+    {
       "id": "marlin",
       "name": "Marlin — Order-Book Imbalance Momentum",
       "emoji": "🐟",
@@ -3573,7 +3635,52 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 5
+      "sort_order": 6
+    },
+    {
+      "id": "oxpecker",
+      "name": "Oxpecker — Elite-Conviction Concentrated Mirror",
+      "emoji": "🐦",
+      "tagline": "Maintains a daily-refreshed pool of the most consistent (ELITE/RELIABLE) Hyperliquid traders, reads each one's open book, and mirrors ONLY their single highest-conviction bet — and only when that one position dominates their whole book (e.g. ~98% of capital in one 3x position). Leans hardest when several elite traders independently pile into the same concentrated trade.",
+      "belief_plain": "Looks past the leaderboard noise and keeps a shortlist of the steadiest, most-proven traders on Hyperliquid. Instead of copying everything they do, Oxpecker copies only the trade they're betting their whole book on — the one position that makes up most of their capital. When more than one of those proven traders is all-in on the same trade in the same direction, it bets harder, then trails a wide stop so the conviction can run.",
+      "version": "1.0.0",
+      "thesis": "A proven trader's signal is loudest exactly when they concentrate. Cohort copiers average a pool and whale mirrors ride a fixed name list; Oxpecker does neither — it screens for the highest consistency tier (ELITE/RELIABLE) and then, within that elite set, only acts on positions that represent real conviction: where one bet is the overwhelming majority of the trader's book. A reliable trader with ~98% of their capital in one short is telling you something an opaque cohort average buries. Quality-tier x position-concentration is the whole edge — consensus across multiple elite traders on the same concentrated trade is the strongest signal there is, and the wide let-winners-run DSL respects that conviction rather than scalping it.",
+      "tags": [
+        "copy-trading",
+        "smart-money",
+        "elite",
+        "conviction",
+        "concentration",
+        "consensus",
+        "quality-tier",
+        "follows-traders",
+        "let-winners-run",
+        "long-short"
+      ],
+      "group": "smart-money",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "elite_conviction",
+      "sub_style_label": "Mirrors only top-tier (elite/reliable) traders' concentrated, high-conviction positions.",
+      "asset_classes": [
+        "none"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "strategy-v2",
+      "sort_order": 7
     },
     {
       "id": "raptor",
@@ -3614,7 +3721,7 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 6
+      "sort_order": 8
     },
     {
       "id": "remora",
@@ -3656,7 +3763,7 @@
       ],
       "max_slots": 1,
       "branch": "strategy-v2",
-      "sort_order": 7
+      "sort_order": 9
     },
     {
       "id": "roach",
@@ -3700,7 +3807,54 @@
       ],
       "max_slots": 2,
       "branch": "strategy-v2",
-      "sort_order": 8
+      "sort_order": 10
+    },
+    {
+      "id": "stingray",
+      "name": "Stingray — Cross-Asset Smart-Money Rotation",
+      "emoji": "🐠",
+      "tagline": "Reads the entire smart-money board every tick, ranks every asset by net smart-money conviction (tilt x notional x breadth), then rides the rotation — LONG the assets the best traders are crowding into and SHORT the ones they're fleeing, gated by price so it never fights a hard trend. Captures days like 'long semis/indices, short the crypto block'.",
+      "belief_plain": "Most copy-trading bots ask 'are the best traders long this one coin?'. Stingray instead looks at the whole market at once and asks 'what are the best traders rotating INTO, and what are they rotating OUT OF?'. It buys the crowd's new favorites and sells the ones they're abandoning — but only when the price chart isn't already screaming the other way — then trails a wide stop so a real rotation can run for days.",
+      "version": "1.0.0",
+      "thesis": "Smart money doesn't just pick coins, it rotates capital across the whole board — out of one asset class and into another. Per-asset copy-traders miss this because they evaluate each market in isolation; they can't see that the SAME flow leaving crypto is funding the bid in indices. Stingray ranks the entire board by net tilt (long_ratio - 50) weighted by notional and trader breadth, so a strong, deep, widely-held lean outranks a thin spike, then takes BOTH sides at once — long the inflows, short the outflows — for a market-neutral-ish rotation book. A price-confirmation gate (no longs into a hard 4h downtrend, no shorts into a hard uptrend) keeps it from fighting price, and a DSL ratchet lets the winning legs run while cutting the losers.",
+      "tags": [
+        "smart-money",
+        "rotation",
+        "cross-asset",
+        "copy-trading",
+        "long-short",
+        "universe-scanner",
+        "net-tilt",
+        "conviction-weight",
+        "let-winners-run"
+      ],
+      "group": "smart-money",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "sm_rotation",
+      "sub_style_label": "Follows where smart money is rotating across asset classes — long the crowded-into, short the fled.",
+      "asset_classes": [
+        "universe_crypto",
+        "xyz_equities",
+        "commodities",
+        "indices"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 4,
+      "branch": "strategy-v2",
+      "sort_order": 11
     },
     {
       "id": "whalehunter",
@@ -3743,7 +3897,7 @@
       ],
       "max_slots": 6,
       "branch": "strategy-v2",
-      "sort_order": 9
+      "sort_order": 12
     },
     {
       "id": "osprey",

--- a/strategies/hyena/main/runtime.yaml
+++ b/strategies/hyena/main/runtime.yaml
@@ -1,0 +1,147 @@
+# ── HYENA · single instance — risk-off crypto SHORT hedge sleeve (NET-NEW Runtime 3.0) ──
+# The fleet's dedicated SHORT-biased crypto/crypto-proxy agent. SHORT_ONLY by design:
+# it shorts the crypto block ONLY when risk-off conditions confirm on three axes —
+#   (1) market-wide funding regime LONG_CROWDED (master gate; crowded longs = squeeze
+#       fuel), (2) smart money net-SHORT the name (rotating OUT), (3) 4h downtrend
+#       (lower-highs) confirming. ALL three must agree. NEVER goes long.
+# It IDLES (emits nothing, WAITING) the rest of the time — a hedge that pairs with long
+# crypto exposure, not a standalone return engine. Universe: BTC/ETH/SOL/HYPE (main DEX)
+# + xyz:MSTR/xyz:COIN/xyz:CRCL (XYZ DEX crypto-proxy equities), all validated live on HL
+# meta 2026-06-30. Parsing for funding_regime + smart-money is copied from the Dog gold
+# template; account read-guard from Bison/Bobcat; dex-aware fetch from Bobcat.
+name: hyena-main
+group: hyena
+version: 1.0.0
+description: >
+  HYENA — risk-off crypto SHORT hedge sleeve. SHORT_ONLY: shorts the crypto block
+  (BTC/ETH/SOL/HYPE + xyz crypto-proxies MSTR/COIN/CRCL) ONLY when risk-off
+  confirms — master gate: market-wide funding regime LONG_CROWDED (or a per-asset
+  crowded-long funding fallback); per name: smart money net-SHORT AND a 4h
+  downtrend (lower-highs). Scores regime crowding + SM short tilt + downtrend
+  strength + funding squeeze; emits the top 1-2 SHORTs per tick. Conservative
+  margin (15% base) at low leverage (4x, clamped [1,5] then to the venue cap).
+  Short-side DSL ladder — Phase 1 max_loss 12%, Phase 2 first lock reachable at
+  +8%, hard_timeout 30h (squeezes resolve fast). NEVER goes long; idles (WAITING)
+  whenever risk-off conditions are not met. A defense sleeve, not a return engine.
+
+strategy:
+  wallet: "${HYENA_WALLET}"
+  slots: 2                                 # emits top 1-2 shorts; runtime owns the ceiling
+  margin_pct: 15                           # baseline %; scan emits the same flat marginPct per signal
+  default_leverage: 4                      # fallback; scan emits 4x clamped [1,5] then venue cap
+  trading_risk: aggressive                 # short-biased leverage carries squeeze risk
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: hyena_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                   # 5 min cadence
+    timeout_seconds: 180                    # account + regime + leaderboard + per-asset candles/funding
+    default_signal_validity_seconds: 600    # 2x tick; a fresh re-score arrives next tick
+    state_history_max_count: 100            # dedup map + per-tick scan-result history
+    inputs:
+      universe: ["BTC", "ETH", "SOL", "HYPE", "xyz:MSTR", "xyz:COIN", "xyz:CRCL"]  # validated live vs HL meta 2026-06-30
+      minScore: 5                           # SHORT-eligibility floor (regime+SM+downtrend baseline)
+      marginPct: 15                         # PERCENT of withdrawable (0,100]; flat
+      leverage: 4                           # clamped to [leverageMin,leverageMax] then venue cap in scan.py
+      leverageMin: 1
+      leverageMax: 5
+      leaderboardLimit: 100                 # leaderboard_get_markets aggregation depth
+      maxEmit: 2                            # emit top 1-2 shorts
+      smShortTiltMinPct: 55                 # SM must be net-SHORT with >=55% tilt (gate)
+      smStrongTiltPct: 70                   # strong-short tilt (+1 bonus)
+      crowdedLongFundingThreshold: 0.0002   # per-asset crowded-long funding fallback/bonus
+      recentSignalTtlSeconds: 240           # race-window dedup
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      smDirection: { type: string, required: false }
+      smTiltPct: { type: number, required: false }
+      downStrength: { type: number, required: false }
+      priceChange4hPct: { type: number, required: false }
+      fundingRegime: { type: string, required: false }
+      assetFunding: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: hyena_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every risk-off filter
+    scanners: [hyena_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true     # a short into a breaking-down market must fill; maker-only rests (CREATE_ORDER_RESTING)
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: hyena_signals
+
+# ── EXIT (DSL — short-side ladder) ────────────────────────────────────────────
+# Short squeezes resolve FAST, so the hold is capped (hard_timeout 30h) and the
+# first profit lock is reachable EARLY (+8% ROE). Phase 1 max_loss 12% (a crowded
+# long unwinding can squeeze hard against a short — tighter floor than the
+# trend-follower family). Phase 2 wide-enough ladder so a real risk-off cascade
+# rides multi-bar. weak_peak_cut KEPT (self-limiting: a short that never works in
+# 90m is a failed thesis). order_type FEE_OPTIMIZED_LIMIT, taker fallback on
+# (closes MUST happen — a stuck short is unbounded risk). interval_seconds 60.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true         # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                         # 30h cap — squeezes resolve fast; don't camp a stale short
+      interval_in_minutes: 1800
+    weak_peak_cut:
+      enabled: true                         # cut if peak ROE < 2.0 in 90m — failed short thesis
+      interval_in_minutes: 90
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                     # tight — an unwinding crowded long can squeeze a short hard
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                 # first lock reachable EARLY (+8%); then breathe for a cascade
+        - { trigger_pct: 8,  lock_hw_pct: 0  }
+        - { trigger_pct: 15, lock_hw_pct: 30 }
+        - { trigger_pct: 25, lock_hw_pct: 50 }
+        - { trigger_pct: 40, lock_hw_pct: 65 }
+        - { trigger_pct: 60, lock_hw_pct: 80 }
+
+# ── RISK guard rails (seconds) ──
+risk:
+  data_retention_seconds: 259200            # 72h; within [3600, 604800]
+  guard_rails:
+    daily_loss_limit_pct: 12                # short-biased squeeze risk -> conservative daily cap
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 3600                   # post-loss cooldown 60m
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 7200         # 2h per-asset cooldown
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/hyena/main/scanners/scan.py
+++ b/strategies/hyena/main/scanners/scan.py
@@ -1,0 +1,380 @@
+"""HYENA — supervised scanner (NET-NEW Runtime 3.0 risk-off SHORT hedge sleeve).
+
+The fleet's dedicated SHORT-biased crypto/crypto-proxy agent. SHORT_ONLY by
+design: it shorts the crypto block ONLY when risk-off conditions confirm, and it
+EMITS NOTHING (idles, WAITING) the rest of the time. It NEVER goes long.
+
+Per tick it:
+  1. reads the account + held set (clearinghouse, dual-DEX equity via max(),
+     XYZ enumerated; bison/bobcat read-sanity guard),
+  2. fetches the MASTER risk-off gate: market_get_funding_regime (READ-GUARDED,
+     dog's parser). New shorts proceed ONLY when the regime is LONG_CROWDED.
+     If the market-wide regime read is unavailable/NEUTRAL, a per-asset
+     crowded-long funding fallback can still confirm a short on a name; a
+     SHORT_CROWDED regime blocks ALL new shorts this tick (WAITING),
+  3. for each universe name: net smart-money direction (leaderboard_get_markets,
+     READ-GUARDED, dog/bison parser) + 4h candles (market_get_asset_data,
+     dex-aware per bobcat, READ-GUARDED) + per-asset funding rate,
+  4. scores SHORT-eligible names (regime crowding + SM short tilt + 4h downtrend
+     strength + funding squeeze) and emits the top 1-2 SHORTs (held +
+     recent-signal dedup).
+
+Read-only + single-pass — emits a `marginPct` intent (PERCENT) + `leverage`
+(clamped [1,5] then to the venue cap). The runtime sizes the dollars, owns
+cooldowns/risk gates, and trails the DSL exit. No daemon, no push_signal, no
+create_position.
+
+PARSING PROVENANCE: market_get_funding_regime + leaderboard_get_markets parsing
+is COPIED from the Dog gold template (dog/main/scanners/scan.py); the account
+read-guard + dual-DEX collapse from Bison/Bobcat; the dex-aware asset fetch from
+Bobcat. None of the MCP response shapes are invented.
+"""
+
+import sys
+import time
+
+import scoring
+
+
+# Defaults (overridable via runtime.yaml inputs)
+_UNIVERSE_DEFAULT = ["BTC", "ETH", "SOL", "HYPE", "xyz:MSTR", "xyz:COIN", "xyz:CRCL"]
+_DEFAULT_MIN_SCORE = 5            # SHORT-eligibility floor (regime+SM+downtrend baseline = 5)
+_DEFAULT_MARGIN_PCT = 15.0       # PERCENT of withdrawable (0,100]
+_DEFAULT_LEVERAGE = 4            # clamped to [leverageMin,leverageMax] then venue cap
+_DEFAULT_LEVERAGE_MIN = 1
+_DEFAULT_LEVERAGE_MAX = 5
+_DEFAULT_LEADERBOARD_LIMIT = 100  # leaderboard_get_markets aggregation depth
+_DEFAULT_MAX_EMIT = 2            # emit top 1-2 shorts
+_DEFAULT_RECENT_TTL = 240        # race-window dedup (seconds)
+_DEFAULT_CROWDED_FUNDING = 0.0002  # per-asset crowded-long funding fallback/bonus
+
+
+def _dex_for(asset, inputs):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass '' (bobcat)."""
+    dex = inputs.get("dex")
+    if dex is not None and not str(asset).lower().startswith("xyz:"):
+        # An explicit non-xyz dex override only applies to non-prefixed names.
+        return dex
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll the
+    whole tick back (the contract rolls ANY exception back to []). Returns None on
+    failure so the degrade paths apply (regime None -> funding fallback; markets
+    empty -> SM None per name; candles None -> name skipped)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[hyena.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+# ── ACCOUNT + HELD ASSETS (bison/bobcat dual-DEX read-guard, verbatim pattern) ──
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across
+    main/xyz (two views of ONE cross-margined wallet — summing double-counts the
+    shared free balance -> 2x sizing). assetPositions enumerated across both
+    sub-DEX sections. Includes the read-sanity guard (margin in use + empty
+    positions -> skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) or {}
+        account_value = max(account_value, scoring.safe_float(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring.safe_float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""),
+                              "margin": scoring.safe_float(pos.get("marginUsed", 0))})
+
+    # read-sanity guard: a corrupt clearinghouse read can report margin/notional
+    # IN USE while returning an EMPTY positions list; running held-asset dedup off
+    # that re-enters held names (pyramiding) and mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring.safe_float(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring.safe_float(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[hyena.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+# ── FUNDING REGIME (master risk-off gate — dog's fetch_funding_regime, verbatim) ──
+
+def _fetch_regime(ctx):
+    """Market-wide funding regime string (LONG_CROWDED / SHORT_CROWDED / NEUTRAL)
+    or None. READ-GUARDED. Parser COPIED from dog/main/scanners/scan.py."""
+    r = _read(ctx, "market_get_funding_regime", {})
+    if not r:
+        return None
+    if isinstance(r, dict) and r.get("success") is False:
+        return None
+    data = r.get("data", r) if isinstance(r, dict) else r
+    if isinstance(data, dict):
+        return data.get("regime")
+    return None
+
+
+# ── SMART-MONEY MARKETS (dog/bison leaderboard parser, verbatim shape) ──
+
+def _fetch_markets(ctx, limit):
+    """Top-N smart-money leaderboard markets list. READ-GUARDED. Parser COPIED
+    from dog/main/scanners/scan.py."""
+    raw = _read(ctx, "leaderboard_get_markets", {"limit": limit})
+    if not raw:
+        return []
+    if isinstance(raw, dict) and raw.get("success") is False:
+        return []
+    markets = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(markets, dict):
+        markets = markets.get("markets", markets)
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return []
+    return markets
+
+
+def _sm_for(markets, coin):
+    """Net smart-money lean for `coin` from the leaderboard markets list. Returns
+    (direction, tilt_pct) or (None, 0.0). Aggregates the long/short rows for the
+    matched token (dog/bison parse: pct_of_top_traders_gain by direction), then
+    bands via scoring.sm_short_tilt. Token match is case-insensitive; XYZ rows
+    carry a `dex` so the bare crypto name and the xyz proxy don't collide."""
+    want = str(coin).upper()
+    is_xyz = want.startswith("XYZ:")
+    long_pct, short_pct, found = 0.0, 0.0, False
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        dex = str(m.get("dex", "") or "")
+        # match the bare token; require the dex tag to agree (xyz row for xyz name)
+        row_is_xyz = bool(dex) or token.startswith("XYZ:")
+        bare = token.split(":", 1)[-1] if ":" in token else token
+        want_bare = want.split(":", 1)[-1] if ":" in want else want
+        if bare != want_bare or row_is_xyz != is_xyz:
+            continue
+        found = True
+        d = str(m.get("direction", "")).upper()
+        pct = scoring.safe_float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        if d == "LONG":
+            long_pct = pct
+        elif d == "SHORT":
+            short_pct = pct
+    if not found:
+        return None, 0.0
+    return scoring.sm_short_tilt(long_pct, short_pct)
+
+
+# ── 4h CANDLES + per-asset funding (bobcat dex-aware + dog funding, read-guarded) ──
+
+def _asset_data(ctx, coin, dex):
+    """{candles_4h, funding} for `coin` or None. READ-GUARDED. dex-aware (bobcat);
+    pulls 4h candles for the downtrend gate + the 8h funding rate (dog)."""
+    md = _read(ctx, "market_get_asset_data", {
+        "asset": coin,
+        "candle_intervals": ["4h"],
+        "include_funding": True,
+        "include_order_book": False,
+        "dex": dex,
+    })
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = d.get("candles", {}) or {}
+    ac = d.get("asset_context", d.get("assetContext", {})) or {}
+    funding = scoring.safe_float(ac.get("funding", d.get("funding", 0)))
+    return {"candles_4h": candles.get("4h", []) or [], "funding": funding}
+
+
+# ── ctx.state: recent-signal dedup (bobcat/bison pattern) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(str(coin).upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    universe = inputs.get("universe", _UNIVERSE_DEFAULT)
+    min_score = float(inputs.get("minScore", _DEFAULT_MIN_SCORE))
+    leaderboard_limit = int(inputs.get("leaderboardLimit", _DEFAULT_LEADERBOARD_LIMIT))
+    max_emit = int(inputs.get("maxEmit", _DEFAULT_MAX_EMIT))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+    crowded_funding = float(inputs.get("crowdedLongFundingThreshold", _DEFAULT_CROWDED_FUNDING))
+
+    # marginPct: PERCENT in (0,100]. Defensive fraction guard (dire/koala/bobcat
+    # pattern): a value <= 1.0 is a pasted FRACTION (e.g. 0.15) -> *100 -> 15.
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if 0 < margin_pct <= 1.0:
+        margin_pct *= 100.0
+
+    # ── account + held ──
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        _persist(ctx, now, {"emitted": False, "gate": "no_account"})
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    # ── MASTER RISK-OFF GATE: market-wide funding regime ──
+    regime = _fetch_regime(ctx)
+    if regime == "SHORT_CROWDED":
+        # Crowd already short — no squeeze fuel for a new short. Idle.
+        print(f"[hyena.scan] WAITING — regime SHORT_CROWDED; no new shorts. "
+              f"held={sorted(held_set)}", file=sys.stderr)
+        _persist(ctx, now, {"emitted": False, "gate": "regime_short_crowded",
+                            "regime": regime, "held": sorted(held_set)})
+        return []
+    # LONG_CROWDED -> full go. NEUTRAL/None -> proceed but each name needs the
+    # per-asset crowded-long funding fallback to confirm (handled below + scoring).
+    regime_permits = (regime == "LONG_CROWDED")
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── smart-money markets (one read, reused per name) ──
+    markets = _fetch_markets(ctx, leaderboard_limit)
+
+    # ── score every SHORT-eligible name (held + recently-signaled filtered BEFORE
+    #    the per-asset MCP fetch) ──
+    candidates = []
+    scanned = 0
+    for coin in universe:
+        if not coin:
+            continue
+        cu = str(coin).upper()
+        if cu in held_set:
+            continue
+        if _was_recently_signaled(signaled, coin, ttl, now):
+            continue
+        scanned += 1
+        md = _asset_data(ctx, coin, _dex_for(coin, inputs))
+        if not md:
+            continue
+        asset_funding = md["funding"]
+
+        # Per-asset regime fallback: when the market-wide regime doesn't permit
+        # (NEUTRAL/None), a name can still short if its OWN funding is crowded-long
+        # (positive beyond threshold). A SHORT_CROWDED market is already excluded.
+        eff_regime = regime
+        if not regime_permits:
+            if asset_funding > crowded_funding:
+                eff_regime = None   # signals "fallback path" to scoring (+1, not +3)
+            else:
+                continue            # no market-wide AND no per-asset confirmation
+
+        sm = _sm_for(markets, coin)
+        th = scoring.score_short(coin, md["candles_4h"], sm, eff_regime,
+                                 asset_funding, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    out = []
+    if not candidates:
+        note = (f"WAITING (regime={regime}, no SHORT-eligible name >= min score "
+                f"{min_score:.0f})")
+        print(f"[hyena.scan] {note}; scanned={scanned} held={sorted(held_set)}",
+              file=sys.stderr)
+        _persist(ctx, now, {"emitted": False, "gate": "no_candidate",
+                            "regime": regime, "scanned": scanned,
+                            "held": sorted(held_set), "note": note})
+        return []
+
+    # ── emit the top 1-2 SHORTs (highest score) ──
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    emitted = []
+    for c in candidates[:max(1, max_emit)]:
+        signaled[c["asset"].upper()] = now
+        out.append({
+            "asset": c["asset"],
+            "direction": "SHORT",             # SHORT_ONLY — never long
+            "marginPct": margin_pct,          # PERCENT (0,100] — runtime sizes the dollars
+            "leverage": c["leverage"],        # clamped [1,5] then venue cap
+            "data": {
+                "score": c["score"],
+                "direction": "SHORT",
+                "leverage": c["leverage"],
+                "reasons": c["reasons"],
+                "smDirection": c["smDirection"],
+                "smTiltPct": c["smTiltPct"],
+                "downStrength": c["downStrength"],
+                "priceChange4hPct": c["priceChange4hPct"],
+                "fundingRegime": c["fundingRegime"],
+                "assetFunding": c["assetFunding"],
+                "heldAssets": sorted(held_set),
+            },
+        })
+        emitted.append({"asset": c["asset"], "score": c["score"],
+                        "leverage": c["leverage"]})
+
+    top = emitted[0]
+    print(f"[hyena.scan] EMIT {len(out)} short(s); top {top['asset']} SHORT "
+          f"score={top['score']} {top['leverage']}x regime={regime} | "
+          f"{candidates[0]['reasons'][:5]}", file=sys.stderr)
+    _persist(ctx, now, {"emitted": True, "count": len(out), "signals": emitted,
+                        "candidates": len(candidates), "regime": regime,
+                        "held": sorted(held_set)})
+
+    # ── persist dedup map + this tick's result EVERY tick (observability) ──
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled,
+                              "result": {"emitted": True, "count": len(out),
+                                         "signals": emitted, "regime": regime,
+                                         "ts": now}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[hyena.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+    return out
+
+
+def _persist(ctx, now, result):
+    """Append a concise per-tick result to ctx.state (observability). Guarded —
+    a disabled history store or append failure must not crash the tick. (The EMIT
+    path persists the full signaled map inline; this is the non-emit path.)"""
+    if ctx.state is None:
+        return
+    try:
+        ctx.state.append({"signaled": result.get("emitted", False),
+                          "result": dict(result, ts=now)})
+    except Exception as exc:  # noqa: BLE001
+        print(f"[hyena.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)

--- a/strategies/hyena/main/scanners/scoring.py
+++ b/strategies/hyena/main/scanners/scoring.py
@@ -1,0 +1,259 @@
+"""HYENA — pure thesis math (no I/O, no MCP, no clock).
+
+Hyena is a NET-NEW Runtime 3.0 strategy: the fleet's dedicated SHORT-biased
+crypto/crypto-proxy agent — a hedge/defense sleeve. It is SHORT_ONLY by design.
+It NEVER goes long; when risk-off conditions do not confirm it emits nothing and
+idles (WAITING).
+
+This module is pure and unit-testable on plain dicts/lists. All side-data the
+caller resolves via MCP (funding regime, per-asset smart-money lean, 4h candles,
+per-asset funding rate) is passed in, so scoring.py stays I/O-free.
+
+THESIS — Crypto risk-off SHORT (a hedge that pairs with long crypto exposure):
+  Short the crypto block ONLY when risk-off confirms on three independent axes:
+    1. MASTER GATE — market-wide funding regime is LONG_CROWDED (crowded longs =
+       squeeze fuel for the short). Set/enforced by the caller (scan.py); if the
+       regime is NEUTRAL or SHORT_CROWDED, scan.py emits nothing this tick.
+       (A per-asset crowded-long funding rate can stand in when the market-wide
+       regime read is unavailable — see scan.py's regime fallback.)
+    2. Smart money is net-SHORT the name (rotating OUT of crypto).
+    3. Price is confirming DOWN — a 4h downtrend (lower-highs structure).
+  All three must agree for a name to be SHORT-eligible. There is no LONG branch.
+
+Parsing shapes are COPIED from the Dog gold template (market_get_funding_regime
++ leaderboard_get_markets) — they are not invented. The smart-money direction
+band (long_ratio > 58 -> LONG, < 42 -> SHORT) follows the Bison/Dog leaderboard
+convention; Hyena only ever acts on the SHORT side of it.
+"""
+
+
+# Default crypto + crypto-proxy universe (validated live on HL meta 2026-06-30:
+# BTC/ETH/SOL/HYPE on the main DEX; xyz:MSTR/xyz:COIN/xyz:CRCL on the XYZ DEX).
+UNIVERSE = ["BTC", "ETH", "SOL", "HYPE", "xyz:MSTR", "xyz:COIN", "xyz:CRCL"]
+
+# Per-asset max leverage caps (from Hyperliquid meta; validated 2026-06-30:
+# BTC 40 / ETH 25 / SOL 20 / HYPE 10; xyz crypto-proxies 10). The leverage
+# emitted is clamped to [1,5] (config) THEN min()'d against this venue cap.
+ASSET_MAX_LEVERAGE = {
+    "BTC": 40, "ETH": 25, "SOL": 20, "HYPE": 10,
+    "XYZ:MSTR": 10, "XYZ:COIN": 10, "XYZ:CRCL": 10,
+}
+
+# Smart-money direction band (leaderboard_get_markets long-ratio), Bison/Dog
+# convention. Hyena only ever acts on SHORT.
+SM_LONG_RATIO = 58.0      # long_ratio > 58 -> SM LONG
+SM_SHORT_RATIO = 42.0     # long_ratio < 42 -> SM SHORT (the side Hyena needs)
+
+# 4h downtrend structure gate (lower-highs), strict-> count, >=0.6 of (lookback-1).
+TREND_LOOKBACK = 6
+
+
+def safe_float(v, d=0.0):
+    if v is None:
+        return d
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# ── candle accessors (dual-shape: dict {high|h, low|l, close|c} OR list
+#    [t,o,h,l,c,v]) — same defensive pattern as Bison/Dog scoring. ──
+
+def _high(c):
+    if isinstance(c, dict):
+        return safe_float(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return safe_float(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return safe_float(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return safe_float(c[3])
+    return 0.0
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return safe_float(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return safe_float(c[4])
+    return 0.0
+
+
+def downtrend_structure(candles, lookback=TREND_LOOKBACK):
+    """Lower-highs => DOWNTREND confirming. Returns (is_down, strength).
+
+    Mirrors Bison/Dog `trend_structure` BEARISH branch (strict > counting,
+    >= 0.6 * (lookback-1) gate). Hyena only cares about the DOWN side, so this
+    returns the bearish verdict + strength directly; insufficient history or a
+    non-bearish structure returns (False, 0.0)."""
+    if len(candles) < lookback:
+        return False, 0.0
+    highs = [_high(c) for c in candles[-lookback:]]
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if total <= 0:
+        return False, 0.0
+    if lower_highs >= total * 0.6:
+        return True, lower_highs / total
+    return False, 0.0
+
+
+def price_change_pct(candles, n_bars=1):
+    """% change over the last n_bars closes (negative = price falling)."""
+    if len(candles) < n_bars + 1:
+        return 0.0
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    if old == 0:
+        return 0.0
+    return ((new - old) / old) * 100.0
+
+
+def sm_short_tilt(long_pct, short_pct):
+    """Net smart-money lean from leaderboard long/short %. Returns
+    (direction, tilt_pct). Bison/Dog band: long_ratio > 58 -> LONG, < 42 ->
+    SHORT, else NEUTRAL. `tilt_pct` for SHORT is (100 - long_ratio) — the
+    magnitude of the short tilt (the score input Hyena cares about)."""
+    long_pct = safe_float(long_pct)
+    short_pct = safe_float(short_pct)
+    total = long_pct + short_pct
+    if total <= 0:
+        return "NEUTRAL", 50.0
+    long_ratio = (long_pct / total) * 100.0
+    if long_ratio > SM_LONG_RATIO:
+        return "LONG", long_ratio
+    if long_ratio < SM_SHORT_RATIO:
+        return "SHORT", 100.0 - long_ratio
+    return "NEUTRAL", 50.0
+
+
+def leverage_for(token, base_leverage, lev_min=1, lev_max=5):
+    """Clamp the configured leverage to [lev_min, lev_max] (config) then to the
+    per-asset venue cap. SHORT-only, conservative-by-design hedge sleeve."""
+    lev = int(round(safe_float(base_leverage, lev_max)))
+    lev = max(lev_min, min(lev, lev_max))
+    cap = ASSET_MAX_LEVERAGE.get(str(token).upper(), lev_max)
+    return min(lev, cap)
+
+
+def score_short(token, candles_4h, sm, regime, asset_funding, inputs):
+    """Score a SHORT-eligibility thesis for one name. Returns a candidate dict
+    or None (not SHORT-eligible / not enough data).
+
+    Inputs the caller (scan.py) resolves so this stays pure:
+      candles_4h    — list of 4h candles (dict or [t,o,h,l,c,v]).
+      sm            — (sm_direction, sm_tilt_pct) from leaderboard_get_markets
+                      (sm_short_tilt), or (None, 0.0) if not found.
+      regime        — market-wide funding regime string
+                      (LONG_CROWDED / SHORT_CROWDED / NEUTRAL) or None. This is
+                      the MASTER risk-off gate; scan.py only calls score_short
+                      when the regime permits new shorts, but the regime is also
+                      a score contributor here.
+      asset_funding — per-asset 8h funding rate (float). Positive funding into a
+                      crowded long = squeeze fuel paying the short.
+      inputs        — scanner inputs (thresholds).
+
+    SHORT-eligibility (ALL required, no LONG branch ever):
+      - smart money net-SHORT the name (sm direction == SHORT), AND
+      - 4h downtrend confirming (lower-highs structure).
+    The funding regime master-gate is enforced upstream in scan.py; here a
+    LONG_CROWDED regime adds confirmation score and a SHORT_CROWDED regime
+    (should never reach here) returns None defensively.
+    """
+    min_sm_tilt = float(inputs.get("smShortTiltMinPct", 55))
+    strong_sm_tilt = float(inputs.get("smStrongTiltPct", 70))
+    crowded_funding = float(inputs.get("crowdedLongFundingThreshold", 0.0002))
+
+    if len(candles_4h) < TREND_LOOKBACK:
+        return None
+
+    sm_dir, sm_tilt = sm if sm else (None, 0.0)
+    sm_dir = (sm_dir or "").upper()
+
+    # ── GATE 1: smart money must be net-SHORT the name (rotating OUT) ──
+    if sm_dir != "SHORT":
+        return None
+    if sm_tilt < min_sm_tilt:
+        return None
+
+    # ── GATE 2: 4h downtrend confirming (lower-highs) ──
+    is_down, down_strength = downtrend_structure(candles_4h)
+    if not is_down:
+        return None
+
+    # ── GATE 3 (defensive): never short into a SHORT_CROWDED regime ──
+    # The MASTER gate is enforced in scan.py (it only calls score_short when the
+    # regime is LONG_CROWDED, or a per-asset funding fallback confirms). This is
+    # belt-and-suspenders: if a SHORT_CROWDED regime ever reaches here, bail.
+    if regime == "SHORT_CROWDED":
+        return None
+
+    score, reasons = 0, []
+
+    # ── Funding regime (master risk-off confirmation, +3 / +1) ──
+    if regime == "LONG_CROWDED":
+        score += 3
+        reasons.append("REGIME_LONG_CROWDED (squeeze fuel)")
+    elif regime is None or regime == "NEUTRAL":
+        # scan.py reached here via the per-asset funding fallback (no usable
+        # market-wide regime). Smaller, asset-local confirmation.
+        score += 1
+        reasons.append("REGIME_FALLBACK (per-asset crowded-long funding)")
+
+    # ── Smart-money short tilt magnitude (+2 / +1) ──
+    if sm_tilt >= strong_sm_tilt:
+        score += 2
+        reasons.append(f"SM_STRONG_SHORT {sm_tilt:.0f}%")
+    else:
+        score += 1
+        reasons.append(f"SM_SHORT {sm_tilt:.0f}%")
+
+    # ── 4h downtrend strength (+2 / +1) ──
+    if down_strength >= 0.8:
+        score += 2
+        reasons.append(f"4H_DOWNTREND_STRONG {down_strength:.0%}")
+    else:
+        score += 1
+        reasons.append(f"4H_DOWNTREND {down_strength:.0%}")
+
+    # ── 4h price already falling, momentum confirmation (+1) ──
+    p4h = price_change_pct(candles_4h, 1)
+    if p4h < 0:
+        score += 1
+        reasons.append(f"4H_FALLING {p4h:+.1f}%")
+
+    # ── Per-asset funding: positive funding into a crowded long pays the short
+    #    (squeeze pressure) (+1). Negative funding (shorts already paying) -1. ──
+    af = safe_float(asset_funding)
+    if af > crowded_funding:
+        score += 1
+        reasons.append(f"FUNDING_PAYS_SHORT {af * 100:.4f}%")
+    elif af < -crowded_funding:
+        score -= 1
+        reasons.append(f"FUNDING_CROWDED_SHORT {af * 100:.4f}%")
+
+    leverage = leverage_for(
+        token,
+        inputs.get("leverage", inputs.get("leverageDefault", 4)),
+        int(inputs.get("leverageMin", 1)),
+        int(inputs.get("leverageMax", 5)),
+    )
+
+    return {
+        "asset": token,
+        "direction": "SHORT",            # SHORT_ONLY — there is no LONG branch
+        "score": score,
+        "leverage": leverage,
+        "reasons": reasons,
+        "smDirection": sm_dir,
+        "smTiltPct": round(sm_tilt, 1),
+        "downStrength": round(down_strength, 3),
+        "priceChange4hPct": round(p4h, 2),
+        "fundingRegime": regime or "UNKNOWN",
+        "assetFunding": af,
+    }

--- a/strategies/hyena/strategy.yaml
+++ b/strategies/hyena/strategy.yaml
@@ -1,0 +1,46 @@
+# Hyena — risk-off crypto SHORT hedge sleeve. A single-instance PACKAGE: this manifest
+# + one self-contained runtime.yaml + scanners/. A NET-NEW Runtime 3.0 strategy (no v2
+# predecessor): the fleet's first dedicated SHORT-biased crypto/crypto-proxy agent. It
+# shorts the crypto block ONLY when risk-off conditions confirm (funding regime
+# LONG_CROWDED + smart money rotating OUT + price confirming down) and otherwise idles.
+# SHORT_ONLY by design — a hedge sleeve that pairs with long crypto exposure. Parsing for
+# market_get_funding_regime + leaderboard_get_markets copied from the Dog gold template;
+# account read-guard from Bison/Bobcat; dex-aware fetch from Bobcat. Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: hyena
+version: "1.0.0"
+
+catalog:
+  name: "Hyena — Risk-Off Crypto Short (Hedge Sleeve)"
+  emoji: "🐺"
+  tagline: "A short-only crypto defense sleeve on majors (BTC/ETH/SOL/HYPE) plus crypto-proxy equities (xyz:MSTR/COIN/CRCL): shorts the block ONLY when risk-off confirms — the market-wide funding regime is LONG_CROWDED (crowded longs = squeeze fuel), smart money is rotating OUT of the name, and the 4h trend is breaking down. Conservative 4x, tight short-side DSL, 30h cap because squeezes resolve fast. CAVEAT: this is a hedge that pairs with long crypto exposure — it idles and emits nothing whenever risk-off conditions are not met."
+  belief_plain: "Most of the time the safe trade on crypto is no trade. But when the best traders are all crowded long, smart money starts rotating out, and price begins rolling over together, that crowded long is fuel for a squeeze to the downside. Hyena bets against that exhausted crowd — short only — on Bitcoin, Ether, Solana, HYPE, and the crypto-proxy stocks MicroStrategy, Coinbase and Circle. It is a defense sleeve you run alongside your long crypto bets to cushion a downturn; when the risk-off picture is not there, it does nothing and waits."
+  thesis: "The fleet has no dedicated short-biased crypto agent — every directional engine is long-or-long/short, so there is no clean defensive sleeve for a risk-off turn. Hyena fills that gap. It treats the market-wide funding regime as a master gate: it only opens new shorts when funding shows the crowd is one-sided LONG (LONG_CROWDED), because a crowded long is the squeeze that a short monetizes. On top of that gate it requires, per name, that smart money is net-SHORT (rotating out) AND that the 4h structure is making lower highs (price confirming the unwind). All three must agree, so it sits idle in normal markets and only acts on genuine risk-off confluence. It is short_only by design — a hedge meant to be paired with long crypto exposure, sized conservatively (15% margin, 4x) with a tight short-side DSL and a 30h hold cap because short squeezes resolve fast."
+  group: smart-money
+  archetype: contrarian_fade
+  sub_style: risk_off_rotation
+  asset_classes: [btc_eth, major_alts, xyz_equities]
+  asset_scope: basket
+  direction: short_only
+  risk_level: aggressive
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 2
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL", "HYPE", "xyz:MSTR", "xyz:COIN", "xyz:CRCL"]
+  tags: [short-only, hedge, risk-off, defense, funding-regime, smart-money, rotation, contrarian, crypto-proxy, btc, eth, sol, hype, mstr, coin, crcl, idles-when-uncertain]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: HYENA_WALLET
+    funding_share: 1.0

--- a/strategies/oxpecker/main/runtime.yaml
+++ b/strategies/oxpecker/main/runtime.yaml
@@ -1,0 +1,162 @@
+# ── OXPECKER · single instance — elite-conviction concentrated mirror ─────────
+# NET-NEW Runtime 3.0 strategy (NOT a v2 port). COPY-TRADER / TRADER-FOLLOWER.
+# Maintains a daily-refreshed pool of the most consistent Hyperliquid traders
+# (discovery_get_top_traders, consistency ELITE/RELIABLE, cached ~24h in ctx.state
+# like Jackal), reads each pooled trader's open book (discovery_get_trader_state),
+# takes their LARGEST-notional position, and mirrors ONLY positions whose
+# concentration (largest notional / total notional) >= minConcentration. Aggregates
+# into (asset, direction) candidates weighted by trader quality x concentration
+# (consensus across multiple elite traders = stronger), emits the top 1-2. Direction
+# comes from the mirrored position; leverage mirror-capped to [1,5]. Let-winners-run
+# DSL with a 72h hard_timeout staleness cap (the whale-exit mirror is a future
+# enhancement). decision_mode: rule — the scan already applied every filter.
+name: oxpecker-main
+group: oxpecker
+version: 1.0.0
+description: >
+  OXPECKER — elite-conviction concentrated mirror. A copy-trader that keeps a
+  daily-refreshed pool of the most consistent Hyperliquid traders (ELITE/RELIABLE
+  via discovery_get_top_traders consistency filter), reads each pooled trader's open
+  positions (discovery_get_trader_state), takes their single largest-notional
+  position, and mirrors ONLY the ones where that position dominates the trader's
+  whole book (concentration = largest notional / total notional >= minConcentration,
+  default 0.5). Aggregates into (asset, direction) candidates weighted by trader
+  quality x concentration — consensus across multiple elite traders on the same
+  concentrated trade is the strongest signal — and emits the top 1-2 highest-
+  conviction mirrors. Direction mirrored from the position; leverage clamped to
+  [1,5]. Long/short, derived universe (coins come from what elite traders hold).
+  Producer enters only — the DSL owns exits: let-winners-run preset (wide ladder,
+  first lock at +10% ROE, max_loss 20%) with a 72h hard_timeout staleness cap.
+
+strategy:
+  wallet: "${OXPECKER_WALLET}"
+  slots: 2                                  # emit up to 2 highest-conviction mirrors
+  margin_pct: 15                            # baseline %; scan emits the conviction-scaled marginPct per signal
+  default_leverage: 3                       # fallback; scan emits the mirror-capped leverage [1,5]
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: oxpecker_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                    # elite-conviction positions change slowly (5 min)
+    timeout_seconds: 180                     # pool fetch (cached) + batched trader-state reads + account
+    default_signal_validity_seconds: 600     # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 50              # cohort cache + dedup map + per-tick scan-results history
+    inputs:
+      # ── pool (discovery_get_top_traders, consistency ELITE/RELIABLE, cached ~24h) ──
+      poolSize: 30                           # keep top-N quality traders in the pool
+      poolFetchLimit: 60                     # overfetch then filter to ELITE/RELIABLE
+      poolRefreshHours: 24                   # daily refresh cadence (cached in ctx.state)
+      poolTimeFrame: "MONTHLY"               # discovery_get_top_traders time_frame
+      poolSortBy: "RETURN_ON_INVESTMENT"     # discovery_get_top_traders sort_by
+      qualityTiers: ["ELITE", "RELIABLE"]    # consistency (TCS) filter — only the top quality tiers
+      minQualityScore: 0.0                   # optional numeric tcsValue floor (0 => tier label is the gate)
+      # ── concentration gate ──
+      minConcentration: 0.5                  # largest position notional / total notional >= this (default 0.5)
+      minNotionalUsd: 5000                   # ignore dust positions when ranking the largest
+      # ── scoring / dedup ──
+      minScore: 4                            # producer floor (base 3 + concentration/consensus/tier bonuses)
+      maxEmit: 2                             # emit up to the top-N highest-conviction mirrors
+      recentSignalTtlSeconds: 300            # race-window dedup: don't re-fire a coin+dir while in flight
+      # ── sizing ──
+      marginPct: 15                          # PERCENT of withdrawable (0,100]; conviction-scaled by score
+      maxMarginPct: 25                       # cap for conviction scaling
+      convictionMarginScale: 0.0             # 0 => flat base marginPct; >0 opts into score-scaled margin
+      leverage: 3                            # mirror default; clamped to [1,5] in scan.py
+      minLeverage: 1                         # MIN_LEVERAGE clamp
+      maxLeverage: 5                         # MAX_LEVERAGE clamp (also venue-capped by the runtime)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      concentration: { type: number, required: false }
+      maxConcentration: { type: number, required: false }
+      traderCount: { type: number, required: false }
+      maxNotionalUsd: { type: number, required: false }
+      eliteTier: { type: boolean, required: false }
+      qualityScore: { type: number, required: false }
+      sourceTraders: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: oxpecker_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                      # the scan already applied every filter (quality + concentration + score)
+    scanners: [oxpecker_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true      # mirror the elite trader's live exposure now — a maker order that
+                                             # rests (CREATE_ORDER_RESTING) drifts from the conviction entry
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: oxpecker_main_signals
+
+# ── EXIT (DSL — let-winners-run preset) ───────────────────────────────────────
+# Elite traders concentrate into winners and hold them, so the mirror must breathe:
+# wide ladder (T0 +10% / lock 0), max_loss 20%, time-cuts OFF except a hard_timeout
+# staleness cap. Oxpecker does not yet mirror the trader's EXIT, so the 72h timeout
+# prevents holding a stale concentrated mirror indefinitely (a trader-exit mirror is
+# a future enhancement). NO weak_peak_cut / dead_weight_cut. First Phase-2 lock at
+# +10% ROE (reachable — not the >+40% unreachable pattern). phase2.tiers present.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true          # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 4320              # 72h staleness cap (trader's exit is not yet mirrored)
+    weak_peak_cut:
+      enabled: false
+      interval_in_minutes: 360
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                 # wide-by-design; FIRST lock at +10% ROE (reachable)
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 45 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+        - { trigger_pct: 90, lock_hw_pct: 88 }
+
+# ── RISK guard rails (seconds) ──
+risk:
+  data_retention_seconds: 259200             # 72h (within [3600, 604800])
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 4
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 5400                    # post-loss cooldown 90m
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400         # 4h per-asset cooldown
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/oxpecker/main/scanners/scan.py
+++ b/strategies/oxpecker/main/scanners/scan.py
@@ -1,0 +1,334 @@
+"""OXPECKER — supervised scanner (NET-NEW Runtime 3.0 elite-conviction mirror).
+
+COPY-TRADER / TRADER-FOLLOWER. Per tick it:
+  - reads account state + held positions (dual-DEX equity via max(), never sum();
+    bison/remora pattern, incl. the read-sanity guard),
+  - refreshes a quality-tier pool from discovery_get_top_traders (consistency
+    ELITE/RELIABLE, cached ~24h in ctx.state like Jackal; on a failed refresh it
+    DEGRADES to the stale cohort cache, never crashes),
+  - reads every pooled trader's open positions (discovery_get_trader_state, batched),
+  - for each trader takes their LARGEST-notional position and computes CONCENTRATION
+    (largest notional / total book notional); keeps only positions with
+    concentration >= minConcentration (the spec's elite-conviction gate),
+  - aggregates the concentrated elite positions into (asset, direction) candidates
+    weighted by trader quality x concentration (consensus across multiple elite
+    traders = stronger), and emits the TOP 1-2 highest-conviction mirrors sized by
+    Oxpecker's OWN marginPct + leverage clamp.
+
+Read-only + single-pass — emits `marginPct` (PERCENT) + `leverage` intents; the
+runtime sizes the dollars, owns slots/cooldowns/risk gates, and trails the DSL exit.
+No daemon, no push_signal, no create_position.
+
+READ-GUARD: EVERY ctx.senpi_mcp.call_tool is wrapped in try/except -> degrade (stale
+cohort cache / skipped trader batch / skip the tick), NEVER propagate. Per the scan
+contract ANY exception rolls the whole tick back to [], so one bad read would
+silently kill all emits — guarded so a single flaky read just drops out.
+
+FIELD-SHAPE FLAGS (no live token in the build env): quality tier (`tcsLabel`),
+trader-state open-position list key, and per-position notional field are sourced from
+the gold templates (jackal/raptor/remora) + the senpi-overview guide §8, NOT
+re-confirmed against a live response. Every parse has fallbacks; concentration is
+derived from the positions themselves so it never depends on a trader-level field.
+See scoring.py module docstring for the per-field flags.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+
+import sys
+import time
+
+import scoring
+
+
+CACHE_VERSION = 1            # bump if pool-BUILDING logic changes (busts a stale cache)
+_DEFAULT_RECENT_TTL = 300    # race-window signal-dedup: don't re-fire a coin+dir while in flight
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll the whole
+    tick back to []. Returns None on failure so the degrade paths apply (cohort falls
+    back to its daily cache; a failed trader-state batch is skipped)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[oxpecker.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _unwrap_list(resp, *keys):
+    """Unwrap a discovery list document: resp -> resp.data -> resp.data.<key> -> list."""
+    if not resp:
+        return []
+    raw = resp.get("data", resp) if isinstance(resp, dict) else resp
+    if isinstance(raw, dict):
+        for k in keys:
+            if isinstance(raw.get(k), list):
+                return raw[k]
+        for v in raw.values():           # single-key dict wrapping the list
+            if isinstance(v, list):
+                return v
+        return []
+    return raw if isinstance(raw, list) else []
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass ''."""
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+# ── account (dual-DEX equity, read-sanity guard) — bison/remora pattern ──
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across main/xyz
+    (two views of ONE cross-margined wallet — summing double-counts the shared free
+    balance -> 2x sizing). assetPositions are per-sub-DEX so they are enumerated
+    across both sections. Includes the read-sanity guard (margin in use + empty
+    positions -> skip tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
+                                     {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[oxpecker.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring.safe_float(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []):
+            pos = ap.get("position", ap)
+            szi = scoring.safe_float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({"coin": pos.get("coin", "")})
+
+    # read-sanity guard (funding/$0 glitch family): a corrupt clearinghouse read can
+    # report margin/notional IN USE while returning an EMPTY positions list; sizing or
+    # running the held-asset dedup off that re-enters held names (pyramiding) and
+    # mis-sizes. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring.safe_float(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring.safe_float(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[oxpecker.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+# ── trader pool: refresh from discovery_get_top_traders (ELITE/RELIABLE), cached ~24h ──
+
+def _refresh_pool(ctx, cached, inputs, now):
+    """Return the active elite-trader pool. Fresh cache (< refresh_h) is reused with
+    NO fetch. On a stale/missing cache, fetch + filter to ELITE/RELIABLE + rank
+    (scoring.build_pool). On a FAILED refresh, DEGRADE to the stale cache. Cached in
+    ctx.state (jackal pattern)."""
+    refresh_h = float(inputs.get("poolRefreshHours", 24))
+    fetch_limit = int(inputs.get("poolFetchLimit", 60))
+    time_frame = str(inputs.get("poolTimeFrame", "MONTHLY"))
+    sort_by = str(inputs.get("poolSortBy", "RETURN_ON_INVESTMENT"))
+    tiers = list(inputs.get("qualityTiers", list(scoring.DEFAULT_QUALITY_TIERS)))
+
+    if (cached.get("traders") and cached.get("cache_version") == CACHE_VERSION
+            and (now - cached.get("refreshed_at", 0)) / 3600 < refresh_h):
+        return cached                                     # fresh cache — no fetch
+
+    resp = _read(ctx, "discovery_get_top_traders", {
+        "time_frame": time_frame,
+        "sort_by": sort_by,
+        "consistency": tiers,                             # ELITE/RELIABLE quality gate at the source
+        "open_position_filter": True,                     # only traders with at least one open position
+        "limit": fetch_limit,
+    })
+    raw = _unwrap_list(resp, "traders", "data")
+    if not raw:
+        return cached                                     # failed refresh — keep old cache (degrade)
+
+    top = scoring.build_pool(raw, inputs)
+    if not top:
+        return cached                                     # filtered to empty — keep old cache
+    return {"refreshed_at": now, "cache_version": CACHE_VERSION,
+            "size": len(top), "traders": top}
+
+
+def _fetch_pool_positions(ctx, pool):
+    """{addr -> [open_position dicts]} for every pooled trader (discovery_get_trader_state,
+    batched by 50, sorted by POSITION_VALUE desc so the largest is first). A failed
+    batch is skipped (those traders just look empty this tick)."""
+    addresses = [t["address"] for t in pool]
+    by_addr = {}
+    for i in range(0, len(addresses), 50):
+        resp = _read(ctx, "discovery_get_trader_state", {
+            "trader_addresses": addresses[i:i + 50],
+            "sort_open_positions_by": "POSITION_VALUE",
+            "sort_open_positions_direction": "DESC",
+        })
+        for t in _unwrap_list(resp, "traders"):
+            if not isinstance(t, dict):
+                continue
+            addr = (t.get("address") or t.get("trader_address") or "").lower()
+            if not addr:
+                continue
+            by_addr[addr] = (t.get("openPositions") or t.get("open_positions")
+                             or t.get("positions") or [])
+    return by_addr
+
+
+# ── ctx.state: recent-signal dedup ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (remora/bison pattern)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _was_recently_signaled(signaled, key, ttl, now):
+    last = signaled.get(key)
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    min_conc = float(inputs.get("minConcentration", scoring.DEFAULT_MIN_CONCENTRATION))
+    min_notional = float(inputs.get("minNotionalUsd", scoring.DEFAULT_MIN_NOTIONAL_USD))
+    min_score = int(inputs.get("minScore", scoring.DEFAULT_MIN_SCORE))
+    max_emit = max(1, int(inputs.get("maxEmit", 2)))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    lev = int(inputs.get("leverage", scoring.DEFAULT_LEVERAGE))
+    min_lev = int(inputs.get("minLeverage", scoring.MIN_LEVERAGE))
+    max_lev = int(inputs.get("maxLeverage", scoring.MAX_LEVERAGE))
+    leverage = max(min_lev, min(lev, max_lev))            # mirror-cap to [1,5]
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    pool = _refresh_pool(ctx, last.get("cohorts", {}), inputs, now)
+    traders = pool.get("traders", [])
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"cohorts": pool, "signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[oxpecker.scan] WARNING: state append failed; next tick may re-emit "
+                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+
+    if not traders:
+        result = {"ts": now, "pool_size": 0, "emitted": 0, "note": "WAITING (no pool)"}
+        print("[oxpecker.scan] WAITING — empty elite-trader pool (cohort refresh/cache empty)",
+              file=sys.stderr)
+        _persist(result)
+        return []
+
+    # current open book for every pooled (elite) trader
+    current_positions = _fetch_pool_positions(ctx, traders)
+
+    # ── per trader: largest position + concentration; keep only concentrated ones ──
+    trader_tops = []
+    concentrated = 0
+    for trader in traders:
+        book = current_positions.get(trader["address"], [])
+        top, concentration = scoring.concentrated_top(book, min_notional)
+        if not top:
+            continue
+        if concentration < min_conc:                      # the elite-conviction gate
+            continue
+        concentrated += 1
+        trader_tops.append((trader, top, concentration))
+
+    # ── aggregate into (asset, direction) candidates weighted by quality x concentration ──
+    candidates = scoring.aggregate_candidates(trader_tops)
+    scored = []
+    for cand in candidates:
+        if cand["asset"].upper() in held_set:             # on-chain held-asset filter
+            continue
+        key = f"{cand['asset'].upper()}|{cand['direction']}"
+        if _was_recently_signaled(signaled, key, ttl, now):
+            continue
+        score, reasons = scoring.score_candidate(cand)
+        if score >= min_score:
+            scored.append((score, reasons, cand))
+
+    out = []
+    if not scored:
+        result = {"ts": now, "pool_size": len(traders), "concentrated": concentrated,
+                  "candidates": len(candidates), "emitted": 0, "held": held_assets,
+                  "note": f"WAITING (min score {min_score}, min conc {min_conc:.0%})"}
+        print(f"[oxpecker.scan] WAITING — no elite-conviction mirror "
+              f"(pool={len(traders)} concentrated={concentrated} "
+              f"candidates={len(candidates)} held={held_assets})", file=sys.stderr)
+        _persist(result)
+        return out
+
+    # rank: highest score, tie-break by concentration, then consensus count, then notional
+    scored.sort(key=lambda t: (t[0], t[2]["max_concentration"], t[2]["count"],
+                               t[2]["max_notional"]), reverse=True)
+
+    emitted = 0
+    for score, reasons, cand in scored:
+        if emitted >= max_emit:
+            break
+        key = f"{cand['asset'].upper()}|{cand['direction']}"
+        margin_pct = scoring.margin_pct_for(cand, inputs)
+        signaled[key] = now
+        emitted += 1
+        print(f"[oxpecker.scan] EMIT {cand['asset']} {cand['direction']} score={score} "
+              f"conc={cand['max_concentration']:.0%} traders={cand['count']} "
+              f"maxNotional=${cand['max_notional']:,.0f} {leverage}x "
+              f"marginPct={margin_pct:.2f}% | {reasons[:5]}", file=sys.stderr)
+        out.append({
+            "asset": cand["asset"],
+            "direction": cand["direction"],
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # clamped to [1,5]; runtime applies + venue-caps it
+            "data": {
+                "score": score,
+                "leverage": leverage,
+                "direction": cand["direction"],
+                "reasons": reasons,
+                "concentration": cand["max_concentration"],
+                "maxConcentration": cand["max_concentration"],
+                "traderCount": cand["count"],
+                "maxNotionalUsd": round(cand["max_notional"], 2),
+                "eliteTier": bool(cand.get("any_elite")),
+                "qualityScore": round(cand.get("best_quality", 0.0), 4),
+                "sourceTraders": [str(t.get("address", ""))[:10] for t in cand.get("traders", [])],
+                "heldAssets": held_assets,
+            },
+        })
+
+    result = {"ts": now, "pool_size": len(traders), "concentrated": concentrated,
+              "candidates": len(candidates), "emitted": emitted, "held": held_assets}
+    _persist(result)
+    return out

--- a/strategies/oxpecker/main/scanners/scoring.py
+++ b/strategies/oxpecker/main/scanners/scoring.py
@@ -1,0 +1,378 @@
+"""OXPECKER — pure elite-conviction-mirror math (no I/O, no MCP, no clock).
+
+NET-NEW Runtime 3.0 strategy (not a v2 port). Given trader/position dicts already
+fetched by scan.py, this module:
+  - parses the discovery_get_top_traders quality fields (tcsLabel / tcsValue /
+    address / ROI) — field accessors COPIED from the Jackal/Raptor gold templates,
+  - parses position notional + direction — COPIED VERBATIM from the Remora gold
+    template (position_notional / mirror_direction / position_asset),
+  - computes per-trader CONCENTRATION = largest-position notional / total notional
+    across all of that trader's open positions (NEW — Oxpecker's whole edge),
+  - aggregates concentrated elite positions into (asset, direction) candidates
+    weighted by trader quality x concentration (consensus across multiple elite
+    traders strengthens the score), and scores them.
+
+Pure / single-pass / unit-testable on plain dicts. All clock/MCP lives in scan.py.
+
+FIELD-SHAPE FLAGS (no live token in the build env — fields sourced from the gold
+templates + the senpi-overview guide §8, NOT confirmed against a live response):
+  - QUALITY TIER: request filter param is `consistency` (enum ELITE/RELIABLE/
+    STREAKY/CHOPPY, guide §8); response field is `tcsLabel` with numeric `tcsValue`
+    (TCS = Trader Consistency Score) — COPIED from raptor/main/scanners/scan.py
+    (fetch_quality_hot_traders). FLAGGED: exact response key not re-verified live.
+  - POSITION NOTIONAL for concentration: each open position's USD notional is taken
+    via position_notional() (size x entry -> marginUsed -> size), the Remora chain.
+    Concentration is derived FROM the positions themselves (largest / total), so it
+    does not depend on any single trader-level "concentration" field existing —
+    exactly the fallback the spec calls for. FLAGGED: positionValue (the
+    discovery_get_trader_state notional field per guide) is tried first, then the
+    Remora chain.
+"""
+# Copyright 2026 Senpi (https://senpi.ai)
+# Licensed under MIT
+
+
+# Quality (consistency / TCS) tiers Oxpecker will mirror. ELITE/RELIABLE are the
+# top two of the four-tier scale (ELITE > RELIABLE > STREAKY > CHOPPY, guide §8).
+DEFAULT_QUALITY_TIERS = ("ELITE", "RELIABLE")
+
+# Producer constants.
+MIN_LEVERAGE = 1
+MAX_LEVERAGE = 5
+DEFAULT_LEVERAGE = 3
+DEFAULT_MIN_SCORE = 4
+DEFAULT_MIN_NOTIONAL_USD = 5000     # ignore dust positions when ranking the largest
+DEFAULT_MIN_CONCENTRATION = 0.5     # largest notional / total notional floor
+
+
+def safe_float(v, default=0.0):
+    """Float coercion (Remora safe_float)."""
+    try:
+        return float(v if v is not None else default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _f(x, *keys, default=0.0):
+    """Float from x. If keys given, x is a dict and we try each key in order
+    (first non-None wins). Mirrors the gold-template camelCase/snake_case fallbacks."""
+    if keys:
+        if not isinstance(x, dict):
+            return default
+        for k in keys:
+            if x.get(k) is not None:
+                try:
+                    return float(x[k])
+                except (TypeError, ValueError):
+                    continue
+        return default
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return default
+
+
+# ── trader-pool quality parsing (COPIED from jackal/raptor gold templates) ──
+
+def trader_address(t):
+    """Lower-cased trader address, or '' (jackal build_pool / raptor)."""
+    addr = t.get("address") or t.get("trader_address") or t.get("traderAddress")
+    return str(addr).lower() if addr else ""
+
+
+def trader_quality_tier(t):
+    """The consistency (TCS) tier label, upper-cased, or '' if absent.
+    COPIED from raptor fetch_quality_hot_traders: response field is `tcsLabel`.
+    Fallbacks (`consistency`, `tier`, `classification`) are defensive only."""
+    label = (t.get("tcsLabel") or t.get("consistency") or t.get("consistencyLabel")
+             or t.get("tier") or t.get("classification") or "")
+    return str(label).upper() if label else ""
+
+
+def trader_quality_value(t):
+    """Numeric TCS value if present (raptor `tcsValue`), else 0.0."""
+    return _f(t, "tcsValue", "tcs_value", default=0.0)
+
+
+def trader_roi(t):
+    """30d/period ROI % (jackal pool_field_roi fallbacks)."""
+    return _f(t, "returnOnInvestment", "return_on_investment", "roi", default=0.0)
+
+
+def build_pool(raw_traders, inputs):
+    """Filter the raw discovery_get_top_traders list to the allowed quality tiers
+    (ELITE/RELIABLE) and an optional numeric tcsValue floor, then keep top-N.
+
+    Returns a list of pool-member dicts. The quality_score carried here is the
+    numeric tcsValue when available, otherwise a tier rank (ELITE=2, RELIABLE=1)
+    scaled so downstream quality-weighting has a usable signal even if only the
+    label is returned. FLAGGED: tcsValue scale not re-verified live; the tier-rank
+    fallback guarantees a non-degenerate weight."""
+    allowed = {str(x).upper() for x in inputs.get("qualityTiers", DEFAULT_QUALITY_TIERS)}
+    min_q = float(inputs.get("minQualityScore", 0.0))
+    pool_size = int(inputs.get("poolSize", 30))
+
+    out = []
+    for t in raw_traders:
+        if not isinstance(t, dict):
+            continue
+        addr = trader_address(t)
+        if not addr:
+            continue
+        tier = trader_quality_tier(t)
+        if allowed and tier not in allowed:
+            continue
+        qv = trader_quality_value(t)
+        if min_q > 0 and qv < min_q:
+            continue
+        out.append({
+            "address": addr,
+            "user_id": t.get("user_id") or t.get("userId"),
+            "username": t.get("username") or t.get("userName"),
+            "tier": tier,
+            "tcs_value": qv,
+            "roi": trader_roi(t),
+            "quality_score": _quality_score(tier, qv),
+        })
+    # rank: highest quality first (tcsValue, then tier rank, then ROI)
+    out.sort(key=lambda x: (x["quality_score"], x["roi"]), reverse=True)
+    return out[:pool_size]
+
+
+def _tier_rank(tier):
+    """ELITE=2, RELIABLE=1, anything else 0 (the two allowed tiers, ranked)."""
+    return {"ELITE": 2, "RELIABLE": 1}.get((tier or "").upper(), 0)
+
+
+def _quality_score(tier, tcs_value):
+    """A 0..1 quality weight for margin/score weighting. Prefer the numeric
+    tcsValue (normalized: TCS appears to be a 0-100-ish score in the templates, so
+    /100 and clamp to 1), else fall back to the tier rank (ELITE=1.0, RELIABLE=0.6).
+    FLAGGED: tcsValue scale assumed 0-100 (raptor carried it raw); the clamp makes
+    a larger scale harmless and the tier fallback covers a missing value."""
+    if tcs_value and tcs_value > 0:
+        return min(1.0, tcs_value / 100.0)
+    return {2: 1.0, 1: 0.6}.get(_tier_rank(tier), 0.0)
+
+
+# ── position notional + direction + asset (COPIED VERBATIM from Remora) ──
+
+def position_notional(pos):
+    """USD notional of a position for conviction ranking. Prefers the
+    discovery_get_trader_state notional field (`positionValue`), then the Remora
+    chain: size x entry -> marginUsed -> raw size. FLAGGED: positionValue is the
+    documented notional field (guide), tried first; the rest is verbatim Remora."""
+    if not isinstance(pos, dict):
+        return 0.0
+    pv = abs(_f(pos, "positionValue", "position_value", "notional", default=0.0))
+    if pv > 0:
+        return pv
+    size = abs(safe_float(pos.get("szi", pos.get("size", 0))))
+    entry = safe_float(pos.get("entryPx", pos.get("entryPrice", pos.get("entry", 0))))
+    notional = size * entry
+    if notional > 0:
+        return notional
+    margin = abs(safe_float(pos.get("marginUsed", pos.get("margin", 0))))
+    return margin if margin > 0 else size
+
+
+def mirror_direction(pos):
+    """LONG / SHORT for a position (explicit direction/side field, else szi sign).
+    None if undeterminable. Verbatim from Remora."""
+    if not isinstance(pos, dict):
+        return None
+    d = str(pos.get("direction", pos.get("side", ""))).upper()
+    if d in ("LONG", "SHORT"):
+        return d
+    szi = safe_float(pos.get("szi", pos.get("size", 0)))
+    if szi > 0:
+        return "LONG"
+    if szi < 0:
+        return "SHORT"
+    return None
+
+
+def position_asset(pos):
+    """Asset symbol, upper-cased. Verbatim from Remora."""
+    if not isinstance(pos, dict):
+        return ""
+    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", ""))))).upper()
+
+
+def position_leverage(pos):
+    """Leverage of a position (dict {value} or scalar). Jackal _leverage_of."""
+    lev = pos.get("leverage")
+    if isinstance(lev, dict):
+        return safe_float(lev.get("value"), default=0.0)
+    return safe_float(lev, default=0.0)
+
+
+# ── NEW: concentration = largest position notional / total notional ──
+
+def concentrated_top(positions, min_notional=0.0):
+    """Return (top_position, concentration) for one trader's open book, where:
+      - top_position = the single largest-notional position with a determinable
+        direction, an asset, and notional >= min_notional,
+      - concentration = top_position notional / SUM of ALL open-position notionals
+        (the whole book, NOT just the qualifying ones) — so a trader with one big
+        bet plus a few tiny ones still reads as highly concentrated.
+
+    Returns (None, 0.0) if the trader holds nothing with a usable top position.
+    Concentration is derived FROM the positions themselves, so it does not depend
+    on any trader-level "concentration" field existing (the spec's fallback)."""
+    if not positions:
+        return None, 0.0
+    total = 0.0
+    best, best_n = None, -1.0
+    for p in positions:
+        if not isinstance(p, dict):
+            continue
+        n = position_notional(p)
+        if n <= 0:
+            continue
+        total += n
+        if mirror_direction(p) is None or not position_asset(p):
+            continue
+        if n < min_notional:
+            continue
+        if n > best_n:
+            best_n, best = n, p
+    if best is None or total <= 0:
+        return None, 0.0
+    concentration = best_n / total if total > 0 else 0.0
+    return best, round(min(1.0, concentration), 4)
+
+
+# ── aggregate concentrated elite positions into (asset, direction) candidates ──
+
+def aggregate_candidates(trader_tops):
+    """Aggregate per-trader (trader, top_position, concentration) tuples into
+    (asset, direction) candidates.
+
+    `trader_tops` is a list of (trader_dict, top_position_dict, concentration)
+    tuples already filtered to concentration >= minConcentration by the caller.
+    Each candidate accumulates:
+      - count            = how many elite traders hold this asset+direction (consensus),
+      - max_notional     = the largest single mirrored notional,
+      - max_concentration= the strongest single concentration,
+      - sum_qc           = sum of (quality_score x concentration) across agreeing
+                           traders (the conviction-weight the score uses),
+      - best_quality     = the strongest single quality_score,
+      - any_elite        = any agreeing trader is ELITE tier,
+      - traders          = short ids for telemetry."""
+    agg = {}
+    for trader, top, concentration in trader_tops:
+        if not top:
+            continue
+        asset = position_asset(top)
+        direction = mirror_direction(top)
+        if not asset or direction is None:
+            continue
+        notional = position_notional(top)
+        q = float(trader.get("quality_score", 0.0))
+        key = (asset, direction)
+        entry = agg.setdefault(key, {
+            "asset": asset, "direction": direction,
+            "count": 0, "max_notional": 0.0, "max_concentration": 0.0,
+            "sum_qc": 0.0, "best_quality": 0.0, "any_elite": False,
+            "traders": [],
+        })
+        entry["count"] += 1
+        entry["max_notional"] = max(entry["max_notional"], notional)
+        entry["max_concentration"] = max(entry["max_concentration"], concentration)
+        entry["sum_qc"] += q * concentration
+        entry["best_quality"] = max(entry["best_quality"], q)
+        if (trader.get("tier") or "").upper() == "ELITE":
+            entry["any_elite"] = True
+        entry["traders"].append({
+            "address": trader.get("address", ""),
+            "tier": trader.get("tier", ""),
+            "concentration": concentration,
+            "notional": round(notional, 2),
+        })
+    return list(agg.values())
+
+
+def consensus_bonus(count):
+    """Score bonus for how many elite traders independently hold the same
+    concentrated asset+direction. 3+ is a strong consensus (Remora pattern)."""
+    if count >= 3:
+        return 3
+    if count == 2:
+        return 2
+    return 0
+
+
+def score_candidate(cand):
+    """(score, reasons) for an aggregated candidate. Quality-tier x concentration
+    is the edge:
+      +3 base                         — a tracked elite trader's concentrated top bet,
+      +2 if max_concentration >= 0.9  — overwhelming conviction (e.g. ~98% of book),
+        +1 if max_concentration >= 0.7
+      +round(sum_qc * 2)              — quality x concentration mass across agreeing
+                                        traders (cap +3),
+      +consensus_bonus(count)         — 2 traders +2, 3+ +3,
+      +1 if any agreeing trader is ELITE tier.
+    """
+    score = 3
+    reasons = [
+        f"{cand['asset']}_{cand['direction']}",
+        f"concentration_{cand['max_concentration']:.0%}",
+        f"traders_{cand['count']}",
+        f"notional_${cand['max_notional']:,.0f}",
+    ]
+
+    mc = cand["max_concentration"]
+    if mc >= 0.9:
+        score += 2
+        reasons.append("overwhelming_conviction")
+    elif mc >= 0.7:
+        score += 1
+        reasons.append("high_conviction")
+
+    qc_bonus = min(3, int(round(cand["sum_qc"] * 2)))
+    if qc_bonus > 0:
+        score += qc_bonus
+        reasons.append(f"quality_x_conc_{qc_bonus}")
+
+    cb = consensus_bonus(cand["count"])
+    if cb:
+        score += cb
+        reasons.append(f"consensus_{cand['count']}_traders")
+
+    if cand.get("any_elite"):
+        score += 1
+        reasons.append("elite_tier")
+
+    return score, reasons
+
+
+# ── sizing (top-level marginPct PERCENT) ──
+
+def margin_pct_for(cand, inputs):
+    """marginPct INTENT as a PERCENT of withdrawable in (0,100] (runtime sizes
+    (marginPct/100)*withdrawable).
+
+    Default is FLAT at the base marginPct (convictionMarginScale defaults to 0).
+    When an operator opts in (>0), margin scales up toward maxMarginPct by the
+    candidate's conviction mass (quality x concentration). Defensive fraction guard
+    (dire/koala/remora pattern): a base/cap pasted as a fraction (<= 1.0, e.g. 0.15)
+    is multiplied x100 to a percent."""
+    base = float(inputs.get("marginPct", 15))
+    if base <= 1.0:                       # pasted fraction (0.15) -> percent (15)
+        base *= 100.0
+    cap = float(inputs.get("maxMarginPct", base))
+    if cap <= 1.0:
+        cap *= 100.0
+    scale = float(inputs.get("convictionMarginScale", 0.0))   # 0 => faithful flat
+    if scale <= 0:
+        return round(min(base, cap), 4)
+    # conviction mass: best quality x max concentration, in [0,1]
+    mass = float(cand.get("best_quality", 0.0)) * float(cand.get("max_concentration", 0.0))
+    return round(min(base * (1.0 + mass * scale), cap), 4)
+
+
+def confidence_score(score, min_score):
+    """A 0..1 confidence for data{} (score normalized over a soft ceiling)."""
+    ceiling = max(float(min_score) + 6.0, 1.0)
+    return round(min(1.0, float(score) / ceiling), 4)

--- a/strategies/oxpecker/strategy.yaml
+++ b/strategies/oxpecker/strategy.yaml
@@ -1,0 +1,46 @@
+# Oxpecker — elite-conviction concentrated mirror. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A NET-NEW Runtime 3.0 strategy
+# (not a v2 port): it maintains a daily-refreshed pool of the highest-quality Hyperliquid
+# traders (discovery_get_top_traders, consistency ELITE/RELIABLE), reads each pooled
+# trader's open positions, takes their LARGEST-notional position, and mirrors ONLY the ones
+# where that single position dominates the trader's whole book (concentration = largest
+# notional / total notional >= minConcentration). Aggregates into (asset, direction)
+# candidates weighted by trader quality x concentration (consensus across elite traders =
+# stronger), emits the top 1-2 highest-conviction mirrors. Let-winners-run DSL.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: oxpecker
+version: "1.0.0"
+
+catalog:
+  name: "Oxpecker — Elite-Conviction Concentrated Mirror"
+  emoji: "🐦"
+  tagline: "Maintains a daily-refreshed pool of the most consistent (ELITE/RELIABLE) Hyperliquid traders, reads each one's open book, and mirrors ONLY their single highest-conviction bet — and only when that one position dominates their whole book (e.g. ~98% of capital in one 3x position). Leans hardest when several elite traders independently pile into the same concentrated trade."
+  belief_plain: "Looks past the leaderboard noise and keeps a shortlist of the steadiest, most-proven traders on Hyperliquid. Instead of copying everything they do, Oxpecker copies only the trade they're betting their whole book on — the one position that makes up most of their capital. When more than one of those proven traders is all-in on the same trade in the same direction, it bets harder, then trails a wide stop so the conviction can run."
+  thesis: "A proven trader's signal is loudest exactly when they concentrate. Cohort copiers average a pool and whale mirrors ride a fixed name list; Oxpecker does neither — it screens for the highest consistency tier (ELITE/RELIABLE) and then, within that elite set, only acts on positions that represent real conviction: where one bet is the overwhelming majority of the trader's book. A reliable trader with ~98% of their capital in one short is telling you something an opaque cohort average buries. Quality-tier x position-concentration is the whole edge — consensus across multiple elite traders on the same concentrated trade is the strongest signal there is, and the wide let-winners-run DSL respects that conviction rather than scalping it."
+  group: smart-money
+  archetype: copy_trading
+  sub_style: elite_conviction
+  asset_classes: [none]
+  asset_scope: follows_traders
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  leverage_max: 5
+  max_slots: 2
+  min_budget: 200
+  assets: []
+  tags: [copy-trading, smart-money, elite, conviction, concentration, consensus, quality-tier, follows-traders, let-winners-run, long-short]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: OXPECKER_WALLET
+    funding_share: 1.0

--- a/strategies/stingray/main/runtime.yaml
+++ b/strategies/stingray/main/runtime.yaml
@@ -1,0 +1,142 @@
+# ── STINGRAY · single instance — cross-asset smart-money rotation ─────────────
+# NET-NEW Runtime 3.0 strategy (not a port). Reads the whole smart-money board,
+# ranks every asset by net SM conviction (tilt x notional/breadth weight), and
+# trades the ROTATION: LONG the assets SM is crowding into, SHORT the ones SM is
+# fleeing — capturing days like "long semis/indices, short the crypto block".
+# Cross-asset by design: universe crypto + xyz equities/commodities/indices.
+# DSL-only exits, trend-following ladder (first lock +10% ROE). See
+# scanners/scan.py (rotation logic + price-confirmation gate) and scanners/scoring.py
+# (pure net-tilt + conviction-weight math). Install/teardown via senpi-strategy-ops.
+name: stingray-main
+group: stingray
+version: 3.0.0
+description: >
+  STINGRAY — cross-asset smart-money rotation. Existing SM agents follow smart money
+  per asset; Stingray follows the rotation across the whole board. Each tick it reads
+  the smart-money leaderboard, computes net tilt (long_ratio - 50) per asset, weights
+  it by notional + trader breadth, and ranks the board. It goes LONG the top
+  net-long-by-conviction assets (long_ratio >= 58) and SHORT the top net-short
+  (long_ratio <= 42), gated by a price-confirmation check (no longs into a hard 4h
+  downtrend, no shorts into a hard 4h uptrend — don't fight price). Emits up to 2
+  longs + 2 shorts, conviction-tiered margin (12% base, x1.25 / x1.5 on stronger
+  tilt), 4x leverage (clamp 1-5). DSL is the ONLY exit — trend-following ladder, first
+  lock at +10% ROE, 48h hard_timeout (mixed crypto + xyz tolerates weekend gaps).
+
+strategy:
+  wallet: "${STINGRAY_WALLET}"
+  slots: 4                                 # up to 2 long + 2 short rotation legs
+  margin_pct: 12                           # baseline %; scan emits the conviction-tier marginPct per signal
+  default_leverage: 4                      # fallback; scan emits 4x (clamped 1-5) per signal
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: stingray_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                   # 5-min cadence; board rotation is a swing signal
+    timeout_seconds: 180                    # account + board + per-shortlisted-asset trend reads
+    default_signal_validity_seconds: 600    # 2x tick; a fresh re-rank arrives next tick
+    state_history_max_count: 100            # dedup map + per-tick scan-results history
+    inputs:
+      minTiltLong: 58                       # long_ratio >= 58 -> LONG side (bison threshold)
+      minTiltShort: 42                      # long_ratio <= 42 -> SHORT side (bison threshold)
+      marginPctBase: 12                     # PERCENT of withdrawable (0,100]; tiered x1.25/x1.5 by |net_tilt|
+      marginPctMax: 0                       # 0 = no extra cap beyond the tier multiplier
+      leverageDefault: 4                    # clamped to [1,5] in scan.py + venue max by runtime
+      maxLong: 2                            # up to 2 longs per tick
+      maxShort: 2                           # up to 2 shorts per tick
+      recentSignalTtlSeconds: 240           # signal-dedup TTL (s)
+      leaderboardLimit: 100                 # board breadth to scan
+      xyzBanned: false                      # cross-asset: xyz equities/commodities/indices INCLUDED
+      convictionVolFloor: 1                 # conviction_weight notional floor
+    signal_data_schema:
+      direction: { type: string }
+      longRatio: { type: number, required: false }
+      netTilt: { type: number, required: false }
+      conviction: { type: number, required: false }
+      weight: { type: number, required: false }
+      smVolume: { type: number, required: false }
+      smTraders: { type: number, required: false }
+      leverage: { type: number, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: stingray_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every filter (tilt + price gate + dedup)
+    scanners: [stingray_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true     # taker fallback: a rotation entry that rests and silently fails
+                                            # misses the move; guarantee fill + DSL attach.
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: stingray_main_signals
+
+# ── EXIT (DSL — trend-following ladder, first lock +10% ROE) ──────────────────
+# hard_timeout 48h: mixed crypto + xyz means weekend gaps (xyz trades 24/7 incl.
+# weekends but crypto/xyz rotation legs can sit through low-activity windows); 48h
+# lets a real rotation breathe across a multi-day move. weak_peak_cut KEPT
+# (self-limiting). dead_weight_cut off. Phase 1 max_loss 30%. Phase 2 wide ladder
+# (T0 +10%/0% lock through T5 +100%/85% lock) so winners run. order_type
+# FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST happen). interval_seconds 60.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true         # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                         # 48h: cap a stalled rotation leg (mixed crypto+xyz, weekend gaps)
+      interval_in_minutes: 2880             # 48 hours
+    weak_peak_cut:
+      enabled: true                         # self-limiting: fires only if peak ROE never clears 3.0 in 60min
+      interval_in_minutes: 60
+      min_value: 3.0
+    dead_weight_cut:
+      enabled: false                        # multi-day rotation tolerates flat windows
+      interval_in_minutes: 45
+    phase1:
+      enabled: true
+      max_loss_pct: 30.0                     # wide floor for a swing rotation leg
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                 # trend-following ladder; FIRST lock at +10% ROE (reachable)
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 25 }
+        - { trigger_pct: 30, lock_hw_pct: 40 }
+        - { trigger_pct: 50, lock_hw_pct: 60 }
+        - { trigger_pct: 75, lock_hw_pct: 75 }
+        - { trigger_pct: 100, lock_hw_pct: 85 }
+
+# ── RISK guard rails (seconds) ──
+risk:
+  data_retention_seconds: 259200            # 72h (in [3600, 604800])
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 6                   # up to 4 legs/tick across the day, capped
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 1800                   # post-loss cooldown 30m (fleet-standard)
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 7200         # 2h per-asset re-entry cooldown
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/stingray/main/scanners/scan.py
+++ b/strategies/stingray/main/scanners/scan.py
@@ -1,0 +1,417 @@
+"""STINGRAY — supervised scanner (NET-NEW Runtime 3.0 cross-asset SM-rotation strategy).
+
+THESIS — cross-asset smart-money rotation. Existing SM agents follow smart money
+*per asset*. Stingray follows the rotation *across the whole board*: it reads the
+smart-money board, ranks every asset by net SM conviction (tilt x notional/breadth
+weight), and goes LONG the assets SM is crowding INTO + SHORT the ones SM is FLEEING
+— capturing days like "long semis/indices, short the crypto block".
+
+Per tick it:
+  1. reads account state + held positions (dual-DEX equity via max(), read-sanity
+     guard — bison pattern),
+  2. fetches `leaderboard_get_markets` (READ-GUARDED) and normalizes every asset on
+     the board into per-asset long%/short% (bison `_get_sm_direction` accumulation)
+     + notional/breadth (cheetah `_fetch_sm_markets` field extraction),
+  3. ranks the board by conviction (|net_tilt| x weight) and splits LONG / SHORT
+     sides, requiring a minimum tilt (58/42 like bison),
+  4. applies a price-confirmation gate per shortlisted asset (READ-GUARDED, dex-aware
+     via `_dex_for`): only LONG if the asset's 4h trend isn't a hard downtrend, only
+     SHORT if not a hard uptrend — don't fight price; skip the asset on read fail,
+  5. emits up to `maxLong` longs + `maxShort` shorts, scored by conviction; held +
+     recent-signal dedup via ctx.state (240s TTL).
+
+Read-only + single-pass — emits `marginPct` intents (PERCENT, conviction-tiered)
+plus `leverage`; the runtime sizes the dollars, owns slots/cooldowns/risk gates, and
+trails the DSL exit. No daemon, no push_signal, no create_position. EVERY MCP call is
+read-guarded so a transient/permission error degrades that read instead of rolling
+back the whole tick.
+"""
+
+import sys
+import time
+
+import scoring
+
+# defaults (overridable via runtime.yaml inputs)
+_DEFAULT_MIN_TILT_LONG = 58.0     # long_ratio >= 58 -> LONG candidate (bison threshold)
+_DEFAULT_MIN_TILT_SHORT = 42.0    # long_ratio <= 42 -> SHORT candidate (bison threshold)
+_DEFAULT_MARGIN_PCT = 12.0        # PERCENT of withdrawable (0,100]; tiered x1.25/x1.5 by |net_tilt|
+_DEFAULT_LEVERAGE = 4             # clamped to [1,5] (+ venue max) in scan()
+_MIN_LEVERAGE = 1
+_MAX_LEVERAGE = 5                 # leverage_max (catalog); runtime also clamps to venue max
+_DEFAULT_MAX_LONG = 2
+_DEFAULT_MAX_SHORT = 2
+_DEFAULT_RECENT_TTL = 240         # signal-dedup TTL (s)
+_DEFAULT_LEADERBOARD_LIMIT = 100  # board breadth to scan
+_DEFAULT_VOL_FLOOR = 1.0          # conviction_weight notional floor
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll back the
+    whole tick. Returns None on failure so the existing degrade paths apply (board
+    empty -> skip tick; per-asset trend read fail -> skip that asset, don't fight an
+    unknown chart)."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[stingray.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _dex_for(asset):
+    """XYZ (HIP-3) assets must pass dex='xyz'; main-DEX assets pass '' (bison pattern).
+    Stingray is cross-asset (crypto + xyz equities/commodities/indices), so this DOES
+    return 'xyz' for xyz: markets — the trend-confirmation read must be dex-aware."""
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+# ── ACCOUNT + HELD ASSETS (bison _get_account, verbatim shape incl. read-sanity guard) ──
+
+def _get_account(ctx):
+    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+
+    READ-GUARDED. Dual-DEX equity collapse: account_value via max() across main/xyz
+    (two views of ONE cross-margined wallet — summing double-counts the shared free
+    balance -> 2x sizing). assetPositions are per-sub-DEX so they are enumerated across
+    both sections. Ported from bison, including the read-sanity guard (margin in use +
+    empty positions -> skip tick)."""
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+
+    positions, account_value = [], 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {})
+        account_value = max(account_value, scoring.safe_float(ms.get("accountValue", 0)))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            szi = scoring.safe_float(pos.get("szi", 0))
+            if szi == 0:
+                continue
+            positions.append({
+                "coin": pos.get("coin", ""),
+                "direction": "LONG" if szi > 0 else "SHORT",
+                "margin": scoring.safe_float(pos.get("marginUsed", 0)),
+            })
+
+    # read-sanity guard (funding/$0 glitch 2026-06, ported from bison): a corrupt read
+    # can report margin/notional IN USE while returning an EMPTY positions list; running
+    # the held dedup off that re-enters held names. Skip the tick.
+    _use = 0.0
+    for _sec in ("main", "xyz"):
+        _s = data.get(_sec, {}) if isinstance(data, dict) else {}
+        _ms = _s.get("marginSummary", {}) if isinstance(_s, dict) else {}
+        _use = max(_use, scoring.safe_float(_ms.get("totalMarginUsed", 0)),
+                   abs(scoring.safe_float(_ms.get("totalNtlPos", 0))))
+    if _use > 1.0 and not positions:
+        print("[stingray.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+# ── SM BOARD (bison _get_sm_direction per-asset long%/short% accumulation +
+#    cheetah _fetch_sm_markets field extraction, COMBINED — do not invent the shape) ──
+
+def _board(ctx, limit, xyz_banned):
+    """Read leaderboard_get_markets (READ-GUARDED) and fold the per-direction rows
+    into ONE normalized dict per asset:
+      { token, dex, long_pct, short_pct, volume, traders }
+
+    The leaderboard returns one ROW per (asset, direction) carrying
+    `pct_of_top_traders_gain` (bison's `_get_sm_direction` reads exactly these long /
+    short rows). We accumulate long_pct + short_pct per (token, dex) so each asset gets
+    a single net-tilt input, and we carry the max volume / trader_count seen across its
+    rows (cheetah's `_fetch_sm_markets` field names: token, dex, direction,
+    pct_of_top_traders_gain, trader_count, volume). Returns [] on read failure."""
+    raw = _read(ctx, "leaderboard_get_markets", {"limit": limit})
+    if not raw:
+        return []
+
+    markets = []
+    if isinstance(raw, dict):
+        data = raw.get("data", raw)
+        if isinstance(data, dict):
+            markets = data.get("markets", [])
+            if isinstance(markets, dict):
+                markets = markets.get("markets", markets.get("leaderboard", []))
+        elif isinstance(data, list):
+            markets = data
+    elif isinstance(raw, list):
+        markets = raw
+    if not isinstance(markets, list):
+        return []
+
+    by_asset = {}
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        token = str(m.get("token", m.get("coin", m.get("asset", "")))).upper()
+        if not token:
+            continue
+        dex = str(m.get("dex", "")).lower()
+        if xyz_banned and dex == "xyz":
+            continue
+        direction = str(m.get("direction", "")).lower()
+        # bison reads pct_of_top_traders_gain (fallback longPct), same field cheetah uses
+        pct = scoring.safe_float(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        vol = scoring.safe_float(m.get("volume", m.get("avg_volume_6h", m.get("avgVolume", 0))))
+        traders = scoring.safe_float(m.get("trader_count", m.get("traders", 0)))
+
+        key = (token, dex)
+        row = by_asset.setdefault(key, {
+            "token": token, "dex": dex,
+            "long_pct": 0.0, "short_pct": 0.0,
+            "volume": 0.0, "traders": 0.0,
+        })
+        if direction == "long":
+            row["long_pct"] += pct
+        elif direction == "short":
+            row["short_pct"] += pct
+        # carry the strongest notional/breadth seen across the asset's rows
+        row["volume"] = max(row["volume"], vol)
+        row["traders"] = max(row["traders"], traders)
+
+    return list(by_asset.values())
+
+
+# ── PRICE-CONFIRMATION GATE (don't fight price). bison _asset_data + trend_structure ──
+
+def _hard_trend(ctx, coin):
+    """Return the 4h trend label ('BULLISH' / 'BEARISH' / 'NEUTRAL') for `coin`, or
+    None on read failure. READ-GUARDED, dex-aware via _dex_for (bison _asset_data +
+    scoring.trend_structure). Used to refuse longs into a hard downtrend and shorts
+    into a hard uptrend — we don't fight price."""
+    md = _read(ctx, "market_get_asset_data", {
+        "asset": coin,
+        "candle_intervals": ["4h"],
+        "include_funding": False,
+        "include_order_book": False,
+        "dex": _dex_for(coin),
+    })
+    if not md:
+        return None
+    if isinstance(md, dict) and md.get("success") is False:
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    if not isinstance(d, dict):
+        return None
+    candles = (d.get("candles", {}) or {}).get("4h", [])
+    if not candles:
+        return None
+    label, _strength = _trend_structure(candles)
+    return label
+
+
+def _trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH (bison scoring.trend_structure,
+    same strict-> counting + 0.6 gate). Kept local to keep the gate self-contained."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+
+    def _low(c):
+        if isinstance(c, dict):
+            return scoring.safe_float(c.get("low", c.get("l", 0)))
+        if isinstance(c, (list, tuple)) and len(c) >= 5:
+            return scoring.safe_float(c[3])
+        return 0.0
+
+    def _high(c):
+        if isinstance(c, dict):
+            return scoring.safe_float(c.get("high", c.get("h", 0)))
+        if isinstance(c, (list, tuple)) and len(c) >= 5:
+            return scoring.safe_float(c[2])
+        return 0.0
+
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def _price_ok(ctx, coin, direction):
+    """Price-confirmation gate. LONG is blocked only by a HARD downtrend (4h BEARISH);
+    SHORT only by a HARD uptrend (4h BULLISH). NEUTRAL passes (rotation can lead price).
+    On read failure -> None: the caller treats an unknown chart as a SKIP (don't size
+    blind into a chart we couldn't read)."""
+    label = _hard_trend(ctx, coin)
+    if label is None:
+        return None
+    if direction == "LONG" and label == "BEARISH":
+        return False
+    if direction == "SHORT" and label == "BULLISH":
+        return False
+    return True
+
+
+# ── ctx.state: recent-signal dedup (240s TTL) ──
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    sig = last.get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def _prune_signaled(signaled, ttl, now):
+    """Drop entries older than 4x TTL (bison _prune_recent_signals)."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in signaled.items() if v >= cutoff}
+
+
+def _recently_signaled(signaled, coin, ttl, now):
+    last = signaled.get(str(coin).upper())
+    if last is None:
+        return False
+    return (now - last) < ttl
+
+
+def _emit_side(ctx, ranked, direction, cap, held_set, signaled, ttl, now,
+               base_margin, leverage, max_margin):
+    """Walk the conviction-ranked side, apply held + recent-signal + price gates, and
+    return up to `cap` emit dicts (highest conviction first). Mutates `signaled` for
+    each emitted asset (dedup). Each emit is sized by conviction (margin_pct_for) and
+    carries the clamped leverage."""
+    emits = []
+    for c in ranked:
+        if len(emits) >= cap:
+            break
+        coin = c["token"]
+        cu = coin.upper()
+        if cu in held_set:
+            continue
+        if _recently_signaled(signaled, coin, ttl, now):
+            continue
+        ok = _price_ok(ctx, coin, direction)
+        if ok is None:
+            print(f"[stingray.scan] SKIP {coin} {direction}: trend read failed (don't size blind)",
+                  file=sys.stderr)
+            continue
+        if not ok:
+            print(f"[stingray.scan] SKIP {coin} {direction}: price gate (hard "
+                  f"{'down' if direction == 'LONG' else 'up'}trend, don't fight price)",
+                  file=sys.stderr)
+            continue
+        margin_pct = scoring.margin_pct_for(abs(c["net_tilt"]), base_margin, max_margin)
+        signaled[cu] = now
+        emits.append({
+            "asset": coin,
+            "direction": direction,
+            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,             # clamped [1,5] + venue max
+            "data": {
+                "direction": direction,
+                "longRatio": c["long_ratio"],
+                "netTilt": c["net_tilt"],
+                "conviction": c["conviction"],
+                "weight": c["weight"],
+                "smVolume": c["volume"],
+                "smTraders": c["traders"],
+                "leverage": leverage,
+            },
+        })
+    return emits
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    min_tilt_long = float(inputs.get("minTiltLong", _DEFAULT_MIN_TILT_LONG))
+    min_tilt_short = float(inputs.get("minTiltShort", _DEFAULT_MIN_TILT_SHORT))
+    base_margin = float(inputs.get("marginPctBase", _DEFAULT_MARGIN_PCT))   # PERCENT (0,100]
+    # marginPct <=1.0 -> x100 guard: a fraction (0.12) slipped in via config means PERCENT
+    if base_margin <= 1.0:
+        print(f"[stingray.scan] marginPctBase={base_margin} looks like a FRACTION; "
+              f"x100 -> {base_margin * 100} PERCENT", file=sys.stderr)
+        base_margin *= 100.0
+    max_margin = float(inputs.get("marginPctMax", 0)) or None
+    leverage_in = int(inputs.get("leverageDefault", _DEFAULT_LEVERAGE))
+    leverage = max(_MIN_LEVERAGE, min(leverage_in, _MAX_LEVERAGE))   # clamp [1,5]; runtime clamps venue max too
+    max_long = int(inputs.get("maxLong", _DEFAULT_MAX_LONG))
+    max_short = int(inputs.get("maxShort", _DEFAULT_MAX_SHORT))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+    limit = int(inputs.get("leaderboardLimit", _DEFAULT_LEADERBOARD_LIMIT))
+    xyz_banned = bool(inputs.get("xyzBanned", False))   # cross-asset: xyz INCLUDED by default
+    vol_floor = float(inputs.get("convictionVolFloor", _DEFAULT_VOL_FLOOR))
+
+    # ── account + held ──
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[stingray.scan] cannot read account value; skip tick", file=sys.stderr)
+        if ctx.state is not None:
+            try:
+                ctx.state.append({"signaled": _prune_signaled(_load_signaled(ctx), ttl, now),
+                                  "result": {"ts": now, "emitted": False, "gate": "no_account"}})
+            except Exception as exc:  # noqa: BLE001
+                print(f"[stingray.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+        return []
+    held_assets = [p["coin"] for p in positions if p.get("coin")]
+    held_set = {h.upper() for h in held_assets}
+
+    signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
+
+    # ── SM board -> conviction-ranked LONG / SHORT sides ──
+    rows = _board(ctx, limit, xyz_banned)
+    if not rows:
+        print("[stingray.scan] empty SM board (leaderboard_get_markets); skip tick", file=sys.stderr)
+        result = {"ts": now, "emitted": False, "gate": "no_board", "held": held_assets}
+    else:
+        longs, shorts = scoring.rank_board(rows, min_tilt_long, min_tilt_short, vol_floor)
+        # weight fallback: if the board carried no notional/breadth, conviction collapses
+        # to a constant -> re-rank both sides on |net_tilt| alone (still a valid rotation rank)
+        if not scoring.board_has_weight(rows):
+            longs.sort(key=lambda c: abs(c["net_tilt"]), reverse=True)
+            shorts.sort(key=lambda c: abs(c["net_tilt"]), reverse=True)
+            print("[stingray.scan] board carries no notional/breadth — ranking on |net_tilt| only",
+                  file=sys.stderr)
+        else:
+            longs.sort(key=lambda c: c["conviction"], reverse=True)
+            shorts.sort(key=lambda c: c["conviction"], reverse=True)
+
+        long_emits = _emit_side(ctx, longs, "LONG", max_long, held_set, signaled, ttl, now,
+                                base_margin, leverage, max_margin)
+        short_emits = _emit_side(ctx, shorts, "SHORT", max_short, held_set, signaled, ttl, now,
+                                 base_margin, leverage, max_margin)
+        out = long_emits + short_emits
+
+        if out:
+            print(f"[stingray.scan] EMIT {len(long_emits)}L + {len(short_emits)}S "
+                  f"| board={len(rows)} longs={len(longs)} shorts={len(shorts)} held={held_assets} "
+                  f"| {[ (e['asset'], e['direction']) for e in out ]}", file=sys.stderr)
+            result = {"ts": now, "emitted": True, "board": len(rows),
+                      "longSide": len(longs), "shortSide": len(shorts),
+                      "emittedAssets": [(e["asset"], e["direction"]) for e in out],
+                      "held": held_assets}
+            if ctx.state is not None:
+                try:
+                    ctx.state.append({"signaled": signaled, "result": result})
+                except Exception as exc:  # noqa: BLE001
+                    print(f"[stingray.scan] WARNING: state append failed; next tick may re-emit "
+                          f"a suppressed signal: {exc!r}", file=sys.stderr)
+            return out
+
+        print(f"[stingray.scan] WAITING — no rotation emit | board={len(rows)} "
+              f"longs={len(longs)} shorts={len(shorts)} held={held_assets} "
+              f"(tilt floors {min_tilt_long:.0f}/{min_tilt_short:.0f})", file=sys.stderr)
+        result = {"ts": now, "emitted": False, "gate": "no_rotation", "board": len(rows),
+                  "longSide": len(longs), "shortSide": len(shorts), "held": held_assets}
+
+    # persist dedup map + this tick's result (bounded by state_history_max_count)
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[stingray.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return []

--- a/strategies/stingray/main/scanners/scoring.py
+++ b/strategies/stingray/main/scanners/scoring.py
@@ -1,0 +1,132 @@
+"""STINGRAY — pure thesis math (no I/O, no MCP, no clock).
+
+Cross-asset smart-money ROTATION scorer. Where per-asset SM agents (bison, cheetah)
+ask "is smart money long this coin?", Stingray ranks the WHOLE board by net
+smart-money conviction and trades the rotation: LONG the assets SM is crowding into,
+SHORT the ones SM is fleeing. The unit of analysis is the board, not one coin.
+
+This module is pure: it consumes already-normalized per-asset SM rows (the caller,
+scan.py, fetches + normalizes `leaderboard_get_markets`, copying bison's
+`_get_sm_direction` per-asset long%/short% accumulation and cheetah's
+`_fetch_sm_markets` field extraction) and returns the conviction-ranked board.
+Unit-testable on plain dicts; no clock, no network. The trend-confirmation gate
+(don't fight price) lives in scan.py because it needs a per-asset MCP read.
+
+Net-tilt math is bison's formula, VERBATIM:
+  long_ratio = long_pct / (long_pct + short_pct) * 100   (50 = balanced)
+  net_tilt   = long_ratio - 50                            (+ = SM net long)
+LONG side requires long_ratio >= minTiltLong (default 58); SHORT side requires
+long_ratio <= minTiltShort (default 42) — the same 58/42 thresholds bison uses.
+Conviction = |net_tilt| * weight, where weight folds in notional/volume + trader
+breadth so a strong tilt on a deep, widely-held market outranks a strong tilt on a
+thin one (the thin-coin-spike failure mode bison's whitelist guards against)."""
+
+import math
+
+
+def safe_float(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def net_tilt(long_pct, short_pct):
+    """Bison's net-tilt formula. Returns (long_ratio, net_tilt).
+    long_ratio in [0,100] (50 = balanced); net_tilt = long_ratio - 50 in [-50, +50]."""
+    total = safe_float(long_pct) + safe_float(short_pct)
+    if total <= 0:
+        return 50.0, 0.0
+    long_ratio = (safe_float(long_pct) / total) * 100.0
+    return long_ratio, long_ratio - 50.0
+
+
+def conviction_weight(volume, traders, vol_floor=1.0):
+    """Notional/breadth weight folded into conviction so a strong tilt on a deep,
+    widely-held market outranks the same tilt on a thin one.
+
+    weight = log10(1 + volume/vol_floor) * (1 + log10(1 + traders))
+
+    Both terms are log-damped so one whale-sized market can't swamp the ranking;
+    breadth (trader_count) is a multiplicative bonus, not an additive one, so a
+    market with zero reported breadth still gets its full notional weight (×1).
+    When the board carries no volume/breadth fields at all the caller passes
+    volume=0, traders=0 -> weight collapses to a constant (log10(1)=0 -> ... -> 0),
+    so the caller falls back to pure |net_tilt| ranking (handled in scan.py)."""
+    vol = max(0.0, safe_float(volume))
+    trd = max(0.0, safe_float(traders))
+    vf = vol_floor if vol_floor and vol_floor > 0 else 1.0
+    vol_term = math.log10(1.0 + vol / vf)
+    breadth_term = 1.0 + math.log10(1.0 + trd)
+    return vol_term * breadth_term
+
+
+def rank_board(rows, min_tilt_long=58.0, min_tilt_short=42.0, vol_floor=1.0):
+    """Rank the whole SM board by conviction and split into LONG / SHORT sides.
+
+    rows: list of normalized per-asset dicts (from scan._board), each:
+      { token, dex, long_pct, short_pct, volume, traders }
+    Returns (longs, shorts), each a list of conviction dicts sorted DESC by
+    conviction:
+      { token, dex, direction, long_ratio, net_tilt, weight, conviction,
+        volume, traders }
+
+    An asset is a LONG candidate iff long_ratio >= min_tilt_long, a SHORT
+    candidate iff long_ratio <= min_tilt_short. Assets between the thresholds are
+    rotation-neutral and dropped. `use_weight` (whether any row carried notional)
+    is decided by the caller; here weight is always computed and conviction is
+    |net_tilt| * max(weight, 0) — if every weight is ~0 the caller re-ranks on
+    |net_tilt| alone (see scan.rank_board fallback)."""
+    longs, shorts = [], []
+    for r in rows:
+        long_ratio, tilt = net_tilt(r.get("long_pct", 0), r.get("short_pct", 0))
+        weight = conviction_weight(r.get("volume", 0), r.get("traders", 0), vol_floor)
+        base = {
+            "token": r.get("token", ""),
+            "dex": r.get("dex", ""),
+            "long_ratio": round(long_ratio, 2),
+            "net_tilt": round(tilt, 2),
+            "weight": round(weight, 4),
+            "volume": safe_float(r.get("volume", 0)),
+            "traders": safe_float(r.get("traders", 0)),
+        }
+        if long_ratio >= min_tilt_long:
+            base = dict(base, direction="LONG",
+                        conviction=round(abs(tilt) * max(weight, 0.0), 4))
+            longs.append(base)
+        elif long_ratio <= min_tilt_short:
+            base = dict(base, direction="SHORT",
+                        conviction=round(abs(tilt) * max(weight, 0.0), 4))
+            shorts.append(base)
+    return longs, shorts
+
+
+def board_has_weight(rows):
+    """True iff at least one board row carries a positive notional/volume field.
+    When False the caller ranks on |net_tilt| alone (conviction weight collapses to
+    a constant when no volume/breadth is present)."""
+    for r in rows:
+        if safe_float(r.get("volume", 0)) > 0 or safe_float(r.get("traders", 0)) > 0:
+            return True
+    return False
+
+
+def margin_pct_for(net_tilt_abs, base_pct, max_pct=None):
+    """Conviction-scaled margin PERCENT. Stronger net tilt -> bigger size, tiered
+    on |net_tilt| (the rotation conviction). Mirrors bison's score-tiered margin
+    shape (1.0 / 1.25 / 1.5) but keyed on |net_tilt| instead of a composite score:
+      |net_tilt| >= 20 (long_ratio >= 70 / <= 30) -> base * 1.5
+      |net_tilt| >= 12 (long_ratio >= 62 / <= 38) -> base * 1.25
+      else                                         -> base
+    Returns a PERCENT in (0,100]; the runtime sizes (marginPct/100)*withdrawable.
+    Clamped to `max_pct` when supplied so the tier multiplier can't exceed the
+    per-position cap."""
+    if net_tilt_abs >= 20:
+        pct = base_pct * 1.5
+    elif net_tilt_abs >= 12:
+        pct = base_pct * 1.25
+    else:
+        pct = base_pct
+    if max_pct is not None and max_pct > 0:
+        pct = min(pct, max_pct)
+    return pct

--- a/strategies/stingray/strategy.yaml
+++ b/strategies/stingray/strategy.yaml
@@ -1,0 +1,44 @@
+# Stingray — cross-asset smart-money rotation. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. A NET-NEW Runtime 3.0 strategy (not a port):
+# instead of following smart money per asset, it reads the WHOLE smart-money board, ranks
+# every asset by net SM conviction (tilt x notional/breadth), and trades the rotation —
+# LONG the assets SM is crowding into, SHORT the ones SM is fleeing. Cross-asset by design
+# (universe crypto + xyz equities/commodities/indices), price-gated, DSL-only exits.
+# Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: stingray
+version: "1.0.0"
+
+catalog:
+  name: "Stingray — Cross-Asset Smart-Money Rotation"
+  emoji: "🐠"
+  tagline: "Reads the entire smart-money board every tick, ranks every asset by net smart-money conviction (tilt x notional x breadth), then rides the rotation — LONG the assets the best traders are crowding into and SHORT the ones they're fleeing, gated by price so it never fights a hard trend. Captures days like 'long semis/indices, short the crypto block'."
+  belief_plain: "Most copy-trading bots ask 'are the best traders long this one coin?'. Stingray instead looks at the whole market at once and asks 'what are the best traders rotating INTO, and what are they rotating OUT OF?'. It buys the crowd's new favorites and sells the ones they're abandoning — but only when the price chart isn't already screaming the other way — then trails a wide stop so a real rotation can run for days."
+  thesis: "Smart money doesn't just pick coins, it rotates capital across the whole board — out of one asset class and into another. Per-asset copy-traders miss this because they evaluate each market in isolation; they can't see that the SAME flow leaving crypto is funding the bid in indices. Stingray ranks the entire board by net tilt (long_ratio - 50) weighted by notional and trader breadth, so a strong, deep, widely-held lean outranks a thin spike, then takes BOTH sides at once — long the inflows, short the outflows — for a market-neutral-ish rotation book. A price-confirmation gate (no longs into a hard 4h downtrend, no shorts into a hard uptrend) keeps it from fighting price, and a DSL ratchet lets the winning legs run while cutting the losers."
+  group: smart-money
+  archetype: copy_trading
+  sub_style: sm_rotation
+  asset_classes: [universe_crypto, xyz_equities, commodities, indices]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 4
+  min_budget: 200
+  assets: []                # derived universe — assets come from the smart-money board each tick, not a fixed list
+  tags: [smart-money, rotation, cross-asset, copy-trading, long-short, universe-scanner, net-tilt, conviction-weight, let-winners-run]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: STINGRAY_WALLET
+    funding_share: 1.0


### PR DESCRIPTION
Three net-new Runtime 3.0 agents built to the current **smart-money cross-asset rotation** read (long the real economy, short the crypto block), filling distinct gaps. Catalog **75 → 78**, 0 warnings, all 78 pass the validator.

### 🐠 stingray — cross-asset smart-money rotation
Reads the whole `leaderboard_get_markets` board, ranks every asset by net smart-money conviction (tilt × notional + trader breadth), and goes LONG the classes SM is crowding into / SHORT the ones it's fleeing, with a price-confirmation gate (won't long into a downtrend). Existing SM agents follow SM *per asset*; this rotates *across* asset classes. `copy_trading/sm_rotation`. Board parsing copied from bison+cheetah.

### 🐦 oxpecker — elite-conviction concentrated mirror
Pools only ELITE/RELIABLE traders (`discovery_get_top_traders consistency:[ELITE,RELIABLE]`), mirrors only their **concentrated** (≥50% of book) high-conviction positions, weighted by quality × concentration with a consensus boost. `copy_trading/elite_conviction`. Discovery field accessors (`tcsLabel`/`tcsValue`/`openPositions`/`positionValue`) copied verbatim from the live-fleet raptor/jackal agents; concentration is derived from the positions themselves and it fails safe to `WAITING`.

### 🦴 hyena — crypto risk-off short (the fleet's first `short_only`)
Shorts the crypto block (BTC/ETH/SOL/HYPE + `xyz:MSTR/COIN/CRCL`) **only** when funding is LONG_CROWDED **and** smart money is net-short **and** 4h price confirms down; idles otherwise. A hedge sleeve that pairs with long crypto exposure. `contrarian_fade/risk_off_rotation`. Funding-regime parse copied from dog.

3 new sub_styles added to `glossary.yaml`. **Caveat:** the discovery/leaderboard endpoints are user-ID-token-gated (this session's token can read clearinghouse but not top-traders), so stingray/oxpecker need a live-token smoke-test on a real host before live money — consistent with the fidelity-then-live gate. Not merged — for your review.
