### PR TITLE
fix: remora autonomous out-of-the-box (whalehunter cohort engine) — 1.0.0 -> 1.1.0

### DIFF
--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -3725,17 +3725,19 @@
     },
     {
       "id": "remora",
-      "name": "Remora — Whale Single-Position Mirror",
+      "name": "Remora — Autonomous Smart-Money Whale Mirror",
       "emoji": "🐟",
-      "tagline": "Rides a small, hand-picked set of whale traders the way a remora fish rides a shark: each tick it takes each whale's highest-conviction open position and mirrors the strongest, leaning hardest when several whales pile into the same trade (consensus) or when a whale is ELITE/RELIABLE tier.",
-      "belief_plain": "You name a few whale traders you trust. Remora watches their open positions, finds each one's biggest bet, and copies the single strongest one — betting bigger when several of your whales are in the same trade and one of them has an elite track record. Then it trails a wide stop so the trade can run.",
-      "version": "1.0.0",
-      "thesis": "The broad trader-followers scan a leaderboard and synthesize an opaque pick. Remora is the opposite: YOU choose whom to ride. Mirroring one whale's single highest-conviction position keeps your exposure tracking specific traders you trust, and the consensus multiplier means it leans hardest exactly when those whales independently agree — one whale can be wrong, three agreeing is a much stronger signal. Whales hold winners, so the exit lets the mirror run and only caps staleness.",
+      "tagline": "Autonomous smart-money whale mirror — auto-builds a top-trader cohort and mirrors their highest-conviction positions; optionally mirror specific whales you name via inputs.whales. Like a remora fish riding a shark, it leans hardest when several whales pile into the same trade (consensus) or when a whale is ELITE/RELIABLE tier.",
+      "belief_plain": "Out of the box, Remora finds the most proven traders on Hyperliquid, watches their open positions, and copies the strongest bets — betting bigger when several of them are in the same trade and one has an elite track record. Prefer to ride specific traders you trust? Name them and Remora mirrors exactly those instead. Either way it trails a wide stop so the trade can run.",
+      "version": "1.1.0",
+      "thesis": "Riding the highest-conviction position of proven traders keeps your exposure tracking real smart money, and the consensus multiplier means it leans hardest exactly when those traders independently agree — one whale can be wrong, three agreeing is a much stronger signal. By default Remora is autonomous: it auto-builds a top-trader cohort (all-time realized PnL, refreshed daily) so it always has whales to mirror — no config required. Name your own whales to make it ride exactly the traders you choose. Whales hold winners, so the exit lets the mirror run and only caps staleness.",
       "tags": [
         "whale",
         "mirror",
         "copy-trading",
         "named-whales",
+        "smart-money",
+        "autonomous",
         "consensus",
         "let-winners-run",
         "follows-traders"
@@ -3761,7 +3763,7 @@
       "funding_split": [
         1.0
       ],
-      "max_slots": 1,
+      "max_slots": 2,
       "branch": "strategy-v2",
       "sort_order": 9
     },

--- a/strategies/remora/main/runtime.yaml
+++ b/strategies/remora/main/runtime.yaml
@@ -1,35 +1,41 @@
-# ── REMORA · single instance — whale single-position mirror ───────────────────
-# Runtime 3.0 port of the v2 Remora (SKILL.md v1.0.0 / remora-producer.py v1.0.1).
-# TRADER-FOLLOWER: mirrors a small, hand-picked set of whale traders (NOT a
-# leaderboard universe). Each tick pulls each whale's open positions, takes their
-# highest-conviction (largest-notional) position, aggregates across whales into
-# (asset, direction) candidates, and emits the strongest — boosting score when
+# ── REMORA · single instance — autonomous smart-money whale mirror ────────────
+# Runtime 3.0 strategy. AUTONOMOUS OUT OF THE BOX: with no config it auto-builds a
+# cohort of proven top traders (WhaleHunter's smart-money cohort engine —
+# discovery_get_top_traders, ALL_TIME realized-PnL ranking, cached daily in
+# ctx.state, degrade-to-cached on a failed refresh) and mirrors their
+# highest-conviction positions. Optionally name specific whales via inputs.whales
+# to mirror exactly those (the override — Remora's named-whale identity).
+# Per tick: resolve the whale set, pull each whale's open positions, take their
+# highest-conviction (largest-notional) position, aggregate across whales into
+# (asset, direction) candidates, and emit the strongest 1-2 — boosting score when
 # multiple whales agree (consensus) and when a whale is ELITE/RELIABLE tier.
 # Let-winners-run DSL with a 120h hard_timeout staleness cap (whales hold winners;
-# the whale-exit mirror is a future enhancement). Faithful port — see
-# scanners/scoring.py (mirror math reproduced verbatim).
+# the whale-exit mirror is a future enhancement). Mirror math reproduced verbatim
+# from the v2 Remora producer; cohort engine reused from WhaleHunter — see
+# scanners/scoring.py + scanners/scan.py.
 name: remora-main
 group: remora
-version: 1.0.0
+version: 1.1.0
 description: >
-  REMORA — whale single-position mirror. Rides a small, hand-picked set of whale
-  traders: each tick it pulls each whale's open positions (leaderboard_get_trader_positions),
+  REMORA — autonomous smart-money whale mirror. By default it auto-builds a cohort
+  of proven top traders (discovery_get_top_traders, ranked by all-time realized PnL,
+  cached daily) and mirrors their highest-conviction positions — so it trades out of
+  the box with no config. Optionally name specific whales via inputs.whales to mirror
+  exactly those. Each tick it pulls each whale's open positions (leaderboard_get_trader_positions),
   takes their highest-conviction (largest-notional) position above minNotionalUsd,
   aggregates across whales into (asset, direction) candidates, scores by consensus
   (how many whales agree) + whale quality (discovery_get_trader_state ELITE/RELIABLE/
-  PROFITABLE tier when useWhaleQuality), and mirrors the strongest — sized by
-  Remora's own marginPct (default 15%), leverage clamped to 10x. Distinct from the
-  broad trader-followers (Raptor/Jackal/Spider) that scan a leaderboard universe;
-  Remora mirrors whales YOU choose (set inputs.whales). Producer enters only — the
-  DSL owns exits: let-winners-run preset (wide ladder, first lock at +10% ROE,
-  max_loss 18%) with a 120h hard_timeout staleness cap. Faithful port of the v2
-  Remora v1.0.0 thesis (all scoring/thresholds verbatim).
+  PROFITABLE tier when useWhaleQuality), and mirrors the strongest 1-2 — sized by
+  Remora's own marginPct (default 15%), leverage clamped to [1,10]. Producer enters
+  only — the DSL owns exits: let-winners-run preset (wide ladder, first lock at +10%
+  ROE, max_loss 18%) with a 120h hard_timeout staleness cap. Mirror scoring verbatim
+  from the v2 Remora producer; smart-money cohort engine reused from WhaleHunter.
 
 strategy:
   wallet: "${REMORA_WALLET}"
-  slots: 1                                  # v2 mirror emits exactly one best candidate
+  slots: 2                                  # auto-cohort mode emits up to 2 strongest mirrors
   margin_pct: 15                            # baseline %; scan emits the marginPct intent per signal
-  default_leverage: 4                       # v2 DEFAULT_LEVERAGE; scan emits leverage (clamped <=10x)
+  default_leverage: 4                       # v2 DEFAULT_LEVERAGE; scan emits leverage (clamped [1,10])
   trading_risk: moderate
   enabled: true
 
@@ -41,20 +47,30 @@ scanners:
     type: external_scanner
     path: ./scanners
     entrypoint: scan.py
-    interval_seconds: 600                    # v2 producer cadence (10 min — whale positions change slowly)
-    timeout_seconds: 240                     # v2 tick_timeout=240; up to ~2 reads/whale + account
+    interval_seconds: 600                    # whale positions change slowly (10 min); cohort cached daily
+    timeout_seconds: 240                     # up to ~2 reads/whale + account + (daily) cohort paging
     default_signal_validity_seconds: 1200    # 2x tick; rule action, a fresh re-score arrives next tick
-    state_history_max_count: 50              # dedup map + per-tick scan-results history
+    state_history_max_count: 50              # dedup map + cohort cache + per-tick scan-results history
     inputs:
-      whales: []                             # SET to your hand-picked trader_ids/wallets, e.g.
+      # ── whale source ──────────────────────────────────────────────────────
+      whales: []                             # OVERRIDE: name your own traders, e.g.
                                              #   [ { trader_id: "0x..." }, { trader_id: "0x..." } ]
-                                             # v2 config.whales default was placeholder; empty -> WAITING
-      useWhaleQuality: true                  # v2 config.useWhaleQuality — ELITE/RELIABLE/PROFITABLE bonus
+                                             # EMPTY (default) -> auto-build a smart-money cohort
+                                             # (Remora trades out of the box; never WAITING-on-config).
+      # ── auto-cohort engine (used only when whales is empty) ───────────────
+      cohortSize: 10                         # top N proven traders to mirror by default
+      cohortRefreshHours: 24                 # rebuild the cohort once a day; degrade-to-cached on failure
+      cohortMinRealizedUsd: 0                # 0 = no floor (rank purely by all-time realized PnL)
+      cohortFetchLimit: 1000                 # discovery_get_top_traders page size
+      cohortMaxPages: 6                      # paging cap to reach a deep, stable ranking
+      # ── mirror scoring (v2 Remora — verbatim) ─────────────────────────────
+      useWhaleQuality: true                  # ELITE/RELIABLE/PROFITABLE bonus (discovery_get_trader_state)
       minNotionalUsd: 5000                   # v2 DEFAULT_MIN_NOTIONAL_USD — skip dust positions
       minScore: 4                            # v2 DEFAULT_MIN_SCORE — producer floor
+      emitTopN: 2                            # emit the strongest 1-2 mirrors per tick (clamped 1..2)
       marginPct: 15                          # PERCENT of withdrawable (0,100]; v2 stored fraction 0.15 -> 15%
-      leverage: 4                            # v2 config.leverage default; clamped to <=10x in scan.py
-      recentSignalTtlSeconds: 240            # v2 RECENT_SIGNAL_TTL_SEC (race-window dedup)
+      leverage: 4                            # v2 config.leverage default; clamped to [1,10] in scan.py
+      recentSignalTtlSeconds: 240            # race-window dedup (re-fire suppression per coin)
     signal_data_schema:
       score: { type: number }
       leverage: { type: number }
@@ -63,6 +79,7 @@ scanners:
       whaleCount: { type: number, required: false }
       maxNotionalUsd: { type: number, required: false }
       eliteTier: { type: boolean, required: false }
+      whaleSource: { type: string, required: false }
       whales: { type: array, required: false }
       heldAssets: { type: array, required: false }
 
@@ -125,17 +142,19 @@ exit:
         - { trigger_pct: 90, lock_hw_pct: 88 }
 
 # ── RISK guard rails (from v2 runtime.yaml; minutes/hours -> seconds) ──
+# Cooldowns must be >= the scanner interval (600s): cooldown_seconds 5400 (90m) and
+# per_asset_cooldown_seconds 28800 (8h) both clear that floor.
 risk:
-  data_retention_seconds: 345600             # 96h (was data_retention_hours 96); in [3600, 604800], no clamp
+  data_retention_seconds: 345600             # 96h; in [3600, 604800], no clamp
   guard_rails:
     daily_loss_limit_pct: 15                 # v2 risk.daily_loss_limit_pct
     max_entries_per_day: 3                   # v2 risk.max_entries_per_day
     bypass_max_entries_per_day_on_profit: false
     max_consecutive_losses: 3                # v2 risk.max_consecutive_losses
-    cooldown_seconds: 5400                   # v2 cooldown_minutes 90 -> 5400s
+    cooldown_seconds: 5400                   # 90m; >= scanner interval (600s)
     drawdown_halt_pct: 22                    # v2 risk.drawdown_halt_pct
     drawdown_reset_on_day_rollover: false
-    per_asset_cooldown_seconds: 28800        # v2 per_asset_cooldown_minutes 480 -> 28800s (8h)
+    per_asset_cooldown_seconds: 28800        # 8h; >= scanner interval (600s)
 
 notifications:
   dsl_lifecycle: true

--- a/strategies/remora/main/scanners/scan.py
+++ b/strategies/remora/main/scanners/scan.py
@@ -1,54 +1,76 @@
 """REMORA — supervised scanner (Runtime 3.0 port of the v2 Remora whale mirror).
 
-TRADER-FOLLOWER archetype: mirrors a small, hand-picked set of whale traders
-(NOT a leaderboard universe). Per tick it:
-  - reads account state + held positions (dual-DEX equity via max(), never sum()),
-  - for each configured whale, pulls their open positions
-    (leaderboard_get_trader_positions — the producer signature) and takes their
-    single largest-notional position above minNotionalUsd,
-  - optionally validates whale quality (discovery_get_trader_state ELITE /
-    RELIABLE / PROFITABLE tier) as a scoring bonus,
-  - aggregates across whales into (asset, direction) candidates (consensus is the
-    edge multiplier), scores via the pure `scoring` module, and emits the SINGLE
-    highest-scoring candidate at/above minScore (v2 main() emitted only `best`),
-    sized by Remora's OWN marginPct + leverage clamp.
+AUTONOMOUS SMART-MONEY WHALE MIRROR. Out of the box, with NO config, Remora
+auto-builds a cohort of proven top traders and mirrors their highest-conviction
+positions. Optionally, name specific whales via inputs.whales to mirror exactly
+those (the override — Remora's named-whale identity).
 
-Read-only + single-pass — emits a `marginPct` intent (PERCENT) plus `leverage`;
-the runtime sizes the dollars, owns cooldowns/risk gates/dedup, and trails the
-DSL exit. No daemon, no push_signal, no create_position.
+WHALE-SOURCE RESOLUTION (per tick):
+  - inputs.whales NON-EMPTY  -> use those hand-picked trader_ids/wallets (the
+    override; original v2 Remora behavior).
+  - inputs.whales EMPTY (default) -> AUTO-BUILD a smart-money cohort using
+    WhaleHunter's engine: discovery_get_top_traders (ALL_TIME, ranked by realized
+    PnL, paged by offset), take the top `cohortSize` (default 10) proven traders,
+    cache the cohort in ctx.state and refresh every `cohortRefreshHours`
+    (default 24). On a failed refresh read, DEGRADE to the cached cohort (so
+    Remora ALWAYS has whales to mirror — never a dead WAITING-on-config tick).
+
+Then Remora's existing mirror logic (unchanged): for each whale, pull their open
+positions (read-guarded), take the single largest-notional position above
+minNotionalUsd, aggregate across whales into (asset, direction) candidates, score
+by consensus count + whale quality, and emit the top `emitTopN` (default 2)
+candidates at/above minScore. Direction comes from the mirrored position; leverage
+is clamped to [1, MAX_LEVERAGE].
+
+Read-only + single-pass — emits `marginPct` (PERCENT) + `leverage` intents; the
+runtime sizes the dollars, owns cooldowns/risk gates/dedup, and trails the DSL
+exit. No daemon, no push_signal, no create_position.
 
 READ-GUARD: every ctx.senpi_mcp.call_tool is wrapped try/except -> degrade (skip
-that whale / neutral tier / skip the tick), NEVER propagate. Per the scan
-contract ANY exception rolls the whole tick back to [], so one bad whale read
-would silently kill all emits — guarded so a single flaky whale just drops out.
+that whale / neutral tier / keep cached cohort / skip the tick), NEVER propagate.
+Per the scan contract ANY exception rolls the whole tick back to [], so one bad
+read would silently kill all emits — guarded so a single flaky read just drops
+out.
 
-FIDELITY NOTES vs the v2 producer (remora-producer.py v1.0.1):
-  - v2 stored margin as a FRACTION (config.marginPct = 0.15) and multiplied by
-    account_value to get a marginUsd, then emitted marginUsd. This port emits
-    `marginPct` (PERCENT in (0,100]) at the top level; the runtime sizes
-    (marginPct/100)*withdrawable. The default 0.15 -> 15 PERCENT. A defensive
-    "<=1.0 means a pasted fraction, x100" guard preserves either input form.
-  - v2 emitted exactly one signal (best, highest score, tie-break by consensus
-    count then max_notional). Preserved: scan() emits <= 1 signal/tick with the
-    SAME sort key.
-  - v2's recent-signals.json race-window dedup cache -> ctx.state dedup map (same
-    TTL semantics: TTL=240s, prune at 4x TTL). The on-chain held-asset filter is
-    preserved verbatim (held names are skipped before scoring).
-  - v2 leverage clamp `min(int(config.leverage), MAX_LEVERAGE)` preserved.
+FIDELITY NOTES:
+  - The cohort engine (discovery_get_top_traders paging -> realized-PnL ranking
+    -> ctx.state daily-refresh cache -> degrade-to-cached-cohort on a failed
+    refresh) is reused VERBATIM from WhaleHunter's scan/scoring (functions
+    _read, _build_cohort modelled on WhaleHunter._read / _build_cohorts, and
+    scoring.realized / scoring.trader_address are WhaleHunter's accessors).
+  - The mirror logic is the v2 Remora producer (remora-producer.py v1.0.1) — all
+    scoring/aggregation thresholds verbatim (see scoring.py). v2 emitted exactly
+    one `best`; this port emits up to `emitTopN` (default 2) using the SAME sort
+    key (score, consensus count, max_notional) per the 1-2 emit allowance.
+  - marginPct emitted as PERCENT in (0,100] at the top level; the runtime sizes
+    (marginPct/100)*withdrawable. Default 15. A defensive "<=1.0 means a pasted
+    fraction, x100" guard preserves either input form.
+  - leverage clamped to [1, MAX_LEVERAGE].
+  - v2 recent-signals.json race-window dedup -> ctx.state dedup map (TTL=240s,
+    prune at 4x TTL). On-chain held-asset filter preserved (held names skipped
+    before scoring).
   - v2 read-sanity guard (margin in use + empty positions -> skip tick) ported
     verbatim from cfg.get_positions.
-  - DROPPED: nothing — the v2 producer is enter-only (no cancel_order /
-    has_resting_orders / stale-order purge to drop). The DSL owns exits; a
-    whale-exit mirror remains a future enhancement (as in v2).
   - No fixed universe to validate against HL meta: Remora has NO whitelist — the
-    assets it mirrors are whatever the configured whales hold, resolved live each
-    tick. (config.whales is the operator's hand-picked trader set, default empty.)
+    assets it mirrors are whatever the resolved whales hold, live each tick.
 """
 
 import sys
 import time
 
 import scoring
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error on a read must NOT roll
+    back the whole tick. Returns None on failure so the degrade paths apply
+    (cohort falls back to its daily cache; a whale just drops out). Modelled on
+    WhaleHunter._read."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
+        print(f"[remora.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
 
 
 def _dex_for(asset):
@@ -65,12 +87,7 @@ def _get_account(ctx):
     shared free balance -> 2x sizing). assetPositions are per-sub-DEX so they are
     enumerated across both sections. Ported verbatim from v2 cfg.get_positions,
     including the read-sanity guard (margin in use + empty positions -> skip tick)."""
-    try:
-        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
-                                     {"strategy_wallet": ctx.wallet})
-    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the whole tick
-        print(f"[remora.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
-        return 0.0, []
+    ch = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
     if not ch:
         return 0.0, []
     data = ch.get("data", ch) if isinstance(ch, dict) else ch
@@ -108,18 +125,81 @@ def _get_account(ctx):
     return account_value, positions
 
 
+# ── auto-cohort engine (reused from WhaleHunter: discovery_get_top_traders paging
+#    -> realized-PnL ranking -> ctx.state daily-refresh cache -> degrade-to-cached) ──
+
+def _build_cohort(ctx, cached, inputs, now):
+    """Auto-build the default whale set from the ALL_TIME realized-PnL ranking
+    when no whales are hand-picked. Top `cohortSize` proven traders, paged by
+    offset. Cached daily in ctx.state and refreshed every `cohortRefreshHours`;
+    a failed refresh DEGRADES to the cached cohort. Returns a cohort dict
+    {refreshed_at, cache_version, whales:[addr,...]}.
+
+    Reuses WhaleHunter's _build_cohorts pattern + scoring.realized /
+    scoring.trader_address accessors so the auto-cohort is bucketed identically.
+    """
+    refresh_h = float(inputs.get("cohortRefreshHours", scoring.DEFAULT_COHORT_REFRESH_HOURS))
+    cohort_size = int(inputs.get("cohortSize", scoring.DEFAULT_COHORT_SIZE))
+    min_realized = float(inputs.get("cohortMinRealizedUsd", 0))   # 0 = no floor; rank by realized
+    page_size = int(inputs.get("cohortFetchLimit", 1000))
+    max_pages = int(inputs.get("cohortMaxPages", 6))
+
+    # fresh cache (still has members, same build version, within TTL) — no fetch.
+    if (cached.get("whales") and cached.get("cache_version") == scoring.COHORT_CACHE_VERSION
+            and (now - cached.get("refreshed_at", 0)) / 3600 < refresh_h):
+        return cached
+
+    ranked, seen = [], set()   # ranked = [(realized, addr), ...] kept sorted desc, capped
+    for page in range(max_pages):
+        resp = _read(ctx, "discovery_get_top_traders", {
+            "time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
+            "open_position_filter": False, "limit": page_size, "offset": page * page_size})
+        if not resp:
+            break
+        raw = resp.get("data", resp) if isinstance(resp, dict) else resp
+        if isinstance(raw, dict):
+            raw = raw.get("traders", raw.get("data", []))
+        if not isinstance(raw, list) or not raw:
+            break
+        for t in raw:
+            if not isinstance(t, dict):
+                continue
+            addr = scoring.trader_address(t)
+            if not addr or addr in seen:
+                continue
+            rp = scoring.realized(t)
+            if rp < min_realized:
+                continue
+            seen.add(addr)
+            ranked.append((rp, addr))
+        # already have enough proven traders well above the deep band — stop paging.
+        if len(seen) >= cohort_size * 3:
+            break
+
+    if not ranked:
+        # failed refresh (read errors / empty pages) — DEGRADE to the cached cohort
+        # so Remora always has whales to mirror. Empty {} only on a true cold start.
+        if cached.get("whales"):
+            print("[remora.scan] cohort refresh failed — degrading to cached cohort "
+                  f"({len(cached['whales'])} whales)", file=sys.stderr)
+        else:
+            print("[remora.scan] cohort refresh failed and no cache yet — cohort empty this tick",
+                  file=sys.stderr)
+        return cached
+
+    ranked.sort(key=lambda r: r[0], reverse=True)
+    whales = [addr for _rp, addr in ranked[:cohort_size]]
+    print(f"[remora.scan] auto-cohort built: top {len(whales)} traders by ALL_TIME realized PnL "
+          f"(refresh every {refresh_h:.0f}h)", file=sys.stderr)
+    return {"refreshed_at": now, "cache_version": scoring.COHORT_CACHE_VERSION, "whales": whales}
+
+
 def _fetch_whale_positions(ctx, trader_id):
     """List of position dicts for one whale (leaderboard_get_trader_positions),
     unwrapping the nested data.positions.positions shape. READ-GUARDED -> []
     on any failure (the whale just drops out of this tick). Verbatim unwrap from
     v2 fetch_whale_positions."""
-    try:
-        raw = ctx.senpi_mcp.call_tool("leaderboard_get_trader_positions",
-                                      {"trader_id": trader_id})
-    except Exception as exc:  # noqa: BLE001 — one flaky whale must not kill the tick
-        print(f"[remora.scan] leaderboard_get_trader_positions({str(trader_id)[:10]}) "
-              f"read failed (whale skipped): {exc!r}", file=sys.stderr)
-        return []
+    raw = _read(ctx, "leaderboard_get_trader_positions", {"trader_id": trader_id})
     if not raw:
         return []
     if not isinstance(raw, dict):
@@ -142,13 +222,7 @@ def _fetch_whale_tier(ctx, trader_id):
     """ELITE / RELIABLE / etc. for one whale, or None if unavailable.
     READ-GUARDED -> None (quality bonus simply not awarded). Verbatim parse from
     v2 fetch_whale_tier."""
-    try:
-        raw = ctx.senpi_mcp.call_tool("discovery_get_trader_state",
-                                      {"trader_id": trader_id})
-    except Exception as exc:  # noqa: BLE001 — quality is a bonus; never crash the tick
-        print(f"[remora.scan] discovery_get_trader_state({str(trader_id)[:10]}) "
-              f"read failed (tier -> none): {exc!r}", file=sys.stderr)
-        return None
+    raw = _read(ctx, "discovery_get_trader_state", {"trader_id": trader_id})
     if not raw or not isinstance(raw, dict):
         return None
     d = raw.get("data", raw)
@@ -168,6 +242,14 @@ def _load_signaled(ctx):
     return dict(sig) if isinstance(sig, dict) else {}
 
 
+def _load_cohort(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    last = ctx.state.last() or {}
+    c = last.get("cohort", {})
+    return dict(c) if isinstance(c, dict) else {}
+
+
 def _prune_signaled(signaled, ttl, now):
     """Drop entries older than 4x TTL (verbatim from v2 _prune_recent_signals)."""
     cutoff = now - (ttl * 4)
@@ -183,7 +265,7 @@ def _was_recently_signaled(signaled, coin, ttl, now):
 
 def _normalize_whale_id(whale):
     """A whale entry can be a dict {trader_id|wallet} or a bare string (v2
-    gather_candidates accepted both)."""
+    gather_candidates accepted both; auto-cohort members are bare address strings)."""
     if isinstance(whale, dict):
         return whale.get("trader_id") or whale.get("wallet") or ""
     return whale or ""
@@ -195,8 +277,9 @@ def scan(inputs, ctx):
     use_tier = bool(inputs.get("useWhaleQuality", True))
     min_notional = float(inputs.get("minNotionalUsd", scoring.DEFAULT_MIN_NOTIONAL_USD))
     min_score = int(inputs.get("minScore", scoring.DEFAULT_MIN_SCORE))
-    leverage = min(int(inputs.get("leverage", scoring.DEFAULT_LEVERAGE)), scoring.MAX_LEVERAGE)
+    leverage = min(max(int(inputs.get("leverage", scoring.DEFAULT_LEVERAGE)), 1), scoring.MAX_LEVERAGE)
     ttl = float(inputs.get("recentSignalTtlSeconds", 240))
+    emit_top_n = max(1, min(2, int(inputs.get("emitTopN", 2))))   # 1-2 emit allowance
 
     # marginPct intent (PERCENT in (0,100]). v2 stored a FRACTION (0.15); the
     # defensive guard converts a pasted fraction (<=1.0) to a percent (x100).
@@ -204,18 +287,42 @@ def scan(inputs, ctx):
     if margin_pct <= 1.0:
         margin_pct *= 100.0
 
-    if not whales_cfg:
-        print("[remora.scan] WAITING — no whales configured (set inputs.whales)", file=sys.stderr)
+    # ── WHALE-SOURCE RESOLUTION ──
+    cohort = _load_cohort(ctx)
+    if whales_cfg:
+        # OVERRIDE: hand-picked whales (Remora's named-whale identity).
+        whales = list(whales_cfg)
+        whale_source = "named"
+    else:
+        # DEFAULT: auto-build a smart-money cohort (never WAITING-on-config).
+        cohort = _build_cohort(ctx, cohort, inputs, now)
+        whales = list(cohort.get("whales", []))
+        whale_source = "cohort"
+
+    if not whales:
+        # only reachable on a true cold start where the very first cohort fetch
+        # failed AND there is no cache yet — next tick retries the fetch.
+        print("[remora.scan] no whales available yet (cohort cold start / fetch failed) — "
+              "will retry next tick", file=sys.stderr)
         if ctx.state is not None:
             try:
-                ctx.state.append({"signaled": {}, "result": {"ts": now, "emitted": False,
-                                                             "note": "no_whales_configured"}})
+                ctx.state.append({"signaled": {}, "cohort": cohort,
+                                  "result": {"ts": now, "emitted": False,
+                                             "note": "cohort_cold_start"}})
             except Exception as exc:  # noqa: BLE001
                 print(f"[remora.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
         return []
 
     account_value, positions = _get_account(ctx)
     if account_value <= 0:
+        # persist cohort cache so the cold-start build isn't lost on a flat tick.
+        if ctx.state is not None:
+            try:
+                ctx.state.append({"signaled": _prune_signaled(_load_signaled(ctx), ttl, now),
+                                  "cohort": cohort,
+                                  "result": {"ts": now, "emitted": False, "note": "no_account_value"}})
+            except Exception as exc:  # noqa: BLE001
+                print(f"[remora.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
         return []
     held_assets = [p["coin"] for p in positions if p.get("coin")]
     held_set = {h.upper() for h in held_assets}
@@ -224,7 +331,7 @@ def scan(inputs, ctx):
 
     # ── per-whale: fetch positions, take the top, validate tier (READ-GUARDED) ──
     whale_tops = []
-    for whale in whales_cfg:
+    for whale in whales:
         trader_id = _normalize_whale_id(whale)
         if not trader_id:
             continue
@@ -249,51 +356,51 @@ def scan(inputs, ctx):
 
     out = []
     if not scored:
-        result = {"ts": now, "emitted": False, "whales_tracked": len(whales_cfg),
-                  "candidates_seen": len(candidates), "held": held_assets,
-                  "note": f"WAITING (min score {min_score})"}
+        result = {"ts": now, "emitted": False, "whaleSource": whale_source,
+                  "whales_tracked": len(whales), "candidates_seen": len(candidates),
+                  "held": held_assets, "note": f"WAITING (min score {min_score})"}
         print(f"[remora.scan] WAITING — no qualifying whale position to mirror "
-              f"(min score {min_score}); whales={len(whales_cfg)} "
+              f"(min score {min_score}); source={whale_source} whales={len(whales)} "
               f"candidates={len(candidates)} held={held_assets}", file=sys.stderr)
     else:
         # v2 sort: highest score, tie-break by consensus count then max_notional.
         scored.sort(key=lambda t: (t[0], t[2]["count"], t[2]["max_notional"]), reverse=True)
-        best_score, best_reasons, best = scored[0]
+        result = {"ts": now, "emitted": True, "whaleSource": whale_source,
+                  "emitCount": 0, "picks": [], "held": held_assets}
+        for score_val, reasons, cand in scored[:emit_top_n]:
+            signaled[cand["asset"].upper()] = now
+            result["picks"].append({"coin": cand["asset"], "direction": cand["direction"],
+                                    "score": score_val, "whaleCount": cand["count"]})
+            print(f"[remora.scan] EMIT {cand['asset']} {cand['direction']} score={score_val} "
+                  f"whales={cand['count']} maxNotional=${cand['max_notional']:,.0f} "
+                  f"{leverage}x marginPct={margin_pct:.2f}% src={whale_source} | {reasons[:5]}",
+                  file=sys.stderr)
+            out.append({
+                "asset": cand["asset"],
+                "direction": cand["direction"],
+                "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
+                "leverage": leverage,             # clamped to [1, MAX_LEVERAGE]; runtime applies it
+                "data": {
+                    "score": score_val,
+                    "leverage": leverage,
+                    "direction": cand["direction"],
+                    "reasons": reasons,
+                    "whaleCount": cand["count"],
+                    "maxNotionalUsd": round(cand["max_notional"], 2),
+                    "eliteTier": bool(cand.get("quality")),
+                    "whaleSource": whale_source,
+                    "whales": cand.get("whales", []),
+                    "heldAssets": held_assets,
+                },
+            })
+        result["emitCount"] = len(out)
 
-        signaled[best["asset"].upper()] = now
-        result = {"ts": now, "emitted": True, "coin": best["asset"],
-                  "direction": best["direction"], "score": best_score,
-                  "whaleCount": best["count"], "maxNotionalUsd": round(best["max_notional"], 2),
-                  "eliteTier": bool(best.get("quality")), "leverage": leverage,
-                  "marginPct": round(margin_pct, 4), "held": held_assets,
-                  "reasons": best_reasons}
-        print(f"[remora.scan] EMIT {best['asset']} {best['direction']} score={best_score} "
-              f"whales={best['count']} maxNotional=${best['max_notional']:,.0f} "
-              f"{leverage}x marginPct={margin_pct:.2f}% | {best_reasons[:5]}", file=sys.stderr)
-        out = [{
-            "asset": best["asset"],
-            "direction": best["direction"],
-            "marginPct": margin_pct,          # PERCENT in (0,100] — runtime sizes the dollars
-            "leverage": leverage,             # clamped to <= MAX_LEVERAGE; runtime applies it
-            "data": {
-                "score": best_score,
-                "leverage": leverage,
-                "direction": best["direction"],
-                "reasons": best_reasons,
-                "whaleCount": best["count"],
-                "maxNotionalUsd": round(best["max_notional"], 2),
-                "eliteTier": bool(best.get("quality")),
-                "whales": best.get("whales", []),
-                "heldAssets": held_assets,
-            },
-        }]
-
-    # ── persist dedup map + this tick's result every tick; bounded by
-    #    state_history_max_count. Read back via ctx.state.recent(n). ──
+    # ── persist dedup map + cohort cache + this tick's result every tick; bounded
+    #    by state_history_max_count. Read back via ctx.state.recent(n). ──
     if ctx.state is not None:
         try:
-            ctx.state.append({"signaled": signaled, "result": result})
+            ctx.state.append({"signaled": signaled, "cohort": cohort, "result": result})
         except Exception as exc:  # noqa: BLE001
             print(f"[remora.scan] WARNING: state append failed; next tick may re-emit "
-                  f"a suppressed signal: {exc!r}", file=sys.stderr)
+                  f"a suppressed signal or rebuild the cohort: {exc!r}", file=sys.stderr)
     return out

--- a/strategies/remora/main/scanners/scoring.py
+++ b/strategies/remora/main/scanners/scoring.py
@@ -1,17 +1,23 @@
 """REMORA — pure whale-mirror math (no I/O, no MCP, no clock).
 
 A faithful Runtime 3.0 port of the v2 Remora producer's pure mirror logic
-(remora-producer.py v1.0.1). Every function here is reproduced VERBATIM from the
-v2 producer so a fidelity harness can diff this against v2 on the same whale
-position snapshot. These are the functions v2 unit-tested in tests/test_signal.py:
-position_notional, mirror_direction, position_asset, top_position,
-consensus_bonus, plus the candidate aggregation/scoring.
+(remora-producer.py v1.0.1). The mirror functions here are reproduced VERBATIM
+from the v2 producer so a fidelity harness can diff this against v2 on the same
+whale position snapshot. These are the functions v2 unit-tested in
+tests/test_signal.py: position_notional, mirror_direction, position_asset,
+top_position, consensus_bonus, plus the candidate aggregation/scoring.
 
-Remora rides a small, hand-picked set of whale traders: take each whale's
-highest-conviction (largest-notional) open position, aggregate across whales into
-(asset, direction) candidates, and score by consensus (how many whales agree) +
-whale quality. The MCP fetches (whale positions, whale tier) are done by the
-caller (scan.py) and passed in, so this module stays pure and unit-testable.
+Remora rides a set of whale traders: take each whale's highest-conviction
+(largest-notional) open position, aggregate across whales into (asset, direction)
+candidates, and score by consensus (how many whales agree) + whale quality. The
+whale set is EITHER the operator's hand-picked override (inputs.whales) OR — by
+default — an auto-built smart-money cohort. The cohort PARSING helper below
+(`realized`, used by the scan's cohort builder) is reused VERBATIM from
+WhaleHunter's scoring module so the two strategies bucket top traders
+identically; the discovery shapes are token-gated, so the field accessors are
+copied, not invented. The MCP fetches (top-trader pages, whale positions, whale
+tier) are done by the caller (scan.py) and passed in, so this module stays pure
+and unit-testable.
 """
 
 # Whale-quality tiers that earn the discovery_get_trader_state bonus
@@ -24,6 +30,12 @@ DEFAULT_LEVERAGE = 4
 DEFAULT_MIN_SCORE = 4
 DEFAULT_MIN_NOTIONAL_USD = 5000   # ignore dust positions
 
+# Auto-cohort defaults (mirror WhaleHunter's smart-money cohort engine). Used by
+# scan._build_cohort when inputs.whales is empty so Remora is autonomous OOTB.
+DEFAULT_COHORT_SIZE = 10          # top N proven traders to mirror by default
+DEFAULT_COHORT_REFRESH_HOURS = 24
+COHORT_CACHE_VERSION = 1          # bump if cohort-BUILDING logic changes (busts a stale cache)
+
 
 def safe_float(v, default=0.0):
     """Verbatim from v2 safe_float."""
@@ -31,6 +43,36 @@ def safe_float(v, default=0.0):
         return float(v if v is not None else default)
     except (TypeError, ValueError):
         return default
+
+
+# ── cohort-build parsing (reused VERBATIM from WhaleHunter/scoring.py) ──
+
+def realized(t):
+    """LIFETIME realized PnL for a top-trader dict — reused VERBATIM from
+    WhaleHunter's scoring.realized so Remora ranks the auto-cohort identically.
+    Never falls back to total PnL (realized+unrealized), which is not monotonic
+    with the realized-PnL sort and mis-ranks the cohort. Token-gated discovery
+    shape — accessors copied, not invented."""
+    def _f(x, *keys, default=0.0):
+        if not isinstance(x, dict):
+            return default
+        for k in keys:
+            if x.get(k) is not None:
+                try:
+                    return float(x[k])
+                except (TypeError, ValueError):
+                    continue
+        return default
+    return _f(t, "realizedProfitAndLoss", "realized_profit_and_loss",
+              "profit_and_loss_realized", "realizedPnl", "realized_pnl", default=0.0)
+
+
+def trader_address(t):
+    """Lower-cased wallet/trader address from a top-trader dict, or "" — reused
+    VERBATIM from WhaleHunter's cohort-build accessor (token-gated shape)."""
+    if not isinstance(t, dict):
+        return ""
+    return (t.get("address") or t.get("trader_address") or "").lower()
 
 
 def position_notional(pos):

--- a/strategies/remora/strategy.yaml
+++ b/strategies/remora/strategy.yaml
@@ -1,22 +1,25 @@
-# Remora — whale single-position mirror. A single-instance PACKAGE: this manifest +
-# one self-contained runtime.yaml + scanners/. A faithful Runtime 3.0 port of the v2
-# Remora (SKILL.md v1.0.0): mirrors a small, hand-picked set of whale traders — takes
-# each whale's highest-conviction (largest-notional) open position, aggregates across
-# whales into (asset, direction) candidates, scores by consensus + whale quality, and
-# mirrors the strongest. Let-winners-run DSL with a 120h staleness cap. No fixed
-# universe — the assets come from whatever the configured whales hold. Install/teardown
-# via senpi-strategy-ops.
+# Remora — autonomous smart-money whale mirror. A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. Runtime 3.0. AUTONOMOUS
+# OUT OF THE BOX: with no config it auto-builds a cohort of proven top traders and
+# mirrors their highest-conviction positions; optionally name specific whales via
+# inputs.whales to mirror exactly those. Each tick it takes each whale's
+# highest-conviction (largest-notional) open position, aggregates across whales into
+# (asset, direction) candidates, scores by consensus + whale quality, and mirrors the
+# strongest 1-2. Let-winners-run DSL with a 120h staleness cap. No fixed universe —
+# the assets come from whatever the resolved whales hold. Mirror math verbatim from
+# the v2 Remora producer; cohort engine reused from WhaleHunter. Install/teardown via
+# senpi-strategy-ops.
 schema_version: 1
 
 id: remora
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
-  name: "Remora — Whale Single-Position Mirror"
+  name: "Remora — Autonomous Smart-Money Whale Mirror"
   emoji: "🐟"
-  tagline: "Rides a small, hand-picked set of whale traders the way a remora fish rides a shark: each tick it takes each whale's highest-conviction open position and mirrors the strongest, leaning hardest when several whales pile into the same trade (consensus) or when a whale is ELITE/RELIABLE tier."
-  belief_plain: "You name a few whale traders you trust. Remora watches their open positions, finds each one's biggest bet, and copies the single strongest one — betting bigger when several of your whales are in the same trade and one of them has an elite track record. Then it trails a wide stop so the trade can run."
-  thesis: "The broad trader-followers scan a leaderboard and synthesize an opaque pick. Remora is the opposite: YOU choose whom to ride. Mirroring one whale's single highest-conviction position keeps your exposure tracking specific traders you trust, and the consensus multiplier means it leans hardest exactly when those whales independently agree — one whale can be wrong, three agreeing is a much stronger signal. Whales hold winners, so the exit lets the mirror run and only caps staleness."
+  tagline: "Autonomous smart-money whale mirror — auto-builds a top-trader cohort and mirrors their highest-conviction positions; optionally mirror specific whales you name via inputs.whales. Like a remora fish riding a shark, it leans hardest when several whales pile into the same trade (consensus) or when a whale is ELITE/RELIABLE tier."
+  belief_plain: "Out of the box, Remora finds the most proven traders on Hyperliquid, watches their open positions, and copies the strongest bets — betting bigger when several of them are in the same trade and one has an elite track record. Prefer to ride specific traders you trust? Name them and Remora mirrors exactly those instead. Either way it trails a wide stop so the trade can run."
+  thesis: "Riding the highest-conviction position of proven traders keeps your exposure tracking real smart money, and the consensus multiplier means it leans hardest exactly when those traders independently agree — one whale can be wrong, three agreeing is a much stronger signal. By default Remora is autonomous: it auto-builds a top-trader cohort (all-time realized PnL, refreshed daily) so it always has whales to mirror — no config required. Name your own whales to make it ride exactly the traders you choose. Whales hold winners, so the exit lets the mirror run and only caps staleness."
   group: smart-money
   archetype: copy_trading
   sub_style: named_whales
@@ -26,10 +29,10 @@ catalog:
   risk_level: moderate
   tier: advanced
   leverage_max: 10
-  max_slots: 1
+  max_slots: 2
   min_budget: 100
   assets: []
-  tags: [whale, mirror, copy-trading, named-whales, consensus, let-winners-run, follows-traders]
+  tags: [whale, mirror, copy-trading, named-whales, smart-money, autonomous, consensus, let-winners-run, follows-traders]
 
 requires:
   runtime: ">=3.0.0"


### PR DESCRIPTION
**Ignas's install sweep flagged remora**: it installs + registers fine but can't trade as-shipped — `inputs.whales` defaulted empty and the scan hard-required it (empty → `WAITING` forever). Per your "rewrite to use parts of whalehunter sm", remora now adopts **whalehunter's smart-money cohort engine** as its default whale source, keeping the hand-picked override.

**New whale-source resolution:**
- **empty `inputs.whales` (default)** → `_build_cohort()` auto-discovers a top-trader cohort via `discovery_get_top_traders`, caches it in `ctx.state`, refreshes every `cohortRefreshHours` (24h), and degrades to the cached cohort on a failed refresh — reusing whalehunter's `_build_cohorts` pattern + `scoring.realized`/`trader_address` (copied verbatim, since discovery field shapes are token-gated).
- **named `inputs.whales`** → mirrors exactly those whales (unchanged — remora's named-whale identity).

Mirror/consensus scoring is kept verbatim (largest-notional per whale → aggregate (asset, direction) → consensus + quality). Emits top 2; slots 1→2. Taxonomy unchanged (`copy_trading/named_whales/follows_traders/long_short`); thesis/tagline rewritten to the autonomous framing. **v1.0.0 → 1.1.0.** Validator 78/0, catalog 0 warnings.

Caveat: like the other discovery-based agents, it needs a live-token smoke-test before live money (`discovery_get_top_traders` is user-ID-token-gated).
