### PR TITLE
discover: budgets are minimums, not recommendations (size from user funds)

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.2.2"
+  version: "2.3.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -96,7 +96,7 @@ Each candidate is a flat record. You rank on the soft fields; you narrate from t
 | `direction`, `funding_split` | direction match · whether it's already a multi-wallet fund (skip stacking) |
 | `market_facts` | the live "why now" for your lead |
 | `caveats` | honesty — surface **verbatim** |
-| `suggested_budget` | sizing in the card |
+| `min_budget` | the **floor** to start (`max(declared, $100 × wallets)`) — NOT a recommendation. Size the actual budget from the user's funds (`meta.user_context.budget`); see Layer 3 |
 | `id`, `version` | the handoff to ops |
 
 ## Conversation flow
@@ -148,11 +148,20 @@ otherwise keep it in your head and rank on `archetype_label`/`belief_plain`/`the
    | a specific market | "Which — a stock, pre-IPO name, commodity, index, or coin?" → `--assets`. |
    | copy | "Multi-week proven winners, live hot streaks, or specific whales?" → rank on `tags`. |
    | breakout / structural | the one drill-down that matters for that branch. |
-3. **Size & lock in (Layer 3)** — ask budget (and risk if not implied) only to size + pick the DSL
-   preset. Optionally `discover.py --context-only` to reference holdings (confirm first; never silently
-   infer). Then run the engine with the FULL concrete flag set (this run does the live market read),
-   **rank the eligible set**, and narrate 2–3 cards leading with the top pick's `market_facts` "why now";
-   surface `caveats` verbatim.
+3. **Size & lock in (Layer 3)** — pick the DSL preset and size the budget. **`min_budget` on each card is
+   the FLOOR to run it, not a recommended amount** — never just parrot it as "Suggested: $X". Size from
+   the user's **available funds** (`meta.user_context.budget`, always attached):
+   - If the user named an amount, use it (must be ≥ `min_budget`; if below, surface the floor honestly).
+   - Otherwise **propose** an amount that scales with their free balance and how many strategies they're
+     deploying — a sensible share of available funds per pick, each **≥ its `min_budget`**, leaving a cash
+     buffer — then **confirm before install** ("you've got ~$X free; I'd put ~$Y in Rhino, ~$Z in Spider —
+     good?"). Never invent a number the user hasn't confirmed, and never default everyone to the floor.
+   - If funds are unavailable (`user_context` missing/errored), ask for the budget rather than assuming.
+
+   Optionally `discover.py --context-only` to reference holdings (confirm first; never silently infer).
+   Then run the engine with the FULL concrete flag set (this run does the live market read), **rank the
+   eligible set**, and narrate 2–3 cards leading with the top pick's `market_facts` "why now"; surface
+   `caveats` verbatim.
 
 ### Always-available moves (any point, on demand)
 
@@ -202,9 +211,9 @@ They lack the vocabulary; recommend *without* making them self-classify:
 ```
 {lead: top pick + why-now from market_facts}.
 🦏  Rhino — Tail-Risk / Crisis-Alpha   [{tier}]
-    {thesis}.   Suggested: ${suggested_budget}{ + funding_split if multi-instance}
+    {thesis}.   Min to start ~${min_budget}{ + funding_split if multi-instance}
 {2nd / 3rd card}.   {caveats, verbatim}.
-"Set up {top}, add a hedge alongside it, or build something custom?"
+"You've got ~${user_context.budget} free — set up {top} with ~$Y, add a hedge alongside it, or build something custom?"
 ```
 Show the STARTER badge iff `tier == "starter"`; show `archetype_label`; lead with `thesis` for the
 worldview/fund picks; offer the stack on single-wallet picks only.

--- a/senpi-strategy-discover/scripts/discover.py
+++ b/senpi-strategy-discover/scripts/discover.py
@@ -253,11 +253,11 @@ def _caveats(r, intent):
     return cav
 
 
-def _suggested_budget(r, intent):
-    mb = r.get("min_budget") or 100
-    if intent["budget"] and intent["budget"] >= mb:
-        return int(intent["budget"])
-    return mb
+def _min_budget(r):
+    """The FLOOR to run this strategy — max(declared, $100 x wallets). NOT a recommended amount.
+    Actual sizing scales with the user's available funds and is the LLM's job (see SKILL.md Layer 3);
+    the engine only reports the minimum so the card can say 'needs ~$X to start'."""
+    return int(r.get("min_budget") or 100)
 
 
 def _intent_echo(intent):
@@ -299,8 +299,9 @@ def _candidate(r, intent):
         "time_horizon": r.get("time_horizon"), "asset_scope": r.get("asset_scope"),
         "direction": r.get("direction"), "asset_classes": r.get("asset_classes") or [],
         "assets": r.get("assets") or [], "tier": r.get("tier"),
-        # narration
-        "suggested_budget": _suggested_budget(r, intent), "caveats": _caveats(r, intent),
+        # narration — min_budget is the FLOOR to start, not a recommendation. Size from the user's
+        # available funds (meta.user_context.budget); see SKILL.md Layer 3.
+        "min_budget": _min_budget(r), "caveats": _caveats(r, intent),
         "market_facts": [],
     }
     if r.get("tag_labels"):
@@ -532,6 +533,13 @@ def main(argv=None):
     intent = normalize_intent(args)
     result = match(intent, records, limit=args.limit)
 
+    # User's available funds — ALWAYS attach (independent of market enrichment / candidate count) so the
+    # LLM can size each pick from real balance, not the per-strategy floor. See SKILL.md Layer 3.
+    try:
+        result["meta"]["user_context"] = fetch_user_context(_get_client())
+    except Exception as e:  # noqa
+        result["meta"].setdefault("warnings", []).append(f"user context unavailable: {e}")
+
     # market enrichment (pass 2): ONE batched fetch over the union of survivors' chosen assets, in
     # candidate order (asset-matched first), capped by unique-asset count inside fetch_market_map.
     if not args.no_market and result["candidates"]:
@@ -546,7 +554,6 @@ def main(argv=None):
                     union.append(a)
         try:
             client = _get_client()
-            result["meta"]["user_context"] = fetch_user_context(client)
             fact_map, _ = fetch_market_map(client, union)
             for cand in result["candidates"]:
                 cand["market_facts"] = [fact_map[a] for a in per_cand[cand["id"]] if a in fact_map]

--- a/senpi-strategy-discover/tests/test_discover.py
+++ b/senpi-strategy-discover/tests/test_discover.py
@@ -84,7 +84,7 @@ def test_return_all():
 def test_soft_surface():
     c = next(x for x in run()["candidates"] if x["id"] == "spider")
     for f in ("thesis", "tags", "risk_level", "belief_plain", "archetype_label", "time_horizon",
-              "asset_scope", "direction", "asset_classes", "tier", "suggested_budget", "caveats",
+              "asset_scope", "direction", "asset_classes", "tier", "min_budget", "caveats",
               "market_facts", "id", "version", "name", "emoji", "tagline"):
         check(f"candidate carries '{f}'", f in c, list(c.keys()))
     check("spider thesis non-empty", bool(c["thesis"]))
@@ -180,7 +180,7 @@ def test_caveats():
     sp = next((c for c in rs["candidates"] if c["id"] == "spider"), None)
     check("spider funding_split present", sp and sp.get("funding_split") == [0.6, 0.4], sp.get("funding_split") if sp else None)
     check("spider multi-leg caveat", sp and any("wallet" in c.lower() for c in sp["caveats"]))
-    check("spider suggested_budget>=200", sp and sp["suggested_budget"] >= 200)
+    check("spider min_budget==200 (floor, not a recommendation)", sp and sp["min_budget"] == 200)
     # below-floor budget caveat
     rb = run(assets="btc_eth", budget="50")
     sp2 = next((c for c in rb["candidates"] if c["id"] == "spider"), None)

--- a/senpi-strategy-discover/tests/test_scenarios.py
+++ b/senpi-strategy-discover/tests/test_scenarios.py
@@ -103,7 +103,7 @@ def multi_instance():
     if sp:
         ck("spider shows funding_split", sp.get("funding_split") == [0.6, 0.4])
         ck("spider has leg caveat", any("wallet" in cv.lower() for cv in sp["caveats"]))
-        print(f"  · spider split={sp.get('funding_split')} budget=${sp['suggested_budget']} caveats={sp['caveats']}")
+        print(f"  · spider split={sp.get('funding_split')} budget=${sp['min_budget']} caveats={sp['caveats']}")
 
 
 def null_catalog_robustness():


### PR DESCRIPTION
## Problem
The agent recommends **fixed dollar amounts** per strategy ($400 Rhino, $200 Spider, $200 each), independent of how much the user has. Root cause in `senpi-strategy-discover`:

- `catalog.json` `min_budget` is a **floor** (`max(declared, $100 × wallets)`) — the catalog even says *"NOT a hard gate; positions scale with budget."*
- But `discover.py::_suggested_budget()` returned that floor whenever the user hadn't typed an explicit amount, and the card rendered it as **"Suggested: $X"**.
- The user's real balance **was** fetched (`meta.user_context.budget`) but never used to size — and only attached when market enrichment happened to run.

So the "suggestion" was the floor, blind to the user's funds. Exactly the bug.

## Fix
- **Engine:** rename the emitted field `suggested_budget → min_budget` (an honest floor via new `_min_budget()`); drop the intent-echo fallback.
- **Engine:** **always** attach `meta.user_context` (available funds), independent of market enrichment / candidate count, so the LLM can size from real balance.
- **SKILL.md Layer 3:** size from `user_context.budget` — use the user's stated amount if given (≥ floor), else **propose** a share of available funds per pick (each ≥ its `min_budget`, keep a buffer) and **confirm before install**; never default everyone to the floor. Card now reads **"Min to start ~$X"**; field table + card template updated.
- **strategy-ops unchanged** — it already *requires* `--budget`, splits by `funding_share`, caps at live balance; it was never the source.

## Behavior change
Before: *"Rhino — $400 suggested"* to everyone.
After: *"Rhino needs ~$400 minimum; you've got ~$X free — I'd put ~$Y here. Good?"*

## Tests
- Field renamed in tests; assert `spider min_budget == 200` (floor, not a recommendation).
- `test_discover.py` **86/86**, `test_scenarios.py` **26/26** pass.
- Live engine verified: card carries `min_budget`, no `suggested_budget`, `user_context` attached even with `--no-market`.
- MINOR bump **2.2.2 → 2.3.0** (auto-upgrades users; within manifest `maxMajor: 2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)