### PR TITLE
Guardrail: validate coin symbols vs live instruments before funding (xyz: prefix)

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.4.0"
+  version: "2.5.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -222,6 +222,12 @@ the user it's trading.
   author → `deploy.py`.
 - **Falling back to a raw `strategy_create_custom_strategy`** when a scanner won't fire — that makes an
   empty custom-position strategy with **no DSL / no automated exits**. Repair the package instead.
+- **Creating with a coin that isn't a live instrument** — a bare `NVDA` instead of `xyz:NVDA` (XYZ
+  equities/indices/metals need the `xyz:` prefix) rejects every position; on a raw
+  `strategy_create_custom_strategy` the strategy is marked `FAILED` **after funding**, parking the capital
+  (the M404726 incident). `deploy.py`'s smoke gate blocks this pre-fund; for a raw create, dry-run first
+  (`estimate_custom_strategy_positions_opening`, or `validate_universe.py --coins …`). Full rule:
+  [`references/coin-symbols.md`](references/coin-symbols.md).
 - **Declaring it "fixed" without a tick** — a redeploy that returns `ACTIVE` is not a fix. Re-run
   `diagnose.py` and confirm a signal emitted.
 - **If a diagnosis doesn't resolve it fast and money is parked idle**, `close.py <id>` to return the funds,

--- a/senpi-strategy-ops/references/coin-symbols.md
+++ b/senpi-strategy-ops/references/coin-symbols.md
@@ -1,0 +1,38 @@
+# Coin symbols must be LIVE instruments — the `xyz:` prefix rule
+
+**Every coin you name — a scan's `signal.asset`, a raw `positions[].coin`, a hardcoded whitelist — must be
+an exact live Hyperliquid instrument.** Get it wrong and the order is REJECTED. On the raw-create path the
+whole strategy is then marked **FAILED after funding**, and the capital sits parked in the sub-wallet until
+someone recovers it.
+
+> **The incident this exists to prevent (M404726):** coins were passed as `NVDA`, `AVGO`, `SKHX` instead of
+> `xyz:NVDA`, `xyz:AVGO`, `xyz:SKHX`. Every position rejected → three strategies marked `FAILED` → ~$6,700
+> parked in sub-wallets. Root cause: the `xyz:` prefix was omitted and nothing dry-ran the coins before funding.
+
+## The rule
+- **Crypto perps (main DEX):** plain symbol — `BTC`, `ETH`, `SOL`, `HYPE`.
+- **XYZ DEX (equities, indices, metals, commodities):** **MUST carry the `xyz:` prefix** — `xyz:NVDA`,
+  `xyz:AVGO`, `xyz:XYZ100`, `xyz:BRENTOIL`, `xyz:GOLD`. A bare `NVDA` is **not** a live instrument; it rejects.
+- The source of truth for what's live is **`market_list_instruments`** — never emit a symbol from memory.
+
+## Validate BEFORE money moves — by path
+
+**Runtime strategies (`deploy.py`):** the pre-fund **smoke gate** runs `scan()` once and cross-checks every
+emitted `asset` against the live instrument list; a bare `NVDA` is **BLOCKED before any wallet is funded**
+(`did you mean 'xyz:NVDA'?`). Nothing to do — just don't `--no-smoke` past a real block.
+
+**Raw custom strategies (`strategy_create_custom_strategy` / `create_position`):** these run through **no**
+deploy gate — you must check first:
+1. **Dry-run** with `estimate_custom_strategy_positions_opening` (read-only; places no orders). A bad coin
+   shows up as a failed/insufficient position. Only create once the estimate is clean.
+2. Or preflight the coin list directly:
+   ```
+   python3 senpi-strategy-ops/scripts/validate_universe.py --coins xyz:NVDA,AVGO,BTC
+   ```
+   → flags `AVGO` with `→ did you mean 'xyz:AVGO'?` and exits non-zero. Fix, then create.
+
+## If a strategy already FAILED
+The funds are **NOT lost.** They sit `withdrawable` on-chain in the strategy sub-wallet — check with
+`strategy_get_clearinghouse_state`. `FAILED` is a Senpi *record* status, not an on-chain freeze; Senpi
+custodies the wallet key, so it's recoverable via the platform's failure-refund (which it queues) or an ops
+withdrawal. **Never conclude "locked/lost"** from a `FAILED` status — read the chain first.

--- a/senpi-strategy-ops/scripts/_smoke.py
+++ b/senpi-strategy-ops/scripts/_smoke.py
@@ -142,12 +142,33 @@ def sizing_warnings(signals, strategy_margin_pct=None):
 # orchestration (imported by deploy.py / diagnose.py)
 # ======================================================================================
 
+def _unknown_asset_violations(signals, live_assets):
+    """Emitted assets whose EXACT string is not a live Hyperliquid instrument — the runtime sends them
+    as-is and the venue REJECTS (a bare `NVDA` when only `xyz:NVDA` is live). The xyz-prefix incident
+    class. Returns violation strings with the prefixed suggestion. No live set ⇒ [] (can't check)."""
+    live = live_assets if isinstance(live_assets, (set, frozenset)) else set(live_assets or [])
+    if not live:
+        return []
+    out = []
+    for i, s in enumerate(signals if isinstance(signals, list) else []):
+        if not isinstance(s, dict):
+            continue
+        a = s.get("asset")
+        if not isinstance(a, str) or not a or a in live:
+            continue
+        sug = next((c for c in (f"xyz:{a}", a.upper(), f"xyz:{a.upper()}") if c in live), None)
+        hint = f" — did you mean '{sug}'?" if sug else " — not a live instrument"
+        out.append(f"signal[{i}]: asset '{a}' will REJECT on Hyperliquid{hint} "
+                   f"(XYZ equities/indices/metals need the 'xyz:' prefix)")
+    return out
+
+
 def _resolve_scan_dir(runtime_path, es):
     sub = (es.get("path") or ".").lstrip("./")
     return (Path(runtime_path).parent / sub).resolve()
 
 
-def smoke(runtime_path, es, wallet=None, timeout=None, strategy_margin_pct=None):
+def smoke(runtime_path, es, wallet=None, timeout=None, strategy_margin_pct=None, live_assets=None):
     """Run one scan() and classify it. Returns:
       {status, detail, signals, violations, sizing_warnings, traceback, returned_repr, n_signals}
     status ∈ clean|empty|threw|bad-return|bad-shape|unloadable|timeout|setup-error (BLOCK/WARN sets above).
@@ -193,6 +214,8 @@ def smoke(runtime_path, es, wallet=None, timeout=None, strategy_margin_pct=None)
                 "signals": [], "violations": [], "sizing_warnings": [], "traceback": "",
                 "returned_repr": raw.get("returned_repr", ""), "n_signals": 0}
     violations = validate_signals(signals, schema)
+    if live_assets:  # strict: an emitted asset not in the live instrument list will REJECT on-venue
+        violations = violations + _unknown_asset_violations(signals, live_assets)
     sizing = sizing_warnings(signals, strategy_margin_pct)
     if violations:
         return {"status": "bad-shape",

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -169,17 +169,25 @@ def cmd_create(pkg, a, log):
         log(f"  (universe preflight skipped: {e})")
 
     # Smoke gate — run scan() ONCE before funding any wallet. A package strategy exists to run a
-    # PRODUCING scanner; funding one whose scan() throws / returns a non-list / emits a shape that fails
-    # signal_data_schema just parks capital in a strategy that can't trade (the divergence-play incident).
-    # Blocks ONLY on an unambiguous defect (threw / bad-return / bad-shape); an empty result (a
+    # PRODUCING scanner; funding one whose scan() throws / returns a non-list / emits a bad shape / won't
+    # import / emits a coin that isn't a live instrument just parks capital in a strategy that can't trade
+    # (the divergence-play + xyz:-prefix incidents). Blocks on any such defect; an empty result (a
     # legitimately quiet strategy) or a harness hiccup (setup-error/timeout) just warns and proceeds.
     if not a.no_smoke:
+        # Live instrument set for the STRICT emitted-asset check (best-effort — no token/network → skip it).
+        live_assets = None
+        try:
+            import validate_universe as _vu
+            live_assets = _vu.live_instruments()
+        except Exception as e:  # noqa — can't reach the live list → skip this cross-check, don't block
+            log(f"  (emitted-asset check skipped: {e})")
         for inst in pkg.instances:
             es = inst.external_scanner
             if not es:
                 continue  # a pure position_tracker/built-in package has nothing to smoke here
             smp = (inst.runtime_doc or {}).get("strategy", {}).get("margin_pct") if inst.runtime_doc else None
-            v = _smoke.smoke(str(inst.runtime_path), es, wallet=_smoke.ZERO_WALLET, strategy_margin_pct=smp)
+            v = _smoke.smoke(str(inst.runtime_path), es, wallet=_smoke.ZERO_WALLET,
+                             strategy_margin_pct=smp, live_assets=live_assets)
             for w in v.get("sizing_warnings", []):  # loud, but not a hard block — sizing is a judgment call
                 log(f"  [{inst.name}] ⚠ SIZING: {w}")
             if v["status"] in _smoke.BLOCK:

--- a/senpi-strategy-ops/scripts/validate_universe.py
+++ b/senpi-strategy-ops/scripts/validate_universe.py
@@ -75,9 +75,63 @@ def package_tickers(pkg_dir):
 
 def unknown_tickers(tickers, live):
     """Tickers with no live instrument in either form. Scanners on the xyz DEX prefix bare names
-    in code (`f"xyz:{token}"`), so a bare ticker is valid if `T` or `xyz:T` is live."""
+    in code (`f"xyz:{token}"`), so a bare ticker is valid if `T` or `xyz:T` is live.
+
+    LENIENT BY DESIGN — checks hardcoded INPUT tickers, trusting scan() to add the `xyz:` prefix at
+    runtime. To validate the ACTUAL coin string sent to Hyperliquid (a raw positions[].coin or an emitted
+    signal.asset), use unknown_symbols() — a bare `NVDA` there WILL reject even if `xyz:NVDA` is live."""
     return sorted(t for t in tickers
                   if t not in live and (":" in t or f"xyz:{t}" not in live))
+
+
+def suggest_symbol(sym, live):
+    """Best live-instrument match for a symbol that isn't live exactly as typed (else None). Chiefly maps a
+    bare XYZ equity/index/metal (`NVDA`) to its real prefixed name (`xyz:NVDA`)."""
+    if not isinstance(sym, str) or sym in live:
+        return None
+    for cand in (f"xyz:{sym}", sym.upper(), f"xyz:{sym.upper()}", sym.split(":")[-1].upper()):
+        if cand in live:
+            return cand
+    return None
+
+
+def unknown_symbols(symbols, live):
+    """STRICT: coin strings whose EXACT value is not a live instrument — i.e. exactly what Hyperliquid would
+    REJECT. Returns [{symbol, suggestion}]. Use for a raw positions[].coin / emitted signal.asset (the real
+    reject path), NOT unknown_tickers (which leniently assumes the scan code prefixes bare names)."""
+    out = []
+    for s in symbols:
+        if not isinstance(s, str) or not s or s in live:
+            continue
+        out.append({"symbol": s, "suggestion": suggest_symbol(s, live)})
+    return out
+
+
+def _check_coins(coins_arg, as_json):
+    """Raw-create preflight: validate explicit coin strings (positions[].coin) against the live instrument
+    list, EXACTLY as Hyperliquid receives them. A bare XYZ equity/index/metal (`NVDA`) is flagged with its
+    prefixed suggestion (`xyz:NVDA`). Run BEFORE strategy_create_custom_strategy / create_position — an
+    invalid coin marks the strategy FAILED *after* funding, parking the capital."""
+    syms = [c.strip() for c in coins_arg.split(",") if c.strip()]
+    try:
+        live = live_instruments()
+    except Exception as e:  # noqa — no token/network must be loud, never a silent pass
+        print(json.dumps({"error": f"live instrument list unavailable: {e}"}) if as_json
+              else f"ERROR: live instrument list unavailable: {e}", file=sys.stderr)
+        return 2
+    bad = unknown_symbols(syms, live)
+    if as_json:
+        print(json.dumps({"checked": syms, "invalid": bad, "ok": not bad}, ensure_ascii=False))
+        return 0 if not bad else 1
+    for b in bad:
+        sug = f"  → did you mean '{b['suggestion']}'?" if b["suggestion"] else "  (no close live instrument)"
+        print(f"✗ {b['symbol']}: NOT a live Hyperliquid instrument{sug}")
+    if not bad:
+        print(f"✓ all {len(syms)} coin(s) are live Hyperliquid instruments")
+    else:
+        print(f"\n{len(bad)} invalid coin(s) — FIX before strategy_create_custom_strategy, or the strategy is "
+              f"marked FAILED after funding (capital parked). XYZ equities/indices/metals need the 'xyz:' prefix.")
+    return 0 if not bad else 1
 
 
 def live_instruments():
@@ -96,8 +150,14 @@ def main(argv=None):
     ap = argparse.ArgumentParser(description="verify hardcoded tickers against live HL instruments")
     ap.add_argument("packages", nargs="*", help="strategy package dirs (e.g. strategies/spider)")
     ap.add_argument("--all", action="store_true", help="validate every package under strategies/")
+    ap.add_argument("--coins", help="raw-create preflight: comma-separated coin strings to validate EXACTLY "
+                                    "as they'd be sent to Hyperliquid, e.g. 'xyz:NVDA,BTC' (catches a bare "
+                                    "'NVDA' that would reject). Run before strategy_create_custom_strategy.")
     ap.add_argument("--json", action="store_true")
     a = ap.parse_args(argv)
+
+    if a.coins is not None:
+        return _check_coins(a.coins, a.json)
 
     pkgs = a.packages
     if a.all:

--- a/senpi-strategy-ops/tests/test_ops.py
+++ b/senpi-strategy-ops/tests/test_ops.py
@@ -14,8 +14,9 @@ import tempfile
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
 
-import _smoke   # noqa: E402
-import protect  # noqa: E402
+import _smoke                    # noqa: E402
+import protect                   # noqa: E402
+import validate_universe as vu   # noqa: E402
 
 
 def _pkg_with_scan(tmp, scan_src, entry="scan.py"):
@@ -123,6 +124,51 @@ def test_reconcile_protected_naked_and_stale():
     assert v["ETH"] == "NAKED"              # open on-chain, engine not tracking it
     v2 = dict(protect.reconcile({"BTC"}, {"BTC", "SOL"}, {"BTC"}))
     assert v2["SOL"] == "CLOSED-OR-STALE"   # engine tracks a position the chain says is gone
+
+
+# ── xyz:-prefix guardrail: an invalid coin string is caught BEFORE funding ──
+# The M404726 incident: bare `NVDA` (not `xyz:NVDA`) → every position rejects → strategy FAILED after
+# funding → $ parked. These lock in the two catches that prevent it.
+
+def test_strict_unknown_symbols_flags_bare_equity_with_suggestion():
+    live = {"xyz:NVDA", "BTC"}
+    bad = {b["symbol"]: b["suggestion"] for b in vu.unknown_symbols(["NVDA", "BTC", "xyz:NVDA", "FAKE"], live)}
+    assert bad == {"NVDA": "xyz:NVDA", "FAKE": None}   # BTC + xyz:NVDA are live → not flagged
+
+
+def test_lenient_unknown_tickers_still_accepts_bare_equity():
+    # contrast: the INPUT checker stays lenient (assumes scan prefixes), but the STRICT one flags the
+    # literal string — that split is the whole point.
+    assert vu.unknown_tickers(["NVDA"], {"xyz:NVDA"}) == []
+    assert vu.unknown_symbols(["NVDA"], {"xyz:NVDA"})[0]["suggestion"] == "xyz:NVDA"
+
+
+def test_unknown_asset_violations_helper():
+    live = {"xyz:NVDA", "BTC", "xyz:AVGO"}
+    v = _smoke._unknown_asset_violations([{"asset": "NVDA"}, {"asset": "BTC"}, {"asset": "xyz:AVGO"}], live)
+    assert len(v) == 1 and "NVDA" in v[0] and "xyz:NVDA" in v[0]
+    assert _smoke._unknown_asset_violations([{"asset": "NVDA"}], None) == []   # no live set → can't check
+
+
+def test_smoke_blocks_scan_emitting_unprefixed_xyz_asset():
+    scan_src = ("def scan(inputs, ctx):\n"
+                "    return [{'asset': 'NVDA', 'direction': 'LONG', 'marginPct': 18, 'leverage': 4,\n"
+                "             'data': {'score': 8}}]\n")
+    with tempfile.TemporaryDirectory() as d:
+        rp, es = _pkg_with_scan(d, scan_src)
+        v = _smoke.smoke(rp, es, live_assets={"xyz:NVDA", "BTC"})
+    assert v["status"] == "bad-shape" and v["status"] in _smoke.BLOCK
+    assert any("REJECT" in x and "xyz:NVDA" in x for x in v["violations"])
+
+
+def test_smoke_passes_scan_emitting_prefixed_xyz_asset():
+    scan_src = ("def scan(inputs, ctx):\n"
+                "    return [{'asset': 'xyz:NVDA', 'direction': 'LONG', 'marginPct': 18, 'leverage': 4,\n"
+                "             'data': {'score': 8}}]\n")
+    with tempfile.TemporaryDirectory() as d:
+        rp, es = _pkg_with_scan(d, scan_src)
+        v = _smoke.smoke(rp, es, live_assets={"xyz:NVDA", "BTC"})
+    assert v["status"] == "clean" and v["status"] not in _smoke.BLOCK
 
 
 if __name__ == "__main__":

--- a/senpi-trading-runtime/references/scan-contract.md
+++ b/senpi-trading-runtime/references/scan-contract.md
@@ -158,6 +158,13 @@ default_signal_validity_seconds)`), the wire envelope, delivery, and dedup. **Do
 `leverage`, are the canonical **top-level** sizing fields (the runtime reads
 `signal.marginPct`/`signal.marginUsd`/`signal.leverage` directly) — don't bury them inside `data{}`.
 
+> **`asset` must be a LIVE instrument — XYZ names need the `xyz:` prefix.** Emit `xyz:NVDA` / `xyz:BRENTOIL`
+> / `xyz:XYZ100`, never a bare `NVDA` (not a live instrument → the venue rejects the order, and on a raw
+> create the strategy FAILS *after funding*). Crypto perps stay plain (`BTC`). Derive symbols from
+> `market_list_instruments`, never memory. The deploy pre-fund smoke gate cross-checks every emitted `asset`
+> against the live board and blocks a bad one before funding — see
+> `senpi-strategy-ops/references/coin-symbols.md`.
+
 ---
 
 ## `scoring.py` — keep the logic pure


### PR DESCRIPTION
**Prevents the M404726 incident class:** an agent created custom strategies with coins as bare `NVDA`/`AVGO`/`SKHX` instead of `xyz:NVDA`/… → every position rejected → 3 strategies marked `FAILED` **after funding** → ~$6,700 parked in sub-wallets. (Funds were never lost — they sit `withdrawable` on-chain; `FAILED` is a record status, not an on-chain freeze.)

The hole: `validate_universe` is deliberately lenient (accepts bare `NVDA` if `xyz:NVDA` is live, assuming the scan code prefixes it), and the raw `strategy_create_custom_strategy` path runs through no deploy gate at all. Nothing validated the **actual coin string** sent to Hyperliquid.

## What this adds
- **Deploy path (enforced):** the #462 pre-fund smoke gate now cross-checks every **emitted** `signal.asset` against the live instrument list and **BLOCKS before funding** a scan that emits a bare `NVDA` (`did you mean 'xyz:NVDA'?`). Best-effort — no token/network → skip, never false-block.
- **`validate_universe`:** strict `unknown_symbols()`/`suggest_symbol()` (exact-match) alongside the lenient input checker, + a `--coins xyz:NVDA,AVGO` **raw-create preflight**.
- **Docs:** new `references/coin-symbols.md` (canonical rule + *estimate-before-create* for the raw path + "FAILED funds are on-chain, not locked"), an ops anti-pattern bullet, and a `scan-contract.md` emitted-asset callout.
- **Tests:** +5 (strict vs lenient split; emitted-asset helper; smoke blocks bare / passes prefixed). **16/16.**

## Not covered here (raw MCP has no skill-side enforcement)
The one *hard* guard for the raw `strategy_create_custom_strategy` path is the **MCP tool description** itself — recommend requiring an `estimate_custom_strategy_positions_opening` dry-run + naming the FAILED-funds-parked consequence. Cross-team; flagged separately.

> ⚠️ **Stacked on #462** (`strategy-debug-hardening`) — it extends that PR's smoke gate. Base is set to `strategy-debug-hardening`; merge #462 first, or retarget to `main` after. Skill bump: strategy-ops 2.4.0 → 2.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)