### PR TITLE
Template-first on-ramp: strategy-author offers a matching template first + discover claims open-ended 'make me a strategy' asks (v2.4.0)

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -15,14 +15,18 @@ description: >-
   a flat stop — the confirmed Decoupling failure). The raw MCP tools are ONLY for
   manual one-off open/close positions or mirror (copy-trade) strategies that have
   NO DSL. If DSL / a trailing stop / "protect this" is anywhere in the intent →
-  author it here. DEFAULT behavior: ask the 7 design decisions one question at a
-  time, reflect each answer back, then assemble + smoke-test the package. Also
+  author it here. FIRST, before building from scratch, offer the fast path: surface
+  the closest matching TEMPLATE (via senpi-strategy-discover) as the recommended
+  on-ramp for new users — start from it, fork-and-customize it, or design your own;
+  the user's choice is final, scratch is a peer not a downsell. If they choose scratch
+  (or already gave a specific custom thesis), DEFAULT behavior: ask the 7 design
+  decisions one question at a time, reflect each answer back, then assemble + smoke-test the package. Also
   edits existing strategies. NOT for installing (senpi-strategy-ops) or picking
   one to run (senpi-strategy-discover).
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.3.0"
+  version: "2.4.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -46,6 +50,41 @@ much risk). Your job is to draw those out, one question at a time, and compile t
 > no name). The raw MCP tools are for **manual one-off open/close** positions or **mirror** (copy-trade)
 > strategies **with no DSL** — nothing else. If protection is anywhere in the ask, you're in the right
 > skill; author it.
+
+## Start here — offer the fast path before building from scratch
+
+Building from scratch is powerful, but it's the **slow** path (the full interview + compile + smoke-test).
+Most users — especially new ones — are best served by starting from a **proven template** and tweaking it
+if they want. So **before the interview, offer three ways to go** — as peers, with the fast one recommended,
+never as a gate:
+
+1. **Start from a matching template** — *the fastest way to get running.* If the user gave any thesis hint,
+   surface the closest one: `python3 senpi-strategy-discover/scripts/discover.py --theme "<their words>"
+   --no-market` and read `meta.theme_matches`. Name the top fit (*"**Cougar** — equity long/short — is
+   close to what you described"*). The template path is **senpi-strategy-discover**'s job (it picks +
+   deploys via ops) — hand it off; don't rebuild the catalog here.
+2. **Start from that template and make it your own** — deploy the template, then **edit it** (this skill's
+   edit path — see "Editing an existing strategy") to change the universe / thresholds / sizing / DSL. The
+   bridge for *"close, but I want changes."*
+3. **Design your own from scratch** — first-class, fully supported; you run the interview below.
+
+**Example opening (new-ish user, thesis hinted):**
+> *"Two ways to go: I can get you running fast from a proven template — **Cougar** is close to what you
+> described, and you can tweak it to make it yours — or if you'd rather, we design one from scratch
+> together. Your call — what sounds better?"*
+
+**Tone — encourage without discouraging (this is the whole point):**
+- Template-first is *"the fastest way to get running,"* **never** *"the right way."* Scratch is a **peer**,
+  not a downsell.
+- **The user's choice is final.** If they pick scratch — or already gave a specific custom thesis — go
+  straight into the interview. **Never re-pitch templates, never nag.**
+- **Calibrate to the signal.** Brand-new / vague ask → lean into template-first + the fork path. Clear
+  custom thesis → surface the closest match **once** (*"heads-up, Cougar is close to this"*), then respect
+  their call and build.
+- If discover surfaces **no** close fit, say so and go straight to scratch — never force a bad-fit template.
+
+Everything below is the **scratch / customize** path — the interview you run once the user chooses to build
+(or to tweak a template they just deployed).
 
 ## ⛔ Never guess syntax — get it from the source (your memory is NOT authoritative)
 

--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: senpi-strategy-discover
 description: >-
-  Help a user choose a Senpi trading strategy to deploy — a
-  conversational, analyst-style picker. Use when the user asks "what should I
-  trade?", "recommend a strategy", "help me pick a strategy", "what's
-  winning?", "set me up", "I have a view on the world (a war, the economy, one
-  coin winning) — trade it", "run a hedge fund / all-weather / tail-risk book",
-  or wants a strategy but has NOT named a specific one. You talk and RANK; a
-  hidden engine (scripts/discover.py) fetches data + filters. NOT for installing a
-  NAMED strategy (that's senpi-strategy-ops) or building one (senpi-strategy-author).
+  Help a user choose a Senpi trading strategy to deploy — a conversational,
+  analyst-style picker, and the DEFAULT first stop for ANY open-ended "I want a
+  strategy" ask. Use when the user asks "what should I trade?", "recommend a
+  strategy", "help me pick a strategy", "make me a strategy", "build me a
+  strategy", "I want a strategy", "get me set up", "set me up with a strategy",
+  "what's winning?", "I have a view on the world (a war, the economy, one coin
+  winning) — trade it", "run a hedge fund / all-weather / tail-risk book", or
+  wants a strategy but has NOT named a specific one. Surface a matching TEMPLATE
+  first — the fastest on-ramp, which the user can then fork/customize — passing
+  their thesis as `--theme` to rank the closest fits. You talk and RANK; a hidden
+  engine (scripts/discover.py) fetches data + filters. Route to senpi-strategy-author
+  ONLY when the user explicitly wants to DESIGN their own from scratch or needs a
+  custom DSL/scanner not in the catalog (and author itself offers the closest
+  template first). NOT for installing a NAMED strategy (that's senpi-strategy-ops).
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.3.0"
+  version: "2.4.0"
   platform: senpi
   exchange: hyperliquid
 ---


### PR DESCRIPTION
Makes **templates the encouraged on-ramp** for new users — without gating anyone out of building from scratch. Two coordinated skill changes (both v2.4.0):

## strategy-author — opening 3-way offer (before the interview)
1. **Start from a matching template** — fastest. Surface the closest via `senpi-strategy-discover --theme "<their thesis>"` (#443), name the top fit, hand the template path to discover.
2. **Fork & customize** — deploy the template, then edit it (universe / thresholds / sizing / DSL).
3. **Build from scratch** — first-class; run the interview.

**Tone guardrails (the nuance):** template-first is "the fastest way to get running," never "the right way"; scratch is a **peer, not a downsell**; the **user's choice is final** (never re-pitch, never nag); calibrate to signal (vague → lean template + fork; specific custom thesis → surface the closest match *once*, then build); no close fit → straight to scratch.

## strategy-discover — the router default
Broadened triggers to also claim the build-verb vague asks (**"make me a strategy," "build me a strategy," "I want a strategy," "get me set up"**) and declared discover the **default first stop** for any open-ended strategy ask — route to author *only* for an explicit from-scratch / custom-DSL design. Since routing here is description-driven (OpenClaw injects skill descriptions; the central routing-map is still an unmerged WIP branch), tuning the two descriptions **is** the router default. Author now redirects to templates anyway, so mis-routes converge.

Verified: `--theme "equity long short"` → cougar/cub/octopus (the Cougar example is grounded). Both MINOR bumps → auto-upgrade, within `maxMajor: 2`. Discover tests 5/5 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)