### PR TITLE
improve-trades: detect partial closes (profit taken on open positions) — v1.2.0

### DIFF
--- a/senpi-improve-trades/SKILL.md
+++ b/senpi-improve-trades/SKILL.md
@@ -6,10 +6,11 @@ description: >-
   to the best whales", "how could I make more gains", "suggest improvements", "review my trades", "am I
   getting shaken out too early / how are my exits firing", "what did my own limits block / what couldn't
   I take", "where am I leaking", "walk me through / explain my [asset] trade", "what am I paying in fees /
-  maker vs taker", "why is [strategy] losing". A hidden engine (scripts/review.py) reconstructs every
-  CLOSED trade from discovery, enriches each exit reason + blocked signals from the runtime telemetry
-  event log, computes the honest "if I'd held to now" counterfactual, and crosses the book against what
-  the market did — you narrate it under strict guardrails: process over outcome (lead with the aggregate,
+  maker vs taker", "why is [strategy] losing", "did I take profit on my open positions". A hidden engine
+  (scripts/review.py) reconstructs every CLOSED trade from discovery, surfaces realized profit already TAKEN
+  on still-open positions (partial closes / TP / SL fills), enriches each exit reason + blocked signals from
+  the runtime telemetry event log, computes the honest "if I'd held to now" counterfactual, and crosses the
+  book against what the market did — you narrate it under strict guardrails: process over outcome (lead with the aggregate,
   not the one reversal), it's the STRATEGY not the user, NO fabricated "+$X/week", no performance-chasing,
   honest sourcing (onchain facts = discovery, exit reason / blocked / leaks = telemetry), and the user
   chooses how deep the fix goes. Composes senpi-market-pulse (movers), senpi-smart-money (whales), and
@@ -17,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.1.1"
+  version: "1.2.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -49,8 +50,11 @@ Two sources, two jobs. Never mix them, and never reconstruct one from the other.
 
 - **Onchain trade facts → `discovery`.** The trade **list itself** + every onchain fact: asset, direction,
   entry/exit price, realized PnL, fees, timing, leverage, size. Discovery **owns** these — they are never
-  re-derived from anything else. `discovery_get_trader_history` is the trade lister; `market_get_asset_data`
-  supplies the current price for the "if I'd held to now" counterfactual.
+  re-derived from anything else. `discovery_get_trader_history` lists **fully-closed** trades (`trades[]`);
+  `discovery_get_open_position_realized_pnl` reports **realized profit already taken on a still-OPEN
+  position** (partial closes / TP / SL fills / size reductions → `partial_closes[]`) — the profit
+  trader_history is blind to; `market_get_asset_data` supplies the current price for the "if I'd held to now"
+  counterfactual.
 - **Runtime / agent events → `telemetry` (the on-disk event log).** The facts discovery *can't* see because
   they left no onchain trace: each trade's **exit reason** (`dsl.closed` / `position.closed` close_reason +
   tier + roe), the **blocked/rejected signals** you never took (`signal.outcome`), and the **leak / exit-
@@ -319,11 +323,36 @@ Concretely: if you're about to say "you have 13 wallets, kill/merge 11 of them,"
 `meta.current_strategy_count`. If most of those 13 are in `closed_strategies[]`, the real live book is small
 and there is **no consolidation problem** — you're looking at redeploy history.
 
-### 9. No trades yet? Stop cleanly — do NOT pivot to setup / config nagging
+### 9. No CLOSED trades? Check partial closes FIRST — "no closed trades" ≠ "no activity"
 
-A trade review with **no closed trades** — especially **brand-new strategies deployed today with no
-positions yet** — is a **complete, correct result**: *"nothing to review yet."* Say that and stop. The
-strategies are **autonomous**; they open positions on their own when their scanners fire. **Do not
+**Before you reach for the fresh-strategy / "nothing to review" framing, check `partial_closes`.** A partial
+close, take-profit fill, stop fill, or size reduction on a position that **stays open** books **real realized
+profit** but leaves the position open — so it creates **no fully-closed-trade entry**, and
+`discovery_get_trader_history` (which lists only FULLY-closed positions) reports **zero closed trades even
+after the user took, say, 80% profit off two live positions.** Two sources, two kinds of realized profit:
+
+- **Fully-closed trades → `discovery_get_trader_history`** — the `trades[]` timing review.
+- **Realized-taken-on-open (partial closes) → `discovery_get_open_position_realized_pnl`** — the standalone
+  `partial_closes[]` stream: profit **already banked** on a **still-open** position. `meta.has_partial_closes`
+  / `meta.partial_close_count` gate this.
+
+**If `partial_closes` is non-empty, there IS something to review — REVIEW IT. Never say "nothing to
+review."** Narrate:
+- **The profit-taking** — how much was banked (`realized_taken`), on which asset/strategy. Was it early or
+  late vs the subsequent move? (You can only judge "early vs late" if you have the current price/move — else
+  say the profit was taken, don't guess the timing.) Keep it process-framed (guardrails 1–3): it's the
+  **strategy's** TP/DSL that took the profit, not the user; **no** "+$X/week."
+- **The REMAINING exposure and its protection** — `remaining_notional` (still on the table) and, per
+  guardrails 2 & 8, whether that open leg is protected by its DSL (**never** call it "unprotected" from an
+  empty ratchet record; the phase-1 floor is on from entry).
+
+**Only use the brand-new / fresh-strategy framing below when there are genuinely ZERO closed trades AND ZERO
+partial closes** (`trade_count == 0` **and** `has_partial_closes` false — which is exactly when
+`meta.degraded` fires). That is the real "just deployed, waiting for its first signal" case:
+
+A trade review with **no closed trades AND no partial closes** — especially **brand-new strategies deployed
+today with no positions yet** — is a **complete, correct result**: *"nothing to review yet."* Say that and
+stop. The strategies are **autonomous**; they open positions on their own when their scanners fire. **Do not
 manufacture a setup/config critique to seem useful.** The specific failures this prevents (all from a live
 run on a just-deployed book):
 
@@ -398,6 +427,13 @@ closed_strategies[]  HISTORY ONLY (CLOSED / INACTIVE / … — churned or retire
   # (part of the timing review, attributed by label). NEVER give these a "consolidate/kill/fix" verdict,
   # NEVER flag their absent mandate as a bug, NEVER count them as live "wallets to consolidate."
 
+partial_closes[]  realized profit ALREADY TAKEN on a STILL-OPEN position (TP/SL fills, partial closes, size
+  reductions) — from discovery_get_open_position_realized_pnl, NOT trader_history (which lists only FULLY-
+  closed trades). "No closed trades" ≠ "no activity" (guardrail 9). CURRENT book only.
+  { asset, strategy_label, wallet, realized_taken, fees, remaining_notional, remaining_pct }
+  # realized_taken = profit banked on the position while it stays open; remaining_notional = current
+  # positionValue still on the table; remaining_pct = current vs (current + implied-closed) or null.
+
 meta          { warnings[], sources[], window, degraded,
                 strategy_count,             # every enumerated strategy (all statuses) — a raw total
                 current_strategy_count,     # the LIVE book — THIS is "how many strategies you run"
@@ -405,7 +441,8 @@ meta          { warnings[], sources[], window, degraded,
                 trade_count,
                 telemetry_source,           # available | partial | unavailable — how much enrichment landed
                 exit_reason_source_counts,  # { telemetry, ratchet, unknown } — where each exit_reason came from
-                missed_signal_count, leak_counts }   # quick glances at the telemetry streams
+                missed_signal_count, leak_counts,   # quick glances at the telemetry streams
+                partial_close_count, has_partial_closes }   # realized profit taken on OPEN positions (guardrail 9)
 ```
 
 `exit_reason.terminal` — **when telemetry enriched it** (`source: "telemetry"`) it's the native

--- a/senpi-improve-trades/scripts/review.py
+++ b/senpi-improve-trades/scripts/review.py
@@ -27,6 +27,16 @@ fuses discovery_get_trader_history + ratchet_stop_list + market prices. Each tra
 tag ("reconstructed"). v2 telemetry (the successor to the removed audit_* tools) slots in HERE as an
 additional/primary trade+exit source without touching the narration, the guardrails, or the output shape.
 
+TWO KINDS OF REALIZED PROFIT — two discovery sources (never confuse them):
+  • FULLY-CLOSED trades (the position is gone) → `discovery_get_trader_history` (closedPositions[]) — this
+    is `trades[]`, the timing review.
+  • REALIZED-TAKEN-ON-OPEN (profit ALREADY banked on a STILL-OPEN position: TP/SL fills, partial closes,
+    size reductions) → `discovery_get_open_position_realized_pnl`. A partial close leaves the position OPEN,
+    so it creates NO closedPositions[] entry — trader_history alone reports "no closed trades" even after the
+    user took, say, 80% profit off two live positions. `fetch_partial_closes()` reads each open position (via
+    strategy_get_clearinghouse_state) and asks discovery how much realized PnL was already taken on it, so the
+    review SEES the profit-taking. Surfaced as the standalone `partial_closes[]` stream + meta flags.
+
 ⚠ All tools here are USER-scoped (your own account): needs a USER-scoped SENPI_AUTH_TOKEN.
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
@@ -745,6 +755,145 @@ def fetch_closed_trades(client, wallet, since_ms, until_ms, cap, meta):
     if cap:
         trades = trades[:cap]
     return trades
+
+
+# ──────────────────────────────── partial closes — realized profit ALREADY TAKEN on a STILL-OPEN position
+# The bug this fixes: a partial close / TP / SL fill / size reduction on a position that STAYS OPEN books
+# realized PnL but creates NO closedPositions[] entry, so `fetch_closed_trades` (trader_history) reports
+# "no closed trades" even after the user took real profit off live positions — and guardrail 9 then wrongly
+# frames it as "brand-new, nothing to review." SOURCE SPLIT: the OPEN (wallet, coin) set comes from
+# strategy_get_clearinghouse_state (the same main+xyz / assetPositions[] read senpi-portfolio uses); the
+# realized-taken $ comes from ONE batched discovery_get_open_position_realized_pnl over all those pairs.
+def _open_positions_for(client, strat, meta):
+    """Read one strategy wallet's OPEN positions from strategy_get_clearinghouse_state → a list of
+    {coin, dex, notional} (notional = current positionValue). Mirrors senpi-portfolio's extraction: both
+    DEX views (main + xyz), assetPositions[], skip szi==0. Read-guarded + fail-open → [] + a meta.warnings
+    note. Onchain-only; no PnL here — that's the discovery call in fetch_partial_closes."""
+    wallet = strat.get("wallet")
+    out = []
+    try:
+        ch = _ok(client.mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet, timeout=20))
+    except Exception as e:  # noqa — fail-open: this wallet contributes no open positions
+        meta.setdefault("warnings", []).append(
+            f"clearinghouse {str(wallet)[:8]} failed: {e}; partial-close read skipped for it")
+        return out
+    if not isinstance(ch, dict):
+        return out
+    for dex in ("main", "xyz"):
+        d = _field(ch, dex, default={}) if isinstance(ch, dict) else {}
+        if not isinstance(d, dict):
+            continue
+        for ap in (_field(d, "assetPositions", "asset_positions", default=[]) or []):
+            pos = _field(ap, "position", default=ap) or {}
+            if not isinstance(pos, dict):
+                continue
+            szi = _f(pos, "szi", "size", default=0.0)
+            if szi == 0:
+                continue                      # flat leg — not an open position
+            coin = _field(pos, "coin", "asset")
+            if not coin:
+                continue
+            out.append({
+                "coin": coin,
+                "dex": dex,
+                "notional": round(abs(_f(pos, "positionValue", "position_value", default=0.0)), 2),
+            })
+    return out
+
+
+def _parse_realized_pnl_rows(resp):
+    """Normalize a discovery_get_open_position_realized_pnl response into a {(wallet_lower, COIN): {realized,
+    fees}} map. Defensive over the real MCP envelope shapes: after _ok() the payload is a dict whose PnL list
+    lives under `realized_pnl` (the tool's response key) or `realizedPnl` (the GraphQL key), or the response
+    may be a bare list. Each row is {walletAddress, coin, realizedPnl, totalFees} with STRING numerics →
+    parsed to float via _num (unknown/odd → skipped, never fabricated)."""
+    rows = resp
+    if isinstance(resp, dict):
+        rows = _field(resp, "realized_pnl", "realizedPnl", "realized_pnls", default=[])
+    if not isinstance(rows, list):
+        return {}
+    out = {}
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        wallet = _field(r, "walletAddress", "wallet_address", "wallet")
+        coin = _field(r, "coin", "asset")
+        if not wallet or not coin:
+            continue
+        out[(str(wallet).lower(), str(coin).upper())] = {
+            "realized": _num(_field(r, "realizedPnl", "realized_pnl")),
+            "fees": _num(_field(r, "totalFees", "total_fees")),
+        }
+    return out
+
+
+def fetch_partial_closes(client, strategies, meta):
+    """Realized profit ALREADY TAKEN on STILL-OPEN positions — the stream the timing review is blind to
+    (trader_history only lists FULLY-closed trades). For every CURRENT strategy (ACTIVE/PAUSED — the live
+    book; a closed strategy has no open positions), read its OPEN (wallet, coin) pairs from the clearinghouse,
+    then make ONE batched discovery_get_open_position_realized_pnl call over ALL those pairs. Returns a list
+    (one entry per position with NON-ZERO realized taken):
+        {asset, strategy_label, wallet, realized_taken, fees, remaining_notional, remaining_pct}
+    remaining_notional = the still-open positionValue. remaining_pct (current value vs current + implied-
+    closed) is only derivable when the realized taken is a positive profit AND we can approximate the closed
+    notional — otherwise it's left null (never fabricated). Fail-open throughout: any read error → [] + a
+    meta.warnings note; NEVER raises.
+
+    Onchain-only + honest: telemetry never touches this (it's a discovery realized-PnL fact). The whole point
+    is that the agent SEES the profit-taking on open positions without being asked."""
+    out = []
+    current = [s for s in (strategies or []) if _is_current(s.get("status"))]
+    if not current:
+        return out
+    # ── gather the OPEN (wallet, coin) pairs across the live book (clearinghouse per wallet, fail-open) ──
+    pairs = []                                 # [{wallet, coin, dex, notional, label}]
+    for strat in current:
+        wallet = strat.get("wallet")
+        if not wallet:
+            continue
+        for op in _open_positions_for(client, strat, meta):
+            pairs.append({"wallet": wallet, "coin": op["coin"], "dex": op.get("dex"),
+                          "notional": op.get("notional"), "label": strat.get("label")})
+    if not pairs:
+        return out                             # no open positions → nothing could have been partially closed
+    # ── ONE batched realized-PnL call over every open pair (discovery owns the realized-taken $) ──
+    positions_arg = [{"walletAddress": p["wallet"], "coin": p["coin"]} for p in pairs]
+    try:
+        resp = _ok(client.mcp_call("discovery_get_open_position_realized_pnl",
+                                   positions=positions_arg, timeout=20))
+    except Exception as e:  # noqa — fail-open: the whole partial-close stream degrades to empty, never raises
+        meta.setdefault("warnings", []).append(
+            f"discovery_get_open_position_realized_pnl failed: {e}; partial-close detection skipped")
+        return out
+    pnl_map = _parse_realized_pnl_rows(resp)
+    if not pnl_map:
+        return out                             # no realized-taken rows → no partial closes to surface
+    for p in pairs:
+        rec = pnl_map.get((str(p["wallet"]).lower(), str(p["coin"]).upper()))
+        if not rec:
+            continue
+        realized = rec.get("realized")
+        if realized is None or realized == 0:
+            continue                           # only surface positions with NON-ZERO realized taken
+        remaining_notional = p.get("notional")
+        # remaining_pct — current value vs (current + implied-closed). Only derivable for a positive realized
+        # profit we can treat as a rough proxy for the closed notional; otherwise leave null (don't fabricate).
+        remaining_pct = None
+        if (remaining_notional is not None and realized is not None and realized > 0
+                and (remaining_notional + realized) > 0):
+            remaining_pct = round(remaining_notional / (remaining_notional + realized) * 100, 1)
+        out.append({
+            "asset": p["coin"],
+            "strategy_label": p.get("label"),
+            "wallet": p["wallet"],
+            "realized_taken": round(realized, 2),
+            "fees": round(rec["fees"], 2) if rec.get("fees") is not None else None,
+            "remaining_notional": remaining_notional,
+            "remaining_pct": remaining_pct,
+        })
+    # biggest realized-taken first — the profit-taking the narrator should lead with
+    out.sort(key=lambda x: abs(x.get("realized_taken") or 0.0), reverse=True)
+    return out
 
 
 # ──────────────────────────────────────────────────────────────── current price (market_get_asset_data)
@@ -1469,7 +1618,8 @@ def _save_state(path, state):
 def _fresh_meta():
     """A meta skeleton seeded like run()'s — the same `sources` list + fail-open scaffolding, so every step's
     meta reads consistently whether it ran standalone or off state."""
-    return {"warnings": [], "sources": ["discovery_get_trader_history", "ratchet_stop_list",
+    return {"warnings": [], "sources": ["discovery_get_trader_history", "discovery_get_open_position_realized_pnl",
+                                        "strategy_get_clearinghouse_state", "ratchet_stop_list",
                                         "market_get_asset_data", "leaderboard_get_markets",
                                         "openclaw senpi events"], "degraded": None}
 
@@ -1559,20 +1709,26 @@ def step_strategies(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_m
     strat_reads = _strategy_reads(trades, strategies)
     closed_reads = _closed_strategy_rollup(trades, strategies)
     dsl_mix = _dsl_close_reason_mix(trades)   # from whatever exit_reason is in state (UNKNOWN until telemetry)
+    # PARTIAL CLOSES — realized profit ALREADY TAKEN on still-OPEN positions (the stream trader_history is
+    # blind to). Read here (the CURRENT-book surface): clearinghouse open positions × discovery realized-PnL.
+    partial_closes = fetch_partial_closes(client, strategies, meta)
     current_count = sum(1 for s in strategies if _is_current(s.get("status")))
     closed_count = len(strategies) - current_count
     meta["strategy_count"] = len(strategies)
     meta["current_strategy_count"] = current_count
     meta["closed_strategy_count"] = closed_count
     meta["trade_count"] = len(trades)
+    meta["partial_close_count"] = len(partial_closes)
+    meta["has_partial_closes"] = bool(partial_closes)   # the SKILL gates guardrail 9 on this
     if not strategies:
         meta["degraded"] = "no strategies — check the token is USER-scoped"
     state["strategies_read"] = strat_reads
     state["closed_strategies"] = closed_reads
     state["dsl_close_reason_mix"] = dsl_mix
+    state["partial_closes"] = partial_closes
     _save_state(state_path, state)
     return {"strategies": strat_reads, "closed_strategies": closed_reads,
-            "dsl_close_reason_mix": dsl_mix, "meta": meta}
+            "dsl_close_reason_mix": dsl_mix, "partial_closes": partial_closes, "meta": meta}
 
 
 def step_telemetry(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True,
@@ -1645,7 +1801,8 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
     """Orchestrate the review. Everything read-guarded + fail-open: partial data → valid JSON +
     meta.warnings/meta.degraded. `last_n` (a trade-count cap) coexists with the window — 'last N trades'
     still respects the window as the outer bound."""
-    meta = {"warnings": [], "sources": ["discovery_get_trader_history", "ratchet_stop_list",
+    meta = {"warnings": [], "sources": ["discovery_get_trader_history", "discovery_get_open_position_realized_pnl",
+                                        "strategy_get_clearinghouse_state", "ratchet_stop_list",
                                         "market_get_asset_data", "leaderboard_get_markets",
                                         "openclaw senpi events"], "degraded": None}
     since_ms, until_ms = _window_bounds(window_days, now_ms=now_ms)
@@ -1669,6 +1826,10 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
     bvm = book_vs_market(client, trades, strategies, meta, want_market)
     strat_reads = _strategy_reads(trades, strategies)          # CURRENT book only (active/paused)
     closed_reads = _closed_strategy_rollup(trades, strategies) # HISTORY: closed/inactive, rollup only
+    # PARTIAL CLOSES — realized profit ALREADY TAKEN on still-OPEN positions (TP/SL fills, size reductions).
+    # trader_history only lists FULLY-closed trades, so this is the ONLY view of profit banked on live
+    # positions. Clearinghouse open positions × ONE batched discovery realized-PnL call. Fail-open to [].
+    partial_closes = fetch_partial_closes(client, strategies, meta)
 
     current_count = sum(1 for s in strategies if _is_current(s.get("status")))
     closed_count = len(strategies) - current_count
@@ -1682,10 +1843,14 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
     meta["telemetry_source"] = _telemetry_source(src_counts, meta.get("_telemetry_warned", False))
     meta["missed_signal_count"] = len(missed_signals)
     meta["leak_counts"] = {k: v["count"] for k, v in leaks.items()}   # quick meta glance at the leak tallies
+    meta["partial_close_count"] = len(partial_closes)
+    meta["has_partial_closes"] = bool(partial_closes)         # the SKILL gates guardrail 9 on this
     meta.pop("_telemetry_warned", None)                        # internal flag — not part of the contract
     if not strategies:
         meta["degraded"] = "no strategies — check the token is USER-scoped"
-    elif not trades:
+    elif not trades and not partial_closes:
+        # "no closed trades" is NOT "no activity": only degrade when there are ALSO zero partial closes
+        # (profit taken on open positions). If partial_closes exist, there IS something to review.
         meta["degraded"] = "no closed trades in the window (or trade history unavailable)"
 
     return {
@@ -1700,6 +1865,7 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
         "execution_quality": exec_quality, # 'fees — maker vs taker' (+ future authoritative-fee ledger hook)
         "strategies": strat_reads,        # CURRENT book only — each judged vs its OWN mandate
         "closed_strategies": closed_reads, # HISTORY — minimal rollup, NO verdict/mandate (never consolidate)
+        "partial_closes": partial_closes,  # realized profit ALREADY TAKEN on still-OPEN positions (TP/SL/partial)
         "meta": meta,
     }
 
@@ -1741,6 +1907,7 @@ def _all_and_persist(client, window_days, last_n, want_market, state_path, now_m
         "execution_quality": result.get("execution_quality"),
         "strategies_read": result.get("strategies"),
         "closed_strategies": result.get("closed_strategies"),
+        "partial_closes": result.get("partial_closes"),
         "meta_warnings": (result.get("meta") or {}).get("warnings", []),
     }
     _save_state(state_path, state)

--- a/senpi-improve-trades/scripts/review.py
+++ b/senpi-improve-trades/scripts/review.py
@@ -857,7 +857,10 @@ def fetch_partial_closes(client, strategies, meta):
     if not pairs:
         return out                             # no open positions → nothing could have been partially closed
     # ── ONE batched realized-PnL call over every open pair (discovery owns the realized-taken $) ──
-    positions_arg = [{"walletAddress": p["wallet"], "coin": p["coin"]} for p in pairs]
+    # the tool REQUIRES snake-case `wallet_address` (verified live against the tool schema); send both
+    # forms defensively since the position item allows extra keys.
+    positions_arg = [{"wallet_address": p["wallet"], "walletAddress": p["wallet"], "coin": p["coin"]}
+                     for p in pairs]
     try:
         resp = _ok(client.mcp_call("discovery_get_open_position_realized_pnl",
                                    positions=positions_arg, timeout=20))

--- a/senpi-improve-trades/tests/fixtures/review_partial_close_fixture.json
+++ b/senpi-improve-trades/tests/fixtures/review_partial_close_fixture.json
@@ -1,0 +1,55 @@
+{
+  "_comment": "PARTIAL-CLOSE fixture. Built from the MCP TYPE shapes in senpi-hyperliquid-mcp/src/types/senpi.types.ts (ClearingHouseStateResult + OpenPositionRealizedPnlResult / GetOpenPositionRealizedPnlResponse) + the discovery.tools.ts handler (response key `realized_pnl` after the createResponse `data` unwrap) — NOT a live recording (the tool was not callable this session). MUST get a live smoke-test before merge. Two CURRENT strategies: `bear` holds an OPEN BTC position with realized profit ALREADY TAKEN (a partial close) → partial_closes surfaces it; `hare` is genuinely flat (open positions, but zero realized taken — and one truly-empty leg) → contributes nothing. Neither has any FULLY-closed trade, so trader_history reports zero closed trades: the exact bug scenario.",
+
+  "strategy_list": {"strategies": [
+    {"tradingStrategyName": "bear", "id": "strat-bear-1",
+     "strategyWalletAddress": "0xBEAR0000000000000000000000000000000bear", "status": "ACTIVE"},
+    {"tradingStrategyName": "hare", "id": "strat-hare-1",
+     "strategyWalletAddress": "0xHARE0000000000000000000000000000000hare", "status": "ACTIVE"}
+  ]},
+
+  "discovery_get_trader_history::0xbear0000000000000000000000000000000bear": {"closedPositions": []},
+  "discovery_get_trader_history::0xhare0000000000000000000000000000000hare": {"closedPositions": []},
+
+  "strategy_get_clearinghouse_state::0xbear0000000000000000000000000000000bear": {
+    "main": {
+      "marginSummary": {"accountValue": "5000.00"},
+      "withdrawable": "1200.00",
+      "assetPositions": [
+        {"type": "oneWay", "position": {
+          "coin": "BTC", "szi": "-0.20", "positionValue": "20000.00", "entryPx": "104000.00",
+          "leverage": {"type": "cross", "value": 3}, "unrealizedPnl": "150.00", "returnOnEquity": "0.05"}}
+      ]
+    },
+    "xyz": {"marginSummary": {"accountValue": "1200.00"}, "withdrawable": "1200.00", "assetPositions": []}
+  },
+
+  "strategy_get_clearinghouse_state::0xhare0000000000000000000000000000000hare": {
+    "main": {
+      "marginSummary": {"accountValue": "800.00"},
+      "withdrawable": "500.00",
+      "assetPositions": [
+        {"type": "oneWay", "position": {
+          "coin": "ETH", "szi": "0.30", "positionValue": "900.00", "entryPx": "2900.00",
+          "leverage": {"type": "cross", "value": 2}, "unrealizedPnl": "0.00", "returnOnEquity": "0.0"}},
+        {"type": "oneWay", "position": {
+          "coin": "SOL", "szi": "0", "positionValue": "0.00", "entryPx": "0.00",
+          "leverage": {"type": "cross", "value": 2}, "unrealizedPnl": "0.00", "returnOnEquity": "0.0"}}
+      ]
+    },
+    "xyz": {"marginSummary": {"accountValue": "500.00"}, "withdrawable": "500.00", "assetPositions": []}
+  },
+
+  "discovery_get_open_position_realized_pnl": {
+    "realized_pnl": [
+      {"walletAddress": "0xBEAR0000000000000000000000000000000bear", "coin": "BTC",
+       "realizedPnl": "480.00", "totalFees": "12.50"},
+      {"walletAddress": "0xHARE0000000000000000000000000000000hare", "coin": "ETH",
+       "realizedPnl": "0", "totalFees": "0"}
+    ],
+    "count": 2,
+    "fetched_at": "2026-07-05T00:00:00Z"
+  },
+
+  "leaderboard_get_markets": {"markets": [], "window": "4h", "timestamp": 1782800100}
+}

--- a/senpi-improve-trades/tests/test_review.py
+++ b/senpi-improve-trades/tests/test_review.py
@@ -529,7 +529,7 @@ def test_step_strategies_slice_reads_state():
         return review.step_strategies(_fresh_client(), window_days=WINDOW_DAYS, want_market=True,
                                       state_path=sp, now_ms=NOW_MS)
     out = _with_env(_seq)
-    assert set(out) == {"strategies", "closed_strategies", "dsl_close_reason_mix", "meta"}
+    assert set(out) == {"strategies", "closed_strategies", "dsl_close_reason_mix", "partial_closes", "meta"}
     strat = {s["label"]: s for s in out["strategies"]}["kodiak"]
     assert strat["dsl"]["hard_stop_roe_pct"] == -15.0    # mandate/DSL from the registry
     assert strat["realized_pnl"] == 340.0
@@ -668,6 +668,109 @@ def test_default_state_path_uses_tempdir_and_window_key():
     assert p.startswith(tempfile.gettempdir())
     assert os.path.join("senpi-improve-trades", "state-7d.json") in p
     assert review._default_state_path(30.0, 20).endswith("state-30d-last20.json")
+
+
+# ─────────────────────────── partial closes — realized profit ALREADY TAKEN on a STILL-OPEN position
+# The bug: a partial close / TP / SL fill / size reduction leaves the position OPEN, so it creates NO
+# closedPositions[] entry — trader_history reports "no closed trades" even after real profit was banked, and
+# guardrail 9 wrongly frames the book as "brand-new, nothing to review." fetch_partial_closes reads each open
+# position (strategy_get_clearinghouse_state, main+xyz, skip szi==0) and asks discovery how much realized PnL
+# was taken on it (ONE batched discovery_get_open_position_realized_pnl). The fixture is built from the MCP
+# TYPE shapes (senpi.types.ts), NOT a live recording → needs a live smoke-test before merge.
+PARTIAL_FIXTURE = os.path.join(HERE, "fixtures", "review_partial_close_fixture.json")
+BEAR_WALLET = "0xBEAR0000000000000000000000000000000bear"
+
+
+def _partial_result(want_market=True):
+    """Run the engine against the partial-close fixture. No registry pinned (bear/hare aren't registered —
+    mandate null is fine; partial closes don't depend on it)."""
+    with open(PARTIAL_FIXTURE) as f:
+        client = review._FixtureClient(json.load(f))
+    return review.run(client, window_days=WINDOW_DAYS, want_market=want_market, now_ms=NOW_MS)
+
+
+def test_partial_close_surfaces_realized_taken_on_open_position():
+    """THE core fix: `bear` has ZERO fully-closed trades (trader_history empty) but an OPEN BTC position with
+    $480 realized ALREADY TAKEN (a partial close). partial_closes surfaces it with the realized amount + fees,
+    and meta.has_partial_closes is true — so guardrail 9 does NOT read the book as 'nothing to review.'"""
+    res = _partial_result()
+    assert res["meta"]["trade_count"] == 0                 # NO fully-closed trades — the trap scenario
+    pc = res["partial_closes"]
+    assert len(pc) == 1                                    # only BTC has non-zero realized taken
+    btc = pc[0]
+    assert btc["asset"] == "BTC"
+    assert btc["strategy_label"] == "bear"
+    assert str(btc["wallet"]).lower() == BEAR_WALLET.lower()
+    assert btc["realized_taken"] == 480.0                  # profit banked on the still-open position
+    assert btc["fees"] == 12.5
+    assert btc["remaining_notional"] == 20000.0            # current positionValue (still open)
+    assert btc["remaining_pct"] == 97.7                    # 20000 / (20000 + 480) → most exposure still on
+    # meta flags the SKILL gates guardrail 9 on
+    assert res["meta"]["has_partial_closes"] is True
+    assert res["meta"]["partial_close_count"] == 1
+    # "no closed trades" is NOT "no activity" → NOT degraded (there is something to review)
+    assert res["meta"].get("degraded") is None
+
+
+def test_flat_strategy_contributes_no_partial_close():
+    """`hare` is genuinely flat for this purpose: its open ETH position has ZERO realized taken and its SOL
+    leg is szi==0 (skipped). It contributes nothing → only bear's BTC is in partial_closes (a zero-realized
+    row is never surfaced, never fabricated)."""
+    res = _partial_result()
+    assets = {p["asset"] for p in res["partial_closes"]}
+    assert "ETH" not in assets                             # zero realized taken → not surfaced
+    assert "SOL" not in assets                             # szi==0 leg → not even an open position
+    assert assets == {"BTC"}
+
+
+def test_no_partial_closes_when_truly_empty():
+    """A book with no strategies at all → partial_closes empty, has_partial_closes false, and (with no trades
+    either) meta.degraded set. The genuinely-fresh case guardrail 9's fresh-strategy framing is FOR."""
+    res = review.run(review._FixtureClient({}), window_days=WINDOW_DAYS, now_ms=NOW_MS)
+    assert res["partial_closes"] == []
+    assert res["meta"]["has_partial_closes"] is False
+    assert res["meta"]["partial_close_count"] == 0
+    assert res["meta"].get("degraded")                     # zero trades AND zero partial closes → degraded
+
+
+def test_partial_closes_fail_open_when_realized_pnl_source_missing():
+    """Fail-open: drop the discovery_get_open_position_realized_pnl response → partial_closes degrades to
+    empty with a meta.warnings note, never raises. The rest of the run is intact."""
+    with open(PARTIAL_FIXTURE) as f:
+        raw = json.load(f)
+    raw.pop("discovery_get_open_position_realized_pnl", None)
+    res = review.run(review._FixtureClient(raw), window_days=WINDOW_DAYS, now_ms=NOW_MS)
+    assert res["partial_closes"] == []
+    assert res["meta"]["has_partial_closes"] is False
+    # the clearinghouse read still found open pairs, so the batched call was attempted then returned no rows —
+    # no crash; the run still produces valid JSON
+    assert "trades" in res
+
+
+def test_partial_closes_only_read_for_current_strategies():
+    """Partial closes are a LIVE-book fact: a CLOSED strategy (no open positions) is never queried. The mixed
+    fixture's CLOSED kodiak redeployment contributes no partial closes (its clearinghouse isn't even read)."""
+    res = _mixed_result()
+    # mixed fixture has no clearinghouse/realized-pnl entries → all reads fail open to empty
+    assert res["partial_closes"] == []
+    assert res["meta"]["has_partial_closes"] is False
+
+
+def test_partial_close_present_in_strategies_step_and_matches_all():
+    """partial_closes is wired into BOTH the `strategies` step output AND `run()`/`all` — same key, same
+    value — so steps and the composed run stay consistent. The strategies step also carries the meta flags."""
+    sp = os.path.join(tempfile.mkdtemp(), "pc.json")
+
+    def _seq():
+        return review.step_strategies(
+            review._FixtureClient(json.load(open(PARTIAL_FIXTURE))),
+            window_days=WINDOW_DAYS, want_market=True, state_path=sp, now_ms=NOW_MS)
+    out = _seq()
+    assert "partial_closes" in out
+    assert out["meta"]["has_partial_closes"] is True
+    assert out["meta"]["partial_close_count"] == 1
+    # the step's partial_closes == the composed run's partial_closes (same key, same value)
+    assert out["partial_closes"] == _partial_result()["partial_closes"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug (real user report, verified against source)
> "The agent wasn't aware of the partial closes until I explicitly asked it to check."

`review.py` reconstructed trades **only** from `discovery_get_trader_history` → `closedPositions[]` = **fully-closed only**. A partial close (TP/SL fill, size reduction on a position that stays open) creates **no closed-trade entry**. So a user who'd taken **~80% profit off two open positions** got "no closed trades, nothing to review" — and guardrail 9 framed a genuinely-trading strategy as "brand-new." The skill's whole premise ("did I exit well?") was blind to partial exits — *the* most common "sold too early" pattern.

## Fix
- **`fetch_partial_closes()`** — reads each current strategy's open positions (`strategy_get_clearinghouse_state`), batches the `(wallet, coin)` pairs into one **`discovery_get_open_position_realized_pnl`** call (the purpose-built "profit already taken on a still-open position" tool the engine never used), and surfaces `partial_closes[]` (realized taken, fees, remaining exposure). Fail-open.
- Wired into `run()` + `step_strategies()` (consistent) with `meta.has_partial_closes`; the "no closed trades → degraded" branch now also requires no partial closes.
- **Guardrail 9 rewritten:** "no closed trades" ≠ "no activity" — check `partial_closes` first, review the profit-taking + remaining exposure; the fresh-strategy framing only at genuinely-zero activity.
- v1.1.1 → **1.2.0**. Tests **46/46** (6 new: detection, flat, truly-empty, fail-open, current-only, step/all consistency).

## Two flags for the reviewer
1. **Field-name verified against source.** The MCP handler returns the list under **`realized_pnl`** (snake_case — `createResponse` renames the GraphQL `realizedPnl`); the extraction reads both defensively so it can't silently null. Confirmed at `senpi-hyperliquid-mcp/src/tools/discovery.tools.ts`.
2. **Fixture is type-derived, not a live recording** — the Senpi MCP wasn't callable this session, so the fixture is built from the MCP's type definitions (`senpi.types.ts`) + the verified handler, not a recorded response. **Wants a quick live smoke-test before merge** (the exact "fixtures from real shapes" discipline the strategy-v2 review flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)