### PR TITLE
Regime Allocator — Chimp (daily) + Gorilla (weekly)

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1608,6 +1608,104 @@
       "sort_order": 1
     },
     {
+      "id": "chimp",
+      "name": "Chimp — Regime Allocator (Daily)",
+      "emoji": "🐒",
+      "tagline": "Reads the whole market once a day — the pulse (risk-on/off, dispersion, gold/dollar/VIX) plus where the proven wallets lean — sets a risk posture, and rotates a long/short book across crypto and tokenized stocks/commodities into that posture. It never sells: a regime change just changes what it buys next, and every position is protected by a ratchet stop that does all the exiting.",
+      "belief_plain": "Once a day it looks at everything — are markets risk-on or risk-off, is it a rotation day, what's gold and the dollar doing, where's the smart money — and picks a stance. In risk-on it leans into the leaders; in risk-off it rotates into gold/oil and shorts the weak; on a choppy rotation day it plays winners-vs-losers at smaller size. It never manually closes; a trailing stop protects and exits every position, so old bets wind down on their own as the new stance takes over.",
+      "version": "1.0.0",
+      "thesis": "Users already run the market-pulse skill and then hand-pick strategies to fit the read. Chimp automates that loop: it re-runs the pulse + smart-money read on a daily clock, re-derives its posture, and expresses the change only through new entries — never by force-closing, so turnover is set by the market (via DSL), not by a scanner re-deciding every minute. Daily recalibration + a moderate DSL make it the nimble regime-follower; Gorilla is the weekly, more-committed sibling.",
+      "tags": [
+        "regime",
+        "allocator",
+        "macro",
+        "pulse",
+        "smart-money",
+        "long-short",
+        "universe",
+        "daily",
+        "no-close",
+        "dsl-only"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "macro_thesis",
+      "archetype_label": "Macro Thesis",
+      "sub_style": "adaptive",
+      "sub_style_label": "Self-tunes its thresholds from its own track record.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities",
+        "commodities",
+        "fx"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 21600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 8,
+      "branch": "main",
+      "sort_order": 1
+    },
+    {
+      "id": "gorilla",
+      "name": "Gorilla — Regime Allocator (Weekly)",
+      "emoji": "🦍",
+      "tagline": "The weekly, more-committed sibling of Chimp. Once a week it reads the whole market — the pulse (risk-on/off, dispersion, gold/dollar/VIX) plus where the proven wallets lean — sets a risk posture, and holds a concentrated long/short book across crypto and tokenized stocks/commodities. It never sells: a regime change just changes what it buys next, and a wide trailing stop does all the exiting, letting winners run for weeks.",
+      "belief_plain": "Like Chimp, but slower and more committed. Once a week it decides the stance — risk-on lean into leaders, risk-off rotate into gold/oil and short the weak, rotation week play winners-vs-losers small — and holds fewer, bigger positions. It never manually closes; a wide ratchet stop protects each one and lets the winners run, so the book turns over on the market's schedule, not a scanner's.",
+      "version": "1.0.0",
+      "thesis": "Same automated pulse-then-allocate loop as Chimp, on a weekly clock with a wider DSL and higher conviction gate — for users who want a deliberate regime-follower that commits to a view and rides it, rather than re-tilting daily. Never force-closes; turnover is set by the market via DSL. Pair with Chimp for a fast + slow allocator sleeve.",
+      "tags": [
+        "regime",
+        "allocator",
+        "macro",
+        "pulse",
+        "smart-money",
+        "long-short",
+        "universe",
+        "weekly",
+        "no-close",
+        "dsl-only"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "macro_thesis",
+      "archetype_label": "Macro Thesis",
+      "sub_style": "adaptive",
+      "sub_style_label": "Self-tunes its thresholds from its own track record.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities",
+        "commodities",
+        "fx"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 21600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 7,
+      "branch": "main",
+      "sort_order": 2
+    },
+    {
       "id": "mantis",
       "name": "Mantis — Cross-Asset Catchup Hunter",
       "emoji": "🦎",
@@ -1651,7 +1749,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 1
+      "sort_order": 3
     },
     {
       "id": "octopus",
@@ -1695,7 +1793,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 2
+      "sort_order": 4
     },
     {
       "id": "asia-ai",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1608,6 +1608,104 @@
       "sort_order": 1
     },
     {
+      "id": "chimp",
+      "name": "Chimp — Regime Allocator (Daily)",
+      "emoji": "🐒",
+      "tagline": "Reads the whole market once a day — the pulse (risk-on/off, dispersion, gold/dollar/VIX) plus where the proven wallets lean — sets a risk posture, and rotates a long/short book across crypto and tokenized stocks/commodities into that posture. It never sells: a regime change just changes what it buys next, and every position is protected by a ratchet stop that does all the exiting.",
+      "belief_plain": "Once a day it looks at everything — are markets risk-on or risk-off, is it a rotation day, what's gold and the dollar doing, where's the smart money — and picks a stance. In risk-on it leans into the leaders; in risk-off it rotates into gold/oil and shorts the weak; on a choppy rotation day it plays winners-vs-losers at smaller size. It never manually closes; a trailing stop protects and exits every position, so old bets wind down on their own as the new stance takes over.",
+      "version": "1.0.0",
+      "thesis": "Users already run the market-pulse skill and then hand-pick strategies to fit the read. Chimp automates that loop: it re-runs the pulse + smart-money read on a daily clock, re-derives its posture, and expresses the change only through new entries — never by force-closing, so turnover is set by the market (via DSL), not by a scanner re-deciding every minute. Daily recalibration + a moderate DSL make it the nimble regime-follower; Gorilla is the weekly, more-committed sibling.",
+      "tags": [
+        "regime",
+        "allocator",
+        "macro",
+        "pulse",
+        "smart-money",
+        "long-short",
+        "universe",
+        "daily",
+        "no-close",
+        "dsl-only"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "macro_thesis",
+      "archetype_label": "Macro Thesis",
+      "sub_style": "adaptive",
+      "sub_style_label": "Self-tunes its thresholds from its own track record.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities",
+        "commodities",
+        "fx"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 21600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 8,
+      "branch": "main",
+      "sort_order": 1
+    },
+    {
+      "id": "gorilla",
+      "name": "Gorilla — Regime Allocator (Weekly)",
+      "emoji": "🦍",
+      "tagline": "The weekly, more-committed sibling of Chimp. Once a week it reads the whole market — the pulse (risk-on/off, dispersion, gold/dollar/VIX) plus where the proven wallets lean — sets a risk posture, and holds a concentrated long/short book across crypto and tokenized stocks/commodities. It never sells: a regime change just changes what it buys next, and a wide trailing stop does all the exiting, letting winners run for weeks.",
+      "belief_plain": "Like Chimp, but slower and more committed. Once a week it decides the stance — risk-on lean into leaders, risk-off rotate into gold/oil and short the weak, rotation week play winners-vs-losers small — and holds fewer, bigger positions. It never manually closes; a wide ratchet stop protects each one and lets the winners run, so the book turns over on the market's schedule, not a scanner's.",
+      "version": "1.0.0",
+      "thesis": "Same automated pulse-then-allocate loop as Chimp, on a weekly clock with a wider DSL and higher conviction gate — for users who want a deliberate regime-follower that commits to a view and rides it, rather than re-tilting daily. Never force-closes; turnover is set by the market via DSL. Pair with Chimp for a fast + slow allocator sleeve.",
+      "tags": [
+        "regime",
+        "allocator",
+        "macro",
+        "pulse",
+        "smart-money",
+        "long-short",
+        "universe",
+        "weekly",
+        "no-close",
+        "dsl-only"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "macro_thesis",
+      "archetype_label": "Macro Thesis",
+      "sub_style": "adaptive",
+      "sub_style_label": "Self-tunes its thresholds from its own track record.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities",
+        "commodities",
+        "fx"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 21600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 7,
+      "branch": "main",
+      "sort_order": 2
+    },
+    {
       "id": "mantis",
       "name": "Mantis — Cross-Asset Catchup Hunter",
       "emoji": "🦎",
@@ -1651,7 +1749,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 1
+      "sort_order": 3
     },
     {
       "id": "octopus",
@@ -1695,7 +1793,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 2
+      "sort_order": 4
     },
     {
       "id": "asia-ai",

--- a/strategies/chimp/main/runtime.yaml
+++ b/strategies/chimp/main/runtime.yaml
@@ -1,0 +1,144 @@
+# ── CHIMP · Regime Allocator (DAILY recalibration) ──────────────────────────
+# Reads the whole market once a day (market-pulse day classification + dispersion,
+# funding regime, smart-money cohorts) and holds a standing risk POSTURE; fills
+# free slots with posture-consistent, tape-confirmed entries across main crypto +
+# xyz equities/commodities. NEVER closes — a regime flip just changes what it
+# opens next; prior positions retire on their own DSL (rotate-by-attrition).
+# Daily cadence + a moderate DSL (positions resolve in days) make Chimp the
+# nimble sibling of the weekly Gorilla.
+name: chimp-main
+group: chimp
+version: 1.0.0
+description: >
+  CHIMP — Regime Allocator, daily. Re-derives a risk-on / risk-off / rotation
+  posture from the live market read every 24h and rotates the book into it by
+  attrition: risk-on tilts long the leaders, risk-off rotates into working
+  havens (gold/oil/FX) + shorts the breaking risk complex, a rotation day runs
+  a long-leaders / short-laggards dispersion book at reduced size. One wallet,
+  up to 8 conviction-banded positions, leverage clamped to venue max. DSL is
+  the ONLY exit (18% Phase 1, profit-lock ladder to +80%, 48h weak-peak cut).
+
+strategy:
+  wallet: "${CHIMP_WALLET}"
+  slots: 8
+  margin_pct: 10                      # fallback; scan emits per-signal marginPct
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker            # built-in: feeds the DSL exit engine
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: chimp_allocator
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 21600           # wake every 6h; the market read is gated to daily
+    timeout_seconds: 300              # due tick: 2 instruments + regime + board (+cohorts)
+    default_signal_validity_seconds: 3600
+    state_history_max_count: 200      # posture + recalibration clock + dedup + tick results
+    inputs:
+      # ── the slow clock — the market check runs at THIS cadence, never nonstop ──
+      recalibrationHours: 24
+      maxSlots: 8
+      # ── universe: DERIVED live from BOTH dexes ──
+      universeVolFloorUsd: 25000000   # main crypto perps
+      xyzVolFloorUsd: 3000000         # xyz equities/commodities
+      maxMainNames: 14
+      maxXyzNames: 16
+      excludeAssets: []
+      defensiveAssets: ["GOLD", "SILVER", "PLATINUM", "PALLADIUM", "BRENTOIL", "CL", "NATGAS", "JPY"]   # tradeable havens only (DXY is read-only in pulseGroups — not a live perp)
+      # ── posture sizing ──
+      riskOffSizeScale: 0.7           # smaller in stress
+      mixedSizeScale: 0.6             # smaller when the day has no clear direction
+      # ── entry gates + conviction bands ──
+      minScore: 5.5
+      goodScore: 6.5
+      apexScore: 8.0
+      leverageTiers: { apex: 5, good: 4, base: 3 }    # diversified book -> modest leverage
+      marginPctTiers: { apex: 14, good: 10, base: 7 } # PERCENT of withdrawable (x size_scale)
+      recentSignalTtlSeconds: 43200   # 12h anti-refire per name after a DSL close
+      # ── smart-money enrichment (degrades to the board when discovery_* is empty) ──
+      useCohorts: true
+      cohorts:
+        smartMinRealizedUsd: 1000000
+        crowdMinRealizedUsd: 10000
+        crowdMaxRealizedUsd: 100000
+        sampleCap: 150
+        pageSize: 1000
+        maxPages: 6
+        stateBatch: 50
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      band: { type: string, required: false }
+      stance: { type: string, required: false }
+      mode: { type: string, required: false }
+      posture: { type: string, required: false }
+      sizeScale: { type: number, required: false }
+      regime: { type: string, required: false }
+      lean: { type: number, required: false }
+      mom24h: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: chimp_open
+    action_type: OPEN_POSITION
+    decision_mode: rule                # the posture + tape confirm already filtered
+    scanners: [chimp_allocator]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: chimp_allocator
+  # NO CLOSE_POSITION action — DSL is the only exit (rotate-by-attrition).
+
+# EXIT — DSL owns every exit. Moderate width for a daily recalibrator: stalled
+# positions cut at 48h (weak-peak) so daily re-tilts have room; winners ride the
+# ladder. No hard_timeout — let winners run; weak-peak retires the dead weight.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 2880        # 48h — a stalled position frees its slot within ~2 days
+      min_value: 2.5
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8, lock_hw_pct: 0 }
+        - { trigger_pct: 20, lock_hw_pct: 35 }
+        - { trigger_pct: 45, lock_hw_pct: 60 }
+        - { trigger_pct: 80, lock_hw_pct: 78 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 8
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 900
+    per_asset_cooldown_seconds: 43200  # 12h — matches the anti-refire TTL
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true

--- a/strategies/chimp/main/scanners/scan.py
+++ b/strategies/chimp/main/scanners/scan.py
@@ -1,0 +1,324 @@
+"""REGIME ALLOCATOR — the single supervised scanner. Shared VERBATIM by Chimp
+(daily) and Gorilla (weekly); cadence + DSL come from runtime.yaml inputs.
+
+One scanner, one OPEN_POSITION action, no CLOSE. Each tick:
+  1) Load the standing POSTURE from ctx.state.
+  2) If it's stale (recalibrationHours elapsed) or unset, run the FULL market
+     read — main + xyz instruments -> pulse day classification + dispersion,
+     funding regime, smart-money cohorts (degrading to the leaderboard board) —
+     and rebuild the posture. This is the ONLY expensive read, and it runs on
+     the slow clock, never nonstop.
+  3) Read this wallet's open positions; fill any FREE slots with the posture's
+     ranked candidates that the tape still confirms — conviction-banded, DSL
+     attached by the runtime. NEVER close anything: prior-regime positions
+     retire on their own DSL (rotate-by-attrition).
+
+Read-only + single-pass. marginPct is a PERCENT in (0,100]. No daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+# cross-asset pulse groups (market-pulse pulse.py; crypto = the derived main pool)
+_PULSE_GROUPS = {
+    "semis": ["NVDA", "AMD", "AVGO", "MU", "TSM", "ASML", "MRVL", "ARM"],
+    "megacap_software": ["AMZN", "MSFT", "META", "GOOGL", "AAPL", "ORCL", "PLTR"],
+    "crypto_proxy": ["MSTR", "COIN", "HOOD"],
+    "indices": ["SP500", "XYZ100", "JP225", "KR200"],
+    "commodities": ["GOLD", "SILVER", "COPPER", "BRENTOIL", "NATGAS"],
+    "macro_fx": ["DXY", "JPY", "EUR", "GBP"],
+}
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
+        print(f"[allocator.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else None
+
+
+def _dex_of(name):
+    return "xyz" if str(name).lower().startswith("xyz:") else ""
+
+
+def _instrument_rows(ctx, dex):
+    """One market_list_instruments read -> [{name, vol, change_pct, price}]
+    (pulse.py fold: quote under context; daily change from prevDayPx)."""
+    data = _read(ctx, "market_list_instruments", ({"dex": dex} if dex else {}),
+                 f"market_list_instruments({dex or 'main'})")
+    if data is None:
+        return None
+    insts = data.get("instruments", data.get("universe", data)) if isinstance(data, dict) else data
+    if not isinstance(insts, list):
+        return None
+    rows = []
+    for inst in insts:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        c = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        price = scoring._num(inst.get("markPx")) or scoring._num(c.get("markPx")) or scoring._num(c.get("midPx"))
+        prev = scoring._num(inst.get("prevDayPx")) or scoring._num(c.get("prevDayPx"))
+        rows.append({"name": str(name), "vol": scoring._f(c.get("dayNtlVlm")),
+                     "price": price, "change_pct": scoring.pct_change(price, prev)})
+    return rows
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["1h", "4h"],
+        "include_funding": False, "include_order_book": False, "dex": _dex_of(name),
+    }, f"market_get_asset_data({name})")
+
+
+def _funding_regime(ctx):
+    d = _read(ctx, "market_get_funding_regime", {}, "market_get_funding_regime")
+    return d.get("regime") if isinstance(d, dict) else None
+
+
+def _board(ctx):
+    """leaderboard_get_markets -> {TOKEN: {direction, pct}} (near-term lean)."""
+    d = _read(ctx, "leaderboard_get_markets", {"limit": 100}, "leaderboard_get_markets")
+    if d is None:
+        return {}
+    markets = d.get("markets", d) if isinstance(d, dict) else d
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return {}
+    acc = {}
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        tok = str(m.get("token", "")).upper()
+        if not tok:
+            continue
+        d2 = str(m.get("direction", "")).lower()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        rec = acc.setdefault(tok, {"long": 0.0, "short": 0.0})
+        if d2 == "long":
+            rec["long"] = pct
+        elif d2 == "short":
+            rec["short"] = pct
+    out = {}
+    for tok, rec in acc.items():
+        tot = rec["long"] + rec["short"]
+        if tot == 0:
+            out[tok] = {"direction": "NEUTRAL", "pct": 50}
+        else:
+            lr = rec["long"] / tot * 100
+            out[tok] = ({"direction": "LONG", "pct": lr} if lr > 58 else
+                        {"direction": "SHORT", "pct": 100 - lr} if lr < 42 else
+                        {"direction": "NEUTRAL", "pct": 50})
+    return out
+
+
+def _cohorts(ctx, inputs):
+    """Proven (>=$1M realized) vs crowd ($10k-100k) bias — smart-money enrichment.
+    Degrades to {available: False} when discovery_* is empty (token scope)."""
+    if not bool(inputs.get("useCohorts", True)):
+        return {"available": False, "smart": {}, "crowd": {}}
+    cfg = inputs.get("cohorts") or {}
+    smin = scoring._f(cfg.get("smartMinRealizedUsd"), 1_000_000)
+    cmin = scoring._f(cfg.get("crowdMinRealizedUsd"), 10_000)
+    cmax = scoring._f(cfg.get("crowdMaxRealizedUsd"), 100_000)
+    cap = int(scoring._f(cfg.get("sampleCap"), 150))
+    psize = int(scoring._f(cfg.get("pageSize"), 1000))
+    pages = int(scoring._f(cfg.get("maxPages"), 6))
+    batch = int(scoring._f(cfg.get("stateBatch"), 50))
+
+    def traders_of(d):
+        if isinstance(d, list):
+            return d
+        if isinstance(d, dict):
+            for k in ("traders", "data", "results"):
+                if isinstance(d.get(k), list):
+                    return d[k]
+        return []
+
+    def realized(t):
+        for k in ("realizedProfitAndLoss", "realized_profit_and_loss",
+                  "profit_and_loss_realized", "realizedPnl", "realized_pnl"):
+            v = scoring._num((t or {}).get(k))
+            if v is not None:
+                return v
+        return 0.0
+
+    smart, crowd, seen = [], [], set()
+    for page in range(pages):
+        d = _read(ctx, "discovery_get_top_traders",
+                  {"time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
+                   "open_position_filter": False, "limit": psize, "offset": page * psize},
+                  f"discovery_get_top_traders(p{page})")
+        rows = traders_of(d)
+        if not rows:
+            break
+        top = None
+        for t in rows:
+            if not isinstance(t, dict):
+                continue
+            a = str(t.get("address") or t.get("trader_address") or t.get("wallet") or "").lower()
+            if not a or a in seen:
+                continue
+            rp = realized(t)
+            top = rp if top is None else max(top, rp)
+            if rp >= smin and len(smart) < cap:
+                smart.append(a); seen.add(a)
+            elif cmin <= rp <= cmax and len(crowd) < cap:
+                crowd.append(a); seen.add(a)
+        if len(smart) >= cap and len(crowd) >= cap:
+            break
+        if top is not None and top < cmin:
+            break
+
+    def bias(addrs, label):
+        per = {}
+        for i in range(0, len(addrs), batch):
+            d = _read(ctx, "discovery_get_trader_state",
+                      {"trader_addresses": addrs[i:i + batch]},
+                      f"discovery_get_trader_state({label} b{i // batch})")
+            scoring.cohort_positions_bias(traders_of(d), per)
+        return scoring.finalize_bias(per)
+
+    sp = bias(smart, "smart") if smart else {}
+    cp = bias(crowd, "crowd") if crowd else {}
+    avail = bool(sp) and bool(cp)
+    if not avail:
+        print("[allocator.scan] cohorts unavailable (discovery_* empty) — using board lean",
+              file=sys.stderr)
+    return {"available": avail, "smart": sp, "crowd": cp}
+
+
+def _held(ctx):
+    """Bare-uppercase set of coins with an open position, or None on read failure."""
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = set()
+    for e in d.get("assetPositions", d.get("asset_positions", [])) or []:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def _rebuild_posture(ctx, inputs, now):
+    main_rows = _instrument_rows(ctx, "")
+    if main_rows is None:
+        print("[allocator.scan] instruments unreadable — keeping prior posture", file=sys.stderr)
+        return None
+    xyz_rows = _instrument_rows(ctx, "xyz") or []
+    pool = scoring.derive_universe(main_rows, xyz_rows, inputs)
+    if len(pool) < 6:
+        print(f"[allocator.scan] only {len(pool)} names over the vol floor — keeping prior posture",
+              file=sys.stderr)
+        return None
+    changes, prices = {}, {}
+    for r in main_rows + xyz_rows:
+        sym = str(r["name"]).upper().replace("XYZ:", "")
+        if r.get("change_pct") is not None:
+            changes[sym] = r["change_pct"]
+        if r.get("price") is not None:
+            prices[sym] = r["price"]
+    groups = dict(inputs.get("pulseGroups") or _PULSE_GROUPS)
+    groups["crypto"] = [i["name"] for i in pool if i["dex"] == ""]
+    pulse = scoring.pulse_stance(changes, groups, vix_price=prices.get("VIX"))
+    cohort = _cohorts(ctx, inputs)
+    board = _board(ctx)
+    regime = _funding_regime(ctx)
+    posture = scoring.build_posture(pool, pulse, regime, cohort, board, inputs, now)
+    print(f"[allocator.scan] POSTURE: {posture['narrative']}", file=sys.stderr)
+    return posture
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    recal_s = scoring._f(inputs.get("recalibrationHours"), 24.0) * 3600.0
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 8))
+    min_score = scoring._f(inputs.get("minScore"), 5.5)
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 43200)
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    posture = st.get("posture")
+    last_recal = scoring._f(st.get("last_recal"), 0.0)
+    recent = st.get("recent", {}) or {}
+    board = None
+
+    # ── SLOW CLOCK: rebuild the posture only when due (or first tick) ──
+    if posture is None or scoring.due(now, last_recal, recal_s):
+        fresh = _rebuild_posture(ctx, inputs, now)
+        if fresh:
+            posture, last_recal = fresh, now
+    if posture is None:
+        return []
+
+    held = _held(ctx)
+    if held is None:
+        return []                                # clearinghouse unreadable — act next tick
+    free = max_slots - len(held)
+
+    out = []
+    if free > 0:
+        if board is None:
+            board = _board(ctx)                  # cheap near-term lean for tape confirm
+        cohort = {"available": posture.get("cohorts_available", False)}  # bias lives in board on topup
+        candidates = ([(n, "LONG") for n in posture.get("longs", [])] +
+                      [(n, "SHORT") for n in posture.get("shorts", [])])
+        looked = 0
+        for name, side in candidates:
+            if free <= 0 or looked >= max(12, free * 4):
+                break
+            bare = str(name).split(":", 1)[-1].upper()
+            if bare in held:
+                continue
+            if recent.get(bare) is not None and (now - recent[bare]) < ttl:
+                continue
+            looked += 1
+            md = _asset_data(ctx, name)
+            if not md:
+                continue
+            candles = md.get("candles", {}) or {}
+            th = scoring.score_candidate(name, side, candles.get("1h", []),
+                                         candles.get("4h", []), cohort, board, inputs)
+            if not th or th["score"] < min_score:
+                continue
+            band = scoring.band_for(th["score"], inputs)
+            venue = (md.get("asset_context", {}) or {}).get(
+                "max_leverage", (md.get("asset_context", {}) or {}).get("maxLeverage"))
+            lev, mgn = scoring.sizing_for(band, posture.get("size_scale", 1.0), inputs, venue)
+            recent[bare] = now
+            free -= 1
+            out.append({
+                "asset": name, "direction": side, "marginPct": mgn, "leverage": lev,
+                "data": {"score": th["score"], "leverage": lev, "direction": side,
+                         "band": band, "stance": posture["stance"], "mode": posture["mode"],
+                         "posture": posture["narrative"], "sizeScale": posture.get("size_scale", 1.0),
+                         "regime": posture.get("regime", "UNKNOWN"),
+                         "lean": th["lean"], "mom24h": th["mom24h"], "reasons": th["reasons"]},
+            })
+            print(f"[allocator.scan] OPEN {side} {name}: score={th['score']} band={band} "
+                  f"{lev}x {mgn}% | {posture['stance']}", file=sys.stderr)
+
+    if not out:
+        print(f"[allocator.scan] no opens: stance={posture['stance']} held={len(held)}/"
+              f"{max_slots} free={free}", file=sys.stderr)
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"posture": posture, "last_recal": last_recal, "recent": recent,
+                              "result": {"ts": now, "stance": posture["stance"],
+                                         "opened": len(out), "held": len(held),
+                                         "narrative": posture["narrative"]}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[allocator.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/chimp/main/scanners/scan.py
+++ b/strategies/chimp/main/scanners/scan.py
@@ -36,7 +36,7 @@ def _read(ctx, tool, args, label):
     try:
         raw = ctx.senpi_mcp.call_tool(tool, args)
     except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
-        print(f"[allocator.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        print(f"[regime.scan] {label} read failed: {exc!r}", file=sys.stderr)
         return None
     if not raw:
         return None
@@ -192,7 +192,7 @@ def _cohorts(ctx, inputs):
     cp = bias(crowd, "crowd") if crowd else {}
     avail = bool(sp) and bool(cp)
     if not avail:
-        print("[allocator.scan] cohorts unavailable (discovery_* empty) — using board lean",
+        print("[regime.scan] cohorts unavailable (discovery_* empty) — using board lean",
               file=sys.stderr)
     return {"available": avail, "smart": sp, "crowd": cp}
 
@@ -215,12 +215,12 @@ def _held(ctx):
 def _rebuild_posture(ctx, inputs, now):
     main_rows = _instrument_rows(ctx, "")
     if main_rows is None:
-        print("[allocator.scan] instruments unreadable — keeping prior posture", file=sys.stderr)
+        print("[regime.scan] instruments unreadable — keeping prior posture", file=sys.stderr)
         return None
     xyz_rows = _instrument_rows(ctx, "xyz") or []
     pool = scoring.derive_universe(main_rows, xyz_rows, inputs)
     if len(pool) < 6:
-        print(f"[allocator.scan] only {len(pool)} names over the vol floor — keeping prior posture",
+        print(f"[regime.scan] only {len(pool)} names over the vol floor — keeping prior posture",
               file=sys.stderr)
         return None
     changes, prices = {}, {}
@@ -237,7 +237,7 @@ def _rebuild_posture(ctx, inputs, now):
     board = _board(ctx)
     regime = _funding_regime(ctx)
     posture = scoring.build_posture(pool, pulse, regime, cohort, board, inputs, now)
-    print(f"[allocator.scan] POSTURE: {posture['narrative']}", file=sys.stderr)
+    print(f"[regime.scan] POSTURE: {posture['narrative']}", file=sys.stderr)
     return posture
 
 
@@ -306,11 +306,11 @@ def scan(inputs, ctx):
                          "regime": posture.get("regime", "UNKNOWN"),
                          "lean": th["lean"], "mom24h": th["mom24h"], "reasons": th["reasons"]},
             })
-            print(f"[allocator.scan] OPEN {side} {name}: score={th['score']} band={band} "
+            print(f"[regime.scan] OPEN {side} {name}: score={th['score']} band={band} "
                   f"{lev}x {mgn}% | {posture['stance']}", file=sys.stderr)
 
     if not out:
-        print(f"[allocator.scan] no opens: stance={posture['stance']} held={len(held)}/"
+        print(f"[regime.scan] no opens: stance={posture['stance']} held={len(held)}/"
               f"{max_slots} free={free}", file=sys.stderr)
 
     if ctx.state is not None:
@@ -320,5 +320,5 @@ def scan(inputs, ctx):
                                          "opened": len(out), "held": len(held),
                                          "narrative": posture["narrative"]}})
         except Exception as exc:  # noqa: BLE001
-            print(f"[allocator.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+            print(f"[regime.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
     return out

--- a/strategies/chimp/main/scanners/scoring.py
+++ b/strategies/chimp/main/scanners/scoring.py
@@ -1,0 +1,339 @@
+"""REGIME ALLOCATOR — pure engine (no I/O, no MCP). Shared VERBATIM by Chimp
+(daily recalibration) and Gorilla (weekly); the cadence + DSL live in runtime.yaml.
+
+The design (fixes the cuttlefish/gorilla-v1 mistakes):
+  * The market read runs on a SLOW clock (recalibrationHours: 24 or 168) — never
+    nonstop. build_posture() re-derives a standing POSTURE from the latest
+    market-pulse + smart-money read; between recalibrations the posture is held.
+  * The strategy NEVER closes a position. A regime flip only changes what it
+    OPENS next; prior-regime positions retire on their own DSL trailing stops
+    (rotate-by-attrition). So there is ONE scanner, ONE OPEN action, no
+    CLOSE_POSITION, no cross-scanner coherence problem. DSL owns every exit.
+  * The universe spans BOTH dexes — main crypto perps AND xyz tokenized
+    equities/commodities/FX — so risk-off can rotate into real havens.
+
+Engine math ported verbatim from the senpi-market-pulse (compute_signals: day
+classification + GOLD/DXY/VIX checklist + dispersion) and senpi-smart-money
+(proven-vs-crowd cohort bias) skills. Cohorts are an ENRICHMENT that degrades
+cleanly to the leaderboard board — the posture never depends on a user-scoped
+discovery token.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+
+LEAN_THRESHOLD = 0.40       # proven-cohort bias past this = a real directional lean
+MIN_MEMBERS = 5
+DIVERGENCE_MIN_GAP = 0.50
+
+
+def _f(v, default=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clamp(v, lo, hi):
+    return max(lo, min(hi, v))
+
+
+def pct_change(mark, prev):
+    m, p = _num(mark), _num(prev)
+    if m is None or p is None or p == 0:
+        return None
+    return round((m - p) / p * 100, 2)
+
+
+def closes(candles):
+    return [_f(c.get("c")) for c in (candles or []) if isinstance(c, dict)]
+
+
+def mom(candles, n=1):
+    cl = closes(candles)
+    if len(cl) < 2:
+        return 0.0
+    n = min(n, len(cl) - 1)
+    if cl[-1 - n] == 0:
+        return 0.0
+    return (cl[-1] / cl[-1 - n] - 1.0) * 100.0
+
+
+def trend_structure(candles, bars=6):
+    """('up'|'down'|'mixed', strength 0..1) over the last `bars` closes."""
+    cl = closes(candles)
+    if len(cl) < bars + 1:
+        return "mixed", 0.0
+    window = cl[-(bars + 1):]
+    ups = sum(1 for a, b in zip(window, window[1:]) if b > a)
+    s = ups / bars
+    if s >= 0.65:
+        return "up", s
+    if s <= 0.35:
+        return "down", 1.0 - s
+    return "mixed", 0.5
+
+
+def clamp_leverage(desired, venue_max):
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))
+
+
+def due(now, anchor_ts, every_seconds):
+    """True when a recalibration boundary has elapsed (0 anchor = never yet)."""
+    return anchor_ts <= 0 or (every_seconds > 0 and (now - anchor_ts) >= every_seconds)
+
+
+# ── UNIVERSE — derived live from BOTH dexes ─────────────────────────────────
+
+def classify(name, inputs):
+    """'defensive' (havens/commodities/defensive FX) | 'risk' (everything else:
+    crypto, equities, indices). Defensive set is tunable via inputs."""
+    bare = str(name).split(":", 1)[-1].upper()
+    defensives = {str(x).upper() for x in (inputs.get("defensiveAssets") or
+                  ["GOLD", "SILVER", "PLATINUM", "PALLADIUM", "BRENTOIL", "CL", "NATGAS",
+                   "DXY", "JPY"])}
+    return "defensive" if bare in defensives else "risk"
+
+
+def derive_universe(main_rows, xyz_rows, inputs):
+    """rows: [{name, vol, change_pct}] per dex (already parsed by scan.py).
+    main perps + xyz instruments over the per-dex volume floor, top-N each,
+    minus excludeAssets. Returns [{name, dex, chg, vol, class}] (name carries the
+    xyz: prefix for xyz)."""
+    main_floor = _f(inputs.get("universeVolFloorUsd"), 25_000_000)
+    xyz_floor = _f(inputs.get("xyzVolFloorUsd"), 3_000_000)
+    max_main = int(_f(inputs.get("maxMainNames"), 14))
+    max_xyz = int(_f(inputs.get("maxXyzNames"), 16))
+    exclude = {str(x).upper() for x in (inputs.get("excludeAssets") or [])}
+
+    def _pick(rows, floor, cap, dex):
+        seen, out = set(), []
+        for r in rows or []:
+            name = str((r or {}).get("name", "")).strip()
+            if not name:
+                continue
+            bare = name.split(":", 1)[-1].upper()
+            if bare in seen or bare in exclude:
+                continue
+            seen.add(bare)
+            if _f(r.get("vol")) < floor:
+                continue
+            out.append((name, _f(r.get("vol")), r.get("change_pct")))
+        out.sort(key=lambda t: t[1], reverse=True)
+        return [{"name": n, "dex": dex, "vol": v, "chg": c,
+                 "class": classify(n, inputs)} for n, v, c in out[:cap]]
+
+    return _pick(main_rows, main_floor, max_main, "") + _pick(xyz_rows, xyz_floor, max_xyz, "xyz")
+
+
+# ── PULSE — cross-asset day read (market-pulse compute_signals port) ────────
+
+def group_averages(changes, groups):
+    out = {}
+    for g, syms in (groups or {}).items():
+        vals = [changes.get(str(s).upper()) for s in (syms or [])]
+        vals = [v for v in vals if v is not None]
+        out[g] = round(sum(vals) / len(vals), 2) if vals else None
+    return out
+
+
+def pulse_stance(changes, groups, vix_price=None):
+    """day classification (groups down vs up at +/-0.5%, 2:1, >=3) + GOLD/DXY/VIX
+    checklist + dispersion (index calm while worst group breaks > 2.5% = rotation)."""
+    gavg = group_averages(changes, groups)
+    breadth = [v for v in gavg.values() if v is not None]
+    down = sum(1 for x in breadth if x < -0.5)
+    up = sum(1 for x in breadth if x > 0.5)
+    if breadth:
+        day = ("risk_off" if down >= up * 2 and down >= 3
+               else "risk_on" if up >= down * 2 and up >= 3 else "mixed")
+    else:
+        day = None
+
+    gold, dxy = changes.get("GOLD"), changes.get("DXY")
+    checklist = {
+        "gold": ("haven bid intact" if (gold is not None and gold > -2)
+                 else "haven also selling" if gold is not None else None),
+        "dxy": ("dollar calm" if (dxy is not None and abs(dxy) < 0.6)
+                else "dollar bid — funding stress" if (dxy is not None and dxy > 0.6) else None),
+        "vix": ("fear contained" if (vix_price is not None and vix_price < 22)
+                else "fear elevated" if vix_price is not None else None),
+    }
+    sp500 = changes.get("SP500")
+    worst_g, worst_avg = None, 0.0
+    for g, a in gavg.items():
+        if a is not None and a < worst_avg:
+            worst_g, worst_avg = g, a
+    dispersion = ("rotation" if (sp500 is not None and worst_g and (sp500 - worst_avg) > 2.5)
+                  else "broad" if (sp500 is not None and worst_g) else None)
+    return {"day": day, "groups_up": up, "groups_down": down, "group_avgs": gavg,
+            "checklist": checklist, "dispersion": dispersion, "worst_group": worst_g,
+            "vix_price": vix_price}
+
+
+# ── COHORTS — proven-vs-crowd bias (smart-money port; ENRICHMENT, degrades) ─
+
+def _signed_notional(p):
+    def f(*keys):
+        for k in keys:
+            v = _num((p or {}).get(k))
+            if v is not None:
+                return v
+        return 0.0
+    szi = f("szi", "size")
+    val = f("positionValue", "notional", "position_value")
+    if val <= 0:
+        val = abs(szi) * f("entryPx", "markPx", "entry_price")
+    return (1.0 if szi > 0 else (-1.0 if szi < 0 else 0.0)) * abs(val)
+
+
+def cohort_positions_bias(traders, per=None):
+    per = per if per is not None else {}
+    for t in traders or []:
+        if not isinstance(t, dict):
+            continue
+        for p in (t.get("openPositions") or t.get("open_positions") or []):
+            if not isinstance(p, dict):
+                continue
+            coin = p.get("coin") or p.get("asset")
+            sn = _signed_notional(p) if coin else 0.0
+            if not coin or sn == 0:
+                continue
+            d = per.setdefault(str(coin).upper(),
+                               {"net": 0.0, "gross": 0.0, "n_long": 0, "n_short": 0})
+            d["net"] += sn
+            d["gross"] += abs(sn)
+            d["n_long" if sn > 0 else "n_short"] += 1
+    return per
+
+
+def finalize_bias(per):
+    for d in (per or {}).values():
+        d["bias"] = round(d["net"] / d["gross"], 3) if d["gross"] > 0 else 0.0
+        d["members"] = d["n_long"] + d["n_short"]
+    return per
+
+
+def smart_lean(name, cohort, board):
+    """Directional lean for `name`: proven cohort bias if available (>= members),
+    else the leaderboard board (near-term). Returns bias in [-1,1] (0 = neutral)."""
+    au = str(name).split(":", 1)[-1].upper()
+    if (cohort or {}).get("available"):
+        d = (cohort.get("smart") or {}).get(au)
+        if d and d.get("members", 0) >= MIN_MEMBERS:
+            return _clamp(d.get("bias", 0.0), -1, 1)
+    b = (board or {}).get(au)
+    if b:
+        if b.get("direction") == "LONG":
+            return _clamp((_f(b.get("pct"), 50) - 50) / 50.0, 0, 1)
+        if b.get("direction") == "SHORT":
+            return -_clamp((_f(b.get("pct"), 50) - 50) / 50.0, 0, 1)
+    return 0.0
+
+
+# ── POSTURE — the standing thesis, re-derived on the recalibration clock ─────
+
+def build_posture(pool, pulse, funding_regime, cohort, board, inputs, now):
+    """Map the market read -> {stance, mode, longs[], shorts[], size_scale,
+    narrative, built_at}. longs/shorts are ranked candidate name lists; scan.py
+    fills free slots from them (tape-confirmed) — it does NOT open all of them."""
+    day = (pulse or {}).get("day")
+    dispersion = (pulse or {}).get("dispersion")
+
+    def rs(item):
+        # relative strength = 24h change biased by the proven/board lean
+        return _f(item.get("chg")) + 4.0 * smart_lean(item["name"], cohort, board)
+
+    ranked = sorted(pool, key=rs, reverse=True)
+    strong = [i["name"] for i in ranked]
+    weak = [i["name"] for i in reversed(ranked)]
+    defensive_up = [i["name"] for i in ranked
+                    if i["class"] == "defensive" and _f(i.get("chg")) > 0]
+    risk_down = [i["name"] for i in reversed(ranked)
+                 if i["class"] == "risk" and _f(i.get("chg")) < 0]
+
+    if day == "risk_on":
+        stance, mode = "RISK_ON", "risk_on"
+        longs = [i["name"] for i in ranked if _f(i.get("chg")) > 0][:12]
+        shorts, size = [], 1.0
+    elif day == "risk_off":
+        stance, mode = "RISK_OFF", "risk_off"
+        longs = defensive_up[:8]                 # rotate into havens that are working
+        shorts = risk_down[:8]                   # short the breaking risk complex
+        size = _f(inputs.get("riskOffSizeScale"), 0.7)
+    else:                                        # mixed / rotation -> dispersion play
+        stance = "ROTATION" if dispersion == "rotation" else "MIXED"
+        mode = "rotation" if dispersion == "rotation" else "mixed"
+        longs = strong[:8]
+        shorts = weak[:8]
+        size = _f(inputs.get("mixedSizeScale"), 0.6)
+
+    # squeeze note: a crowded funding regime favors the fade side (informational)
+    reg = funding_regime or "UNKNOWN"
+    chk = (pulse or {}).get("checklist") or {}
+    chk_bits = "; ".join(v for v in (chk.get("gold"), chk.get("dxy"), chk.get("vix")) if v)
+    disp_bit = (f"; DISPERSION rotation (worst: {pulse.get('worst_group')})"
+                if dispersion == "rotation" else "")
+    coh = "" if (cohort or {}).get("available") else " [cohorts unavailable — board lean]"
+    narrative = (f"{stance} (pulse {day or 'no-read'}: {(pulse or {}).get('groups_up',0)} up / "
+                 f"{(pulse or {}).get('groups_down',0)} down; {chk_bits or 'no checklist'}"
+                 f"{disp_bit}); funding {reg}; long {','.join(longs[:5]) or '—'}; "
+                 f"short {','.join(shorts[:5]) or '—'}{coh}")
+    return {"stance": stance, "mode": mode, "longs": longs, "shorts": shorts,
+            "size_scale": size, "regime": reg, "dispersion": dispersion,
+            "cohorts_available": bool((cohort or {}).get("available")),
+            "narrative": narrative, "built_at": now}
+
+
+# ── ENTRY — tape must confirm the posture direction for THIS name ───────────
+
+def score_candidate(name, side, c1, c4, cohort, board, inputs):
+    """0-10 conviction for opening `name` in `side`. None on thin candles;
+    None (as a soft skip) when the tape does not confirm the posture direction."""
+    if len(closes(c1)) < 8 or len(closes(c4)) < 4:
+        return None
+    sign = 1 if side == "LONG" else -1
+    want = "up" if side == "LONG" else "down"
+    t4, s4 = trend_structure(c4)
+    t1, _ = trend_structure(c1)
+    if t4 != want:                               # hard confirm: 4h structure must agree
+        return None
+    m24 = mom(c1, 24)
+    lean = smart_lean(name, cohort, board) * sign
+
+    w_t4, w_t1, w_m, w_sm = 3.0, 2.0, 3.0, 2.0
+    t4_c = w_t4 * s4
+    t1_c = w_t1 if t1 == want else 0.0
+    m_c = w_m * _clamp((m24 * sign) / 6.0, 0, 1)
+    sm_c = w_sm * _clamp(lean, 0, 1)
+    score = _clamp(10.0 * (t4_c + t1_c + m_c + sm_c) / (w_t4 + w_t1 + w_m + w_sm), 0, 10)
+    return {"asset": name, "score": round(score, 2), "trend4h": t4,
+            "mom24h": round(m24, 2), "lean": round(lean, 3),
+            "reasons": [f"4h {t4} {s4:.0%}", f"24h {m24:+.1f}%", f"lean {lean:+.2f}"]}
+
+
+def band_for(score, inputs):
+    if score >= _f(inputs.get("apexScore"), 8.0):
+        return "apex"
+    if score >= _f(inputs.get("goodScore"), 6.5):
+        return "good"
+    if score >= _f(inputs.get("minScore"), 5.5):
+        return "base"
+    return None
+
+
+def sizing_for(band, size_scale, inputs, venue_max=None):
+    lev = _f((inputs.get("leverageTiers") or {}).get(band), 3)
+    mgn = _f((inputs.get("marginPctTiers") or {}).get(band), 10) * _f(size_scale, 1.0)
+    return clamp_leverage(lev, venue_max if venue_max is not None else lev), max(round(mgn, 2), 3.0)

--- a/strategies/chimp/strategy.yaml
+++ b/strategies/chimp/strategy.yaml
@@ -1,0 +1,43 @@
+# Chimp — Regime Allocator (DAILY). Single-wallet PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. Reads the whole market once a day
+# (market-pulse + smart-money), holds a standing risk POSTURE, and rotates the
+# book into it BY ATTRITION — it never closes a position; a regime flip only
+# changes what it opens next, and prior positions retire on their own DSL.
+# The daily sibling of Gorilla (weekly). Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: chimp
+version: "1.0.0"
+
+catalog:
+  name: "Chimp — Regime Allocator (Daily)"
+  emoji: "🐒"
+  tagline: "Reads the whole market once a day — the pulse (risk-on/off, dispersion, gold/dollar/VIX) plus where the proven wallets lean — sets a risk posture, and rotates a long/short book across crypto and tokenized stocks/commodities into that posture. It never sells: a regime change just changes what it buys next, and every position is protected by a ratchet stop that does all the exiting."
+  belief_plain: "Once a day it looks at everything — are markets risk-on or risk-off, is it a rotation day, what's gold and the dollar doing, where's the smart money — and picks a stance. In risk-on it leans into the leaders; in risk-off it rotates into gold/oil and shorts the weak; on a choppy rotation day it plays winners-vs-losers at smaller size. It never manually closes; a trailing stop protects and exits every position, so old bets wind down on their own as the new stance takes over."
+  thesis: "Users already run the market-pulse skill and then hand-pick strategies to fit the read. Chimp automates that loop: it re-runs the pulse + smart-money read on a daily clock, re-derives its posture, and expresses the change only through new entries — never by force-closing, so turnover is set by the market (via DSL), not by a scanner re-deciding every minute. Daily recalibration + a moderate DSL make it the nimble regime-follower; Gorilla is the weekly, more-committed sibling."
+  group: multi-asset-universe
+  archetype: macro_thesis
+  sub_style: adaptive
+  asset_classes: [btc_eth, major_alts, xyz_equities, commodities, fx]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 8
+  min_budget: 100
+  assets: []                 # DERIVED live daily from both dexes (vol floor + top-N)
+  tags: [regime, allocator, macro, pulse, smart-money, long-short, universe, daily, no-close, dsl-only]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name chimp-main, group chimp
+    wallet_env: CHIMP_WALLET
+    funding_share: 1.0

--- a/strategies/chimp/tests/test_engine.py
+++ b/strategies/chimp/tests/test_engine.py
@@ -1,0 +1,116 @@
+"""Regime-Allocator engine fidelity (pure scoring.py) — shared by Chimp & Gorilla.
+
+Run: python3 strategies/chimp/tests/test_engine.py
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "main", "scanners"))
+
+import scoring  # noqa: E402
+
+PASS = FAIL = 0
+
+
+def check(name, cond):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+    else:
+        FAIL += 1
+        print(f"FAIL: {name}")
+
+
+def candles(n, start, drift):
+    out, px = [], start
+    for i in range(n):
+        o = px
+        px *= (1 + drift)
+        out.append({"o": str(o), "c": str(px), "h": str(max(o, px)), "l": str(min(o, px)),
+                    "v": "100", "n": 5})
+    return out
+
+
+INPUTS = {"minScore": 5.5, "goodScore": 6.5, "apexScore": 8.0,
+          "leverageTiers": {"apex": 5, "good": 4, "base": 3},
+          "marginPctTiers": {"apex": 14, "good": 10, "base": 7},
+          "riskOffSizeScale": 0.7, "mixedSizeScale": 0.6}
+
+# ── universe: BOTH dexes, vol floors, class tagging ──
+main_rows = [{"name": "BTC", "vol": 900e6, "change_pct": 1.7},
+             {"name": "SOL", "vol": 300e6, "change_pct": 1.2},
+             {"name": "PUMP", "vol": 2e6, "change_pct": 5.0}]       # under main floor
+xyz_rows = [{"name": "xyz:NVDA", "vol": 80e6, "change_pct": 2.0},
+            {"name": "xyz:GOLD", "vol": 40e6, "change_pct": -0.3},
+            {"name": "xyz:TINY", "vol": 1e6, "change_pct": 9.0}]    # under xyz floor
+pool = scoring.derive_universe(main_rows, xyz_rows, dict(INPUTS,
+       universeVolFloorUsd=25_000_000, xyzVolFloorUsd=3_000_000, maxMainNames=14, maxXyzNames=16))
+names = {i["name"] for i in pool}
+check("universe spans both dexes", {"BTC", "SOL", "xyz:NVDA", "xyz:GOLD"} <= names)
+check("under-floor names dropped (both dexes)", "PUMP" not in names and "xyz:TINY" not in names)
+check("xyz prefix preserved", any(i["name"] == "xyz:NVDA" and i["dex"] == "xyz" for i in pool))
+check("class: GOLD defensive", scoring.classify("xyz:GOLD", INPUTS) == "defensive")
+check("class: BTC risk", scoring.classify("BTC", INPUTS) == "risk")
+
+# ── pulse: day + dispersion + checklist ──
+GROUPS = {"crypto": ["BTC", "ETH"], "semis": ["NVDA", "AMD"], "indices": ["SP500"],
+          "commodities": ["GOLD"], "macro_fx": ["DXY"]}
+on = {"BTC": 2, "ETH": 3, "NVDA": 1.5, "AMD": 2.5, "SP500": 1.0, "GOLD": 0.2, "DXY": 0.1}
+off = {"BTC": -2, "ETH": -3, "NVDA": -1.5, "AMD": -2.5, "SP500": -1.0, "GOLD": 0.5, "DXY": 0.9}
+rot = {"BTC": 1.4, "ETH": 1.2, "NVDA": -4.0, "AMD": -4.6, "SP500": 0.4, "GOLD": -0.3, "DXY": 0.0}
+check("risk_on day", scoring.pulse_stance(on, GROUPS, 15)["day"] == "risk_on")
+check("risk_off day", scoring.pulse_stance(off, GROUPS, 28)["day"] == "risk_off")
+p_off = scoring.pulse_stance(off, GROUPS, 28)
+check("dxy funding-stress read", p_off["checklist"]["dxy"] == "dollar bid — funding stress")
+p_rot = scoring.pulse_stance(rot, GROUPS, 20)
+check("rotation dispersion (mixed day)", p_rot["day"] == "mixed" and p_rot["dispersion"] == "rotation")
+
+# ── posture across regimes ──
+POOL = [{"name": "BTC", "dex": "", "chg": 3.0, "class": "risk"},
+        {"name": "SOL", "dex": "", "chg": 2.0, "class": "risk"},
+        {"name": "xyz:NVDA", "dex": "xyz", "chg": 2.5, "class": "risk"},
+        {"name": "xyz:GOLD", "dex": "xyz", "chg": 0.8, "class": "defensive"},
+        {"name": "xyz:BRENTOIL", "dex": "xyz", "chg": 0.5, "class": "defensive"},
+        {"name": "DOGE", "dex": "", "chg": -3.0, "class": "risk"},
+        {"name": "xyz:MU", "dex": "xyz", "chg": -4.0, "class": "risk"}]
+board = {"BTC": {"direction": "LONG", "pct": 70}}
+noco = {"available": False}
+
+p_on = scoring.build_posture(POOL, scoring.pulse_stance(on, GROUPS, 15), "SHORT_CROWDED", noco, board, INPUTS, 100.0)
+check("risk_on: long-only, full size", p_on["stance"] == "RISK_ON" and p_on["shorts"] == [] and p_on["size_scale"] == 1.0)
+check("risk_on longs are the strong risk names", "BTC" in p_on["longs"] and "DOGE" not in p_on["longs"])
+
+p_of = scoring.build_posture(POOL, scoring.pulse_stance(off, GROUPS, 28), "LONG_CROWDED", noco, board, INPUTS, 0.0)
+check("risk_off: defensives long, risk short, reduced size", p_of["stance"] == "RISK_OFF"
+      and "xyz:GOLD" in p_of["longs"] and "xyz:MU" in p_of["shorts"] and p_of["size_scale"] == 0.7)
+check("risk_off never longs a risk asset", all(scoring.classify(n, INPUTS) == "defensive" for n in p_of["longs"]))
+
+p_rt = scoring.build_posture(POOL, p_rot, "LONG_CROWDED", noco, board, INPUTS, 0.0)
+check("rotation: long strong / short weak, small size", p_rt["stance"] == "ROTATION"
+      and p_rt["longs"][0] in ("BTC", "xyz:NVDA", "SOL") and p_rt["size_scale"] == 0.6)
+check("posture carries a narrative", "RISK_OFF" in p_of["narrative"])
+check("cohorts-unavailable flagged", "board lean" in p_of["narrative"])
+
+# ── entry: tape must confirm the posture direction ──
+up1, up4 = candles(30, 100, 0.004), candles(10, 95, 0.01)
+dn1, dn4 = candles(30, 100, -0.004), candles(10, 105, -0.01)
+check("long confirmed on uptrend", (scoring.score_candidate("BTC", "LONG", up1, up4, noco, board, INPUTS) or {}).get("score", 0) >= 5.5)
+check("long REJECTED on downtrend (hard 4h confirm)", scoring.score_candidate("BTC", "LONG", dn1, dn4, noco, board, INPUTS) is None)
+check("short confirmed on downtrend", (scoring.score_candidate("DOGE", "SHORT", dn1, dn4, noco, board, INPUTS) or {}).get("score", 0) >= 5.5)
+check("short REJECTED on uptrend", scoring.score_candidate("DOGE", "SHORT", up1, up4, noco, board, INPUTS) is None)
+
+# ── bands + size-scaled sizing + venue clamp ──
+check("band apex", scoring.band_for(8.5, INPUTS) == "apex")
+lev, mgn = scoring.sizing_for("apex", 1.0, INPUTS, venue_max=3)
+check("venue clamp", lev == 3 and mgn == 14)
+_, mgn_small = scoring.sizing_for("apex", 0.6, INPUTS)
+check("size_scale shrinks margin", mgn_small == round(14 * 0.6, 2))
+
+# ── recalibration clock ──
+check("first tick is due (anchor 0)", scoring.due(1000.0, 0.0, 86400))
+check("not due inside window", not scoring.due(1000.0 + 80000, 1000.0, 86400))
+check("due after the window", scoring.due(1000.0 + 90000, 1000.0, 86400))
+
+print(f"{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/strategies/chimp/tests/test_package_shape.py
+++ b/strategies/chimp/tests/test_package_shape.py
@@ -1,0 +1,64 @@
+"""Regime-Allocator package-shape invariants — encode the corrected architecture.
+
+The design guarantees, asserted structurally:
+  * exactly ONE external scanner (not the cuttlefish/gorilla-v1 two-scanner mess),
+  * NO CLOSE_POSITION action — DSL is the sole exit (rotate-by-attrition),
+  * a slow recalibration clock (the market check is not nonstop),
+  * a DERIVED universe (no hardcoded asset list),
+  * marginPct tiers a PERCENT in (0,100].
+
+Run: python3 strategies/chimp/tests/test_package_shape.py
+"""
+import os
+import sys
+
+import yaml
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PKG_ID = os.path.basename(ROOT)
+PASS = FAIL = 0
+
+
+def check(name, cond):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+    else:
+        FAIL += 1
+        print(f"FAIL: {name}")
+
+
+spec = yaml.safe_load(open(os.path.join(ROOT, "strategy.yaml")))
+check("asset_scope universe (derived)", spec["catalog"]["asset_scope"] == "universe")
+check("assets [] (nothing hardcoded)", spec["catalog"].get("assets") == [])
+
+for inst in spec["instances"]:
+    book = inst["name"]
+    ry = yaml.safe_load(open(os.path.join(ROOT, book, inst["runtime"].split("/")[-1])))
+    ext = [s for s in ry["scanners"] if s.get("type") == "external_scanner"]
+    check(f"{book}: exactly ONE external scanner", len(ext) == 1)
+
+    actions = {a["action_type"] for a in ry["actions"]}
+    check(f"{book}: has OPEN_POSITION", "OPEN_POSITION" in actions)
+    check(f"{book}: has POSITION_TRACKER", "POSITION_TRACKER" in actions)
+    check(f"{book}: NO CLOSE_POSITION (DSL is the only exit)", "CLOSE_POSITION" not in actions)
+
+    check(f"{book}: exit engine is dsl", ry["exit"]["engine"] == "dsl")
+    tiers = ry["exit"]["dsl_preset"]["phase2"]["tiers"]
+    trg = [t["trigger_pct"] for t in tiers]
+    check(f"{book}: DSL tiers ascending, <=100", trg == sorted(trg) and all(0 < t <= 100 for t in trg))
+    check(f"{book}: DSL phase1 stop present", ry["exit"]["dsl_preset"]["phase1"]["max_loss_pct"] > 0)
+
+    inp = ext[0]["inputs"]
+    check(f"{book}: recalibration clock set (slow, not nonstop)", float(inp.get("recalibrationHours", 0)) >= 24)
+    check(f"{book}: no hardcoded universe", "universe" not in inp and "assets" not in inp)
+    check(f"{book}: both-dex vol floors set", float(inp.get("universeVolFloorUsd", 0)) > 0
+          and float(inp.get("xyzVolFloorUsd", 0)) > 0)
+    for band, pct in (inp.get("marginPctTiers") or {}).items():
+        check(f"{book}: marginPct[{band}] in (0,100]", 0 < float(pct) <= 100)
+    # scanner wakes must be far slower than the old 15m churn
+    check(f"{book}: scanner cadence is a longer-play cadence (>=1h)",
+          int(ext[0].get("interval_seconds", 0)) >= 3600)
+
+print(f"{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/strategies/gorilla/main/runtime.yaml
+++ b/strategies/gorilla/main/runtime.yaml
@@ -1,0 +1,137 @@
+# ── GORILLA · Regime Allocator (WEEKLY recalibration) ───────────────────────
+# The committed sibling of Chimp. Same engine (scanners byte-identical) — reads
+# the whole market and holds a standing risk POSTURE, never closes, DSL-only —
+# but recalibrates WEEKLY, holds fewer/bigger higher-conviction positions, and
+# rides a wide DSL that lets winners run for weeks. A regime flip changes what it
+# opens next; prior positions retire on their own DSL (rotate-by-attrition).
+name: gorilla-main
+group: gorilla
+version: 1.0.0
+description: >
+  GORILLA — Regime Allocator, weekly. Re-derives a risk-on / risk-off / rotation
+  posture from the live market read every 7 days and commits to it: risk-on
+  tilts long the leaders, risk-off rotates into working havens + shorts the
+  breaking risk complex, a rotation week runs a smaller long/short dispersion
+  book. Fewer, larger, higher-conviction positions than Chimp (up to 7),
+  leverage clamped to venue max. DSL is the ONLY exit — wide let-winners-run
+  ladder (20% Phase 1, lock ladder to +100%, 7d weak-peak cut).
+
+strategy:
+  wallet: "${GORILLA_WALLET}"
+  slots: 7
+  margin_pct: 12
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: gorilla_allocator
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 21600           # wake every 6h; the market read is gated to weekly
+    timeout_seconds: 300
+    default_signal_validity_seconds: 3600
+    state_history_max_count: 200
+    inputs:
+      recalibrationHours: 168         # WEEKLY — the only market check cadence
+      maxSlots: 7
+      universeVolFloorUsd: 25000000
+      xyzVolFloorUsd: 3000000
+      maxMainNames: 14
+      maxXyzNames: 16
+      excludeAssets: []
+      defensiveAssets: ["GOLD", "SILVER", "PLATINUM", "PALLADIUM", "BRENTOIL", "CL", "NATGAS", "JPY"]   # tradeable havens only (DXY is read-only in pulseGroups — not a live perp)
+      riskOffSizeScale: 0.7
+      mixedSizeScale: 0.6
+      minScore: 6.0                    # more selective / committed than Chimp (5.5)
+      goodScore: 7.0
+      apexScore: 8.5
+      leverageTiers: { apex: 5, good: 4, base: 3 }
+      marginPctTiers: { apex: 16, good: 12, base: 8 }   # bigger positions than Chimp (concentrated)
+      recentSignalTtlSeconds: 86400   # 24h anti-refire — slower book
+      useCohorts: true
+      cohorts:
+        smartMinRealizedUsd: 1000000
+        crowdMinRealizedUsd: 10000
+        crowdMaxRealizedUsd: 100000
+        sampleCap: 150
+        pageSize: 1000
+        maxPages: 6
+        stateBatch: 50
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      band: { type: string, required: false }
+      stance: { type: string, required: false }
+      mode: { type: string, required: false }
+      posture: { type: string, required: false }
+      sizeScale: { type: number, required: false }
+      regime: { type: string, required: false }
+      lean: { type: number, required: false }
+      mom24h: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: gorilla_open
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [gorilla_allocator]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: gorilla_allocator
+  # NO CLOSE_POSITION action — DSL is the only exit (rotate-by-attrition).
+
+# EXIT — DSL only. WIDE ladder for a weekly holder: a stalled position frees its
+# slot within ~a week (weak-peak 7d); winners ride the ladder to +100%. No
+# hard_timeout — let winners run.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 10080       # 7d — matches the weekly recalibration
+      min_value: 2.5
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 9
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 25, lock_hw_pct: 40 }
+        - { trigger_pct: 55, lock_hw_pct: 62 }
+        - { trigger_pct: 100, lock_hw_pct: 80 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 7
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 1800
+    per_asset_cooldown_seconds: 86400  # 24h — matches the anti-refire TTL
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true

--- a/strategies/gorilla/main/scanners/scan.py
+++ b/strategies/gorilla/main/scanners/scan.py
@@ -1,0 +1,324 @@
+"""REGIME ALLOCATOR — the single supervised scanner. Shared VERBATIM by Chimp
+(daily) and Gorilla (weekly); cadence + DSL come from runtime.yaml inputs.
+
+One scanner, one OPEN_POSITION action, no CLOSE. Each tick:
+  1) Load the standing POSTURE from ctx.state.
+  2) If it's stale (recalibrationHours elapsed) or unset, run the FULL market
+     read — main + xyz instruments -> pulse day classification + dispersion,
+     funding regime, smart-money cohorts (degrading to the leaderboard board) —
+     and rebuild the posture. This is the ONLY expensive read, and it runs on
+     the slow clock, never nonstop.
+  3) Read this wallet's open positions; fill any FREE slots with the posture's
+     ranked candidates that the tape still confirms — conviction-banded, DSL
+     attached by the runtime. NEVER close anything: prior-regime positions
+     retire on their own DSL (rotate-by-attrition).
+
+Read-only + single-pass. marginPct is a PERCENT in (0,100]. No daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+# cross-asset pulse groups (market-pulse pulse.py; crypto = the derived main pool)
+_PULSE_GROUPS = {
+    "semis": ["NVDA", "AMD", "AVGO", "MU", "TSM", "ASML", "MRVL", "ARM"],
+    "megacap_software": ["AMZN", "MSFT", "META", "GOOGL", "AAPL", "ORCL", "PLTR"],
+    "crypto_proxy": ["MSTR", "COIN", "HOOD"],
+    "indices": ["SP500", "XYZ100", "JP225", "KR200"],
+    "commodities": ["GOLD", "SILVER", "COPPER", "BRENTOIL", "NATGAS"],
+    "macro_fx": ["DXY", "JPY", "EUR", "GBP"],
+}
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
+        print(f"[allocator.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else None
+
+
+def _dex_of(name):
+    return "xyz" if str(name).lower().startswith("xyz:") else ""
+
+
+def _instrument_rows(ctx, dex):
+    """One market_list_instruments read -> [{name, vol, change_pct, price}]
+    (pulse.py fold: quote under context; daily change from prevDayPx)."""
+    data = _read(ctx, "market_list_instruments", ({"dex": dex} if dex else {}),
+                 f"market_list_instruments({dex or 'main'})")
+    if data is None:
+        return None
+    insts = data.get("instruments", data.get("universe", data)) if isinstance(data, dict) else data
+    if not isinstance(insts, list):
+        return None
+    rows = []
+    for inst in insts:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        c = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        price = scoring._num(inst.get("markPx")) or scoring._num(c.get("markPx")) or scoring._num(c.get("midPx"))
+        prev = scoring._num(inst.get("prevDayPx")) or scoring._num(c.get("prevDayPx"))
+        rows.append({"name": str(name), "vol": scoring._f(c.get("dayNtlVlm")),
+                     "price": price, "change_pct": scoring.pct_change(price, prev)})
+    return rows
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["1h", "4h"],
+        "include_funding": False, "include_order_book": False, "dex": _dex_of(name),
+    }, f"market_get_asset_data({name})")
+
+
+def _funding_regime(ctx):
+    d = _read(ctx, "market_get_funding_regime", {}, "market_get_funding_regime")
+    return d.get("regime") if isinstance(d, dict) else None
+
+
+def _board(ctx):
+    """leaderboard_get_markets -> {TOKEN: {direction, pct}} (near-term lean)."""
+    d = _read(ctx, "leaderboard_get_markets", {"limit": 100}, "leaderboard_get_markets")
+    if d is None:
+        return {}
+    markets = d.get("markets", d) if isinstance(d, dict) else d
+    if isinstance(markets, dict):
+        markets = markets.get("markets", [])
+    if not isinstance(markets, list):
+        return {}
+    acc = {}
+    for m in markets:
+        if not isinstance(m, dict):
+            continue
+        tok = str(m.get("token", "")).upper()
+        if not tok:
+            continue
+        d2 = str(m.get("direction", "")).lower()
+        pct = scoring._f(m.get("pct_of_top_traders_gain", m.get("longPct", 0)))
+        rec = acc.setdefault(tok, {"long": 0.0, "short": 0.0})
+        if d2 == "long":
+            rec["long"] = pct
+        elif d2 == "short":
+            rec["short"] = pct
+    out = {}
+    for tok, rec in acc.items():
+        tot = rec["long"] + rec["short"]
+        if tot == 0:
+            out[tok] = {"direction": "NEUTRAL", "pct": 50}
+        else:
+            lr = rec["long"] / tot * 100
+            out[tok] = ({"direction": "LONG", "pct": lr} if lr > 58 else
+                        {"direction": "SHORT", "pct": 100 - lr} if lr < 42 else
+                        {"direction": "NEUTRAL", "pct": 50})
+    return out
+
+
+def _cohorts(ctx, inputs):
+    """Proven (>=$1M realized) vs crowd ($10k-100k) bias — smart-money enrichment.
+    Degrades to {available: False} when discovery_* is empty (token scope)."""
+    if not bool(inputs.get("useCohorts", True)):
+        return {"available": False, "smart": {}, "crowd": {}}
+    cfg = inputs.get("cohorts") or {}
+    smin = scoring._f(cfg.get("smartMinRealizedUsd"), 1_000_000)
+    cmin = scoring._f(cfg.get("crowdMinRealizedUsd"), 10_000)
+    cmax = scoring._f(cfg.get("crowdMaxRealizedUsd"), 100_000)
+    cap = int(scoring._f(cfg.get("sampleCap"), 150))
+    psize = int(scoring._f(cfg.get("pageSize"), 1000))
+    pages = int(scoring._f(cfg.get("maxPages"), 6))
+    batch = int(scoring._f(cfg.get("stateBatch"), 50))
+
+    def traders_of(d):
+        if isinstance(d, list):
+            return d
+        if isinstance(d, dict):
+            for k in ("traders", "data", "results"):
+                if isinstance(d.get(k), list):
+                    return d[k]
+        return []
+
+    def realized(t):
+        for k in ("realizedProfitAndLoss", "realized_profit_and_loss",
+                  "profit_and_loss_realized", "realizedPnl", "realized_pnl"):
+            v = scoring._num((t or {}).get(k))
+            if v is not None:
+                return v
+        return 0.0
+
+    smart, crowd, seen = [], [], set()
+    for page in range(pages):
+        d = _read(ctx, "discovery_get_top_traders",
+                  {"time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
+                   "open_position_filter": False, "limit": psize, "offset": page * psize},
+                  f"discovery_get_top_traders(p{page})")
+        rows = traders_of(d)
+        if not rows:
+            break
+        top = None
+        for t in rows:
+            if not isinstance(t, dict):
+                continue
+            a = str(t.get("address") or t.get("trader_address") or t.get("wallet") or "").lower()
+            if not a or a in seen:
+                continue
+            rp = realized(t)
+            top = rp if top is None else max(top, rp)
+            if rp >= smin and len(smart) < cap:
+                smart.append(a); seen.add(a)
+            elif cmin <= rp <= cmax and len(crowd) < cap:
+                crowd.append(a); seen.add(a)
+        if len(smart) >= cap and len(crowd) >= cap:
+            break
+        if top is not None and top < cmin:
+            break
+
+    def bias(addrs, label):
+        per = {}
+        for i in range(0, len(addrs), batch):
+            d = _read(ctx, "discovery_get_trader_state",
+                      {"trader_addresses": addrs[i:i + batch]},
+                      f"discovery_get_trader_state({label} b{i // batch})")
+            scoring.cohort_positions_bias(traders_of(d), per)
+        return scoring.finalize_bias(per)
+
+    sp = bias(smart, "smart") if smart else {}
+    cp = bias(crowd, "crowd") if crowd else {}
+    avail = bool(sp) and bool(cp)
+    if not avail:
+        print("[allocator.scan] cohorts unavailable (discovery_* empty) — using board lean",
+              file=sys.stderr)
+    return {"available": avail, "smart": sp, "crowd": cp}
+
+
+def _held(ctx):
+    """Bare-uppercase set of coins with an open position, or None on read failure."""
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = set()
+    for e in d.get("assetPositions", d.get("asset_positions", [])) or []:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def _rebuild_posture(ctx, inputs, now):
+    main_rows = _instrument_rows(ctx, "")
+    if main_rows is None:
+        print("[allocator.scan] instruments unreadable — keeping prior posture", file=sys.stderr)
+        return None
+    xyz_rows = _instrument_rows(ctx, "xyz") or []
+    pool = scoring.derive_universe(main_rows, xyz_rows, inputs)
+    if len(pool) < 6:
+        print(f"[allocator.scan] only {len(pool)} names over the vol floor — keeping prior posture",
+              file=sys.stderr)
+        return None
+    changes, prices = {}, {}
+    for r in main_rows + xyz_rows:
+        sym = str(r["name"]).upper().replace("XYZ:", "")
+        if r.get("change_pct") is not None:
+            changes[sym] = r["change_pct"]
+        if r.get("price") is not None:
+            prices[sym] = r["price"]
+    groups = dict(inputs.get("pulseGroups") or _PULSE_GROUPS)
+    groups["crypto"] = [i["name"] for i in pool if i["dex"] == ""]
+    pulse = scoring.pulse_stance(changes, groups, vix_price=prices.get("VIX"))
+    cohort = _cohorts(ctx, inputs)
+    board = _board(ctx)
+    regime = _funding_regime(ctx)
+    posture = scoring.build_posture(pool, pulse, regime, cohort, board, inputs, now)
+    print(f"[allocator.scan] POSTURE: {posture['narrative']}", file=sys.stderr)
+    return posture
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    recal_s = scoring._f(inputs.get("recalibrationHours"), 24.0) * 3600.0
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 8))
+    min_score = scoring._f(inputs.get("minScore"), 5.5)
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 43200)
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    posture = st.get("posture")
+    last_recal = scoring._f(st.get("last_recal"), 0.0)
+    recent = st.get("recent", {}) or {}
+    board = None
+
+    # ── SLOW CLOCK: rebuild the posture only when due (or first tick) ──
+    if posture is None or scoring.due(now, last_recal, recal_s):
+        fresh = _rebuild_posture(ctx, inputs, now)
+        if fresh:
+            posture, last_recal = fresh, now
+    if posture is None:
+        return []
+
+    held = _held(ctx)
+    if held is None:
+        return []                                # clearinghouse unreadable — act next tick
+    free = max_slots - len(held)
+
+    out = []
+    if free > 0:
+        if board is None:
+            board = _board(ctx)                  # cheap near-term lean for tape confirm
+        cohort = {"available": posture.get("cohorts_available", False)}  # bias lives in board on topup
+        candidates = ([(n, "LONG") for n in posture.get("longs", [])] +
+                      [(n, "SHORT") for n in posture.get("shorts", [])])
+        looked = 0
+        for name, side in candidates:
+            if free <= 0 or looked >= max(12, free * 4):
+                break
+            bare = str(name).split(":", 1)[-1].upper()
+            if bare in held:
+                continue
+            if recent.get(bare) is not None and (now - recent[bare]) < ttl:
+                continue
+            looked += 1
+            md = _asset_data(ctx, name)
+            if not md:
+                continue
+            candles = md.get("candles", {}) or {}
+            th = scoring.score_candidate(name, side, candles.get("1h", []),
+                                         candles.get("4h", []), cohort, board, inputs)
+            if not th or th["score"] < min_score:
+                continue
+            band = scoring.band_for(th["score"], inputs)
+            venue = (md.get("asset_context", {}) or {}).get(
+                "max_leverage", (md.get("asset_context", {}) or {}).get("maxLeverage"))
+            lev, mgn = scoring.sizing_for(band, posture.get("size_scale", 1.0), inputs, venue)
+            recent[bare] = now
+            free -= 1
+            out.append({
+                "asset": name, "direction": side, "marginPct": mgn, "leverage": lev,
+                "data": {"score": th["score"], "leverage": lev, "direction": side,
+                         "band": band, "stance": posture["stance"], "mode": posture["mode"],
+                         "posture": posture["narrative"], "sizeScale": posture.get("size_scale", 1.0),
+                         "regime": posture.get("regime", "UNKNOWN"),
+                         "lean": th["lean"], "mom24h": th["mom24h"], "reasons": th["reasons"]},
+            })
+            print(f"[allocator.scan] OPEN {side} {name}: score={th['score']} band={band} "
+                  f"{lev}x {mgn}% | {posture['stance']}", file=sys.stderr)
+
+    if not out:
+        print(f"[allocator.scan] no opens: stance={posture['stance']} held={len(held)}/"
+              f"{max_slots} free={free}", file=sys.stderr)
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"posture": posture, "last_recal": last_recal, "recent": recent,
+                              "result": {"ts": now, "stance": posture["stance"],
+                                         "opened": len(out), "held": len(held),
+                                         "narrative": posture["narrative"]}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[allocator.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/gorilla/main/scanners/scan.py
+++ b/strategies/gorilla/main/scanners/scan.py
@@ -36,7 +36,7 @@ def _read(ctx, tool, args, label):
     try:
         raw = ctx.senpi_mcp.call_tool(tool, args)
     except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
-        print(f"[allocator.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        print(f"[regime.scan] {label} read failed: {exc!r}", file=sys.stderr)
         return None
     if not raw:
         return None
@@ -192,7 +192,7 @@ def _cohorts(ctx, inputs):
     cp = bias(crowd, "crowd") if crowd else {}
     avail = bool(sp) and bool(cp)
     if not avail:
-        print("[allocator.scan] cohorts unavailable (discovery_* empty) — using board lean",
+        print("[regime.scan] cohorts unavailable (discovery_* empty) — using board lean",
               file=sys.stderr)
     return {"available": avail, "smart": sp, "crowd": cp}
 
@@ -215,12 +215,12 @@ def _held(ctx):
 def _rebuild_posture(ctx, inputs, now):
     main_rows = _instrument_rows(ctx, "")
     if main_rows is None:
-        print("[allocator.scan] instruments unreadable — keeping prior posture", file=sys.stderr)
+        print("[regime.scan] instruments unreadable — keeping prior posture", file=sys.stderr)
         return None
     xyz_rows = _instrument_rows(ctx, "xyz") or []
     pool = scoring.derive_universe(main_rows, xyz_rows, inputs)
     if len(pool) < 6:
-        print(f"[allocator.scan] only {len(pool)} names over the vol floor — keeping prior posture",
+        print(f"[regime.scan] only {len(pool)} names over the vol floor — keeping prior posture",
               file=sys.stderr)
         return None
     changes, prices = {}, {}
@@ -237,7 +237,7 @@ def _rebuild_posture(ctx, inputs, now):
     board = _board(ctx)
     regime = _funding_regime(ctx)
     posture = scoring.build_posture(pool, pulse, regime, cohort, board, inputs, now)
-    print(f"[allocator.scan] POSTURE: {posture['narrative']}", file=sys.stderr)
+    print(f"[regime.scan] POSTURE: {posture['narrative']}", file=sys.stderr)
     return posture
 
 
@@ -306,11 +306,11 @@ def scan(inputs, ctx):
                          "regime": posture.get("regime", "UNKNOWN"),
                          "lean": th["lean"], "mom24h": th["mom24h"], "reasons": th["reasons"]},
             })
-            print(f"[allocator.scan] OPEN {side} {name}: score={th['score']} band={band} "
+            print(f"[regime.scan] OPEN {side} {name}: score={th['score']} band={band} "
                   f"{lev}x {mgn}% | {posture['stance']}", file=sys.stderr)
 
     if not out:
-        print(f"[allocator.scan] no opens: stance={posture['stance']} held={len(held)}/"
+        print(f"[regime.scan] no opens: stance={posture['stance']} held={len(held)}/"
               f"{max_slots} free={free}", file=sys.stderr)
 
     if ctx.state is not None:
@@ -320,5 +320,5 @@ def scan(inputs, ctx):
                                          "opened": len(out), "held": len(held),
                                          "narrative": posture["narrative"]}})
         except Exception as exc:  # noqa: BLE001
-            print(f"[allocator.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+            print(f"[regime.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
     return out

--- a/strategies/gorilla/main/scanners/scoring.py
+++ b/strategies/gorilla/main/scanners/scoring.py
@@ -1,0 +1,339 @@
+"""REGIME ALLOCATOR — pure engine (no I/O, no MCP). Shared VERBATIM by Chimp
+(daily recalibration) and Gorilla (weekly); the cadence + DSL live in runtime.yaml.
+
+The design (fixes the cuttlefish/gorilla-v1 mistakes):
+  * The market read runs on a SLOW clock (recalibrationHours: 24 or 168) — never
+    nonstop. build_posture() re-derives a standing POSTURE from the latest
+    market-pulse + smart-money read; between recalibrations the posture is held.
+  * The strategy NEVER closes a position. A regime flip only changes what it
+    OPENS next; prior-regime positions retire on their own DSL trailing stops
+    (rotate-by-attrition). So there is ONE scanner, ONE OPEN action, no
+    CLOSE_POSITION, no cross-scanner coherence problem. DSL owns every exit.
+  * The universe spans BOTH dexes — main crypto perps AND xyz tokenized
+    equities/commodities/FX — so risk-off can rotate into real havens.
+
+Engine math ported verbatim from the senpi-market-pulse (compute_signals: day
+classification + GOLD/DXY/VIX checklist + dispersion) and senpi-smart-money
+(proven-vs-crowd cohort bias) skills. Cohorts are an ENRICHMENT that degrades
+cleanly to the leaderboard board — the posture never depends on a user-scoped
+discovery token.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+
+LEAN_THRESHOLD = 0.40       # proven-cohort bias past this = a real directional lean
+MIN_MEMBERS = 5
+DIVERGENCE_MIN_GAP = 0.50
+
+
+def _f(v, default=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _clamp(v, lo, hi):
+    return max(lo, min(hi, v))
+
+
+def pct_change(mark, prev):
+    m, p = _num(mark), _num(prev)
+    if m is None or p is None or p == 0:
+        return None
+    return round((m - p) / p * 100, 2)
+
+
+def closes(candles):
+    return [_f(c.get("c")) for c in (candles or []) if isinstance(c, dict)]
+
+
+def mom(candles, n=1):
+    cl = closes(candles)
+    if len(cl) < 2:
+        return 0.0
+    n = min(n, len(cl) - 1)
+    if cl[-1 - n] == 0:
+        return 0.0
+    return (cl[-1] / cl[-1 - n] - 1.0) * 100.0
+
+
+def trend_structure(candles, bars=6):
+    """('up'|'down'|'mixed', strength 0..1) over the last `bars` closes."""
+    cl = closes(candles)
+    if len(cl) < bars + 1:
+        return "mixed", 0.0
+    window = cl[-(bars + 1):]
+    ups = sum(1 for a, b in zip(window, window[1:]) if b > a)
+    s = ups / bars
+    if s >= 0.65:
+        return "up", s
+    if s <= 0.35:
+        return "down", 1.0 - s
+    return "mixed", 0.5
+
+
+def clamp_leverage(desired, venue_max):
+    try:
+        venue = int(venue_max)
+    except (TypeError, ValueError):
+        venue = desired
+    if venue <= 0:
+        venue = desired
+    return max(1, min(int(desired), venue))
+
+
+def due(now, anchor_ts, every_seconds):
+    """True when a recalibration boundary has elapsed (0 anchor = never yet)."""
+    return anchor_ts <= 0 or (every_seconds > 0 and (now - anchor_ts) >= every_seconds)
+
+
+# ── UNIVERSE — derived live from BOTH dexes ─────────────────────────────────
+
+def classify(name, inputs):
+    """'defensive' (havens/commodities/defensive FX) | 'risk' (everything else:
+    crypto, equities, indices). Defensive set is tunable via inputs."""
+    bare = str(name).split(":", 1)[-1].upper()
+    defensives = {str(x).upper() for x in (inputs.get("defensiveAssets") or
+                  ["GOLD", "SILVER", "PLATINUM", "PALLADIUM", "BRENTOIL", "CL", "NATGAS",
+                   "DXY", "JPY"])}
+    return "defensive" if bare in defensives else "risk"
+
+
+def derive_universe(main_rows, xyz_rows, inputs):
+    """rows: [{name, vol, change_pct}] per dex (already parsed by scan.py).
+    main perps + xyz instruments over the per-dex volume floor, top-N each,
+    minus excludeAssets. Returns [{name, dex, chg, vol, class}] (name carries the
+    xyz: prefix for xyz)."""
+    main_floor = _f(inputs.get("universeVolFloorUsd"), 25_000_000)
+    xyz_floor = _f(inputs.get("xyzVolFloorUsd"), 3_000_000)
+    max_main = int(_f(inputs.get("maxMainNames"), 14))
+    max_xyz = int(_f(inputs.get("maxXyzNames"), 16))
+    exclude = {str(x).upper() for x in (inputs.get("excludeAssets") or [])}
+
+    def _pick(rows, floor, cap, dex):
+        seen, out = set(), []
+        for r in rows or []:
+            name = str((r or {}).get("name", "")).strip()
+            if not name:
+                continue
+            bare = name.split(":", 1)[-1].upper()
+            if bare in seen or bare in exclude:
+                continue
+            seen.add(bare)
+            if _f(r.get("vol")) < floor:
+                continue
+            out.append((name, _f(r.get("vol")), r.get("change_pct")))
+        out.sort(key=lambda t: t[1], reverse=True)
+        return [{"name": n, "dex": dex, "vol": v, "chg": c,
+                 "class": classify(n, inputs)} for n, v, c in out[:cap]]
+
+    return _pick(main_rows, main_floor, max_main, "") + _pick(xyz_rows, xyz_floor, max_xyz, "xyz")
+
+
+# ── PULSE — cross-asset day read (market-pulse compute_signals port) ────────
+
+def group_averages(changes, groups):
+    out = {}
+    for g, syms in (groups or {}).items():
+        vals = [changes.get(str(s).upper()) for s in (syms or [])]
+        vals = [v for v in vals if v is not None]
+        out[g] = round(sum(vals) / len(vals), 2) if vals else None
+    return out
+
+
+def pulse_stance(changes, groups, vix_price=None):
+    """day classification (groups down vs up at +/-0.5%, 2:1, >=3) + GOLD/DXY/VIX
+    checklist + dispersion (index calm while worst group breaks > 2.5% = rotation)."""
+    gavg = group_averages(changes, groups)
+    breadth = [v for v in gavg.values() if v is not None]
+    down = sum(1 for x in breadth if x < -0.5)
+    up = sum(1 for x in breadth if x > 0.5)
+    if breadth:
+        day = ("risk_off" if down >= up * 2 and down >= 3
+               else "risk_on" if up >= down * 2 and up >= 3 else "mixed")
+    else:
+        day = None
+
+    gold, dxy = changes.get("GOLD"), changes.get("DXY")
+    checklist = {
+        "gold": ("haven bid intact" if (gold is not None and gold > -2)
+                 else "haven also selling" if gold is not None else None),
+        "dxy": ("dollar calm" if (dxy is not None and abs(dxy) < 0.6)
+                else "dollar bid — funding stress" if (dxy is not None and dxy > 0.6) else None),
+        "vix": ("fear contained" if (vix_price is not None and vix_price < 22)
+                else "fear elevated" if vix_price is not None else None),
+    }
+    sp500 = changes.get("SP500")
+    worst_g, worst_avg = None, 0.0
+    for g, a in gavg.items():
+        if a is not None and a < worst_avg:
+            worst_g, worst_avg = g, a
+    dispersion = ("rotation" if (sp500 is not None and worst_g and (sp500 - worst_avg) > 2.5)
+                  else "broad" if (sp500 is not None and worst_g) else None)
+    return {"day": day, "groups_up": up, "groups_down": down, "group_avgs": gavg,
+            "checklist": checklist, "dispersion": dispersion, "worst_group": worst_g,
+            "vix_price": vix_price}
+
+
+# ── COHORTS — proven-vs-crowd bias (smart-money port; ENRICHMENT, degrades) ─
+
+def _signed_notional(p):
+    def f(*keys):
+        for k in keys:
+            v = _num((p or {}).get(k))
+            if v is not None:
+                return v
+        return 0.0
+    szi = f("szi", "size")
+    val = f("positionValue", "notional", "position_value")
+    if val <= 0:
+        val = abs(szi) * f("entryPx", "markPx", "entry_price")
+    return (1.0 if szi > 0 else (-1.0 if szi < 0 else 0.0)) * abs(val)
+
+
+def cohort_positions_bias(traders, per=None):
+    per = per if per is not None else {}
+    for t in traders or []:
+        if not isinstance(t, dict):
+            continue
+        for p in (t.get("openPositions") or t.get("open_positions") or []):
+            if not isinstance(p, dict):
+                continue
+            coin = p.get("coin") or p.get("asset")
+            sn = _signed_notional(p) if coin else 0.0
+            if not coin or sn == 0:
+                continue
+            d = per.setdefault(str(coin).upper(),
+                               {"net": 0.0, "gross": 0.0, "n_long": 0, "n_short": 0})
+            d["net"] += sn
+            d["gross"] += abs(sn)
+            d["n_long" if sn > 0 else "n_short"] += 1
+    return per
+
+
+def finalize_bias(per):
+    for d in (per or {}).values():
+        d["bias"] = round(d["net"] / d["gross"], 3) if d["gross"] > 0 else 0.0
+        d["members"] = d["n_long"] + d["n_short"]
+    return per
+
+
+def smart_lean(name, cohort, board):
+    """Directional lean for `name`: proven cohort bias if available (>= members),
+    else the leaderboard board (near-term). Returns bias in [-1,1] (0 = neutral)."""
+    au = str(name).split(":", 1)[-1].upper()
+    if (cohort or {}).get("available"):
+        d = (cohort.get("smart") or {}).get(au)
+        if d and d.get("members", 0) >= MIN_MEMBERS:
+            return _clamp(d.get("bias", 0.0), -1, 1)
+    b = (board or {}).get(au)
+    if b:
+        if b.get("direction") == "LONG":
+            return _clamp((_f(b.get("pct"), 50) - 50) / 50.0, 0, 1)
+        if b.get("direction") == "SHORT":
+            return -_clamp((_f(b.get("pct"), 50) - 50) / 50.0, 0, 1)
+    return 0.0
+
+
+# ── POSTURE — the standing thesis, re-derived on the recalibration clock ─────
+
+def build_posture(pool, pulse, funding_regime, cohort, board, inputs, now):
+    """Map the market read -> {stance, mode, longs[], shorts[], size_scale,
+    narrative, built_at}. longs/shorts are ranked candidate name lists; scan.py
+    fills free slots from them (tape-confirmed) — it does NOT open all of them."""
+    day = (pulse or {}).get("day")
+    dispersion = (pulse or {}).get("dispersion")
+
+    def rs(item):
+        # relative strength = 24h change biased by the proven/board lean
+        return _f(item.get("chg")) + 4.0 * smart_lean(item["name"], cohort, board)
+
+    ranked = sorted(pool, key=rs, reverse=True)
+    strong = [i["name"] for i in ranked]
+    weak = [i["name"] for i in reversed(ranked)]
+    defensive_up = [i["name"] for i in ranked
+                    if i["class"] == "defensive" and _f(i.get("chg")) > 0]
+    risk_down = [i["name"] for i in reversed(ranked)
+                 if i["class"] == "risk" and _f(i.get("chg")) < 0]
+
+    if day == "risk_on":
+        stance, mode = "RISK_ON", "risk_on"
+        longs = [i["name"] for i in ranked if _f(i.get("chg")) > 0][:12]
+        shorts, size = [], 1.0
+    elif day == "risk_off":
+        stance, mode = "RISK_OFF", "risk_off"
+        longs = defensive_up[:8]                 # rotate into havens that are working
+        shorts = risk_down[:8]                   # short the breaking risk complex
+        size = _f(inputs.get("riskOffSizeScale"), 0.7)
+    else:                                        # mixed / rotation -> dispersion play
+        stance = "ROTATION" if dispersion == "rotation" else "MIXED"
+        mode = "rotation" if dispersion == "rotation" else "mixed"
+        longs = strong[:8]
+        shorts = weak[:8]
+        size = _f(inputs.get("mixedSizeScale"), 0.6)
+
+    # squeeze note: a crowded funding regime favors the fade side (informational)
+    reg = funding_regime or "UNKNOWN"
+    chk = (pulse or {}).get("checklist") or {}
+    chk_bits = "; ".join(v for v in (chk.get("gold"), chk.get("dxy"), chk.get("vix")) if v)
+    disp_bit = (f"; DISPERSION rotation (worst: {pulse.get('worst_group')})"
+                if dispersion == "rotation" else "")
+    coh = "" if (cohort or {}).get("available") else " [cohorts unavailable — board lean]"
+    narrative = (f"{stance} (pulse {day or 'no-read'}: {(pulse or {}).get('groups_up',0)} up / "
+                 f"{(pulse or {}).get('groups_down',0)} down; {chk_bits or 'no checklist'}"
+                 f"{disp_bit}); funding {reg}; long {','.join(longs[:5]) or '—'}; "
+                 f"short {','.join(shorts[:5]) or '—'}{coh}")
+    return {"stance": stance, "mode": mode, "longs": longs, "shorts": shorts,
+            "size_scale": size, "regime": reg, "dispersion": dispersion,
+            "cohorts_available": bool((cohort or {}).get("available")),
+            "narrative": narrative, "built_at": now}
+
+
+# ── ENTRY — tape must confirm the posture direction for THIS name ───────────
+
+def score_candidate(name, side, c1, c4, cohort, board, inputs):
+    """0-10 conviction for opening `name` in `side`. None on thin candles;
+    None (as a soft skip) when the tape does not confirm the posture direction."""
+    if len(closes(c1)) < 8 or len(closes(c4)) < 4:
+        return None
+    sign = 1 if side == "LONG" else -1
+    want = "up" if side == "LONG" else "down"
+    t4, s4 = trend_structure(c4)
+    t1, _ = trend_structure(c1)
+    if t4 != want:                               # hard confirm: 4h structure must agree
+        return None
+    m24 = mom(c1, 24)
+    lean = smart_lean(name, cohort, board) * sign
+
+    w_t4, w_t1, w_m, w_sm = 3.0, 2.0, 3.0, 2.0
+    t4_c = w_t4 * s4
+    t1_c = w_t1 if t1 == want else 0.0
+    m_c = w_m * _clamp((m24 * sign) / 6.0, 0, 1)
+    sm_c = w_sm * _clamp(lean, 0, 1)
+    score = _clamp(10.0 * (t4_c + t1_c + m_c + sm_c) / (w_t4 + w_t1 + w_m + w_sm), 0, 10)
+    return {"asset": name, "score": round(score, 2), "trend4h": t4,
+            "mom24h": round(m24, 2), "lean": round(lean, 3),
+            "reasons": [f"4h {t4} {s4:.0%}", f"24h {m24:+.1f}%", f"lean {lean:+.2f}"]}
+
+
+def band_for(score, inputs):
+    if score >= _f(inputs.get("apexScore"), 8.0):
+        return "apex"
+    if score >= _f(inputs.get("goodScore"), 6.5):
+        return "good"
+    if score >= _f(inputs.get("minScore"), 5.5):
+        return "base"
+    return None
+
+
+def sizing_for(band, size_scale, inputs, venue_max=None):
+    lev = _f((inputs.get("leverageTiers") or {}).get(band), 3)
+    mgn = _f((inputs.get("marginPctTiers") or {}).get(band), 10) * _f(size_scale, 1.0)
+    return clamp_leverage(lev, venue_max if venue_max is not None else lev), max(round(mgn, 2), 3.0)

--- a/strategies/gorilla/strategy.yaml
+++ b/strategies/gorilla/strategy.yaml
@@ -1,0 +1,43 @@
+# Gorilla — Regime Allocator (WEEKLY). Single-wallet PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/ (byte-identical engine to Chimp). Reads
+# the whole market once a week (market-pulse + smart-money), holds a standing risk
+# POSTURE, and rotates the book into it BY ATTRITION — never closes a position; a
+# regime flip only changes what it opens next, and prior positions retire on their
+# own DSL. The committed weekly sibling of Chimp (daily). Install via senpi-strategy-ops.
+schema_version: 1
+
+id: gorilla
+version: "1.0.0"
+
+catalog:
+  name: "Gorilla — Regime Allocator (Weekly)"
+  emoji: "🦍"
+  tagline: "The weekly, more-committed sibling of Chimp. Once a week it reads the whole market — the pulse (risk-on/off, dispersion, gold/dollar/VIX) plus where the proven wallets lean — sets a risk posture, and holds a concentrated long/short book across crypto and tokenized stocks/commodities. It never sells: a regime change just changes what it buys next, and a wide trailing stop does all the exiting, letting winners run for weeks."
+  belief_plain: "Like Chimp, but slower and more committed. Once a week it decides the stance — risk-on lean into leaders, risk-off rotate into gold/oil and short the weak, rotation week play winners-vs-losers small — and holds fewer, bigger positions. It never manually closes; a wide ratchet stop protects each one and lets the winners run, so the book turns over on the market's schedule, not a scanner's."
+  thesis: "Same automated pulse-then-allocate loop as Chimp, on a weekly clock with a wider DSL and higher conviction gate — for users who want a deliberate regime-follower that commits to a view and rides it, rather than re-tilting daily. Never force-closes; turnover is set by the market via DSL. Pair with Chimp for a fast + slow allocator sleeve."
+  group: multi-asset-universe
+  archetype: macro_thesis
+  sub_style: adaptive
+  asset_classes: [btc_eth, major_alts, xyz_equities, commodities, fx]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 7
+  min_budget: 100
+  assets: []                 # DERIVED live weekly from both dexes (vol floor + top-N)
+  tags: [regime, allocator, macro, pulse, smart-money, long-short, universe, weekly, no-close, dsl-only]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name gorilla-main, group gorilla
+    wallet_env: GORILLA_WALLET
+    funding_share: 1.0

--- a/strategies/gorilla/tests/test_engine.py
+++ b/strategies/gorilla/tests/test_engine.py
@@ -1,0 +1,116 @@
+"""Regime-Allocator engine fidelity (pure scoring.py) — shared by Chimp & Gorilla.
+
+Run: python3 strategies/chimp/tests/test_engine.py
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "main", "scanners"))
+
+import scoring  # noqa: E402
+
+PASS = FAIL = 0
+
+
+def check(name, cond):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+    else:
+        FAIL += 1
+        print(f"FAIL: {name}")
+
+
+def candles(n, start, drift):
+    out, px = [], start
+    for i in range(n):
+        o = px
+        px *= (1 + drift)
+        out.append({"o": str(o), "c": str(px), "h": str(max(o, px)), "l": str(min(o, px)),
+                    "v": "100", "n": 5})
+    return out
+
+
+INPUTS = {"minScore": 5.5, "goodScore": 6.5, "apexScore": 8.0,
+          "leverageTiers": {"apex": 5, "good": 4, "base": 3},
+          "marginPctTiers": {"apex": 14, "good": 10, "base": 7},
+          "riskOffSizeScale": 0.7, "mixedSizeScale": 0.6}
+
+# ── universe: BOTH dexes, vol floors, class tagging ──
+main_rows = [{"name": "BTC", "vol": 900e6, "change_pct": 1.7},
+             {"name": "SOL", "vol": 300e6, "change_pct": 1.2},
+             {"name": "PUMP", "vol": 2e6, "change_pct": 5.0}]       # under main floor
+xyz_rows = [{"name": "xyz:NVDA", "vol": 80e6, "change_pct": 2.0},
+            {"name": "xyz:GOLD", "vol": 40e6, "change_pct": -0.3},
+            {"name": "xyz:TINY", "vol": 1e6, "change_pct": 9.0}]    # under xyz floor
+pool = scoring.derive_universe(main_rows, xyz_rows, dict(INPUTS,
+       universeVolFloorUsd=25_000_000, xyzVolFloorUsd=3_000_000, maxMainNames=14, maxXyzNames=16))
+names = {i["name"] for i in pool}
+check("universe spans both dexes", {"BTC", "SOL", "xyz:NVDA", "xyz:GOLD"} <= names)
+check("under-floor names dropped (both dexes)", "PUMP" not in names and "xyz:TINY" not in names)
+check("xyz prefix preserved", any(i["name"] == "xyz:NVDA" and i["dex"] == "xyz" for i in pool))
+check("class: GOLD defensive", scoring.classify("xyz:GOLD", INPUTS) == "defensive")
+check("class: BTC risk", scoring.classify("BTC", INPUTS) == "risk")
+
+# ── pulse: day + dispersion + checklist ──
+GROUPS = {"crypto": ["BTC", "ETH"], "semis": ["NVDA", "AMD"], "indices": ["SP500"],
+          "commodities": ["GOLD"], "macro_fx": ["DXY"]}
+on = {"BTC": 2, "ETH": 3, "NVDA": 1.5, "AMD": 2.5, "SP500": 1.0, "GOLD": 0.2, "DXY": 0.1}
+off = {"BTC": -2, "ETH": -3, "NVDA": -1.5, "AMD": -2.5, "SP500": -1.0, "GOLD": 0.5, "DXY": 0.9}
+rot = {"BTC": 1.4, "ETH": 1.2, "NVDA": -4.0, "AMD": -4.6, "SP500": 0.4, "GOLD": -0.3, "DXY": 0.0}
+check("risk_on day", scoring.pulse_stance(on, GROUPS, 15)["day"] == "risk_on")
+check("risk_off day", scoring.pulse_stance(off, GROUPS, 28)["day"] == "risk_off")
+p_off = scoring.pulse_stance(off, GROUPS, 28)
+check("dxy funding-stress read", p_off["checklist"]["dxy"] == "dollar bid — funding stress")
+p_rot = scoring.pulse_stance(rot, GROUPS, 20)
+check("rotation dispersion (mixed day)", p_rot["day"] == "mixed" and p_rot["dispersion"] == "rotation")
+
+# ── posture across regimes ──
+POOL = [{"name": "BTC", "dex": "", "chg": 3.0, "class": "risk"},
+        {"name": "SOL", "dex": "", "chg": 2.0, "class": "risk"},
+        {"name": "xyz:NVDA", "dex": "xyz", "chg": 2.5, "class": "risk"},
+        {"name": "xyz:GOLD", "dex": "xyz", "chg": 0.8, "class": "defensive"},
+        {"name": "xyz:BRENTOIL", "dex": "xyz", "chg": 0.5, "class": "defensive"},
+        {"name": "DOGE", "dex": "", "chg": -3.0, "class": "risk"},
+        {"name": "xyz:MU", "dex": "xyz", "chg": -4.0, "class": "risk"}]
+board = {"BTC": {"direction": "LONG", "pct": 70}}
+noco = {"available": False}
+
+p_on = scoring.build_posture(POOL, scoring.pulse_stance(on, GROUPS, 15), "SHORT_CROWDED", noco, board, INPUTS, 100.0)
+check("risk_on: long-only, full size", p_on["stance"] == "RISK_ON" and p_on["shorts"] == [] and p_on["size_scale"] == 1.0)
+check("risk_on longs are the strong risk names", "BTC" in p_on["longs"] and "DOGE" not in p_on["longs"])
+
+p_of = scoring.build_posture(POOL, scoring.pulse_stance(off, GROUPS, 28), "LONG_CROWDED", noco, board, INPUTS, 0.0)
+check("risk_off: defensives long, risk short, reduced size", p_of["stance"] == "RISK_OFF"
+      and "xyz:GOLD" in p_of["longs"] and "xyz:MU" in p_of["shorts"] and p_of["size_scale"] == 0.7)
+check("risk_off never longs a risk asset", all(scoring.classify(n, INPUTS) == "defensive" for n in p_of["longs"]))
+
+p_rt = scoring.build_posture(POOL, p_rot, "LONG_CROWDED", noco, board, INPUTS, 0.0)
+check("rotation: long strong / short weak, small size", p_rt["stance"] == "ROTATION"
+      and p_rt["longs"][0] in ("BTC", "xyz:NVDA", "SOL") and p_rt["size_scale"] == 0.6)
+check("posture carries a narrative", "RISK_OFF" in p_of["narrative"])
+check("cohorts-unavailable flagged", "board lean" in p_of["narrative"])
+
+# ── entry: tape must confirm the posture direction ──
+up1, up4 = candles(30, 100, 0.004), candles(10, 95, 0.01)
+dn1, dn4 = candles(30, 100, -0.004), candles(10, 105, -0.01)
+check("long confirmed on uptrend", (scoring.score_candidate("BTC", "LONG", up1, up4, noco, board, INPUTS) or {}).get("score", 0) >= 5.5)
+check("long REJECTED on downtrend (hard 4h confirm)", scoring.score_candidate("BTC", "LONG", dn1, dn4, noco, board, INPUTS) is None)
+check("short confirmed on downtrend", (scoring.score_candidate("DOGE", "SHORT", dn1, dn4, noco, board, INPUTS) or {}).get("score", 0) >= 5.5)
+check("short REJECTED on uptrend", scoring.score_candidate("DOGE", "SHORT", up1, up4, noco, board, INPUTS) is None)
+
+# ── bands + size-scaled sizing + venue clamp ──
+check("band apex", scoring.band_for(8.5, INPUTS) == "apex")
+lev, mgn = scoring.sizing_for("apex", 1.0, INPUTS, venue_max=3)
+check("venue clamp", lev == 3 and mgn == 14)
+_, mgn_small = scoring.sizing_for("apex", 0.6, INPUTS)
+check("size_scale shrinks margin", mgn_small == round(14 * 0.6, 2))
+
+# ── recalibration clock ──
+check("first tick is due (anchor 0)", scoring.due(1000.0, 0.0, 86400))
+check("not due inside window", not scoring.due(1000.0 + 80000, 1000.0, 86400))
+check("due after the window", scoring.due(1000.0 + 90000, 1000.0, 86400))
+
+print(f"{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)

--- a/strategies/gorilla/tests/test_package_shape.py
+++ b/strategies/gorilla/tests/test_package_shape.py
@@ -1,0 +1,64 @@
+"""Regime-Allocator package-shape invariants — encode the corrected architecture.
+
+The design guarantees, asserted structurally:
+  * exactly ONE external scanner (not the cuttlefish/gorilla-v1 two-scanner mess),
+  * NO CLOSE_POSITION action — DSL is the sole exit (rotate-by-attrition),
+  * a slow recalibration clock (the market check is not nonstop),
+  * a DERIVED universe (no hardcoded asset list),
+  * marginPct tiers a PERCENT in (0,100].
+
+Run: python3 strategies/chimp/tests/test_package_shape.py
+"""
+import os
+import sys
+
+import yaml
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PKG_ID = os.path.basename(ROOT)
+PASS = FAIL = 0
+
+
+def check(name, cond):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+    else:
+        FAIL += 1
+        print(f"FAIL: {name}")
+
+
+spec = yaml.safe_load(open(os.path.join(ROOT, "strategy.yaml")))
+check("asset_scope universe (derived)", spec["catalog"]["asset_scope"] == "universe")
+check("assets [] (nothing hardcoded)", spec["catalog"].get("assets") == [])
+
+for inst in spec["instances"]:
+    book = inst["name"]
+    ry = yaml.safe_load(open(os.path.join(ROOT, book, inst["runtime"].split("/")[-1])))
+    ext = [s for s in ry["scanners"] if s.get("type") == "external_scanner"]
+    check(f"{book}: exactly ONE external scanner", len(ext) == 1)
+
+    actions = {a["action_type"] for a in ry["actions"]}
+    check(f"{book}: has OPEN_POSITION", "OPEN_POSITION" in actions)
+    check(f"{book}: has POSITION_TRACKER", "POSITION_TRACKER" in actions)
+    check(f"{book}: NO CLOSE_POSITION (DSL is the only exit)", "CLOSE_POSITION" not in actions)
+
+    check(f"{book}: exit engine is dsl", ry["exit"]["engine"] == "dsl")
+    tiers = ry["exit"]["dsl_preset"]["phase2"]["tiers"]
+    trg = [t["trigger_pct"] for t in tiers]
+    check(f"{book}: DSL tiers ascending, <=100", trg == sorted(trg) and all(0 < t <= 100 for t in trg))
+    check(f"{book}: DSL phase1 stop present", ry["exit"]["dsl_preset"]["phase1"]["max_loss_pct"] > 0)
+
+    inp = ext[0]["inputs"]
+    check(f"{book}: recalibration clock set (slow, not nonstop)", float(inp.get("recalibrationHours", 0)) >= 24)
+    check(f"{book}: no hardcoded universe", "universe" not in inp and "assets" not in inp)
+    check(f"{book}: both-dex vol floors set", float(inp.get("universeVolFloorUsd", 0)) > 0
+          and float(inp.get("xyzVolFloorUsd", 0)) > 0)
+    for band, pct in (inp.get("marginPctTiers") or {}).items():
+        check(f"{book}: marginPct[{band}] in (0,100]", 0 < float(pct) <= 100)
+    # scanner wakes must be far slower than the old 15m churn
+    check(f"{book}: scanner cadence is a longer-play cadence (>=1h)",
+          int(ext[0].get("interval_seconds", 0)) >= 3600)
+
+print(f"{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)


### PR DESCRIPTION
Two new **Regime Allocator** templates, built to the corrected design after the cuttlefish/gorilla-v1 rework was scrapped. Same engine (scanners byte-identical); they differ only in cadence + DSL width + conviction.

## The pattern (both)

Users run the market-pulse skill, then hand-pick strategies to fit the read. These automate that loop, fixing all three prior mistakes:

- **Slow clock, never nonstop.** The whole-market read — market-pulse day classification + dispersion + GOLD/DXY/VIX checklist, funding regime, smart-money cohorts (degrading to the leaderboard board) — runs on a `recalibrationHours` clock: **24h (Chimp) / 168h (Gorilla)**. The scanner wakes every 6h but the expensive read is gated to the cadence and restart-safe (persisted `last_recal`).
- **Never closes.** One scanner, one `OPEN_POSITION` action, **no `CLOSE_POSITION`**. A regime flip only changes what it *opens next*; prior-regime positions retire on their own DSL — **rotate-by-attrition**. This erases the cross-scanner coherence bug class entirely.
- **Always DSL.** DSL is the sole exit. Chimp moderate (18% Phase 1, ladder to +80%, 48h weak-peak — resolves in days); Gorilla wide (20%, +100%, 7d weak-peak — rides for weeks). No hard_timeout.
- **Main + xyz universe.** Derived live from **both dexes** each recalibration (crypto perps over \$25M + xyz equities/commodities over \$3M, top-N), so risk-off can rotate into working havens.

## The posture

| pulse read | longs | shorts | size |
|---|---|---|---|
| risk_on | leaders (full pool) | — | 1.0 |
| risk_off | working defensives (gold/oil/JPY…) | breaking risk complex | 0.7 |
| mixed / rotation | strong names | weak names | 0.6 |

Entries are tape-confirmed (hard 4h-structure gate), conviction-banded, leverage clamped to venue max.

## Chimp vs Gorilla

- **Chimp 🐒 (daily):** nimble, 8 slots, 14/10/7% margin bands, minScore 5.5.
- **Gorilla 🦍 (weekly):** committed, 7 slots, 16/12/8% bands, minScore 6.0, wide DSL. Fewer/bigger/longer-held.

Pair them for a fast + slow allocator sleeve.

## Gates

- `py_compile` clean; **26** engine + **16** package-shape tests each (shape tests assert the architecture: exactly one external scanner, **no CLOSE action**, DSL-only exit, slow recalibration clock, derived universe).
- **End-to-end audit harness** (bull/bear × cohorts on/off, real `scan()` under canned MCP): 0 findings — regime logic differentiates (risk_on longs vs risk_off shorts+havens at 0.7×), every signal schema-clean, **zero closes ever emitted**.
- Static schema check 0 issues; `gen_catalog` 81 strategies zero warnings; `validate_universe` **8/8 live** each (caught + dropped DXY — not a tradeable perp; kept read-only in the pulse groups).

## Deploy

Single wallet each: `CHIMP_WALLET` / `GORILLA_WALLET`, min budget \$100.

Note: reuses the name "gorilla" (the prior closed gorilla-v1 PR was never merged; this is a fresh, different package). Follow-up Rotation Rider pair (Gibbon/Orangutan) coming as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)