### PR TITLE
senpi-strategy-discover 2.3.0 — ship current catalog to agents (4 new strategies)

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.2.2"
+  version: "2.3.0"
   platform: senpi
   exchange: hyperliquid
 ---


### PR DESCRIPTION
## Why
Chimp/Gorilla/Gibbon/Orangutan are in main's catalog (`gen_catalog.py` regenerated it on #457/#458 merge — **83 strategies**), but **deployed agents still show 79** and can't find them.

Root cause: `catalog.json` is bundled **inside** the `senpi-strategy-discover` package, and the skills-manager only re-installs a skill when its **version** increases. Adding strategies changed the catalog *data*, not the discover *version* (stayed 2.2.2) → no re-install → agents keep the stale bundled catalog.

## What
Bump **2.2.2 → 2.3.0** (within manifest `maxMajor: 2`). No code change — the package content (bundled catalog) already changed on main; this re-cut forces the auto-upgrader to re-install discover and deliver the current 83-strategy catalog to every agent.

Verified: main's bundled `senpi-strategy-discover/catalog.json` has all 4 primates; `gen_catalog.py` run produces **no diff** (already current).

## ⚠️ Version coordination
PR **#456** (discover budget fix) is open and **also** bumps discover to 2.3.0. This PR is launch-critical (agents need the strategies visible now) and should merge first; **#456 then needs to rebase to 2.3.1.**

## Durable follow-up
This bump is the *stopgap*. Every future strategy add hits the same wall. The permanent fix is to decouple catalog delivery from skill version — have `discover.py` fetch the catalog live from main (bundled copy as offline fallback) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)