### PR TITLE
docs(runtime): teach the agent to verify positions are DSL-protected

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   Use when the user names a strategy to run — "install spider", "deploy polar",
   "set up kodiak", "run the spider strategy", "is my strategy live?", "what am I
   running", "list my strategies" (→ status.py),
+  "are my positions protected? / do they have a stop-loss (DSL)?",
   "stop/close/uninstall polar" — and for teardown like "close all strategies",
   "return funds to main", "tear everything down" (→ close.py --all). ALWAYS tear
   down via close.py, never a raw strategy_close (that strands the runtime). A
@@ -17,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.1.0"
+  version: "2.1.1"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -142,6 +143,11 @@ flagged **no-runtime** with the fix (likely an interrupted deploy). Also **runti
 of **orphan runtimes**. `--fast` skips the per-runtime health call; `--json` for machine output. **Tell the
 user the management mode for off-runtime strategies — do not call them idle.** Don't hand-compose
 `strategy_list` — use `status.py`.
+
+**"Are my open positions protected? / do they have a stop-loss?"** → the DSL coverage verdict
+(PROTECTED / UNPROTECTED / STOP-NOT-ON-VENUE). Key trap: an unprotected position shows up as an
+**absence** in `senpi dsl positions`, so you must reconcile open positions against the tracked set — full
+procedure in [`senpi-trading-runtime/references/dsl-protection-check.md`](../senpi-trading-runtime/references/dsl-protection-check.md).
 
 Do **not** trust "runtime: running" alone. A strategy is **live** only when its runtime is running AND
 each instance's `external_scanner` has a recent successful tick (`status.py` reports `running`; confirm a

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.0.0"
+  version: "3.0.1"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -74,6 +74,10 @@ positions|inspect|closes` (the exit engine), `senpi action list|inspect|history|
 decision layer), `senpi status`/`senpi state` (health), and `senpi guide …` (in-shell reference).
 Full surface with every option → `references/runtime-cli.md`.
 
+**To confirm open positions are actually stop-loss protected** (a position with no DSL shows up as an
+*absence* in `dsl positions`, so it's easy to miss) → the verdict procedure in
+`references/dsl-protection-check.md`.
+
 ## The reference set
 
 | Read this | For |
@@ -82,6 +86,7 @@ Full surface with every option → `references/runtime-cli.md`.
 | `references/runtime-yaml.md` | The `runtime.yaml` schema — every section, the `external_scanner` fields, the risk guard-rails |
 | `references/scan-contract.md` | The author contract in depth: `scan(inputs, ctx)`, the `ctx` surface, the signal shape, and `scoring.py` |
 | `references/runtime-cli.md` | The full `openclaw senpi …` command surface — runtime, dsl, action, status/state, skills, guide |
+| `references/dsl-protection-check.md` | **Verify open positions are DSL-protected** — the PROTECTED / UNPROTECTED / STOP-NOT-ON-VENUE verdict + the open-vs-tracked reconciliation |
 
 ## Package naming (load-bearing)
 

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   exports scan(inputs, ctx), which the runtime supervises and calls each interval, then
   owns execution, risk guard_rails, and two-phase DSL trailing-stop exits. Use when
   working with runtime.yaml, the scan(inputs, ctx) contract, external_scanner, ctx, or
-  the DSL exit engine — the shared runtime contract the lifecycle skills reference. NOT
+  the DSL exit engine — including verifying open positions are protected by DSL (have a
+  working stop-loss). The shared runtime contract the lifecycle skills reference. NOT
   for building, installing, or picking a strategy (→ senpi-strategy-author /
   senpi-strategy-ops / senpi-strategy-discover).
 license: Apache-2.0

--- a/senpi-trading-runtime/references/dsl-protection-check.md
+++ b/senpi-trading-runtime/references/dsl-protection-check.md
@@ -1,0 +1,102 @@
+# Is my position protected? — verifying DSL coverage
+
+**Short version:** run **`senpi dsl positions -r <runtime-id>`** — every open position must appear there,
+each with a `floorPrice` (its live stop). **An open position that is *missing* from that list is
+UNPROTECTED.** That is the whole trap: an unprotected position shows up as an *absence*, not a warning, so
+you have to look for what's *not* there. The rest of this doc is how to be sure and how to triage.
+
+Run these checks yourself when you deploy a strategy, before you tell the user "you're covered," or any
+time positions might be running without a stop. Don't ask the user to confirm — read it from the runtime.
+
+## Mental model — why this is usually simple
+
+DSL (Dynamic Stop-Loss) is the autonomous trailing-stop engine. **If a strategy's `runtime.yaml` has an
+`exit: engine: dsl` block, its `position_tracker` scanner auto-starts DSL on every position the strategy
+opens** — you never arm it per trade. So a position is protected when three things hold, and the checks
+below confirm each:
+
+1. **Configured** — the strategy has `exit: engine: dsl` (with a `dsl_preset`).
+2. **Monitor alive** — the DSL monitor is enabled and ticking.
+3. **Tracked + synced** — the position is in the tracked set, with a floor, and its stop reached the venue.
+
+If the strategy has **no** `exit:` block, there is **no engine stop at all** — every one of its positions
+is unprotected by design. That's the first thing to rule out.
+
+## The one command that answers it
+
+```
+senpi dsl positions -r <runtime-id>          # [-a <addr>] [--json]
+```
+Lists every position DSL is protecting — each with `phase`, `currentROE`, `currentTierIndex`, and
+**`floorPrice`** (the live stop). Every open position should appear here with a `floorPrice`.
+
+## Confirm nothing is missing (the reconciliation — do NOT skip)
+
+`dsl positions` lists only *tracked* positions, so compare it against what's actually open:
+
+1. **Open positions** for the strategy wallet → MCP `strategy_get_clearinghouse_state` (or
+   `account_get_portfolio`, filtering `positions` by the strategy's `strategyWalletAddress`).
+2. **Tracked positions** → `senpi dsl positions -r <id>`.
+3. **Every open asset must appear in the tracked set.** Open-but-not-tracked = **UNPROTECTED** → flag it
+   loudly. Causes: the strategy has no `exit: engine: dsl`, the `position_tracker` missed the open, or the
+   position was opened outside the strategy.
+
+## Per-position detail
+
+```
+senpi dsl inspect <ASSET> -r <id>            # e.g. senpi dsl inspect BTC
+```
+Full state for one position: **phase** (1 = fixed floor + retrace from high-water; 2 = tier locks),
+computed **floor/stop price**, active **tier**, and ROE. Use it to confirm the stop is where you expect.
+
+## Strategy + monitor health
+
+```
+senpi status -r <id>
+```
+Read the DSL line — `DSL: enabled=… activePositions=N …`:
+- `enabled=false` / no DSL line → **the strategy has no exit engine — positions are unprotected.** Check
+  the package's `runtime.yaml` `exit:` block.
+- monitor stopped or a stale next-tick → DSL isn't evaluating, so positions won't be trailed or cut.
+
+## Why a position closed
+
+```
+senpi dsl closes -r <id>                     # [-l N]
+```
+Archived positions with the close **reason** (floor breach / tier / `hard_timeout` / `weak_peak_cut` /
+`dead_weight_cut`) and realized ROE.
+
+## The "stop never reached the exchange" alarm  (runtime with the event surface)
+
+A position can be *tracked* yet its stop never actually posted to Hyperliquid (an `editPosition` threw).
+On a runtime that ships the agent event surface:
+- `senpi events -r <id> --name dsl.sl_sync_failed --level error` → **⚠ tracked, but the venue never got
+  the stop** — effectively unprotected until it re-syncs. Treat as urgent.
+- `senpi explain <ASSET> -r <id>` → that position's DSL narrative (`dsl.created` → `dsl.sl_updated` →
+  `dsl.tier_advanced` → `dsl.closed`).
+
+> These two need a runtime build that includes the agent event surface (`senpi events`/`explain`). On
+> older runtimes they return "unknown command" — fall back to `dsl positions` / `inspect` / `status`
+> above, which are always available.
+
+## Verdict rubric (what to tell the user)
+
+| Verdict | When |
+|---|---|
+| ✅ **PROTECTED** | open, appears in `dsl positions` with a `floorPrice`, monitor healthy, no recent `dsl.sl_sync_failed` |
+| ⛔ **UNPROTECTED** | open but **absent** from `dsl positions`, or the strategy has no `exit: engine: dsl` |
+| ⚠ **STOP NOT ON VENUE** | tracked, but a recent `dsl.sl_sync_failed` for that asset |
+
+## Config reference — what "DSL is set up" looks like
+
+```yaml
+exit:
+  engine: dsl
+  interval_seconds: 30            # how often DSL re-evaluates each position
+  dsl_preset:
+    phase1: { max_loss_pct: 3.0, retrace_threshold: 10, consecutive_breaches_required: 3 }
+    phase2: { tiers: [ { trigger_pct: 10, lock_hw_pct: 50 }, { trigger_pct: 20, lock_hw_pct: 70 } ] }
+    # optional time cuts: hard_timeout / weak_peak_cut / dead_weight_cut
+```
+Full engine semantics: `senpi guide dsl`, and `references/runtime-concepts.md` (DSL Exit Engine).

--- a/senpi-trading-runtime/references/runtime-cli.md
+++ b/senpi-trading-runtime/references/runtime-cli.md
@@ -47,6 +47,10 @@ openclaw senpi runtime delete --id iguana-tracker  # tear down
 | `dsl inspect <asset>` | Show the full DSL state for an open position by asset symbol (e.g. `SOL`, `BTC`, `xyz:GOLD`). | `-r` · `-a` · `--json` |
 | `dsl closes` | List archived (closed) DSL positions with close reason and ROE. | `-r` · `-a` · `-l, --limit <n>` (max rows after merge) · `--json` |
 
+**"Are my open positions actually protected by DSL?"** → the step-by-step verdict (PROTECTED /
+UNPROTECTED / STOP-NOT-ON-VENUE), incl. the open-vs-tracked reconciliation an unprotected position hides
+behind: **`references/dsl-protection-check.md`**.
+
 ## `senpi action` — inspect the action layer
 
 | Command | What it does | Options |


### PR DESCRIPTION
## Why
Agents can't easily answer **"are my open positions actually protected by a stop-loss?"** — and the runtime already exposes everything needed. The real gap is teaching, plus one non-obvious trap: **an UNPROTECTED position is an *absence*** — `senpi dsl positions` only lists *tracked* positions, so a position with no DSL just doesn't appear. You have to reconcile against the real open set to notice.

**No new command** (per the discussion — the data's all in the runtime). Just a teaching reference.

## What
`senpi-trading-runtime/references/dsl-protection-check.md`:
- **Mental model:** DSL auto-tracks every position when the strategy has `exit: engine: dsl` → "protected" = configured + monitor alive + tracked/synced.
- **The one command:** `senpi dsl positions -r <id>` (every open position → `floorPrice`).
- **The reconciliation:** open positions (MCP `strategy_get_clearinghouse_state`) vs tracked — open-but-not-tracked = UNPROTECTED.
- **Detail / health / history:** `dsl inspect <asset>`, `senpi status` DSL line, `dsl closes` (reason + ROE).
- **The urgent alarm:** `dsl.sl_sync_failed` = tracked but the stop never reached the venue (flagged as needing the newer event surface; graceful fallback noted).
- **Verdict rubric:** ✅ PROTECTED / ⛔ UNPROTECTED / ⚠ STOP-NOT-ON-VENUE.

Grounded in the **shipped** commands (verified against the runtime source + the live box), with the event-based checks (`senpi events`/`explain`) clearly marked "requires the newer runtime build." Pointers added from `SKILL.md` + `runtime-cli.md`; runtime skill `3.0.0 → 3.0.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)