### PR TITLE
Fix invalid trading_risk 'balanced' → 'moderate' (coyote +4, unblocks deploy)

### DIFF
--- a/strategies/beaver/main/runtime.yaml
+++ b/strategies/beaver/main/runtime.yaml
@@ -15,7 +15,7 @@ strategy:
   wallet: "${BEAVER_WALLET}"
   slots: 1                                # single asset, single position
   default_leverage: 5                     # flat; scan also emits leverage=5 per signal
-  trading_risk: balanced
+  trading_risk: moderate
   enabled: true
 
 scanners:

--- a/strategies/coyote/main/runtime.yaml
+++ b/strategies/coyote/main/runtime.yaml
@@ -24,7 +24,7 @@ strategy:
   slots: 1                                # single regime bet on BTC
   margin_pct: 25                          # baseline %; scan emits marginPct per signal
   default_leverage: 3                     # fallback; scan emits 1-5x per signal (clamped to 5)
-  trading_risk: balanced
+  trading_risk: moderate
   enabled: true
 
 scanners:

--- a/strategies/heron/main/runtime.yaml
+++ b/strategies/heron/main/runtime.yaml
@@ -16,7 +16,7 @@ strategy:
   wallet: "${HERON_WALLET}"
   slots: 1                                # single asset, single position
   default_leverage: 5                     # heron is FIXED 5x — scan emits leverage:5 every signal
-  trading_risk: balanced
+  trading_risk: moderate
   enabled: true
 
 scanners:

--- a/strategies/hummingbird/main/runtime.yaml
+++ b/strategies/hummingbird/main/runtime.yaml
@@ -16,7 +16,7 @@ strategy:
   wallet: "${HUMMINGBIRD_WALLET}"
   slots: 1                                # single asset, single position
   default_leverage: 5                     # v2 DEFAULT==MAX==5; scan emits the same flat 5x
-  trading_risk: balanced                  # v2 trading_risk: balanced (onboarding tier)
+  trading_risk: moderate                  # v2 "balanced" (onboarding tier) → moderate (canonical; enum = conservative|moderate|aggressive)
   enabled: true
 
 scanners:

--- a/strategies/sailfish/main/runtime.yaml
+++ b/strategies/sailfish/main/runtime.yaml
@@ -24,7 +24,7 @@ strategy:
   slots: 1                                # v2 slots 1 — single-position rotator
   margin_pct: 20                          # baseline %; scan emits marginPct per signal (= this value)
   default_leverage: 3                     # fallback; scan emits 3x (clamped to 5x max) per signal
-  trading_risk: balanced
+  trading_risk: moderate
   enabled: true
 
 scanners:


### PR DESCRIPTION
`deploy.py runtime <id>` fails config validation because the runtime schema enum is `trading_risk ∈ {conservative, moderate, aggressive}` (`runtime-schema.ts:93`) and these strategies set `trading_risk: balanced` — not a member.

**Blocked the live launch of `coyote`**; the same latent failure sits in **beaver, heron, hummingbird, sailfish**.

Fix: `balanced → moderate` (the canonical v2→3.0 port mapping — the middle/onboarding tier, matching the 85 sibling strategies already on `moderate`). `dsl_preset` is a free-form object (`z.record`), not an enum, so the descriptive "balanced preset" comments are unaffected and left as-is.

Verified: all 5 `runtime.yaml` parse; `trading_risk` is now a valid enum member in each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)