### PR TITLE
fix(asia-ai): minScore 5 was the unreachable max → no trades (5→4)

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-06-17",
+  "_updated": "2026-07-01",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -1706,7 +1706,7 @@
       "emoji": "🌏",
       "tagline": "Long the Asian AI/semiconductor complex (TSMC, Samsung, SK Hynix, ARM, ASML) with a broad/US-tech short hedge that strips out market beta.",
       "belief_plain": "Buys the Asian AI chipmakers while they're trending up, and shorts the broad US/tech index when it rolls over — so the bet is on Asia AI outperforming, not just the market going up.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "thesis": "You think the AI buildout is increasingly an Asia story — Taiwan and Korea fabs, the chip supply chain — and you want a long on that sector with market beta hedged out, not a naked tech long.",
       "tags": [
         "ai",

--- a/strategies/asia-ai/hedge/runtime.yaml
+++ b/strategies/asia-ai/hedge/runtime.yaml
@@ -35,7 +35,8 @@ scanners:
       universe: ["xyz:XYZ100", "xyz:SP500"]
       direction: "SHORT"
       wantTrend: "DOWN"
-      minScore: 5
+      minScore: 4          # see main/runtime.yaml — 5 was the unreachable max (a >6% down-move AND RSI-room
+                           # are anti-correlated) → ~0.3% emit → no trades. 4 = confirmed downtrend + one confirmation.
       marginPct: 10          # percent of withdrawable (runtime sizes (marginPct/100)*withdrawable)
       rsiMin: 25
       recentSignalTtlSeconds: 1800

--- a/strategies/asia-ai/main/runtime.yaml
+++ b/strategies/asia-ai/main/runtime.yaml
@@ -31,7 +31,9 @@ scanners:
       universe: ["xyz:TSM", "xyz:SMSN", "xyz:SKHX", "xyz:ARM", "xyz:ASML"]
       direction: "LONG"
       wantTrend: "UP"
-      minScore: 5
+      minScore: 4          # max score is 5 (dual-trend base 3 + strength + RSI-room); reaching 5 needs BOTH
+                           # bonuses, which are anti-correlated (a >6% move lifts RSI out of "room") → fired
+                           # ~0.3% of ticks → no trades. 4 = confirmed dual-timeframe trend + one confirmation.
       marginPct: 12          # percent of withdrawable (runtime sizes (marginPct/100)*withdrawable)
       rsiMax: 75
       recentSignalTtlSeconds: 1800

--- a/strategies/asia-ai/strategy.yaml
+++ b/strategies/asia-ai/strategy.yaml
@@ -4,7 +4,7 @@
 schema_version: 1
 
 id: asia-ai
-version: "1.0.0"
+version: "1.0.1"
 
 catalog:
   name: "Asia AI — Hedged Sector Long"

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-06-17",
+  "_updated": "2026-07-01",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -1706,7 +1706,7 @@
       "emoji": "🌏",
       "tagline": "Long the Asian AI/semiconductor complex (TSMC, Samsung, SK Hynix, ARM, ASML) with a broad/US-tech short hedge that strips out market beta.",
       "belief_plain": "Buys the Asian AI chipmakers while they're trending up, and shorts the broad US/tech index when it rolls over — so the bet is on Asia AI outperforming, not just the market going up.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "thesis": "You think the AI buildout is increasingly an Asia story — Taiwan and Korea fabs, the chip supply chain — and you want a long on that sector with market beta hedged out, not a naked tech long.",
       "tags": [
         "ai",


### PR DESCRIPTION
**Asia-AI has never traded for anyone who installed it.** Root cause: both instances ship `minScore: 5`, but **5 is the theoretical max** of the shared scorer — base `3` (confirmed dual-timeframe trend, RSI in band) `+1` if the 4h 6-candle move `>6%` `+1` if there's RSI "room" (`<60` for longs). Reaching 5 needs **both** bonuses, and they're **anti-correlated**: a >6% move lifts RSI out of the room band.

Monte-Carlo over 5,000 noisy uptrends:

| minScore | emit rate |
|---|---|
| 5 (shipped) | **0.30%** — effectively never |
| 4 (fix) | 9.58% — 32× |

On a 5-name universe scanning every 900s with a 30-min dedup, 0.3% ≈ no trades. Both instances share the scorer, so the long *and* the hedge are both dead.

**Fix:** `minScore` 5 → 4 on `main` (long) and `hedge` (short). Score 4 = confirmed dual-timeframe trend **+ one** confirmation (momentum OR pullback-room) — exactly the "accumulate rather than chase" entry the scorer is built for. Score 5 remains as the rare high-conviction case.

Ruled out as **not** the cause (verified): all 7 tickers are live on HL xyz (`TSM/SMSN/SKHX/ARM/ASML/XYZ100/SP500`); the candle-extraction shape matches the working `bobcat` agent. The threshold was the only bug. `1.0.0 → 1.0.1`; catalog regenerated (both copies).
