### PR TITLE
strategy-ops: name strategy sub-wallets by role on create

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.0.2"
+  version: "2.1.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.0.1"
+  version: "2.0.2"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -62,8 +62,13 @@ curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/strat
 ```
 python3 scripts/deploy.py create spider --budget 200
 ```
-Per instance it calls `strategy_create_custom_strategy(skillName=<id>, skillVersion=<version>)`, records
-the `strategyId`, and polls `strategy_list` to **ACTIVE** — **bounded** (~150s). If it prints
+Per instance it calls `strategy_create_custom_strategy(skillName=<id>, skillVersion=<version>,
+strategyName=<id>-<instance>)` — **every wallet is named for its role in the strategy** (e.g. a
+WhaleHunter deploy with two sub-wallets creates `whalehunter-long` and `whalehunter-short`), **never
+left as a bare `0x…` address**, so the user can tell a strategy's wallets apart in the app, balances,
+and notifications. Naming is best-effort: if the backend rejects a name (conflict/format), that wallet
+is still created (unnamed) rather than failing the deploy. It records the `strategyId`, and polls
+`strategy_list` to **ACTIVE** — **bounded** (~150s). If it prints
 **`creating`** (wallets still funding), just **re-run the same `create` command** — it resumes and
 **never re-creates** a wallet. It prints **`wallets-ready`** when done. `create` is **self-healing**: it
 reconciles recorded wallets against the backend (drops any CLOSED/FAILED and recreates) and **sizes each

--- a/senpi-strategy-ops/references/lifecycle.md
+++ b/senpi-strategy-ops/references/lifecycle.md
@@ -38,8 +38,10 @@ just means re-run that step.
      (`total_in_hyperliquid`) minus a per-wallet fee buffer, split by `funding_share` and capped to
      available — so sequential funding + creation fees can't leave an instance $1 short. **Never lower `--budget`
      to dodge rounding; just re-run.**
-   - Per instance: `strategy_create_custom_strategy(skillName=<id>, skillVersion=<version>, initialBudget=…)`,
-     record `strategyId` **immediately**, poll `strategy_list` to **ACTIVE** (bounded by `--max-wait`).
+   - Per instance: `strategy_create_custom_strategy(skillName=<id>, skillVersion=<version>, initialBudget=…,
+     strategyName=<id>-<instance>)` — names the wallet for its role (e.g. `whalehunter-short`), never a bare
+     address; best-effort (falls back to unnamed if the name is rejected). Record `strategyId` **immediately**,
+     poll `strategy_list` to **ACTIVE** (bounded by `--max-wait`).
      Not all ACTIVE → **`creating`** (re-run to resume); all ACTIVE → **`wallets-ready`**.
 2. **`runtime <id>`** — per instance: render the instance's `runtime.yaml` (substitute `${wallet_env}` + the
    decision-model env iff a `decision_mode: llm` action) **beside the source** (so `path: ./scanners`

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -24,6 +24,7 @@ on first use if it isn't on disk.
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import argparse
 import json
+import re
 import sys
 import time
 from pathlib import Path
@@ -189,15 +190,39 @@ def cmd_create(pkg, a, log):
         if s.get("strategyId"):
             continue
         amt = amounts.get(inst.name, max(MIN_WALLET, round((a.budget or 0) * (inst.funding_share or 1.0), 2)))
-        log(f"  [{inst.name}] creating wallet (initialBudget=${amt:g})…")
+        # Name each wallet for its role in the strategy (matches the pkg-instance runtime naming),
+        # so wallets are legible in the app / balances / notifications instead of a bare 0x address.
+        # e.g. a WhaleHunter deploy → "whalehunter-long", "whalehunter-short". Sanitized to the
+        # strategyName rules: 3-40 chars, no whitespace (-> '-'), [A-Za-z0-9_-] only.
+        multi = len(pkg.instances) > 1
+        sname = f"{pkg.id}-{inst.name}" if (multi and inst.name) else str(pkg.id)
+        sname = re.sub(r"[^A-Za-z0-9_-]", "", re.sub(r"\s+", "-", sname.strip())).strip("-_")[:40] or str(pkg.id)[:40]
+        log(f"  [{inst.name}] creating wallet {sname!r} (initialBudget=${amt:g})…")
+
+        def _create(name=None):
+            kw = dict(initialBudget=amt, positions=[], skillName=pkg.id, skillVersion=pkg.version)
+            if name:
+                kw["strategyName"] = name
+            return mcp.mcp_call("strategy_create_custom_strategy", timeout=SUBMIT_TIMEOUT, **kw)
+
         try:
-            res = mcp.mcp_call("strategy_create_custom_strategy", timeout=SUBMIT_TIMEOUT,
-                               initialBudget=amt, positions=[], skillName=pkg.id, skillVersion=pkg.version)
+            res = _create(sname)
         except MCPError as e:
-            s["status"] = "pending"
-            s["error"] = f"create submit: {e}"
-            save_state(pkg, st)
-            return report(pkg, st, "failed", as_json=a.json)
+            # Naming is best-effort — a name conflict/format rejection must never block the deploy.
+            if any(c in str(e) for c in ("SERR055", "SERR056", "SERR058")) or "name" in str(e).lower():
+                log(f"  [{inst.name}] name {sname!r} rejected ({e}); creating without a custom name")
+                try:
+                    res = _create()
+                except MCPError as e2:
+                    s["status"] = "pending"
+                    s["error"] = f"create submit: {e2}"
+                    save_state(pkg, st)
+                    return report(pkg, st, "failed", as_json=a.json)
+            else:
+                s["status"] = "pending"
+                s["error"] = f"create submit: {e}"
+                save_state(pkg, st)
+                return report(pkg, st, "failed", as_json=a.json)
         sid = _cli.strategy_id_of(res)
         if not sid:
             s["error"] = f"create returned no strategyId: {res!r}"


### PR DESCRIPTION
**Problem:** agents deploying multi-wallet strategies weren't consistently naming the sub-wallets, so they showed as bare `0x…` addresses. This also degrades the notification `[label]` — it falls back to `[0x1234]` instead of `[whalehunter-short]`.

**Fix:** `deploy.py` now passes `strategyName` to `strategy_create_custom_strategy`, derived from the package + instance (matching the existing `<id>-<instance>` runtime-naming convention already in `_pkg.py`), so **every wallet is named for its role** — deterministically, not left to the agent to remember.

- **Multi-instance** → `<id>-<instance>` — e.g. a WhaleHunter deploy with 2 sub-wallets → `whalehunter-long`, `whalehunter-short`.
- **Single-instance** → `<id>` — e.g. `spider` (not `spider-spider`).
- **Sanitized** to the `strategyName` rules (3–40 chars, no whitespace → `-`, `[A-Za-z0-9_-]` only).
- **Best-effort / non-regressive:** if the backend rejects a name (SERR055 conflict / 056 length / 058 spaces), the wallet is still created **without** a name rather than failing the deploy.

**Made explicit** in `SKILL.md` Step 1 and `references/lifecycle.md` (the create call now documents `strategyName=<id>-<instance>` and the "never a bare address" intent). Version bumped `2.0.1 → 2.0.2`.

**Verified:** `py_compile` clean; name derivation checked across cases (`whalehunter/short`→`whalehunter-short`, single-instance `spider`→`spider`, short-id edge → graceful fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)