### PR TITLE
fix(runtime): marginPct in scan-contract (H2) + validator DSL-exit check (3.0.2)

### DIFF
--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -66,6 +66,13 @@ def validate(pkg: Path) -> list:
             if cm and int(cm.group(1)) < _lo:
                 errs.append(f"instance {name}: {rt_rel} {_field} {cm.group(1)} below runtime min {_lo}")
 
+        # Protection is not optional: every instance must ship a DSL exit block (the built-in
+        # trailing stop-loss / two-phase exit). Downstream skills (senpi-portfolio / -strategy-ops)
+        # treat a deployed strategy as risk-managed — a strategy with no DSL exit is a naked position.
+        if not re.search(r"^\s*(exit|dsl_preset)\s*:", rt_text, re.M):
+            errs.append(f"instance {name}: {rt_rel} has no DSL exit block (exit:/dsl_preset:) — "
+                        f"every strategy must ship built-in protection")
+
         # Runtime 3.0 scanner package: <runtime_dir>/scanners/scan.py exports scan(inputs, ctx);
         # the thesis math is a sibling scanners/scoring.py imported as `import scoring` (NO __init__.py).
         scn_dir = rt.parent / "scanners"

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.0.1"
+  version: "3.0.2"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-trading-runtime/references/scan-contract.md
+++ b/senpi-trading-runtime/references/scan-contract.md
@@ -37,7 +37,8 @@ def scan(inputs, ctx):
     out = [{
         "asset": p["coin"],            # REQUIRED
         "direction": p["direction"],   # REQUIRED — "LONG" | "SHORT"
-        "marginUsd": p["margin_usd"],  # top-level USD margin (not a percent)
+        "marginPct": p["margin_pct"],  # top-level PERCENT of withdrawable — the fleet-standard sizing field
+        # (or "marginUsd": p["margin_usd"] for a fixed USD amount — pick one)
         "leverage": p["leverage"],     # top-level
         "data": {                      # validated against signal_data_schema
             "score": p["score"], "direction": p["direction"], "reasons": p["reasons"],
@@ -140,7 +141,8 @@ Return a `list[dict]`, one per candidate. Keys:
 |---|---|---|
 | `asset` | ✅ | non-empty string |
 | `direction` | ✅ | normalized to `LONG` / `SHORT` (case-insensitive in) |
-| `marginUsd` | — | **top-level**, a USD amount (not a percent); a positive number when present — a present-but-non-positive value is a **loud reject** |
+| `marginPct` | — | **top-level**, PERCENT of withdrawable in (0,100] — **the fleet standard** (~97 of 102 scanners); the runtime sizes `(marginPct/100) × withdrawable`. Positive when present; a present-but-non-positive value is a **loud reject** |
+| `marginUsd` | — | **top-level**, a fixed USD amount (not a percent) — the alternative to `marginPct`; positive when present, non-positive is a **loud reject** |
 | `leverage` | — | **top-level**, positive number when present |
 | `data` | — | validated against the recipe's `signal_data_schema`: unknown key → reject, missing required key → reject, wrong type → reject (types `string`/`number`/`boolean`/`object`/`array`) |
 | `valid_for_seconds` | — | per-signal TTL (relative); a non-positive/non-int falls back to `default_signal_validity_seconds` |
@@ -152,8 +154,9 @@ default_signal_validity_seconds)`), the wire envelope, delivery, and dedup. **Do
 `valid_until`/`produced_at`.** You also don't normalize a `[0,1]` wire score — emit your raw score on
 `data{}`.
 
-`marginUsd`/`leverage` are the canonical **top-level** sizing fields (the runtime reads
-`signal.marginUsd`/`signal.leverage` directly) — don't bury them inside `data{}`.
+`marginPct` (percent of withdrawable — the fleet standard) **or** `marginUsd` (fixed USD), plus
+`leverage`, are the canonical **top-level** sizing fields (the runtime reads
+`signal.marginPct`/`signal.marginUsd`/`signal.leverage` directly) — don't bury them inside `data{}`.
 
 ---
 
@@ -184,7 +187,7 @@ Both are valid — it's your thesis:
 - ✅ Pure scoring in `scoring.py`; MCP + state in `scan.py`.
 - ✅ Keep dedup / rotation / first-seen ledgers in `ctx.state` (`last()` → mutate → `append()`).
 - ✅ Declare every `data{}` key in `signal_data_schema`; set `default_signal_validity_seconds`.
-- ✅ Put `marginUsd`/`leverage` at the **top level**, not inside `data{}`.
+- ✅ Put `marginPct` (fleet standard) or `marginUsd`, plus `leverage`, at the **top level**, not inside `data{}`.
 - ✅ On any failure, **return `[]`** (or a partial list) — don't crash.
 - ❌ Don't set `valid_until`/`produced_at` — the scaffold owns the envelope (`signal_id` optional).
 - ❌ Don't schedule the scanner yourself or POST signals — the runtime does it.


### PR DESCRIPTION
Two clean, **#386-independent** fixes salvaged from the closed #429:

- **H2** (review): `scan-contract.md` documented `marginUsd` and never `marginPct`, but the fleet sizes with `marginPct` (~97/102 scanners). Added `marginPct` as the fleet-standard sizing field. `senpi-trading-runtime` skill **3.0.1 → 3.1.0**.
- **Validator DSL-exit check**: `validate_strategy.py` now rejects any instance with no DSL `exit:` block (a strategy with no exit is a naked position). **All 78 packages pass.** (Rescued from the closed #424.)

Neither touches the author `SKILL.md`/references → no conflict with **#386**.