### PR TITLE
senpi-trading-runtime: fix 4 author-breaking doc errors (for Sarvesh's review)

### DIFF
--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -54,7 +54,7 @@ The interaction surface is small and one-directional — you read, you return si
   - **`ctx.wallet`** — the strategy's wallet address.
   - → `references/scan-contract.md`
 - **The return value** is a `list[dict]`, one per candidate signal (`asset`, `direction`,
-  `marginUsd`, `leverage`, `data{}`). The runtime validates each `data{}` against the runtime.yaml's
+  `marginPct`, `leverage`, `data{}`). The runtime validates each `data{}` against the runtime.yaml's
   `signal_data_schema`, then sizes, executes, and manages exits.
 
 Keep the thesis logic in a sibling pure **`scoring.py`** (no I/O, no MCP) so it is unit-testable;

--- a/senpi-trading-runtime/references/runtime-concepts.md
+++ b/senpi-trading-runtime/references/runtime-concepts.md
@@ -91,7 +91,7 @@ tracking) and closes (to clean up). Without this scanner the DSL never learns ab
 ## Actions: how signals become trades and exits
 
 An action consumes signals from one or more scanners and reacts. `decision_mode` is `rule`, `llm`, or
-`no_decision`.
+`none`.
 
 - **`OPEN_POSITION`** consumes the signals your `external_scanner` returns and opens a position via
   `FEE_OPTIMIZED_LIMIT`. In `rule` mode it opens on every accepted signal; in `llm` mode a decision
@@ -198,19 +198,16 @@ price_retrace = retrace_threshold / 100 / leverage
 Configured at the **preset root** (siblings of `phase1`/`phase2`), each runs every tick alongside the
 phase logic, after Phase 1 floor-breach counting. Their phase behavior:
 
-- **`hard_timeout` is Phase 1 only.** If the position enters Phase 2 before the interval elapses, it
-  never fires.
-- **`weak_peak_cut` and `dead_weight_cut` are evaluated in any phase** while the position is open
-  (though `weak_peak_cut`'s guard usually only holds in Phase 1 — see below).
+- **`hard_timeout`, `weak_peak_cut`, and `dead_weight_cut` are all evaluated in any phase** while the
+  position is open (`weak_peak_cut`'s guard usually only holds in Phase 1 — see below).
 
-#### `hard_timeout` — Phase 1 only
+#### `hard_timeout` — any phase
 
-> "Close a position that has stayed in Phase 1 for at least N minutes."
+> "Close a position that has been open for at least N minutes."
 
-Fires only **while the position is still in Phase 1**. If the position **enters Phase 2** (first tier
-crossed) before the interval elapses, `hard_timeout` **never fires** for that position — in Phase 2,
-elapsed time is ignored for this cut. On the exact tick where the interval has elapsed *and* price
-crosses into the first tier, **tier/phase advance wins** and no `hard_timeout` is emitted.
+A preset-level time cut (a `dsl_preset` root key, sibling of `phase1`/`phase2` — **not** nested under
+`phase1`). It fires on wall-clock minutes since open **regardless of phase**: once the interval has
+elapsed the position is closed whether it is still in Phase 1 or has already advanced into Phase 2.
 
 **Field:** `interval_in_minutes` — wall-clock minutes since open. Must be > 0 (clamped to ≥ the cron
 interval).
@@ -252,7 +249,7 @@ phase.
 |---|---|
 | `dsl_breach` | Phase 1 floor breached for `consecutive_breaches_required` consecutive ticks |
 | `exchange_sl_hit` | Exchange stop-loss filled (Phase 2 floor, or the Phase 1 absolute floor) |
-| `hard_timeout` | Open past `hard_timeout.interval_in_minutes` while still in Phase 1 |
+| `hard_timeout` | Open past `hard_timeout.interval_in_minutes` (any phase) |
 | `weak_peak_cut` | Peak ROE stayed below `min_value` and price retraced from it |
 | `dead_weight_cut` | ROE stayed non-positive past `dead_weight_cut.interval_in_minutes` |
 | `flipped` | Position direction reversed (detected by `position_tracker`) |
@@ -272,7 +269,7 @@ POSITION_TRACKER action → fires ON_POSITION_OPENED { SOL, LONG, 150, 10× }
 DSL monitor → creates state for SOL; absolute floor at max_loss_pct
    ↓ (DSL tick every interval_seconds)
 Tick: price $152 → ROE +1.33% → hw $152, retrace floor below → no breach, no tier
-Tick: price $165 → ROE +10% → Tier 1 (trigger 10) → ENTER PHASE 2 (hard_timeout no longer applies)
+Tick: price $165 → ROE +10% → Tier 1 (trigger 10) → ENTER PHASE 2
 Tick: price $180 → ROE +20% → Tier 3 → SL ratchets to tier floor
 Tick: price $155 → exchange SL at the locked floor executes → CLOSE, reason exchange_sl_hit
    ↓
@@ -290,7 +287,7 @@ Telegram notification (if dsl_lifecycle enabled)
 | `max_loss_pct` | Hard absolute floor — never lose more than this ROE% from entry. Positive number. |
 | `trigger_pct` (tier) | ROE% that activates this tier and enters Phase 2. Strictly ascending across tiers. |
 | `lock_hw_pct` (tier) | % of peak high-water ROE to protect as the Phase 2 trailing floor. Higher = tighter. |
-| `hard_timeout` | Max minutes in Phase 1 before giving up on an undeveloped position. Phase 1 only. |
+| `hard_timeout` | Max wall-clock minutes open before giving up on the position. Fires in any phase. |
 | `weak_peak_cut` | Exits faded positions whose peak never reached `min_value` ROE. |
 | `dead_weight_cut` | Exits positions held continuously non-positive past the interval. |
 | `interval_seconds` (exit) | How often the DSL evaluates open positions. Integer, 5–3600. |

--- a/senpi-trading-runtime/references/runtime-yaml.md
+++ b/senpi-trading-runtime/references/runtime-yaml.md
@@ -62,7 +62,7 @@ actions:
     scanners: [position_tracker]
   - name: iguana_entry
     action_type: OPEN_POSITION
-    decision_mode: rule             # rule | llm | no_decision
+    decision_mode: rule             # rule | llm | none
     scanners: [iguana_signals]
     params:
       order_type: FEE_OPTIMIZED_LIMIT
@@ -116,8 +116,8 @@ notifications:
 | `risk` | — | Risk guard-rails |
 | `notifications` | — | Telegram + lifecycle toggles |
 
-> The schema is **passthrough** — unknown keys are accepted but ignored. Do not rely on undeclared
-> fields (e.g. there is no `budget` field). Use `strategy:` (singular); plural `strategies:` is rejected.
+> The schema is **passthrough** — unknown keys are accepted but ignored, so do not rely on undeclared
+> fields. Use `strategy:` (singular); plural `strategies:` is rejected.
 
 ### Environment substitution
 
@@ -133,6 +133,7 @@ the resolved config.
 |---|---|---|
 | `wallet` | ✅ | min 1 char; the runtime's wallet address (use `${...}`) |
 | `slots` | — | concurrent position slots |
+| `budget` | — | strategy budget (USD); the sizing fallback **and** the base for `daily_loss_limit_pct` — the runtime computes `dailyLossLimit = daily_loss_limit_pct/100 × budget` |
 | `margin_per_slot` | — | fixed margin per slot (USD) |
 | `margin_pct` | — | margin as % of account; > 0, ≤ 100 |
 | `default_leverage` | — | default leverage multiplier |
@@ -184,7 +185,7 @@ delivers the returned signals — there is no push/ingest model.
 ## `actions` block
 
 Each entry needs a unique `name` and an `action_type` ∈ `OPEN_POSITION` | `CLOSE_POSITION` |
-`POSITION_TRACKER`. `decision_mode` ∈ `rule` | `llm` | `no_decision`.
+`POSITION_TRACKER`. `decision_mode` ∈ `rule` | `llm` | `none`.
 
 | Field | Notes |
 |---|---|
@@ -246,7 +247,7 @@ every `OPEN_POSITION`; if `risk` is absent, none are evaluated.
 | Field | Constraints |
 |---|---|
 | `data_retention_seconds` | integer, 3600–604800 |
-| `guard_rails.daily_loss_limit_pct` | ≥ 0 |
+| `guard_rails.daily_loss_limit_pct` | ≥ 0; % of `strategy.budget` (`dailyLossLimit = daily_loss_limit_pct/100 × budget`) |
 | `guard_rails.max_entries_per_day` | integer ≥ 1 |
 | `guard_rails.bypass_max_entries_per_day_on_profit` | bool (default false) |
 | `guard_rails.max_consecutive_losses` | integer ≥ 1 |

--- a/senpi-trading-runtime/references/scan-contract.md
+++ b/senpi-trading-runtime/references/scan-contract.md
@@ -37,8 +37,7 @@ def scan(inputs, ctx):
     out = [{
         "asset": p["coin"],            # REQUIRED
         "direction": p["direction"],   # REQUIRED — "LONG" | "SHORT"
-        "marginPct": p["margin_pct"],  # top-level PERCENT of withdrawable — the fleet-standard sizing field
-        # (or "marginUsd": p["margin_usd"] for a fixed USD amount — pick one)
+        "marginPct": p["margin_pct"],  # top-level PERCENT of withdrawable/equity in (0,100] — the sizing field the runtime reads
         "leverage": p["leverage"],     # top-level
         "data": {                      # validated against signal_data_schema
             "score": p["score"], "direction": p["direction"], "reasons": p["reasons"],
@@ -141,8 +140,8 @@ Return a `list[dict]`, one per candidate. Keys:
 |---|---|---|
 | `asset` | ✅ | non-empty string |
 | `direction` | ✅ | normalized to `LONG` / `SHORT` (case-insensitive in) |
-| `marginPct` | — | **top-level**, PERCENT of withdrawable in (0,100] — **the fleet standard** (~97 of 102 scanners); the runtime sizes `(marginPct/100) × withdrawable`. Positive when present; a present-but-non-positive value is a **loud reject** |
-| `marginUsd` | — | **top-level**, a fixed USD amount (not a percent) — the alternative to `marginPct`; positive when present, non-positive is a **loud reject** |
+| `marginPct` | — | **top-level**, PERCENT of withdrawable/equity in (0,100] — **the sizing field the runtime reads**; it sizes `(marginPct/100) × withdrawable`. Positive when present; a present-but-non-positive value is a **loud reject** |
+| `marginUsd` | — | **not read** — the runtime has no top-level `marginUsd`; if you emit one it is **silently dropped**. Size with `marginPct` instead |
 | `leverage` | — | **top-level**, positive number when present |
 | `data` | — | validated against the recipe's `signal_data_schema`: unknown key → reject, missing required key → reject, wrong type → reject (types `string`/`number`/`boolean`/`object`/`array`) |
 | `valid_for_seconds` | — | per-signal TTL (relative); a non-positive/non-int falls back to `default_signal_validity_seconds` |
@@ -154,9 +153,9 @@ default_signal_validity_seconds)`), the wire envelope, delivery, and dedup. **Do
 `valid_until`/`produced_at`.** You also don't normalize a `[0,1]` wire score — emit your raw score on
 `data{}`.
 
-`marginPct` (percent of withdrawable — the fleet standard) **or** `marginUsd` (fixed USD), plus
-`leverage`, are the canonical **top-level** sizing fields (the runtime reads
-`signal.marginPct`/`signal.marginUsd`/`signal.leverage` directly) — don't bury them inside `data{}`.
+`marginPct` (percent of withdrawable/equity, (0,100]) plus `leverage` are the canonical **top-level**
+sizing fields — the runtime reads `signal.marginPct`/`signal.leverage` directly. A top-level
+`marginUsd` is **not** read (silently dropped). Don't bury the sizing fields inside `data{}`.
 
 ---
 
@@ -187,7 +186,7 @@ Both are valid — it's your thesis:
 - ✅ Pure scoring in `scoring.py`; MCP + state in `scan.py`.
 - ✅ Keep dedup / rotation / first-seen ledgers in `ctx.state` (`last()` → mutate → `append()`).
 - ✅ Declare every `data{}` key in `signal_data_schema`; set `default_signal_validity_seconds`.
-- ✅ Put `marginPct` (fleet standard) or `marginUsd`, plus `leverage`, at the **top level**, not inside `data{}`.
+- ✅ Put `marginPct` (percent of withdrawable/equity) plus `leverage` at the **top level**, not inside `data{}` (a top-level `marginUsd` is silently dropped).
 - ✅ On any failure, **return `[]`** (or a partial list) — don't crash.
 - ❌ Don't set `valid_until`/`produced_at` — the scaffold owns the envelope (`signal_id` optional).
 - ❌ Don't schedule the scanner yourself or POST signals — the runtime does it.


### PR DESCRIPTION
**For Sarvesh** — owner of the `senpi-trading-runtime` skill. Four doc errors in the skill references were misleading strategy authors; I **verified each against the runtime source** (`@senpi-ai/runtime`) before fixing. Docs only, no version bump — opening for your review, not self-merged.

| # | Error | Verified against | Fix |
|---|---|---|---|
| 1 | `marginUsd` presented as a valid emit / sizing field | runtime reads top-level `marginPct`+`leverage`; `marginUsd` silently dropped (confirmed live — nullified 5 sleeves' sizing) | SKILL.md + `scan-contract.md` (~5 spots): emit `marginPct`, note `marginUsd` is not read |
| 2 | `hard_timeout` "Phase 1 only" | `map-exit-config.ts` — it's a `dsl_preset` root key, sibling of phase1/phase2 | `runtime-concepts.md`: fires in **any** phase |
| 3 | `decision_mode` third value `no_decision` | `DECISION_MODES = ['llm','rule','none']` (`actions/types.ts:88`) | → `none` (runtime-concepts.md, runtime-yaml.md) |
| 4 | "there is no `budget` field" | `strategy.budget` exists (`types/strategy.ts:19`); it's the sizing fallback AND `daily_loss_limit_pct` base (`daily_loss_limit_pct/100 × budget`, `map-strategies.ts:90`) | removed the false claim; added the `budget` row + corrected the daily-loss base |

These pair with the marginUsd→marginPct P0 in #450 — the doc that *taught* `marginUsd` is what led those 5 sleeves astray.

One thing to confirm: I described `budget` without a positivity constraint (wasn't in the verified facts) — add `budget > 0` if the runtime enforces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)