### PR TITLE
feat(portfolio): DSL tier awareness — how it works per strategy + which position in which tier (1.4.0)

### DIFF
--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -8,13 +8,14 @@ description: >-
   / PnL / trade-history question, BEFORE any raw strategy_get_clearinghouse_state / account_get_portfolio
   / strategy_list MCP call. Use for "analyze my strategies", "how are my strategies doing", "analyze my
   portfolio", "how am I doing", "show my positions", "balance across all wallets", "how much is idle", and
-  "are my open positions protected? / do they have a stop-loss?". A hidden engine (scripts/portfolio.py)
+  "are my open positions protected? / do they have a stop-loss?", and "tell me about my strategies and
+  their DSL / what tier are my positions in?". A hidden engine (scripts/portfolio.py)
   does the multi-wallet pull and taxonomy; you narrate. Requires a USER-scoped Senpi token.
 license: Apache-2.0
 compatibility: OpenClaw, Hyperclaw, Claude Code
 metadata:
   author: Senpi
-  version: "1.3.0"
+  version: "1.4.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -242,11 +243,14 @@ directly.)
   trades: asset, direction, realized pnl, closed time). A strategy flat right now may have *already
   booked* real gains; report both realized and unrealized. If `closed.realized_pnl` is `null`, the
   history read failed (see `meta.warnings`) — say realized PnL is unavailable, don't imply zero.
-- **Surface the protection posture per strategy.** Each strategy carries `protected` (bool): `True`
-  when its **deployed `runtime.yaml` ships an `exit:` block** (the universal signal — works for
-  user-authored strategies too), OR it was template-deployed (has a `skill_name`). Either way it ships a
-  built-in DSL exit by construction. State it as posture ("deployed with a DSL exit"). This is
-  config-level, not a live per-position DSL-tracking check — for that, use the DSL coverage check below.
+- **Surface the protection posture per strategy — then the live tiers.** Each strategy carries
+  `protected` (bool): `True` when its **deployed `runtime.yaml` ships an `exit:` block** (the universal
+  signal — works for user-authored strategies too), OR it was template-deployed (has a `skill_name`).
+  Either way it ships a built-in DSL exit by construction. State it as posture ("deployed with a DSL
+  exit"), then give the **ladder** (`profile.dsl`: hard stop + arm-at + tiers) and each **open position's
+  live tier** (`positions[].dsl`). This config-level bool is NOT the per-position tier — see "DSL — how
+  it works per strategy, and which position is in which tier" below. **Never call a live position
+  "unprotected" just because it has no ratchet record — sub-Tier-1 positions have none by design.**
 - **Don't infer "wiped out" from a low balance.** Check `total_funded` / `total_withdrawn` — a
   strategy can show a small balance because profits were withdrawn (`netFunded` can be negative). That
   is not a loss.
@@ -261,19 +265,63 @@ directly.)
 - **Deployed strategies are already risk-managed — don't prescribe a stop-loss they already have.** Every
   strategy deployed from a Senpi template runs a built-in DSL exit (trailing stop) + risk guard-rails,
   enforced every tick. Never tell a user to "add a 10–15% SL via `strategy_update`" on a deployed
-  strategy — it already has one. To *verify* protection, use the DSL coverage check (next section); never
-  infer "no stop" from the absence of a resting stop order (DSL exits are runtime-managed, not resting
-  orders).
+  strategy — it already has one. To *verify* protection, read `profile.dsl` (the ladder) + each
+  `positions[].dsl` (the live tier) — see "DSL — how it works per strategy, and which position is in
+  which tier"; never infer "no stop" from the absence of a resting stop order (DSL exits are
+  runtime-managed, not resting orders) or from a missing ratchet record (sub-Tier-1 positions have none).
 - **Always end with the two CTAs** (below), verbatim.
 
-## Are my positions protected? (stop-loss / DSL coverage)
+## DSL — how it works per strategy, and which position is in which tier
 
-When the user asks **"are my open positions protected? / do they have a stop-loss?"**, give the DSL
-coverage verdict per position — **PROTECTED / UNPROTECTED / STOP-NOT-ON-VENUE**. Key trap: an
-unprotected position shows up as an **absence** in `senpi dsl positions` (it lists only *tracked*
-positions), so you must **reconcile the open set against the tracked set** — an open position missing
-from `dsl positions` is UNPROTECTED. Full procedure:
-[`senpi-trading-runtime/references/dsl-protection-check.md`](../senpi-trading-runtime/references/dsl-protection-check.md).
+When the user asks about **their strategies' DSL** ("tell me about my strategies and their DSL," "are my
+open positions protected? / do they have a stop-loss?"), answer in **two parts, per strategy**:
+
+**(1) How its DSL works — the tier ladder.** Read the strategy's `profile.dsl` (also on each
+`strategy_groups[]` entry as `dsl` — surface it once per strategy). Parsed from the strategy's deployed
+`runtime.yaml` `exit.dsl_preset`, it has:
+- `hard_stop_roe_pct` — the **phase1 hard stop floor, active FROM ENTRY** (e.g. `-14` = the position is
+  cut if it hits −14% ROE). This protects every position **immediately, before any profit**.
+- `arm_at_roe_pct` — where the **phase2 profit-ratchet ARMS** (Tier 1, e.g. `+8%`). Below this the
+  ratchet hasn't engaged yet; the hard stop is still on.
+- `tiers[]` — the **profit-lock ladder**: `{trigger_pct, lock_hw_pct}` pairs. Read it as "arms at +8%,
+  locks 40% of the peak by +18%, 60% by +35%, 78% by +60%, 88% by +100%." `lock_hw_pct: 0` at Tier 1 =
+  priming only (arms the trail, no lock yet).
+- `has_phase2` — `false`/empty `tiers` ⟹ **phase1-only** (a hard stop, no profit ratchet). Say
+  "hard-stop protected, no profit-lock ratchet," not "unprotected."
+- **Named-string preset** (some strategies ship `dsl_preset: conviction`): `profile.dsl` is
+  `{preset_name, note}` — say "DSL preset: `conviction` (ladder managed by the runtime, not inlined)."
+  Still protected — never call a named preset "no DSL."
+
+**(2) Which OPEN position is in which tier — live.** Each open position carries a **`dsl`** object (live
+per-position ratchet state, from `ratchet_stop_list`):
+- **`armed: true`** → the position has crossed Tier 1; report **"Tier N, locked at L% of peak, high-water
+  +H% ROE"** from `tier_index` / `locked` / `high_water_roe` (`status` = `ACTIVE`/`PAUSED`/…).
+- **`armed: false`** → the position is **sub-Tier-1**: the profit-ratchet hasn't armed yet, but it is
+  **still protected from entry by the phase1 hard stop.** Report it that way — `note` already phrases it
+  ("protected from entry by the phase1 hard stop; profit-ratchet arms at Tier 1 (+X%) — currently +Y%").
+  Use `arm_at_roe_pct` + the position's `roe`: "protected, ratchet arms at +8% — currently at +6%."
+
+### HARD rule — NEVER say a live position has "no active DSL / no monitoring"
+
+This is the failure this section exists to prevent. An **empty ratchet record on a sub-Tier-1 position is
+NOT "unprotected"** — `ratchet_stop_list` only returns a record **once a position crosses Tier 1**, so a
+position at, say, +6% ROE correctly has **no ratchet record yet**. It is protected **two ways**: the
+phase1 hard stop (active from entry) and the phase2 ratchet that will arm at Tier 1. **Never read "no
+ratchet record" as "no DSL."** Say **"protected; profit-ratchet arms at Tier 1 (+X%)"** — never
+"unprotected / unmonitored / no stop." (The engine already frames every `armed: false` position this way
+in `dsl.note`; do not override it with an "unprotected" reading.)
+
+- **Config-level `protected` ≠ live per-position tier.** `strategy.protected` / `group.protected` (bool)
+  is the **config posture** — the strategy ships an `exit:` block (always true for template strategies).
+  It says "this strategy has a DSL exit," not which tier a given position sits in. The per-position tier
+  is the `dsl` object above. Report both: "cougar runs a DSL exit (hard stop −14%, ratchet from +8%);
+  its NVDA short is sub-Tier-1 at +6% — hard-stop protected, ratchet arms at +8%."
+- **`SL_TRIGGERED` is history, not current exposure.** A `SL_TRIGGERED` (or `MANUALLY_CLOSED` /
+  `LIQUIDATED`) record on a **closed** position means the DSL **did its job** — it locked profit / cut the
+  loss. Present it as history ("DSL locked profit on the ETH short last week"), never as current risk.
+- **Never infer "no stop" from the absence of a resting stop order.** DSL exits are **runtime-managed**,
+  not resting venue orders — you won't see them as open orders. Absence of a resting SL is expected and
+  says nothing about protection. Use the `dsl` objects, not the order book.
 
 ## How to run the engine
 
@@ -294,10 +342,15 @@ Returns `{totals, embedded_wallet, strategies, strategy_groups, exposure, signal
     / `direction` (catalog facets when present).
   - `mandate` — the strategy's declared job (its `profile.description`, else `belief_plain`); shared by
     all instances. Judge the whole strategy against this.
+  - `dsl` — the strategy's **DSL protection ladder** (how its DSL works), shared by all instances:
+    `hard_stop_roe_pct` / `arm_at_roe_pct` / `tiers[]` / `has_phase2`, or `{preset_name, note}` for a
+    named preset, or `null`. Surface it **once per strategy**; each open position's *live* tier is on
+    `positions[].dsl`. See "DSL — how it works per strategy" above.
   - `is_multi_wallet` (bool) — `true` when the strategy spans >1 wallet (long+short, core+ballast,
     multi-sleeve). When true, the wallets are legs of ONE design — see "A strategy is ALL its wallets."
   - `instances[]` — the per-wallet detail: `name` (= `runtime_name`, e.g. `ox-core`), `wallet`,
-    `wallet_short`, `account_value`, `idle_withdrawable`, `deployed`, `upnl`, `positions[]`, `closed`.
+    `wallet_short`, `account_value`, `idle_withdrawable`, `deployed`, `upnl`, `positions[]` (each with a
+    live `dsl` tier object), `closed`.
   - `totals` — summed across every instance: `account_value`, `idle_withdrawable`, `deployed`, `upnl`,
     and `realized_pnl` (when available). **Report the strategy's figures from here, not per-wallet.**
   - `protected` (bool) — `true` **only if ALL instances are protected** (a strategy with one unguarded
@@ -315,7 +368,12 @@ Returns `{totals, embedded_wallet, strategies, strategy_groups, exposure, signal
     load-bearing field is **`profile.description` — read from the strategy's DEPLOYED `runtime.yaml`**
     (the top-level folded `description:` the runtime registers), collapsed to a single line. Also from
     the runtime.yaml: `runtime_name`, `group`, `dsl_preset` (named preset string, or `true` for a
-    bespoke inline preset). Optional **catalog enrichment** (templates only, keyed by `skill_name`;
+    bespoke inline preset), and **`dsl`** — the parsed **DSL protection ladder** (how DSL works for this
+    strategy): `hard_stop_roe_pct` (phase1 floor, active from entry), `arm_at_roe_pct` (where the
+    profit-ratchet arms = Tier 1), `tiers[]` (`{trigger_pct, lock_hw_pct}` profit-lock ladder), and
+    `has_phase2`. For a **named-string preset** it's `{preset_name, note}` instead; `null` when the
+    `exit:` block has no `dsl_preset`. This is the CONFIG side — pair it with each position's live `dsl`
+    tier (see `positions[].dsl`). Optional **catalog enrichment** (templates only, keyed by `skill_name`;
     `null` for authored strategies): `belief_plain`, `thesis`, `archetype`, `sub_style`, `asset_classes`,
     `risk_level`, `time_horizon`, `tagline`. `profile.source` = `"registry"` / `"registry+catalog"` /
     `"catalog"`. **This is the yardstick — judge the strategy against `profile.description`, not memory
@@ -330,7 +388,15 @@ Returns `{totals, embedded_wallet, strategies, strategy_groups, exposure, signal
     `closed_time`). On a read failure `realized_pnl` is `null` and a `meta.warnings` entry is added —
     treat as "realized PnL unavailable," never as zero.
   - `positions[]` (asset, dex, direction, leverage, notional, margin, `upnl`, `return_on_equity_pct`,
-    `liq_px`, `market_24h_pct`, `vs_market`).
+    `liq_px`, `market_24h_pct`, `vs_market`, and **`dsl`** — the live per-position ratchet tier).
+    - **`dsl`** — this position's live DSL/ratchet state. **`armed: true`** → `tier_index`,
+      `high_water_roe`, `status`, `locked` (= `lock_hw_pct` at the active tier). **`armed: false`** (no
+      ratchet record — the position is sub-Tier-1) → `hard_stop_roe_pct`, `arm_at_roe_pct`, `roe`, and a
+      `note` that reads "protected from entry by the phase1 hard stop; profit-ratchet arms at Tier 1
+      (+X%) — currently +Y%." **`armed: false` means the profit-ratchet hasn't ARMED yet, NOT that the
+      position is unprotected** — the phase1 hard stop protects it from entry. Never present it as "no
+      DSL." If the ratchet read failed entirely, every position still gets this config-based `armed:
+      false` object (+ a `meta.warnings` note).
 - `exposure` — `net_notional_usd` + `net_bias`, gross long/short, `by_asset_net_usd`,
   `largest_position`.
 - `signals` — `idle_drag_pct` (how much capital isn't working), `deployed_pct`,
@@ -378,7 +444,13 @@ See "A strategy is ALL its wallets."
    4. **PnL — realized + unrealized, summed across the strategy.** The group's `totals.realized_pnl`
       and `totals.upnl` (+ a couple of `closed.recent[]` trades from its instances). A flat sleeve may
       have already banked real gains on the other sleeve.
-   5. **Protection posture.** The group's `protected` (⟹ **all** instances ship a DSL exit).
+   5. **DSL protection — ladder + live tiers.** State the group's `protected` posture (⟹ **all**
+      instances ship a DSL exit), then **how its DSL works** from `group.dsl` / `profile.dsl` (hard stop
+      at `hard_stop_roe_pct`, ratchet arms at `arm_at_roe_pct`, the tier ladder), then **each open
+      position's live tier** from `positions[].dsl` — "armed at Tier N, locked L% of peak" or, for a
+      sub-Tier-1 position, "protected from entry, ratchet arms at +X% — currently +Y%." **Never say a
+      live position has "no DSL" because it lacks a ratchet record** (sub-Tier-1 positions have none by
+      design). See "DSL — how it works per strategy, and which position is in which tier."
    6. **Any lever is WHOLE-STRATEGY.** If you suggest close / pause / adjust-config / top-up, it applies
       to the **entire strategy (all its wallets)** — never one sleeve. And the lever is the STRATEGY,
       not a hand-picked position the scanner will just re-open. See the HARD rule under "A strategy is

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -134,19 +134,82 @@ def _dsl_preset_summary(exit_block):
     return None, has_exit              # an `exit:` with no dsl_preset still counts as an exit
 
 
+def _dsl_ladder(exit_block):
+    """Parse the DSL PROTECTION LADDER from a runtime.yaml `exit:` block for reporting. Returns a dict
+    that says (a) HOW DSL works for this strategy and (b) the tier ladder — the config side of the
+    "protected from entry" story. NEVER raises; fail-open to None.
+
+    From `exit.dsl_preset`:
+      - inline mapping with phase1/phase2 →
+          {hard_stop_roe_pct: -phase1.max_loss_pct,      # the hard stop floor, active FROM ENTRY
+           arm_at_roe_pct: tiers[0].trigger_pct,          # Tier 1 = where the profit-ratchet ARMS
+           tiers: [{trigger_pct, lock_hw_pct}, …],        # the profit-lock ladder
+           has_phase2: bool}
+        If phase2 is absent/disabled → tiers: [], arm_at_roe_pct: null (phase1-only protection).
+        If phase1 is absent → hard_stop_roe_pct: null (rare; still report the ladder we have).
+      - a NAMED string preset ("conviction", …) → {preset_name: "<name>", note: "named preset — ladder
+        not inlined"} (the ladder lives in the runtime's preset table, not here).
+      - no dsl_preset (an `exit:` with none) → None.
+    """
+    if not isinstance(exit_block, dict):
+        return None
+    dp = exit_block.get("dsl_preset")
+    if isinstance(dp, str):
+        return {"preset_name": dp, "note": "named preset — ladder not inlined"}
+    if not isinstance(dp, dict) or not dp:
+        return None
+
+    p1 = dp.get("phase1") if isinstance(dp.get("phase1"), dict) else {}
+    p2 = dp.get("phase2") if isinstance(dp.get("phase2"), dict) else {}
+
+    # hard stop = the phase1 floor (active from entry). ROE floor is negative: -max_loss_pct.
+    hard = None
+    if p1 and p1.get("enabled") is not False:
+        ml = _num(p1.get("max_loss_pct"))
+        if ml is not None:
+            hard = -abs(ml)
+
+    # the profit-lock ratchet ladder (phase2). Present + enabled → parse the tiers; else empty ladder.
+    tiers, has_phase2, arm_at = [], False, None
+    if p2 and p2.get("enabled") is not False:
+        raw_tiers = p2.get("tiers")
+        if isinstance(raw_tiers, list):
+            for t in raw_tiers:
+                if not isinstance(t, dict):
+                    continue
+                trig = _num(t.get("trigger_pct"))
+                lock = _num(t.get("lock_hw_pct"))
+                tiers.append({"trigger_pct": trig, "lock_hw_pct": lock})
+        has_phase2 = bool(tiers)
+        if tiers and tiers[0].get("trigger_pct") is not None:
+            arm_at = tiers[0]["trigger_pct"]   # Tier 1 arms the trail (first trigger)
+
+    return {
+        "hard_stop_roe_pct": hard,       # e.g. -14.0 — floor, active FROM ENTRY (phase1)
+        "arm_at_roe_pct": arm_at,        # e.g. 8 — where the profit-ratchet ARMS (Tier 1), or null
+        "tiers": tiers,                  # the profit-lock ladder ([] when phase2 off)
+        "has_phase2": has_phase2,
+    }
+
+
 def _profile_from_runtime_yaml(text):
     """Parse one deployed runtime.yaml TEXT into the universal profile fields. Returns a dict (possibly
     partial) or None if the text doesn't parse to a mapping. Never raises."""
     doc = _yaml_loads(text)
     if not isinstance(doc, dict):
         return None
-    dsl_preset, has_exit = _dsl_preset_summary(doc.get("exit"))
+    exit_block = doc.get("exit")
+    dsl_preset, has_exit = _dsl_preset_summary(exit_block)
     return {
         "runtime_name": doc.get("name"),
         "group": doc.get("group"),
         "version": doc.get("version"),
         "description": _collapse_ws(doc.get("description")),   # the UNIVERSAL "what it does / how it works"
         "dsl_preset": dsl_preset,
+        # The DSL protection LADDER — how DSL works for this strategy: phase1 hard-stop floor (active
+        # FROM ENTRY) + the phase2 profit-lock tiers. Reported per strategy; the per-position tier state
+        # comes live from ratchet_stop_list (see hydrate). None when there's no dsl_preset to parse.
+        "dsl": _dsl_ladder(exit_block),
         "has_exit": bool(has_exit),
     }
 
@@ -220,7 +283,7 @@ def _merge_profile(registry_prof, catalog_facets):
     if not registry_prof and not catalog_facets:
         return None
     prof = {
-        "description": None, "runtime_name": None, "group": None, "dsl_preset": None,
+        "description": None, "runtime_name": None, "group": None, "dsl_preset": None, "dsl": None,
         "belief_plain": None, "thesis": None, "archetype": None, "sub_style": None,
         "asset_classes": None, "risk_level": None, "time_horizon": None, "tagline": None,
         "source": None,
@@ -230,6 +293,7 @@ def _merge_profile(registry_prof, catalog_facets):
         prof["runtime_name"] = registry_prof.get("runtime_name")
         prof["group"] = registry_prof.get("group")
         prof["dsl_preset"] = registry_prof.get("dsl_preset")
+        prof["dsl"] = registry_prof.get("dsl")   # the DSL protection ladder (how DSL works for this strat)
     if catalog_facets:
         for k in ("belief_plain", "thesis", "archetype", "sub_style", "asset_classes",
                   "risk_level", "time_horizon", "tagline"):
@@ -312,7 +376,7 @@ class _FixtureClient:
         self._r = recorded
 
     def mcp_call(self, tool, timeout=12, **kw):
-        for keyer in ("strategy_wallet", "trader_address", "asset"):
+        for keyer in ("strategy_wallet", "strategy_wallet_address", "trader_address", "strategyId", "asset"):
             if kw.get(keyer):
                 k = f"{tool}::{str(kw[keyer]).lower()}"
                 if k in self._r:
@@ -421,6 +485,9 @@ def fetch_strategies(client, meta):
         strategies.append({
             "name": _field(s, "tradingStrategyName", "name", default="strategy"),
             "wallet": wallet,
+            # strategyId — needed for the live per-position DSL/ratchet lookup (ratchet_stop_list keys
+            # on strategyId + wallet). Kept off the presentation surface; used only by hydrate().
+            "strategy_id": _field(s, "id", "strategyId", "strategy_id"),
             "status": _field(s, "status", default="ACTIVE"),
             "total_funded": _f(s, "totalFunded", "total_funded", default=None),
             "total_withdrawn": _f(s, "totalWithdrawn", "total_withdrawn", default=None),
@@ -485,6 +552,10 @@ def fetch_strategies(client, meta):
         strat["account_value"] = round(shared_idle + deployed, 2)  # = main.av + xyz.av − shared_idle
         strat["position_margin"] = round(sum(p["margin"] for p in positions), 2)   # initial margin detail
         strat["positions"] = positions
+        # LIVE per-position DSL/ratchet tier — read-guarded + fail-open. Attaches a `dsl` object to each
+        # open position (armed → tier/lock; not armed → "protected from entry, ratchet arms at +X%").
+        # NEVER leaves a live position looking "unprotected." (See attach_position_dsl.)
+        attach_position_dsl(client, strat, meta)
         strat["closed"] = fetch_closed(client, strat["wallet"], meta)
         return strat
 
@@ -536,6 +607,108 @@ def fetch_closed(client, wallet, meta):
                 "closed_time": _field(p, "closeTime", "closed_time", "closeTimeMs"),
             })
     return {"realized_pnl": round(realized_total, 2), "trade_count": len(rows), "recent": recent}
+
+
+# ──────────────────────────────────────────────────────────────── live per-position DSL / ratchet tier
+def _locked_pct_at_tier(ladder, tier_index):
+    """The lock_hw_pct configured at `tier_index` in the parsed profile.dsl ladder (what % of the peak
+    is locked once the ratchet reaches that tier). None if the ladder/index isn't available."""
+    if not isinstance(ladder, dict):
+        return None
+    tiers = ladder.get("tiers")
+    if not isinstance(tiers, list) or tier_index is None:
+        return None
+    try:
+        i = int(tier_index)
+    except (TypeError, ValueError):
+        return None
+    if 0 <= i < len(tiers) and isinstance(tiers[i], dict):
+        return tiers[i].get("lock_hw_pct")
+    return None
+
+
+def _unarmed_dsl(ladder, roe):
+    """The DSL object for an open position that has NOT yet crossed Tier 1 (no ratchet record). This is
+    the WHOLE POINT of the fix: an empty ratchet record is NOT "no DSL / unprotected" — the phase1 hard
+    stop protects the position FROM ENTRY, and the profit-ratchet simply hasn't ARMED yet. Frame it that
+    way, NEVER as unmonitored. `ladder` = the strategy's profile.dsl (config); `roe` = this position's
+    return_on_equity_pct. Stands alone even if the live ratchet call failed (config + ROE only)."""
+    ladder = ladder if isinstance(ladder, dict) else {}
+    hard = ladder.get("hard_stop_roe_pct")
+    arm = ladder.get("arm_at_roe_pct")
+    obj = {
+        "armed": False,
+        "hard_stop_roe_pct": hard,        # floor active FROM ENTRY (phase1) — always protecting
+        "arm_at_roe_pct": arm,            # where the profit-ratchet ARMS (Tier 1)
+        "roe": roe,                       # this position's current ROE
+    }
+    # A plain-language note the narrator can lean on — never reads as "unprotected."
+    if arm is not None:
+        roe_txt = f"+{roe}%" if (roe is not None and roe >= 0) else (f"{roe}%" if roe is not None else "n/a")
+        floor_txt = f"; hard stop at {hard}% ROE" if hard is not None else ""
+        obj["note"] = (f"protected from entry by the phase1 hard stop{floor_txt}; profit-ratchet arms at "
+                       f"Tier 1 (+{arm}%) — currently {roe_txt}")
+    elif hard is not None:
+        obj["note"] = (f"protected from entry by the phase1 hard stop (floor {hard}% ROE); "
+                       f"phase1-only preset — no profit-ratchet tiers")
+    else:
+        obj["note"] = ("protected by the strategy's DSL exit from entry; live ratchet tier not yet armed")
+    return obj
+
+
+def attach_position_dsl(client, strat, meta):
+    """Attach a `dsl` object to each open position of ONE strategy instance — its LIVE ratchet tier state.
+
+    Read-guarded + FAIL-OPEN. One `ratchet_stop_list(strategyId, wallet, status:ACTIVE)` call per
+    instance, indexed by asset:
+      - a record exists (position crossed Tier 1) → armed: true, tier_index, high_water_roe, status,
+        locked (= lock_hw_pct at that tier from the parsed ladder).
+      - NO record (sub-Tier-1) → the `_unarmed_dsl` object: armed: false + the "protected from entry,
+        ratchet arms at +X%" framing. This is EXPECTED, not a gap — never "unprotected."
+      - the ratchet call fails entirely → EVERY position still gets the config-based `_unarmed_dsl`
+        object (config + ROE stands alone), plus a meta.warnings note.
+    NEVER emits anything that reads as "no DSL / no monitoring."
+    """
+    positions = strat.get("positions") or []
+    if not positions:
+        return
+    prof = strat.get("profile") or {}
+    ladder = prof.get("dsl")
+    sid = strat.get("strategy_id")
+    wallet = strat.get("wallet")
+
+    records = None
+    try:
+        rl = _ok(client.mcp_call("ratchet_stop_list", strategyId=sid,
+                                 strategy_wallet_address=wallet, status="ACTIVE", timeout=15))
+        rows = rl if isinstance(rl, list) else _field(rl, "configs", "ratchetStops", "data", "items", default=[])
+        records = {}
+        for r in (rows if isinstance(rows, list) else []):
+            if not isinstance(r, dict):
+                continue
+            asset = _field(r, "asset", "coin")
+            if asset:
+                records[str(asset)] = r
+    except Exception as e:  # noqa — fail-open: config-based framing stands alone
+        meta.setdefault("warnings", []).append(
+            f"ratchet_stop_list {str(wallet)[:8]} failed: {e}; DSL tier from config only")
+        records = None
+
+    for p in positions:
+        roe = p.get("return_on_equity_pct")
+        rec = records.get(str(p.get("asset"))) if isinstance(records, dict) else None
+        if rec is not None:
+            ti = _field(rec, "currentTierIndex", "current_tier_index")
+            p["dsl"] = {
+                "armed": True,
+                "tier_index": ti,
+                "high_water_roe": _field(rec, "highWaterRoe", "high_water_roe"),
+                "status": _field(rec, "status", default="ACTIVE"),
+                "locked": _locked_pct_at_tier(ladder, ti),   # lock_hw_pct at the active tier
+            }
+        else:
+            # no ratchet record (sub-Tier-1) OR the list call failed — either way, config-based framing
+            p["dsl"] = _unarmed_dsl(ladder, roe)
 
 
 # ──────────────────────────────────────────────────────────────── market context (for analysis)
@@ -742,6 +915,10 @@ def group_strategies(strategies, meta):
             "archetype_label": prof.get("archetype_label"),
             "direction": prof.get("direction"),
             "mandate": mandate,                                 # the strategy's declared job (shared)
+            # HOW the strategy's DSL works — the phase1 hard-stop floor + phase2 tier ladder, shared by
+            # every instance (one config per strategy). Surfaced once here; per-position tier state lives
+            # on each position's `dsl` object. None for a named-preset/no-phase2 strategy handled inline.
+            "dsl": prof.get("dsl"),
             "is_multi_wallet": len(insts) > 1,
             "instances": instances,                             # per-wallet detail
             "totals": totals,                                   # summed across all wallets

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -236,6 +236,167 @@ def test_single_wallet_strategy_is_one_instance_group():
     assert res["meta"]["has_multi_wallet_strategy"] is False
 
 
+def test_dsl_ladder_parses_from_runtime_yaml():
+    """(1) HOW DSL works: the kodiak registry runtime.yaml has a real phase1+phase2 dsl_preset; the
+    engine parses profile.dsl into a hard-stop floor + arm-at + the full tier ladder — the CONFIG side of
+    the "protected from entry" story. (kodiak ships phase1.max_loss_pct 15 → -15, tiers[0].trigger 10.)"""
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"portfolio": {
+            "total_balance_usd": 200, "total_withdrawable": 200,
+            "total_in_hyperliquid": 0, "token_balances": []}},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "kodiak", "strategyWalletAddress": KODIAK_WALLET, "status": "ACTIVE"}]},
+        f"strategy_get_clearinghouse_state::{KODIAK_WALLET.lower()}": {
+            "main": {"marginSummary": {"accountValue": "200"}, "withdrawable": "200", "assetPositions": []},
+            "xyz": {"marginSummary": {"accountValue": "200"}, "withdrawable": "200", "assetPositions": []}},
+    }
+    old = os.environ.get("SENPI_STATE_DIR")
+    os.environ["SENPI_STATE_DIR"] = REGISTRY_DIR
+    try:
+        res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    finally:
+        if old is None:
+            os.environ.pop("SENPI_STATE_DIR", None)
+        else:
+            os.environ["SENPI_STATE_DIR"] = old
+    dsl = {s["name"]: s for s in res["strategies"]}["kodiak"]["profile"]["dsl"]
+    assert dsl is not None
+    assert dsl["hard_stop_roe_pct"] == -15.0        # phase1.max_loss_pct 15 → the hard floor
+    assert dsl["arm_at_roe_pct"] == 10              # tiers[0].trigger_pct — where the ratchet ARMS
+    assert dsl["has_phase2"] is True
+    assert len(dsl["tiers"]) == 5
+    assert dsl["tiers"][1] == {"trigger_pct": 18, "lock_hw_pct": 40}   # tiers parse fully
+    # the group surfaces the ladder once per strategy too
+    assert res["strategy_groups"][0]["dsl"]["arm_at_roe_pct"] == 10
+
+
+def test_dsl_ladder_parses_cougar_short_repo_yaml():
+    """Ground-truth check on the actual deployed cougar/short/runtime.yaml in the repo: profile.dsl has
+    hard_stop -14, arm-at 8, and the exact 5-tier ladder (the example from the task spec)."""
+    path = os.path.join(REPO_ROOT, "strategies", "cougar", "short", "runtime.yaml")
+    with open(path) as f:
+        prof = portfolio._profile_from_runtime_yaml(f.read())
+    dsl = prof["dsl"]
+    assert dsl["hard_stop_roe_pct"] == -14.0
+    assert dsl["arm_at_roe_pct"] == 8
+    assert [t["trigger_pct"] for t in dsl["tiers"]] == [8, 18, 35, 60, 100]
+    assert [t["lock_hw_pct"] for t in dsl["tiers"]] == [0, 40, 60, 78, 88]
+
+
+def test_named_preset_dsl_is_reported_not_dropped():
+    """A NAMED string preset ("conviction", from the cougar registry fixture) → profile.dsl records the
+    preset name + a note, never None — the ladder just isn't inlined in the runtime.yaml."""
+    with open(os.path.join(REGISTRY_COUGAR_DIR, "installed_runtimes.json")) as f:
+        reg = json.load(f)
+    text = reg["runtimes"][0]["runtimeYamlContent"]
+    prof = portfolio._profile_from_runtime_yaml(text)
+    assert prof["dsl"] == {"preset_name": "conviction", "note": "named preset — ladder not inlined"}
+
+
+def test_live_position_dsl_armed_and_unarmed():
+    """(2) WHICH open position is in WHICH tier — the core fix.
+
+    Two open positions on a kodiak-style strategy:
+      - SOL: a LIVE ratchet record at tier 2 → dsl.armed True, tier_index 2, locked = lock_hw_pct at
+        tier 2 (from the parsed ladder = 40).
+      - ETH: NO ratchet record (sub-Tier-1) → dsl.armed False, but framed as PROTECTED from entry with
+        the arm-at note — NEVER a falsy/'none' that reads as unprotected.
+    ratchet_stop_list is keyed by wallet in the fixture (the engine calls it with strategy_wallet_address)."""
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"portfolio": {
+            "total_balance_usd": 500, "total_withdrawable": 100,
+            "total_in_hyperliquid": 0, "token_balances": []}},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "kodiak", "id": "strat-kodiak-1",
+             "strategyWalletAddress": KODIAK_WALLET, "status": "ACTIVE"}]},
+        f"strategy_get_clearinghouse_state::{KODIAK_WALLET.lower()}": {
+            "main": {"marginSummary": {"accountValue": "500"}, "withdrawable": "100", "assetPositions": [
+                # SOL: deep in profit, has crossed Tier 1 → will get a live ratchet record
+                {"position": {"coin": "SOL", "szi": 3.0, "positionValue": 600, "marginUsed": 120,
+                              "entryPx": 150, "unrealizedPnl": 40, "returnOnEquity": 0.33,
+                              "leverage": {"value": 5}, "liquidationPx": 90}},
+                # ETH: only +6% ROE, sub-Tier-1 → NO ratchet record, must still read as protected
+                {"position": {"coin": "ETH", "szi": 0.2, "positionValue": 400, "marginUsed": 100,
+                              "entryPx": 1700, "unrealizedPnl": 6, "returnOnEquity": 0.06,
+                              "leverage": {"value": 4}, "liquidationPx": 1300}}]},
+            "xyz": {"marginSummary": {"accountValue": "100"}, "withdrawable": "100", "assetPositions": []}},
+        # LIVE ratchet state — only SOL has crossed Tier 1 (tier 2 = 35% trigger). ETH is absent BY DESIGN.
+        f"ratchet_stop_list::{KODIAK_WALLET.lower()}": {"configs": [
+            {"asset": "SOL", "status": "ACTIVE", "currentTierIndex": 2, "highWaterRoe": 36.5}]},
+    }
+    old = os.environ.get("SENPI_STATE_DIR")
+    os.environ["SENPI_STATE_DIR"] = REGISTRY_DIR
+    try:
+        res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    finally:
+        if old is None:
+            os.environ.pop("SENPI_STATE_DIR", None)
+        else:
+            os.environ["SENPI_STATE_DIR"] = old
+
+    pos = {p["asset"]: p for p in {s["name"]: s for s in res["strategies"]}["kodiak"]["positions"]}
+
+    # SOL — armed at the live tier, with the locked % pulled from the parsed ladder (tier 2 → 60 for kodiak)
+    sol = pos["SOL"]["dsl"]
+    assert sol["armed"] is True
+    assert sol["tier_index"] == 2
+    assert sol["high_water_roe"] == 36.5
+    assert sol["status"] == "ACTIVE"
+    assert sol["locked"] == 60          # lock_hw_pct at kodiak tier 2 (tiers = 20/40/60/75/88)
+
+    # ETH — NO ratchet record, but NEVER unprotected: armed False + the arm-at framing, and the note
+    # must read as PROTECTED, not as a gap.
+    eth = pos["ETH"]["dsl"]
+    assert eth["armed"] is False
+    assert eth["hard_stop_roe_pct"] == -15.0    # phase1 floor still protecting from entry
+    assert eth["arm_at_roe_pct"] == 10          # ratchet arms at Tier 1 (+10%)
+    assert eth["roe"] == 6.0                    # this position is at +6% — below the arm point
+    assert "protected from entry" in eth["note"]
+    low = eth["note"].lower()
+    assert "no dsl" not in low and "unprotected" not in low and "no monitoring" not in low
+
+
+def test_live_position_dsl_fails_open_when_ratchet_call_absent():
+    """If the ratchet_stop_list call returns nothing at all (no fixture entry → the engine's list read
+    yields no records), an open position STILL gets a config-based dsl object (armed False + arm-at
+    framing) that stands alone — never left looking unprotected."""
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"portfolio": {
+            "total_balance_usd": 500, "total_withdrawable": 100,
+            "total_in_hyperliquid": 0, "token_balances": []}},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "kodiak", "id": "strat-kodiak-1",
+             "strategyWalletAddress": KODIAK_WALLET, "status": "ACTIVE"}]},
+        f"strategy_get_clearinghouse_state::{KODIAK_WALLET.lower()}": {
+            "main": {"marginSummary": {"accountValue": "500"}, "withdrawable": "100", "assetPositions": [
+                {"position": {"coin": "SOL", "szi": 3.0, "positionValue": 600, "marginUsed": 120,
+                              "entryPx": 150, "unrealizedPnl": 40, "returnOnEquity": 0.33,
+                              "leverage": {"value": 5}, "liquidationPx": 90}}]},
+            "xyz": {"marginSummary": {"accountValue": "100"}, "withdrawable": "100", "assetPositions": []}},
+        # NOTE: no ratchet_stop_list::<wallet> fixture — the list call yields no records at all.
+    }
+    old = os.environ.get("SENPI_STATE_DIR")
+    os.environ["SENPI_STATE_DIR"] = REGISTRY_DIR
+    try:
+        res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    finally:
+        if old is None:
+            os.environ.pop("SENPI_STATE_DIR", None)
+        else:
+            os.environ["SENPI_STATE_DIR"] = old
+    sol = {s["name"]: s for s in res["strategies"]}["kodiak"]["positions"][0]["dsl"]
+    assert sol["armed"] is False
+    assert sol["hard_stop_roe_pct"] == -15.0
+    assert sol["arm_at_roe_pct"] == 10
+    assert "protected from entry" in sol["note"]
+
+
 def test_embedded_idle_reads_nested_total_in_hyperliquid():
     """Regression (the invisible-$10k bug): account_get_portfolio nests balances under a `portfolio`
     key and the idle-HL field is `total_in_hyperliquid` — NOT `total_usdc_in_hyperliquid`. The old code


### PR DESCRIPTION
From the live "tell me about my strategies and their DSL" run: the agent said *"no open positions have active DSL monitoring"* because `ratchet_stop_list` came back empty for the open positions. That's the **Tier-1 surfacing misread** — DSL protects every position **from entry** (the phase1 hard stop) and the phase2 ratchet only **surfaces a record once a position crosses Tier 1 (~8–10% ROE)**. A sub-Tier-1 position (NVDA short at +6%) is protected two ways yet has no ratchet record → read as "unprotected."

Now the engine surfaces the DSL so the agent narrates both things asked: **how DSL works per strategy** and **which position is in which tier.**

### Engine
- `profile.dsl` parsed from each deployed `runtime.yaml` `exit.dsl_preset`: `hard_stop_roe_pct` (phase1 floor, active from entry), `arm_at_roe_pct` (where the ratchet arms — Tier 1), and the `tiers[]` ladder. Named-string / phase1-only presets handled. Surfaced per strategy + per `strategy_groups[]`.
- Per open position `dsl` state via a read-guarded `ratchet_stop_list({strategyId, wallet, status:ACTIVE})` per instance: **armed** → `{tier_index, high_water_roe, locked}`; **sub-Tier-1** → `{armed:false, hard_stop_roe_pct, arm_at_roe_pct, roe, note:"protected from entry … arms at Tier 1 (+X%)"}`. Fail-open — never emits anything reading as "no DSL."

### SKILL.md (1.3.0 → 1.4.0)
- New DSL section: report **(1)** how each strategy's DSL works (hard stop + tier ladder) and **(2)** each open position's current tier (armed → "Tier N, locked L% of peak"; sub-Tier-1 → "protected from entry, ratchet arms at +X%, currently +Y%").
- **HARD rule: never say a live position has "no active DSL / no monitoring."** An empty ratchet record below Tier 1 means the profit-lock hasn't *armed* — the phase1 hard stop still protects it. `SL_TRIGGERED` on closed positions = history (the DSL did its job), not current exposure.

**18/18 tests** (5 new incl. armed tier-2, sub-Tier-1 framing, fail-open). MINOR bump → auto-upgrades users. Follows #432.