### PR TITLE
strategy-debug hardening: turn a live-deploy failure into deterministic gates

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.5.0"
+  version: "2.6.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -192,6 +192,21 @@ the catalog entry, then unit-test → validate → hand to smoke-test."* Then ti
    status ACTIVE" is **not** done — `ACTIVE` only means `position_tracker` runs; done means a scanner tick
    that **emitted a schema-valid signal**. Never declare a strategy fixed/built without that tick, and
    never substitute a raw `strategy_create_custom_strategy` (it drops the DSL and automated exits).
+10. **Deploy, then confirm it's LIVE *and* PROTECTED — the job is NOT done until this passes.** Authoring a
+    clean package is not the finish line. A strategy the user can't see running — or one running
+    **unprotected** — is the exact failure this flow exists to prevent (a user lost real money on a
+    strategy that funded but never got a runtime, so it had **no DSL and no guardrails**, and nothing said
+    so). Hand to `senpi-strategy-ops` (`deploy.py create <id> --budget <usd>` → `deploy.py runtime <id>`),
+    then verify the **full** definition of done — never stop at "ACTIVE":
+    - **Live** — `python3 senpi-strategy-ops/scripts/diagnose.py <id>`: the external_scanner is registered,
+      `interval_seconds > 0`, has **ticked**, and emitted a **schema-valid signal sized ≈ the intended %**.
+    - **Protected** — `python3 senpi-strategy-ops/scripts/protect.py <id>`: every open position is
+      **DSL-tracked with a resting stop** (not NAKED).
+    - **Guard-railed** — `openclaw senpi risk -r <id>-<inst>`: the `risk.guard_rails` (drawdown halt,
+      daily-loss, per-day / per-asset limits) are loaded and eligible.
+    If the runtime never registered (gateway scope, a bad path, a raw-create shortcut), the strategy is
+    **funded but running with NO runtime — no DSL, no guardrails.** Say so plainly; **never report a
+    strategy as live or protected until these three confirm it.**
 
 Report each numbered stage as it lands — a short line is enough. The point is the user sees forward motion
 the whole way and can catch a wrong turn early, instead of after the entire package is already built.
@@ -248,8 +263,12 @@ Same references; usually no rebuild: tune `runtime.yaml` `inputs` (universe/thre
 the `dsl_preset`, adjust `risk.guard_rails`, or change the `scoring.py` math. Re-validate, then
 re-smoke-test if you touched `scan.py`/`runtime.yaml`.
 
-## Handoff
+## Handoff — but not before it's live and protected
 
-Authoring produces the package only. **Deploy/monitor/close is `senpi-strategy-ops`** — hand off the
-`id` once the smoke test is green. Attribution (`skillName`/`skillVersion`) is set by ops from
-`strategy.yaml` `id`/`version`.
+Deploy/monitor/close run through **`senpi-strategy-ops`**, but authoring is **not done when the package is
+written or the smoke test is green.** It is done when the strategy is **deployed and confirmed live +
+DSL-protected + guard-railed** (step 10) — drive it through deploy and run `diagnose.py` + `protect.py` +
+`openclaw senpi risk` yourself, and only report success once all three pass. A package that was authored
+but never made it onto a **running, protected runtime** is an unprotected position waiting to happen — the
+one outcome that must never be reported as "done." Attribution (`skillName`/`skillVersion`) is set by ops
+from `strategy.yaml` `id`/`version`.

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.4.2"
+  version: "2.5.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -183,9 +183,15 @@ the catalog entry, then unit-test → validate → hand to smoke-test."* Then ti
    — every hardcoded ticker must be a live HL instrument (`deploy.py create` also runs this as a preflight
    and refuses to fund a bad universe; derived-universe strategies pass trivially). Run each, report the
    result. **If validation fails, narrate the fix and re-run — don't go silent while you debug.**
-9. **Smoke-test (hand to `senpi-strategy-ops`):** dry-run → run `scan()` once on live read-only MCP →
-   tiny deploy → confirm the runtime **accepted** a signal (`openclaw senpi state -r <id>-<inst>
-   --json`), not just that it ticked. **Green = `scan` → signal → runtime-accepted, end to end.**
+9. **Smoke-test (hand to `senpi-strategy-ops`):** run `scan()` once on live read-only MCP with
+   `python3 senpi-strategy-ops/scripts/diagnose.py <id> --run-scan` — it prints the literal return and
+   validates the emitted `data{}` against `signal_data_schema` **before** you deploy, so a shape mismatch
+   (which the runtime would drop *silently*) fails loud here instead of as a strategy that funds ACTIVE and
+   never trades. Then tiny deploy → `diagnose.py <id>` and confirm the runtime **accepted** a signal, not
+   just that it ticked. **Green = `scan` → valid-shape signal → runtime-accepted, end to end.** "Deployed,
+   status ACTIVE" is **not** done — `ACTIVE` only means `position_tracker` runs; done means a scanner tick
+   that **emitted a schema-valid signal**. Never declare a strategy fixed/built without that tick, and
+   never substitute a raw `strategy_create_custom_strategy` (it drops the DSL and automated exits).
 
 Report each numbered stage as it lands — a short line is enough. The point is the user sees forward motion
 the whole way and can catch a wrong turn early, instead of after the entire package is already built.

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -223,7 +223,11 @@ makes one new wallet per instance). Authoring just designs the package; **concur
 - **`scan(inputs, ctx)` is read-only, pure, single-pass.** Return `[]` on any error. No daemon, no
   `push_signal`, no `sleep`, no file writes, no wallet hardcoding.
 - **Emit a `marginPct` *intent*, not dollars** — top-level, not inside `data{}`. The runtime sizes the
-  dollars off the live account; don't read the clearinghouse to size.
+  dollars off the live account; don't read the clearinghouse to size. **`marginPct` is a PERCENT: `18`
+  for 18%, NEVER the decimal `0.18`** — `0.18` is schema-valid but sizes 0.18% (~$3.60 on $2k, not $360),
+  and if a constant like `MARGIN_PCT = 0.18` feeds it, that's the bug. It must match your
+  `strategy.margin_pct`. Smoke-test and confirm the first position's margin ≈ the intended % — a signal
+  firing with tiny size is **not** "done."
 - **Pure thesis math in `scoring.py`** (no I/O, no MCP, no clock) so it unit-tests.
 - **Memory = `ctx.state`** (`.last()/.recent()/.append()`); set `state_history_max_count` > 0. Cohort
   rotation, dedup, and first-seen ledgers all live here.

--- a/senpi-strategy-author/scripts/_yaml.py
+++ b/senpi-strategy-author/scripts/_yaml.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Tiny stdlib-only YAML safe-loader — the subset the strategy.yaml + runtime.yaml packages use.
+
+Why: the deploy/close scripts run on agent hosts that may not have PyYAML (or pip). `_pkg` uses real
+PyYAML when importable and falls back to this. It is NOT a general YAML parser — it covers exactly what
+our packages use: block maps + sequences, nested blocks, flow `[...]`/`{...}`, scalars (str/int/float/
+bool/null), single/double quotes, `#` comments, and `>`/`|` block scalars (captured loosely as text —
+we don't interpret descriptions). Validated for byte-equality against PyYAML on the example packages.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import re
+
+_INT_RE = re.compile(r"^[-+]?\d+$")
+_FLOAT_RE = re.compile(r"^[-+]?(\d+\.\d*|\.\d+|\d+)([eE][-+]?\d+)?$")
+
+
+class YAMLError(Exception):
+    pass
+
+
+# ---------- scalars + comments ----------
+
+def _strip_comment(s):
+    """Remove a trailing ` # comment` at depth 0 outside quotes (YAML: # starts a comment at col 0 or
+    after whitespace)."""
+    depth = 0
+    q = None
+    for i, c in enumerate(s):
+        if q:
+            if c == q:
+                q = None
+        elif c in "\"'":
+            q = c
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == "#" and depth == 0 and (i == 0 or s[i - 1] in " \t"):
+            return s[:i].rstrip()
+    return s.rstrip()
+
+
+def _scalar(tok):
+    tok = tok.strip()
+    if tok == "" or tok == "~" or tok.lower() == "null":
+        return None
+    if len(tok) >= 2 and tok[0] == tok[-1] and tok[0] in "\"'":
+        return tok[1:-1]
+    low = tok.lower()
+    if low == "true":
+        return True
+    if low == "false":
+        return False
+    if _INT_RE.match(tok):
+        return int(tok)
+    if _FLOAT_RE.match(tok):
+        return float(tok)
+    return tok
+
+
+# ---------- flow [...] / {...} ----------
+
+def _split_top(s):
+    """Split a flow body on top-level commas (respecting nesting + quotes)."""
+    out, depth, q, start = [], 0, None, 0
+    for i, c in enumerate(s):
+        if q:
+            if c == q:
+                q = None
+        elif c in "\"'":
+            q = c
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == "," and depth == 0:
+            out.append(s[start:i])
+            start = i + 1
+    tail = s[start:]
+    if tail.strip() or out:
+        out.append(tail)
+    return out
+
+
+def _split_kv(item):
+    """Split a flow-map entry on the first top-level ':'."""
+    depth, q = 0, None
+    for i, c in enumerate(item):
+        if q:
+            if c == q:
+                q = None
+        elif c in "\"'":
+            q = c
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ":" and depth == 0:
+            return item[:i], item[i + 1:]
+    return item, None
+
+
+def _parse_flow(s):
+    s = s.strip()
+    if s.startswith("["):
+        if not s.endswith("]"):
+            raise YAMLError(f"unterminated flow sequence: {s!r}")
+        inner = s[1:-1].strip()
+        return [_parse_flow(x) for x in _split_top(inner)] if inner else []
+    if s.startswith("{"):
+        if not s.endswith("}"):
+            raise YAMLError(f"unterminated flow mapping: {s!r}")
+        inner = s[1:-1].strip()
+        d = {}
+        for item in (_split_top(inner) if inner else []):
+            if not item.strip():
+                continue
+            k, v = _split_kv(item)
+            if v is None:
+                raise YAMLError(f"bad flow mapping entry: {item!r}")
+            d[str(_scalar(k))] = _parse_flow(v)
+        return d
+    return _scalar(s)
+
+
+def _value(s):
+    """A value that may be a flow collection or a plain scalar."""
+    s = _strip_comment(s).strip()
+    if s[:1] in "[{":
+        return _parse_flow(s)
+    return _scalar(s)
+
+
+# ---------- block parser ----------
+
+def _indent(line):
+    return len(line) - len(line.lstrip(" "))
+
+
+def _key_split(content):
+    """Split a block-mapping line into (key, rest) on the first ': ' / trailing ':' at depth 0 outside
+    quotes/flow. Returns (None, None) if it is not a mapping line."""
+    depth, q = 0, None
+    for i, c in enumerate(content):
+        if q:
+            if c == q:
+                q = None
+        elif c in "\"'":
+            q = c
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ":" and depth == 0 and (i + 1 == len(content) or content[i + 1] in " \t"):
+            return content[:i].strip(), content[i + 1:]
+    return None, None
+
+
+class _P:
+    def __init__(self, text):
+        self.lines = text.split("\n")
+        self.i = 0
+
+    def _skip(self):
+        while self.i < len(self.lines):
+            s = self.lines[self.i].strip()
+            if s == "" or s.startswith("#"):
+                self.i += 1
+            else:
+                return
+
+    def parse_node(self, indent):
+        self._skip()
+        if self.i >= len(self.lines):
+            return None
+        ci = _indent(self.lines[self.i])
+        if ci < indent:
+            return None
+        content = self.lines[self.i].strip()
+        if content[:1] in "[{":
+            self.i += 1
+            return _value(content)
+        if content == "-" or content.startswith("- "):
+            return self.parse_seq(ci)
+        key, _rest = _key_split(content)
+        if key is not None:
+            return self.parse_map(ci)
+        self.i += 1
+        return _value(content)
+
+    def parse_map(self, indent):
+        d = {}
+        while True:
+            self._skip()
+            if self.i >= len(self.lines):
+                break
+            ci = _indent(self.lines[self.i])
+            if ci != indent:
+                break
+            content = self.lines[self.i].strip()
+            key, rest = _key_split(content)
+            if key is None:
+                break
+            self.i += 1
+            rest = (rest or "").strip()
+            stripped = _strip_comment(rest).strip()
+            if stripped in (">", "|", ">-", "|-", ">+", "|+"):
+                d[str(_scalar(key))] = self._block_scalar(indent)
+            elif rest == "" or _strip_comment(rest).strip() == "":
+                d[str(_scalar(key))] = self.parse_node(indent + 1)
+            else:
+                d[str(_scalar(key))] = _value(rest)
+        return d
+
+    def parse_seq(self, indent):
+        items = []
+        while True:
+            self._skip()
+            if self.i >= len(self.lines):
+                break
+            line = self.lines[self.i]
+            if _indent(line) != indent:
+                break
+            stripped = line.strip()
+            if stripped != "-" and not stripped.startswith("- "):
+                break
+            # rewrite the leading '-' to a space so the item content sits at indent+2 and reparse
+            self.lines[self.i] = line[:indent] + " " + line[indent + 1:]
+            if stripped == "-":
+                self.i += 1
+                items.append(self.parse_node(indent + 1))
+            else:
+                items.append(self.parse_node(indent + 2))
+        return items
+
+    def _block_scalar(self, key_indent):
+        """Capture a `>`/`|` block as text (folded loosely). We never interpret these, just consume."""
+        out = []
+        while self.i < len(self.lines):
+            line = self.lines[self.i]
+            if line.strip() == "":
+                out.append("")
+                self.i += 1
+                continue
+            if _indent(line) <= key_indent:
+                break
+            out.append(line.strip())
+            self.i += 1
+        return " ".join(x for x in out if x).strip()
+
+
+def safe_load(text):
+    if text is None:
+        return None
+    p = _P(text)
+    p._skip()
+    if p.i >= len(p.lines):
+        return None
+    return p.parse_node(_indent(p.lines[p.i]))

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -72,6 +72,40 @@ def _external_scanner_errs(name, rt_rel, rt_text):
     return errs
 
 
+# Common stdlib modules a scanner reaches for. Using `mod.attr` without importing `mod` is a NameError
+# at runtime — and it loves to hide in the `except` handler (the "missing import sys" bug that let a
+# broken error path mask the real failure). Static AST catch, no token / no live MCP needed.
+_STDLIB_MODS = {"sys", "os", "json", "re", "math", "time", "random", "datetime", "itertools",
+                "collections", "statistics", "functools", "decimal", "uuid"}
+
+
+def _missing_stdlib_imports(tree):
+    """Return {module: first_lineno} for stdlib modules used as `mod.attr` but never imported/bound."""
+    bound = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for al in node.names:
+                bound.add((al.asname or al.name).split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            for al in node.names:
+                bound.add(al.asname or al.name)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            bound.add(node.name)
+        elif isinstance(node, ast.arg):
+            bound.add(node.arg)
+        elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+            bound.add(node.id)
+        elif isinstance(node, (ast.Global, ast.Nonlocal)):
+            bound.update(node.names)
+    used = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            mod = node.value.id
+            if mod in _STDLIB_MODS and mod not in bound:
+                used.setdefault(mod, node.lineno)
+    return used
+
+
 def validate(pkg: Path) -> list:
     errs = []
     man_path = pkg / "strategy.yaml"
@@ -172,9 +206,14 @@ def validate(pkg: Path) -> list:
     # scanner present + parses; no '@senpi/runtime' without -ai anywhere
     for py in pkg.rglob("*.py"):
         try:
-            ast.parse(py.read_text())
+            tree = ast.parse(py.read_text())
         except SyntaxError as e:
             errs.append(f"{py.name}: syntax error ({e})")
+            continue
+        for mod, ln in _missing_stdlib_imports(tree).items():
+            errs.append(f"{py.name}:{ln} uses `{mod}.` but never imports `{mod}` — add `import {mod}` "
+                        f"(a NameError here crashes the scanner at runtime; often hides in the error "
+                        f"handler, so the scan looks fine until something fails)")
     for f in pkg.rglob("*"):
         if f.is_file() and f.suffix in (".py", ".yaml", ".md"):
             t = f.read_text(errors="ignore")

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -12,10 +12,64 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 try:
-    import yaml
+    import yaml  # prefer PyYAML when present
 except ImportError:
-    sys.exit("PyYAML required: pip install pyyaml")
+    import _yaml as yaml  # vendored stdlib-only fallback — agent hosts block pip/PyYAML (PEP 668),
+    #                       so importing PyYAML fatally is why this validator was unrunnable in prod.
+
+
+# external_scanner fields the runtime REQUIRES (senpi-trading-runtime/references/runtime-yaml.md →
+# "external_scanner field set"). A scanner missing these — or with interval_seconds ≤ 0 — registers
+# but silently never trades: exactly the failure this validator now catches before deploy.
+def _external_scanner_errs(name, rt_rel, rt_text):
+    errs = []
+    try:
+        doc = yaml.safe_load(rt_text) or {}
+    except Exception:  # noqa: BLE001 — unparseable YAML is already flagged by the caller
+        return errs
+    if not isinstance(doc, dict):
+        return errs
+    scanners = doc.get("scanners") or []
+    ext = [s for s in scanners if isinstance(s, dict) and s.get("type") == "external_scanner"]
+    if not ext:
+        # a signal-driven package with an OPEN_POSITION action but no scanner to feed it can never
+        # open a position (the "only position_tracker runs" trap). Pure tracker packages are legal.
+        opens = [a for a in (doc.get("actions") or [])
+                 if isinstance(a, dict) and a.get("action_type") == "OPEN_POSITION"]
+        if opens:
+            errs.append(f"instance {name}: {rt_rel} has an OPEN_POSITION action but NO external_scanner "
+                        f"to feed it — it registers ACTIVE but never opens a position")
+        return errs
+    for es in ext:
+        sn = es.get("name", "?")
+        for f in ("path", "entrypoint", "signal_data_schema", "default_signal_validity_seconds"):
+            if es.get(f) is None:
+                errs.append(f"instance {name}: {rt_rel} external_scanner {sn!r} missing required '{f}'")
+        iv = es.get("interval_seconds")
+        if iv is not None and (not isinstance(iv, int) or isinstance(iv, bool) or iv <= 0):
+            errs.append(f"instance {name}: {rt_rel} external_scanner {sn!r} interval_seconds={iv!r} must "
+                        f"be a positive integer (0/negative → the scanner is never scheduled)")
+        dv = es.get("default_signal_validity_seconds")
+        if dv is not None and (not isinstance(dv, int) or isinstance(dv, bool) or dv <= 0):
+            errs.append(f"instance {name}: {rt_rel} external_scanner {sn!r} "
+                        f"default_signal_validity_seconds={dv!r} must be a positive integer")
+        sch = es.get("signal_data_schema")
+        if isinstance(sch, dict):
+            if not sch:
+                errs.append(f"instance {name}: {rt_rel} external_scanner {sn!r} signal_data_schema is "
+                            f"empty (declare every data{{}} key your scan() emits)")
+            for key, spec in sch.items():
+                t = spec.get("type") if isinstance(spec, dict) else None
+                if t not in ("string", "number", "boolean", "object", "array"):
+                    errs.append(f"instance {name}: {rt_rel} signal_data_schema.{key} invalid type {t!r} "
+                                f"(must be string/number/boolean/object/array)")
+        elif sch is not None:
+            errs.append(f"instance {name}: {rt_rel} signal_data_schema must be a map of key→{{type}}")
+    # NOTE: whether scan()'s ACTUAL output keys match this schema can only be known by RUNNING scan()
+    # — that's the deploy.py smoke gate + `diagnose.py --run-scan`, not a static check.
+    return errs
 
 
 def validate(pkg: Path) -> list:
@@ -47,6 +101,7 @@ def validate(pkg: Path) -> list:
             errs.append(f"instance {name}: runtime {rt_rel!r} not found")
             continue
         rt_text = rt.read_text()
+        errs += _external_scanner_errs(name, rt_rel, rt_text)
 
         # data_retention: Runtime 3.0 uses data_retention_seconds (integer 3600–604800);
         # the v2 data_retention_hours field is deprecated. (See senpi-trading-runtime/references/runtime-yaml.md.)

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -162,6 +162,15 @@ def validate(pkg: Path) -> list:
             errs.append(f"instance {name}: {rt_rel} has no DSL exit block (exit:/dsl_preset:) — "
                         f"every strategy must ship built-in protection")
 
+        # Guardrails are not optional either: DSL exits a position, guard_rails bound the account
+        # (drawdown halt, daily-loss, per-day / per-asset entry limits). A runtime with no guard_rails
+        # trades unbounded — the failure that let a user revenge-re-enter into a drawdown. All 83 catalog
+        # packages ship one, so requiring it never false-positives.
+        if not re.search(r"^\s*guard_rails\s*:", rt_text, re.M):
+            errs.append(f"instance {name}: {rt_rel} has no risk.guard_rails block — every strategy must "
+                        f"ship guardrails (drawdown_halt_pct, daily_loss_limit_pct, max_entries_per_day, "
+                        f"cooldowns); a runtime with no guardrails trades unbounded")
+
         # Self-describing is not optional: every instance needs a substantive top-level `description`.
         # The runtime REGISTERS it (installed_runtimes.json) and senpi-portfolio reads it back as the
         # strategy's mandate — "is it doing its job?". A missing/stub description makes an authored

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -40,6 +40,7 @@ python3 senpi-strategy-ops/scripts/deploy.py runtime <id>                  # 2. 
 python3 senpi-strategy-ops/scripts/deploy.py verify  <id>                  # optional: confirm a scan fired (only if asked)
 python3 senpi-strategy-ops/scripts/status.py                               # what am I running? (+ health)
 python3 senpi-strategy-ops/scripts/diagnose.py       <id> [--run-scan]     # WHY isn't it trading? (non-firing scanner)
+python3 senpi-strategy-ops/scripts/protect.py        <id>                  # are positions DSL-protected? (PROTECTED/NAKED)
 python3 senpi-strategy-ops/scripts/close.py          <id>                  # teardown one strategy
 python3 senpi-strategy-ops/scripts/close.py          --all                 # teardown EVERY open strategy
 ```
@@ -163,10 +164,15 @@ interrupted deploy. `--fast` skips the per-runtime health call; `--json` for mac
 user the management mode for off-runtime strategies — do not call them idle.** Don't hand-compose
 `strategy_list` — use `status.py`.
 
-**"Are my open positions protected? / do they have a stop-loss?"** → the DSL coverage verdict
-(PROTECTED / UNPROTECTED / STOP-NOT-ON-VENUE). Key trap: an unprotected position shows up as an
-**absence** in `senpi dsl positions`, so you must reconcile open positions against the tracked set — full
-procedure in [`senpi-trading-runtime/references/dsl-protection-check.md`](../senpi-trading-runtime/references/dsl-protection-check.md).
+**"Are my open positions protected? / do they have a stop-loss?"** → `python3 scripts/protect.py <id>`.
+It reconciles the **on-chain** positions (clearinghouse) against the DSL-tracked set and the resting stop
+orders, and prints a per-position verdict: **PROTECTED / NAKED / STOP-NOT-ON-VENUE**. Two traps it exists
+to kill: (1) an unprotected position shows up as an **absence** in `senpi dsl positions`, so you must
+reconcile against what's actually open — the chain, not a list of what's tracked; (2) a DSL state file
+going **`active: false` (archived) does NOT mean the position closed** — that happens on every breach and
+only means the engine stopped tracking; archived **+** still-open-on-chain = **NAKED**. Never conclude
+"closed" or "protected" from a DSL state file's flag — read the clearinghouse. Full procedure:
+[`senpi-trading-runtime/references/dsl-protection-check.md`](../senpi-trading-runtime/references/dsl-protection-check.md).
 
 Do **not** trust "runtime: running" alone. A strategy is **live** only when its runtime is running AND
 each instance's `external_scanner` has a recent successful tick (`status.py` reports `running`; confirm a

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.3.0"
+  version: "2.4.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -39,6 +39,7 @@ python3 senpi-strategy-ops/scripts/deploy.py create  <id> --budget <usd>   # 1. 
 python3 senpi-strategy-ops/scripts/deploy.py runtime <id>                  # 2. set up autonomous trading (DONE after this)
 python3 senpi-strategy-ops/scripts/deploy.py verify  <id>                  # optional: confirm a scan fired (only if asked)
 python3 senpi-strategy-ops/scripts/status.py                               # what am I running? (+ health)
+python3 senpi-strategy-ops/scripts/diagnose.py       <id> [--run-scan]     # WHY isn't it trading? (non-firing scanner)
 python3 senpi-strategy-ops/scripts/close.py          <id>                  # teardown one strategy
 python3 senpi-strategy-ops/scripts/close.py          --all                 # teardown EVERY open strategy
 ```
@@ -179,6 +180,39 @@ tick with `deploy.py verify <id>`). Verify with the runtime CLI:
 carry `group: <id>`, so you can rediscover a deployed strategy's runtimes ledger-free via
 `openclaw senpi runtime list` matching `group == <id>`.
 
+## Not trading? — `diagnose.py` (deployed but no positions)
+
+**"It's ACTIVE and funded but nothing is opening."** `status.py` says the runtime is *up*; it does **not**
+say the `external_scanner` is *producing*. Don't infer — run the doctor:
+```
+python3 scripts/diagnose.py <id>              # names ONE cause per instance
+python3 scripts/diagnose.py <id> --run-scan   # ALSO runs scan() live + shows its literal return (read-only)
+```
+It checks, in order, and stops at the first definitive cause: external_scanner declared? required fields
+present? `interval_seconds > 0`? entrypoint on disk? runtime registered + running? scanner registered on
+the runtime? erroring? **ticking** (via the scanner-liveness clock, **not `runCount`** — `runCount` counts
+*emits*, so a healthy-but-quiet scanner reads 0)? **BARREN** (alive + ran + 0 signals)? `--run-scan` splits
+BARREN for you: scan() returns `[]` ⇒ thresholds/logic; a shape violation ⇒ the `data{}` fails
+`signal_data_schema` and the runtime drops it. Symptom→cause→fix table:
+[`senpi-trading-runtime/references/troubleshooting.md`](../senpi-trading-runtime/references/troubleshooting.md).
+
+**Definition of done — NOT "status: ACTIVE".** A deploy is only actually working when the scanner is
+**registered**, `interval_seconds > 0`, has had **≥1 successful tick**, and has **emitted ≥1 signal that
+passes `signal_data_schema`**. `ACTIVE` alone only means the strategy record is live and `position_tracker`
+runs. Confirm the tick (`deploy.py verify <id>` / `diagnose.py <id>`) before you tell the user it's trading.
+
+**Anti-patterns (do NOT do these):**
+- **Hand-editing deployed state** (`state.json`, `.deploy-state.json`) to "fix" a scanner — the runtime
+  owns and overwrites it every tick. The fix is always: correct the **source package** → `close.py` →
+  author → `deploy.py`.
+- **Falling back to a raw `strategy_create_custom_strategy`** when a scanner won't fire — that makes an
+  empty custom-position strategy with **no DSL / no automated exits**. Repair the package instead.
+- **Declaring it "fixed" without a tick** — a redeploy that returns `ACTIVE` is not a fix. Re-run
+  `diagnose.py` and confirm a signal emitted.
+- **If a diagnosis doesn't resolve it fast and money is parked idle**, `close.py <id>` to return the funds,
+  then rebuild from a known-good template via `senpi-strategy-author` — never leave capital in a strategy
+  that can't trade.
+
 ## Close — stop → trigger → (agent polls)
 
 ```
@@ -202,6 +236,7 @@ all). **Redeploy** = `close` then `create`/`runtime`/`verify`.
 
 ## Install — include the MCP helper
 
-The scripts in `scripts/` import a vendored MCP helper, `scripts/mcp_client.py`, at runtime.
-**Install the whole `scripts/` directory** — omitting `mcp_client.py` fails with
-`No module named 'mcp_client'`. Stdlib only, no other runtime dependencies.
+The scripts in `scripts/` cross-import vendored helpers at runtime — `mcp_client.py` (MCP transport),
+`_cli.py`/`_pkg.py`/`_fetch.py`/`_yaml.py`, and `_smoke.py` (the scan-runner behind `diagnose.py
+--run-scan` and the `deploy.py` pre-fund smoke gate). **Install the whole `scripts/` directory** —
+omitting any of them fails with `No module named '…'`. Stdlib only, no other runtime dependencies.

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -196,10 +196,19 @@ BARREN for you: scan() returns `[]` ⇒ thresholds/logic; a shape violation ⇒ 
 `signal_data_schema` and the runtime drops it. Symptom→cause→fix table:
 [`senpi-trading-runtime/references/troubleshooting.md`](../senpi-trading-runtime/references/troubleshooting.md).
 
-**Definition of done — NOT "status: ACTIVE".** A deploy is only actually working when the scanner is
-**registered**, `interval_seconds > 0`, has had **≥1 successful tick**, and has **emitted ≥1 signal that
-passes `signal_data_schema`**. `ACTIVE` alone only means the strategy record is live and `position_tracker`
-runs. Confirm the tick (`deploy.py verify <id>` / `diagnose.py <id>`) before you tell the user it's trading.
+**Definition of done — NOT "status: ACTIVE".** A deploy is only actually working when **all** of these
+hold — check every one, don't stop at the first green:
+1. the `external_scanner` is **registered** and `interval_seconds > 0`;
+2. it has had **≥1 successful tick** and **emitted ≥1 signal that passes `signal_data_schema`**;
+3. the first position is **sized ≈ the intended %** of the wallet (a `marginPct` of `0.18` where the
+   strategy wants `18` opens ~$3.60 on $2k — a signal firing with trivial size is **not** done);
+4. every open position is **DSL-protected** (reconcile open vs tracked — see `dsl-protection-check.md`);
+5. there are **no orphaned wallets/strategies** from earlier redeploys (`status.py <id>` shows exactly the
+   instances you deployed, nothing stranded).
+
+`ACTIVE` alone only means the strategy record is live and `position_tracker` runs. "Positions opened"
+alone skips 3–5. Confirm all five (`diagnose.py <id>` + `status.py <id>` + the DSL check) before you tell
+the user it's trading.
 
 **Anti-patterns (do NOT do these):**
 - **Hand-editing deployed state** (`state.json`, `.deploy-state.json`) to "fix" a scanner — the runtime

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -147,6 +147,30 @@ def load(pkg_dir) -> Package:
     return Package(pkg, man)
 
 
+def duplicate_copies(pkg_id, chosen_dir):
+    """Return the OTHER on-disk copies of `<pkg_id>/strategy.yaml` besides `chosen_dir`.
+
+    The two-copy trap: a package can exist at both `strategies/<id>` and `scripts/strategies/<id>` (CWD-
+    vs skill-relative fetch/resolve), so an agent edits one copy while deploy/validate silently load the
+    other — the edit "doesn't take", or a stale copy ships. Deterministic bounded candidate roots (no
+    disk-wide scan). Return [] when there's exactly one copy (the healthy case)."""
+    here = Path(__file__).resolve().parent  # .../scripts
+    roots = [Path.cwd(), here, here.parent, here.parent.parent]
+    chosen = Path(chosen_dir).resolve()
+    seen, others = {chosen}, []
+    for root in roots:
+        for cand in (root / "strategies" / pkg_id, root / pkg_id):
+            try:
+                if (cand / "strategy.yaml").is_file():
+                    r = cand.resolve()
+                    if r not in seen:
+                        seen.add(r)
+                        others.append(r)
+            except OSError:
+                continue
+    return others
+
+
 def validate(pkg: Package) -> list:
     """Return a list of consistency errors ([] == valid). Asserts the manifest ↔ runtime ↔
     package invariants deploy relies on, including the group/name linkage convention."""

--- a/senpi-strategy-ops/scripts/_smoke.py
+++ b/senpi-strategy-ops/scripts/_smoke.py
@@ -15,12 +15,14 @@ module/sys.path state never leaks between instances. Invoke this file as
 
 FIDELITY / SAFETY — the child rebuilds the runtime's `ctx` faithfully enough to catch the failure
 modes, and enforces the SAME read-only MCP boundary the real scaffold does (see scan-contract.md):
-every money/state-mutating tool raises PermissionError BEFORE any network call. A smoke test can read
-the market with the strategy's token; it can NEVER place, close, or edit a trade.
+every money/state-mutating tool raises PermissionError BEFORE any network call. The block is enforced on
+BOTH ctx.senpi_mcp AND (via _install_readonly_guard) the mcp_client class itself, so a scan that imports
+MCPClient directly can't bypass it. A smoke test can read the market with the strategy's token; it can
+NEVER place, close, or edit a trade.
 
   verdict = smoke(runtime_path, external_scanner_dict, wallet)   # -> {status, detail, signals, ...}
-  status ∈ clean | empty | threw | bad-return | bad-shape | timeout | setup-error
-           ^pass    ^warn   ^block   ^block       ^block      ^warn     ^warn
+  status ∈ clean | empty | threw | bad-return | bad-shape | unloadable | timeout | setup-error
+           ^pass    ^warn   ^block   ^block       ^block       ^block       ^warn     ^warn
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import argparse
@@ -45,8 +47,8 @@ BLOCKED_TOOLS = frozenset({
 # which is the correct view for a fresh deploy; the scan still exercises its full market-read path.
 ZERO_WALLET = "0x0000000000000000000000000000000000000000"
 
-BLOCK = ("threw", "bad-return", "bad-shape")   # a real defect — do not fund
-WARN = ("empty", "timeout", "setup-error")     # inconclusive or benignly quiet — proceed with a note
+BLOCK = ("threw", "bad-return", "bad-shape", "unloadable")  # a real package defect — do not fund
+WARN = ("empty", "timeout", "setup-error")                  # inconclusive or benignly quiet — proceed with a note
 _CALL_TIMEOUT = 20                             # per read-only MCP call inside the child (s)
 
 _SCHEMA_PY = {"string": str, "number": (int, float), "boolean": bool,
@@ -148,8 +150,8 @@ def _resolve_scan_dir(runtime_path, es):
 def smoke(runtime_path, es, wallet=None, timeout=None, strategy_margin_pct=None):
     """Run one scan() and classify it. Returns:
       {status, detail, signals, violations, sizing_warnings, traceback, returned_repr, n_signals}
-    status ∈ clean|empty|threw|bad-return|bad-shape|timeout|setup-error (BLOCK/WARN sets above).
-    `sizing_warnings` flags schema-valid-but-broken sizing (the marginPct decimal/percent confusion)."""
+    status ∈ clean|empty|threw|bad-return|bad-shape|unloadable|timeout|setup-error (BLOCK/WARN sets above).
+    `sizing_warnings` (ALWAYS present) flags schema-valid-but-broken sizing (marginPct percent/fraction confusion)."""
     scan_dir = _resolve_scan_dir(runtime_path, es)
     entry = es.get("entrypoint", "scan.py")
     inputs = es.get("inputs") or {}
@@ -162,26 +164,33 @@ def smoke(runtime_path, es, wallet=None, timeout=None, strategy_margin_pct=None)
     if raw.get("timed_out"):
         return {"status": "timeout", "detail": f"scan() did not finish in {tmo}s "
                 "(a single-pass scan should be quick — check for a loop/sleep or a slow MCP read)",
-                "signals": [], "violations": [], "traceback": raw.get("stderr", ""),
+                "signals": [], "violations": [], "sizing_warnings": [], "traceback": raw.get("stderr", ""),
                 "returned_repr": "", "n_signals": 0}
     if not raw.get("spawned"):
         return {"status": "setup-error", "detail": raw.get("error", "could not run the scan child"),
-                "signals": [], "violations": [], "traceback": raw.get("stderr", ""),
+                "signals": [], "violations": [], "sizing_warnings": [], "traceback": raw.get("stderr", ""),
                 "returned_repr": "", "n_signals": 0}
     if raw.get("threw"):
         return {"status": "threw", "detail": raw.get("error", "scan() raised"),
-                "signals": [], "violations": [], "traceback": raw.get("traceback", ""),
+                "signals": [], "violations": [], "sizing_warnings": [], "traceback": raw.get("traceback", ""),
                 "returned_repr": "", "n_signals": 0}
     if raw.get("setup_error"):  # child could not import the module / build ctx
+        # A package DEFECT (module won't import, no callable scan, entrypoint missing) can NEVER register a
+        # scanner — funding it just parks capital that can't trade (the divergence-play failure). BLOCK it.
+        # A mere HARNESS problem (no python, or no token to build ctx here) is inconclusive — WARN + proceed.
+        if raw.get("defect"):
+            return {"status": "unloadable", "detail": raw.get("error", "scan module failed to load"),
+                    "signals": [], "violations": [], "sizing_warnings": [], "traceback": raw.get("traceback", ""),
+                    "returned_repr": "", "n_signals": 0}
         return {"status": "setup-error", "detail": raw.get("error", "scan module did not load"),
-                "signals": [], "violations": [], "traceback": raw.get("traceback", ""),
+                "signals": [], "violations": [], "sizing_warnings": [], "traceback": raw.get("traceback", ""),
                 "returned_repr": "", "n_signals": 0}
     signals = raw.get("signals")
     if not isinstance(signals, list):
         return {"status": "bad-return",
                 "detail": f"scan() returned {type(signals).__name__}, must return a list[dict] "
                           "(return [] when there's nothing to trade — never None)",
-                "signals": [], "violations": [], "traceback": "",
+                "signals": [], "violations": [], "sizing_warnings": [], "traceback": "",
                 "returned_repr": raw.get("returned_repr", ""), "n_signals": 0}
     violations = validate_signals(signals, schema)
     sizing = sizing_warnings(signals, strategy_margin_pct)
@@ -299,6 +308,27 @@ class _Ctx:
         raise AttributeError("ctx is frozen — scan() must not mutate it")
 
 
+def _install_readonly_guard():
+    """Harden the read-only boundary at the mcp_client layer, so a scan that imports MCPClient DIRECTLY
+    (bypassing ctx.senpi_mcp) still cannot mutate money/state. Idempotent; no-op if mcp_client is absent."""
+    try:
+        import mcp_client as _mc
+    except Exception:  # noqa: BLE001 — no client to guard; the scan can't reach the network anyway
+        return
+    if getattr(_mc.MCPClient.mcp_call, "_senpi_readonly", False):
+        return
+    _orig = _mc.MCPClient.mcp_call
+
+    def _guarded(self, tool, *args, **kwargs):
+        if tool in BLOCKED_TOOLS:
+            raise PermissionError(
+                f"{tool} is a mutation tool — blocked by the read-only smoke boundary (scan() may only read)")
+        return _orig(self, tool, *args, **kwargs)
+
+    _guarded._senpi_readonly = True
+    _mc.MCPClient.mcp_call = _guarded
+
+
 def _child_main():
     """Import the scan module, build ctx, call scan() once, print one JSON verdict line."""
     try:
@@ -315,9 +345,10 @@ def _child_main():
     scripts_dir = str(Path(__file__).resolve().parent)
     sys.path.insert(0, scripts_dir)
     sys.path.insert(0, str(scan_dir))
+    _install_readonly_guard()  # block mutating tools even if the scan imports MCPClient directly (before exec)
 
     if not scan_file.is_file():
-        print(json.dumps({"setup_error": True,
+        print(json.dumps({"setup_error": True, "defect": True,
                           "error": f"entrypoint not found: {scan_file}"}))
         return
     try:
@@ -326,12 +357,12 @@ def _child_main():
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)   # runs top-level `import scoring`
     except Exception:  # noqa: BLE001 — import/scoring failure is a real package defect
-        print(json.dumps({"setup_error": True, "error": "scan module failed to import",
+        print(json.dumps({"setup_error": True, "defect": True, "error": "scan module failed to import",
                           "traceback": traceback.format_exc()[-4000:]}))
         return
     scan = getattr(mod, "scan", None)
     if not callable(scan):
-        print(json.dumps({"setup_error": True,
+        print(json.dumps({"setup_error": True, "defect": True,
                           "error": f"{entry} does not export a callable scan(inputs, ctx)"}))
         return
 

--- a/senpi-strategy-ops/scripts/_smoke.py
+++ b/senpi-strategy-ops/scripts/_smoke.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Run a strategy's `scan(inputs, ctx)` ONCE, out of the runtime, against live MCP — the smoke test.
+
+Two consumers share this engine:
+  - deploy.py    — a pre-fund gate: refuse to fund wallets if scan() throws / returns a non-list /
+                   emits a signal whose shape violates signal_data_schema (the whole divergence-play
+                   incident was the cost of NOT having this gate).
+  - diagnose.py  — `--run-scan`: show the literal scan() return + traceback + any schema violations,
+                   to tell "runs but emits nothing" (thresholds) from "emits a bad shape" (dropped).
+
+Why a subprocess: scan() is author code that does live I/O and (when buggy) can hang or loop. Running
+it in a child with a wall-clock timeout means a bad scan can't wedge or crash the deploy, and its
+module/sys.path state never leaks between instances. Invoke this file as
+`python3 _smoke.py --run …` to BE that child; import it for the library API (smoke / validate_signals).
+
+FIDELITY / SAFETY — the child rebuilds the runtime's `ctx` faithfully enough to catch the failure
+modes, and enforces the SAME read-only MCP boundary the real scaffold does (see scan-contract.md):
+every money/state-mutating tool raises PermissionError BEFORE any network call. A smoke test can read
+the market with the strategy's token; it can NEVER place, close, or edit a trade.
+
+  verdict = smoke(runtime_path, external_scanner_dict, wallet)   # -> {status, detail, signals, ...}
+  status ∈ clean | empty | threw | bad-return | bad-shape | timeout | setup-error
+           ^pass    ^warn   ^block   ^block       ^block      ^warn     ^warn
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import argparse
+import json
+import subprocess
+import sys
+import traceback
+from pathlib import Path
+
+# The read-only boundary the real scaffold enforces (scan-contract.md → "Mutations blocked"). Kept
+# verbatim so a smoke run can never mutate money/state even if the scan is buggy or hostile.
+BLOCKED_TOOLS = frozenset({
+    "create_position", "close_position", "edit_position", "cancel_order", "send_usdc",
+    "transfer_spot_to_perps", "strategy_create", "strategy_create_custom_strategy", "strategy_close",
+    "strategy_close_positions", "strategy_update", "strategy_pause", "strategy_top_up",
+    "strategy_withdraw_funds", "strategy_bridge_funds_from_hyperliquid_to_evm", "ratchet_stop_add",
+    "ratchet_stop_edit", "ratchet_stop_delete", "user_claim_referral_rewards",
+})
+
+# A syntactically valid zero wallet — used when a smoke test runs BEFORE the strategy wallet exists
+# (deploy pre-fund gate). Read-only clearinghouse/account calls on it just return "no positions",
+# which is the correct view for a fresh deploy; the scan still exercises its full market-read path.
+ZERO_WALLET = "0x0000000000000000000000000000000000000000"
+
+BLOCK = ("threw", "bad-return", "bad-shape")   # a real defect — do not fund
+WARN = ("empty", "timeout", "setup-error")     # inconclusive or benignly quiet — proceed with a note
+_CALL_TIMEOUT = 20                             # per read-only MCP call inside the child (s)
+
+_SCHEMA_PY = {"string": str, "number": (int, float), "boolean": bool,
+              "object": dict, "array": list}
+
+
+# ======================================================================================
+# signal validation — the same rules the scaffold applies at intake (scan-contract.md)
+# ======================================================================================
+
+def validate_signals(signals, schema):
+    """Return a flat list of human violation strings ([] == every signal is well-formed). Mirrors the
+    scaffold's intake validation: top-level asset/direction/margin/leverage + the data{} schema
+    (unknown key / missing required / wrong type). A signal the scaffold would silently DROP shows up
+    here as a violation — that silent drop is exactly how a BARREN scanner "emits nothing"."""
+    out = []
+    schema = schema if isinstance(schema, dict) else {}
+    for idx, sig in enumerate(signals):
+        tag = f"signal[{idx}]"
+        if not isinstance(sig, dict):
+            out.append(f"{tag}: not a dict (got {type(sig).__name__})")
+            continue
+        asset = sig.get("asset")
+        if not (isinstance(asset, str) and asset.strip()):
+            out.append(f"{tag}: 'asset' missing/empty (required non-empty string)")
+        d = sig.get("direction")
+        if not (isinstance(d, str) and d.strip().upper() in ("LONG", "SHORT")):
+            out.append(f"{tag}: 'direction' must be LONG/SHORT (got {d!r})")
+        for fld in ("marginPct", "marginUsd", "leverage"):
+            if fld in sig:
+                v = sig[fld]
+                if isinstance(v, bool) or not isinstance(v, (int, float)) or v <= 0:
+                    out.append(f"{tag}: '{fld}' present but not a positive number ({v!r})")
+        if "marginPct" in sig and isinstance(sig["marginPct"], (int, float)) \
+                and not isinstance(sig["marginPct"], bool) and sig["marginPct"] > 100:
+            out.append(f"{tag}: 'marginPct' {sig['marginPct']} > 100 (it is a percent of withdrawable)")
+        # data{} vs signal_data_schema
+        data = sig.get("data")
+        if data is None:
+            data = {}
+        if not isinstance(data, dict):
+            out.append(f"{tag}: 'data' must be a map (got {type(data).__name__})")
+            continue
+        for key, spec in schema.items():
+            spec = spec if isinstance(spec, dict) else {}
+            required = spec.get("required", True) is not False
+            if required and key not in data:
+                out.append(f"{tag}: data.{key} missing (required by signal_data_schema)")
+        for key, val in data.items():
+            if key not in schema:
+                out.append(f"{tag}: data.{key} not declared in signal_data_schema (unknown key → reject)")
+                continue
+            want = (schema[key] or {}).get("type") if isinstance(schema.get(key), dict) else None
+            pytype = _SCHEMA_PY.get(want)
+            if pytype is None:
+                continue
+            bad = isinstance(val, bool) and pytype is not bool  # bool is an int subclass — exclude
+            if bad or not isinstance(val, pytype):
+                out.append(f"{tag}: data.{key} is {type(val).__name__}, schema wants {want}")
+    return out
+
+
+# ======================================================================================
+# orchestration (imported by deploy.py / diagnose.py)
+# ======================================================================================
+
+def _resolve_scan_dir(runtime_path, es):
+    sub = (es.get("path") or ".").lstrip("./")
+    return (Path(runtime_path).parent / sub).resolve()
+
+
+def smoke(runtime_path, es, wallet=None, timeout=None):
+    """Run one scan() and classify it. Returns:
+      {status, detail, signals, violations, traceback, returned_repr, n_signals}
+    status ∈ clean|empty|threw|bad-return|bad-shape|timeout|setup-error (BLOCK/WARN sets above)."""
+    scan_dir = _resolve_scan_dir(runtime_path, es)
+    entry = es.get("entrypoint", "scan.py")
+    inputs = es.get("inputs") or {}
+    schema = es.get("signal_data_schema") or {}
+    name = es.get("name") or "external_scanner"
+    interval = es.get("interval_seconds", 30)
+    tmo = int(timeout or es.get("timeout_seconds") or es.get("interval_seconds") or 60)
+
+    raw = _run_child(scan_dir, entry, inputs, wallet or ZERO_WALLET, name, interval, tmo)
+    if raw.get("timed_out"):
+        return {"status": "timeout", "detail": f"scan() did not finish in {tmo}s "
+                "(a single-pass scan should be quick — check for a loop/sleep or a slow MCP read)",
+                "signals": [], "violations": [], "traceback": raw.get("stderr", ""),
+                "returned_repr": "", "n_signals": 0}
+    if not raw.get("spawned"):
+        return {"status": "setup-error", "detail": raw.get("error", "could not run the scan child"),
+                "signals": [], "violations": [], "traceback": raw.get("stderr", ""),
+                "returned_repr": "", "n_signals": 0}
+    if raw.get("threw"):
+        return {"status": "threw", "detail": raw.get("error", "scan() raised"),
+                "signals": [], "violations": [], "traceback": raw.get("traceback", ""),
+                "returned_repr": "", "n_signals": 0}
+    if raw.get("setup_error"):  # child could not import the module / build ctx
+        return {"status": "setup-error", "detail": raw.get("error", "scan module did not load"),
+                "signals": [], "violations": [], "traceback": raw.get("traceback", ""),
+                "returned_repr": "", "n_signals": 0}
+    signals = raw.get("signals")
+    if not isinstance(signals, list):
+        return {"status": "bad-return",
+                "detail": f"scan() returned {type(signals).__name__}, must return a list[dict] "
+                          "(return [] when there's nothing to trade — never None)",
+                "signals": [], "violations": [], "traceback": "",
+                "returned_repr": raw.get("returned_repr", ""), "n_signals": 0}
+    violations = validate_signals(signals, schema)
+    if violations:
+        return {"status": "bad-shape",
+                "detail": f"{len(signals)} signal(s) emitted but the shape is invalid — the runtime "
+                          "would DROP these silently (→ a BARREN scanner that 'never trades')",
+                "signals": signals, "violations": violations, "traceback": "",
+                "returned_repr": raw.get("returned_repr", ""), "n_signals": len(signals)}
+    if not signals:
+        return {"status": "empty",
+                "detail": "scan() ran cleanly and returned [] (no candidates this tick). Normal for a "
+                          "quiet strategy (regime/tail-risk); for an always-on scanner it suggests the "
+                          "thresholds are too tight or the universe is empty.",
+                "signals": [], "violations": [], "traceback": "",
+                "returned_repr": raw.get("returned_repr", ""), "n_signals": 0}
+    return {"status": "clean",
+            "detail": f"scan() ran cleanly and emitted {len(signals)} valid signal(s)",
+            "signals": signals, "violations": [], "traceback": "",
+            "returned_repr": raw.get("returned_repr", ""), "n_signals": len(signals)}
+
+
+def _run_child(scan_dir, entry, inputs, wallet, name, interval, timeout):
+    """Spawn `python3 _smoke.py --run …` and parse its JSON verdict. Never raises — every failure
+    (spawn error, timeout, garbage output) comes back as a dict the caller classifies."""
+    payload = json.dumps({"dir": str(scan_dir), "entry": entry, "inputs": inputs, "wallet": wallet,
+                          "name": name, "interval": interval})
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(Path(__file__).resolve()), "--run"],
+            input=payload, capture_output=True, text=True, timeout=timeout + 5)
+    except subprocess.TimeoutExpired as e:
+        return {"spawned": True, "timed_out": True, "stderr": (e.stderr or "")[-2000:] if isinstance(e.stderr, str) else ""}
+    except Exception as e:  # noqa: BLE001 — spawn itself failed (no python? bad path?)
+        return {"spawned": False, "error": f"could not spawn scan child: {e}"}
+    out = (proc.stdout or "").strip()
+    # the child prints exactly one JSON line on its last line; tolerate leading stray prints
+    doc = None
+    for line in reversed(out.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                doc = json.loads(line)
+                break
+            except json.JSONDecodeError:
+                continue
+    if doc is None:
+        return {"spawned": True, "setup_error": True,
+                "error": f"scan child produced no parseable result (exit {proc.returncode})",
+                "traceback": (proc.stderr or "")[-2000:]}
+    doc["spawned"] = True
+    return doc
+
+
+# ======================================================================================
+# the child: python3 _smoke.py --run   (reads one JSON job on stdin, prints one JSON verdict)
+# ======================================================================================
+
+class _ReadOnlyMCP:
+    """ctx.senpi_mcp — .call_tool(name, args) with the scaffold's read-only boundary enforced."""
+
+    def __init__(self, client):
+        self._c = client
+
+    def call_tool(self, name, args=None):
+        if name in BLOCKED_TOOLS:
+            raise PermissionError(
+                f"{name} is a mutation tool — blocked by the read-only scan boundary (scan() may only read)")
+        return self._c.mcp_call(name, timeout=_CALL_TIMEOUT, **(args or {}))
+
+
+class _MemState:
+    """ctx.state — a bounded, in-memory stand-in for the runtime's transactional store. Faithful to
+    the API scan() sees (last/recent/append/len); persistence/rollback are the runtime's job, not the
+    smoke test's, so append here just mutates the local ring."""
+
+    def __init__(self, bound):
+        self._bound = int(bound or 0)
+        self._rows = []
+
+    def last(self):
+        return self._rows[-1] if self._rows else None
+
+    def recent(self, n):
+        return self._rows[-int(n):] if n else []
+
+    def append(self, record):
+        if self._bound <= 0:
+            raise RuntimeError("state history is disabled (state_history_max_count 0/unset)")
+        if not isinstance(record, dict):
+            raise TypeError("ctx.state.append(record): record must be a dict")
+        self._rows.append(record)
+        if len(self._rows) > self._bound:
+            self._rows = self._rows[-self._bound:]
+
+    def __len__(self):
+        return len(self._rows)
+
+
+class _Ctx:
+    """ctx — frozen (exactly the 5 members scan-contract.md lists; setattr is rejected)."""
+    __slots__ = ("senpi_mcp", "state", "wallet", "scanner_name", "interval_seconds", "_frozen")
+
+    def __init__(self, senpi_mcp, state, wallet, scanner_name, interval_seconds):
+        object.__setattr__(self, "senpi_mcp", senpi_mcp)
+        object.__setattr__(self, "state", state)
+        object.__setattr__(self, "wallet", wallet)
+        object.__setattr__(self, "scanner_name", scanner_name)
+        object.__setattr__(self, "interval_seconds", interval_seconds)
+        object.__setattr__(self, "_frozen", True)
+
+    def __setattr__(self, k, v):
+        raise AttributeError("ctx is frozen — scan() must not mutate it")
+
+
+def _child_main():
+    """Import the scan module, build ctx, call scan() once, print one JSON verdict line."""
+    try:
+        job = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError as e:
+        print(json.dumps({"setup_error": True, "error": f"bad job payload: {e}"}))
+        return
+    scan_dir = Path(job["dir"])
+    entry = job.get("entry", "scan.py")
+    scan_file = scan_dir / entry
+
+    # sys.path: scan_dir FIRST so `import scoring` resolves to the sibling; then this scripts/ dir so
+    # the child can import mcp_client. (No scoring.py in scripts/, so no shadowing.)
+    scripts_dir = str(Path(__file__).resolve().parent)
+    sys.path.insert(0, scripts_dir)
+    sys.path.insert(0, str(scan_dir))
+
+    if not scan_file.is_file():
+        print(json.dumps({"setup_error": True,
+                          "error": f"entrypoint not found: {scan_file}"}))
+        return
+    try:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("_smoke_scan_target", str(scan_file))
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)   # runs top-level `import scoring`
+    except Exception:  # noqa: BLE001 — import/scoring failure is a real package defect
+        print(json.dumps({"setup_error": True, "error": "scan module failed to import",
+                          "traceback": traceback.format_exc()[-4000:]}))
+        return
+    scan = getattr(mod, "scan", None)
+    if not callable(scan):
+        print(json.dumps({"setup_error": True,
+                          "error": f"{entry} does not export a callable scan(inputs, ctx)"}))
+        return
+
+    try:
+        from mcp_client import MCPClient
+        ctx = _Ctx(_ReadOnlyMCP(MCPClient()), _MemState(job.get("state_bound", 200)),
+                   job.get("wallet", ZERO_WALLET), job.get("name", "external_scanner"),
+                   job.get("interval", 30))
+    except Exception:  # noqa: BLE001
+        print(json.dumps({"setup_error": True, "error": "could not build scan ctx",
+                          "traceback": traceback.format_exc()[-4000:]}))
+        return
+
+    try:
+        result = scan(job.get("inputs") or {}, ctx)
+    except Exception as e:  # noqa: BLE001 — scan() raising IS the finding (block the deploy)
+        print(json.dumps({"threw": True, "error": f"scan() raised: {type(e).__name__}: {e}",
+                          "traceback": traceback.format_exc()[-4000:]}))
+        return
+
+    # JSON-round-trip the return so the parent gets plain data (and we detect non-serializable junk)
+    try:
+        signals = json.loads(json.dumps(result, default=str)) if result is not None else None
+    except (TypeError, ValueError):
+        signals = None
+    print(json.dumps({"signals": signals, "returned_repr": repr(result)[:2000]}))
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--run", action="store_true", help="(internal) act as the scan-runner child.")
+    a = ap.parse_args(argv[1:])
+    if a.run:
+        _child_main()
+        return 0
+    ap.error("nothing to do — import this module, or run the child with --run")
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/senpi-strategy-ops/scripts/_smoke.py
+++ b/senpi-strategy-ops/scripts/_smoke.py
@@ -109,6 +109,33 @@ def validate_signals(signals, schema):
     return out
 
 
+def sizing_warnings(signals, strategy_margin_pct=None):
+    """Flag economically-broken-but-SCHEMA-VALID sizing — chiefly the decimal/percent confusion that
+    sizes 0.18% instead of 18% (marginPct is a PERCENT: 18 == 18%, NEVER a fraction 0.18). A signal with
+    marginPct 0.18 passes every schema check — positive, ≤100 — yet opens ~$3.60 on a $2k wallet. The
+    strongest tell: the signal's marginPct is ~100× smaller than the runtime.yaml's strategy.margin_pct
+    (the author set the percent in YAML but emitted the fraction in scan). Advisory, not a hard reject."""
+    out = []
+    for i, s in enumerate(signals if isinstance(signals, list) else []):
+        if not isinstance(s, dict):
+            continue
+        mp = s.get("marginPct")
+        if isinstance(mp, bool) or not isinstance(mp, (int, float)) or mp <= 0:
+            continue
+        if isinstance(strategy_margin_pct, (int, float)) and not isinstance(strategy_margin_pct, bool) \
+                and strategy_margin_pct > 0:
+            ratio = strategy_margin_pct / mp
+            if 40 <= ratio <= 250:  # ~100× → the signal is a fraction where the runtime speaks percent
+                out.append(f"signal[{i}] marginPct {mp} vs runtime strategy.margin_pct {strategy_margin_pct} "
+                           f"(~{round(ratio)}×) — the runtime sizes off the SIGNAL's {mp}%, i.e. ~{mp}% of the "
+                           f"wallet. marginPct is a PERCENT: emit {strategy_margin_pct:g}, not {mp:g}.")
+                continue
+        if mp < 1:
+            out.append(f"signal[{i}] marginPct {mp:g} sizes <1% of the wallet (~${mp * 20:.2f} on a $2k wallet)"
+                       f" — marginPct is a PERCENT (18 == 18%); did you mean {mp * 100:g}?")
+    return out
+
+
 # ======================================================================================
 # orchestration (imported by deploy.py / diagnose.py)
 # ======================================================================================
@@ -118,10 +145,11 @@ def _resolve_scan_dir(runtime_path, es):
     return (Path(runtime_path).parent / sub).resolve()
 
 
-def smoke(runtime_path, es, wallet=None, timeout=None):
+def smoke(runtime_path, es, wallet=None, timeout=None, strategy_margin_pct=None):
     """Run one scan() and classify it. Returns:
-      {status, detail, signals, violations, traceback, returned_repr, n_signals}
-    status ∈ clean|empty|threw|bad-return|bad-shape|timeout|setup-error (BLOCK/WARN sets above)."""
+      {status, detail, signals, violations, sizing_warnings, traceback, returned_repr, n_signals}
+    status ∈ clean|empty|threw|bad-return|bad-shape|timeout|setup-error (BLOCK/WARN sets above).
+    `sizing_warnings` flags schema-valid-but-broken sizing (the marginPct decimal/percent confusion)."""
     scan_dir = _resolve_scan_dir(runtime_path, es)
     entry = es.get("entrypoint", "scan.py")
     inputs = es.get("inputs") or {}
@@ -156,22 +184,25 @@ def smoke(runtime_path, es, wallet=None, timeout=None):
                 "signals": [], "violations": [], "traceback": "",
                 "returned_repr": raw.get("returned_repr", ""), "n_signals": 0}
     violations = validate_signals(signals, schema)
+    sizing = sizing_warnings(signals, strategy_margin_pct)
     if violations:
         return {"status": "bad-shape",
                 "detail": f"{len(signals)} signal(s) emitted but the shape is invalid — the runtime "
                           "would DROP these silently (→ a BARREN scanner that 'never trades')",
-                "signals": signals, "violations": violations, "traceback": "",
+                "signals": signals, "violations": violations, "sizing_warnings": sizing, "traceback": "",
                 "returned_repr": raw.get("returned_repr", ""), "n_signals": len(signals)}
     if not signals:
         return {"status": "empty",
                 "detail": "scan() ran cleanly and returned [] (no candidates this tick). Normal for a "
                           "quiet strategy (regime/tail-risk); for an always-on scanner it suggests the "
                           "thresholds are too tight or the universe is empty.",
-                "signals": [], "violations": [], "traceback": "",
+                "signals": [], "violations": [], "sizing_warnings": [], "traceback": "",
                 "returned_repr": raw.get("returned_repr", ""), "n_signals": 0}
-    return {"status": "clean",
-            "detail": f"scan() ran cleanly and emitted {len(signals)} valid signal(s)",
-            "signals": signals, "violations": [], "traceback": "",
+    detail = f"scan() ran cleanly and emitted {len(signals)} valid signal(s)"
+    if sizing:
+        detail += f" — but {len(sizing)} SIZING WARNING(S): {sizing[0]}"
+    return {"status": "clean", "detail": detail,
+            "signals": signals, "violations": [], "sizing_warnings": sizing, "traceback": "",
             "returned_repr": raw.get("returned_repr", ""), "n_signals": len(signals)}
 
 

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -482,6 +482,18 @@ def main(argv):
     ps = sub.add_parser("status", help="Show the deploy state.")
     common(ps)
 
+    # `deploy.py <id>` is the natural guess but there's no bare form — deploy runs in resumable steps.
+    # Redirect clearly instead of an argparse "invalid choice" stack trace that leaves the agent stuck
+    # (an agent hit exactly this and thrashed for an hour). Flags fall through to argparse.
+    if len(argv) > 1 and not argv[1].startswith("-") and argv[1] not in ("create", "runtime", "verify", "status"):
+        sid = argv[1]
+        sys.exit(
+            f"deploy runs in resumable steps — there is no bare `deploy.py {sid}`. To deploy {sid!r}:\n"
+            f"  1. python3 scripts/deploy.py create {sid} --budget <usd>   # create + fund the wallet(s)\n"
+            f"  2. python3 scripts/deploy.py runtime {sid}                 # register the runtime\n"
+            f"  3. python3 scripts/deploy.py verify {sid}                  # optional: confirm a scan tick\n"
+            f"Then confirm it's live + protected: diagnose.py {sid}  and  protect.py {sid}.")
+
     a = ap.parse_args(argv[1:])
     log = (lambda m: None) if a.json else (lambda m: print(m))
 

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -486,6 +486,10 @@ def main(argv):
     log = (lambda m: None) if a.json else (lambda m: print(m))
 
     pkg = ensure_pkg(a.package, a.ref, log)
+    for d in _pkg.duplicate_copies(pkg.id, pkg.dir):
+        print(f"⚠ another on-disk copy of {pkg.id!r} exists at {d} — this run uses {pkg.dir}. Edits to the "
+              f"other copy are IGNORED; fix THIS one or delete the stray so you can't edit the wrong copy.",
+              file=sys.stderr)
     errs = _pkg.validate(pkg)
     if errs:
         print(f"✗ {pkg.id}: invalid package", file=sys.stderr)

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -178,7 +178,10 @@ def cmd_create(pkg, a, log):
             es = inst.external_scanner
             if not es:
                 continue  # a pure position_tracker/built-in package has nothing to smoke here
-            v = _smoke.smoke(str(inst.runtime_path), es, wallet=_smoke.ZERO_WALLET)
+            smp = (inst.runtime_doc or {}).get("strategy", {}).get("margin_pct") if inst.runtime_doc else None
+            v = _smoke.smoke(str(inst.runtime_path), es, wallet=_smoke.ZERO_WALLET, strategy_margin_pct=smp)
+            for w in v.get("sizing_warnings", []):  # loud, but not a hard block — sizing is a judgment call
+                log(f"  [{inst.name}] ⚠ SIZING: {w}")
             if v["status"] in _smoke.BLOCK:
                 msg = (f"error: {pkg.id} [{inst.name}] failed the pre-fund scan() smoke test "
                        f"({v['status']}): {v['detail']}")

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -33,6 +33,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import _cli  # noqa: E402
 import _fetch  # noqa: E402
 import _pkg  # noqa: E402
+import _smoke  # noqa: E402
 from mcp_client import MCPClient, MCPError  # noqa: E402
 
 SUBMIT_TIMEOUT = 60     # HTTP timeout for the async create submit
@@ -166,6 +167,32 @@ def cmd_create(pkg, a, log):
         raise
     except Exception as e:  # noqa
         log(f"  (universe preflight skipped: {e})")
+
+    # Smoke gate — run scan() ONCE before funding any wallet. A package strategy exists to run a
+    # PRODUCING scanner; funding one whose scan() throws / returns a non-list / emits a shape that fails
+    # signal_data_schema just parks capital in a strategy that can't trade (the divergence-play incident).
+    # Blocks ONLY on an unambiguous defect (threw / bad-return / bad-shape); an empty result (a
+    # legitimately quiet strategy) or a harness hiccup (setup-error/timeout) just warns and proceeds.
+    if not a.no_smoke:
+        for inst in pkg.instances:
+            es = inst.external_scanner
+            if not es:
+                continue  # a pure position_tracker/built-in package has nothing to smoke here
+            v = _smoke.smoke(str(inst.runtime_path), es, wallet=_smoke.ZERO_WALLET)
+            if v["status"] in _smoke.BLOCK:
+                msg = (f"error: {pkg.id} [{inst.name}] failed the pre-fund scan() smoke test "
+                       f"({v['status']}): {v['detail']}")
+                if v["violations"]:
+                    msg += "\n  violations:\n    - " + "\n    - ".join(v["violations"][:6])
+                if v["traceback"]:
+                    msg += "\n  traceback (tail):\n" + "\n".join(v["traceback"].strip().splitlines()[-6:])
+                msg += ("\n  Fix scan()/scoring.py/runtime.yaml in source, then re-run create "
+                        "(or --no-smoke if you're certain it's a false positive). No wallet was funded.")
+                raise SystemExit(msg)
+            if v["status"] in _smoke.WARN:
+                log(f"  [{inst.name}] smoke: {v['status']} — {v['detail']}")
+            else:
+                log(f"  [{inst.name}] smoke: scan() emitted {v['n_signals']} valid signal(s) ✓")
 
     # Reconcile recorded strategies against the backend — drop any that aren't ACTIVE so we never
     # reuse a CLOSED wallet or get stuck on a FAILED one. Self-heals stale state; no manual editing.
@@ -351,6 +378,24 @@ def _deep_find_scanner(obj, name):
     return None
 
 
+def _ticked(sc):
+    """Has this scanner actually RUN (an invocation) — independent of whether it EMITTED a signal?
+    `runCount` counts EMITS, so a healthy but selective scanner that correctly stayed quiet reads
+    `runCount: 0` forever; keying liveness off it falsely reports such a scanner as "never ticked".
+    Liveness is `alive` / `lastRun*` / invocation counts; `runCount`/`signals` > 0 only CONFIRM."""
+    if not isinstance(sc, dict):
+        return False
+    if _cli.dig(sc, "alive"):
+        return True
+    if _cli.dig(sc, "lastRunFinishedAt", "lastRunStartedAt", "lastRunAt"):
+        return True
+    for k in ("runs", "ticks", "runCount", "signals"):
+        v = _cli.dig(sc, k)
+        if isinstance(v, (int, float)) and not isinstance(v, bool) and v > 0:
+            return True
+    return False
+
+
 def _check_ticks(pkg, st):
     """One pass: mark each instance live if its external_scanner has ticked. Returns the list of
     instances not yet live as (name, reason)."""
@@ -363,10 +408,15 @@ def _check_ticks(pkg, st):
         if not rt or not _cli.runtime_running(rt):
             pending.append((inst.name, "no live runtime"))
             continue
-        state = _cli.cli_json(["openclaw", "senpi", "state", "-r", inst.runtime_name, "--json"], POLL_HTTP_TIMEOUT)
-        sc = _deep_find_scanner(state, inst.external_scanner.get("name")) if state else None
-        runs = _cli.dig(sc or {}, "runCount", "ticks", "runs", default=0) or 0
-        if isinstance(runs, (int, float)) and runs > 0:
+        sname = inst.external_scanner.get("name")
+        # Prefer the purpose-built per-scanner health RPC (separates runs from signals, exposes alive);
+        # fall back to the full state RPC. Liveness via _ticked (NOT runCount — see its docstring).
+        health = _cli.cli_json(["openclaw", "senpi", "scanner", "-r", inst.runtime_name, "--json"], POLL_HTTP_TIMEOUT)
+        sc = _deep_find_scanner(health, sname) if health else None
+        if sc is None:
+            state = _cli.cli_json(["openclaw", "senpi", "state", "-r", inst.runtime_name, "--json"], POLL_HTTP_TIMEOUT)
+            sc = _deep_find_scanner(state, sname) if state else None
+        if _ticked(sc):
             s["status"] = "live"
             save_state(pkg, st)
         else:
@@ -412,6 +462,8 @@ def main(argv):
     pc.add_argument("--budget", type=float, default=None, help="Total USDC split across wallets by funding_share.")
     pc.add_argument("--max-wait", type=int, default=DEFAULT_MAX_WAIT, help="Poll budget for this call (s).")
     pc.add_argument("--dry-run", action="store_true")
+    pc.add_argument("--no-smoke", action="store_true",
+                    help="Skip the pre-fund scan() smoke test (escape hatch for a known false positive).")
 
     pr = sub.add_parser("runtime", help="Step 2: render + create the runtime(s) on the ready wallet(s).")
     common(pr)

--- a/senpi-strategy-ops/scripts/diagnose.py
+++ b/senpi-strategy-ops/scripts/diagnose.py
@@ -285,6 +285,10 @@ def main(argv):
     log = (lambda m: None) if a.json else (lambda m: print(m))
 
     pkg = ensure_pkg(a.package, a.ref, log)
+    dup_copies = _pkg.duplicate_copies(pkg.id, pkg.dir)
+    for d in dup_copies:
+        print(f"⚠ another on-disk copy of {pkg.id!r} exists at {d} — this run reads {pkg.dir}. If you "
+              f"edited that other copy, your fix isn't in the copy the runtime loads.", file=sys.stderr)
     errs = _pkg.validate(pkg)  # structural sanity first (mirrors deploy)
     host_ok = _cli.run_cli(["openclaw", "--version"], timeout=15)[0] == 0
 

--- a/senpi-strategy-ops/scripts/diagnose.py
+++ b/senpi-strategy-ops/scripts/diagnose.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Why isn't my strategy trading? — a deterministic doctor for a non-firing external_scanner.
+
+  python3 diagnose.py <id>              # diagnose every instance of a deployed package
+  python3 diagnose.py <id> --run-scan   # ALSO run scan() once against live MCP + show the literal return
+  python3 diagnose.py <id> --json
+
+`status.py` answers "is the runtime up?"; this answers the harder one: "the runtime is up and funded
+but no positions are opening — WHY?" It names ONE cause instead of making you infer, checking in order
+of what's cheap-and-definitive first:
+
+  STATIC (runtime.yaml on disk — no host needed)
+    1. is an external_scanner even declared?        (only position_tracker → nothing ever trades)
+    2. are its required fields present?             (path/entrypoint/signal_data_schema/validity)
+    3. interval_seconds > 0?                         (0/negative → the scanner is never scheduled)
+    4. does the entrypoint resolve on disk?          (scan.py / sibling scoring.py actually there?)
+  RUNTIME (this host, via `openclaw senpi …`)
+    5. is a runtime registered + running for it?
+    6. is the external_scanner registered on that runtime? (or did only position_tracker load?)
+    7. is it erroring?   (consecutive-error latch → scan() throws every tick)
+    8. is it ticking?    (via `senpi scanner` liveness — NOT runCount, which counts EMITS not runs)
+    9. is it BARREN?     (alive + has run + 0 signals → runs clean but emits nothing: the divergence-play
+                          case — thresholds too tight, OR data{} fails signal_data_schema → dropped)
+  OPTIONALLY (--run-scan) runs scan() once and shows the literal return + traceback + schema violations,
+  which splits case 9 for you: `[]` ⇒ logic/thresholds; a shape violation ⇒ fix your data{} keys.
+
+The fix is ALWAYS: correct the source package + redeploy (`close.py` → author → `deploy.py`). NEVER
+hand-edit deployed state — the runtime owns it and will overwrite you. This tool only READS.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _cli   # noqa: E402
+import _pkg   # noqa: E402
+import _smoke  # noqa: E402
+import _fetch  # noqa: E402
+
+_ICON = {"live": "✅", "not-ticked-yet": "⏳", "barren": "⚠", "scanner-erroring": "❌",
+         "no-scanner": "❌", "malformed-scanner": "❌", "interval-zero": "❌", "entrypoint-missing": "❌",
+         "no-runtime": "❌", "runtime-stopped": "❌", "scanner-not-registered": "❌",
+         "host-unknown": "·", "unknown": "·"}
+
+# external_scanner fields the runtime REQUIRES (runtime-yaml.md → external_scanner field set).
+# interval_seconds defaults to 30 so absence is legal — but 0/negative never schedules, checked apart.
+_REQUIRED_ES = ("path", "entrypoint", "signal_data_schema", "default_signal_validity_seconds")
+
+
+# ---------------------------------------------------------------- host: scanner health RPC
+
+def _scanner_health(runtime_name):
+    """`openclaw senpi scanner -r <name> --json` — the runtime's OWN per-scanner health digest (run/
+    error/consecutive-error counts, cumulative signals, external `alive` heartbeat, BARREN flag). This
+    is the purpose-built read for "is my scanner producing?"; returns the parsed JSON or None."""
+    return _cli.cli_json(["openclaw", "senpi", "scanner", "-r", runtime_name, "--json"], timeout=20)
+
+
+def _state_rpc(runtime_name):
+    return _cli.cli_json(["openclaw", "senpi", "state", "-r", runtime_name, "--json"], timeout=20)
+
+
+def _find_scanner_entry(obj, name):
+    """Deep-find the dict describing scanner `name` in a scanner/state payload — shape-tolerant (the
+    exact JSON layout isn't pinned, so match on a name field + any scanner-ish counter key)."""
+    KEYS = ("runcount", "runs", "ticks", "signals", "signalcount", "alive", "barren",
+            "lastrunfinishedat", "lastrunstartedat", "errorcount", "consecutiveerrors", "nextrun")
+    if isinstance(obj, dict):
+        nm = _cli.dig(obj, "name", "scanner", "scannerName", "scanner_name")
+        if nm == name and any(k.lower() in KEYS for k in obj):
+            return obj
+        for v in obj.values():
+            r = _find_scanner_entry(v, name)
+            if r:
+                return r
+    elif isinstance(obj, list):
+        for v in obj:
+            r = _find_scanner_entry(v, name)
+            if r:
+                return r
+    return None
+
+
+def _num(d, *keys):
+    v = _cli.dig(d or {}, *keys)
+    return v if isinstance(v, (int, float)) and not isinstance(v, bool) else None
+
+
+def _read_disk_state(runtime_name):
+    """The handoff's ground-truth artifact: the on-disk state.json, read directly (not via the CLI,
+    which can swallow output). Returns (path, parsed-or-None). Best-effort — locates the state dir via
+    `senpi config get state-dir`, else the default, then globs for the runtime's state.json."""
+    base = None
+    got = _cli.run_cli(["openclaw", "senpi", "config", "get", "state-dir"], timeout=15)
+    if got[0] == 0 and got[1].strip():
+        base = got[1].strip().splitlines()[-1].strip()
+    candidates = [base] if base else []
+    candidates += [os.path.expanduser("~/.openclaw/senpi-state"), os.path.expanduser("~/.openclaw")]
+    for root in candidates:
+        if not root or not Path(root).is_dir():
+            continue
+        # prefer a state.json under a dir named for the runtime; else any that mentions it
+        hits = list(Path(root).rglob("state.json"))
+        named = [p for p in hits if runtime_name in str(p)]
+        for p in (named or hits):
+            try:
+                return str(p), json.loads(p.read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+    return None, None
+
+
+# ---------------------------------------------------------------- per-instance diagnosis
+
+def diagnose_instance(pkg, inst, host_ok, want_scan):
+    """Return a verdict dict for one instance: {instance, status, headline, fix, evidence{...}}."""
+    es = inst.external_scanner
+    rt_name = inst.runtime_name or f"{pkg.id}-{inst.name}"
+    ev = {"runtime": rt_name, "scanner": es.get("name") if es else None}
+
+    def V(status, headline, fix, **extra):
+        ev.update(extra)
+        return {"instance": inst.name, "status": status, "headline": headline, "fix": fix, "evidence": ev}
+
+    # ---- STATIC (runtime.yaml) ----
+    if inst.runtime_doc is None:
+        return V("malformed-scanner", "runtime.yaml is missing or not valid YAML",
+                 f"Rebuild the package with senpi-strategy-author; validate with "
+                 f"validate_strategy.py before redeploying.")
+    if not es:
+        scn = [s.get("type") for s in (inst.runtime_doc.get("scanners") or []) if isinstance(s, dict)]
+        return V("no-scanner",
+                 f"no external_scanner declared (scanners: {scn or 'none'}) — only position_tracker "
+                 f"runs, so nothing ever OPENS a position",
+                 "Add the external_scanner block (path/entrypoint/signal_data_schema/"
+                 "default_signal_validity_seconds) in source, then close.py → deploy.py.")
+    missing = [f for f in _REQUIRED_ES if not es.get(f)]
+    if missing:
+        return V("malformed-scanner",
+                 f"external_scanner is missing required field(s): {', '.join(missing)}",
+                 "Add them in the runtime.yaml (see runtime-yaml.md → external_scanner field set); "
+                 "fix source + redeploy.")
+    iv = es.get("interval_seconds")
+    if iv is not None and (not isinstance(iv, (int, float)) or isinstance(iv, bool) or iv <= 0):
+        return V("interval-zero",
+                 f"interval_seconds = {iv!r} → the scanner is never scheduled (must be a positive integer)",
+                 "Set a positive interval_seconds (e.g. 300) in source; fix source + redeploy.")
+    sub = (es.get("path") or ".").lstrip("./")
+    ep = inst.runtime_path.parent / sub / es.get("entrypoint", "scan.py")
+    if not ep.is_file():
+        return V("entrypoint-missing",
+                 f"scan entrypoint not found on disk: {ep}",
+                 "The package is broken — re-fetch/rebuild it and redeploy.", entrypoint=str(ep))
+    scoring = ep.with_name("scoring.py")
+    ev["entrypoint"] = str(ep)
+    ev["scoring_present"] = scoring.is_file()
+
+    # optional: run scan() now (works regardless of host — needs only SENPI_AUTH_TOKEN + the package)
+    scan_result = None
+    if want_scan:
+        scan_result = _smoke.smoke(str(inst.runtime_path), es, wallet=None)
+        ev["scan"] = {k: scan_result[k] for k in ("status", "detail", "n_signals", "violations",
+                                                   "returned_repr", "traceback")}
+
+    # ---- RUNTIME (host) ----
+    if not host_ok:
+        base = ("Package looks well-formed. openclaw isn't on THIS host, so runtime/scanner liveness "
+                "is UNKNOWN from here — run diagnose.py on the runtime host.")
+        if scan_result:
+            base += f"  scan() smoke: {scan_result['status']} — {scan_result['detail']}"
+        return V("host-unknown", "package is well-formed; runtime state unknown (no openclaw here)", base)
+
+    rt = _cli.find_runtime(rt_name)
+    if not rt:
+        return V("no-runtime", f"no runtime registered for {rt_name!r} (funded but not autonomous)",
+                 f"python3 deploy.py runtime {pkg.id}  (or close.py {pkg.id} to recover funds).")
+    if not _cli.runtime_running(rt):
+        return V("runtime-stopped", f"runtime {rt_name!r} is registered but NOT running",
+                 "Start the OpenClaw gateway, or redeploy: close.py → deploy.py.")
+
+    # scanner-health RPC — the BARREN-aware read
+    health = _scanner_health(rt_name)
+    entry = _find_scanner_entry(health, es.get("name")) if health else None
+    if entry is None:  # fall back to the full state RPC, then to disk
+        st = _state_rpc(rt_name)
+        entry = _find_scanner_entry(st, es.get("name")) if st else None
+    disk_path, disk_state = _read_disk_state(rt_name)
+    if disk_path:
+        ev["state_json"] = disk_path
+        if entry is None and disk_state is not None:
+            entry = _find_scanner_entry(disk_state, es.get("name"))
+
+    if entry is None:
+        # the runtime is up but the external_scanner isn't in its scanner set → it didn't register
+        return V("scanner-not-registered",
+                 f"external_scanner {es.get('name')!r} is not registered on runtime {rt_name!r} — it "
+                 f"failed to load (only position_tracker is running)",
+                 f"Read the load error:  openclaw senpi scanner -r {rt_name} --json  and  openclaw "
+                 f"senpi state -r {rt_name} --json  (and {disk_path or 'the on-disk state.json'}); "
+                 f"fix the cause in source + redeploy.",
+                 scanner_rpc_empty=True)
+
+    runs = _num(entry, "runCount", "runs", "ticks") or 0
+    signals = _num(entry, "signals", "signalCount", "signalsProduced")
+    errs = _num(entry, "consecutiveErrors", "consecutive_errors", "errorCount", "errors") or 0
+    alive = _cli.dig(entry, "alive")
+    barren_flag = _cli.dig(entry, "barren")
+    ev.update(runs=runs, signals=signals, consecutive_errors=errs, alive=alive)
+
+    if errs and errs > 0:
+        d = f"scanner is erroring ({errs} consecutive) — scan() likely throws every tick"
+        if scan_result and scan_result["status"] == "threw":
+            d += f"; smoke confirms: {scan_result['detail']}"
+        return V("scanner-erroring", d,
+                 f"See the traceback:  openclaw senpi events -r {rt_name} --level error   (or re-run "
+                 f"with --run-scan). Fix the exception in scan()/scoring.py; fix source + redeploy.")
+
+    barren = bool(barren_flag) or (bool(alive) and runs > 0 and (signals == 0))
+    if runs == 0 and not alive:
+        return V("not-ticked-yet",
+                 f"registered but hasn't run yet (runs=0) — first scan() fires on its "
+                 f"{iv or es.get('interval_seconds') or '?'}s interval; normal right after deploy",
+                 f"Re-check after the interval:  python3 diagnose.py {pkg.id}")
+
+    if barren:
+        d = (f"BARREN — scanner is alive and has run ({runs}x) but has emitted 0 signals. It runs "
+             f"cleanly; it just never produces a candidate.")
+        fix = (f"Either it's correctly quiet (regime/tail-risk strategies sit idle by design), OR the "
+               f"thresholds are too tight / the universe is empty, OR the emitted data{{}} fails "
+               f"signal_data_schema and is dropped. Run  python3 diagnose.py {pkg.id} --run-scan  to "
+               f"split it: [] ⇒ loosen the thesis/inputs; a shape violation ⇒ fix your data{{}} keys. "
+               f"Fix source + redeploy — NEVER hand-edit state.")
+        if scan_result:
+            if scan_result["status"] == "empty":
+                d += "  --run-scan: scan() returned [] → the LOGIC/THRESHOLDS never fire (not a shape bug)."
+            elif scan_result["status"] == "bad-shape":
+                d += (f"  --run-scan: scan() emitted {scan_result['n_signals']} signal(s) but the SHAPE "
+                      f"is invalid → the runtime drops them. Violations: "
+                      f"{'; '.join(scan_result['violations'][:3])}")
+            elif scan_result["status"] == "threw":
+                d += f"  --run-scan: scan() THREW → {scan_result['detail']}"
+            elif scan_result["status"] == "clean":
+                d += (f"  --run-scan: scan() emitted {scan_result['n_signals']} VALID signal(s) just now "
+                      f"— the earlier barrenness may have been transient; re-check liveness.")
+        return V("barren", d, fix)
+
+    if signals and signals > 0:
+        return V("live", f"healthy — scanner alive, {runs} run(s), {signals} signal(s) emitted "
+                 f"(positions open when risk gates + slots allow)",
+                 "Nothing to fix. If positions still aren't opening, check risk eligibility: "
+                 f"openclaw senpi risk -r {rt_name} --json")
+    # ran, not flagged barren, signals unknown — inconclusive
+    return V("unknown", f"scanner has run {runs}x; signal count unavailable from the RPC",
+             f"Inspect directly:  openclaw senpi scanner -r {rt_name} --json")
+
+
+# ---------------------------------------------------------------- driver
+
+def ensure_pkg(arg, ref, log):
+    try:
+        return _pkg.load(arg)
+    except _pkg.BadPackage as e:
+        sid = Path(arg).name
+        log(f"package not on disk — fetching {sid}…")
+        try:
+            _fetch.fetch_package(sid, "strategies", ref=ref)
+            return _pkg.load(sid)
+        except (_fetch.FetchError, _pkg.BadPackage):
+            raise SystemExit(f"error: {e}")
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description="Diagnose why a deployed strategy isn't opening positions.")
+    ap.add_argument("package", help="Strategy id (e.g. divergence-play) or package dir.")
+    ap.add_argument("--run-scan", action="store_true",
+                    help="Also run scan() once against live MCP and show the literal return + traceback "
+                         "(needs SENPI_AUTH_TOKEN). Read-only: it can never place a trade.")
+    ap.add_argument("--ref", default=None, help="Branch/ref to fetch the package from if not on disk.")
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args(argv[1:])
+    log = (lambda m: None) if a.json else (lambda m: print(m))
+
+    pkg = ensure_pkg(a.package, a.ref, log)
+    errs = _pkg.validate(pkg)  # structural sanity first (mirrors deploy)
+    host_ok = _cli.run_cli(["openclaw", "--version"], timeout=15)[0] == 0
+
+    verdicts = [diagnose_instance(pkg, inst, host_ok, a.run_scan) for inst in pkg.instances]
+
+    if a.json:
+        print(json.dumps({"strategy": pkg.id, "version": pkg.version, "openclaw_available": host_ok,
+                          "package_errors": errs, "instances": verdicts}, indent=2))
+        return 0
+
+    print(f"\n{pkg.id} v{pkg.version} — scanner diagnosis"
+          + ("" if host_ok else "  (openclaw not on this host — runtime checks limited)"))
+    if errs:
+        print("  ⚠ package structural errors (fix these first):")
+        for e in errs:
+            print(f"      - {e}")
+    worst = None
+    for v in verdicts:
+        icon = _ICON.get(v["status"], "·")
+        print(f"\n  {icon} {v['instance']}: {v['status']}")
+        print(f"      {v['headline']}")
+        print(f"      → {v['fix']}")
+        sc = v["evidence"].get("scan")
+        if sc and a.run_scan:
+            print(f"      scan(): {sc['status']} — {sc['detail'][:100]}")
+            if sc.get("returned_repr"):
+                print(f"        returned: {sc['returned_repr'][:200]}")
+            for vio in (sc.get("violations") or [])[:5]:
+                print(f"        • {vio}")
+            if sc.get("traceback"):
+                tb = sc["traceback"].strip().splitlines()
+                print("        traceback (tail):")
+                for ln in tb[-6:]:
+                    print(f"          {ln}")
+        if v["status"] not in ("live", "not-ticked-yet", "host-unknown"):
+            worst = worst or v
+    if worst:
+        print(f"\n  Verdict: {worst['instance']} → {worst['headline']}")
+    elif all(v["status"] in ("live",) for v in verdicts):
+        print("\n  Verdict: all scanners are producing — this strategy is trading (or gated by risk/slots).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/senpi-strategy-ops/scripts/diagnose.py
+++ b/senpi-strategy-ops/scripts/diagnose.py
@@ -161,9 +161,10 @@ def diagnose_instance(pkg, inst, host_ok, want_scan):
     # optional: run scan() now (works regardless of host — needs only SENPI_AUTH_TOKEN + the package)
     scan_result = None
     if want_scan:
-        scan_result = _smoke.smoke(str(inst.runtime_path), es, wallet=None)
+        smp = (inst.runtime_doc or {}).get("strategy", {}).get("margin_pct")
+        scan_result = _smoke.smoke(str(inst.runtime_path), es, wallet=None, strategy_margin_pct=smp)
         ev["scan"] = {k: scan_result[k] for k in ("status", "detail", "n_signals", "violations",
-                                                   "returned_repr", "traceback")}
+                                                   "sizing_warnings", "returned_repr", "traceback")}
 
     # ---- RUNTIME (host) ----
     if not host_ok:
@@ -313,6 +314,8 @@ def main(argv):
                 print(f"        returned: {sc['returned_repr'][:200]}")
             for vio in (sc.get("violations") or [])[:5]:
                 print(f"        • {vio}")
+            for sw in (sc.get("sizing_warnings") or [])[:5]:
+                print(f"        ⚠ sizing: {sw}")
             if sc.get("traceback"):
                 tb = sc["traceback"].strip().splitlines()
                 print("        traceback (tail):")

--- a/senpi-strategy-ops/scripts/diagnose.py
+++ b/senpi-strategy-ops/scripts/diagnose.py
@@ -163,8 +163,8 @@ def diagnose_instance(pkg, inst, host_ok, want_scan):
     if want_scan:
         smp = (inst.runtime_doc or {}).get("strategy", {}).get("margin_pct")
         scan_result = _smoke.smoke(str(inst.runtime_path), es, wallet=None, strategy_margin_pct=smp)
-        ev["scan"] = {k: scan_result[k] for k in ("status", "detail", "n_signals", "violations",
-                                                   "sizing_warnings", "returned_repr", "traceback")}
+        ev["scan"] = {k: scan_result.get(k) for k in ("status", "detail", "n_signals", "violations",
+                                                       "sizing_warnings", "returned_repr", "traceback")}
 
     # ---- RUNTIME (host) ----
     if not host_ok:

--- a/senpi-strategy-ops/scripts/protect.py
+++ b/senpi-strategy-ops/scripts/protect.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Are my positions protected? — the DSL-coverage doctor (PROTECTED / NAKED / STOP-NOT-ON-VENUE).
+
+  python3 protect.py <id>        # every wallet of the deployed package
+  python3 protect.py <id> --json
+
+Answers the one question a DSL state file CANNOT: is each on-chain position actually covered by a live
+stop? It reconciles THREE sources and treats the **chain** as the source of truth:
+
+  1. open positions  — MCP strategy_get_clearinghouse_state (main + xyz)   ← what is ACTUALLY open
+  2. DSL-tracked     — openclaw senpi dsl positions -a <wallet> --json      ← what the engine protects
+  3. resting stops   — MCP strategy_get_open_orders                         ← what is on the venue
+
+THE TRAP THIS EXISTS TO KILL: a DSL state file going `active: false` (archived) means the engine STOPPED
+TRACKING — which happens on EVERY breach — NOT that the position closed. So "archived" is equally
+consistent with "closed cleanly" and "breach fired, the close order never filled, position still open and
+now untracked = NAKED." You can only tell them apart by the on-chain position. NEVER conclude "closed" or
+"protected" from a DSL file's `active` flag. This tool reads the clearinghouse and refuses to call a
+position protected unless the chain agrees.
+
+Verdict per OPEN on-chain position:
+  ✅ PROTECTED          in the DSL-tracked set AND a resting stop is on the venue
+  ⚠ STOP-NOT-ON-VENUE  tracked, but no reduce-only/stop order is actually resting (stop never posted)
+  ❌ NAKED             open on-chain but NOT tracked (the archived-but-still-open case) — re-protect NOW
+This tool only READS. It never closes or arms anything — it tells you what to fix.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _cli  # noqa: E402
+from mcp_client import MCPClient, MCPError  # noqa: E402
+
+_ICON = {"PROTECTED": "✅", "STOP-NOT-ON-VENUE": "⚠", "NAKED": "❌",
+         "CLOSED-OR-STALE": "·", "UNKNOWN": "·"}
+
+
+# ---------------------------------------------------------------- pure reconciliation (unit-tested)
+
+def reconcile(open_assets, tracked_assets, stop_assets):
+    """The core verdict logic — pure, so it is testable without a host. Inputs are three sets/dicts of
+    asset symbols; the CHAIN (`open_assets`) drives every verdict. Returns list[(asset, verdict)]."""
+    verdicts = []
+    for asset in sorted(open_assets):
+        tracked = asset in tracked_assets
+        has_stop = asset in stop_assets
+        if tracked and has_stop:
+            verdicts.append((asset, "PROTECTED"))
+        elif tracked and not has_stop:
+            verdicts.append((asset, "STOP-NOT-ON-VENUE"))
+        else:
+            verdicts.append((asset, "NAKED"))  # open on-chain but the engine isn't tracking it
+    for asset in sorted(tracked_assets):
+        if asset not in open_assets:
+            verdicts.append((asset, "CLOSED-OR-STALE"))  # engine tracks a position the chain says is gone
+    return verdicts
+
+
+# ---------------------------------------------------------------- source reads (chain = truth)
+
+def _open_assets(mcp, wallet):
+    """Assets with a non-zero position on-chain (main + xyz). Returns {asset: szi} or None if unreadable
+    (None ⇒ we must NOT claim anything is protected — surface UNKNOWN)."""
+    try:
+        ch = mcp.mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet, timeout=20)
+    except MCPError:
+        return None
+    out = {}
+    for dex in ("main", "xyz"):
+        sub = _cli.dig(ch or {}, dex, default={}) or {}
+        positions = _cli.dig(sub, "assetPositions", "positions", default=[]) or []
+        for p in positions:
+            pos = _cli.dig(p, "position", default=p) if isinstance(p, dict) else {}
+            asset = _cli.dig(pos, "coin", "asset", "symbol")
+            szi = _cli.dig(pos, "szi", "size", "sz")
+            try:
+                if asset and float(szi) != 0.0:
+                    out[str(asset)] = float(szi)
+            except (TypeError, ValueError):
+                continue
+    return out
+
+
+def _tracked_assets(wallet):
+    """Assets the DSL engine is ACTIVELY tracking (from the live RPC, not a state file)."""
+    js = _cli.cli_json(["openclaw", "senpi", "dsl", "positions", "-a", wallet, "--json"], timeout=20)
+    return _assets_from(js, extra=("floorPrice", "phase", "currentROE"))
+
+
+def _stop_assets(mcp, wallet):
+    """Assets with a resting reduce-only / trigger (stop) order on the venue."""
+    try:
+        oo = mcp.mcp_call("strategy_get_open_orders", strategy_wallet=wallet, timeout=20)
+    except MCPError:
+        return set()
+    out = set()
+    for o in _flatten_orders(oo):
+        if not isinstance(o, dict):
+            continue
+        asset = _cli.dig(o, "coin", "asset", "symbol")
+        is_stop = bool(_cli.dig(o, "reduceOnly", "isPositionTpsl", "isTrigger")) or \
+            str(_cli.dig(o, "orderType", "type") or "").lower() in ("stop", "trigger", "stop_market", "stop_limit")
+        if asset and is_stop:
+            out.add(str(asset))
+    return out
+
+
+def _assets_from(js, extra=()):  # tolerant: pull asset symbols out of a list/dict payload
+    out = set()
+
+    def walk(o):
+        if isinstance(o, dict):
+            a = _cli.dig(o, "asset", "coin", "symbol")
+            if a and (not extra or any(k in o for k in extra)):
+                out.add(str(a))
+            for v in o.values():
+                walk(v)
+        elif isinstance(o, list):
+            for v in o:
+                walk(v)
+    walk(js)
+    return out
+
+
+def _flatten_orders(oo):
+    if isinstance(oo, list):
+        return oo
+    if isinstance(oo, dict):
+        for k in ("orders", "openOrders", "data", "main", "xyz"):
+            v = oo.get(k)
+            if isinstance(v, list):
+                return v
+        # {main:{orders:[]}, xyz:{orders:[]}}
+        acc = []
+        for v in oo.values():
+            if isinstance(v, dict):
+                acc += _flatten_orders(v)
+            elif isinstance(v, list):
+                acc += v
+        return acc
+    return []
+
+
+# ---------------------------------------------------------------- driver
+
+def check_wallet(mcp, wallet, host_ok):
+    open_map = _open_assets(mcp, wallet)
+    if open_map is None:
+        return {"wallet": wallet, "verdicts": [], "error": "clearinghouse unreadable — cannot verify (do NOT assume protected)"}
+    tracked = _tracked_assets(wallet) if host_ok else set()
+    stops = _stop_assets(mcp, wallet)
+    verds = reconcile(set(open_map), tracked, stops)
+    # host-blind caveat: without openclaw we can't read the tracked set, so an open position can't be
+    # confirmed PROTECTED — downgrade any PROTECTED/NAKED to UNKNOWN and say why.
+    if not host_ok:
+        verds = [(a, "UNKNOWN" if v in ("PROTECTED", "NAKED", "STOP-NOT-ON-VENUE") else v) for a, v in verds]
+    return {"wallet": wallet, "open": open_map, "tracked": sorted(tracked), "stops": sorted(stops),
+            "verdicts": [{"asset": a, "verdict": v} for a, v in verds],
+            "host_ok": host_ok}
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description="Verify every open position of a deployed strategy is DSL-protected.")
+    ap.add_argument("package", help="Strategy id (e.g. divergence-play).")
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args(argv[1:])
+
+    mcp = MCPClient()
+    host_ok = _cli.run_cli(["openclaw", "--version"], timeout=15)[0] == 0
+    strategies = [s for s in _cli.strategies_for(mcp, skill_name=a.package) if _cli.strategy_open(s)]
+    wallets = sorted({str(_cli.strategy_wallet(s)) for s in strategies if _cli.strategy_wallet(s)})
+
+    rows = [check_wallet(mcp, w, host_ok) for w in wallets]
+
+    if a.json:
+        print(json.dumps({"strategy": a.package, "openclaw_available": host_ok, "wallets": rows}, indent=2))
+        return 0
+
+    if not wallets:
+        print(f"No open strategies found for {a.package!r}.")
+        return 0
+    print(f"\n{a.package} — DSL protection" + ("" if host_ok else "  (no openclaw here — tracked set unknown; run on the runtime host)"))
+    naked = 0
+    for r in rows:
+        print(f"\n  wallet {r['wallet'][:12]}…")
+        if r.get("error"):
+            print(f"    · {r['error']}")
+            continue
+        if not r["verdicts"]:
+            print("    (no open positions)")
+            continue
+        for v in r["verdicts"]:
+            icon = _ICON.get(v["verdict"], "·")
+            print(f"    {icon} {v['asset']:<12} {v['verdict']}")
+            if v["verdict"] == "NAKED":
+                naked += 1
+    if naked:
+        print(f"\n  ❌ {naked} NAKED position(s) — open on-chain, not DSL-tracked, no stop. Re-protect NOW: "
+              f"`ratchet_stop_add` a stop, or `close.py {a.package}` the leg. Do not leave it running.")
+    elif host_ok and any(r.get("verdicts") for r in rows):
+        print("\n  ✅ every open position is tracked with a resting stop." if all(
+            v["verdict"] == "PROTECTED" for r in rows for v in r["verdicts"])
+            else "\n  ⚠ see STOP-NOT-ON-VENUE above — tracked but the stop isn't resting on the venue.")
+    return 2 if naked else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/senpi-strategy-ops/scripts/protect.py
+++ b/senpi-strategy-ops/scripts/protect.py
@@ -90,20 +90,31 @@ def _tracked_assets(wallet):
     return _assets_from(js, extra=("floorPrice", "phase", "currentROE"))
 
 
+def _is_stop_order(o):
+    """True iff order `o` is a protective DOWNSIDE stop — NOT a take-profit and not a plain reduce-only
+    scale-out. A take-profit is ALSO reduceOnly (and isPositionTpsl), so `reduceOnly` alone must not count
+    as a stop: a TP-only position would then read PROTECTED with no real stop behind it. Exclude explicit
+    take-profits FIRST, then accept reduce-only / trigger / stop-typed orders."""
+    if not isinstance(o, dict):
+        return False
+    otype = str(_cli.dig(o, "orderType", "type") or "").lower()
+    tpsl = str(_cli.dig(o, "tpsl", "tpSl", "triggerType") or "").lower()
+    if "take" in otype or "profit" in otype or tpsl == "tp":   # a take-profit is not downside protection
+        return False
+    return bool(_cli.dig(o, "reduceOnly", "isPositionTpsl", "isTrigger")) or "stop" in otype or \
+        otype in ("trigger", "stop", "stop_market", "stop_limit") or tpsl == "sl"
+
+
 def _stop_assets(mcp, wallet):
-    """Assets with a resting reduce-only / trigger (stop) order on the venue."""
+    """Assets with a resting protective STOP order on the venue (take-profits excluded — see _is_stop_order)."""
     try:
         oo = mcp.mcp_call("strategy_get_open_orders", strategy_wallet=wallet, timeout=20)
     except MCPError:
         return set()
     out = set()
     for o in _flatten_orders(oo):
-        if not isinstance(o, dict):
-            continue
-        asset = _cli.dig(o, "coin", "asset", "symbol")
-        is_stop = bool(_cli.dig(o, "reduceOnly", "isPositionTpsl", "isTrigger")) or \
-            str(_cli.dig(o, "orderType", "type") or "").lower() in ("stop", "trigger", "stop_market", "stop_limit")
-        if asset and is_stop:
+        asset = _cli.dig(o, "coin", "asset", "symbol") if isinstance(o, dict) else None
+        if asset and _is_stop_order(o):
             out.add(str(asset))
     return out
 

--- a/senpi-strategy-ops/tests/test_ops.py
+++ b/senpi-strategy-ops/tests/test_ops.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Offline tests for the strategy-ops safety scripts — no network / no token needed.
+
+The `unloadable` smoke cases fail at IMPORT time (before ctx/MCP), and the protect verdicts are pure,
+so this whole file runs hermetically.
+
+    python3 -m pytest senpi-strategy-ops/tests/
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import os
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+
+import _smoke   # noqa: E402
+import protect  # noqa: E402
+
+
+def _pkg_with_scan(tmp, scan_src, entry="scan.py"):
+    """Write a minimal runtime.yaml + scanners/<entry> under tmp; return (runtime_path, es)."""
+    scdir = os.path.join(tmp, "scanners")
+    os.makedirs(scdir, exist_ok=True)
+    with open(os.path.join(scdir, entry), "w") as f:
+        f.write(scan_src)
+    rp = os.path.join(tmp, "runtime.yaml")
+    with open(rp, "w") as f:
+        f.write("name: t\n")
+    es = {"name": "t_signals", "path": "./scanners", "entrypoint": entry,
+          "signal_data_schema": {"score": {"type": "number"}},
+          "default_signal_validity_seconds": 600, "interval_seconds": 300, "timeout_seconds": 20}
+    return rp, es
+
+
+# ── Finding 2: an unimportable/non-runnable scan is BLOCK (unloadable) — never funded ──
+# Each of these can NEVER register a scanner, so funding it just parks capital that can't trade
+# (the divergence-play failure). They fail BEFORE the child needs a token, so they run offline.
+
+def test_syntax_error_scan_is_unloadable_and_blocks():
+    with tempfile.TemporaryDirectory() as d:
+        rp, es = _pkg_with_scan(d, "def scan(inputs, ctx)\n    return []\n")   # missing ':' → SyntaxError
+        v = _smoke.smoke(rp, es)
+    assert v["status"] == "unloadable"
+    assert v["status"] in _smoke.BLOCK
+    assert v["status"] not in _smoke.WARN
+
+
+def test_import_error_scan_is_unloadable():
+    with tempfile.TemporaryDirectory() as d:
+        rp, es = _pkg_with_scan(d, "import a_module_that_does_not_exist_xyz\ndef scan(i, c):\n    return []\n")
+        v = _smoke.smoke(rp, es)
+    assert v["status"] == "unloadable" and v["status"] in _smoke.BLOCK
+
+
+def test_missing_entrypoint_is_unloadable():
+    with tempfile.TemporaryDirectory() as d:
+        rp, es = _pkg_with_scan(d, "def scan(i, c):\n    return []\n")
+        es["entrypoint"] = "nope.py"
+        v = _smoke.smoke(rp, es)
+    assert v["status"] == "unloadable" and v["status"] in _smoke.BLOCK
+
+
+def test_scan_not_callable_is_unloadable():
+    with tempfile.TemporaryDirectory() as d:
+        rp, es = _pkg_with_scan(d, "scan = 42\n")   # 'scan' exists but isn't callable
+        v = _smoke.smoke(rp, es)
+    assert v["status"] == "unloadable" and v["status"] in _smoke.BLOCK
+
+
+# ── Finding 1: every smoke() verdict carries sizing_warnings; diagnose's extraction never KeyErrors ──
+
+def test_every_smoke_return_has_sizing_warnings_key():
+    with tempfile.TemporaryDirectory() as d:
+        rp, es = _pkg_with_scan(d, "def scan(inputs, ctx)\n")   # syntax error → unloadable (no sizing_warnings pre-fix)
+        v = _smoke.smoke(rp, es)
+    # exactly the comprehension diagnose.py runs on the smoke result — must not KeyError on ANY status
+    extracted = {k: v.get(k) for k in ("status", "detail", "n_signals", "violations",
+                                       "sizing_warnings", "returned_repr", "traceback")}
+    assert extracted["status"] == "unloadable"
+    assert extracted["sizing_warnings"] == []          # present + empty, not missing
+
+
+# ── sizing_warnings logic (the marginPct percent/fraction confusion) ──
+
+def test_sizing_warning_flags_fraction_vs_runtime_percent():
+    # runtime says 18(%) but the signal emitted 0.18 (the v2 fraction) → ~100× tell
+    w = _smoke.sizing_warnings([{"marginPct": 0.18}], strategy_margin_pct=18)
+    assert w and "PERCENT" in w[0]
+
+
+def test_sizing_warning_silent_when_consistent():
+    assert _smoke.sizing_warnings([{"marginPct": 18}], strategy_margin_pct=18) == []
+
+
+# ── Secondary B: a take-profit is NOT a protective stop ──
+
+def test_take_profit_is_not_a_stop():
+    assert protect._is_stop_order({"coin": "BTC", "reduceOnly": True, "orderType": "Take Profit Market"}) is False
+    assert protect._is_stop_order({"coin": "BTC", "reduceOnly": True, "tpsl": "tp"}) is False
+
+
+def test_stop_loss_is_a_stop():
+    for sl in ({"coin": "BTC", "reduceOnly": True, "orderType": "Stop Market"},
+               {"coin": "ETH", "isTrigger": True, "orderType": "Stop Limit"},
+               {"coin": "SOL", "reduceOnly": True}):        # bare reduce-only still counts (conservative)
+        assert protect._is_stop_order(sl) is True
+
+
+def test_take_profit_only_position_is_not_reported_protected():
+    """DSL-tracked, but the ONLY resting order is a take-profit (no real stop). Must read STOP-NOT-ON-VENUE,
+    never PROTECTED — a TP is not downside protection."""
+    stops = set()   # a TP would previously have leaked into stop_assets; _is_stop_order now drops it
+    verdicts = dict(protect.reconcile({"BTC"}, {"BTC"}, stops))
+    assert verdicts["BTC"] == "STOP-NOT-ON-VENUE"
+
+
+# ── reconcile baseline: the chain is the source of truth ──
+
+def test_reconcile_protected_naked_and_stale():
+    v = dict(protect.reconcile({"BTC", "ETH"}, {"BTC"}, {"BTC"}))
+    assert v["BTC"] == "PROTECTED"          # tracked + stop resting on venue
+    assert v["ETH"] == "NAKED"              # open on-chain, engine not tracking it
+    v2 = dict(protect.reconcile({"BTC"}, {"BTC", "SOL"}, {"BTC"}))
+    assert v2["SOL"] == "CLOSED-OR-STALE"   # engine tracks a position the chain says is gone
+
+
+if __name__ == "__main__":
+    sys.exit(__import__("pytest").main([__file__, "-q"]))

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.0.2"
+  version: "3.0.3"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -91,6 +91,7 @@ reference). Full surface with every option → `references/runtime-cli.md`.
 | `references/scan-contract.md` | The author contract in depth: `scan(inputs, ctx)`, the `ctx` surface, the signal shape, and `scoring.py` |
 | `references/runtime-cli.md` | The full `openclaw senpi …` command surface — runtime, dsl, action, status/state, skills, guide |
 | `references/dsl-protection-check.md` | **Verify open positions are DSL-protected** — the PROTECTED / UNPROTECTED / STOP-NOT-ON-VENUE verdict + the open-vs-tracked reconciliation |
+| `references/troubleshooting.md` | **"Deployed but not trading"** — the symptom→cause→fix table for a non-firing `external_scanner` (ACTIVE ≠ trading; `runCount` lies; BARREN; read the real state). Encoded by `senpi-strategy-ops/scripts/diagnose.py`. |
 
 ## Package naming (load-bearing)
 

--- a/senpi-trading-runtime/references/dsl-protection-check.md
+++ b/senpi-trading-runtime/references/dsl-protection-check.md
@@ -25,10 +25,24 @@ is unprotected by design. That's the first thing to rule out.
 ## The one command that answers it
 
 ```
+python3 senpi-strategy-ops/scripts/protect.py <id>     # PROTECTED / NAKED / STOP-NOT-ON-VENUE per position
+```
+`protect.py` runs the reconciliation below deterministically: it reads the **on-chain** positions
+(clearinghouse), the DSL-tracked set, and the resting stop orders, and prints a per-position verdict —
+treating the **chain as the source of truth**. Use it instead of eyeballing state — it exists because the
+manual version is easy to misread. The raw CLI underneath it:
+```
 senpi dsl positions -r <runtime-id>          # [-a <addr>] [--json]
 ```
 Lists every position DSL is protecting — each with `phase`, `currentROE`, `currentTierIndex`, and
 **`floorPrice`** (the live stop). Every open position should appear here with a `floorPrice`.
+
+> **⚠️ NEVER read a DSL *state file* to decide if a position is protected, and NEVER treat an archived /
+> `active: false` DSL as "the position closed."** A DSL goes inactive/archived on **every** breach — that
+> means the engine **stopped tracking**, which is EQUALLY consistent with "closed cleanly" and "the breach
+> fired, the close order never filled, and the position is still open, untracked, and NAKED." The `active`
+> flag tells you nothing about the on-chain position. Only the **clearinghouse** does. `archived DSL` **+**
+> `position still open on-chain` = **NAKED** — re-protect it now.
 
 ## Confirm nothing is missing (the reconciliation — do NOT skip)
 
@@ -85,8 +99,8 @@ On a runtime that ships the agent event surface:
 | Verdict | When |
 |---|---|
 | ✅ **PROTECTED** | open, appears in `dsl positions` with a `floorPrice`, monitor healthy, no recent `dsl.sl_sync_failed` |
-| ⛔ **UNPROTECTED** | open but **absent** from `dsl positions`, or the strategy has no `exit: engine: dsl` |
-| ⚠ **STOP NOT ON VENUE** | tracked, but a recent `dsl.sl_sync_failed` for that asset |
+| ⛔ **UNPROTECTED / NAKED** | open on-chain but **absent** from `dsl positions` — including when its DSL is **archived / `active: false`** (a breach fired but the close never filled, so it's open + untracked + no stop), or the strategy has no `exit: engine: dsl` |
+| ⚠ **STOP NOT ON VENUE** | tracked, but no resting reduce-only/stop order on the venue, or a recent `dsl.sl_sync_failed` for that asset |
 
 ## Config reference — what "DSL is set up" looks like
 

--- a/senpi-trading-runtime/references/scan-contract.md
+++ b/senpi-trading-runtime/references/scan-contract.md
@@ -141,7 +141,7 @@ Return a `list[dict]`, one per candidate. Keys:
 |---|---|---|
 | `asset` | ✅ | non-empty string |
 | `direction` | ✅ | normalized to `LONG` / `SHORT` (case-insensitive in) |
-| `marginPct` | — | **top-level**, PERCENT of withdrawable in (0,100] — **the fleet standard** (~97 of 102 scanners); the runtime sizes `(marginPct/100) × withdrawable`. Positive when present; a present-but-non-positive value is a **loud reject** |
+| `marginPct` | — | **top-level**, PERCENT of withdrawable in (0,100] — **the fleet standard** (~97 of 102 scanners); the runtime sizes `(marginPct/100) × withdrawable`. Positive when present; a present-but-non-positive value is a **loud reject**. ⚠️ **It is a PERCENT, not a decimal fraction: emit `18` for 18%, NEVER `0.18`.** `0.18` is schema-valid (positive, ≤100) but means **0.18%** → ~$3.60 on a $2k wallet instead of $360. A `marginPct` below 1 is almost always this unit bug — and if your `runtime.yaml`'s `strategy.margin_pct` is `18`, your signal must emit `18` too, not `18/100`. |
 | `marginUsd` | — | **top-level**, a fixed USD amount (not a percent) — the alternative to `marginPct`; positive when present, non-positive is a **loud reject** |
 | `leverage` | — | **top-level**, positive number when present |
 | `data` | — | validated against the recipe's `signal_data_schema`: unknown key → reject, missing required key → reject, wrong type → reject (types `string`/`number`/`boolean`/`object`/`array`) |
@@ -188,6 +188,7 @@ Both are valid — it's your thesis:
 - ✅ Keep dedup / rotation / first-seen ledgers in `ctx.state` (`last()` → mutate → `append()`).
 - ✅ Declare every `data{}` key in `signal_data_schema`; set `default_signal_validity_seconds`.
 - ✅ Put `marginPct` (fleet standard) or `marginUsd`, plus `leverage`, at the **top level**, not inside `data{}`.
+- ✅ Emit `marginPct` as a **PERCENT** (`18` for 18%), not a decimal (`0.18`). Below 1 = a unit bug; match your `strategy.margin_pct`. Smoke-test and confirm the first position's margin ≈ the intended % of the wallet — not just that a signal fired.
 - ✅ On any failure, **return `[]`** (or a partial list) — don't crash.
 - ❌ Don't set `valid_until`/`produced_at` — the scaffold owns the envelope (`signal_id` optional).
 - ❌ Don't schedule the scanner yourself or POST signals — the runtime does it.

--- a/senpi-trading-runtime/references/troubleshooting.md
+++ b/senpi-trading-runtime/references/troubleshooting.md
@@ -1,0 +1,72 @@
+# Troubleshooting — "it's deployed but not trading"
+
+The trap this page exists to break: a strategy shows **`status: ACTIVE`** and is funded, but no positions
+ever open. `ACTIVE` only means the strategy record is live and its **`position_tracker`** is running — it
+says **nothing** about whether the `external_scanner` is producing signals. A strategy is only actually
+working when its scanner has **ticked at least once and emitted a valid signal**.
+
+> **Definition of done** (not "ACTIVE"): the `external_scanner` is **registered**, `interval_seconds > 0`,
+> it has **≥1 successful tick**, and it has **emitted ≥1 signal that passes `signal_data_schema`**. Confirm
+> it — don't assume it.
+
+## One command first
+
+Before inspecting files by hand, run the doctor — it names ONE cause instead of making you infer:
+
+```bash
+python3 senpi-strategy-ops/scripts/diagnose.py <id>              # deterministic verdict per instance
+python3 senpi-strategy-ops/scripts/diagnose.py <id> --run-scan   # also run scan() live + show its literal return
+```
+
+It checks, in order: scanner declared? required fields present? `interval_seconds > 0`? entrypoint on
+disk? runtime registered + running? scanner registered on the runtime? erroring? **ticking** (via the
+scanner-liveness clock, *not* `runCount`)? **BARREN** (alive + ran + 0 signals)? If you only read one thing,
+read its verdict line.
+
+## Symptom → cause → fix
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| ACTIVE + funded, **no positions ever**, `position_tracker` runs fine | The `external_scanner` isn't producing — see the specific rows below (this is the umbrella symptom). | `diagnose.py <id>` to get the specific cause; then fix **source** + redeploy. |
+| `diagnose` says **only `position_tracker` registered** / no `external_scanner` | The runtime.yaml declares no `external_scanner` (or it failed to load). Nothing feeds `OPEN_POSITION`. | Add/repair the `external_scanner` block; `validate_strategy.py` before deploy. |
+| **`interval_seconds: 0`** (or missing/negative) | An `external_scanner` with a non-positive interval is **never scheduled** — it never ticks. | Set a positive integer `interval_seconds` (e.g. `300`). Fix source + redeploy. |
+| Scanner **registered but never ran** (`runs = 0`, not alive), just deployed | Not a bug — the first `scan()` fires on its `interval_seconds`, not at deploy time. | Wait one interval, re-run `diagnose.py`. Don't `sleep`-poll right after deploy. |
+| **BARREN** — scanner is alive, has run, but **0 signals** | (a) correctly quiet (regime/tail-risk sit idle by design); **or** (b) thresholds too tight / universe empty → `scan()` returns `[]`; **or** (c) `scan()` emits a shape that fails `signal_data_schema` → the runtime **drops it silently**. | `diagnose.py <id> --run-scan`: `[]` ⇒ loosen the thesis/inputs; a **shape violation** ⇒ fix your `data{}` keys/types to match `signal_data_schema`. Fix source + redeploy. |
+| Scanner shows **consecutive errors** | `scan()` (or its `import scoring`) throws every tick — a bug in the scan module, a bad MCP arg, or a missing dependency. | `openclaw senpi events -r <id> --level error` for the traceback (or `--run-scan`). Fix the exception; redeploy. |
+| Signals emitted but **still no positions** | Not a scanner problem — a **risk gate** (cooldown, daily-loss, drawdown-halt, max-entries) or **no free slot**. | `openclaw senpi risk -r <id> --json` (eligibility + per-gate reasons) and check `slots` vs open positions. |
+| Positions open but **unprotected** (no stop) | DSL exit not wired: missing `position_tracker` scanner / `POSITION_TRACKER` action, or no `exit.dsl_preset`. | See [`dsl-protection-check.md`](dsl-protection-check.md). Every strategy must ship a DSL exit. |
+| `entrypoint … not found` at deploy/diagnose | `path`/`entrypoint` don't resolve against the runtime.yaml dir, or `scan.py`/sibling `scoring.py` is missing. | Re-fetch/rebuild the package; `validate_strategy.py` checks this statically. |
+
+## `runCount` lies — use the scanner-liveness clock
+
+For a **selective** scanner (one that only emits when its thesis fires), the counter surfaced as
+`runCount` in raw state counts **emitted signals, not invocations**. A healthy scanner that has run 200
+times but correctly stayed quiet reads as `runCount: 0` — so **never use `runCount` to decide "did it
+tick".** Liveness is the scanner's `alive` heartbeat / `lastRunFinishedAt` (or the state file's mtime).
+`openclaw senpi scanner -r <id> --json` separates the two — `runs` (invocations) vs `signals` (emits) —
+and flags **BARREN** = alive + ran + 0 signals. `diagnose.py` uses that, not `runCount`.
+
+## Read the REAL runtime state (not a swallowed CLI line)
+
+When the CLI output looks empty/truncated, read the source of truth directly:
+
+```bash
+openclaw senpi scanner -r <id> --json     # per-scanner health: runs, signals, errors, alive, BARREN
+openclaw senpi state   -r <id> --json     # full runtime state (the escape hatch)
+openclaw senpi events  -r <id> --level error --limit 50   # the actual scan()/action tracebacks
+
+# the on-disk state, read straight from the filesystem (CLI-independent):
+STATE_DIR="$(openclaw senpi config get state-dir 2>/dev/null || echo ~/.openclaw/senpi-state)"
+find "$STATE_DIR" -name 'state.json' | xargs -I{} sh -c 'echo "== {} =="; cat "{}"'
+```
+
+## Rules
+
+- **Fix source, never deployed state.** The runtime owns its state files and overwrites them every tick —
+  hand-editing `state.json` fixes nothing and is erased. The fix is always: correct the **package**
+  (`scan.py`/`scoring.py`/`runtime.yaml`) → `close.py <id>` → author → `deploy.py <id>`.
+- **Never "fix" a non-firing scanner by falling back to a raw `strategy_create_custom_strategy`.** That
+  makes an empty custom-position strategy with **no DSL and no automated exits** — you lose the entire
+  point of the runtime. Repair the package instead.
+- **Don't declare it fixed without a tick.** "Redeployed, status ACTIVE" is not a fix. Re-run
+  `diagnose.py <id>` (and `--run-scan`) and confirm a **signal emitted**.


### PR DESCRIPTION
## Why

A hand-authored strategy (**divergence-play**, 2 legs, \$4k) deployed **ACTIVE + funded** but never traded, and an operator agent couldn't get it live across many turns and **four redeploys** — because the skills gave *capability* but **no diagnostic path, no gate, and no clear definition of done**. It looped on cheap-to-check things (does the file exist? indentation?), declared "done" three times prematurely (ACTIVE → signal fired → positions opened), and nearly left a naked short by misreading a DSL state file. Every one of those failures is now a **tool that names the cause** or a **gate that makes the mistake impossible** — validated against the real incident end to end.

## The incident → the fix

| What actually went wrong | What now catches it |
|---|---|
| `interval_seconds: 0` → scanner never scheduled (agent saw the clue, misread it as "runtime not wired up") | `validate_strategy` rejects interval ≤ 0; `diagnose.py` verdict `interval-zero` |
| `scan()` threw (missing `dex` arg on `xyz:` reads) → deployed + funded anyway | **pre-fund smoke gate** — runs `scan()` before funding, refuses on throw/bad-shape |
| missing `import sys` → the `except` handler itself crashed (NameError), masking the real error | static **`sys`-import lint** in `validate_strategy` (no token needed) |
| `marginPct: 0.18` (decimal) vs `strategy.margin_pct: 18` → sized **\$3.60 on \$2k**, schema-valid so nothing flagged it | **sizing-sanity** check names "emit 18, not 0.18"; scan-contract + author invariant |
| agent declared "done" at each surface-green step | **5-point Definition-of-done** (registered · ticks · schema-valid signal · sized ≈ intended % · DSL-protected · no orphans) |
| naked-position scare: agent read a **DSL state file**, saw `active:false`, flip-flopped "NAKED"↔"closed" | **`protect.py`** reconciles the **chain** vs tracked vs stops → PROTECTED/NAKED; doc trap: archived ≠ closed |
| **6 copies** of the package on disk; edits kept landing in a copy the runtime didn't load (stale fix persisted) | **duplicate-copy guard** — `deploy`/`diagnose` warn which copy is in use |
| the validator that would've caught the bad field **couldn't run** (imported PyYAML; PEP-668 host blocks pip) | `validate_strategy` falls back to vendored `_yaml` — runnable everywhere |

## What's in the PR

**New tools** (`senpi-strategy-ops/scripts/`)
- **`diagnose.py`** — "why isn't it trading?" doctor; leads with the runtime's own `senpi scanner` BARREN RPC; `--run-scan` runs `scan()` live and shows the literal return + schema + sizing warnings.
- **`protect.py`** — "are my positions protected?" doctor; reconciles clearinghouse × DSL-tracked × resting stops → PROTECTED/NAKED/STOP-NOT-ON-VENUE; refuses to call anything protected unless the chain agrees.
- **`_smoke.py`** — isolated (subprocess + timeout) `scan()` runner enforcing the read-only mutation boundary (a smoke test can never place a trade); classifies clean/empty/threw/bad-return/bad-shape + sizing warnings. Shared by the deploy gate and `diagnose --run-scan`.

**Changed**
- **`deploy.py`** — pre-fund smoke gate (`--no-smoke` escape); `verify` liveness uses `alive`/invocations not `runCount` (which counts *emits*, so a quiet scanner read "never ticked"); duplicate-copy warning.
- **`validate_strategy.py`** — PyYAML→vendored fallback; assert external_scanner fields (interval>0, path/entrypoint/schema/validity); `sys`-import lint.
- **Docs/DoD** — `troubleshooting.md` (new symptom→cause→fix table); `dsl-protection-check.md` (the archived-DSL trap); `scan-contract.md` (marginPct is a percent); ops/author/runtime SKILL.md (5-point DoD + anti-patterns). Versions: ops `2.4.0`, author `2.5.0`, runtime `3.0.3`.

## Design deviations from the original spec (deliberate)
- The smoke gate **allows an empty result** — blocking "0 signals" would break Rhino/Ox/regime allocators that correctly emit nothing on a cold tick. It blocks only unambiguous defects (throw / non-list / bad-shape).
- Sizing + duplicate-copy issues are **loud warnings, not hard blocks** — both have legitimate (if rare) forms, and a false block on the money-path is worse than a warning the DoD backstops.

## Tested
- Every `_smoke` branch incl. the safety ones (scan calling `create_position` → blocked `PermissionError`; mutating `ctx` → frozen guard).
- `diagnose` static causes + `--run-scan` on a real scanner; `protect.reconcile` on the exact HYPE(naked)/META(protected) end-state; the sizing catch on the exact 0.18-vs-18 case.
- The gate refuses throwing/bad-shape and passes clean-but-quiet; dupe-guard detects a two-copy layout with no false positive on the normal one.
- `validate_strategy` runs with PyYAML blocked; **all 83 catalog packages still pass** (zero false positives) after every static addition.

## Out of scope (runtime-team item)
The runtime archiving a position on breach **before confirming the close order filled** is what *creates* the naked window (breach → cancel SL → maker close doesn't fill → archived + open + unprotected). That's a runtime-plugin fix, filed separately — this PR makes it *detectable* (`protect.py`), not impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)