### PR TITLE
Restore strategy skill md

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.0.0"
+  version: "2.0.1"
   platform: senpi
   exchange: hyperliquid
   requires:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Mass removal of root strategy install paths and operator docs is a breaking layout change; anyone still deploying from `/<name>/` must use `strategies/<id>` and `senpi-strategy-ops` instead.
> 
> **Overview**
> This PR finishes the **strategy-v2** split: trading theses move from root-level **skill** directories (`SKILL.md`, producer daemons, `config/*.json`) into **`strategies/<id>/` packages** governed by **`strategy.yaml`** and runtime-supervised **`scan()`** scanners.
> 
> **Docs and repo hygiene:** **`CLAUDE.md`** and **`README.md`** are rewritten around the four lifecycle skills (`senpi-strategy-discover`, `senpi-strategy-author`, `senpi-strategy-ops`, `senpi-trading-runtime`), generated **`strategies/catalog.json`**, and **`deploy.py` / `close.py`** flows instead of per-skill install curls. **`.gitignore`** adds deploy outputs (`*.deploy.runtime.yaml`, `.deploy-state.json`, `*/.build/`).
> 
> **Removed from repo root:** Large deletions of legacy strategy trees (e.g. **albatross**, **badger**, **bald-eagle**, **beaver** and peers in the same pattern)—including **`SKILL.md`**, **`references/skill-attribution.md`**, standalone **`runtime.yaml`**, and **`*-producer.py`** daemons—so the root no longer advertises the old “one directory = one skill” model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 572874c43c626a35daa656294778072cd80f5dd4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->