### PR TITLE
portfolio: data-integrity guardrails from live transcripts (DSL-bypass + clearinghouse-is-truth) — v1.7.0

### DIFF
--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -15,7 +15,7 @@ license: Apache-2.0
 compatibility: OpenClaw, Hyperclaw, Claude Code
 metadata:
   author: Senpi
-  version: "1.6.0"
+  version: "1.7.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -267,6 +267,27 @@ directly.)
   reach for `strategy_list` directly, pass `status: ["ACTIVE"]` — a bare call returns CLOSED/PAUSED too
   and they must not be presented as current. Mention PAUSED strategies only if relevant, clearly
   labeled "paused," never as active.
+- **The live clearinghouse is the source of truth for whether a strategy holds capital — over the `status`
+  field AND over what anyone asserts about the wallet.** The engine reconciles this: a strategy whose live
+  wallet holds **$0 account value, no positions, no idle** is flagged **`empty: true`** (`empty_reason`:
+  `closed_or_drained` when `total_withdrawn ≈ total_funded`, else `unfunded`; listed in
+  `meta.dormant_active`) — report those as closed. A strategy with **`account_value > 0`** is **live**,
+  even if `status` is stale or someone believes it's closed.
+- **Don't cave to a claim the wallet contradicts, and NEVER fabricate account history to agree.** If the
+  user says a strategy is "closed / has no funds" but its `account_value > 0`, it is **live** — say so with
+  the number ("wolf is live — $X in the wallet, flat right now, waiting for its signal"). Do not abandon a
+  correct reading, and do not invent a story to justify agreeing (a "strategy-grinder cascade," a "close at
+  14:58," "funds returned to embedded"). This is the real failure this section prevents: a **live** strategy
+  was re-narrated as closed — with a fabricated close-cascade — because the model deferred to a mistaken
+  "it's closed" instead of re-reading the clearinghouse. Verify first, then correct the record.
+- **Live capital = clearinghouse `account_value`, NEVER `total_funded` / `budget` / `status`.**
+  `total_funded` / `total_withdrawn` are **lifetime history**, not a current balance. A strategy with
+  `total_funded: 3000` and `account_value: 0` has **$0 now**; one with `account_value: 3000` has **$3K now**
+  regardless of what it was funded. Never present `total_funded` (or a configured budget) as current idle /
+  reserved money — read `idle_withdrawable` / `account_value` from the live clearinghouse.
+- **A flat strategy that still holds idle margin (`account_value > 0`, no positions) is NOT empty** — it's
+  funded and waiting for a signal (or the flat sleeve of a multi-wallet pair); report it as **live**. Only
+  `empty: true` (a genuinely $0 wallet) means closed/drained. Don't conflate "flat but funded" with "closed."
 - **Present active strategies as known state, not a fresh discovery.** Pull the data quietly and state
   what's running as established fact ("Your two active strategies are…"). Don't narrate the lookup
   ("let me check… oh, I see you have…") — that reads like you didn't already know your own book.

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -15,7 +15,7 @@ license: Apache-2.0
 compatibility: OpenClaw, Hyperclaw, Claude Code
 metadata:
   author: Senpi
-  version: "1.5.0"
+  version: "1.6.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -49,6 +49,14 @@ dump when the user asked about their **strategies** — is a failure. The user w
 > un-bucketed dumps that mislead — idle-vs-deployed conflation, per-wallet collateral double-counting,
 > and **sub-wallets mistaken for separate strategies** (a strategy's `main`/`hedge` legs are ONE
 > strategy, not two). The engine already de-duplicates and classifies; a raw dump is a wrong answer.
+>
+> **This includes DSL / "are my positions protected?" questions — do NOT hand-roll them.** Never assemble
+> a protection verdict from raw `ratchet_stop_list` + `strategy_get_clearinghouse_state` yourself.
+> `ratchet_stop_list` shows **only** the live ratchet for positions that have already crossed Tier 1 — it
+> does **not** carry the strategy's config DSL exit, so a by-hand read makes every sub-Tier-1 position look
+> "unprotected" when it isn't. The engine reads BOTH the config ladder (`profile.dsl`) and the live tier
+> (`positions[].dsl`) and frames every position correctly; run it. (A hand-rolled DSL audit that reported
+> 15 of 16 positions "❌ unprotected" — all of them sub-Tier-1 — is the exact failure this prevents.)
 
 ## The wallet model (get this exactly right)
 
@@ -311,6 +319,16 @@ ratchet record" as "no DSL."** Say **"protected; profit-ratchet arms at Tier 1 (
 "unprotected / unmonitored / no stop." (The engine already frames every `armed: false` position this way
 in `dsl.note`; do not override it with an "unprotected" reading.)
 
+- **An ERRORED or empty DSL query is "unknown," never "unprotected."** `ratchet_stop_list` can fail
+  (e.g. `SERR031` auth, or the DSL engine lagging behind a just-opened position) or come back empty. That
+  is a **data gap**, not evidence of missing protection — treat it exactly like `dsl:null`. The engine
+  fails open here (config framing stands alone, plus a `meta.warnings` note); a by-hand call has no such
+  fallback, which is why hand-rolling produces false "unprotected" verdicts. Never turn a failed read into
+  a risk finding.
+- **A strategy with `tradingStrategyName: null` is still a real strategy.** Custom strategies created via
+  `strategy_create_custom_strategy` can come back with a null/blank name — identify and analyze them by
+  `strategyId` + wallet, never skip, mislabel ("Unnamed"), or double-count them for lacking a display name.
+  (If you *created* it this session, you already know its name — don't re-derive it as "unknown.")
 - **Config-level `protected` ≠ live per-position tier.** `strategy.protected` / `group.protected` (bool)
   is the **config posture** — the strategy ships an `exit:` block (always true for template strategies).
   It says "this strategy has a DSL exit," not which tier a given position sits in. The per-position tier

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -553,6 +553,17 @@ def fetch_strategies(client, meta):
         strat["account_value"] = round(shared_idle + deployed, 2)  # = main.av + xyz.av − shared_idle
         strat["position_margin"] = round(sum(p["margin"] for p in positions), 2)   # initial margin detail
         strat["positions"] = positions
+        # RECONCILE status vs live wallet — the clearinghouse is the TRUTH, `status` is not. `strategy_list`
+        # can report a just-closed strategy as ACTIVE (the status lags the close). A $0 account value with
+        # NO positions AND NO idle is an EMPTY wallet: the strategy was CLOSED/DRAINED (funds returned to
+        # the embedded wallet) or never funded. Flag it so the narrator never presents `total_funded` as
+        # live/idle/reserved capital and never counts a ghost as a live strategy. (A FLAT sleeve merely
+        # waiting for a signal still holds idle margin → account_value > 0 → NOT flagged empty.)
+        tf, tw = strat.get("total_funded"), strat.get("total_withdrawn")
+        strat["empty"] = (strat["account_value"] <= 0.01 and strat["idle_withdrawable"] <= 0.01 and not positions)
+        if strat["empty"]:
+            drained = bool(tf and tf > 0 and tw is not None and tw >= tf - 0.01)
+            strat["empty_reason"] = "closed_or_drained" if drained else "unfunded"
         # LIVE per-position DSL/ratchet tier — read-guarded + fail-open. Attaches a `dsl` object to each
         # open position (armed → tier/lock; not armed → "protected from entry, ratchet arms at +X%").
         # NEVER leaves a live position looking "unprotected." (See attach_position_dsl.)
@@ -566,6 +577,13 @@ def fetch_strategies(client, meta):
             strategies = list(ex.map(hydrate, strategies))
     except Exception:  # noqa
         strategies = [hydrate(s) for s in strategies]
+    # Roll up any strategy reported ACTIVE but holding $0 (empty wallet) — status/clearinghouse mismatch.
+    dormant = [s["name"] for s in strategies if s.get("empty")]
+    if dormant:
+        meta["dormant_active"] = dormant
+        meta.setdefault("warnings", []).append(
+            f"{len(dormant)} strategy(ies) report status ACTIVE but hold $0 (empty wallet) — likely just "
+            f"closed, funds returned to embedded (or never funded): {', '.join(str(d) for d in dormant)}")
     return strategies
 
 

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -539,6 +539,76 @@ def test_steps_fail_open_on_corrupt_state():
     assert p["exposure"]["net_bias"] == "short"
 
 
+def test_closed_but_active_strategy_flagged_empty_not_idle():
+    """RECONCILE status vs live wallet: strategy_list can report a just-CLOSED strategy as ACTIVE (status
+    lags the close). The engine must flag such a $0 wallet `empty: true` (never count its `total_funded`
+    as live/idle capital) — the exact failure where a closed strategy was narrated as holding $3K idle.
+    A flat-but-FUNDED strategy (idle margin, no positions) must NOT be flagged empty."""
+    WOLF = "0xwolf000000000000000000000000000000000wf"      # CLOSED — drained, reported ACTIVE
+    HORNET = "0xhornet00000000000000000000000000000hnt"     # funded + one position
+    IDLE = "0xidle000000000000000000000000000000000id"      # funded, flat, waiting (NOT empty)
+    fixture = {
+        "user_get_me": {"wallets": [{"walletType": "embedded",
+                                     "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"total_balance_usd": 12605, "total_withdrawable": 4620,
+                                  "total_usdc_in_hyperliquid": 12605, "token_balances": []},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "wolf", "strategyWalletAddress": WOLF, "status": "ACTIVE",
+             "id": "wolf-1", "totalFunded": 3000, "totalWithdrawn": 3000},
+            {"tradingStrategyName": "hornet", "strategyWalletAddress": HORNET, "status": "ACTIVE",
+             "id": "hornet-1", "totalFunded": 4000, "totalWithdrawn": 0},
+            {"tradingStrategyName": "idlecat", "strategyWalletAddress": IDLE, "status": "ACTIVE",
+             "id": "idle-1", "totalFunded": 2000, "totalWithdrawn": 0},
+        ]},
+        f"strategy_get_clearinghouse_state::{WOLF.lower()}": {   # EMPTY: closed/drained
+            "main": {"marginSummary": {"accountValue": "0"}, "withdrawable": "0", "assetPositions": []},
+            "xyz":  {"marginSummary": {"accountValue": "0"}, "withdrawable": "0", "assetPositions": []}},
+        f"strategy_get_clearinghouse_state::{HORNET.lower()}": {  # $2000 idle + one position
+            "main": {"marginSummary": {"accountValue": "2000"}, "withdrawable": "2000", "assetPositions": []},
+            "xyz":  {"marginSummary": {"accountValue": "3420"}, "withdrawable": "2000", "assetPositions": [
+                {"position": {"coin": "SKHX", "szi": "3.5", "positionValue": "5679", "marginUsed": "1420",
+                              "entryPx": "1594.3", "unrealizedPnl": "42.79", "returnOnEquity": "0.03"}}]}},
+        f"strategy_get_clearinghouse_state::{IDLE.lower()}": {    # funded, FLAT (idle margin, no positions)
+            "main": {"marginSummary": {"accountValue": "2000"}, "withdrawable": "2000", "assetPositions": []},
+            "xyz":  {"marginSummary": {"accountValue": "2000"}, "withdrawable": "2000", "assetPositions": []}},
+    }
+    res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    strat = {s["name"]: s for s in res["strategies"]}
+    # wolf: reported ACTIVE but $0 wallet → empty, closed_or_drained (totalWithdrawn ≈ totalFunded)
+    assert strat["wolf"]["empty"] is True
+    assert strat["wolf"]["empty_reason"] == "closed_or_drained"
+    assert strat["wolf"]["account_value"] == 0 and strat["wolf"]["idle_withdrawable"] == 0
+    # a funded-but-flat strategy is NOT empty (idle margin still there)
+    assert strat["idlecat"]["empty"] is False
+    assert strat["hornet"]["empty"] is False
+    # meta surfaces the status/clearinghouse mismatch
+    assert "wolf" in res["meta"].get("dormant_active", [])
+    # the closed strategy contributes $0 — idle_in_strategies is hornet+idlecat only, NOT +$3K wolf
+    assert res["totals"]["idle_in_strategies"] == 4000    # 2000 (hornet) + 2000 (idlecat); no phantom 3K
+
+
+def test_unfunded_empty_strategy_reason():
+    """An ACTIVE strategy never funded ($0 wallet, totalFunded 0) → empty with reason 'unfunded' (distinct
+    from closed/drained), still excluded from idle."""
+    W = "0xunfund000000000000000000000000000000un"
+    fixture = {
+        "user_get_me": {"wallets": [{"walletType": "embedded",
+                                     "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"total_balance_usd": 100, "total_withdrawable": 0,
+                                  "total_usdc_in_hyperliquid": 100, "token_balances": []},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "newbie", "strategyWalletAddress": W, "status": "ACTIVE",
+             "id": "n-1", "totalFunded": 0, "totalWithdrawn": 0}]},
+        f"strategy_get_clearinghouse_state::{W.lower()}": {
+            "main": {"marginSummary": {"accountValue": "0"}, "withdrawable": "0", "assetPositions": []},
+            "xyz":  {"marginSummary": {"accountValue": "0"}, "withdrawable": "0", "assetPositions": []}},
+    }
+    res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    s = {x["name"]: x for x in res["strategies"]}["newbie"]
+    assert s["empty"] is True and s["empty_reason"] == "unfunded"
+    assert res["totals"]["idle_in_strategies"] == 0
+
+
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     for fn in fns:


### PR DESCRIPTION
Two portfolio-engine correctness fixes, both from real live transcripts where the narration went wrong. Engine `run()` output shape is unchanged (`all` stays byte-identical to `run()`); these add guardrail fields + SKILL rules. Tests 27/27.

## 1. DSL / "are my positions protected?" — raw-MCP bypass (v1.6.0)
Agent hand-rolled a DSL audit from raw `ratchet_stop_list` + `strategy_get_clearinghouse_state` and reported **15 of 16 (all sub-Tier-1) positions "❌ unprotected"** — the exact thing the engine is built to prevent. The engine + guardrails were already correct; the agent never ran the skill. Added guardrails naming the failure: anti-bypass now covers DSL; an **errored/empty** `ratchet_stop_list` (`SERR031` / DSL-engine lag) is "unknown," never "unprotected"; a `tradingStrategyName:null` strategy is still real.

## 2. Clearinghouse is the truth for strategy state (v1.7.0)
In a live transcript, a **live** strategy (`wolf`) was re-narrated as **closed** — with a **fabricated close-cascade** ("strategy grinder," "closed at 14:58," "funds returned to embedded") — because the model deferred to a mistaken "it's closed" claim instead of re-reading the clearinghouse. (The "it's closed" assertion was itself a mistake — wolf was live the whole time.)

The lesson: **the live clearinghouse is the source of truth for whether a strategy holds capital — over the `status` field AND over what anyone asserts.**

**Fix:**
- **Engine** — reconcile status vs live wallet: a strategy whose clearinghouse holds **$0 account value + no positions + no idle** is flagged **`empty: true`** (`empty_reason`: `closed_or_drained` when `total_withdrawn ≈ total_funded`, else `unfunded`; `meta.dormant_active` lists them). `account_value > 0` ⇒ **live**, whatever `status` says. A flat-but-**funded** sleeve keeps `account_value > 0` → **not** flagged. (Keys on the live wallet, so a funded strategy is never mislabeled — it gives the narrator the ground truth to hold the correct line.)
- **SKILL** — don't cave to a claim the wallet contradicts; **never fabricate account history to agree**; live capital = clearinghouse `account_value`, never `total_funded`/`budget`/`status`.

## Verification
- `run()` shape unchanged; **`all` == `run()` byte-identical** (test).
- Tests **27/27** (25 + 2 new: `closed_or_drained` + `unfunded`, both keyed on a genuinely $0 wallet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)