### PR TITLE
fix+feat(portfolio): embedded-balance bug + a strategy is ALL its wallets (1.3.0)

### DIFF
--- a/senpi-portfolio/README.md
+++ b/senpi-portfolio/README.md
@@ -47,7 +47,7 @@ tests/                 offline fixture test (no network) — guards the conflati
 ## How it works
 
 1. **Embedded wallet** — `user_get_me` for the embedded address; `account_get_portfolio(forceFetch)`
-   for `total_usdc_in_hyperliquid` + EVM `token_balances` = idle-in-embedded (the only truly free
+   for `total_in_hyperliquid` (nested under a `portfolio` wrapper) + EVM `token_balances` = idle-in-embedded (the only truly free
    cash). Also grabs the portfolio aggregate for a reconciliation cross-check.
 2. **Strategy wallets** — `strategy_list` → per-wallet `strategy_get_clearinghouse_state` (live, both
    DEXes). Each wallet's `withdrawable` = its idle margin (bucket 2); its positions = deployed.
@@ -76,7 +76,7 @@ rather than reporting "$0."
 ## Status / review notes
 
 - **Field names verified against the Senpi MCP tool schemas + overview guide** (`total_withdrawable`,
-  `total_usdc_in_hyperliquid`, `total_allocated_in_strategy`, `token_balances`; clearinghouse
+  `total_in_hyperliquid`, `total_allocated_in_strategy`, `token_balances` — all nested under `portfolio`; clearinghouse
   `marginSummary.accountValue` / `withdrawable` / `assetPositions[].position`). The engine reads
   defensively with alias fallbacks — run `--dry` to confirm the live shape and adjust if needed.
 - Offline fixture test: guards that idle-in-embedded ≠ `total_withdrawable`, plus position/exposure

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -14,7 +14,7 @@ license: Apache-2.0
 compatibility: OpenClaw, Hyperclaw, Claude Code
 metadata:
   author: Senpi
-  version: "1.2.0"
+  version: "1.3.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -84,6 +84,51 @@ The engine computes these as two separate fields precisely so you don't mix them
 idle," **always say *where*** — "$X idle in the embedded wallet, ready to deploy or withdraw" vs. "$Y
 sitting in strategy wallets waiting for signals." They are not the same money and not the same thing.
 
+## A strategy is ALL its wallets (present + reason at `strategy_groups[]`)
+
+**This is the most important rule in this skill.** A single strategy can deploy as **MULTIPLE instances
+on SEPARATE wallets** — **ox** = `core`+`ballast` (risk-parity), **cougar** = `long`+`short`
+(market-neutral), **cub** = `long`+`short`+`preipo` (multi-sleeve dispersion). `strategy_list` returns
+**each instance/wallet as its own row**, so the raw list looks like several separate strategies. **It is
+not.** A multi-wallet strategy (long+short, core+ballast, multi-sleeve) is **ONE strategy across N
+wallets/instances** — the wallets are the *legs of one design*, not independent bets.
+
+**Lead and reason at the `strategy_groups[]` level, not `strategies[]`.** The engine re-unites the
+per-wallet rows into **`strategy_groups[]`** — one entry per real strategy, with `is_multi_wallet`,
+`instances[]` (the per-wallet detail), and `totals` summed across every wallet. **Present each group as
+one strategy**; never present its wallets/instances as separate strategies. (`strategies[]` is still
+there for per-wallet detail and the bucket math — but the *unit of analysis and recommendation* is the
+group.) When `meta.has_multi_wallet_strategy` is true, at least one strategy spans multiple wallets —
+be especially careful.
+
+### HARD rule — the no-no (this is a real failure that broke live strategies)
+
+> **Never recommend closing / keeping / topping-up / repurposing a SINGLE wallet or instance of a
+> multi-wallet strategy.** Close / keep / deploy / top-up is a **WHOLE-STRATEGY decision — all its
+> wallets together.**
+
+The agent has done exactly this and it is catastrophic:
+
+- "Close ox's \$600 wallet, keep the \$1,400 one" — **gutting one sleeve of a risk-parity core destroys
+  the design.** The two sleeves are balanced *against each other*; keeping one is a different, unbalanced
+  strategy the user never chose.
+- "Keep cougar's short sleeve, repurpose its flat long sleeve" — **closing one sleeve of a long/short
+  strategy leaves a NAKED directional position.** A market-neutral book with only its short leg is just
+  a short — the exact opposite of neutral.
+
+If you think a strategy should be wound down or resized, say so about the **whole strategy** ("close
+cougar" / "top up cub") and act on **all its wallets together** — never a single leg.
+
+### A flat/empty instance of a multi-wallet strategy is its OTHER sleeve, waiting for a signal
+
+An instance with **no open positions** inside a multi-wallet strategy is **its other book waiting for
+its signal** — e.g. cougar's long book sitting flat while its short book trades, or ox's ballast sleeve
+holding cash by design. The engine names these in `strategy_groups[].flat_instances`. **It is NOT idle
+capital to redeploy elsewhere, and never "dead money."** That capital is *committed to the strategy* —
+it's the dry powder the other half of the design needs to do its job. Only truly-free
+`idle_in_embedded` (and, with care, a *whole* strategy's idle) is redeployable — a flat sleeve of a
+live multi-wallet strategy is not.
+
 ## Judge each strategy against its OWN mandate — not a momentum benchmark
 
 This is the core of the analysis. Every strategy was deployed to do a *specific* job. "Is it working?"
@@ -140,6 +185,36 @@ judge conservatively on behavior — do **not** default to a momentum yardstick.
 to be trading and holds nothing for weeks, or a hedge that doesn't pay off in a real crisis, or a
 directional book fighting its own thesis, IS worth flagging. The point is to grade against the right
 yardstick, not to excuse everything.
+
+### "Counter to smart money / the crowd" is NOT a defect for a hedge / neutral / all-weather / contrarian mandate
+
+For a **hedge, market-neutral, all-weather, or contrarian** strategy, **being counter is the DESIGN.** A
+market-neutral book is *supposed* to be short the names the crowd is long; a hedge is *supposed* to lean
+against the prevailing move; a contrarian book is *supposed* to fade the consensus. **Judge it against
+its own `mandate` / `profile.description`, NOT against alignment with the 4h leaderboard / Predators
+view.** Do **not** recommend closing a hedge/neutral/all-weather strategy because it's "fighting the
+whales" or "on the wrong side of smart money" — that IS its job. (For a *directional momentum* strategy,
+fighting the tape is a real red flag — but only for a strategy whose mandate is to ride the move.)
+
+### Don't tear down a deliberate book to chase a short-window signal
+
+The **leaderboard / Predators view is a ~4h momentum window, not a portfolio mandate.** A strategy can be
+"behind the current 4h rotation" and still be doing exactly its multi-week job. **Never recommend a
+wholesale close+redeploy of a deliberate book to chase what's hot on a 4h screen.** Before proposing any
+close+redeploy, weigh **turnover cost** (fees compound on churn) and **regime durability** (is this a
+lasting shift or a 4h blip?). A deliberate, on-mandate strategy is not "underperforming" because it
+didn't catch this afternoon's move.
+
+### Recommend at the STRATEGY level, not cherry-picked positions
+
+For an **autonomous strategy the scanner owns entries and exits** — it opens and closes positions every
+tick per its DSL and signal logic. **Hand-closing an individual position it will simply re-open on the
+next tick is futile** (and pays fees twice). The levers that actually change anything are at the
+**STRATEGY** level: **close it, pause it, adjust its config, or top up the whole strategy** — not its
+individual positions. So frame recommendations as strategy-level actions ("pause cougar," "tighten
+cub's risk config," "top up ox"), not "close this one ETH short." (Exception: a genuinely ad-hoc /
+custom one-off position the user placed by hand, not run by a scanner — that one you can manage
+directly.)
 
 ## Golden rules
 
@@ -206,12 +281,32 @@ from `dsl positions` is UNPROTECTED. Full procedure:
 python3 scripts/portfolio.py [--no-market]
 ```
 
-Returns `{totals, embedded_wallet, strategies, exposure, signals, meta}`:
+Returns `{totals, embedded_wallet, strategies, strategy_groups, exposure, signals, meta}`:
 - `totals` — the three buckets + `grand_total_usd`, `unrealized_pnl`, and a `reconciles` flag (cross-
   checks the per-wallet sum against the portfolio aggregate; if `false`, say the numbers don't tie out
   and lead with the per-wallet figures).
 - `embedded_wallet` — `address`, `idle_hl_usdc`, `evm_usdc[]` (per chain), `spot_usd`, `idle_total`.
-- `strategies[]` — per strategy: `name`, `wallet`, `account_value`, `idle_withdrawable` (bucket 2 for
+- **`strategy_groups[]` — ONE entry per real strategy (a strategy is ALL its wallets). LEAD HERE.** The
+  engine re-unites the per-wallet `strategies[]` rows into one group per strategy, keyed by
+  `profile.group` (→ fallback `skill_name` → fallback the wallet). **This is the unit of analysis and
+  recommendation** — present and reason at this level, never at individual wallets. Each group:
+  - `label` — the group id (e.g. `ox`, `cougar`, `cub`); `skill_name`; `archetype` / `archetype_label`
+    / `direction` (catalog facets when present).
+  - `mandate` — the strategy's declared job (its `profile.description`, else `belief_plain`); shared by
+    all instances. Judge the whole strategy against this.
+  - `is_multi_wallet` (bool) — `true` when the strategy spans >1 wallet (long+short, core+ballast,
+    multi-sleeve). When true, the wallets are legs of ONE design — see "A strategy is ALL its wallets."
+  - `instances[]` — the per-wallet detail: `name` (= `runtime_name`, e.g. `ox-core`), `wallet`,
+    `wallet_short`, `account_value`, `idle_withdrawable`, `deployed`, `upnl`, `positions[]`, `closed`.
+  - `totals` — summed across every instance: `account_value`, `idle_withdrawable`, `deployed`, `upnl`,
+    and `realized_pnl` (when available). **Report the strategy's figures from here, not per-wallet.**
+  - `protected` (bool) — `true` **only if ALL instances are protected** (a strategy with one unguarded
+    sleeve is not fully protected).
+  - `flat_instances` — names of instances with **no open positions**. For a multi-wallet strategy these
+    are the OTHER sleeve(s) **waiting for a signal** — NOT redeployable idle, never "dead money."
+  - `profile_source` — where this strategy's profile came from (`registry` / `registry+catalog` / …).
+- `strategies[]` — the per-wallet detail (kept for the bucket math + `exposure`; `strategy_groups[]` is
+  the level you *present* from). Per wallet: `name`, `wallet`, `account_value`, `idle_withdrawable` (bucket 2 for
   *this* strategy), `deployed` (equity tied up in positions = account_value − withdrawable),
   `position_margin` (initial margin detail), `total_funded`/`total_withdrawn`, and:
   - `skill_name` / `skill_version` — the strategy's package attribution (e.g. `ox`, `cougar`, `lion`),
@@ -242,7 +337,9 @@ Returns `{totals, embedded_wallet, strategies, exposure, signals, meta}`:
   `largest_position_pct_of_deployed` (concentration).
 - `meta` — `profile_source` (`registry` / `catalog` / `mixed` / `null` — where the strategies' mandates
   came from, in aggregate), `registry_source` (`registry` / `null`), `catalog_source`
-  (`local` / `remote` / `null`), `strategy_count`, and `warnings[]`.
+  (`local` / `remote` / `null`), `strategy_count`, **`has_multi_wallet_strategy`** (bool — `true` when at
+  least one strategy spans multiple wallets/instances; a cue to reason at `strategy_groups[]` and apply
+  the "a strategy is all its wallets" rules), and `warnings[]`.
 - The engine **fails open** — partial data still returns valid JSON with `meta.warnings`. If the runtime
   registry is unreadable, mandates fall back to the catalog (templates only); if that's also gone,
   `profile` is `null` and you judge on behavior.
@@ -253,45 +350,64 @@ Order matters: **strategy verdicts lead; positions are evidence underneath them.
 is purely "how much / where is my money," you can open with the money map instead — but for anything
 about "my strategies / how am I doing," lead with the per-strategy read.)
 
+**Lead from `strategy_groups[]` — one verdict per real strategy, NOT per wallet.** A multi-wallet
+strategy (long+short, core+ballast, multi-sleeve) is ONE strategy across N wallets; present it as one.
+See "A strategy is ALL its wallets."
+
 1. **Total + the three buckets.** `grand_total_usd`, broken into idle-in-embedded / idle-in-strategies
    / deployed — each labeled by *where*. Keep it tight; this is the money map, not the analysis.
-2. **Per-strategy verdict (the real value).** For **each** strategy, in this order:
-   1. **Label + mandate.** Its name and what it was deployed to *do* — from `strategies[].profile`
-      (its `profile.description`, read from the deployed `runtime.yaml`; add catalog facets like
-      `belief_plain`/`archetype` when present). Works the same for a user-authored strategy. "cub is a
-      K-shaped long/short dispersion book — long the structural winners, short the laggards; the P&L is
-      the spread."
-   2. **Is it doing its job — against its OWN mandate.** Not vs a momentum benchmark. A hedge that's
-      flat in calm, an all-weather core that's steady-not-flashy, a selective strategy waiting with no
-      position — all **working as designed**. See "Judge each strategy against its OWN mandate."
-   3. **Positions as evidence.** The open positions that *show* it's on-mandate: direction, leveraged
-      return (`return_on_equity_pct`), and **vs the market** (`market_24h_pct`, `vs_market`) — "short
-      ETH, +11% on margin, *with* today's 4% selloff." Flag any fighting the tape / near `liq_px` /
-      oversized. A strategy with `positions == []` and `deployed == 0` is **waiting for its signal** —
-      say that, don't call it dead.
-   4. **PnL — realized + unrealized.** Booked `closed.realized_pnl` (+ a couple of `closed.recent[]`
-      trades) *and* open `upnl`. A flat strategy may have already banked real gains.
-   5. **Protection posture.** `protected` ⟹ the deployed `runtime.yaml` ships an `exit:` block (or it's
-      template-deployed), DSL-protected by construction.
+2. **Per-strategy verdict (the real value).** For **each `strategy_groups[]` entry** (one per real
+   strategy — never one per wallet), in this order:
+   1. **Label + mandate.** The group's `label` and what it was deployed to *do* — from the group's
+      `mandate` (its `profile.description`, read from the deployed `runtime.yaml`; add catalog facets
+      like `belief_plain`/`archetype` when present). Works the same for a user-authored strategy. "cub
+      is a K-shaped long/short dispersion book — long the structural winners, short the laggards; the
+      P&L is the spread." **If `is_multi_wallet`, name it as ONE strategy across its sleeves** ("cougar
+      is a market-neutral long/short pair") — never as two strategies.
+   2. **Is it doing its job — against its OWN mandate.** Not vs a momentum benchmark, and **not vs the 4h
+      leaderboard.** A hedge flat in calm, an all-weather core steady-not-flashy, a market-neutral book
+      counter to the crowd, a selective strategy waiting with no position — all **working as designed**.
+      See "Judge each strategy against its OWN mandate" and "Counter to smart money is not a defect."
+   3. **Positions as evidence — across ALL the strategy's instances.** The open positions (from every
+      instance in the group) that *show* it's on-mandate: direction, leveraged return
+      (`return_on_equity_pct`), and **vs the market** (`market_24h_pct`, `vs_market`) — "short ETH, +11%
+      on margin, *with* today's 4% selloff." A group instance in `flat_instances` is the strategy's
+      **OTHER sleeve waiting for its signal** (for a multi-wallet strategy) or the whole strategy
+      waiting for its setup (for a single-wallet one) — say that, never "dead money." Flag any position
+      fighting the tape *for a directional-momentum mandate* / near `liq_px` / oversized.
+   4. **PnL — realized + unrealized, summed across the strategy.** The group's `totals.realized_pnl`
+      and `totals.upnl` (+ a couple of `closed.recent[]` trades from its instances). A flat sleeve may
+      have already banked real gains on the other sleeve.
+   5. **Protection posture.** The group's `protected` (⟹ **all** instances ship a DSL exit).
+   6. **Any lever is WHOLE-STRATEGY.** If you suggest close / pause / adjust-config / top-up, it applies
+      to the **entire strategy (all its wallets)** — never one sleeve. And the lever is the STRATEGY,
+      not a hand-picked position the scanner will just re-open. See the HARD rule under "A strategy is
+      ALL its wallets" and "Recommend at the STRATEGY level."
 3. **Portfolio-level read.** Net exposure (net long/short and by sector), concentration (largest
    position), idle drag (capital sitting in cash), and the overall posture — is this book hedged,
    directional, mostly in cash? Compare the net tilt to where the broader market is.
 4. **The two CTAs** (next section).
 
-Formatting: group by strategy; show `Δ%` and leveraged return; emoji sparingly (🟢/🔴 for green/red
-books). Show strategy wallet addresses in short form (`0x35d1...acb1`) unless asked for full.
+Formatting: group by strategy (a `strategy_groups[]` entry = one strategy; show its instances as its
+sleeves, not as peers); show `Δ%` and leveraged return; emoji sparingly (🟢/🔴 for green/red books).
+Show strategy wallet addresses in short form (`0x35d1...acb1`) unless asked for full.
 
 ## Mandatory closing (verbatim)
 
 > **1. Want me to rebalance or adjust any of these positions?**
 > **2. Want me to put the idle capital to work in a new strategy?**
 
-- **CTA 1 → position management.** Route to the execution tools (`edit_position` / `close_position` /
-  `strategy_update`) for the specific position — confirm before any change; never trade unprompted.
-- **CTA 2 → deploy idle.** If there's meaningful idle capital (lead from `signals.idle_drag_pct`),
-  offer to hand it to **senpi-strategy-discover** / **senpi-strategy-author** — fund a new strategy
-  from the embedded idle, or top up an existing one from `strategy_top_up`. Propose; never deploy
-  without confirmation.
+- **CTA 1 → strategy / position management.** For an **autonomous strategy**, route to the
+  STRATEGY-level levers (`strategy_pause` / `strategy_update` config / `strategy_close` / `strategy_top_up`)
+  and apply them to the **whole strategy (all its wallets)** — never to a single sleeve of a multi-wallet
+  strategy, and never hand-close a position the scanner will just re-open. Only use per-position tools
+  (`edit_position` / `close_position`) for a genuinely ad-hoc position the user placed by hand. Confirm
+  before any change; never trade unprompted.
+- **CTA 2 → deploy idle.** If there's meaningful **truly-free** idle capital (lead from
+  `signals.idle_drag_pct` and `idle_in_embedded` — NOT a flat sleeve of a live multi-wallet strategy,
+  which is committed), offer to hand it to **senpi-strategy-discover** / **senpi-strategy-author** — fund
+  a new strategy from the embedded idle, or top up an existing *whole* strategy via `strategy_top_up`.
+  Propose; never deploy without confirmation.
 
 ## Resilience (engine handles; narrate honestly)
 

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -346,7 +346,17 @@ def fetch_embedded(client, meta):
         meta.setdefault("warnings", []).append(f"account_get_portfolio failed: {e}")
         return out, {}
 
-    out["idle_hl_usdc"] = _f(p, "total_usdc_in_hyperliquid", default=0.0)
+    # account_get_portfolio (GetPortfolioV3) nests the balance fields under a `portfolio` key
+    # ({data: {portfolio: {...}}}); _ok() strips only the outer `data`. Unwrap `portfolio` here so the
+    # field reads below hit real values (else the whole embedded read is $0). Robust to both shapes.
+    # This nesting + the wrong field name below is why a $10k+ embedded infusion read as $0.
+    if isinstance(p, dict) and isinstance(p.get("portfolio"), dict):
+        p = p["portfolio"]
+
+    # Idle HL balance is `total_in_hyperliquid` (per the account_get_portfolio schema + ops deploy.py) —
+    # NOT `total_usdc_in_hyperliquid` (does not exist; the wrong name made this $0). Old name kept as a
+    # harmless fallback so it can never regress.
+    out["idle_hl_usdc"] = _f(p, "total_in_hyperliquid", "total_usdc_in_hyperliquid", default=0.0)
     out["spot_usd"] = _f(p, "total_spot_usd_in_hyperliquid", default=0.0)
     evm = 0.0
     for tb in (_field(p, "token_balances", default=[]) or []):

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -645,6 +645,118 @@ def compute(embedded, strategies, portfolio_totals):
     return totals, exposure, signals
 
 
+# ──────────────────────────────────────────────────────────────── strategy grouping (A STRATEGY IS ALL ITS WALLETS)
+def _group_key(strat):
+    """The grouping key for a per-wallet `strategies[]` row → the STRATEGY it belongs to.
+
+    A single strategy can deploy as MULTIPLE instances on SEPARATE wallets (ox = core+ballast,
+    cougar = long+short, cub = long+short+preipo). `strategy_list` returns each instance/wallet as its
+    OWN row, so the engine lists them as separate `strategies[]` entries. Re-uniting them is the whole
+    point: `profile.group` (from the deployed runtime.yaml, shared by every instance of a strategy) is
+    the authoritative key → fall back to `skill_name` (package attribution) → fall back to the wallet
+    itself (a genuinely ungrouped / custom one-off is its own group of one). Fail-open: never raises."""
+    prof = strat.get("profile") or {}
+    grp = prof.get("group")
+    if grp:
+        return str(grp)
+    if strat.get("skill_name"):
+        return str(strat["skill_name"])
+    return str(strat.get("wallet") or id(strat))
+
+
+def _short_wallet(w):
+    w = str(w or "")
+    return f"{w[:6]}...{w[-4:]}" if len(w) > 12 else w
+
+
+def group_strategies(strategies, meta):
+    """Collapse the per-wallet `strategies[]` rows into `strategy_groups[]` — ONE entry per real strategy.
+
+    SUPPLEMENTS `strategies[]` (does not replace it — the bucket math + per-wallet detail still rely on
+    the flat list). Each group re-unites every instance/wallet of a strategy so the agent reasons at the
+    STRATEGY level: a multi-wallet strategy (long+short, core+ballast, multi-sleeve) is ONE strategy
+    across N wallets, never N separate strategies. Order is preserved by first appearance. Fail-open:
+    a malformed row can't sink the grouping; worst case it lands in its own wallet-keyed group."""
+    order = []          # group keys, first-seen order
+    buckets = {}        # key → list of strategies
+    for s in (strategies or []):
+        try:
+            key = _group_key(s)
+        except Exception:  # noqa — a malformed row must not sink the grouping
+            key = str(s.get("wallet") or id(s))
+        if key not in buckets:
+            buckets[key] = []
+            order.append(key)
+        buckets[key].append(s)
+
+    groups = []
+    for key in order:
+        insts = buckets[key]
+        # Instances share the strategy's identity (profile is per-strategy, mirrored on every wallet);
+        # pull the shared facets from the first instance that carries a profile, else the first row.
+        prof = next((s.get("profile") for s in insts if s.get("profile")), None) or {}
+        first = insts[0]
+        # mandate = the strategy's declared job — description (universal, from the deployed runtime.yaml)
+        # or belief_plain (catalog facet); instances share it.
+        mandate = prof.get("description") or prof.get("belief_plain")
+        skill_name = next((s.get("skill_name") for s in insts if s.get("skill_name")), None)
+
+        instances = []
+        for s in insts:
+            instances.append({
+                "name": s.get("name"),                          # = runtime_name, e.g. ox-core
+                "wallet": s.get("wallet"),
+                "wallet_short": _short_wallet(s.get("wallet")),
+                "account_value": s.get("account_value"),
+                "idle_withdrawable": s.get("idle_withdrawable"),
+                "deployed": s.get("deployed"),
+                "upnl": round(sum(_num(p.get("upnl")) or 0.0 for p in (s.get("positions") or [])), 2),
+                "positions": s.get("positions", []),
+                "closed": s.get("closed"),
+            })
+
+        # totals — summed across every instance/wallet of the strategy (a strategy is all its wallets)
+        def _sum(field):
+            vals = [_num(i.get(field)) for i in instances]
+            vals = [v for v in vals if v is not None]
+            return round(sum(vals), 2) if vals else None
+        realized_vals = [_num((s.get("closed") or {}).get("realized_pnl")) for s in insts]
+        realized_vals = [v for v in realized_vals if v is not None]
+        totals = {
+            "account_value": _sum("account_value"),
+            "idle_withdrawable": _sum("idle_withdrawable"),
+            "deployed": _sum("deployed"),
+            "upnl": _sum("upnl"),
+            "realized_pnl": round(sum(realized_vals), 2) if realized_vals else None,
+        }
+
+        # flat instances = an instance with NO open positions. For a multi-wallet strategy this is its
+        # OTHER sleeve waiting for its signal (e.g. cougar's long book flat while its short book trades),
+        # NOT redeployable idle. Named so the agent never calls it "dead money."
+        flat_instances = [i["name"] for i, s in zip(instances, insts) if not (s.get("positions") or [])]
+
+        groups.append({
+            "label": key,                                       # the group id, e.g. ox / cougar / cub
+            "skill_name": skill_name,
+            "archetype": prof.get("archetype"),
+            "archetype_label": prof.get("archetype_label"),
+            "direction": prof.get("direction"),
+            "mandate": mandate,                                 # the strategy's declared job (shared)
+            "is_multi_wallet": len(insts) > 1,
+            "instances": instances,                             # per-wallet detail
+            "totals": totals,                                   # summed across all wallets
+            # protected ONLY if ALL instances are protected — a strategy with one unguarded sleeve is not
+            # fully protected.
+            "protected": all(bool(s.get("protected")) for s in insts),
+            "flat_instances": flat_instances,
+            "profile_source": prof.get("source"),
+        })
+
+    if any(g["is_multi_wallet"] for g in groups):
+        meta["has_multi_wallet_strategy"] = True
+    return groups
+
+
 # ──────────────────────────────────────────────────────────────── orchestration
 def run(client, want_market=True):
     meta = {"warnings": [], "real_time": True, "force_fetch": True}
@@ -654,6 +766,10 @@ def run(client, want_market=True):
         enrich_market(client, strategies, meta)
     totals, exposure, signals = compute(embedded, strategies, portfolio_totals)
     meta["strategy_count"] = len(strategies)
+    meta.setdefault("has_multi_wallet_strategy", False)   # default; group_strategies flips it to True
+    # A STRATEGY IS ALL ITS WALLETS — re-unite the per-wallet rows into one entry per real strategy.
+    # SUPPLEMENTS `strategies[]` (kept — bucket math + detail rely on it); groups add the strategy-level view.
+    strategy_groups = group_strategies(strategies, meta)
     if not strategies and not embedded.get("address"):
         meta["degraded"] = "no wallet data — check the token is USER-scoped"
     return {
@@ -661,6 +777,8 @@ def run(client, want_market=True):
         "totals": totals,           # the three buckets — NEVER conflate them
         "embedded_wallet": embedded,
         "strategies": strategies,
+        # ONE entry per real strategy (a strategy is ALL its wallets); reason + recommend at THIS level.
+        "strategy_groups": strategy_groups,
         "exposure": exposure,
         "signals": signals,
         "meta": meta,

--- a/senpi-portfolio/tests/fixtures/portfolio_fixture.json
+++ b/senpi-portfolio/tests/fixtures/portfolio_fixture.json
@@ -3,14 +3,14 @@
     {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"},
     {"walletType": "external", "walletAddress": "0xext0000000000000000000000000000000000ext"}
   ]},
-  "account_get_portfolio": {
+  "account_get_portfolio": {"portfolio": {
     "total_balance_usd": 3102.94,
     "total_allocated_in_strategy": 3101.43,
     "total_withdrawable": 2461.98,
-    "total_usdc_in_hyperliquid": 0,
+    "total_in_hyperliquid": 0,
     "total_spot_usd_in_hyperliquid": 0,
     "token_balances": [{"symbol": "USDC", "chain": "Base", "usdValue": 1.51}]
-  },
+  }},
   "strategy_list": {"strategies": [
     {"tradingStrategyName": "cub-long", "strategyWalletAddress": "0xlong0000000000000000000000000000000long", "status": "ACTIVE", "totalFunded": 1739, "totalWithdrawn": 0},
     {"tradingStrategyName": "cub-short", "strategyWalletAddress": "0xshort000000000000000000000000000000shrt", "status": "ACTIVE", "totalFunded": 1378, "totalWithdrawn": 0},

--- a/senpi-portfolio/tests/fixtures/registry_cougar/installed_runtimes.json
+++ b/senpi-portfolio/tests/fixtures/registry_cougar/installed_runtimes.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "runtimes": [
+    {
+      "id": "cougar-long",
+      "wallet": "0xCOUGARLONG000000000000000000000000000lng",
+      "runtimeYamlContent": "# \u2500\u2500 COUGAR \u00b7 long sleeve \u2014 market-neutral long book \u2500\u2500\nname: cougar-long\ngroup: cougar\nversion: 1.0.0\ndescription: >\n  COUGAR \u2014 a market-neutral long/short pair. This LONG sleeve holds the structural\n  winners; its paired SHORT sleeve holds the laggards. The strategy's P&L is the\n  spread between the two books, not either leg alone. Being counter to the crowd on\n  either leg is the design of a market-neutral book, not a defect.\n\nstrategy:\n  wallet: \"${COUGAR_LONG_WALLET}\"\n  slots: 4\n  default_leverage: 3\n  enabled: true\n\nexit:\n  engine: dsl\n  dsl_preset: conviction\n",
+      "schemaVersion": 1
+    },
+    {
+      "id": "cougar-short",
+      "wallet": "0xCOUGARSHORT00000000000000000000000000sht",
+      "runtimeYamlContent": "# \u2500\u2500 COUGAR \u00b7 short sleeve \u2014 market-neutral short book \u2500\u2500\nname: cougar-short\ngroup: cougar\nversion: 1.0.0\ndescription: >\n  COUGAR \u2014 a market-neutral long/short pair. This SHORT sleeve holds the laggards;\n  its paired LONG sleeve holds the structural winners. The strategy's P&L is the\n  spread between the two books, not either leg alone. Being counter to the crowd on\n  either leg is the design of a market-neutral book, not a defect.\n\nstrategy:\n  wallet: \"${COUGAR_SHORT_WALLET}\"\n  slots: 4\n  default_leverage: 3\n  enabled: true\n\nexit:\n  engine: dsl\n  dsl_preset: conviction\n",
+      "schemaVersion": 1
+    }
+  ]
+}

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -140,6 +140,25 @@ def test_profile_description_from_runtime_registry():
     assert res["meta"]["profile_source"] in ("registry", "mixed")
 
 
+def test_embedded_idle_reads_nested_total_in_hyperliquid():
+    """Regression (the invisible-$10k bug): account_get_portfolio nests balances under a `portfolio`
+    key and the idle-HL field is `total_in_hyperliquid` — NOT `total_usdc_in_hyperliquid`. The old code
+    missed both, so embedded idle always read $0 and a large infusion was invisible. This fixture
+    (nested + correct field, $10,446 idle, no strategies) must surface as idle-in-embedded; it reads $0
+    under the pre-fix code."""
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"portfolio": {
+            "total_balance_usd": 10446.0, "total_allocated_in_strategy": 0, "total_withdrawable": 0,
+            "total_in_hyperliquid": 10446.0, "total_spot_usd_in_hyperliquid": 0, "token_balances": []}},
+        "strategy_list": {"strategies": []},
+    }
+    res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    assert res["embedded_wallet"]["idle_hl_usdc"] == 10446.0
+    assert res["totals"]["idle_in_embedded"] == 10446.0
+
+
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     for fn in fns:

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -20,10 +20,14 @@ import _yaml  # noqa: E402
 
 FIXTURE = os.path.join(HERE, "fixtures", "portfolio_fixture.json")
 REGISTRY_DIR = os.path.join(HERE, "fixtures", "registry")           # holds installed_runtimes.json
+REGISTRY_COUGAR_DIR = os.path.join(HERE, "fixtures", "registry_cougar")   # 2-instance strategy fixture
 REPO_ROOT = os.path.dirname(os.path.dirname(HERE))                  # senpi-skills/
 KODIAK_YAML = os.path.join(REPO_ROOT, "strategies", "kodiak", "main", "runtime.yaml")
 # the wallet the registry fixture keys the kodiak runtime.yaml under (see fixtures/registry/…json)
 KODIAK_WALLET = "0xKODIAK00000000000000000000000000000kdk"
+# the two wallets of the cougar long/short pair (one strategy, two instances — see registry_cougar/…json)
+COUGAR_LONG_WALLET = "0xCOUGARLONG000000000000000000000000000lng"
+COUGAR_SHORT_WALLET = "0xCOUGARSHORT00000000000000000000000000sht"
 
 
 def _result():
@@ -138,6 +142,98 @@ def test_profile_description_from_runtime_registry():
     assert strat["protected"] is True                      # runtime.yaml ships an `exit:` block
     assert res["meta"]["registry_source"] == "registry"
     assert res["meta"]["profile_source"] in ("registry", "mixed")
+
+
+def test_multi_wallet_strategy_groups_into_one():
+    """A STRATEGY IS ALL ITS WALLETS. cougar deploys as TWO instances on TWO wallets (cougar-long +
+    cougar-short, sharing `group: cougar` in their runtime.yamls). `strategy_list` returns them as two
+    separate rows; the engine must re-unite them into ONE `strategy_groups[]` entry with
+    `is_multi_wallet: true` and 2 instances — never present the two sleeves as two strategies."""
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"portfolio": {
+            "total_balance_usd": 2000, "total_withdrawable": 1200,
+            "total_in_hyperliquid": 0, "token_balances": []}},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "cougar-long", "strategyWalletAddress": COUGAR_LONG_WALLET, "status": "ACTIVE"},
+            {"tradingStrategyName": "cougar-short", "strategyWalletAddress": COUGAR_SHORT_WALLET, "status": "ACTIVE"}]},
+        # long sleeve: flat, all idle (its other-sleeve-waiting-for-signal case)
+        f"strategy_get_clearinghouse_state::{COUGAR_LONG_WALLET.lower()}": {
+            "main": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "1000", "assetPositions": []},
+            "xyz": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "1000", "assetPositions": []}},
+        # short sleeve: one working short
+        f"strategy_get_clearinghouse_state::{COUGAR_SHORT_WALLET.lower()}": {
+            "main": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "800", "assetPositions": [
+                {"position": {"coin": "ETH", "szi": -0.5, "positionValue": 800, "marginUsed": 200,
+                              "entryPx": 1719.7, "unrealizedPnl": 20, "returnOnEquity": 0.1,
+                              "leverage": {"value": 4}, "liquidationPx": 2100}}]},
+            "xyz": {"marginSummary": {"accountValue": "800"}, "withdrawable": "800", "assetPositions": []}},
+    }
+    old = os.environ.get("SENPI_STATE_DIR")
+    os.environ["SENPI_STATE_DIR"] = REGISTRY_COUGAR_DIR
+    try:
+        res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    finally:
+        if old is None:
+            os.environ.pop("SENPI_STATE_DIR", None)
+        else:
+            os.environ["SENPI_STATE_DIR"] = old
+
+    # still two per-wallet rows in strategies[] (bucket math relies on it) …
+    assert len(res["strategies"]) == 2
+    # … but ONE strategy_groups[] entry re-uniting them
+    groups = res["strategy_groups"]
+    assert len(groups) == 1
+    g = groups[0]
+    assert g["label"] == "cougar"
+    assert g["is_multi_wallet"] is True
+    assert len(g["instances"]) == 2
+    names = {i["name"] for i in g["instances"]}
+    assert names == {"cougar-long", "cougar-short"}
+    # the flat long sleeve is its OTHER book waiting for a signal — surfaced, not "dead money"
+    assert g["flat_instances"] == ["cougar-long"]
+    # totals summed across BOTH wallets
+    assert g["totals"]["account_value"] == 1000 + 1000        # long wallet + short wallet
+    assert g["totals"]["deployed"] == 200                     # only the short sleeve has a position
+    assert g["totals"]["upnl"] == 20
+    # mandate shared across instances (from the deployed runtime.yaml description)
+    assert isinstance(g["mandate"], str) and "market-neutral" in g["mandate"]
+    # meta flag flips on
+    assert res["meta"]["has_multi_wallet_strategy"] is True
+
+
+def test_single_wallet_strategy_is_one_instance_group():
+    """A single-instance strategy is its own group with is_multi_wallet: false and one instance —
+    and with no multi-wallet strategy present, the meta flag stays False."""
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"portfolio": {
+            "total_balance_usd": 200, "total_withdrawable": 200,
+            "total_in_hyperliquid": 0, "token_balances": []}},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "kodiak", "strategyWalletAddress": KODIAK_WALLET, "status": "ACTIVE"}]},
+        f"strategy_get_clearinghouse_state::{KODIAK_WALLET.lower()}": {
+            "main": {"marginSummary": {"accountValue": "200"}, "withdrawable": "200", "assetPositions": []},
+            "xyz": {"marginSummary": {"accountValue": "200"}, "withdrawable": "200", "assetPositions": []}},
+    }
+    old = os.environ.get("SENPI_STATE_DIR")
+    os.environ["SENPI_STATE_DIR"] = REGISTRY_DIR
+    try:
+        res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    finally:
+        if old is None:
+            os.environ.pop("SENPI_STATE_DIR", None)
+        else:
+            os.environ["SENPI_STATE_DIR"] = old
+    groups = res["strategy_groups"]
+    assert len(groups) == 1
+    g = groups[0]
+    assert g["label"] == "kodiak"                # profile.group from the deployed runtime.yaml
+    assert g["is_multi_wallet"] is False
+    assert len(g["instances"]) == 1
+    assert res["meta"]["has_multi_wallet_strategy"] is False
 
 
 def test_embedded_idle_reads_nested_total_in_hyperliquid():

--- a/senpi-strategy-discover/scripts/discover.py
+++ b/senpi-strategy-discover/scripts/discover.py
@@ -400,8 +400,13 @@ def fetch_user_context(client):
     ctx = {"budget": None, "holdings": [], "favored_assets": [], "favored_direction": None}
     try:
         data = _ok(client.mcp_call("account_get_portfolio", timeout=15))
+        # GetPortfolioV3 nests the fields under a `portfolio` key; _ok strips only the outer `data`.
+        # Unwrap it (else budget/positions read empty) and use `total_in_hyperliquid` (the real field
+        # name — `total_usdc_in_hyperliquid` does not exist). Robust to both flat and nested shapes.
+        if isinstance(data, dict) and isinstance(data.get("portfolio"), dict):
+            data = data["portfolio"]
         if data:
-            ctx["budget"] = data.get("total_balance_usd") or data.get("total_usdc_in_hyperliquid")
+            ctx["budget"] = data.get("total_balance_usd") or data.get("total_in_hyperliquid")
             for pos in (data.get("positions") or []):
                 sym = pos.get("coin") or pos.get("asset")
                 if sym:


### PR DESCRIPTION
Two things from the live transcripts: a real **balance bug** (the "you didn't pull my live balance" one) and the **multi-wallet strategy** failure (recommending close/keep on a single sleeve of a strategy that spans several wallets).

## 1. Balance bug — embedded idle always read $0 (`portfolio.py` + `discover.py`)
`account_get_portfolio` (GetPortfolioV3) nests all balance fields under a `portfolio` key (`{data:{portfolio:{…}}}`) and the idle-HL field is **`total_in_hyperliquid`** — but the code read **`total_usdc_in_hyperliquid`** (a field that doesn't exist) off the un-unwrapped outer dict. So the embedded-wallet idle **always read $0**, and a real cash infusion (~$10k) was invisible until the user called it out.
- Confirmed against the `account_get_portfolio` tool schema + `senpi-strategy-ops/deploy.py` (which reads `total_in_hyperliquid` via a recursive dig).
- Fix: unwrap the `portfolio` wrapper (robust to flat or nested) + read `total_in_hyperliquid` (old name kept as a harmless fallback). Same fix in `discover.py` (feeds the deploy budget).
- **The old test fixture had embedded = $0, which HID the bug** — rebuilt it to the real nested shape + added a regression test that reads a nested $10,446 (reads $0 under the old code).

## 2. A strategy is ALL its wallets (`portfolio.py` + `SKILL.md`, 1.2.0 → 1.3.0)
A strategy can deploy as multiple instances on separate wallets — **ox** = core+ballast (risk-parity), **cougar** = long+short (market-neutral), **cub** = long+short+preipo. `strategy_list` returns each as its own row, and the agent treated them as independent strategies — recommending "close ox's $600 wallet, keep the $1,400," "repurpose cougar's flat long sleeve" — which **breaks the strategy** (a long/short with one leg closed is a naked directional bet).
- Engine: `strategy_groups[]` re-unites per-wallet rows by `profile.group` — `is_multi_wallet`, `instances[]`, summed `totals`, `protected` (all instances), `flat_instances`. `meta.has_multi_wallet_strategy`.
- SKILL.md hard rule: close/keep/top-up/repurpose is a **whole-strategy** decision (all wallets together); a **flat sleeve is the strategy's other leg waiting for its signal**, not redeployable idle / "dead money."

### Plus, strategy-level judgment guidance (from the same transcripts)
- **"Counter to smart money / the crowd" is the DESIGN** for a hedge / market-neutral / all-weather / contrarian mandate — judge against the strategy's own mandate, not alignment with the 4h leaderboard. Don't recommend closing a hedge because it's "fighting the whales."
- **Don't tear down a deliberate book to chase a short-window signal** — the Predators/leaderboard view is a ~4h momentum window; weigh turnover + regime durability before wholesale close+redeploy.
- **Recommend at the strategy level, not cherry-picked positions** — an autonomous strategy's scanner owns entries/exits; hand-closing a position it re-opens is futile.

**13/13 tests pass.** MINOR bump → auto-upgrades installed users. Follows #428 (registry-sourced mandate).