### PR TITLE
feat: make agents aware deployed strategies are already DSL-protected

### DIFF
--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -11,7 +11,7 @@ license: Apache-2.0
 compatibility: OpenClaw, Hyperclaw, Claude Code
 metadata:
   author: Senpi
-  version: "1.0.0"
+  version: "1.0.1"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -83,6 +83,15 @@ sitting in strategy wallets waiting for signals." They are not the same money an
 - **Present active strategies as known state, not a fresh discovery.** Pull the data quietly and state
   what's running as established fact ("Your two active strategies are…"). Don't narrate the lookup
   ("let me check… oh, I see you have…") — that reads like you didn't already know your own book.
+- **Deployed strategies are already risk-managed — never prescribe a stop-loss they already have.** Every
+  strategy deployed from a Senpi template runs a built-in **DSL exit** (a two-phase trailing stop-loss on
+  every position) plus **risk guard-rails** (daily-loss / drawdown circuit breakers), enforced by the
+  runtime every tick. When you flag a position's risk, say what's *already protecting* it — "it trails a
+  stop, and the strategy halts on a drawdown circuit breaker" — and **never** recommend "set a 10–15% SL
+  on all active strategies via `strategy_update`"; that's redundant and reads as not knowing your own
+  book. Only a **naked** holding — a manual Hyperliquid position, or a raw custom strategy with no runtime
+  — needs a stop you add. If the user wants *tighter* limits than the built-in, that's a DSL / guard-rail
+  change (via senpi-strategy-author), not a missing stop.
 - **Always end with the two CTAs** (below), verbatim.
 
 ## How to run the engine
@@ -131,7 +140,9 @@ books). Show strategy wallet addresses in short form (`0x35d1...acb1`) unless as
 > **2. Want me to put the idle capital to work in a new strategy?**
 
 - **CTA 1 → position management.** Route to the execution tools (`edit_position` / `close_position` /
-  `strategy_update`) for the specific position — confirm before any change; never trade unprompted.
+  `strategy_update`) for the specific position — confirm before any change; never trade unprompted. For a
+  **deployed** strategy, "adjust risk" means its built-in DSL / guard-rails — don't add a redundant manual
+  stop (see the risk-managed golden rule above).
 - **CTA 2 → deploy idle.** If there's meaningful idle capital (lead from `signals.idle_drag_pct`),
   offer to hand it to **senpi-strategy-discover** / **senpi-strategy-author** — fund a new strategy
   from the embedded idle, or top up an existing one from `strategy_top_up`. Propose; never deploy

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -10,7 +10,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.0.0"
+  version: "1.0.1"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -69,3 +69,8 @@ After any edit, run the validator, then re-run `install_strategy` (idempotent) v
   appears as `${…}` in that `runtime.yaml`.
 - `params` is the only tunable source — the scanner reads it via `load_params()`; no second copy.
 - The runtime package is **`@senpi-ai/runtime`** (with `-ai`) — never `@senpi/runtime`.
+- **Protection is built in, not optional.** Every instance ships a **DSL exit** + **risk guard-rails** in
+  its `runtime.yaml`, so downstream (senpi-portfolio / senpi-strategy-ops) treats a deployed strategy as
+  **risk-managed, never a naked position**. Don't ship an instance without a DSL exit — the only path that
+  produces an *unprotected* strategy is a raw `strategy_create_custom_strategy` (no runtime), which is out
+  of scope for authored packages.

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -66,6 +66,13 @@ def validate(pkg: Path) -> list:
             if cm and int(cm.group(1)) < _lo:
                 errs.append(f"instance {name}: {rt_rel} {_field} {cm.group(1)} below runtime min {_lo}")
 
+        # Protection is not optional: every instance must ship a DSL exit block (the built-in
+        # trailing stop-loss / two-phase exit). Downstream skills (senpi-portfolio / -strategy-ops)
+        # treat a deployed strategy as risk-managed — a strategy with no DSL exit is a naked position.
+        if not re.search(r"^\s*(exit|dsl_preset)\s*:", rt_text, re.M):
+            errs.append(f"instance {name}: {rt_rel} has no DSL exit block (exit:/dsl_preset:) — "
+                        f"every strategy must ship built-in protection")
+
         # Runtime 3.0 scanner package: <runtime_dir>/scanners/scan.py exports scan(inputs, ctx);
         # the thesis math is a sibling scanners/scoring.py imported as `import scoring` (NO __init__.py).
         scn_dir = rt.parent / "scanners"

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.0.1"
+  version: "2.0.2"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -80,6 +80,17 @@ runtime spider` renders each instance's runtime.yaml with its wallet and runs `o
 It scans on its own schedule and opens positions when *its* signals fire (spider swing ~300s, scalp ~60s
 cadence). Tell the user it's set up and running; **do NOT sleep/poll waiting for the first scan tick** —
 that's normal strategy behavior, not part of deploy.
+
+**Say what's protecting it (in every deploy summary).** A template strategy deploys **already
+risk-managed** — the runtime runs a built-in two-phase **DSL trailing stop-loss** on every position plus
+**risk guard-rails** (daily-loss + drawdown circuit breakers), enforced each tick. Put this in the
+"it's live" summary — e.g. *"Spider is live and trading. It's protecting every position automatically —
+trailing stop-loss + daily-loss/drawdown circuit breakers — so you don't need to set a manual stop."*
+**Never tell the user to add a manual stop-loss (e.g. a 10–15% `strategy_update` SL) to a
+template-deployed strategy — it already has one.** The only unprotected holdings are a **manual
+Hyperliquid position** or a **raw `strategy_create_custom_strategy`** with no runtime; if the user wants
+*tighter* limits than the built-in, that's a DSL / `risk.guard_rails` config change (via
+senpi-strategy-author), not a missing stop.
 
 **Optional — `verify`** (only if the user asks "is it actually scanning / live yet?"): `python3
 scripts/deploy.py verify spider` checks each `external_scanner` once. The first `scan()` only fires on its


### PR DESCRIPTION
**Problem:** consumer agents recommend *"set a 10–15% strategy-level SL on all active strategies — I can do this with `strategy_update`."* They treat deployed strategies as naked positions because nothing surfaces the built-in DSL. Every strategy deployed from a Senpi template already runs a two-phase DSL trailing stop-loss on each position **plus** daily-loss/drawdown circuit breakers, enforced every tick — so that recommendation is redundant and reads as not knowing the book.

Prompt-layer guardrail placed where risk advice + deploys actually happen:

- **senpi-portfolio** (1.0.0→1.0.1) — golden rule: deployed template strategies are already risk-managed; when flagging risk, say what's *already protecting* the position; never prescribe a redundant manual SL; distinguish **managed** (template-deployed) vs **naked** (manual HL position / raw custom strategy with no runtime); "tighter than built-in" = a DSL/guard-rail change, not a missing stop. CTA1 (`strategy_update`) qualified the same way.
- **senpi-strategy-ops** (2.0.1→2.0.2) — the deploy-completion summary now states the built-in protection on **every** deploy, and an explicit "never recommend a manual SL on a template strategy" rule.
- **senpi-strategy-author** (1.0.0→1.0.1) — invariant: protection is built in (DSL + guard-rails per instance); the only unprotected path is a raw `strategy_create_custom_strategy`.

The behavioral rule is intentionally **duplicated, not shared** — skills load independently, so each must be self-contained; a stable rule is safe to repeat. Per-strategy protection *facts* stay as data (`runtime.yaml`), never hand-copied prose (see the answer to Q2 in the thread).
