### PR TITLE
Streaming steps for portfolio / market-pulse / smart-money (same pattern as improve-trades)

### DIFF
--- a/senpi-market-pulse/README.md
+++ b/senpi-market-pulse/README.md
@@ -53,10 +53,16 @@ market thesis (proposes, never auto-builds).
 ## Run
 
 ```sh
-python3 scripts/pulse.py            # full live pull
+python3 scripts/pulse.py            # `all` (default): full live pull, one composed dict
+python3 scripts/pulse.py pulse      # step 1 — FAST core read (movers/groups/funding/signals); narrate first
+python3 scripts/pulse.py smart      # step 2 — smart-money overlay, layered on the persisted core read
 python3 scripts/pulse.py --no-smart # skip the leaderboard layer
 python3 scripts/pulse.py --fixture tests/fixtures/pulse_fixture.json   # offline (tests)
 ```
+
+Streamed reads run as fast, resumable **steps** (`pulse` → `smart`) over a shared state file
+(`<tempdir>/senpi-market-pulse/state.json`, `--state` to override) so no single `exec` call blows the
+timeout; `all` stays the one-shot fallback. See SKILL.md "Run it in steps."
 
 Env: `SENPI_AUTH_TOKEN`, `SENPI_MCP_URL` (defaults to prod).
 

--- a/senpi-market-pulse/SKILL.md
+++ b/senpi-market-pulse/SKILL.md
@@ -11,7 +11,7 @@ license: Apache-2.0
 compatibility: OpenClaw, Hyperclaw, Claude Code
 metadata:
   author: Senpi
-  version: "1.0.0"
+  version: "1.1.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -28,7 +28,10 @@ they couldn't get from a price screen on their own.
 
 - **Run the engine; never hand-pull the market.** `python3 scripts/pulse.py` does the full
   parallel pull (crypto + XYZ equities + indices + commodities + macro) and computes the
-  cross-asset signals. Read its JSON — don't fire `market_*` calls yourself.
+  cross-asset signals. Read its JSON — don't fire `market_*` calls yourself. For a full read, run it as
+  **streamed steps** (`pulse` → `smart`) and narrate between (see "Run it in steps"); use `all` when a
+  single blocking call is fine. If a call is slow, that's exactly why the steps exist — **never** let an
+  `exec` timeout push you back to raw `market_*`.
 - **Always cover every asset class.** Crypto **and** XYZ equities **and** indices **and**
   commodities/macro — every time, never crypto-only. The engine always returns all of them; your
   answer must too.
@@ -49,13 +52,15 @@ they couldn't get from a price screen on their own.
 
 ## How to run the engine
 
-Invoke via the `exec` tool:
+Invoke via the `exec` tool. Optional leading STEP (`pulse` · `smart` · `all`; default `all`):
 
 ```
-python3 scripts/pulse.py [--no-smart]
+python3 scripts/pulse.py pulse [--no-smart]   # 1. FAST core read: movers/groups/funding/signals (narrate first)
+python3 scripts/pulse.py smart                # 2. smart-money overlay, layered on the persisted core read
+python3 scripts/pulse.py all  [--no-smart]    # one-shot fallback: the full composed dict (same output as before)
 ```
 
-- Returns one JSON doc: `{day_classification, signals, groups, smart_money, meta}`.
+- `all` (the default with no step) returns one JSON doc: `{day_classification, signals, groups, smart_money, meta}`.
 - `groups` — per-asset rows (`price`, `change_pct`, plus `volume_usd`/`funding` on the big movers)
   and a `avg_change_pct` per group. Groups are pre-split by structure: `semis_memory`,
   `semis_equipment`, `semis_logic`, `software_megacap`, `crypto_proxy`, `indices`, `commodities`,
@@ -68,6 +73,47 @@ python3 scripts/pulse.py [--no-smart]
   pretend a class you couldn't read is fine.
 - The engine **fails open** — partial data still returns valid JSON. Work with what you got; flag
   what's missing.
+
+## Run it in steps — narrate as you go
+
+A full market read is several MCP round-trips (both dexes' instruments, the capped mover deep-pull,
+**and** the leaderboard / Hyperfeed layer). Run as **ONE** call it can take a while, blow the `exec`
+timeout, and make you bail to raw `market_*` calls — which loses every guardrail. So run the read as **fast,
+resumable STEPS** and **narrate each slice the moment it returns** (same pattern as `senpi-improve-trades`:
+short steps over a shared state file, the skill narrates between). Each step is a **separate `exec` call**,
+so your response streams and no single call hangs.
+
+```sh
+python3 scripts/pulse.py pulse    # 1. instruments + build_groups + compute_signals + mover deep-pull → movers/groups/funding/signals (FAST, narrate first)
+python3 scripts/pulse.py smart    # 2. the smart-money overlay (leaderboard/Hyperfeed) layered on the persisted core read
+python3 scripts/pulse.py all      # one-shot fallback: the full composed dict (byte-identical to before)
+```
+
+**For a FULL market read** — "what's happening today", "market overview / update", "give me a read" — run
+the two steps **in order** and narrate between:
+
+1. `pulse.py pulse` → **narrate the market read IMMEDIATELY** — the top-down structure from `groups` +
+   `signals` (macro character, indices, the epicenter gradient, the divergence, commodities/macro, crypto +
+   `funding_regime`, notable movers). Don't wait for the smart-money layer. This is the whole output
+   contract below **except** the smart-money note.
+2. `pulse.py smart` → narrate the **smart-money overlay** (`smart_money`: cohort concentration, top traders,
+   momentum events) — "the >$1M cohort is X% concentrated short HYPE and adding." If `smart_money` is null,
+   note "smart-money layer unavailable" once and move on.
+
+**Narrate each slice as it returns — never wait for both steps.** The steps share a state file
+(`<tempdir>/senpi-market-pulse/state.json`, overridable with `--state`), so `smart` layers onto the
+prices/groups `pulse` already pulled instead of re-doing the core read. **For a NARROW ask, run only the
+minimal step:**
+
+- *"what's moving / today's markets / funding regime / market overview"* → just **`pulse`** (the core read;
+  no smart-money round-trips).
+- *"what's smart money doing in the market / compare to the whales"* → **`smart`** (it self-heals the core
+  read if you skipped `pulse`), or compose **`senpi-smart-money`** for the deep trader-level whale read.
+
+`--no-smart` applies to every step (it makes `smart` a clean null overlay). Same fail-open contract as `all`:
+each step returns valid JSON with `meta.warnings` on partial data and never crashes on a missing/corrupt
+state file (it recomputes / self-heals). Keep **`all`** as the fallback when a single blocking call is fine —
+and all the golden rules + the two CTAs still apply to a stepped read.
 
 ## Output contract
 

--- a/senpi-market-pulse/scripts/pulse.py
+++ b/senpi-market-pulse/scripts/pulse.py
@@ -29,6 +29,7 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -340,13 +341,192 @@ def run(client, want_smart=True):
     }
 
 
+# ──────────────────────────────────────────────────────────────── shared state file (resumable steps)
+# The step subcommands (pulse → smart) are FAST, resumable slices that persist their work to a shared JSON
+# state file so the smart-money overlay never re-does the core market read. The agent runs them in sequence
+# and NARRATES between — no single call carries the whole multi-round-trip pull (which trips the exec timeout
+# and makes the agent bail to raw market_* calls, losing every guardrail). Each step is idempotent +
+# fail-open: a missing/corrupt state file → recompute (self-heal); each step also works STANDALONE (just
+# slower). `all` writes the same state but prints the full composed dict (byte-identical to the pre-steps
+# output of the untouched run()). State default: <tempdir>/senpi-market-pulse/state.json.
+STATE_SUBDIR = "senpi-market-pulse"
+
+
+def _default_state_path():
+    """Default shared-state path: <tempdir>/senpi-market-pulse/state.json. Uses tempfile.gettempdir()
+    (never $HOME) so it works on any host regardless of where the skill installs."""
+    return os.path.join(tempfile.gettempdir(), STATE_SUBDIR, "state.json")
+
+
+def _load_state(path):
+    """Read the shared state JSON. Never raises — a missing/corrupt/unreadable file → {} (fail-open: the
+    step then recomputes its prerequisites and self-heals)."""
+    if not path or not os.path.isfile(path):
+        return {}
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:  # noqa — corrupt/unreadable state is fail-open → recompute
+        return {}
+
+
+def _save_state(path, state):
+    """Merge-write the shared state JSON (best-effort; a write failure never sinks the step — the slice was
+    already printed to stdout). Creates the parent dir. Atomic-ish via a temp file + replace."""
+    if not path:
+        return
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "w") as fh:
+            json.dump(state, fh)
+        os.replace(tmp, path)
+    except Exception:  # noqa — persistence is best-effort; the printed slice is the contract
+        pass
+
+
+def _core_market_read(client, meta):
+    """The FAST core market read shared by `step_pulse` and the self-heal path: bulk instruments →
+    per-group rows/averages → concrete cross-asset signals, then a capped deep-pull of the biggest movers
+    (volume/funding conviction folded onto the rows + the funding_regime signal). Returns (prices, groups,
+    signals). This is exactly what run() does MINUS the smart-money layer, so pulse+smart reproduces all.
+    Fail-open throughout (each layer degrades to a meta flag, never an exception)."""
+    prices = fetch_instruments(client, meta)
+    groups = build_groups(prices)
+    signals = compute_signals(prices, groups)
+
+    # deep-pull the biggest movers for volume/funding conviction (capped) — same as run()
+    ranked = sorted(
+        ((a, p.get("change_pct")) for a, p in prices.items() if p.get("change_pct") is not None),
+        key=lambda x: abs(x[1]), reverse=True,
+    )
+    xyz_set = set(XYZ_ALL)
+    movers = [(a, a in xyz_set) for a, _ in ranked[:MOVER_DEEP_PULL]]
+    deep, regime = ({}, None)
+    if movers:
+        deep, regime = deep_pull_movers(client, movers, meta)
+    for g in groups.values():
+        for row in g["rows"]:
+            if row["asset"] in deep:
+                row.update({k: v for k, v in deep[row["asset"]].items() if v is not None})
+    signals["funding_regime"] = regime
+    return prices, groups, signals
+
+
+def _ensure_core_in_state(client, state, meta):
+    """Self-heal: return (prices, groups, signals) — from the state file when the `pulse` step already ran,
+    else recompute the core market read right here (so the `smart` step works STANDALONE). Merges the
+    recompute back into state + carries forward the warnings the fetch produced."""
+    prices = state.get("prices")
+    groups = state.get("groups")
+    signals = state.get("signals")
+    if isinstance(prices, dict) and isinstance(groups, dict) and isinstance(signals, dict):
+        meta["warnings"] = list(state.get("meta_warnings", []))
+        return prices, groups, signals
+    # state absent/partial → recompute the core slice (instruments + groups + signals + movers).
+    prices, groups, signals = _core_market_read(client, meta)
+    state["prices"] = prices
+    state["groups"] = groups
+    state["signals"] = signals
+    state["meta_warnings"] = meta.get("warnings", [])
+    return prices, groups, signals
+
+
+# ──────────────────────────────────────────────────────── step subcommands (fast, resumable, standalone)
+def step_pulse(client, want_smart=True, state_path=None):
+    """STEP 1 `pulse` — the FAST core market read the agent NARRATES FIRST: instruments + build_groups +
+    compute_signals + the capped deep-pull of movers (volume/funding conviction + funding_regime). Prints
+    ONLY its slice — {as_of, day_classification, signals, groups, meta} — plus `meta`. Persists prices +
+    groups + signals to state so the `smart` step layers on without re-pulling. NO smart-money layer here
+    (that's the heavier `smart` step). `want_smart` is accepted for a uniform step signature; ignored here."""
+    if state_path is None:
+        state_path = _default_state_path()
+    state = _load_state(state_path)
+    meta = {"warnings": []}
+    prices, groups, signals = _core_market_read(client, meta)
+    if not prices:
+        meta["degraded"] = "no price data — all instrument pulls failed"
+    state["prices"] = prices
+    state["groups"] = groups
+    state["signals"] = signals
+    state["meta_warnings"] = meta.get("warnings", [])
+    _save_state(state_path, state)
+    return {
+        "as_of": "live",
+        "day_classification": signals.get("day_classification"),
+        "signals": signals,
+        "groups": groups,
+        "meta": meta,
+    }
+
+
+def step_smart(client, want_smart=True, state_path=None):
+    """STEP 2 `smart` — the heavier smart-money OVERLAY (leaderboard / Hyperfeed layer), health-gated. Reads
+    the persisted prices/groups (or self-heals the core read if state is absent) and layers `fetch_smart_money`
+    onto it. Prints ONLY its slice — {smart_money, meta} (with meta.smart_money_available) — never re-computes
+    the movers/signals. `--no-smart` returns a clean null overlay. Fail-open: Hyperfeed down → smart_money null."""
+    if state_path is None:
+        state_path = _default_state_path()
+    state = _load_state(state_path)
+    meta = {"warnings": []}
+    # self-heal the core read so the held prices/groups exist (smart-money enriches on top of them).
+    _ensure_core_in_state(client, state, meta)
+    smart = fetch_smart_money(client, meta) if want_smart else None
+    meta["smart_money_available"] = smart is not None
+    state["smart_money"] = smart
+    state["meta_warnings"] = meta.get("warnings", [])
+    _save_state(state_path, state)
+    return {"smart_money": smart, "meta": meta}
+
+
 # ──────────────────────────────────────────────────────────────── CLI
+_STEPS = ("pulse", "smart", "all")
+_STEP_FNS = {"pulse": step_pulse, "smart": step_smart}
+
+
+def _all_and_persist(client, want_smart, state_path):
+    """`all` = the composed one-shot. Runs the UNCHANGED run() (its output is byte-identical to the pre-steps
+    engine) and ALSO writes the shared state file (same shape the steps build) so an `all` run can seed a
+    later `smart` step. The state write never alters the printed dict."""
+    result = run(client, want_smart=want_smart)
+    if state_path is None:
+        state_path = _default_state_path()
+    state = {
+        "prices": None,   # `all` doesn't retain the raw price map; the smart step self-heals by re-reading
+        "groups": result.get("groups"),
+        "signals": result.get("signals"),
+        "smart_money": result.get("smart_money"),
+        "meta_warnings": (result.get("meta") or {}).get("warnings", []),
+    }
+    _save_state(state_path, state)
+    return result
+
+
 def main(argv=None):
-    ap = argparse.ArgumentParser(description="senpi market-pulse engine (cross-asset snapshot + signals)")
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # optional leading positional STEP (pulse|smart|all); default `all` = the composed one-shot (unchanged
+    # output + shape). Parsed before argparse so the flags stay shared across every step.
+    step = "all"
+    if argv and not argv[0].startswith("-"):
+        cand = argv[0]
+        if cand not in _STEPS:
+            print(json.dumps({"groups": {}, "meta": {"error": f"unknown step {cand!r}; "
+                                                     f"expected one of {', '.join(_STEPS)}"}}))
+            return 1
+        step, argv = cand, argv[1:]
+
+    ap = argparse.ArgumentParser(
+        description="senpi market-pulse engine (cross-asset snapshot + signals). Optional leading STEP: "
+                    "pulse|smart|all (default all = the composed one-shot). Steps share a state file so the "
+                    "smart-money overlay doesn't re-do the core market read.")
     ap.add_argument("--no-smart", action="store_true", help="skip the leaderboard / smart-money layer")
+    ap.add_argument("--state", default=None,
+                    help="shared state file path (default <tempdir>/senpi-market-pulse/state.json)")
     ap.add_argument("--fixture", help="offline: path to a recorded MCP-response map (tests only)")
     ap.add_argument("--dry", action="store_true",
                     help="dump raw MCP responses (instruments both dexes + one asset) for schema debugging")
+    # `step` was already peeled off argv above; feed the remainder (flags only).
     args = ap.parse_args(argv)
 
     if args.dry:
@@ -380,8 +560,13 @@ def main(argv=None):
             print(json.dumps({"groups": {}, "meta": {"error": f"mcp client init failed: {e}"}}))
             return 1
 
+    want_smart = not args.no_smart
     try:
-        result = run(client, want_smart=not args.no_smart)
+        if step == "all":
+            result = _all_and_persist(client, want_smart, args.state)
+        else:
+            fn = _STEP_FNS[step]
+            result = fn(client, want_smart=want_smart, state_path=args.state)
     except Exception as e:  # noqa  — last-resort guard; the layer functions already fail open
         print(json.dumps({"groups": {}, "meta": {"error": f"engine failure: {e}"}}))
         return 1

--- a/senpi-market-pulse/tests/test_pulse.py
+++ b/senpi-market-pulse/tests/test_pulse.py
@@ -7,6 +7,7 @@
 import json
 import os
 import sys
+import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 SCRIPTS = os.path.join(HERE, "..", "scripts")
@@ -17,10 +18,18 @@ import pulse  # noqa: E402
 FIXTURE = os.path.join(HERE, "fixtures", "pulse_fixture.json")
 
 
-def _result():
+def _client():
     with open(FIXTURE) as f:
-        client = pulse._FixtureClient(json.load(f))
-    return pulse.run(client, want_smart=True)
+        return pulse._FixtureClient(json.load(f))
+
+
+def _result():
+    return pulse.run(_client(), want_smart=True)
+
+
+def _state_path():
+    """A fresh state-file path in a throwaway temp dir (the file itself does not exist yet)."""
+    return os.path.join(tempfile.mkdtemp(prefix="pulse-test-"), "state.json")
 
 
 def test_all_classes_present():
@@ -82,6 +91,74 @@ def test_fails_open_on_empty():
     res = pulse.run(pulse._FixtureClient({}), want_smart=True)
     assert "groups" in res and "meta" in res
     assert res["meta"].get("degraded")
+
+
+# ──────────────────────────────────────────────────────────── streaming steps (pulse · smart · all)
+def test_step_pulse_emits_only_its_slice():
+    """`pulse` = the FAST core market read: groups/signals/day_classification, NO smart_money key."""
+    p = pulse.step_pulse(_client(), want_smart=True, state_path=_state_path())
+    assert set(p.keys()) == {"as_of", "day_classification", "signals", "groups", "meta"}
+    assert "smart_money" not in p                       # the overlay is the separate `smart` step
+    assert p["day_classification"]["label"] == "risk_off"
+    assert p["groups"]["crypto"]["avg_change_pct"] is not None
+    assert p["signals"]["funding_regime"] == "neutral"  # movers were deep-pulled (funding regime folded in)
+
+
+def test_step_smart_emits_only_its_slice():
+    """`smart` = the heavier overlay: prints ONLY {smart_money, meta} (with smart_money_available)."""
+    s = pulse.step_smart(_client(), want_smart=True, state_path=_state_path())
+    assert set(s.keys()) == {"smart_money", "meta"}
+    assert s["meta"]["smart_money_available"] is True
+    assert s["smart_money"]["concentration"]["concentration"][0]["asset"] == "HYPE"
+
+
+def test_pulse_then_smart_reproduces_all():
+    """pulse → smart over the SHARED state file reproduces the composed `all` (core + overlay)."""
+    sp = _state_path()
+    p = pulse.step_pulse(_client(), want_smart=True, state_path=sp)
+    s = pulse.step_smart(_client(), want_smart=True, state_path=sp)   # reads the state pulse wrote
+    composed = {
+        "as_of": p["as_of"],
+        "day_classification": p["day_classification"],
+        "signals": p["signals"],
+        "groups": p["groups"],
+        "smart_money": s["smart_money"],
+    }
+    ref = pulse.run(_client(), want_smart=True)
+    assert composed == {k: ref[k] for k in composed}
+
+
+def test_all_is_byte_identical_to_run():
+    """`all` (via _all_and_persist) prints byte-for-byte what the untouched run() produced."""
+    ref = json.dumps(pulse.run(_client(), want_smart=True), ensure_ascii=False)
+    got = json.dumps(pulse._all_and_persist(_client(), True, _state_path()), ensure_ascii=False)
+    assert got == ref
+
+
+def test_smart_self_heals_on_absent_state():
+    """`smart` standalone (no prior `pulse`, empty state dir) self-heals the core read, still overlays."""
+    sp = _state_path()                                  # dir exists, state file does NOT
+    s = pulse.step_smart(_client(), want_smart=True, state_path=sp)
+    assert s["smart_money"] is not None                 # overlay still landed
+    st = json.load(open(sp))                            # and the recomputed core was persisted
+    assert "crypto" in (st.get("groups") or {})
+
+
+def test_step_fails_open_on_corrupt_state():
+    """A corrupt/unreadable state file → recompute (never crash); the slice is still valid."""
+    sp = _state_path()
+    with open(sp, "w") as fh:
+        fh.write("{ this is not valid json ]]]")
+    p = pulse.step_pulse(_client(), want_smart=True, state_path=sp)   # pulse overwrites the corrupt file
+    assert p["groups"]["crypto"]["avg_change_pct"] is not None
+    s = pulse.step_smart(_client(), want_smart=True, state_path=sp)
+    assert s["smart_money"] is not None
+
+
+def test_step_no_smart_yields_null_overlay():
+    """`smart --no-smart` returns a clean null overlay (available False), no exception."""
+    s = pulse.step_smart(_client(), want_smart=False, state_path=_state_path())
+    assert s["smart_money"] is None and s["meta"]["smart_money_available"] is False
 
 
 if __name__ == "__main__":

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -15,7 +15,7 @@ license: Apache-2.0
 compatibility: OpenClaw, Hyperclaw, Claude Code
 metadata:
   author: Senpi
-  version: "1.4.0"
+  version: "1.5.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -323,11 +323,62 @@ in `dsl.note`; do not override it with an "unprotected" reading.)
   not resting venue orders — you won't see them as open orders. Absence of a resting SL is expected and
   says nothing about protection. Use the `dsl` objects, not the order book.
 
+## Run it in steps — narrate as you go
+
+A full portfolio read is several MCP round-trips (embedded wallet + a live clearinghouse pull per strategy
+wallet + the live DSL/ratchet reads + the per-asset market fan-out). Run as **ONE** call it can take
+minutes, blow the `exec` timeout, and push you to raw MCP — which loses every guardrail. So run the read as
+**fast, resumable STEPS** and **narrate each slice the moment it returns** (this mirrors
+`senpi-improve-trades` / `senpi-strategy-ops` — short steps over a shared state file, the skill narrates
+between). Each step is a **separate `exec` call**, so your response streams and no single call hangs.
+
+```sh
+python3 scripts/portfolio.py money        # 1. the FAST money map: embedded idle + each wallet's value → the three buckets (narrate FIRST)
+python3 scripts/portfolio.py strategies   # 2. per-strategy detail: mandate + DSL ladder + protected + closed/realized + strategy_groups[]
+python3 scripts/portfolio.py positions    # 3. position-level: per-position market (market_24h_pct/vs_market) + exposure + signals
+python3 scripts/portfolio.py all          # one-shot fallback: the full composed dict (same output as before)
+```
+
+**For a FULL portfolio read** — "analyze my portfolio / my strategies", "how am I doing" — run the steps
+**in order** and narrate between:
+
+1. `portfolio.py money` → **narrate the money map IMMEDIATELY** — `grand_total_usd` broken into the three
+   buckets (idle-in-embedded / idle-in-strategies / deployed-in-positions), each labeled by *where*, plus
+   `reconciles`. Don't wait for the other steps.
+2. `portfolio.py strategies` → narrate the **per-strategy verdict** — lead from `strategy_groups[]` (a
+   strategy is ALL its wallets), each judged vs its OWN `mandate`, its `protected` posture + `dsl` ladder,
+   realized/unrealized PnL as evidence.
+3. `portfolio.py positions` → narrate the **position-level read** — each position vs the market
+   (`market_24h_pct`, `vs_market`, leveraged return), then `exposure` (net bias, concentration) + `signals`
+   (idle drag).
+
+**Narrate each slice as it returns — never wait for all steps.** The steps share a state file
+(`<tempdir>/senpi-portfolio/state.json`, overridable with `--state`), so a later step reuses what an earlier
+one fetched instead of re-pulling. **For a NARROW ask, run only the minimal step:**
+
+| The ask | Step to run |
+|---|---|
+| *"how much idle / where's my money / balance across wallets / grand total"* | `money` |
+| *"are my strategies protected? / do they have a stop-loss? / how are my strategies doing / analyze my strategies / what's their DSL / mandate"* | `strategies` |
+| *"analyze my positions / my positions vs the market / net exposure / concentration / idle drag"* | `positions` |
+| *"analyze my portfolio / how am I doing"* (the full read) | `money` → `strategies` → `positions`, narrating between |
+
+`--no-market` applies to every step (skips the `positions` market fan-out). Same fail-open contract as
+`all`: each step returns valid JSON with `meta.warnings` on partial data and **never crashes on a
+missing/corrupt state file** (it self-heals by recomputing its prerequisites — every step also works
+STANDALONE, just slower). Keep `all` as the one-shot fallback when a single blocking call is fine; every
+existing guardrail (the three-bucket taxonomy, `protected`, the mandate reads, multi-wallet grouping, the
+DSL ladder + live tiers) holds identically across the steps and `all`.
+
 ## How to run the engine
 
 ```
-python3 scripts/portfolio.py [--no-market]
+python3 scripts/portfolio.py [money|strategies|positions|all] [--no-market] [--state PATH]
 ```
+
+`all` is the default when no step is given — it composes every slice into one dict (the same output the
+engine always produced). Prefer the **steps** above for a full read (they stream and don't trip the
+timeout); use `all` only when a single blocking call is fine.
 
 Returns `{totals, embedded_wallet, strategies, strategy_groups, exposure, signals, meta}`:
 - `totals` — the three buckets + `grand_total_usd`, `unrealized_pnl`, and a `reconciles` flag (cross-

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -30,6 +30,7 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 MARKET_ENRICH_CAP = 24      # cap the per-asset market pull
@@ -962,6 +963,272 @@ def run(client, want_market=True):
     }
 
 
+# ──────────────────────────────────────────────────────────── shared state file (resumable steps)
+# The step subcommands (money → strategies → positions) are FAST, resumable slices that persist their work
+# to a shared JSON state file so a later step never re-fetches what an earlier one already pulled. The
+# agent runs them in sequence and NARRATES between — no single call carries the whole multi-wallet pull
+# (which trips the exec timeout and pushes the agent to raw MCP, losing every guardrail). Each step is
+# idempotent + fail-open: a missing/corrupt state file → recompute (self-heal); every step also works
+# STANDALONE (just slower). `all` writes the same state but prints run()'s full composed dict
+# (byte-identical to the pre-steps output). State default: <tempdir>/senpi-portfolio/state.json.
+STATE_SUBDIR = "senpi-portfolio"
+
+
+def _default_state_path():
+    """Default shared-state path <tempdir>/senpi-portfolio/state.json. Uses tempfile.gettempdir()
+    (never $HOME — the state dir may live somewhere else on a runtime host)."""
+    return os.path.join(tempfile.gettempdir(), STATE_SUBDIR, "state.json")
+
+
+def _load_state(path):
+    """Read the shared state JSON. Never raises — a missing/corrupt/unreadable file → {} (fail-open: the
+    step then recomputes its prerequisites and self-heals)."""
+    if not path or not os.path.isfile(path):
+        return {}
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:  # noqa — corrupt/unreadable state is fail-open → recompute
+        return {}
+
+
+def _save_state(path, state):
+    """Merge-write the shared state JSON (best-effort; a write failure never sinks the step — the slice was
+    already printed to stdout). Creates the parent dir. Atomic-ish via a temp file + replace."""
+    if not path:
+        return
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "w") as fh:
+            json.dump(state, fh)
+        os.replace(tmp, path)
+    except Exception:  # noqa — persistence is best-effort; the printed slice is the contract
+        pass
+
+
+def _fresh_meta():
+    """A meta skeleton seeded like run()'s — the same real_time/force_fetch scaffolding, so every step's
+    meta reads consistently whether it ran standalone or off state."""
+    return {"warnings": [], "real_time": True, "force_fetch": True}
+
+
+# ─────────────────────────────────────────── money-lite hydrate (fast bucket math, no positions detail)
+def _hydrate_money(client, strat, meta):
+    """The FAST per-strategy money pull for the `money` step: ONE strategy_get_clearinghouse_state call
+    per wallet → account_value / idle_withdrawable / deployed ONLY. This is exactly the bucket math from
+    fetch_strategies.hydrate (the shared-idle de-dup across the main+xyz views), WITHOUT the positions
+    detail, the live DSL/ratchet pull, the closed-history read, or the market enrichment — those are the
+    slow parts and belong to the `strategies`/`positions` steps. Fail-open: a read error leaves the
+    strategy money-less + a meta.warnings note, never crashes."""
+    try:
+        ch = _ok(client.mcp_call("strategy_get_clearinghouse_state", strategy_wallet=strat["wallet"], timeout=20))
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"clearinghouse {strat['wallet'][:8]} failed: {e}")
+        return strat
+    dex_av, dex_wd = {}, {}
+    for dex in ("main", "xyz"):
+        d = _field(ch, dex, default={}) if isinstance(ch, dict) else {}
+        ms = _field(d, "marginSummary", "margin_summary", default={}) or {}
+        dex_av[dex] = _f(ms, "accountValue", "account_value", default=0.0)
+        dex_wd[dex] = _f(d, "withdrawable", default=0.0)
+    # main + xyz are two VIEWS of ONE wallet — `withdrawable` is the SHARED idle, mirrored in both; count
+    # it ONCE (see fetch_strategies.hydrate for the full derivation). deployed = each DEX's own position
+    # equity (accountValue − shared idle), summed. wallet_value = main.av + xyz.av − shared_idle.
+    shared_idle = max(dex_wd.get("main", 0.0), dex_wd.get("xyz", 0.0))
+    deployed = sum(max(0.0, dex_av.get(dex, 0.0) - shared_idle) for dex in ("main", "xyz"))
+    strat["idle_withdrawable"] = round(shared_idle, 2)
+    strat["deployed"] = round(deployed, 2)
+    strat["account_value"] = round(shared_idle + deployed, 2)
+    return strat
+
+
+def fetch_strategy_money(client, meta):
+    """The FAST money-map strategy fetch: enumerate ACTIVE strategies (same strategy_list call + wallet
+    extraction as fetch_strategies) and money-lite-hydrate each wallet in parallel. Returns lightweight
+    strategy rows carrying name / wallet / strategy_id / status / total_funded / total_withdrawn plus the
+    account_value / idle_withdrawable / deployed money fields — NO profile / dsl / protected / positions /
+    closed (those are the `strategies` step). Deliberately DOES NOT read the runtime registry or catalog
+    (both are for the mandate read, not the money map). Fail-open: []. Mirrors fetch_strategies' skeleton
+    so the two agree on the wallet set + the bucket math."""
+    try:
+        sl = _ok(client.mcp_call("strategy_list", status=["ACTIVE"], timeout=20))
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"strategy_list failed: {e}")
+        return []
+    rows = sl if isinstance(sl, list) else _field(sl, "strategies", "data", default=[])
+    strategies = []
+    for s in (rows or []):
+        wallet = _field(s, "strategyWalletAddress", "strategy_wallet_address", "walletAddress")
+        if not wallet:
+            continue
+        strategies.append({
+            "name": _field(s, "tradingStrategyName", "name", default="strategy"),
+            "wallet": wallet,
+            "strategy_id": _field(s, "id", "strategyId", "strategy_id"),
+            "status": _field(s, "status", default="ACTIVE"),
+            "total_funded": _f(s, "totalFunded", "total_funded", default=None),
+            "total_withdrawn": _f(s, "totalWithdrawn", "total_withdrawn", default=None),
+        })
+    try:
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(max_workers=6) as ex:
+            strategies = list(ex.map(lambda s: _hydrate_money(client, s, meta), strategies))
+    except Exception:  # noqa — fail-open to sequential
+        strategies = [_hydrate_money(client, s, meta) for s in strategies]
+    return strategies
+
+
+def _money_totals(embedded, strategies, portfolio_totals):
+    """The three-bucket money map — the SAME classification compute() does, over money-lite strategy rows
+    (which carry idle_withdrawable / deployed / account_value). idle_in_embedded / idle_in_strategies /
+    deployed_in_positions + grand_total_usd + reconciles. No exposure/signals here (those need the full
+    positions detail — the `positions` step)."""
+    idle_strat = round(sum(_num(s.get("idle_withdrawable")) or 0.0 for s in strategies), 2)
+    deployed = round(sum(_num(s.get("deployed")) or 0.0 for s in strategies), 2)
+    idle_emb = embedded.get("idle_total") or 0.0
+    strat_acct = round(sum(_num(s.get("account_value")) or 0.0 for s in strategies), 2)
+    grand_total = round(idle_emb + strat_acct, 2)
+    totals = {
+        "grand_total_usd": grand_total,
+        "idle_in_embedded": round(idle_emb, 2),
+        "idle_in_strategies": idle_strat,
+        "deployed_in_positions": deployed,
+        "strategy_account_value": strat_acct,
+        "portfolio_total_balance_usd": portfolio_totals.get("total_balance_usd"),
+        "portfolio_total_withdrawable": portfolio_totals.get("total_withdrawable"),
+    }
+    pbal = portfolio_totals.get("total_balance_usd")
+    totals["reconciles"] = (pbal is None) or (abs(pbal - grand_total) <= max(2.0, 0.01 * grand_total))
+    return totals
+
+
+# ─────────────────────────────────────────────── self-heal: full strategies[] in state (for step 2 / 3)
+def _ensure_full_strategies_in_state(client, state, want_market, meta):
+    """Return the FULLY-hydrated strategies[] (positions + DSL + closed + profile/mandate) — from the state
+    file when the `strategies` step already ran, else recompute the full fetch right here (so the
+    `strategies` and `positions` steps each work STANDALONE). Also rehydrates the embedded wallet +
+    portfolio totals from state (or re-fetches). Merges its work back into state for the next step.
+    Returns (embedded, strategies, portfolio_totals)."""
+    embedded = state.get("embedded_wallet")
+    portfolio_totals = state.get("portfolio_totals")
+    strategies = state.get("strategies_full")
+    if isinstance(embedded, dict) and isinstance(strategies, list) and isinstance(portfolio_totals, dict):
+        return embedded, strategies, portfolio_totals
+    # state absent/partial → recompute the full pull (embedded + fully-hydrated strategies). The market
+    # enrichment is the `positions` step's job — skip it here (want_market only gates step 3's fold).
+    embedded, portfolio_totals = fetch_embedded(client, meta)
+    strategies = fetch_strategies(client, meta)
+    state["embedded_wallet"] = embedded
+    state["portfolio_totals"] = portfolio_totals
+    state["strategies_full"] = strategies
+    state.setdefault("meta_warnings", [])
+    state["meta_warnings"] = meta.get("warnings", [])
+    state["registry_source"] = meta.get("registry_source")
+    state["catalog_source"] = meta.get("catalog_source")
+    state["profile_source"] = meta.get("profile_source")
+    return embedded, strategies, portfolio_totals
+
+
+# ──────────────────────────────────────────── step subcommands (fast, resumable, standalone)
+def step_money(client, want_market=True, state_path=None):
+    """STEP 1 `money` — the FAST money map the agent NARRATES FIRST. Embedded idle + each strategy wallet's
+    account_value/withdrawable → the three buckets (idle_in_embedded / idle_in_strategies /
+    deployed_in_positions) + grand_total_usd + reconciles. Persists the strategy list + wallets so
+    `strategies`/`positions` don't re-enumerate. FAST: no positions detail, no DSL/ratchet, no closed
+    history, no market. `want_market` is accepted for a uniform step signature but unused here."""
+    if state_path is None:
+        state_path = _default_state_path()
+    state = _load_state(state_path)
+    meta = _fresh_meta()
+    embedded, portfolio_totals = fetch_embedded(client, meta)
+    strategies = fetch_strategy_money(client, meta)
+    totals = _money_totals(embedded, strategies, portfolio_totals)
+    meta["strategy_count"] = len(strategies)
+    if not strategies and not embedded.get("address"):
+        meta["degraded"] = "no wallet data — check the token is USER-scoped"
+    # persist the money-lite strategy rows (name/wallet/id/status/money) so the later steps reuse the
+    # wallet set; the full hydrate (positions/DSL/closed/profile) is the `strategies` step's self-heal.
+    state["embedded_wallet"] = embedded
+    state["portfolio_totals"] = portfolio_totals
+    state["strategies_money"] = strategies
+    state["totals"] = totals
+    state["meta_warnings"] = meta.get("warnings", [])
+    _save_state(state_path, state)
+    return {"totals": totals, "embedded_wallet": embedded, "strategies": strategies, "meta": meta}
+
+
+def step_strategies(client, want_market=True, state_path=None):
+    """STEP 2 `strategies` — the per-strategy detail (the verdict surface). Reads state (or self-heals the
+    full fetch when state is absent): fully-hydrated `strategies[]` (mandate/DSL from the registry +
+    `protected` + closed/realized) + `strategy_groups[]` (a strategy is ALL its wallets). Runs the runtime
+    registry + catalog reads here (the mandate source). NO market enrichment (that's `positions`)."""
+    if state_path is None:
+        state_path = _default_state_path()
+    state = _load_state(state_path)
+    meta = _fresh_meta()
+    embedded, strategies, portfolio_totals = _ensure_full_strategies_in_state(
+        client, state, want_market, meta)
+    # carry forward any warnings the self-heal fetch (or an earlier step) recorded
+    for w in state.get("meta_warnings", []):
+        if w not in meta["warnings"]:
+            meta["warnings"].append(w)
+    meta["registry_source"] = state.get("registry_source", meta.get("registry_source"))
+    meta["catalog_source"] = state.get("catalog_source", meta.get("catalog_source"))
+    meta["profile_source"] = state.get("profile_source", meta.get("profile_source"))
+    meta["strategy_count"] = len(strategies)
+    meta.setdefault("has_multi_wallet_strategy", False)
+    strategy_groups = group_strategies(strategies, meta)
+    if not strategies and not embedded.get("address"):
+        meta["degraded"] = "no wallet data — check the token is USER-scoped"
+    state["strategies_full"] = strategies
+    state["strategy_groups"] = strategy_groups
+    state["meta_warnings"] = meta.get("warnings", [])
+    state["has_multi_wallet_strategy"] = meta.get("has_multi_wallet_strategy", False)
+    _save_state(state_path, state)
+    return {"strategies": strategies, "strategy_groups": strategy_groups, "meta": meta}
+
+
+def step_positions(client, want_market=True, state_path=None):
+    """STEP 3 `positions` — position-level analysis. Reads the full strategies[] from state (self-heals if
+    absent), runs the per-asset market enrichment (`market_24h_pct`/`vs_market` — the fan-out isolated
+    HERE), then computes `exposure` + `signals` off the full positions detail. Skipped-to-no-fold when
+    --no-market (positions keep their bucket math; market fields stay absent)."""
+    if state_path is None:
+        state_path = _default_state_path()
+    state = _load_state(state_path)
+    meta = _fresh_meta()
+    embedded, strategies, portfolio_totals = _ensure_full_strategies_in_state(
+        client, state, want_market, meta)
+    for w in state.get("meta_warnings", []):
+        if w not in meta["warnings"]:
+            meta["warnings"].append(w)
+    if want_market and strategies:
+        enrich_market(client, strategies, meta)
+    totals, exposure, signals = compute(embedded, strategies, portfolio_totals)
+    meta["strategy_count"] = len(strategies)
+    meta.setdefault("has_multi_wallet_strategy", False)
+    # REBUILD strategy_groups AFTER the market fold so the persisted groups reference the market-enriched
+    # positions — this is exactly run()'s order (enrich_market → group_strategies), keeping the shared
+    # state after the full pipeline byte-consistent with `all`.
+    strategy_groups = group_strategies(strategies, meta)
+    if not strategies and not embedded.get("address"):
+        meta["degraded"] = "no wallet data — check the token is USER-scoped"
+    # persist the enriched strategies (market fields now folded onto positions) + exposure/signals + the
+    # refreshed groups (over the enriched positions).
+    state["strategies_full"] = strategies
+    state["strategy_groups"] = strategy_groups
+    state["exposure"] = exposure
+    state["signals"] = signals
+    state["totals"] = totals            # the full totals (incl. unrealized_pnl from positions)
+    state["meta_warnings"] = meta.get("warnings", [])
+    state["has_multi_wallet_strategy"] = meta.get("has_multi_wallet_strategy", False)
+    _save_state(state_path, state)
+    return {"strategies": strategies, "strategy_groups": strategy_groups, "exposure": exposure,
+            "signals": signals, "totals": totals, "meta": meta}
+
+
 # ──────────────────────────────────────────────────────────────── CLI
 def _dry(client):
     out = {}
@@ -975,11 +1242,57 @@ def _dry(client):
     return out
 
 
+_STEPS = ("money", "strategies", "positions", "all")
+_STEP_FNS = {"money": step_money, "strategies": step_strategies, "positions": step_positions}
+
+
+def _all_and_persist(client, want_market, state_path):
+    """`all` = the composed one-shot. Runs the UNCHANGED `run()` (its output is byte-identical to the
+    pre-steps engine) and ALSO writes the shared state file (the same shape the steps build) so an `all`
+    run can seed a later narrow step. The state write never alters the printed dict."""
+    result = run(client, want_market=want_market)
+    if state_path is None:
+        state_path = _default_state_path()
+    state = {
+        "embedded_wallet": result.get("embedded_wallet"),
+        "strategies_full": result.get("strategies"),
+        "strategy_groups": result.get("strategy_groups"),
+        "totals": result.get("totals"),
+        "exposure": result.get("exposure"),
+        "signals": result.get("signals"),
+        "meta_warnings": (result.get("meta") or {}).get("warnings", []),
+        "registry_source": (result.get("meta") or {}).get("registry_source"),
+        "catalog_source": (result.get("meta") or {}).get("catalog_source"),
+        "profile_source": (result.get("meta") or {}).get("profile_source"),
+        "has_multi_wallet_strategy": (result.get("meta") or {}).get("has_multi_wallet_strategy", False),
+    }
+    _save_state(state_path, state)
+    return result
+
+
 def main(argv=None):
-    ap = argparse.ArgumentParser(description="senpi portfolio engine (real-time wallet taxonomy + analysis)")
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # optional leading positional STEP (money|strategies|positions|all); default `all` = the composed
+    # one-shot (unchanged output + shape). Parsed before argparse so the flags stay shared.
+    step = "all"
+    if argv and not argv[0].startswith("-"):
+        cand = argv[0]
+        if cand not in _STEPS:
+            print(json.dumps({"strategies": [], "meta": {"error": f"unknown step {cand!r}; "
+                                                         f"expected one of {', '.join(_STEPS)}"}}))
+            return 1
+        step, argv = cand, argv[1:]
+
+    ap = argparse.ArgumentParser(
+        description="senpi portfolio engine (real-time wallet taxonomy + analysis). Optional leading STEP: "
+                    "money|strategies|positions|all (default all = the composed one-shot). Steps share a "
+                    "state file so later steps don't re-fetch.")
     ap.add_argument("--no-market", action="store_true", help="skip per-asset market enrichment")
+    ap.add_argument("--state", default=None,
+                    help="shared state file path (default <tempdir>/senpi-portfolio/state.json)")
     ap.add_argument("--fixture", help="offline: path to a recorded MCP-response map (tests only)")
     ap.add_argument("--dry", action="store_true", help="dump raw MCP responses for schema debugging")
+    # `step` was already peeled off argv above; feed the remainder (flags only).
     args = ap.parse_args(argv)
 
     if args.fixture:
@@ -1000,8 +1313,13 @@ def main(argv=None):
         print(json.dumps(_dry(client), ensure_ascii=False, indent=2, default=str))
         return 0
 
+    want_market = not args.no_market
     try:
-        result = run(client, want_market=not args.no_market)
+        if step == "all":
+            result = _all_and_persist(client, want_market, args.state)
+        else:
+            fn = _STEP_FNS[step]
+            result = fn(client, want_market=want_market, state_path=args.state)
     except Exception as e:  # noqa
         print(json.dumps({"strategies": [], "meta": {"error": f"engine failure: {e}"}}))
         return 1

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -11,6 +11,7 @@ SEPARATE buckets and never collapses strategy-margin into "embedded idle."
 import json
 import os
 import sys
+import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
@@ -414,6 +415,128 @@ def test_embedded_idle_reads_nested_total_in_hyperliquid():
     res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
     assert res["embedded_wallet"]["idle_hl_usdc"] == 10446.0
     assert res["totals"]["idle_in_embedded"] == 10446.0
+
+
+# ──────────────────────────────────────────────── streaming STEPS (money · strategies · positions · all)
+def _client():
+    """A fresh fixture client on the canonical portfolio fixture (each step consumes its own client)."""
+    with open(FIXTURE) as f:
+        return portfolio._FixtureClient(json.load(f))
+
+
+def _tmp_state():
+    return os.path.join(tempfile.mkdtemp(), "state.json")
+
+
+def test_step_money_emits_the_three_buckets_offline():
+    """STEP `money` — the fast money map: the three buckets + grand_total + reconciles, offline against
+    the fixture. Same bucket values run() produces (idle-in-embedded is the $1.51 EVM USDC, NOT the
+    $2,461 idle-in-strategies), computed WITHOUT the positions/DSL/closed detail."""
+    out = portfolio.step_money(_client(), want_market=True, state_path=_tmp_state())
+    t = out["totals"]
+    assert set(("grand_total_usd", "idle_in_embedded", "idle_in_strategies",
+                "deployed_in_positions", "reconciles")) <= set(t)
+    assert t["idle_in_embedded"] == 1.51                  # only the EVM USDC (bucket 1)
+    assert t["idle_in_strategies"] > 2000                 # total_withdrawable lives here (bucket 2)
+    assert t["deployed_in_positions"] == 639.45           # margin backing open positions (bucket 3)
+    assert 3050 <= t["grand_total_usd"] <= 3150
+    s = t["idle_in_embedded"] + t["idle_in_strategies"] + t["deployed_in_positions"]
+    assert abs(s - t["grand_total_usd"]) <= 2.0           # the buckets reconcile to the total
+    # money-lite strategy rows carry the money fields but NOT the heavy detail
+    assert len(out["strategies"]) == 3
+    row = out["strategies"][0]
+    assert "account_value" in row and "idle_withdrawable" in row and "deployed" in row
+    assert "positions" not in row and "profile" not in row and "closed" not in row
+
+
+def test_step_strategies_emits_per_strategy_detail_offline():
+    """STEP `strategies` — the per-strategy verdict surface: fully-hydrated strategies[] (positions +
+    mandate/DSL + closed) + strategy_groups[]. Self-heals its own fetch when state is absent."""
+    out = portfolio.step_strategies(_client(), want_market=False, state_path=_tmp_state())
+    assert len(out["strategies"]) == 3
+    assert len(out["strategy_groups"]) >= 1
+    short = {s["name"]: s for s in out["strategies"]}["cub-short"]
+    assert len(short["positions"]) == 3                   # full positions detail present
+    assert "closed" in short                              # closed/realized block present
+    # each open position carries its live DSL tier object (never left looking unprotected)
+    assert all("dsl" in p for p in short["positions"])
+
+
+def test_step_positions_emits_market_exposure_signals_offline():
+    """STEP `positions` — the position-level slice: market enrichment folded onto positions
+    (market_24h_pct/vs_market) + exposure + signals. The market fan-out is isolated in this step."""
+    out = portfolio.step_positions(_client(), want_market=True, state_path=_tmp_state())
+    assert out["exposure"]["net_bias"] == "short"         # every open position is a short
+    assert out["exposure"]["gross_long_usd"] == 0
+    assert set(("idle_drag_pct", "deployed_pct")) <= set(out["signals"])
+    short = {s["name"]: s for s in out["strategies"]}["cub-short"]
+    eth = next(p for p in short["positions"] if p["asset"] == "ETH")
+    assert eth["market_24h_pct"] < 0 and eth["vs_market"] == "with the move"
+
+
+def test_step_sequence_reproduces_all_values():
+    """money → strategies → positions over ONE shared state reproduces `all`'s values: the money buckets,
+    and (after the market-folding positions step) the enriched strategies[], strategy_groups, exposure,
+    signals, and full totals all match run()/`all` exactly."""
+    allres = portfolio._all_and_persist(_client(), want_market=True, state_path=_tmp_state())
+    sp = _tmp_state()
+    m = portfolio.step_money(_client(), want_market=True, state_path=sp)
+    s = portfolio.step_strategies(_client(), want_market=True, state_path=sp)
+    p = portfolio.step_positions(_client(), want_market=True, state_path=sp)
+    # money buckets match all
+    for k in ("grand_total_usd", "idle_in_embedded", "idle_in_strategies", "deployed_in_positions",
+              "reconciles"):
+        assert m["totals"][k] == allres["totals"][k]
+    # after the positions step (which folds market, then rebuilds groups over the enriched positions,
+    # exactly as run() does) the full picture matches all exactly
+    assert p["strategies"] == allres["strategies"]
+    assert p["strategy_groups"] == allres["strategy_groups"]
+    assert p["exposure"] == allres["exposure"]
+    assert p["signals"] == allres["signals"]
+    assert p["totals"] == allres["totals"]
+    # the `strategies` step also produced groups (pre-market) — a valid standalone verdict surface
+    assert len(s["strategy_groups"]) == len(allres["strategy_groups"])
+
+
+def test_all_step_is_byte_identical_to_run():
+    """`all` (via _all_and_persist) is BYTE-IDENTICAL to run() — the steps machinery must not perturb the
+    one-shot composed output. State is written to a temp path so no real state file is touched."""
+    direct = portfolio.run(_client(), want_market=True)
+    allres = portfolio._all_and_persist(_client(), want_market=True, state_path=_tmp_state())
+    a = json.dumps(direct, ensure_ascii=False, sort_keys=True)
+    b = json.dumps(allres, ensure_ascii=False, sort_keys=True)
+    assert a == b
+
+
+def test_steps_self_heal_on_absent_state():
+    """Each step works STANDALONE against an ABSENT state file (self-heals its prerequisite fetch). The
+    strategies + positions steps recompute the full pull when the state file doesn't exist yet."""
+    missing = os.path.join(tempfile.mkdtemp(), "does-not-exist.json")
+    assert not os.path.isfile(missing)
+    s = portfolio.step_strategies(_client(), want_market=False, state_path=missing)
+    assert len(s["strategies"]) == 3                      # recomputed from scratch
+    missing2 = os.path.join(tempfile.mkdtemp(), "nope.json")
+    p = portfolio.step_positions(_client(), want_market=True, state_path=missing2)
+    assert p["exposure"]["net_bias"] == "short"           # self-healed the fetch, then computed exposure
+
+
+def test_steps_fail_open_on_corrupt_state():
+    """A corrupt/garbage state file → each step RECOMPUTES (never crashes). Guards the fail-open contract:
+    the money map, the per-strategy detail, and the positions analysis all recover from unparseable state."""
+    corrupt = os.path.join(tempfile.mkdtemp(), "state.json")
+    with open(corrupt, "w") as f:
+        f.write("}{ not json at all ][")
+    m = portfolio.step_money(_client(), want_market=True, state_path=corrupt)
+    assert 3050 <= m["totals"]["grand_total_usd"] <= 3150   # recovered the money map
+    # overwrite corrupt again (money just wrote valid state) and prove strategies/positions also recover
+    with open(corrupt, "w") as f:
+        f.write("<<<garbage>>>")
+    s = portfolio.step_strategies(_client(), want_market=False, state_path=corrupt)
+    assert len(s["strategies"]) == 3
+    with open(corrupt, "w") as f:
+        f.write("null and void")
+    p = portfolio.step_positions(_client(), want_market=True, state_path=corrupt)
+    assert p["exposure"]["net_bias"] == "short"
 
 
 if __name__ == "__main__":

--- a/senpi-smart-money/SKILL.md
+++ b/senpi-smart-money/SKILL.md
@@ -11,7 +11,7 @@ license: Apache-2.0
 compatibility: OpenClaw, Hyperclaw, Claude Code
 metadata:
   author: Senpi
-  version: "1.0.0"
+  version: "1.1.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -56,15 +56,20 @@ surfacing.
   Surface it as positioning, not a timing call.
 - **Always end with the two CTAs** (below), verbatim.
 
-## How to run the engine
+## How to run the engine (the output shape)
 
-Invoke via the `exec` tool:
+Invoke via the `exec` tool. **Prefer the STEPS below** for the full read (they stream and don't trip the
+timeout); this one-shot form is the fallback for when a single blocking call is fine:
 
 ```
-python3 scripts/smartmoney.py [--no-near]
+python3 scripts/smartmoney.py [cohorts|near_term|all] [--no-near] [--state PATH]
 ```
 
-- Returns one JSON doc: `{cohorts, smart_leaning, divergences, near_term, meta}`.
+The leading word is an optional **step** (`cohorts` · `near_term` · `all`, default `all`). `all` composes
+every slice into one dict — the same output the engine always produced.
+
+- Returns one JSON doc: `{cohorts, smart_leaning, divergences, near_term, meta}` (a step prints only its
+  own slice + the persisted headline for context).
 - `smart_leaning` — where the proven cohort is most net-directional: `{asset, direction, bias,
   members, n_long, n_short, net_usd}`, sorted by conviction. **The headline.**
 - `divergences` — smart vs crowd on the same coin: `{asset, opposite_sides, gap, smart_direction,
@@ -76,6 +81,48 @@ python3 scripts/smartmoney.py [--no-near]
   user knows the sample behind the bias.
 - `meta` — `warnings`, `near_term_available`, and **`cohorts_unavailable`** (see token note below).
 - The engine **fails open** — partial data still returns valid JSON. Work with what you got.
+
+## Run it in steps — narrate as you go
+
+A full pull is several MCP round-trips (the per-wallet cohort read is the heavy one). Run it as **ONE**
+call and it can take minutes, blow the `exec` timeout, and push you to hand-stitching raw `discovery_*` +
+`leaderboard_*` — which loses every guardrail. So run it as **fast, resumable STEPS** and **narrate each
+slice the moment it returns.** Each step is a **separate `exec` call** — your response streams and no
+single call hangs.
+
+```sh
+python3 scripts/smartmoney.py cohorts      # 1. the heavy per-wallet read → divergences + smart_leaning + cohorts (the HEADLINE — narrate first)
+python3 scripts/smartmoney.py near_term    # 2. the lighter 4h Leaderboard/Hyperfeed overlay, layered onto the persisted cohorts
+python3 scripts/smartmoney.py all          # one-shot fallback: the full composed dict (same output as before)
+```
+
+**For the full read** — "where's smart money", "what are the whales doing", "smart money vs the crowd" —
+run both steps **in order** and narrate between:
+
+1. `smartmoney.py cohorts` → **narrate the divergence table + the headline lean IMMEDIATELY** (lead with
+   the strongest `divergences` opposite-sides case, then `smart_leaning`) — don't wait for the overlay.
+   `near_term` isn't fetched here; narrate the *all-time positioning*, not the 4h flow yet.
+2. `smartmoney.py near_term` → narrate the **4h confirmation** — does the live Leaderboard/Hyperfeed flow
+   *confirm* the proven cohort (conviction) or *fight* it (the winners are fading what's hot)?
+
+**Narrate each slice as it returns — never wait for both.** The steps share a state file
+(`<tempdir>/senpi-smart-money/state.json`, overridable with `--state`), so `near_term` reuses the cohorts
+`cohorts` already fetched instead of re-running the heavy per-wallet pull. **For a NARROW ask, run only the
+minimal step:**
+
+| Intent (what the user asks) | Step to run | Slice it returns |
+|---|---|---|
+| *"who's profiting / what's smart money doing / where are the whales leaning"* | `cohorts` | `smart_leaning` + `divergences` + `cohorts` |
+| *"smart money vs the crowd / crowd-fade setups / where do the winners split from the crowd"* | `cohorts` | `divergences` (opposite-sides first) |
+| *"what's the 4h hot-money flow / is the move building or fading"* | `near_term` (self-heals the cohorts) | `near_term` + the persisted cohort headline for context |
+| *"the full read" (any of the above together)* | **both in order** (`cohorts`→`near_term`) — the fallback | the full composed dict |
+
+Each step is **idempotent + fail-open**: a missing/corrupt state file → recompute (self-heal), so
+`near_term` **also works standalone** (it just re-runs the cohort fetch first). `--no-near` / `--fixture` /
+`--state` apply to every step; same fail-open contract as `all` — each step returns valid JSON with
+`meta.warnings` on partial data, `meta.cohorts_unavailable` on an app-scoped token, and never crashes on a
+missing/corrupt state file. Prefer the steps for the full read; use `all` only when a single blocking call
+is fine.
 
 ## ⚠ Token scope
 

--- a/senpi-smart-money/scripts/smartmoney.py
+++ b/senpi-smart-money/scripts/smartmoney.py
@@ -6,10 +6,20 @@ The agent (LLM) runs this via the OpenClaw `exec` tool, reads the JSON on stdout
 build the proven cohort vs the crowd, aggregate net positioning, find the divergences, pull the
 near-term Leaderboard/Hyperfeed flow — and the LLM does all the prose, the "why", and the CTAs.
 
-  python3 smartmoney.py               # full pull (cohorts + divergence + near-term)
+  python3 smartmoney.py               # `all` (default): full pull (cohorts + divergence + near-term)
+  python3 smartmoney.py cohorts       # STEP 1 — the proven-vs-crowd divergence table (the headline)
+  python3 smartmoney.py near_term     # STEP 2 — the 4h leaderboard confirmation, layered on state
+  python3 smartmoney.py all           # one-shot fallback: the full composed dict (unchanged output)
   python3 smartmoney.py --no-near     # skip the leaderboard / Hyperfeed near-term layer
+  python3 smartmoney.py --state f.json     # override the shared step-state file path
   python3 smartmoney.py --fixture f.json   # offline: recorded MCP-response map (tests)
   python3 smartmoney.py --dry         # dump raw MCP responses for schema debugging
+
+RUN IT IN STEPS: a full pull is several MCP round-trips (the per-wallet cohort fetch is the heavy
+one). Run it as FAST, RESUMABLE STEPS the agent narrates between — `cohorts` (the headline
+divergence table) then `near_term` (the 4h confirmation, layered onto the persisted cohorts). Each
+step is a separate `exec` call, prints ONLY its slice + `meta`, and shares a JSON state file so the
+second step never re-runs the first. `all` (the default) stays the byte-identical composed one-shot.
 
 Modeled on the whalehunter strategy's cohort engine (same definitions + bias math), and on
 senpi-strategy-discover's hidden-engine pattern: guarded I/O, fails open, always valid JSON.
@@ -23,6 +33,7 @@ import argparse
 import json
 import os
 import sys
+import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -299,6 +310,166 @@ def run(client, want_near=True):
     }
 
 
+# ──────────────────────────────────────────────────────────────── shared state file (resumable steps)
+# The step subcommands (cohorts → near_term) are FAST, resumable slices that persist their work to a
+# shared JSON state file so `near_term` never re-runs the heavy per-wallet cohort fetch. The agent runs
+# them in sequence and NARRATES between — no single call carries the whole multi-round-trip pull (the
+# per-wallet trader_state fetch is the slow one; running it inside one blocking call risks the exec
+# timeout and pushes the agent to raw MCP, losing the guardrails). Each step is idempotent + fail-open:
+# a missing/corrupt state file → recompute (self-heal); every step also works STANDALONE (just slower).
+# `all` writes the same state but prints the full composed dict (byte-identical to the pre-steps output).
+# State default: <tempdir>/senpi-smart-money/state.json.
+STATE_SUBDIR = "senpi-smart-money"
+
+
+def _default_state_path():
+    """Default shared-state path: <tempdir>/senpi-smart-money/state.json. Uses tempfile.gettempdir()
+    (never $HOME)."""
+    return os.path.join(tempfile.gettempdir(), STATE_SUBDIR, "state.json")
+
+
+def _load_state(path):
+    """Read the shared state JSON. Never raises — a missing/corrupt/unreadable file → {} (fail-open: the
+    step then recomputes its prerequisites and self-heals)."""
+    if not path or not os.path.isfile(path):
+        return {}
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:  # noqa — corrupt/unreadable state is fail-open → recompute
+        return {}
+
+
+def _save_state(path, state):
+    """Merge-write the shared state JSON (best-effort; a write failure never sinks the step — the slice
+    was already printed to stdout). Creates the parent dir. Atomic-ish via a temp file + replace."""
+    if not path:
+        return
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "w") as fh:
+            json.dump(state, fh)
+        os.replace(tmp, path)
+    except Exception:  # noqa — persistence is best-effort; the printed slice is the contract
+        pass
+
+
+def _cohorts_slice(client, meta):
+    """The `cohorts` engine core — the heavy per-wallet read, factored so both the step and the self-heal
+    use it. Builds the smart/crowd cohorts, aggregates each cohort's per-coin bias, and computes the
+    `smart_leaning` headline + the `divergences` table. Produces EXACTLY the values run() folds into the
+    composed dict (same cohort order → same batched fixture lookups → byte-identical to `all`). Returns
+    (smart_addrs, crowd_addrs, smart_per, crowd_per, leaning, diverge)."""
+    smart_addrs, crowd_addrs = build_cohorts(client, meta)
+    meta["smart_cohort_size"] = len(smart_addrs)
+    meta["crowd_cohort_size"] = len(crowd_addrs)
+    if not smart_addrs and not crowd_addrs:
+        meta["cohorts_unavailable"] = (
+            "no cohort data — discovery_get_top_traders returned empty. discovery_* needs a "
+            "USER-scoped SENPI_AUTH_TOKEN; an app-scoped token returns nothing here.")
+    smart_per = cohort_bias(client, smart_addrs, meta, "smart") if smart_addrs else {}
+    crowd_per = cohort_bias(client, crowd_addrs, meta, "crowd") if crowd_addrs else {}
+    leaning = smart_conviction(smart_per)
+    diverge = divergences(smart_per, crowd_per)
+    return smart_addrs, crowd_addrs, smart_per, crowd_per, leaning, diverge
+
+
+def _cohorts_payload(smart_addrs, crowd_addrs, smart_per, crowd_per, leaning, diverge):
+    """Assemble the `cohorts` step's output slice — the same `cohorts`/`smart_leaning`/`divergences`
+    fields (identical shape) that run() emits."""
+    return {
+        "cohorts": {
+            "smart": {"min_realized_usd": SMART_MIN_REALIZED, "members_sampled": len(smart_addrs),
+                      "coins": len(smart_per)},
+            "crowd": {"realized_band_usd": [CROWD_MIN_REALIZED, CROWD_MAX_REALIZED],
+                      "members_sampled": len(crowd_addrs), "coins": len(crowd_per)},
+        },
+        "smart_leaning": leaning,        # where the proven cohort is concentrated (headline)
+        "divergences": diverge,          # smart vs crowd, opposite sides (the core signal)
+    }
+
+
+# ──────────────────────────────────────────────────── step subcommands (fast, resumable, standalone)
+def step_cohorts(client, want_near=True, state_path=None):
+    """STEP 1 `cohorts` — the headline read the agent NARRATES FIRST. Runs the heavy per-wallet cohort
+    fetch (build_cohorts + cohort_bias) → the proven-vs-crowd `divergences` table + the `smart_leaning`
+    headline + the `cohorts` sample sizes. Persists the cohort payload to state so `near_term` layers on
+    top without re-running the heavy fetch. Prints ONLY its slice + `meta`."""
+    if state_path is None:
+        state_path = _default_state_path()
+    state = _load_state(state_path)
+    meta = {"warnings": []}
+    (smart_addrs, crowd_addrs, smart_per, crowd_per,
+     leaning, diverge) = _cohorts_slice(client, meta)
+    payload = _cohorts_payload(smart_addrs, crowd_addrs, smart_per, crowd_per, leaning, diverge)
+    # persist the cohort slice so near_term reuses it (and can report the same as_of/cohorts).
+    state["as_of"] = "live"
+    state["cohorts"] = payload["cohorts"]
+    state["smart_leaning"] = payload["smart_leaning"]
+    state["divergences"] = payload["divergences"]
+    state["meta_warnings"] = meta.get("warnings", [])
+    if "cohorts_unavailable" in meta:
+        state["cohorts_unavailable"] = meta["cohorts_unavailable"]
+    else:
+        state.pop("cohorts_unavailable", None)
+    _save_state(state_path, state)
+    result = {"as_of": "live"}
+    result.update(payload)
+    result["meta"] = meta
+    return result
+
+
+def step_near_term(client, want_near=True, state_path=None):
+    """STEP 2 `near_term` — the lighter 4h overlay, layered onto the persisted cohorts. Reads the cohort
+    slice from state (self-heals by re-running the cohort fetch when state is absent/corrupt), pulls the
+    health-gated Leaderboard/Hyperfeed flow, and emits `near_term` alongside the persisted cohort headline
+    so the agent can narrate confirm/contradict in one slice. Prints its slice + `meta`."""
+    if state_path is None:
+        state_path = _default_state_path()
+    state = _load_state(state_path)
+    meta = {"warnings": list(state.get("meta_warnings", []))}
+    # self-heal: reuse the persisted cohort slice, else recompute it here so near_term works standalone.
+    cohorts = state.get("cohorts")
+    leaning = state.get("smart_leaning")
+    diverge = state.get("divergences")
+    if not (isinstance(cohorts, dict) and isinstance(leaning, list) and isinstance(diverge, list)):
+        cmeta = {"warnings": []}
+        (smart_addrs, crowd_addrs, smart_per, crowd_per,
+         leaning, diverge) = _cohorts_slice(client, cmeta)
+        payload = _cohorts_payload(smart_addrs, crowd_addrs, smart_per, crowd_per, leaning, diverge)
+        cohorts = payload["cohorts"]
+        leaning, diverge = payload["smart_leaning"], payload["divergences"]
+        # fold the recompute's warnings/flag in (dedup-preserving order) and reseed the cohort slice.
+        for w in cmeta.get("warnings", []):
+            if w not in meta["warnings"]:
+                meta["warnings"].append(w)
+        state["as_of"] = "live"
+        state["cohorts"] = cohorts
+        state["smart_leaning"] = leaning
+        state["divergences"] = diverge
+        if "cohorts_unavailable" in cmeta:
+            state["cohorts_unavailable"] = cmeta["cohorts_unavailable"]
+    if state.get("cohorts_unavailable"):
+        meta["cohorts_unavailable"] = state["cohorts_unavailable"]
+
+    near = fetch_near_term(client, meta) if want_near else None
+    meta["near_term_available"] = near is not None
+
+    state["near_term"] = near
+    state["meta_warnings"] = meta.get("warnings", [])
+    _save_state(state_path, state)
+    return {
+        "as_of": "live",
+        "cohorts": cohorts,              # the persisted headline, so the overlay reads in context
+        "smart_leaning": leaning,
+        "divergences": diverge,
+        "near_term": near,               # Leaderboard / Hyperfeed 4h flow (confirm or contradict)
+        "meta": meta,
+    }
+
+
 # ──────────────────────────────────────────────────────────────── CLI
 def _dry(client):
     out = {}
@@ -316,11 +487,55 @@ def _dry(client):
     return out
 
 
+_STEPS = ("cohorts", "near_term", "all")
+_STEP_FNS = {"cohorts": step_cohorts, "near_term": step_near_term}
+
+
+def _all_and_persist(client, want_near, state_path):
+    """`all` = the composed one-shot. Runs the UNCHANGED `run()` (its output is byte-identical to the
+    pre-steps engine) and ALSO writes the shared state file (same shape the steps build) so an `all` run
+    can seed a later `near_term`. The state write never alters the printed dict."""
+    result = run(client, want_near=want_near)
+    if state_path is None:
+        state_path = _default_state_path()
+    state = {
+        "as_of": result.get("as_of"),
+        "cohorts": result.get("cohorts"),
+        "smart_leaning": result.get("smart_leaning"),
+        "divergences": result.get("divergences"),
+        "near_term": result.get("near_term"),
+        "meta_warnings": (result.get("meta") or {}).get("warnings", []),
+    }
+    cu = (result.get("meta") or {}).get("cohorts_unavailable")
+    if cu:
+        state["cohorts_unavailable"] = cu
+    _save_state(state_path, state)
+    return result
+
+
 def main(argv=None):
-    ap = argparse.ArgumentParser(description="senpi smart-money engine (cohort + divergence + near-term)")
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # optional leading positional STEP (cohorts|near_term|all); default `all` = the composed one-shot
+    # (unchanged output + shape). Parsed before argparse so the flags stay shared.
+    step = "all"
+    if argv and not argv[0].startswith("-"):
+        cand = argv[0]
+        if cand not in _STEPS:
+            print(json.dumps({"smart_leaning": [], "meta": {"error": f"unknown step {cand!r}; "
+                                                            f"expected one of {', '.join(_STEPS)}"}}))
+            return 1
+        step, argv = cand, argv[1:]
+
+    ap = argparse.ArgumentParser(
+        description="senpi smart-money engine (cohort + divergence + near-term). Optional leading STEP: "
+                    "cohorts|near_term|all (default all = the composed one-shot). Steps share a state "
+                    "file so near_term doesn't re-run the heavy cohort fetch.")
     ap.add_argument("--no-near", action="store_true", help="skip the leaderboard / Hyperfeed near-term layer")
+    ap.add_argument("--state", default=None,
+                    help="shared state file path (default <tempdir>/senpi-smart-money/state.json)")
     ap.add_argument("--fixture", help="offline: path to a recorded MCP-response map (tests only)")
     ap.add_argument("--dry", action="store_true", help="dump raw MCP responses for schema debugging")
+    # `step` was already peeled off argv above; feed the remainder (flags only).
     args = ap.parse_args(argv)
 
     if args.fixture:
@@ -341,8 +556,13 @@ def main(argv=None):
         print(json.dumps(_dry(client), ensure_ascii=False, indent=2, default=str))
         return 0
 
+    want_near = not args.no_near
     try:
-        result = run(client, want_near=not args.no_near)
+        if step == "all":
+            result = _all_and_persist(client, want_near, args.state)
+        else:
+            fn = _STEP_FNS[step]
+            result = fn(client, want_near=want_near, state_path=args.state)
     except Exception as e:  # noqa  — last-resort guard; layer functions already fail open
         print(json.dumps({"smart_leaning": [], "meta": {"error": f"engine failure: {e}"}}))
         return 1

--- a/senpi-smart-money/tests/test_smartmoney.py
+++ b/senpi-smart-money/tests/test_smartmoney.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Offline engine test — runs smartmoney.run() against a recorded MCP fixture (no network).
+"""Offline engine test — runs smartmoney.run() + the step subcommands against a recorded MCP fixture
+(no network).
 
     python3 -m pytest senpi-smart-money/tests/   # or: python3 tests/test_smartmoney.py
 """
@@ -7,6 +8,7 @@
 import json
 import os
 import sys
+import tempfile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
@@ -16,10 +18,21 @@ import smartmoney  # noqa: E402
 FIXTURE = os.path.join(HERE, "fixtures", "smartmoney_fixture.json")
 
 
-def _result():
+def _client():
     with open(FIXTURE) as f:
-        client = smartmoney._FixtureClient(json.load(f))
-    return smartmoney.run(client, want_near=True)
+        return smartmoney._FixtureClient(json.load(f))
+
+
+def _result():
+    return smartmoney.run(_client(), want_near=True)
+
+
+def _tmp_state():
+    return os.path.join(tempfile.mkdtemp(), "state.json")
+
+
+def _canon(obj):
+    return json.dumps(obj, sort_keys=True)
 
 
 def test_cohorts_built():
@@ -56,6 +69,65 @@ def test_cohorts_unavailable_flag_on_empty():
     res = smartmoney.run(smartmoney._FixtureClient({}), want_near=True)
     assert res["meta"].get("cohorts_unavailable")
     assert res["smart_leaning"] == [] and res["divergences"] == []
+
+
+# ──────────────────────────────────────────────────────────── step subcommands (fast, resumable)
+def test_step_cohorts_emits_its_slice():
+    """`cohorts` step emits ONLY the cohort slice (headline + divergence table), no near_term, offline."""
+    res = smartmoney.step_cohorts(_client(), want_near=True, state_path=_tmp_state())
+    assert set(res.keys()) == {"as_of", "cohorts", "smart_leaning", "divergences", "meta"}
+    assert "near_term" not in res
+    div = {x["asset"]: x for x in res["divergences"]}
+    assert div["HYPE"]["opposite_sides"] is True   # the core signal survives the step boundary
+
+
+def test_step_near_term_emits_its_slice():
+    """`near_term` step layers the 4h flow onto the (self-healed) cohort headline, offline."""
+    res = smartmoney.step_near_term(_client(), want_near=True, state_path=_tmp_state())
+    assert "near_term" in res and res["meta"]["near_term_available"] is True
+    assert res["near_term"]["concentration"]["concentration"][0]["asset"] == "HYPE"
+
+
+def test_cohorts_then_near_term_reproduces_all():
+    """cohorts → near_term over a SHARED state file reproduces the composed `all` output, field by field."""
+    all_res = _result()
+    statep = _tmp_state()
+    c_res = smartmoney.step_cohorts(_client(), want_near=True, state_path=statep)
+    n_res = smartmoney.step_near_term(_client(), want_near=True, state_path=statep)
+    composed = {"as_of": n_res["as_of"], "cohorts": c_res["cohorts"],
+                "smart_leaning": c_res["smart_leaning"], "divergences": c_res["divergences"],
+                "near_term": n_res["near_term"]}
+    for k in ("as_of", "cohorts", "smart_leaning", "divergences", "near_term"):
+        assert _canon(all_res[k]) == _canon(composed[k]), f"{k} diverged from all"
+
+
+def test_near_term_self_heals_on_absent_state():
+    """`near_term` with NO prior state re-runs the cohort fetch itself → still produces the full read."""
+    all_res = _result()
+    res = smartmoney.step_near_term(_client(), want_near=True, state_path=_tmp_state())
+    assert _canon(res["divergences"]) == _canon(all_res["divergences"])
+    assert res["meta"]["near_term_available"] is True
+
+
+def test_near_term_fails_open_on_corrupt_state():
+    """A corrupt state file → fail-open recompute (self-heal), never an exception."""
+    all_res = _result()
+    statep = _tmp_state()
+    os.makedirs(os.path.dirname(statep), exist_ok=True)
+    with open(statep, "w") as fh:
+        fh.write("{ not valid json ]]")
+    res = smartmoney.step_near_term(_client(), want_near=True, state_path=statep)
+    assert _canon(res["divergences"]) == _canon(all_res["divergences"])
+
+
+def test_step_cohorts_unavailable_flag_offline():
+    """Empty discovery → `cohorts` step flags cohorts_unavailable and near_term reads it from state."""
+    statep = _tmp_state()
+    ec = smartmoney.step_cohorts(smartmoney._FixtureClient({}), want_near=True, state_path=statep)
+    assert ec["meta"].get("cohorts_unavailable")
+    assert ec["smart_leaning"] == [] and ec["divergences"] == []
+    en = smartmoney.step_near_term(smartmoney._FixtureClient({}), want_near=True, state_path=statep)
+    assert en["meta"].get("cohorts_unavailable")   # propagated through the shared state
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Applies the streaming-steps pattern (shipped in `senpi-improve-trades`) to three more engines so the agent keeps generating a response for the user instead of stalling on one long `exec` call — the failure mode that made the agent bail to raw MCP and lose the skill's guardrails.

Each engine's `run()` is **left completely untouched**, and the default `all` subcommand routes through it, so the one-shot output is **byte-identical** to before (verified against `origin/strategy-v2` per skill). The new subcommands split the long pull into fast, resumable slices over a shared temp-dir state file; the agent runs them in sequence and narrates each as it goes. Steps are fail-open and self-healing (recompute if state is absent/corrupt), so any step works standalone.

## What changed

| Skill | Version | Steps (default `all`) |
|---|---|---|
| **senpi-portfolio** | 1.4.0 → **1.5.0** | `money` → `strategies` → `positions` |
| **senpi-market-pulse** | 1.0.0 → **1.1.0** | `pulse` → `smart` |
| **senpi-smart-money** | 1.0.0 → **1.1.0** | `cohorts` → `near_term` |

- **portfolio** — `money` (fast three-bucket map: embedded idle + per-wallet margin) → `strategies` (full mandate/DSL/protected/closed detail) → `positions` (market enrichment + exposure + signals).
- **market-pulse** — `pulse` (fast core: movers/signals/groups/funding regime) → `smart` (heavier smart-money overlay).
- **smart-money** — `cohorts` (per-wallet cohort read → leaning + divergences) → `near_term` (4h hot-money overlay).

Each SKILL.md gets a **"Run it in steps — narrate as you go"** section + a narrow-ask routing table so a scoped question runs only the minimal step. MINOR bumps → installed users auto-upgrade.

## Verification (all local, offline fixtures)
- `py_compile` clean on all three.
- **`all` byte-identical to the original `run()`** — compared current vs `origin/strategy-v2` on each skill's own fixture (sha256 match).
- Step composition reproduces `all` field-by-field; self-heal on absent state; fail-open on corrupt state.
- Tests: **portfolio 25/25, market-pulse 15/15, smart-money 11/11** (originals green + new step tests).

## Risk
Additive and non-regressing — the `all` path is unchanged, so the worst case for the existing one-shot behavior is zero change. Only new code is the step subcommands + state file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)