### PR TITLE
fix: zero cooldowns fail runtime registration (owl/otter/turbine) + validator guard

### DIFF
--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -58,6 +58,14 @@ def validate(pkg: Path) -> list:
             errs.append(f"instance {name}: {rt_rel} data_retention_seconds {m.group(1)} "
                         f"out of range [3600, 604800] (1h-7d)")
 
+        # guard_rails cooldowns: the runtime REJECTS below-minimum values at registration
+        # (cooldown_seconds >= 60, per_asset_cooldown_seconds >= 300) — a 0 fails to register.
+        # (See senpi-trading-runtime/references/runtime-yaml.md.)
+        for _field, _lo in (("cooldown_seconds", 60), ("per_asset_cooldown_seconds", 300)):
+            cm = re.search(rf"^\s*{_field}\s*:\s*([0-9]+)", rt_text, re.M)
+            if cm and int(cm.group(1)) < _lo:
+                errs.append(f"instance {name}: {rt_rel} {_field} {cm.group(1)} below runtime min {_lo}")
+
         # Runtime 3.0 scanner package: <runtime_dir>/scanners/scan.py exports scan(inputs, ctx);
         # the thesis math is a sibling scanners/scoring.py imported as `import scoring` (NO __init__.py).
         scn_dir = rt.parent / "scanners"

--- a/strategies/otter/main/runtime.yaml
+++ b/strategies/otter/main/runtime.yaml
@@ -127,7 +127,7 @@ risk:
     max_entries_per_day: 8                    # v2 max_entries_per_day
     bypass_max_entries_per_day_on_profit: false
     max_consecutive_losses: 4                 # v2 max_consecutive_losses
-    cooldown_seconds: 0                        # v2 cooldown_minutes 0 — scan manages per-asset cooldowns
+    cooldown_seconds: 60                     # runtime guard_rails min 60 (scan manages the real per-asset cooldown)
     drawdown_halt_pct: 20                      # v2 drawdown_halt_pct
     drawdown_reset_on_day_rollover: true
     per_asset_cooldown_seconds: 14400          # v2 per_asset_cooldown_minutes 240 ×60

--- a/strategies/owl/main/runtime.yaml
+++ b/strategies/owl/main/runtime.yaml
@@ -135,7 +135,7 @@ risk:
     max_entries_per_day: 4                  # v2 upper bound of dynamicSlots (4 at +$400 PnL)
     bypass_max_entries_per_day_on_profit: false
     max_consecutive_losses: 4               # v2 max_consecutive_losses
-    cooldown_seconds: 0                      # v2 cooldown_minutes 0 — scanner manages cooldowns
+    cooldown_seconds: 60                     # runtime guard_rails min 60 (scan manages the real per-asset cooldown)
     drawdown_halt_pct: 25                    # v2 drawdown_halt_pct — explicit -25% HARD STOP
     drawdown_reset_on_day_rollover: true     # v2 drawdown_reset_on_day_rollover
     per_asset_cooldown_seconds: 21600        # v2 per_asset_cooldown_minutes 360 -> 360*60 (6h post-loss)

--- a/strategies/turbine/volume/runtime.yaml
+++ b/strategies/turbine/volume/runtime.yaml
@@ -125,7 +125,7 @@ risk:
     cooldown_seconds: 60                    # v2 cooldown_minutes 1 -> 60s
     drawdown_halt_pct: 50                   # v2 drawdown_halt_pct
     drawdown_reset_on_day_rollover: true    # v2
-    per_asset_cooldown_seconds: 0           # v2 per_asset_cooldown_minutes 0 (rapid re-rotation)
+    per_asset_cooldown_seconds: 300         # runtime guard_rails min 300 (volume engine still rotates across the basket)
 
 notifications:
   dsl_lifecycle: false                      # v2: quiet (high-frequency volume engine)


### PR DESCRIPTION
From Ignas's install-warning sweep: owl only registered because the deploying agent auto-patched an invalid config value. Root cause — the runtime rejects `guard_rails` cooldowns below the schema minimum (`cooldown_seconds` ≥ 60, `per_asset_cooldown_seconds` ≥ 300), and **three** packages shipped a `0` (carried verbatim from v2 `cooldown_minutes: 0`):

- **owl**, **otter** — `cooldown_seconds: 0` → **60**
- **turbine/volume** — `per_asset_cooldown_seconds: 0` → **300** (the volume engine still rotates across the basket; only same-name re-entry waits 5 min)

The author-side `validate_strategy.py` checked `data_retention` but not cooldowns, so these slipped through to the *runtime* validator at deploy time. Added a below-min cooldown check so it's caught pre-deploy.

These are **live on strategy-v2** today, so any deploy of owl/otter/turbine hits the register-fail until merged.
