### PR TITLE
feat: strategies become known state at deploy — memory step in ops (2.2.0) + author (2.1.0)

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.0.0"
+  version: "2.1.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -170,3 +170,11 @@ re-smoke-test if you touched `scan.py`/`runtime.yaml`.
 Authoring produces the package only. **Deploy/monitor/close is `senpi-strategy-ops`** — hand off the
 `id` once the smoke test is green. Attribution (`skillName`/`skillVersion`) is set by ops from
 `strategy.yaml` `id`/`version`.
+
+**What you author here becomes the strategy's memory + yardstick.** At deploy, `senpi-strategy-ops`
+records the strategy to memory — `wallet → label` + a one-line **mandate** (from `strategy.yaml`
+`belief_plain`/`thesis`/`archetype`) + its **DSL preset** — so later "how's my `<label>` doing?" gets
+judged against what it was *designed* to do. That makes **the `belief_plain`/`thesis` you write the
+yardstick**, not marketing copy: state plainly what the strategy is *for* — an all-weather core, a
+crisis hedge, a selective breakout that waits for its signal. A vague or momentum-flavored mandate is
+how a strategy that's doing its job later gets misread as "misaligned" or "dead weight." Write it true.

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.1.1"
+  version: "2.2.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -112,6 +112,32 @@ Overall status across the steps: `create` → `creating` (re-run) | `wallets-rea
 `registered`; `verify` → `live` (scanner ticked) | `registered` (re-run verify). Per-instance status
 flows `pending → creating → active → registered → live`. **`registered` ≠ ticking.** `create`/`runtime`
 take `--dry-run` (plan only; no side effects).
+
+## Remember it — the last step of every deploy (and close)
+
+A deploy isn't finished until you've **recorded it to memory**, so *any future chat* knows this strategy
+exists and what it's *for* without re-deriving it (a fresh chat that can't recall the mandate ends up
+grading an all-weather core or a crisis hedge on a momentum benchmark and calling it "dead weight"). On a
+successful deploy, save one small, **stable** record per strategy:
+
+- **`strategy_wallet → label`** — e.g. `0x4c68…9f91 → ox` — so you always know your strategies by name.
+- **Mandate + expected behavior** — what it's *for* and how it's *meant* to run, from its `strategy.yaml`
+  `catalog` (`belief_plain` / `thesis` / `archetype`). e.g. *"ox — risk-parity all-weather core:
+  diversified, low-turnover, uncorrelated to rotations; flat-ish in calm is normal."*
+- **DSL preset (intent)** — the `exit:` preset from `runtime.yaml`, so you know it's protected and roughly how.
+- Why the user chose it, and the date.
+
+On **close**, update the record the same way — drop the closed strategy.
+
+**Do NOT memorize live state** — PnL, positions, DSL floor/tier, or "is it running." Those are queryable
+and they drift; read them live (senpi-portfolio / `status.py` / the DSL check) when asked. Memory holds
+the **names + mandates**; the live tools hold the **truth**.
+
+**Reconcile before you assert.** A strategy can be closed from the app, a heartbeat, or another chat, or
+redeployed to a new wallet — so before you state what's running, reconcile your remembered set against
+`status.py` / `strategy_list`. Memory is the narrative; `status.py` is authoritative for what's live. The
+full config (exact scanner / scoring / DSL tiers) is **not** memory — look it up in the package
+(`runtime.yaml` / `scan.py`, keyed by `skillName`+`version`) only when the user wants the exact mechanics.
 
 ### Worked example — "install spider"
 ```


### PR DESCRIPTION
Fixes the "agent doesn't know the strategies it launched" problem on both sides of the deploy: the strategy's **name · mandate · DSL preset** become durable known-state the moment it deploys, so later "how's my `<label>` doing?" is judged against what it was *designed* to do — not a generic momentum benchmark, and not a re-discovery.

## `senpi-strategy-ops` — 2.1.1 → **2.2.0**
New **"Remember it — the last step of every deploy (and close)"** section. After a deploy, ops records to memory:
- `strategy_wallet → label` (e.g. `0x4c68…9f91 → ox`)
- one-line **mandate** + expected behavior (from the catalog `belief_plain`/`thesis`/`archetype`)
- **DSL preset** (intent) from `runtime.yaml exit:`
- **Not** live state — PnL / positions / DSL floor / is-running are read live, never memorized
- Reconcile against `status.py`/`strategy_list` before asserting; full config = look it up in the package, not memory

This fires for author-built strategies too (they deploy through ops).

## `senpi-strategy-author` — 2.0.0 → **2.1.0**
New note in **Handoff**: the `strategy.yaml` `belief_plain`/`thesis` the author writes **is** what ops records to memory and what `senpi-portfolio` later judges the strategy against — so a vague or momentum-flavored mandate is exactly how an all-weather core, a crisis hedge, or a selective waiting strategy gets misread as "dead weight." Write the mandate true. No behavior change.

Both are MINOR bumps → auto-upgrade installed users. Pairs with the portfolio enrichment in #428 (memory holds the names + why; the live engine holds the truth; both judged against the mandate).