### PR TITLE
senpi-portfolio: telemetry-verified runtime liveness in the health check

### DIFF
--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -164,12 +164,15 @@ strategy and per group. Narrate it honestly — a registered runtime is not auto
   Say **"runtime liveness unverified from here"** — never upgrade `unknown` to "healthy/protected" or
   downgrade it to "broken." This is the honest bar: **only `live` means "confirmed working."**
 
-This health check owns **liveness** (is it registered + running + healthy). For the depth *behind* a bad
-verdict, hand off — don't re-derive it here: **`not_running` / `degraded` →** `senpi-strategy-ops`
-`diagnose.py <id>` (why the scanner isn't producing — registered? ticked? BARREN? erroring?) and redeploy;
-**"where am I leaking / did a stop fail / any halts / exit quality" →** `senpi-improve-trades` (it reads the
-runtime event log for protection gaps, risk halts, failed orders, and exit quality). Point the user to the
-right tool rather than duplicating that analysis in the health check.
+This health check owns **liveness triage** (registered + running + healthy) via telemetry, and **references
+`diagnose.py` as the confirmation step** — it does not re-derive the deep checks. A thorough health check
+does not stop at the verdict: for **any** strategy that isn't cleanly `live` (`not_running` / `degraded` /
+`unknown`), running **`senpi-strategy-ops` `diagnose.py <id>`** (registered? ticked? BARREN? erroring?
+`--run-scan` for the literal scan output) is how you **confirm what's actually wrong and fix it** — surface
+it as the required next step (and its verdict, if you can run it), then close.py → redeploy as needed. For
+**"where am I leaking / did a stop fail / any halts / exit quality"**, hand to `senpi-improve-trades` (it
+reads the runtime event log for protection gaps, risk halts, failed orders, and exit quality). Reference the
+right tool to *confirm* — never re-derive its analysis here.
 
 ## Judge each strategy against its OWN mandate — not a momentum benchmark
 

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -164,6 +164,13 @@ strategy and per group. Narrate it honestly — a registered runtime is not auto
   Say **"runtime liveness unverified from here"** — never upgrade `unknown` to "healthy/protected" or
   downgrade it to "broken." This is the honest bar: **only `live` means "confirmed working."**
 
+This health check owns **liveness** (is it registered + running + healthy). For the depth *behind* a bad
+verdict, hand off — don't re-derive it here: **`not_running` / `degraded` →** `senpi-strategy-ops`
+`diagnose.py <id>` (why the scanner isn't producing — registered? ticked? BARREN? erroring?) and redeploy;
+**"where am I leaking / did a stop fail / any halts / exit quality" →** `senpi-improve-trades` (it reads the
+runtime event log for protection gaps, risk halts, failed orders, and exit quality). Point the user to the
+right tool rather than duplicating that analysis in the health check.
+
 ## Judge each strategy against its OWN mandate — not a momentum benchmark
 
 This is the core of the analysis. Every strategy was deployed to do a *specific* job. "Is it working?"

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -152,6 +152,18 @@ the flat-but-running case above: a flat sleeve with a *registered, ticking* runt
 (fine); a `not_running` strategy has **no runtime behind it** (broken). When `runtime_registered` is `null`,
 the registry isn't visible on this host — say "runtime status unknown from here," don't assert either way.
 
+**Telemetry-verified liveness — `runtime_health`.** Beyond "is a runtime registered," the engine asks the
+runtime itself (`openclaw senpi status`) whether it's actually *working*, and sets `runtime_health` per
+strategy and per group. Narrate it honestly — a registered runtime is not automatically a healthy one:
+- **`live`** — registered and telemetry reports healthy. Only this earns "running / protected."
+- **`degraded`** — registered but telemetry reports **unhealthy** (scanner erroring, monitor stalled). It's
+  *running but not cleanly*: say **"⚠ runtime degraded — running but not healthy; check `openclaw senpi
+  status`,"** not a clean all-clear. Flagged in `meta.warnings` too.
+- **`not_running`** — no runtime at all (above). ⛔ NOT RUNNING / UNPROTECTED.
+- **`unknown`** — telemetry unavailable from here (no `openclaw` on this host, or a build without the RPC).
+  Say **"runtime liveness unverified from here"** — never upgrade `unknown` to "healthy/protected" or
+  downgrade it to "broken." This is the honest bar: **only `live` means "confirmed working."**
+
 ## Judge each strategy against its OWN mandate — not a momentum benchmark
 
 This is the core of the analysis. Every strategy was deployed to do a *specific* job. "Is it working?"

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.7.1"
+  version: "1.8.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -136,6 +136,21 @@ capital to redeploy elsewhere, and never "dead money."** That capital is *commit
 it's the dry powder the other half of the design needs to do its job. Only truly-free
 `idle_in_embedded` (and, with care, a *whole* strategy's idle) is redeployable — a flat sleeve of a
 live multi-wallet strategy is not.
+
+### "ACTIVE" ≠ running — a strategy with no runtime registered is NOT alive, and NOT protected
+
+`status: ACTIVE` only means the strategy *record* exists and is funded — it does **not** mean a runtime is
+actually running it. The engine checks the runtime registry and flags any strategy that is **ACTIVE +
+funded but has NO runtime registered** via `strategy_groups[].not_running` (and per-instance `not_running`
+/ `runtime_registered`), plus a `meta.warnings` line. Such a strategy is **not running at all** — its
+scanner has never ticked, so it has **no DSL and no guardrails** — even though it shows ACTIVE and holds
+capital. Report it as **⛔ NOT RUNNING / UNPROTECTED — funded but no runtime; no scanner, no DSL, no
+guardrails**, and tell the user to redeploy it via `senpi-strategy-ops`. **Never** call a `not_running`
+strategy "alive and waiting," "scanner is live," or "DSL-protected" — that is a false all-clear (a funded
+strategy sat exactly like this while the user believed it was protected and running). This is DISTINCT from
+the flat-but-running case above: a flat sleeve with a *registered, ticking* runtime is waiting for a signal
+(fine); a `not_running` strategy has **no runtime behind it** (broken). When `runtime_registered` is `null`,
+the registry isn't visible on this host — say "runtime status unknown from here," don't assert either way.
 
 ## Judge each strategy against its OWN mandate — not a momentum benchmark
 

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -226,33 +226,38 @@ def load_runtime_registry(meta):
 
     SOURCE OF TRUTH for a strategy's "what it does / how it works" — read from the DEPLOYED runtime.yaml
     the runtime itself registers in installed_runtimes.json (state dir). UNIVERSAL: covers user-authored
-    strategies too, not just catalog templates. Read-guarded + fail-open: any problem → ({}, None). A
+    strategies too, not just catalog templates. Read-guarded + fail-open: any problem → ({}, {}, set(), None). A
     meta.warnings note is added ONLY for a real parse error, not for a simply-absent registry file.
     Also returns a wallet_lower → runtime_id map (the `senpi status --runtime <id>` address, for the
-    telemetry liveness read). Returns (profiles_map, id_map, source)."""
+    telemetry liveness read). Returns (profiles_map, id_map, registered_wallets, source)."""
     state_dir = os.environ.get(STATE_DIR_ENV) or DEFAULT_STATE_DIR
     path = os.path.join(state_dir, REGISTRY_FILENAME)
     if not os.path.isfile(path):          # absent registry is normal, not an error
-        return {}, {}, None
+        return {}, {}, set(), None
     try:
         with open(path) as fh:
             raw = json.load(fh)
     except Exception as e:  # noqa — a corrupt registry is a real parse error worth surfacing
         meta.setdefault("warnings", []).append(
             f"runtime registry unreadable ({e}); mandates fall back to catalog")
-        return {}, {}, None
+        return {}, {}, set(), None
     entries = raw.get("runtimes", raw) if isinstance(raw, dict) else raw
     out = {}
     id_map = {}                            # wallet_lower → runtime id (the `senpi status --runtime <id>` key)
+    registered = set()                     # wallet_lower for EVERY registry entry — PRESENCE, independent of
+                                           # whether its runtime.yaml parses. A registered runtime with an
+                                           # unreadable/non-mapping mandate is still RUNNING, not "not running".
     for entry in (entries if isinstance(entries, list) else []):
         if not isinstance(entry, dict):
             continue
         wallet = entry.get("wallet")
         if not wallet:
             continue
+        wl = str(wallet).lower()
+        registered.add(wl)                 # a runtime IS registered for this wallet — mandate-parse aside
         rid = _field(entry, "id", "runtimeId", "runtime_id")   # address for the status/liveness read
         if rid:
-            id_map[str(wallet).lower()] = rid
+            id_map[wl] = rid
         text = entry.get("runtimeYamlContent")
         if text is None:
             ypath = entry.get("runtimeYamlPath")   # rarer form — a file path instead of inline content
@@ -271,8 +276,8 @@ def load_runtime_registry(meta):
                 f"runtime.yaml parse failed for {str(wallet)[:8]} ({e})")
             prof = None
         if prof:
-            out[str(wallet).lower()] = prof
-    return out, id_map, "registry"
+            out[wl] = prof
+    return out, id_map, registered, "registry"
 
 
 # ──────────────────────────────────────────── telemetry liveness (is a REGISTERED runtime actually working?)
@@ -284,27 +289,6 @@ def _note_telemetry_unavailable(meta, msg):
     if not meta.get("_telemetry_warned"):
         meta.setdefault("warnings", []).append(f"telemetry: {msg}")
         meta["_telemetry_warned"] = True
-
-
-def _deep_first(obj, keys, _depth=0):
-    """First non-None value for any of `keys`, depth-first through dicts/lists — the `senpi status --json`
-    payload shape isn't strictly pinned, so dig tolerantly."""
-    if _depth > 6 or obj is None:
-        return None
-    if isinstance(obj, dict):
-        for k in keys:
-            if obj.get(k) is not None:
-                return obj[k]
-        for v in obj.values():
-            r = _deep_first(v, keys, _depth + 1)
-            if r is not None:
-                return r
-    elif isinstance(obj, list):
-        for v in obj:
-            r = _deep_first(v, keys, _depth + 1)
-            if r is not None:
-                return r
-    return None
 
 
 def _fetch_runtime_status(runtime_id, meta):
@@ -351,11 +335,24 @@ def _fetch_runtime_status(runtime_id, meta):
 
 def _liveness_from_status(status):
     """Map a `senpi status` payload → runtime_health. The payload existing at all means the runtime is up
-    (the gateway answered for it); the health field refines healthy→'live' vs degraded/unhealthy→'degraded'.
-    None ⇒ 'unknown' (telemetry unavailable — never asserted as broken)."""
+    (the gateway answered for it); an explicit overall-health verdict refines healthy→'live' vs
+    degraded/unhealthy→'degraded'. None ⇒ 'unknown' (telemetry unavailable — never asserted as broken).
+
+    Reads the verdict ONLY from the top of the payload (or a well-known wrapper) — NOT via a deep search.
+    A deep search would pick up a per-scanner / per-order `status:"error"` on an otherwise-healthy runtime
+    and cry DEGRADED (a false alarm); the OVERALL verdict is a top-level concern."""
     if not isinstance(status, dict) or not status:
         return "unknown"
-    h = _deep_first(status, ["overallHealth", "health", "overall", "status"])
+    h = None
+    for scope in (status, status.get("data"), status.get("runtime"), status.get("result")):
+        if not isinstance(scope, dict):
+            continue
+        for k in ("overallHealth", "health", "overall", "status"):
+            if scope.get(k) is not None:
+                h = scope.get(k)
+                break
+        if h is not None:
+            break
     h = str(h).lower() if h is not None else None
     if h in ("degraded", "warn", "warning", "unhealthy", "failed", "error", "down", "false", "stopped"):
         return "degraded"
@@ -550,7 +547,7 @@ def fetch_strategies(client, meta):
     rows = sl if isinstance(sl, list) else _field(sl, "strategies", "data", default=[])
     # UNIVERSAL source of "what it does / how it works": the deployed runtime.yaml the runtime registers,
     # keyed by wallet — works for user-authored strategies, not just our catalog templates.
-    registry, runtime_id_map, registry_src = load_runtime_registry(meta)   # profiles + wallet→runtime_id
+    registry, runtime_id_map, registered_wallets, registry_src = load_runtime_registry(meta)  # profiles + ids + presence
     meta["registry_source"] = registry_src
     # OPTIONAL template enrichment (archetype/belief_plain/…), keyed by skill_name.
     catalog, catalog_src = load_catalog(meta)
@@ -587,7 +584,9 @@ def fetch_strategies(client, meta):
         # so it has NO DSL and NO guardrails despite "status: ACTIVE" (the exact trap that let a user think
         # a funded-but-never-registered strategy was live and protected). Only judgeable when the registry
         # is actually present on THIS host; an absent registry ⇒ unknown (never claim not-running from it).
-        runtime_registered = bool(registry_prof) if registry_src == "registry" else None
+        # PRESENCE-based, NOT mandate-parse: a registered runtime whose runtime.yaml we can't read/parse is
+        # still RUNNING (just undescribed) — keying off registry_prof would falsely call it "not running".
+        runtime_registered = (str(wallet).lower() in registered_wallets) if registry_src == "registry" else None
         not_running = bool(skill_name) and runtime_registered is False
         strategies.append({
             "name": _field(s, "tradingStrategyName", "name", default="strategy"),

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -29,6 +29,7 @@ engine always passes forceFetch. Per-strategy truth comes from live strategy_get
 import argparse
 import json
 import os
+import subprocess
 import sys
 import tempfile
 
@@ -50,6 +51,11 @@ CLOSED_HISTORY_PULL = 50    # closed positions to pull for the realized-PnL tota
 STATE_DIR_ENV = "SENPI_STATE_DIR"
 DEFAULT_STATE_DIR = os.path.expanduser("~/.openclaw/senpi-state")
 REGISTRY_FILENAME = "installed_runtimes.json"
+# Telemetry liveness (health check): `openclaw senpi status -r <runtime_id> --json` says whether a
+# REGISTERED runtime is actually WORKING (healthy vs degraded), not just present in the registry. Same
+# fail-open + fixture pattern as senpi-improve-trades' event-log read. Offline test hook: a JSON file at
+# $SENPI_STATUS_FIXTURE keyed {"<runtime_id>": {status payload}} is read instead of shelling out.
+STATUS_FIXTURE_ENV = "SENPI_STATUS_FIXTURE"
 
 CATALOG_REF = os.environ.get("SENPI_SKILLS_REF", "main")
 CATALOG_URL = f"https://raw.githubusercontent.com/Senpi-ai/senpi-skills/{CATALOG_REF}/strategies/catalog.json"
@@ -222,26 +228,31 @@ def load_runtime_registry(meta):
     the runtime itself registers in installed_runtimes.json (state dir). UNIVERSAL: covers user-authored
     strategies too, not just catalog templates. Read-guarded + fail-open: any problem → ({}, None). A
     meta.warnings note is added ONLY for a real parse error, not for a simply-absent registry file.
-    Returns (map, source)."""
+    Also returns a wallet_lower → runtime_id map (the `senpi status --runtime <id>` address, for the
+    telemetry liveness read). Returns (profiles_map, id_map, source)."""
     state_dir = os.environ.get(STATE_DIR_ENV) or DEFAULT_STATE_DIR
     path = os.path.join(state_dir, REGISTRY_FILENAME)
     if not os.path.isfile(path):          # absent registry is normal, not an error
-        return {}, None
+        return {}, {}, None
     try:
         with open(path) as fh:
             raw = json.load(fh)
     except Exception as e:  # noqa — a corrupt registry is a real parse error worth surfacing
         meta.setdefault("warnings", []).append(
             f"runtime registry unreadable ({e}); mandates fall back to catalog")
-        return {}, None
+        return {}, {}, None
     entries = raw.get("runtimes", raw) if isinstance(raw, dict) else raw
     out = {}
+    id_map = {}                            # wallet_lower → runtime id (the `senpi status --runtime <id>` key)
     for entry in (entries if isinstance(entries, list) else []):
         if not isinstance(entry, dict):
             continue
         wallet = entry.get("wallet")
         if not wallet:
             continue
+        rid = _field(entry, "id", "runtimeId", "runtime_id")   # address for the status/liveness read
+        if rid:
+            id_map[str(wallet).lower()] = rid
         text = entry.get("runtimeYamlContent")
         if text is None:
             ypath = entry.get("runtimeYamlPath")   # rarer form — a file path instead of inline content
@@ -261,7 +272,94 @@ def load_runtime_registry(meta):
             prof = None
         if prof:
             out[str(wallet).lower()] = prof
-    return out, "registry"
+    return out, id_map, "registry"
+
+
+# ──────────────────────────────────────────── telemetry liveness (is a REGISTERED runtime actually working?)
+# Registry presence says a runtime was DEPLOYED; telemetry says it's actually RUNNING/healthy. Same
+# fail-open + fixture pattern as senpi-improve-trades' event-log read: absence degrades to "unknown" (never
+# a false "broken"), and once a host shows no CLI we stop shelling out.
+def _note_telemetry_unavailable(meta, msg):
+    """One-time telemetry warning; marks meta so the rollup can say liveness is unverified (registry-only)."""
+    if not meta.get("_telemetry_warned"):
+        meta.setdefault("warnings", []).append(f"telemetry: {msg}")
+        meta["_telemetry_warned"] = True
+
+
+def _deep_first(obj, keys, _depth=0):
+    """First non-None value for any of `keys`, depth-first through dicts/lists — the `senpi status --json`
+    payload shape isn't strictly pinned, so dig tolerantly."""
+    if _depth > 6 or obj is None:
+        return None
+    if isinstance(obj, dict):
+        for k in keys:
+            if obj.get(k) is not None:
+                return obj[k]
+        for v in obj.values():
+            r = _deep_first(v, keys, _depth + 1)
+            if r is not None:
+                return r
+    elif isinstance(obj, list):
+        for v in obj:
+            r = _deep_first(v, keys, _depth + 1)
+            if r is not None:
+                return r
+    return None
+
+
+def _fetch_runtime_status(runtime_id, meta):
+    """`openclaw senpi status -r <id> --json` → parsed dict or None. FAIL-OPEN: no `openclaw` / non-zero
+    exit / unknown method / parse error → None + a one-time note; NEVER raises. `meta._telemetry_dead`
+    short-circuits once the host has no CLI. Offline test hook: $SENPI_STATUS_FIXTURE = JSON
+    {"<runtime_id>": {status payload}} is read instead of shelling out (tests use this — no subprocess)."""
+    if not runtime_id or meta.get("_telemetry_dead"):
+        return None
+    fixture = os.environ.get(STATUS_FIXTURE_ENV)
+    if fixture:
+        try:
+            with open(fixture) as fh:
+                data = json.load(fh)
+            v = data.get(str(runtime_id)) if isinstance(data, dict) else None
+            return v if isinstance(v, dict) else None
+        except Exception as e:  # noqa — a bad fixture is fail-open too
+            _note_telemetry_unavailable(meta, f"status fixture unreadable ({e})")
+            return None
+    try:
+        proc = subprocess.run(["openclaw", "senpi", "status", "-r", str(runtime_id), "--json"],
+                              capture_output=True, text=True, timeout=15)
+    except FileNotFoundError:                # not a runtime host → every call fails; stop shelling out
+        meta["_telemetry_dead"] = True
+        _note_telemetry_unavailable(meta, "openclaw CLI not found — runtime liveness unverified (registry-only)")
+        return None
+    except Exception as e:  # noqa — timeout / OS error → fail-open
+        _note_telemetry_unavailable(meta, f"status read failed ({e})")
+        return None
+    if proc.returncode != 0:
+        err = (proc.stderr or "")[:200]
+        if "unknown method" in err.lower():
+            meta["_telemetry_dead"] = True
+            _note_telemetry_unavailable(meta, "runtime build predates the status RPC — liveness unverified")
+        else:
+            _note_telemetry_unavailable(meta, f"status read exit {proc.returncode} ({err.strip()})")
+        return None
+    try:
+        return json.loads(proc.stdout or "null")
+    except Exception as e:  # noqa — malformed JSON → fail-open
+        _note_telemetry_unavailable(meta, f"status JSON parse failed ({e})")
+        return None
+
+
+def _liveness_from_status(status):
+    """Map a `senpi status` payload → runtime_health. The payload existing at all means the runtime is up
+    (the gateway answered for it); the health field refines healthy→'live' vs degraded/unhealthy→'degraded'.
+    None ⇒ 'unknown' (telemetry unavailable — never asserted as broken)."""
+    if not isinstance(status, dict) or not status:
+        return "unknown"
+    h = _deep_first(status, ["overallHealth", "health", "overall", "status"])
+    h = str(h).lower() if h is not None else None
+    if h in ("degraded", "warn", "warning", "unhealthy", "failed", "error", "down", "false", "stopped"):
+        return "degraded"
+    return "live"   # healthy/ok/running/live, or answered with no explicit health field → it's running
 
 
 # ──────────────────────────────────────────────────────────────── strategy profile (catalog enrichment)
@@ -452,7 +550,7 @@ def fetch_strategies(client, meta):
     rows = sl if isinstance(sl, list) else _field(sl, "strategies", "data", default=[])
     # UNIVERSAL source of "what it does / how it works": the deployed runtime.yaml the runtime registers,
     # keyed by wallet — works for user-authored strategies, not just our catalog templates.
-    registry, registry_src = load_runtime_registry(meta)   # wallet_lower → runtime profile
+    registry, runtime_id_map, registry_src = load_runtime_registry(meta)   # profiles + wallet→runtime_id
     meta["registry_source"] = registry_src
     # OPTIONAL template enrichment (archetype/belief_plain/…), keyed by skill_name.
     catalog, catalog_src = load_catalog(meta)
@@ -590,6 +688,18 @@ def fetch_strategies(client, meta):
             strategies = list(ex.map(hydrate, strategies))
     except Exception:  # noqa
         strategies = [hydrate(s) for s in strategies]
+    # TELEMETRY LIVENESS — for each strategy WITH a registered runtime, ask the runtime itself (senpi
+    # status) whether it's actually healthy, not just registered. runtime_health: not_running (no registry)
+    # / degraded (registered but reports unhealthy) / live (healthy) / unknown (telemetry unavailable — do
+    # NOT assert broken). Fail-open + short-circuited by _telemetry_dead; sequential (few per user).
+    for s in strategies:
+        if s.get("not_running"):
+            s["runtime_health"] = "not_running"
+        elif s.get("runtime_registered") is not True:
+            s["runtime_health"] = "unknown"        # no registry on this host, or a custom/no-skill one-off
+        else:
+            rid = runtime_id_map.get(str(s.get("wallet")).lower())
+            s["runtime_health"] = _liveness_from_status(_fetch_runtime_status(rid, meta) if rid else None)
     # Roll up any strategy reported ACTIVE but holding $0 (empty wallet) — status/clearinghouse mismatch.
     dormant = [s["name"] for s in strategies if s.get("empty")]
     if dormant:
@@ -607,6 +717,15 @@ def fetch_strategies(client, meta):
             f"{len(not_running)} strategy(ies) show status ACTIVE but have NO runtime registered — NOT "
             f"running: no scanner, no DSL, no guardrails despite 'ACTIVE'. Report as UNPROTECTED / not "
             f"running, never as live or 'waiting for a setup': {', '.join(str(n) for n in not_running)}")
+    # Registered but telemetry says the runtime is DEGRADED/unhealthy — running, but not cleanly (scanner
+    # erroring, monitor stalled, etc.). Distinct from not_running (no runtime) and from live (healthy).
+    degraded = [s["name"] for s in strategies if s.get("runtime_health") == "degraded"]
+    if degraded:
+        meta["degraded_runtimes"] = degraded
+        meta.setdefault("warnings", []).append(
+            f"{len(degraded)} strategy(ies) have a runtime that telemetry reports DEGRADED/unhealthy — "
+            f"registered but not working cleanly (check `openclaw senpi status`): "
+            f"{', '.join(str(d) for d in degraded)}")
     return strategies
 
 
@@ -973,6 +1092,10 @@ def group_strategies(strategies, meta):
             "not_running": any(bool(s.get("not_running")) for s in insts),
             "runtime_registered": (None if any(s.get("runtime_registered") is None for s in insts)
                                    else all(bool(s.get("runtime_registered")) for s in insts)),
+            # runtime_health = the WORST across instances (not_running > degraded > unknown > live) — one
+            # dead/degraded sleeve makes the whole strategy not-fully-live.
+            "runtime_health": next((v for v in ("not_running", "degraded", "unknown", "live")
+                                    if any(s.get("runtime_health") == v for s in insts)), "unknown"),
             "flat_instances": flat_instances,
             "profile_source": prof.get("source"),
         })

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -716,7 +716,8 @@ def fetch_strategies(client, meta):
         meta.setdefault("warnings", []).append(
             f"{len(not_running)} strategy(ies) show status ACTIVE but have NO runtime registered — NOT "
             f"running: no scanner, no DSL, no guardrails despite 'ACTIVE'. Report as UNPROTECTED / not "
-            f"running, never as live or 'waiting for a setup': {', '.join(str(n) for n in not_running)}")
+            f"running, never as live or 'waiting for a setup': {', '.join(str(n) for n in not_running)}. "
+            f"Confirm + fix with senpi-strategy-ops `diagnose.py <id>` (then close.py → redeploy).")
     # Registered but telemetry says the runtime is DEGRADED/unhealthy — running, but not cleanly (scanner
     # erroring, monitor stalled, etc.). Distinct from not_running (no runtime) and from live (healthy).
     degraded = [s["name"] for s in strategies if s.get("runtime_health") == "degraded"]
@@ -724,7 +725,8 @@ def fetch_strategies(client, meta):
         meta["degraded_runtimes"] = degraded
         meta.setdefault("warnings", []).append(
             f"{len(degraded)} strategy(ies) have a runtime that telemetry reports DEGRADED/unhealthy — "
-            f"registered but not working cleanly (check `openclaw senpi status`): "
+            f"registered but not working cleanly. Confirm the cause with senpi-strategy-ops "
+            f"`diagnose.py <id>` (scanner registered? ticked? BARREN? erroring?): "
             f"{', '.join(str(d) for d in degraded)}")
     return strategies
 

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -483,6 +483,14 @@ def fetch_strategies(client, meta):
         # template deploy (skill_name present ⟹ built-in DSL exit by the validator invariant). Config-
         # level protection posture, not a live per-position DSL-tracking check.
         has_exit = bool(registry_prof and registry_prof.get("has_exit"))
+        # RUNTIME LIVENESS — is a runtime actually REGISTERED for this strategy? The runtime records every
+        # deployed strategy in installed_runtimes.json (keyed by wallet). A skill_name strategy that is
+        # ACTIVE + funded but ABSENT from that registry has NO runtime behind it — its scanner never ran,
+        # so it has NO DSL and NO guardrails despite "status: ACTIVE" (the exact trap that let a user think
+        # a funded-but-never-registered strategy was live and protected). Only judgeable when the registry
+        # is actually present on THIS host; an absent registry ⇒ unknown (never claim not-running from it).
+        runtime_registered = bool(registry_prof) if registry_src == "registry" else None
+        not_running = bool(skill_name) and runtime_registered is False
         strategies.append({
             "name": _field(s, "tradingStrategyName", "name", default="strategy"),
             "wallet": wallet,
@@ -494,7 +502,12 @@ def fetch_strategies(client, meta):
             "total_withdrawn": _f(s, "totalWithdrawn", "total_withdrawn", default=None),
             "skill_name": skill_name,
             "skill_version": skill_version,
-            "protected": bool(has_exit or skill_name),
+            # PROTECTED — config posture (deployed runtime.yaml ships an `exit` block, or a template deploy
+            # carries the validator-guaranteed DSL). But a strategy with NO registered runtime is running
+            # NOTHING, so it is NOT protected regardless of config — force False when not_running.
+            "protected": False if not_running else bool(has_exit or skill_name),
+            "runtime_registered": runtime_registered,   # True | False | None (unknown — no registry here)
+            "not_running": not_running,                  # ACTIVE + funded skill strategy, no runtime → dead
             # The strategy's declared job — `profile.description` from its DEPLOYED runtime.yaml (the
             # runtime registers it), plus optional catalog facets. The yardstick to judge it against.
             "profile": profile,
@@ -584,6 +597,16 @@ def fetch_strategies(client, meta):
         meta.setdefault("warnings", []).append(
             f"{len(dormant)} strategy(ies) report status ACTIVE but hold $0 (empty wallet) — likely just "
             f"closed, funds returned to embedded (or never funded): {', '.join(str(d) for d in dormant)}")
+    # Roll up any ACTIVE + funded strategy with NO runtime registered — status says ACTIVE but there is no
+    # runtime, so it is NOT running: no scanner, no DSL, no guardrails. The "ACTIVE record ≠ live runtime"
+    # trap — must be surfaced as unprotected/not-running, never as "alive and waiting".
+    not_running = [s["name"] for s in strategies if s.get("not_running")]
+    if not_running:
+        meta["not_running"] = not_running
+        meta.setdefault("warnings", []).append(
+            f"{len(not_running)} strategy(ies) show status ACTIVE but have NO runtime registered — NOT "
+            f"running: no scanner, no DSL, no guardrails despite 'ACTIVE'. Report as UNPROTECTED / not "
+            f"running, never as live or 'waiting for a setup': {', '.join(str(n) for n in not_running)}")
     return strategies
 
 
@@ -942,8 +965,14 @@ def group_strategies(strategies, meta):
             "instances": instances,                             # per-wallet detail
             "totals": totals,                                   # summed across all wallets
             # protected ONLY if ALL instances are protected — a strategy with one unguarded sleeve is not
-            # fully protected.
+            # fully protected. (An instance with no registered runtime is forced unprotected upstream.)
             "protected": all(bool(s.get("protected")) for s in insts),
+            # not_running: ANY instance is ACTIVE + funded but has no runtime registered → the strategy (or
+            # a sleeve of it) isn't actually running. runtime_registered: True (all registered) / False
+            # (some missing) / None (unknown — no registry on this host, don't assert either way).
+            "not_running": any(bool(s.get("not_running")) for s in insts),
+            "runtime_registered": (None if any(s.get("runtime_registered") is None for s in insts)
+                                   else all(bool(s.get("runtime_registered")) for s in insts)),
             "flat_instances": flat_instances,
             "profile_source": prof.get("source"),
         })

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -145,6 +145,74 @@ def test_profile_description_from_runtime_registry():
     assert res["meta"]["profile_source"] in ("registry", "mixed")
 
 
+def test_active_but_no_runtime_is_not_running():
+    """A skill_name strategy that is ACTIVE + funded but ABSENT from the runtime registry has NO runtime
+    behind it — the engine must flag it not_running + unprotected, never 'alive/protected'. The registry
+    IS present (kodiak only), so a different funded wallet is judgeable as 'no runtime registered' — the
+    exact gibbon case where the user was told a never-registered strategy was live and DSL-protected."""
+    GHOST = "0xGHOST00000000000000000000000000000ghost"
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"total_balance_usd": 2000, "total_withdrawable": 2000,
+                                  "total_usdc_in_hyperliquid": 0, "token_balances": []},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "gibbon", "skillName": "gibbon", "status": "ACTIVE",
+             "totalFunded": 2000, "strategyWalletAddress": GHOST}]},
+        f"strategy_get_clearinghouse_state::{GHOST.lower()}": {
+            "main": {"marginSummary": {"accountValue": "2000"}, "withdrawable": "2000", "assetPositions": []},
+            "xyz": {"marginSummary": {"accountValue": "2000"}, "withdrawable": "2000", "assetPositions": []}},
+    }
+    old = os.environ.get("SENPI_STATE_DIR")
+    os.environ["SENPI_STATE_DIR"] = REGISTRY_DIR   # registry present (kodiak only) → GHOST wallet is absent
+    try:
+        res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    finally:
+        if old is None:
+            os.environ.pop("SENPI_STATE_DIR", None)
+        else:
+            os.environ["SENPI_STATE_DIR"] = old
+    strat = {s["name"]: s for s in res["strategies"]}["gibbon"]
+    assert strat["runtime_registered"] is False   # registry present, wallet not in it → no runtime
+    assert strat["not_running"] is True
+    assert strat["protected"] is False            # not running ⇒ not protected, despite skill_name
+    assert res["meta"].get("not_running") == ["gibbon"]
+    assert any("not running" in w.lower() for w in res["meta"]["warnings"])
+    grp = {g["label"]: g for g in res["strategy_groups"]}.get("gibbon")
+    assert grp is not None and grp["not_running"] is True and grp["protected"] is False
+
+
+def test_registry_absent_leaves_runtime_status_unknown():
+    """With NO registry on this host (SENPI_STATE_DIR unset/empty), the engine must NOT claim not_running —
+    runtime_registered is None (unknown) and protected falls back to the config posture."""
+    GHOST = "0xNOREG000000000000000000000000000000nrg"
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"total_balance_usd": 2000, "total_withdrawable": 2000,
+                                  "total_usdc_in_hyperliquid": 0, "token_balances": []},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "gibbon", "skillName": "gibbon", "status": "ACTIVE",
+             "totalFunded": 2000, "strategyWalletAddress": GHOST}]},
+        f"strategy_get_clearinghouse_state::{GHOST.lower()}": {
+            "main": {"marginSummary": {"accountValue": "2000"}, "withdrawable": "2000", "assetPositions": []},
+            "xyz": {"marginSummary": {"accountValue": "2000"}, "withdrawable": "2000", "assetPositions": []}},
+    }
+    old = os.environ.get("SENPI_STATE_DIR")
+    os.environ["SENPI_STATE_DIR"] = os.path.join(HERE, "fixtures", "does_not_exist")
+    try:
+        res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+    finally:
+        if old is None:
+            os.environ.pop("SENPI_STATE_DIR", None)
+        else:
+            os.environ["SENPI_STATE_DIR"] = old
+    strat = {s["name"]: s for s in res["strategies"]}["gibbon"]
+    assert strat["runtime_registered"] is None    # no registry visible → unknown, do not assert
+    assert strat["not_running"] is False           # never claim not-running without the registry
+    assert "not_running" not in res["meta"]
+
+
 def test_multi_wallet_strategy_groups_into_one():
     """A STRATEGY IS ALL ITS WALLETS. cougar deploys as TWO instances on TWO wallets (cougar-long +
     cougar-short, sharing `group: cougar` in their runtime.yamls). `strategy_list` returns them as two

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -276,6 +276,72 @@ def test_registered_runtime_no_telemetry_is_unknown():
     assert strat["runtime_health"] == "unknown"
 
 
+def test_nested_component_status_does_not_falsely_degrade():
+    """A healthy runtime whose telemetry carries NO top-level health verdict but DOES have a nested
+    per-scanner `status:"error"` must read 'live', not 'degraded'. Deep-matching a bare `status` anywhere
+    would cry DEGRADED on an otherwise-fine runtime — a false alarm."""
+    res = _run_with_status({"kodiak-main": {"activePositions": 2,
+                                            "scanners": [{"name": "kodiak_signals", "status": "error"}]}})
+    strat = {s["name"]: s for s in res["strategies"]}["kodiak"]
+    assert strat["runtime_health"] == "live"
+    assert "degraded_runtimes" not in res["meta"]
+
+
+def test_toplevel_status_still_classifies_degraded():
+    """Guard the other side of the liveness fix: a TOP-LEVEL `status` verdict is still honored — a runtime
+    that reports status 'stopped' at the top level → degraded (we only ignore NESTED bare status)."""
+    res = _run_with_status({"kodiak-main": {"status": "stopped"}})
+    strat = {s["name"]: s for s in res["strategies"]}["kodiak"]
+    assert strat["runtime_health"] == "degraded"
+
+
+def test_registered_but_unparseable_yaml_is_still_running():
+    """A runtime that IS registered (wallet present in installed_runtimes.json with an id) but whose
+    runtimeYamlContent doesn't parse to a mapping must be treated as REGISTERED + running — NEVER flagged
+    not_running/UNPROTECTED. Registration is PRESENCE, independent of whether we can read its mandate.
+    Mirror-image of the false-all-clear this PR fixes: don't false-alarm a fine runtime we can't describe."""
+    UNMAP = "0xUNMAPPED0000000000000000000000000unmapd"
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"total_balance_usd": 2000, "total_withdrawable": 2000,
+                                  "total_usdc_in_hyperliquid": 0, "token_balances": []},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "myquant", "skillName": "myquant", "status": "ACTIVE",
+             "totalFunded": 2000, "strategyWalletAddress": UNMAP}]},
+        f"strategy_get_clearinghouse_state::{UNMAP.lower()}": {
+            "main": {"marginSummary": {"accountValue": "2000"}, "withdrawable": "2000", "assetPositions": []},
+            "xyz": {"marginSummary": {"accountValue": "2000"}, "withdrawable": "2000", "assetPositions": []}},
+    }
+    # a registry that HAS this wallet (id set) but a non-mapping runtimeYamlContent (parses to a list)
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "installed_runtimes.json"), "w") as f:
+            json.dump({"version": 1, "runtimes": [
+                {"id": "myquant-main", "wallet": UNMAP,
+                 "runtimeYamlContent": "- this\n- is a list\n- not a mapping\n"}]}, f)
+        status_path = os.path.join(d, "status.json")
+        with open(status_path, "w") as f:
+            json.dump({"myquant-main": {"overallHealth": "healthy"}}, f)
+        saved = {k: os.environ.get(k) for k in ("SENPI_STATE_DIR", "SENPI_STATUS_FIXTURE")}
+        os.environ["SENPI_STATE_DIR"] = d
+        os.environ["SENPI_STATUS_FIXTURE"] = status_path
+        try:
+            res = portfolio.run(portfolio._FixtureClient(fixture), want_market=False)
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+    strat = {s["name"]: s for s in res["strategies"]}["myquant"]
+    assert strat["runtime_registered"] is True      # present in the registry → registered (mandate-parse aside)
+    assert strat["not_running"] is False            # registered ⇒ NOT "not running"
+    assert strat["runtime_health"] == "live"        # telemetry says healthy
+    assert strat["protected"] is True               # skill deploy ⇒ validator-guaranteed DSL, still protected
+    assert strat["profile"] is None                 # mandate unparseable — undescribed, but that must NOT
+    assert "not_running" not in res["meta"]          # downgrade it to not-running
+
+
 def test_multi_wallet_strategy_groups_into_one():
     """A STRATEGY IS ALL ITS WALLETS. cougar deploys as TWO instances on TWO wallets (cougar-long +
     cougar-short, sharing `group: cougar` in their runtime.yamls). `strategy_list` returns them as two

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -213,6 +213,69 @@ def test_registry_absent_leaves_runtime_status_unknown():
     assert "not_running" not in res["meta"]
 
 
+def _kodiak_active_fixture():
+    """One ACTIVE kodiak strategy whose wallet matches the registry fixture (id=kodiak-main)."""
+    return {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"total_balance_usd": 200, "total_withdrawable": 200,
+                                  "total_usdc_in_hyperliquid": 0, "token_balances": []},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "kodiak", "strategyWalletAddress": KODIAK_WALLET, "status": "ACTIVE"}]},
+        f"strategy_get_clearinghouse_state::{KODIAK_WALLET.lower()}": {
+            "main": {"marginSummary": {"accountValue": "200"}, "withdrawable": "200", "assetPositions": []},
+            "xyz": {"marginSummary": {"accountValue": "200"}, "withdrawable": "200", "assetPositions": []}},
+    }
+
+
+def _run_with_status(status_by_id):
+    """Run the engine with the registry present (kodiak registered) and a `senpi status` telemetry fixture
+    keyed by runtime id — no subprocess. Returns the result dict."""
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as tf:
+        json.dump(status_by_id, tf)
+        status_path = tf.name
+    saved = {k: os.environ.get(k) for k in ("SENPI_STATE_DIR", "SENPI_STATUS_FIXTURE")}
+    os.environ["SENPI_STATE_DIR"] = REGISTRY_DIR
+    os.environ["SENPI_STATUS_FIXTURE"] = status_path
+    try:
+        return portfolio.run(portfolio._FixtureClient(_kodiak_active_fixture()), want_market=False)
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        os.unlink(status_path)
+
+
+def test_registered_runtime_healthy_status_is_live():
+    """A registered runtime whose `senpi status` telemetry reports healthy → runtime_health 'live'."""
+    res = _run_with_status({"kodiak-main": {"overallHealth": "healthy", "activePositions": 0}})
+    strat = {s["name"]: s for s in res["strategies"]}["kodiak"]
+    assert strat["runtime_registered"] is True
+    assert strat["runtime_health"] == "live"
+    assert "degraded_runtimes" not in res["meta"]
+
+
+def test_registered_runtime_degraded_status_is_flagged():
+    """Registered runtime whose telemetry reports degraded/unhealthy → runtime_health 'degraded' + warning
+    (running, but not cleanly — distinct from not_running and from live)."""
+    res = _run_with_status({"kodiak-main": {"overallHealth": "degraded"}})
+    strat = {s["name"]: s for s in res["strategies"]}["kodiak"]
+    assert strat["runtime_health"] == "degraded"
+    assert res["meta"].get("degraded_runtimes") == ["kodiak"]
+    assert any("degraded" in w.lower() for w in res["meta"]["warnings"])
+
+
+def test_registered_runtime_no_telemetry_is_unknown():
+    """Registered runtime but telemetry has no entry for it (and no subprocess) → runtime_health 'unknown'
+    — liveness unverified, never asserted broken."""
+    res = _run_with_status({"some-other-runtime-id": {"overallHealth": "healthy"}})
+    strat = {s["name"]: s for s in res["strategies"]}["kodiak"]
+    assert strat["runtime_registered"] is True
+    assert strat["runtime_health"] == "unknown"
+
+
 def test_multi_wallet_strategy_groups_into_one():
     """A STRATEGY IS ALL ITS WALLETS. cougar deploys as TWO instances on TWO wallets (cougar-long +
     cougar-short, sharing `group: cougar` in their runtime.yamls). `strategy_list` returns them as two


### PR DESCRIPTION
## Why

A user's **health check** reported a funded strategy as *"gibbon — ACTIVE — Scanner is live — Runs with a DSL exit"* when it had **no runtime at all** (registration failed) — zero scanner spans, ever. A false all-clear on the primary "is my stuff OK?" surface. Root cause: `portfolio.py` inferred `protected` from **config** (`has_exit or skill_name`) and never checked whether a runtime actually exists or is running. Improve-trades was built on telemetry; portfolio never got the equivalent.

## What (two layers)

**1. Registry check** — is a runtime even registered?
- For each ACTIVE strategy, cross-check its wallet against `installed_runtimes.json`. A `skill_name` strategy that's funded but **absent** → `runtime_registered=False`, `not_running=True`, `protected` forced **False**, + a `meta.warnings` line. Registry absent on the host → `runtime_registered=None` (unknown) — never asserts not-running without evidence.

**2. Telemetry-verified liveness** — is the registered runtime actually *working*?
- Same **fail-open + fixture** pattern as senpi-improve-trades' event-log read: `load_runtime_registry` now also returns `wallet→runtime_id`, and a per-runtime `openclaw senpi status -r <id> --json` read sets **`runtime_health`**:
  - **`live`** — registered + healthy (only this = "confirmed working")
  - **`degraded`** — registered but telemetry reports unhealthy (running, not cleanly) + warning
  - **`not_running`** — no runtime at all
  - **`unknown`** — telemetry unavailable from this host (never asserted broken)
- Short-circuits once the host shows no CLI; offline test hook `SENPI_STATUS_FIXTURE`.

**SKILL.md (1.8.0)** — narrate it honestly: `ACTIVE` ≠ running; only `live` earns "running/protected"; `degraded` = "running but not healthy, check it"; `not_running` = ⛔ NOT RUNNING / UNPROTECTED; `unknown` = "liveness unverified from here." Explicitly distinct from a *flat-but-running* selective strategy.

## Behavioral change
Separates three states the old health check collapsed into "alive and waiting": **live** (fine), **degraded** (running but unhealthy), and **not running at all** (broken). That's the false all-clear this fixes — proven on the exact gibbon case.

**tests:** +5 (registry present/absent; telemetry live/degraded/unknown). Full suite **32/32**. Independent of #462. Closes #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)