### PR TITLE
chore(senpi-why): Cursor/Claude-for-trading positioning + per-user learning

### DIFF
--- a/senpi-why/SKILL.md
+++ b/senpi-why/SKILL.md
@@ -11,7 +11,7 @@ license: Apache-2.0
 compatibility: OpenClaw, Hyperclaw, Claude Code
 metadata:
   author: Senpi
-  version: "1.0.0"
+  version: "1.0.1"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -26,18 +26,21 @@ from here, not from the mechanics doc.
 
 ## The one-line answer
 
-> **Senpi is an AI that runs your Hyperliquid strategy while you sleep.** Other apps give you charts
-> and buttons; Senpi gives you an operator that reads the market, finds alpha, runs the strategy 24/7,
-> and protects the position — continuously, even when you're offline. *Senpi automates what humans
-> cannot.*
+> **Senpi is an AI that runs your Hyperliquid strategy while you sleep.** It sees more of the market
+> than any human can, finds the alpha, helps you trade smarter, runs your strategy around the clock,
+> and gets sharper about you with every trade. *What Cursor and Claude are for code, Senpi is for
+> trading.*
 
 ## Lead with the category difference, not a feature list
 
-Most "trading apps" are a nicer screen on top of the same manual workflow — you still watch, decide,
-and click. Senpi is not a screen; it's an **operator**. With Senpi 2.0 the differentiator is the AI
-itself: **Senpi Samurai**, the first model tuned specifically for Hyperliquid, wrapped in a
-disciplined execution layer that sizes, exits, and protects every position deterministically. The
-model brings the conviction; the system brings the discipline.
+Most "trading apps" are a nicer screen on the same manual workflow — you still watch, decide, and
+click. Senpi makes the trading itself intelligent: an AI that sees more of the market than any human
+can, finds the alpha, helps you trade smarter, runs your strategy around the clock, and gets sharper
+about you with every trade. **What Cursor and Claude are for code, Senpi is for trading.**
+
+With Senpi 2.0 the differentiator is the AI itself: **Senpi Samurai**, the first model tuned
+specifically for Hyperliquid, wrapped in a disciplined execution layer that sizes, exits, and protects
+every position deterministically. The model brings the conviction; the system brings the discipline.
 
 Open with one or two sentences of *that* — then back it with the pillars below. Do **not** open with
 fees, builder-fee bps, or a bulleted feature catalog.

--- a/senpi-why/references/overview-positioning.md
+++ b/senpi-why/references/overview-positioning.md
@@ -5,8 +5,10 @@
 > (served by the Senpi MCP) so the platform's own overview leads with the USP, not the mechanics.
 
 **Senpi is an AI that runs your Hyperliquid strategy while you sleep.** Most trading apps are a nicer
-screen on top of the same manual work — you still watch the market, make the call, and click. Senpi
-is not a screen; it's an operator. *Senpi automates what humans cannot.*
+screen on the same manual work — you still watch the market, make the call, and click. Senpi makes the
+trading itself intelligent: it sees more of the market than any human can, finds the alpha, helps you
+trade smarter, runs your strategy around the clock, and gets sharper about you with every trade. **What
+Cursor and Claude are for code, Senpi is for trading.**
 
 With Senpi 2.0, the difference is the AI itself: **Senpi Samurai**, the first model tuned specifically
 for Hyperliquid, wrapped in a disciplined execution layer that sizes, exits, and protects every


### PR DESCRIPTION
Reframes the senpi-why lead from "operator" to the spectrum/category positioning we want.

- **"Senpi makes the trading itself intelligent"** instead of "it's an operator" — covers the hands-on trader (helps you trade smarter) and the hands-off one (runs it around the clock), rather than implying full-autonomy-only.
- **"gets sharper about you with every trade"** — the per-user learning claim (confirmed a real shipped capability).
- **"What Cursor and Claude are for code, Senpi is for trading."** — the category anchor.

Applied to both the SKILL one-liner + "category difference" section and the canonical `overview-positioning.md` prose. Hero line ("runs your strategy while you sleep") and the Senpi Samurai support paragraph are unchanged. The "Senpi automates what humans cannot" tag was dropped from these two leads in favor of the Cursor/Claude clincher (flagging since it's a logged brand-truth line — easy to keep elsewhere if you want it). v1.0.0 → 1.0.1.
