### PR TITLE
improve-trades v1.2.0 — total PnL (open book) + honesty guardrails

### DIFF
--- a/senpi-improve-trades/SKILL.md
+++ b/senpi-improve-trades/SKILL.md
@@ -39,7 +39,11 @@ more" questions; use `senpi-portfolio` for live state.
 ## HARD RULES (never violate — obey these even if you skim the rest)
 
 1. **Lead with TOTAL PnL** (`pnl_summary.total` = realized + unrealized), never realized alone. Realized-only
-   is half the ledger — it calls a book riding open winners a "loser" and penalizes hold-strategies.
+   is half the ledger — it calls a book riding open winners a "loser" and penalizes hold-strategies. **If
+   `pnl_summary.unrealized_partial` is true (or `unrealized_coverage.read < .current_strategies`), TOTAL is a
+   FLOOR, not a complete number** — some current wallets couldn't be read. Say **"at least $X (N of M wallets
+   readable)"**, never present it as the finished total. (`total: null` = the open book was *entirely*
+   unreadable → UNKNOWN, not 0 and not a floor.)
 2. **The hold-to-now counterfactual is CONTEXT, never a verdict.** `held_higher` / a positive
    `if_all_reclosed_now_total` just means the asset kept running THIS window (hindsight; it ignores the risk
    the exit avoided). NEVER say "you exited too early / N% premature / left $X on the table," and NEVER let it
@@ -196,6 +200,9 @@ These are non-negotiable. Each fixes a real failure from live agent responses to
 
 **Lead with `pnl_summary.total`** (realized closed + unrealized open) — NOT `realized_pnl_total` alone.
 Realized-only is half the ledger: it calls a book riding open winners a "loser" and penalizes hold-strategies.
+**Degraded-read honesty (same principle as `undetermined ≠ all-clear`):** if `pnl_summary.unrealized_partial`
+is true (some current wallets read, some didn't), `total` is a **FLOOR** — headline it as *"at least $X (N of M
+wallets readable)"*, never as a complete total. `total: null` = the open book was entirely unreadable → UNKNOWN.
 Then give the aggregate exit counts (`timing_summary`: `exits_ahead` / `exits_held_higher` / flat). Only after
 the aggregate may you mention a single trade, and only as *one data point*, never the headline.
 
@@ -398,7 +405,8 @@ trades[]      per CLOSED trade (from strategies of ALL statuses — a churned bo
 pnl_summary      TOTAL LEDGER — LEAD WITH THIS (realized closed + unrealized open):
   realized, unrealized (None = UNKNOWN read, not 0), total (None when unrealized UNKNOWN),
   realized_by_book{ current, closed },      # quote this split — never re-derive a closed-book figure
-  unrealized_coverage{ read, current_strategies }
+  unrealized_coverage{ read, current_strategies },
+  unrealized_partial   # true → some wallets UNKNOWN; unrealized/total are a FLOOR ("at least $X, N of M") — HARD RULE 1
 
 telemetry_availability   the 'undetermined ≠ all-clear' signal — READ IT FIRST (guardrail 6):
   status ∈ available | partial | undetermined | no_trades,

--- a/senpi-improve-trades/SKILL.md
+++ b/senpi-improve-trades/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.1.1"
+  version: "1.2.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -35,6 +35,27 @@ This is the counterpart to `senpi-portfolio`. Portfolio answers *"where is my mo
 doing right now."* **Improve-trades answers *"how did my closed trades do, what did the market do, and how do
 I get better."*** Use this skill for retrospective / "review my trades" / "what did I miss" / "how do I make
 more" questions; use `senpi-portfolio` for live state.
+
+## HARD RULES (never violate — obey these even if you skim the rest)
+
+1. **Lead with TOTAL PnL** (`pnl_summary.total` = realized + unrealized), never realized alone. Realized-only
+   is half the ledger — it calls a book riding open winners a "loser" and penalizes hold-strategies.
+2. **The hold-to-now counterfactual is CONTEXT, never a verdict.** `held_higher` / a positive
+   `if_all_reclosed_now_total` just means the asset kept running THIS window (hindsight; it ignores the risk
+   the exit avoided). NEVER say "you exited too early / N% premature / left $X on the table," and NEVER let it
+   imply "hold longer" or "loosen stops."
+3. **Undetermined ≠ all-clear.** When `telemetry_availability.streams_computed` is false (or `.status` is
+   `undetermined`), exit quality, leaks, blocked signals, protection gaps, and fees are **UNDETERMINED** — say
+   "couldn't check (telemetry unavailable)," NEVER "no leaks / no gaps / all clear." When
+   `exit_attribution.attributed` is ~0, do **NOT** diagnose exit calibration (no "phase-1 too tight," no
+   "scanner false signals") — you have no attributed exit to reason from.
+4. **Quote the engine's numbers verbatim.** Every $ and count you state must be a field the engine emitted
+   (`pnl_summary`, `timing_summary`, `strategies[]`, `realized_by_book`). NEVER re-derive or estimate an
+   aggregate — that is how fabrications like "closed did −$405" happen.
+5. **It's the strategy, not the user.** Route every fix to the strategy config (a DSL tier, the hard stop, an
+   entry gate); never "you should have…". No fabricated forward numbers (no $/week).
+
+The detailed guardrails below explain each; these five are the floor.
 
 > **Use this skill FIRST — before any raw MCP.** For any "review my trades / did I sell too early / what did
 > I miss / master my week / how could I make more gains" question, run this engine **before** reaching for
@@ -73,7 +94,7 @@ step(s) the ask needs; route every fix through the depth choice at the end — n
 
 | Intent (what the user asks) | Step(s) to run | Data (engine output) | Actionable lever |
 |---|---|---|---|
-| *"Did I sell too early / late? / improve my last 10"* | `timing` | `timing_summary` (beat/worse/flat) + per-trade `if_held_delta_usd`, `exit_vs_hold` | Lead with the aggregate; a reversal is one data point → the DSL tier that fired (`exit_reason`) |
+| *"Did I sell too early / late? / improve my last 10"* | `timing` | `timing_summary` (exit_ahead/held_higher/flat) + per-trade `if_held_delta_usd`, `exit_vs_hold` | NEUTRAL context — a reversal is one data point, never "premature"; the counterfactual is not a grade (guardrail 1) → the DSL tier that fired (`exit_reason`) |
 | *"Master my week" / "analyze my strategies and trades" / "suggest improvements"* | **all steps in order** (`timing`→`strategies`→`telemetry`→`market`) | `timing_summary` + `strategies[]` (per-mandate) + `book_vs_market` + the telemetry streams | Process recap, each strategy vs its own mandate |
 | *"What did I miss this week? / compare to market"* | `market` (+ `telemetry` for the blocked cohort) | `book_vs_market.gaps` (unheld movers) + `missed_signals` (telemetry-blocked) | Is the missed mover in the mandate? loosen a gate only if so |
 | *"How could I make more gains?"* | `strategies` + `telemetry` | `strategies[]` mandate reads + `dsl_close_reason_mix` + `blocked_summary` | Strategy tune (DSL / entry gate), never a $/week promise |
@@ -118,9 +139,10 @@ python3 scripts/review.py all          # one-shot fallback: the full composed di
 **For a FULL review** — "analyze my strategies and trades", "master my week", "suggest improvements", "how
 could I make more" — run the steps **in order** and narrate between:
 
-1. `review.py timing` → **narrate the timing teardown IMMEDIATELY** (lead with `timing_summary`: "N of M
-   exits beat holding-to-now") — don't wait for the other steps. `exit_reason` is still `UNKNOWN` here
-   (telemetry hasn't run) — narrate the *timing*, not the mechanism yet.
+1. `review.py timing` → narrate the timing teardown (the NEUTRAL exit counts `exits_ahead` / `exits_held_higher`
+   + realized so far) — but this is NOT your headline: TOTAL PnL (realized + unrealized) lands with the
+   `strategies` step (`pnl_summary.total`). `exit_reason` is still `UNKNOWN` here (telemetry hasn't run) —
+   narrate the *timing*, not the mechanism yet, and never call `held_higher` "premature / left on the table."
 2. `review.py strategies` → narrate the **per-strategy read** (each CURRENT strategy vs its OWN mandate,
    realized PnL as evidence; `closed_strategies[]` is history — no verdict).
 3. `review.py telemetry` → narrate **exit quality / leaks / blocked** (now `exit_reason` is filled: the
@@ -170,31 +192,36 @@ for), never to replace it.
 
 These are non-negotiable. Each fixes a real failure from live agent responses to these prompts.
 
-### 1. Process over outcome — lead with the aggregate, `if_held` is CONTEXT not the verdict
+### 1. TOTAL PnL leads; `if_held` is NEUTRAL context, symmetric, never the verdict
 
-`if_held_delta_usd` is **context, never the verdict.** A disciplined exit is **not "wrong" because the asset
-later reversed.** Grading "you sold COIN too early, it ran +$126 after" is hindsight bias — the exit was a
-process decision made on the information at the time.
+**Lead with `pnl_summary.total`** (realized closed + unrealized open) — NOT `realized_pnl_total` alone.
+Realized-only is half the ledger: it calls a book riding open winners a "loser" and penalizes hold-strategies.
+Then give the aggregate exit counts (`timing_summary`: `exits_ahead` / `exits_held_higher` / flat). Only after
+the aggregate may you mention a single trade, and only as *one data point*, never the headline.
 
-**Lead with `timing_summary`** — the aggregate counts: *"N of M exits beat holding-to-now."* Only after the
-aggregate may you discuss a single reversal, and only as *one data point*, never the headline. The engine
-computes `exit_vs_hold` per trade and the beat/worse/flat counts precisely so you can't cherry-pick the two
-trades that reversed and call the whole week a failure. `if_all_reclosed_now_total` is the honest aggregate
-counterfactual — report it as context ("the whole book, held to now, would be +$X vs the realized +$Y"),
-never as a target the user "should" have hit.
+`if_held_delta_usd` / `if_all_reclosed_now_total` are **NEUTRAL context, symmetric both ways — never a grade:**
+- A **negative** aggregate → your exits, in aggregate, **got out ahead of reversals** (a *good* exit-discipline
+  sign).
+- A **positive** aggregate → the market kept running this window after your exits. This is **NOT** "money left
+  on the table," and the `held_higher` count is **NOT** "premature exits." You cannot know the future at exit
+  time, and the number ignores the drawdown/liquidation risk holding would have carried. Report it as context
+  ("held to now, the closed book would be +$X vs the realized +$Y"), **never** a target, a grade, or a reason
+  to hold longer / loosen stops.
 
-**What `if_all_reclosed_now_total` is — and is NOT.** It is the counterfactual on the **CLOSED trades in this
-review** (what they'd be worth if you'd held each to now, instead of at the actual exit). It says **nothing
-about current OPEN positions** or live drawdown. Do NOT read a negative value as "your open positions are
-underwater" or "the book is bleeding" — that's a different question (live state → senpi-portfolio). A
-negative `if_all_reclosed_now_total` means your **exits, in aggregate, beat holding** (you got out ahead of
-reversals) — which is a *good* sign about exit discipline, not a warning.
+**The real evidence for "do you let winners run" is the OPEN book, not this counterfactual** —
+`strategies[].open_positions[]` (what you hold now + its unrealized ROE). A book with open winners running IS
+letting winners run, whatever the closed-trade counterfactual says. Grading exits off a hindsight number while
+blind to the open positions is the core failure this skill exists to prevent.
+
+**What `if_all_reclosed_now_total` is NOT:** the counterfactual on the **closed** trades only — it says nothing
+about current OPEN positions or live drawdown; don't read it as "the book is bleeding."
 
 ### 2. It's the strategy, not you — fixes route to the strategy config
 
 These are **autonomous strategy** trades. The strategy exited them, not the user clicking sell. So **never**
-say "you should have held" or "you sold too early." When an exit was worse than holding, the lever is the
-**strategy config** — the DSL preset (per-asset volatility) or the entry gates — reported in strategy terms.
+say "you should have held" or "you sold too early." When the counterfactual favored holding (`held_higher`), the
+lever — IF you decide to act at all — is the **strategy config** (the DSL preset / entry gates), reported in
+strategy terms; `held_higher` is not itself a defect.
 The engine gives you the exact lever: each trade's `exit_reason` (which DSL tier or hard stop fired) and each
 strategy's `dsl` ladder (`hard_stop_roe_pct`, `arm_at_roe_pct`, the `tiers[]`). A fix reads like *"Kodiak's
 SOL exit locked at tier 2 (+41% high-water) then trailed out; if you want it to ride further, that's the
@@ -262,6 +289,15 @@ otherwise it's just an asset the strategy was never designed to trade.
 
 ### 6. Honest sourcing — say what's missing, name your source
 
+- **Undetermined ≠ all-clear (READ `telemetry_availability` FIRST).** `telemetry_availability.status`
+  (`available`/`partial`/`undetermined`/`no_trades`) + `.streams_computed` tell you whether the telemetry
+  streams are real. When `streams_computed` is **false** (telemetry down / older build / a closed ring), the
+  `leaks`, `blocked_summary`, `execution_quality`, and `dsl_close_reason_mix` ZEROS are **fail-open
+  placeholders, NOT findings** — report them as "couldn't check (telemetry unavailable)," **never** "no leaks /
+  no protection gaps / no blocked signals / all clear." When `exit_attribution.attributed` is ~0 (status
+  `undetermined`), **do NOT diagnose exit calibration at all** (no "phase-1 too tight," no "scanner false
+  signals") — you have no attributed exit; say "exit mechanism undetermined — I'd need the runtime event log,"
+  and stop.
 - **Name your source (onchain vs runtime).** Closed trades + every onchain fact come from **`discovery`**
   (`discovery_get_trader_history`) — **never `audit_*`** (deprecated). Exit reason, blocked signals, leaks and
   maker/taker come from **telemetry** (the event log) and *enrich* those discovery trades. See the "Sources —
@@ -355,13 +391,23 @@ trades[]      per CLOSED trade (from strategies of ALL statuses — a churned bo
   realized_pnl,                           # strategy_status: ACTIVE|PAUSED = current book; else = HISTORY
   price_now, price_since_exit_pct,        # subsequent action (current price only, v1)
   if_held_delta_usd,                      # counterfactual — CONTEXT, not verdict (short-sign adjusted)
-  exit_vs_hold: beat | worse | flat | unknown,   # engine verdict of the exit vs holding-to-now
+  exit_vs_hold: exit_ahead | held_higher | flat | unknown,   # NEUTRAL context (exit_ahead=got out ahead), NOT a grade
   exit_reason: { terminal, tier_index/tier_reached, high_water_roe, source },   # which DSL lever fired
   source: "telemetry" | "reconstructed"   # telemetry = exit_reason came from the event log; else discovery+ratchet
 
-timing_summary   PROCESS-framed COUNTS (never $/week):
-  trade_count, exits_beat_holding, exits_worse, exits_flat, exits_unknown,
-  realized_pnl_total, if_all_reclosed_now_total, by_asset_class{}
+pnl_summary      TOTAL LEDGER — LEAD WITH THIS (realized closed + unrealized open):
+  realized, unrealized (None = UNKNOWN read, not 0), total (None when unrealized UNKNOWN),
+  realized_by_book{ current, closed },      # quote this split — never re-derive a closed-book figure
+  unrealized_coverage{ read, current_strategies }
+
+telemetry_availability   the 'undetermined ≠ all-clear' signal — READ IT FIRST (guardrail 6):
+  status ∈ available | partial | undetermined | no_trades,
+  streams_computed,                          # false → leaks/blocked/execution_quality/dsl_close_reason_mix zeros are UNKNOWN, not 'none'
+  exit_attribution{ attributed, total, telemetry, ratchet, unknown }   # attributed ~0 → NO calibration diagnosis
+
+timing_summary   PROCESS-framed COUNTS (never $/week; NEUTRAL, never a grade):
+  trade_count, exits_ahead, exits_held_higher, exits_flat, exits_unknown,
+  realized_pnl_total, if_all_reclosed_now_total (CONTEXT, symmetric — see guardrail 1), by_asset_class{}
 
 dsl_close_reason_mix   "shaken out too early / how are my exits firing" (from trades[] exit_reason):
   overall        { by_terminal{}, trade_count, premature_exits }
@@ -388,8 +434,13 @@ book_vs_market   the "what did I miss" gap:
   gaps[]          { asset, pct, ... }                 # movers the book had NO exposure to
   window                                              # the leaderboard's rolling window (e.g. "4h")
 
-strategies[]  the CURRENT book ONLY (status ACTIVE | PAUSED) — each judged vs ITS mandate:
-  { label, wallet, status, mandate, dsl, closed_trade_count, realized_pnl, on_mandate_note }
+strategies[]  the CURRENT book ONLY (status ACTIVE | PAUSED) — each judged vs ITS mandate, on TOTAL PnL:
+  { label, wallet, status, mandate, dsl, closed_trade_count, realized_pnl,
+    unrealized_pnl,           # current open positions' unrealized — None = UNKNOWN read (never a fake 0)
+    total_pnl,                # realized + unrealized (None when unrealized UNKNOWN) — JUDGE ON THIS, not realized
+    open_position_count,
+    open_positions[]{ asset, direction, unrealized_pnl, return_on_equity_pct, entry_px, position_value, leverage },
+    on_mandate_note }         # open_positions = the 'are winners running' evidence (guardrail 1)
   # THIS is the verdict + improvement surface. Nothing here is closed.
 
 closed_strategies[]  HISTORY ONLY (CLOSED / INACTIVE / … — churned or retired redeployments):
@@ -417,9 +468,10 @@ not recorded on this build," never guess. `tier_index`/`tier_reached` = the tier
 
 ## The output contract — what you produce
 
-1. **Timing teardown** — the per-trade read, **led by the aggregate** (`timing_summary`: "N of M exits beat
-   holding"), each exit attributed via `exit_reason` (which tier / hard stop fired). Process-framed
-   throughout. Discuss individual reversals only after the aggregate, and only as evidence. Trades whose
+1. **Total-PnL + timing teardown** — **led by TOTAL PnL** (`pnl_summary.total` = realized + unrealized), then
+   the NEUTRAL aggregate (`timing_summary`: `exits_ahead` / `exits_held_higher`), each exit attributed via
+   `exit_reason` (which tier / hard stop fired). Process-framed, NEVER "premature / left on the table."
+   Discuss individual reversals only after the aggregate, and only as evidence. Trades whose
    `strategy_status` isn't ACTIVE/PAUSED are **history** (from a closed strategy) — narrate them as past
    timing, attributed by label, never as a live strategy to act on.
 2. **Book-vs-market gap** — what moved vs what you held (`book_vs_market`). The honest "what did I miss." For

--- a/senpi-improve-trades/scripts/review.py
+++ b/senpi-improve-trades/scripts/review.py
@@ -35,6 +35,7 @@ import concurrent.futures
 import datetime
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -766,18 +767,49 @@ def _price_now(client, asset, dex, meta):
 
 
 # ──────────────────────────────────────────────── open book (unrealized PnL — the TOTAL-ledger read)
+_CLEARINGHOUSE_ATTEMPTS = 2   # bounded retries on the open-book read — transient blips only
+_CLEARINGHOUSE_BACKOFF_S = 0.4
+
+
+def _is_transient(exc):
+    """Retry the open-book read ONLY on a transient transport/5xx/429/timeout blip — never on a definitive
+    answer. An MCPError carrying an HTTP 4xx (other than 429), a JSON-RPC error, a tool isError, or an
+    app-level {success:false} is the server SAYING something real; retrying just repeats it (and could hide a
+    genuine 'no'). A raw transport error (socket timeout / connection reset / DNS) is a blip worth one more
+    try. Retries only REDUCE the frequency of a `None` read — they never remove it, so a still-failed read
+    stays UNKNOWN (never a fabricated 0) and partial coverage stays flagged."""
+    from mcp_client import MCPError
+    if isinstance(exc, MCPError):
+        m = re.search(r"HTTP (\d{3})", str(exc))
+        return bool(m) and (int(m.group(1)) == 429 or 500 <= int(m.group(1)) < 600)
+    return True
+
+
 def fetch_open_positions(client, wallet, meta):
     """Open positions + unrealized PnL for ONE current strategy wallet (strategy_get_clearinghouse_state,
     main+xyz). This is what makes the review a TOTAL ledger (realized closed trades + unrealized open) rather
     than realized-only — closing the biggest distortion: a book RIDING open winners looks like a loser on
-    realized PnL alone, and a realized-only read biases against hold-strategies. Read-guarded + fail-open: a
-    failed/unreadable read → (None, []) so unrealized reads UNKNOWN (never a fabricated 0); a clean read with
-    no open positions → (0.0, []) — a REAL zero. Returns (unrealized_pnl_total | None, positions[])."""
-    try:
-        ch = _ok(client.mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet, timeout=12))
-    except Exception as e:  # noqa — fail-open: unrealized becomes UNKNOWN, never guessed 0
+    realized PnL alone, and a realized-only read biases against hold-strategies. Read-guarded + fail-open with
+    a bounded retry on transient blips (transport/5xx/429/timeout): a still-unreadable read → (None, []) so
+    unrealized reads UNKNOWN (never a fabricated 0); a clean read with no open positions → (0.0, []) — a REAL
+    zero. Returns (unrealized_pnl_total | None, positions[])."""
+    ch, err, attempts = None, None, 0
+    for attempt in range(1, _CLEARINGHOUSE_ATTEMPTS + 1):
+        attempts = attempt
+        try:
+            ch = _ok(client.mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet, timeout=12))
+            err = None
+            break
+        except Exception as e:  # noqa — fail-open: unrealized becomes UNKNOWN, never guessed 0
+            err = e
+            if attempt < _CLEARINGHOUSE_ATTEMPTS and _is_transient(e):
+                time.sleep(_CLEARINGHOUSE_BACKOFF_S * attempt)
+                continue
+            break
+    if err is not None:
         meta.setdefault("warnings", []).append(
-            f"clearinghouse {str(wallet)[:8]} failed: {e}; unrealized PnL unavailable for it")
+            f"clearinghouse {str(wallet)[:8]} failed after {attempts} attempt(s): {err}; "
+            f"unrealized PnL unavailable for it")
         return None, []
     if not isinstance(ch, dict):
         return None, []
@@ -1524,14 +1556,22 @@ def _pnl_summary(realized_total, strat_reads):
              if isinstance(u, (int, float)) and not isinstance(u, bool)]
     unrealized = round(sum(known), 2) if known else None
     total = round(realized + unrealized, 2) if unrealized is not None else None
+    # PARTIAL coverage: some current wallets were readable, some were NOT — so `unrealized` (and therefore
+    # `total`) sums only the readable ones: a FLOOR, not a complete number. Flag it so the narrator says
+    # "at least $X (N of M wallets readable)" and never presents a partial sum as the finished total. (0
+    # readable is the all-UNKNOWN case: unrealized/total = None above, not a floor.)
+    partial = unrealized is not None and len(known) < len(strat_reads)
     return {
         "realized": realized,
         "realized_by_book": {"current": current_realized, "closed": closed_realized},
         "unrealized": unrealized,                 # None → no current open book readable (UNKNOWN, not 0)
         "unrealized_coverage": {"read": len(known), "current_strategies": len(strat_reads)},
-        "total": total,                           # realized + unrealized; None when unrealized UNKNOWN
+        "unrealized_partial": partial,            # True → unrealized/total are a FLOOR (some wallets UNKNOWN)
+        "total": total,                           # realized + unrealized; None when UNKNOWN; a FLOOR when partial
         "note": ("TOTAL = realized (closed trades) + unrealized (current open positions). LEAD with TOTAL, "
-                 "not realized alone. unrealized None = the open book couldn't be read (UNKNOWN, not 0)."),
+                 "not realized alone. unrealized None = the open book couldn't be read (UNKNOWN, not 0). "
+                 "unrealized_partial True = only some current wallets read, so unrealized/total are a FLOOR "
+                 "('at least $X, N of M wallets readable') — never present them as complete."),
     }
 
 

--- a/senpi-improve-trades/scripts/review.py
+++ b/senpi-improve-trades/scripts/review.py
@@ -765,6 +765,81 @@ def _price_now(client, asset, dex, meta):
     return _num(mark)
 
 
+# ──────────────────────────────────────────────── open book (unrealized PnL — the TOTAL-ledger read)
+def fetch_open_positions(client, wallet, meta):
+    """Open positions + unrealized PnL for ONE current strategy wallet (strategy_get_clearinghouse_state,
+    main+xyz). This is what makes the review a TOTAL ledger (realized closed trades + unrealized open) rather
+    than realized-only — closing the biggest distortion: a book RIDING open winners looks like a loser on
+    realized PnL alone, and a realized-only read biases against hold-strategies. Read-guarded + fail-open: a
+    failed/unreadable read → (None, []) so unrealized reads UNKNOWN (never a fabricated 0); a clean read with
+    no open positions → (0.0, []) — a REAL zero. Returns (unrealized_pnl_total | None, positions[])."""
+    try:
+        ch = _ok(client.mcp_call("strategy_get_clearinghouse_state", strategy_wallet=wallet, timeout=12))
+    except Exception as e:  # noqa — fail-open: unrealized becomes UNKNOWN, never guessed 0
+        meta.setdefault("warnings", []).append(
+            f"clearinghouse {str(wallet)[:8]} failed: {e}; unrealized PnL unavailable for it")
+        return None, []
+    if not isinstance(ch, dict):
+        return None, []
+    positions, unrealized = [], 0.0
+    for section in ("main", "xyz"):
+        s = ch.get(section) if isinstance(ch.get(section), dict) else {}
+        for ap in (s.get("assetPositions") or []):
+            pos = ap.get("position", ap) if isinstance(ap, dict) else {}
+            if not isinstance(pos, dict):
+                continue
+            szi = _num(pos.get("szi"))
+            if not szi:
+                continue
+            up = _num(_field(pos, "unrealizedPnl", "unrealized_pnl")) or 0.0
+            unrealized += up
+            roe = _num(_field(pos, "returnOnEquity", "return_on_equity"))
+            lev = pos.get("leverage")
+            positions.append({
+                "asset": _field(pos, "coin", "asset"),
+                "direction": "long" if szi > 0 else "short",
+                "size": abs(szi),
+                "entry_px": _num(_field(pos, "entryPx", "entry_px")),
+                "unrealized_pnl": round(up, 2),
+                "return_on_equity_pct": round(roe * 100, 2) if roe is not None else None,
+                "position_value": _num(_field(pos, "positionValue", "position_value")),
+                "leverage": _f(lev, "value", default=None) if isinstance(lev, dict) else _num(lev),
+            })
+    return round(unrealized, 2), positions
+
+
+def fetch_open_book(client, strategies, meta):
+    """wallet_lower → {unrealized_pnl, positions[]} for the CURRENT (active/paused) strategies only — the live
+    book whose UNREALIZED PnL completes the total-ledger picture (closed strategies have no open positions).
+    Parallel clearinghouse fetches (dedup by wallet), each fail-open. A wallet whose read failed is kept with
+    `unrealized_pnl: None` (UNKNOWN) — the caller must NOT treat that as 0. {} when there are no current
+    wallets."""
+    wallets, seen = [], set()
+    for s in strategies:
+        if not _is_current(s.get("status")):
+            continue
+        w = s.get("wallet")
+        wl = str(w or "").lower()
+        if w and wl not in seen:
+            seen.add(wl)
+            wallets.append(w)
+    if not wallets:
+        return {}
+
+    def _worker(w):
+        priv = {}
+        unreal, positions = fetch_open_positions(client, w, priv)
+        return str(w).lower(), unreal, positions, priv
+
+    out = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, len(wallets))) as ex:
+        for wl, unreal, positions, priv in ex.map(_worker, wallets):
+            out[wl] = {"unrealized_pnl": unreal, "positions": positions}
+            if priv.get("warnings"):
+                meta.setdefault("warnings", []).extend(priv["warnings"])
+    return out
+
+
 # ──────────────────────────────────────────────────────────────── the counterfactual math (per trade)
 def _if_held(trade, price_now):
     """The honest 'if I'd held to now' counterfactual for ONE closed trade — CONTEXT, never the verdict.
@@ -773,9 +848,9 @@ def _if_held(trade, price_now):
     if_held_delta_usd = notional × since_exit_pct, DIRECTION-ADJUSTED — a short GAINS when price falls,
       so a short's delta flips the sign. This is the extra $ the position WOULD have made (or lost) if it
       had stayed open from the exit to now, on top of the realized PnL.
-    exit_vs_hold ∈ {beat, worse, flat}: did the realized exit BEAT holding-to-now? A negative
-      if_held_delta means holding would have LOST money vs the exit → the exit BEAT holding.
-    Returns (since_exit_pct, if_held_delta_usd, exit_vs_hold) — any None-input → (None, None, "unknown")."""
+    exit_vs_hold ∈ {exit_ahead, held_higher, flat}: NEUTRAL context, never a grade. held_higher = holding
+      to now would be higher (this-window trend; ignores the risk the exit avoided); exit_ahead = holding
+      would have given gains back. Returns (since_exit_pct, if_held_delta_usd, exit_vs_hold); None → "unknown"."""
     exit_px = _num(trade.get("exit_px"))
     if price_now is None or exit_px is None or exit_px == 0:
         return None, None, "unknown"
@@ -790,13 +865,14 @@ def _if_held(trade, price_now):
     # flip ONLY for an explicit short; long / unknown → no flip (don't mistreat a null direction as short)
     signed = -raw_move if trade.get("direction") == "short" else raw_move
     if_held_delta = round(notional * signed, 2)
-    # exit_vs_hold: holding would have added if_held_delta on top of realized. Positive delta → holding
-    # beat the exit (exit was "worse"); negative → the exit beat holding; ~0 → flat.
+    # exit_vs_hold — NEUTRAL context, never a grade. Positive delta → holding-to-now would be higher
+    # (this-window trend; says nothing about exit quality, and ignores the risk the exit avoided);
+    # negative → the exit got out ahead of a reversal; ~0 → flat. NEVER read held_higher as "premature".
     eps = max(1.0, 0.001 * (notional or 0.0))     # $1 or 0.1% of notional, whichever larger — noise floor
     if if_held_delta > eps:
-        verdict = "worse"       # holding would have made more → the exit was worse than holding
+        verdict = "held_higher"   # holding to now would be higher — NOT "you exited too early" (hindsight)
     elif if_held_delta < -eps:
-        verdict = "beat"        # holding would have lost → the exit beat holding
+        verdict = "exit_ahead"    # holding would have given gains back → the exit got out ahead
     else:
         verdict = "flat"
     return since_exit_pct, if_held_delta, verdict
@@ -1087,8 +1163,8 @@ def _timing_summary(trades):
     if_held_delta_usd (what the whole book WOULD have added, net, if every position had stayed open to
     now). Reported as context alongside realized_pnl_total, never as a verdict or a projection."""
     trade_count = len(trades)
-    beat = sum(1 for t in trades if t.get("exit_vs_hold") == "beat")
-    worse = sum(1 for t in trades if t.get("exit_vs_hold") == "worse")
+    ahead = sum(1 for t in trades if t.get("exit_vs_hold") == "exit_ahead")
+    held_higher = sum(1 for t in trades if t.get("exit_vs_hold") == "held_higher")
     flat = sum(1 for t in trades if t.get("exit_vs_hold") == "flat")
     unknown = sum(1 for t in trades if t.get("exit_vs_hold") == "unknown")
     realized_total = round(sum(_num(t.get("realized_pnl")) or 0.0 for t in trades), 2)
@@ -1099,23 +1175,23 @@ def _timing_summary(trades):
     by_class = {}
     for t in trades:
         cls = "equity/index" if t.get("dex") == "xyz" else "crypto"
-        b = by_class.setdefault(cls, {"trade_count": 0, "exits_beat_holding": 0, "exits_worse": 0,
+        b = by_class.setdefault(cls, {"trade_count": 0, "exits_ahead": 0, "exits_held_higher": 0,
                                       "realized_pnl_total": 0.0})
         b["trade_count"] += 1
-        if t.get("exit_vs_hold") == "beat":
-            b["exits_beat_holding"] += 1
-        elif t.get("exit_vs_hold") == "worse":
-            b["exits_worse"] += 1
+        if t.get("exit_vs_hold") == "exit_ahead":
+            b["exits_ahead"] += 1
+        elif t.get("exit_vs_hold") == "held_higher":
+            b["exits_held_higher"] += 1
         b["realized_pnl_total"] = round(b["realized_pnl_total"] + (_num(t.get("realized_pnl")) or 0.0), 2)
 
     return {
         "trade_count": trade_count,
-        "exits_beat_holding": beat,
-        "exits_worse": worse,
+        "exits_ahead": ahead,                  # exit got out ahead of a reversal (holding would've given back)
+        "exits_held_higher": held_higher,      # holding to now would be higher — NEUTRAL, NOT 'premature'
         "exits_flat": flat,
-        "exits_unknown": unknown,           # price missing → couldn't compare (honest sourcing)
+        "exits_unknown": unknown,              # price missing → couldn't compare (honest sourcing)
         "realized_pnl_total": realized_total,
-        "if_all_reclosed_now_total": if_all,   # counterfactual aggregate — CONTEXT, NEVER a projection
+        "if_all_reclosed_now_total": if_all,   # counterfactual aggregate — CONTEXT, NEVER a projection/target
         "by_asset_class": by_class,
     }
 
@@ -1334,24 +1410,35 @@ def _pnl_by_wallet(trades):
     return by_wallet
 
 
-def _strategy_reads(trades, strategies):
+def _strategy_reads(trades, strategies, open_book=None):
     """Per CURRENT strategy (ACTIVE/PAUSED ONLY): {label, wallet, status, mandate, dsl, closed_trade_count,
-    realized_pnl, on_mandate_note}. This is the LIVE-BOOK verdict surface — closed strategies are excluded
-    here (they're history; see closed_strategy_rollup). Realized PnL is EVIDENCE for the mandate verdict,
-    not the headline — the narrator judges each strategy against its OWN mandate (guardrail 5: don't grade
-    a deliberate book against a momentum benchmark). A CURRENT strategy with no mandate on file → note it
-    plainly ("look it up / check the registry"), NEVER call it a bug."""
+    realized_pnl, unrealized_pnl, total_pnl, open_position_count, open_positions, on_mandate_note}. The
+    LIVE-BOOK verdict surface — closed strategies are excluded (history; see closed_strategy_rollup). Judge
+    each on TOTAL PnL (realized closed + unrealized open) against its OWN mandate — NOT realized alone, which
+    penalizes hold-strategies and misreads a book riding open winners. `unrealized_pnl` is None when the open
+    book couldn't be read (UNKNOWN, never a fake 0) → `total_pnl` stays None. A CURRENT strategy with no
+    mandate → note it plainly ("look it up"), NEVER a bug."""
     by_wallet = _pnl_by_wallet(trades)
+    open_book = open_book or {}
     out = []
     for s in strategies:
         if not _is_current(s.get("status")):
             continue                          # closed/historical → not a live-book verdict; see rollup
         w = str(s.get("wallet") or "").lower()
         agg = by_wallet.get(w, {"count": 0, "pnl": 0.0})
+        ob = open_book.get(w) or {}
+        unrealized = ob.get("unrealized_pnl")       # None → open book unreadable (UNKNOWN, never a fake 0)
+        open_positions = ob.get("positions") or []
+        realized = agg["pnl"]
+        total = (round(realized + unrealized, 2)
+                 if isinstance(unrealized, (int, float)) and not isinstance(unrealized, bool) else None)
         mandate = s.get("mandate")
         if mandate is None:
             note = ("mandate unavailable on this CURRENT strategy — look it up / check the runtime "
                     "registry; NOT a bug. Judge the trades, not a benchmark")
+        elif agg["count"] == 0 and open_positions:
+            note = (f"no CLOSED trades in this window, but {len(open_positions)} open position(s) held now — "
+                    "judge it on UNREALIZED + mandate, not a realized blank")
         elif agg["count"] == 0:
             note = "no closed trades in this window — often by design (waiting for its signal), not a defect"
         else:
@@ -1363,7 +1450,11 @@ def _strategy_reads(trades, strategies):
             "mandate": mandate,
             "dsl": s.get("dsl"),                 # the levers a fix routes to
             "closed_trade_count": agg["count"],
-            "realized_pnl": agg["pnl"],
+            "realized_pnl": realized,
+            "unrealized_pnl": unrealized,        # current open positions' unrealized — None = UNKNOWN read
+            "total_pnl": total,                  # realized + unrealized; None when unrealized UNKNOWN
+            "open_position_count": len(open_positions),
+            "open_positions": open_positions,    # asset/direction/unrealized_pnl/return_on_equity_pct/entry/lev
             "on_mandate_note": note,
         })
     return out
@@ -1416,6 +1507,69 @@ def _telemetry_source(source_counts, telemetry_warned):
     if telemetry_warned:
         return "partial" if tele else "unavailable"
     return "available" if tele else "unavailable"
+
+
+# ──────────────────────────────────────────────── total-ledger PnL + the 'undetermined ≠ all-clear' signal
+def _pnl_summary(realized_total, strat_reads):
+    """The TOTAL-ledger headline the narrator LEADS with — realized (closed trades) + unrealized (current
+    open positions) + total — PLUS the current-vs-closed realized split (so the narrator QUOTES it and never
+    re-derives a wrong closed-book figure). `realized_total` is ALL closed trades; current-book realized = the
+    current strategies' realized sum; closed-book = the remainder (reconciles by construction). `unrealized`
+    sums only the current strategies whose open book was READABLE → None when none were, so `total` stays an
+    honest UNKNOWN rather than collapsing to a realized-only headline."""
+    realized = round(_num(realized_total) or 0.0, 2)
+    current_realized = round(sum(_num(s.get("realized_pnl")) or 0.0 for s in strat_reads), 2)
+    closed_realized = round(realized - current_realized, 2)
+    known = [u for u in (s.get("unrealized_pnl") for s in strat_reads)
+             if isinstance(u, (int, float)) and not isinstance(u, bool)]
+    unrealized = round(sum(known), 2) if known else None
+    total = round(realized + unrealized, 2) if unrealized is not None else None
+    return {
+        "realized": realized,
+        "realized_by_book": {"current": current_realized, "closed": closed_realized},
+        "unrealized": unrealized,                 # None → no current open book readable (UNKNOWN, not 0)
+        "unrealized_coverage": {"read": len(known), "current_strategies": len(strat_reads)},
+        "total": total,                           # realized + unrealized; None when unrealized UNKNOWN
+        "note": ("TOTAL = realized (closed trades) + unrealized (current open positions). LEAD with TOTAL, "
+                 "not realized alone. unrealized None = the open book couldn't be read (UNKNOWN, not 0)."),
+    }
+
+
+def _exit_attribution_coverage(source_counts, trade_count):
+    """How many closed trades have an ATTRIBUTED exit mechanism (telemetry-native or ratchet fallback) vs
+    UNKNOWN. attributed == 0 → there is NO basis for ANY exit-mechanism or DSL-calibration claim."""
+    tele = int(source_counts.get("telemetry", 0))
+    ratchet = int(source_counts.get("ratchet", 0))
+    return {"attributed": tele + ratchet, "total": int(trade_count),
+            "telemetry": tele, "ratchet": ratchet, "unknown": int(source_counts.get("unknown", 0))}
+
+
+def _telemetry_availability(coverage, telemetry_source):
+    """The ONE signal the narrator keys off for 'undetermined ≠ all-clear'. status:
+      no_trades    — nothing closed this window
+      undetermined — telemetry unavailable AND 0 exits attributed → exit quality / leaks / blocked /
+                     protection / fees are UNKNOWN ('couldn't check'), NEVER 'none/all-clear', and NO
+                     exit-calibration diagnosis
+      partial      — some enrichment landed, some didn't
+      available    — telemetry read and every closed trade is attributed
+    `streams_computed` False → the leaks/blocked/execution_quality/dsl_close_reason_mix ZEROS are fail-open
+    placeholders (telemetry down), NOT genuine 'no leaks / no gaps'."""
+    total = coverage.get("total", 0)
+    attributed = coverage.get("attributed", 0)
+    if total == 0:
+        status = "no_trades"
+    elif telemetry_source == "unavailable" and attributed == 0:
+        status = "undetermined"
+    elif telemetry_source == "available" and attributed == total:
+        status = "available"
+    else:
+        status = "partial"
+    computed = telemetry_source != "unavailable"
+    note = ("telemetry unavailable — exit quality, leaks, blocked signals, protection gaps and fees are "
+            "UNDETERMINED (couldn't check), NOT zero/none; do NOT diagnose exit calibration"
+            if not computed else "telemetry read — the exit-quality / leak / fee streams are computed")
+    return {"status": status, "telemetry_source": telemetry_source,
+            "exit_attribution": coverage, "streams_computed": computed, "note": note}
 
 
 # ──────────────────────────────────────────────────────────────── shared state file (resumable steps)
@@ -1556,8 +1710,11 @@ def step_strategies(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_m
         client, state, window_days, last_n, want_market, now_ms=now_ms)
     meta["warnings"] = list(state.get("meta_warnings", []))
     meta["window"] = window
-    strat_reads = _strategy_reads(trades, strategies)
+    open_book = fetch_open_book(client, strategies, meta)   # unrealized PnL for current wallets (total ledger)
+    strat_reads = _strategy_reads(trades, strategies, open_book)
     closed_reads = _closed_strategy_rollup(trades, strategies)
+    realized_total = round(sum(_num(t.get("realized_pnl")) or 0.0 for t in trades), 2)
+    pnl_summary = _pnl_summary(realized_total, strat_reads)
     dsl_mix = _dsl_close_reason_mix(trades)   # from whatever exit_reason is in state (UNKNOWN until telemetry)
     current_count = sum(1 for s in strategies if _is_current(s.get("status")))
     closed_count = len(strategies) - current_count
@@ -1569,10 +1726,11 @@ def step_strategies(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_m
         meta["degraded"] = "no strategies — check the token is USER-scoped"
     state["strategies_read"] = strat_reads
     state["closed_strategies"] = closed_reads
+    state["pnl_summary"] = pnl_summary
     state["dsl_close_reason_mix"] = dsl_mix
     _save_state(state_path, state)
     return {"strategies": strat_reads, "closed_strategies": closed_reads,
-            "dsl_close_reason_mix": dsl_mix, "meta": meta}
+            "pnl_summary": pnl_summary, "dsl_close_reason_mix": dsl_mix, "meta": meta}
 
 
 def step_telemetry(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True,
@@ -1597,6 +1755,9 @@ def step_telemetry(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_ma
     src_counts = _exit_reason_source_counts(trades)
     meta["exit_reason_source_counts"] = src_counts
     meta["telemetry_source"] = _telemetry_source(src_counts, meta.get("_telemetry_warned", False))
+    coverage = _exit_attribution_coverage(src_counts, len(trades))
+    meta["exit_attribution_coverage"] = coverage
+    telemetry_availability = _telemetry_availability(coverage, meta["telemetry_source"])
     meta["missed_signal_count"] = len(missed_signals)
     meta["leak_counts"] = {k: v["count"] for k, v in leaks.items()}
     meta["trade_count"] = len(trades)
@@ -1609,10 +1770,12 @@ def step_telemetry(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_ma
     state["leaks"] = leaks
     state["execution_quality"] = exec_quality
     state["dsl_close_reason_mix"] = dsl_mix
+    state["telemetry_availability"] = telemetry_availability
     state["meta_warnings"] = meta.get("warnings", [])
     _save_state(state_path, state)
     return {"trades": trades, "missed_signals": missed_signals, "blocked_summary": blocked,
-            "leaks": leaks, "execution_quality": exec_quality, "dsl_close_reason_mix": dsl_mix, "meta": meta}
+            "leaks": leaks, "execution_quality": exec_quality, "dsl_close_reason_mix": dsl_mix,
+            "telemetry_availability": telemetry_availability, "meta": meta}
 
 
 def step_market(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True,
@@ -1657,6 +1820,9 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
     # ALL statuses are enumerated (so a churned book's CLOSED trades stay in trades[]) — but the per-strategy
     # verdict is CURRENT-only. Closed/historical strategies get a minimal rollup, never a verdict.
     strategies = fetch_strategies(client, meta)
+    # OPEN BOOK — current strategies' unrealized PnL (strategy_get_clearinghouse_state), so the review is a
+    # TOTAL ledger (realized closed + unrealized open), not realized-only. Fail-open per wallet → None (UNKNOWN).
+    open_book = fetch_open_book(client, strategies, meta)
     # DISCOVERY owns trades[] (onchain facts); TELEMETRY enriches exit_reason + yields the standalone streams
     # (missed_signals + the leak/fill rollups), all from ONE per-runtime event fetch (no re-fetch downstream).
     trades, missed_signals, leaks, fills = _collect_trades(
@@ -1667,8 +1833,9 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
     blocked = _blocked_summary(missed_signals)                  # 'what did my own limits block'
     exec_quality = _execution_quality(fills)                    # 'fees — maker vs taker'
     bvm = book_vs_market(client, trades, strategies, meta, want_market)
-    strat_reads = _strategy_reads(trades, strategies)          # CURRENT book only (active/paused)
+    strat_reads = _strategy_reads(trades, strategies, open_book)   # CURRENT book — now with unrealized/total/open
     closed_reads = _closed_strategy_rollup(trades, strategies) # HISTORY: closed/inactive, rollup only
+    pnl_summary = _pnl_summary(timing["realized_pnl_total"], strat_reads)   # realized + unrealized = TOTAL ledger
 
     current_count = sum(1 for s in strategies if _is_current(s.get("status")))
     closed_count = len(strategies) - current_count
@@ -1680,6 +1847,9 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
     src_counts = _exit_reason_source_counts(trades)
     meta["exit_reason_source_counts"] = src_counts             # telemetry / ratchet / unknown
     meta["telemetry_source"] = _telemetry_source(src_counts, meta.get("_telemetry_warned", False))
+    coverage = _exit_attribution_coverage(src_counts, len(trades))
+    meta["exit_attribution_coverage"] = coverage               # attributed vs UNKNOWN — 0 attributed → no calibration claim
+    telemetry_availability = _telemetry_availability(coverage, meta["telemetry_source"])
     meta["missed_signal_count"] = len(missed_signals)
     meta["leak_counts"] = {k: v["count"] for k, v in leaks.items()}   # quick meta glance at the leak tallies
     meta.pop("_telemetry_warned", None)                        # internal flag — not part of the contract
@@ -1698,8 +1868,10 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
         "blocked_summary": blocked,       # 'what did my own limits block' → slot / margin / risk-gate lever
         "leaks": leaks,                   # 'where am I leaking' — failed orders, protection gaps, risk halts
         "execution_quality": exec_quality, # 'fees — maker vs taker' (+ future authoritative-fee ledger hook)
-        "strategies": strat_reads,        # CURRENT book only — each judged vs its OWN mandate
+        "pnl_summary": pnl_summary,       # TOTAL ledger: realized + unrealized (+ current/closed split) — LEAD with this
+        "strategies": strat_reads,        # CURRENT book only — each judged vs its OWN mandate (+ unrealized/total/open)
         "closed_strategies": closed_reads, # HISTORY — minimal rollup, NO verdict/mandate (never consolidate)
+        "telemetry_availability": telemetry_availability,   # undetermined ≠ all-clear signal for the narrator
         "meta": meta,
     }
 
@@ -1741,6 +1913,8 @@ def _all_and_persist(client, window_days, last_n, want_market, state_path, now_m
         "execution_quality": result.get("execution_quality"),
         "strategies_read": result.get("strategies"),
         "closed_strategies": result.get("closed_strategies"),
+        "pnl_summary": result.get("pnl_summary"),
+        "telemetry_availability": result.get("telemetry_availability"),
         "meta_warnings": (result.get("meta") or {}).get("warnings", []),
     }
     _save_state(state_path, state)

--- a/senpi-improve-trades/tests/fixtures/review_fixture.json
+++ b/senpi-improve-trades/tests/fixtures/review_fixture.json
@@ -26,6 +26,15 @@
     {"asset": "ETH", "status": "ACTIVE", "currentTierIndex": 0, "highWaterRoe": 6.0}
   ]},
 
+  "strategy_get_clearinghouse_state::0xkodiak00000000000000000000000000000kdk": {
+    "main": {"assetPositions": [
+      {"position": {"coin": "SOL", "szi": "10.0", "entryPx": "120.00", "unrealizedPnl": "120.00",
+                    "returnOnEquity": "0.10", "positionValue": "1300.00",
+                    "leverage": {"type": "cross", "value": 5}}}
+    ]},
+    "xyz": {"assetPositions": []}
+  },
+
   "market_get_asset_data::sol": {"asset_context": {"markPx": "130.00", "prevDayPx": "148.0"}},
   "market_get_asset_data::eth": {"asset_context": {"markPx": "2200.00", "prevDayPx": "2010.0"}},
   "market_get_asset_data::btc": {"asset_context": {"markPx": "95000.00", "prevDayPx": "99000.0"}},

--- a/senpi-improve-trades/tests/test_review.py
+++ b/senpi-improve-trades/tests/test_review.py
@@ -73,7 +73,7 @@ def test_if_held_and_since_exit_compute_for_a_long():
     sol = _by_asset(_result())["SOL"]
     assert sol["price_since_exit_pct"] == -13.33
     assert sol["if_held_delta_usd"] == -60.0
-    assert sol["exit_vs_hold"] == "beat"
+    assert sol["exit_vs_hold"] == "exit_ahead"
 
 
 def test_exit_worse_when_price_ran_after_a_long_exit():
@@ -82,7 +82,7 @@ def test_exit_worse_when_price_ran_after_a_long_exit():
     eth = _by_asset(_result())["ETH"]
     assert eth["price_since_exit_pct"] == 10.0
     assert eth["if_held_delta_usd"] == 100.0
-    assert eth["exit_vs_hold"] == "worse"
+    assert eth["exit_vs_hold"] == "held_higher"
 
 
 def test_short_sign_is_direction_adjusted():
@@ -93,7 +93,7 @@ def test_short_sign_is_direction_adjusted():
     assert btc["direction"] == "short"
     assert btc["price_since_exit_pct"] == -5.0        # raw price move is down
     assert btc["if_held_delta_usd"] == 250.0          # but the SHORT counterfactual is POSITIVE
-    assert btc["exit_vs_hold"] == "worse"
+    assert btc["exit_vs_hold"] == "held_higher"
 
 
 def test_timing_summary_counts_beat_vs_worse():
@@ -102,8 +102,8 @@ def test_timing_summary_counts_beat_vs_worse():
     projection."""
     ts = _result()["timing_summary"]
     assert ts["trade_count"] == 3
-    assert ts["exits_beat_holding"] == 1
-    assert ts["exits_worse"] == 2
+    assert ts["exits_ahead"] == 1
+    assert ts["exits_held_higher"] == 2
     assert ts["exits_flat"] == 0
     assert ts["realized_pnl_total"] == 340.0
     assert ts["if_all_reclosed_now_total"] == 290.0
@@ -168,6 +168,45 @@ def test_strategy_read_carries_mandate_and_dsl_lever():
     assert strat["realized_pnl"] == 340.0
 
 
+def test_open_book_unrealized_and_total_pnl():
+    """WS1 total-ledger: kodiak holds an open SOL long (+$120 unrealized) → the strategy read carries
+    unrealized_pnl + total_pnl (realized 340 + unrealized 120 = 460), and pnl_summary rolls up TOTAL with
+    the current/closed realized split. A book riding an open winner is NOT judged on realized alone."""
+    res = _result()
+    strat = {s["label"]: s for s in res["strategies"]}["kodiak"]
+    assert strat["realized_pnl"] == 340.0
+    assert strat["unrealized_pnl"] == 120.0
+    assert strat["total_pnl"] == 460.0
+    assert strat["open_position_count"] == 1
+    op = strat["open_positions"][0]
+    assert op["asset"] == "SOL" and op["direction"] == "long"
+    assert op["unrealized_pnl"] == 120.0 and op["return_on_equity_pct"] == 10.0
+    ps = res["pnl_summary"]
+    assert ps["realized"] == 340.0 and ps["unrealized"] == 120.0 and ps["total"] == 460.0
+    assert ps["realized_by_book"] == {"current": 340.0, "closed": 0.0}
+
+
+def test_open_book_unreadable_is_unknown_not_zero():
+    """WS1 fail-open: when the clearinghouse can't be read, unrealized reads None (UNKNOWN) and total_pnl is
+    None — NEVER a fabricated 0. Guards a realized-only headline from masquerading as total."""
+    with open(FIXTURE) as f:
+        raw = json.load(f)
+    raw.pop("strategy_get_clearinghouse_state::0xkodiak00000000000000000000000000000kdk", None)
+    old = os.environ.get("SENPI_STATE_DIR")
+    os.environ["SENPI_STATE_DIR"] = REGISTRY_DIR
+    try:
+        res = review.run(review._FixtureClient(raw), window_days=WINDOW_DAYS, now_ms=NOW_MS)
+    finally:
+        if old is None:
+            os.environ.pop("SENPI_STATE_DIR", None)
+        else:
+            os.environ["SENPI_STATE_DIR"] = old
+    strat = {s["label"]: s for s in res["strategies"]}["kodiak"]
+    assert strat["unrealized_pnl"] is None and strat["total_pnl"] is None   # UNKNOWN, not 0
+    assert res["pnl_summary"]["unrealized"] is None and res["pnl_summary"]["total"] is None
+    assert res["pnl_summary"]["realized"] == 340.0                          # realized still known
+
+
 def test_last_n_caps_trade_count():
     """--last N keeps only the N most-recent closed trades (by close time). last_n=1 → only BTC (latest)."""
     res = _result(last_n=1)
@@ -212,7 +251,12 @@ def test_fails_open_when_ratchet_source_missing():
             os.environ["SENPI_STATE_DIR"] = old
     assert all(t["exit_reason"]["terminal"] == "UNKNOWN" for t in res["trades"])
     # timing still works — SOL still beat holding
-    assert {t["asset"]: t["exit_vs_hold"] for t in res["trades"]}["SOL"] == "beat"
+    assert {t["asset"]: t["exit_vs_hold"] for t in res["trades"]}["SOL"] == "exit_ahead"
+    # WS3: telemetry down AND zero exits attributed → the M404726 case → status UNDETERMINED, not all-clear
+    ta = res["telemetry_availability"]
+    assert ta["status"] == "undetermined"
+    assert ta["streams_computed"] is False
+    assert ta["exit_attribution"]["attributed"] == 0
 
 
 # ──────────────────────────────────────────────────────── current vs closed partition (the live-run fix)
@@ -388,6 +432,11 @@ def test_telemetry_unavailable_leaves_discovery_intact():
     assert by["BTC"]["exit_reason"]["terminal"] == "UNKNOWN"
     # discovery facts untouched with zero telemetry
     assert by["SOL"]["realized_pnl"] == 90.0 and by["BTC"]["direction"] == "short"
+    # WS3: telemetry down → the leak/blocked/fee streams are UNDETERMINED (not computed), never 'none'.
+    ta = res["telemetry_availability"]
+    assert ta["streams_computed"] is False
+    assert ta["exit_attribution"]["attributed"] == 1     # SOL attributed via the ratchet fallback
+    assert ta["status"] == "partial"
 
 
 # ──────────────────────────────────── telemetry quick-action aggregations (reuse the fetched events/trades)
@@ -509,11 +558,11 @@ def test_step_timing_slice_standalone():
                                                want_market=True, state_path=sp, now_ms=NOW_MS))
     assert set(out) == {"window", "trades", "timing_summary", "meta"}   # ONLY the timing slice
     assert out["timing_summary"]["trade_count"] == 3
-    assert out["timing_summary"]["exits_beat_holding"] == 1
+    assert out["timing_summary"]["exits_ahead"] == 1
     # exit_reason is the placeholder here — telemetry/ratchet has not run on the fast path
     assert all(t["exit_reason"]["terminal"] == "UNKNOWN" for t in out["trades"])
     # but the timing counterfactual (prices only) is already correct
-    assert {t["asset"]: t["exit_vs_hold"] for t in out["trades"]}["SOL"] == "beat"
+    assert {t["asset"]: t["exit_vs_hold"] for t in out["trades"]}["SOL"] == "exit_ahead"
     all_ts = _result()["timing_summary"]
     assert out["timing_summary"] == all_ts               # timing slice == all's timing_summary
 
@@ -529,7 +578,7 @@ def test_step_strategies_slice_reads_state():
         return review.step_strategies(_fresh_client(), window_days=WINDOW_DAYS, want_market=True,
                                       state_path=sp, now_ms=NOW_MS)
     out = _with_env(_seq)
-    assert set(out) == {"strategies", "closed_strategies", "dsl_close_reason_mix", "meta"}
+    assert set(out) == {"strategies", "closed_strategies", "pnl_summary", "dsl_close_reason_mix", "meta"}
     strat = {s["label"]: s for s in out["strategies"]}["kodiak"]
     assert strat["dsl"]["hard_stop_roe_pct"] == -15.0    # mandate/DSL from the registry
     assert strat["realized_pnl"] == 340.0
@@ -586,6 +635,8 @@ def test_step_sequence_reproduces_all_combined():
     assert te["execution_quality"] == allr["execution_quality"]
     assert te["dsl_close_reason_mix"] == allr["dsl_close_reason_mix"]   # telemetry-refreshed mix
     assert m["book_vs_market"] == allr["book_vs_market"]
+    assert s["pnl_summary"] == allr["pnl_summary"]                      # total-ledger rollup parity
+    assert te["telemetry_availability"] == allr["telemetry_availability"]   # undetermined-signal parity
     # meta sub-fields each step owns line up with all
     assert te["meta"]["exit_reason_source_counts"] == allr["meta"]["exit_reason_source_counts"]
     assert te["meta"]["telemetry_source"] == allr["meta"]["telemetry_source"]

--- a/senpi-improve-trades/tests/test_review.py
+++ b/senpi-improve-trades/tests/test_review.py
@@ -207,6 +207,88 @@ def test_open_book_unreadable_is_unknown_not_zero():
     assert res["pnl_summary"]["realized"] == 340.0                          # realized still known
 
 
+def test_pnl_summary_partial_coverage_is_flagged_floor_not_complete():
+    """WS1 degraded-read honesty (Sarvesh review): when SOME current wallets read and some are UNKNOWN,
+    unrealized/total sum only the readable ones — a FLOOR, not a complete total. The engine MUST flag that
+    (`unrealized_partial`) with the coverage counts, so the narrator says 'at least $X (N of M readable)'
+    and never presents a partial sum as complete. Same principle as all-fail→None and undetermined≠all-clear,
+    for the PARTIALLY-known case."""
+    strat_reads = [
+        {"realized_pnl": 100.0, "unrealized_pnl": 500.0},   # wallet A: readable, +$500 open
+        {"realized_pnl": 50.0, "unrealized_pnl": None},     # wallet B: read FAILED → UNKNOWN
+    ]
+    ps = review._pnl_summary(150.0, strat_reads)
+    assert ps["unrealized"] == 500.0                         # only the readable wallet — a FLOOR
+    assert ps["total"] == 650.0                              # 150 realized + 500 known unrealized (floor)
+    assert ps["unrealized_partial"] is True                 # <-- flagged, not silent
+    assert ps["unrealized_coverage"] == {"read": 1, "current_strategies": 2}
+
+
+def test_pnl_summary_full_coverage_is_not_partial():
+    """Control: every current wallet reads → unrealized_partial False (total is complete, not a floor)."""
+    strat_reads = [{"realized_pnl": 100.0, "unrealized_pnl": 500.0},
+                   {"realized_pnl": 50.0, "unrealized_pnl": -20.0}]
+    ps = review._pnl_summary(150.0, strat_reads)
+    assert ps["unrealized"] == 480.0 and ps["total"] == 630.0
+    assert ps["unrealized_partial"] is False
+
+
+def test_pnl_summary_all_unreadable_is_none_not_partial():
+    """Control: 0 wallets readable is the all-UNKNOWN case (unrealized/total None), NOT a partial floor."""
+    strat_reads = [{"realized_pnl": 100.0, "unrealized_pnl": None},
+                   {"realized_pnl": 50.0, "unrealized_pnl": None}]
+    ps = review._pnl_summary(150.0, strat_reads)
+    assert ps["unrealized"] is None and ps["total"] is None
+    assert ps["unrealized_partial"] is False                # None ≠ floor
+
+
+def test_is_transient_classifies_retryable_vs_definitive():
+    """Retry policy: transport blips + 5xx/429 retry; a definitive answer (4xx, {success:false}, JSON-RPC,
+    tool error) does NOT — retrying a real 'no' just repeats it."""
+    from mcp_client import MCPError
+    assert review._is_transient(TimeoutError("timed out")) is True
+    assert review._is_transient(ConnectionResetError()) is True
+    assert review._is_transient(MCPError("strategy_get_clearinghouse_state HTTP 503")) is True
+    assert review._is_transient(MCPError("x HTTP 429")) is True
+    assert review._is_transient(MCPError("x HTTP 404")) is False
+    assert review._is_transient(MCPError("tool failed: SERR001: no access")) is False
+    assert review._is_transient(MCPError("JSON-RPC error -32601: method not found")) is False
+
+
+def test_fetch_open_positions_retries_transient_then_succeeds():
+    """A transient blip is retried; the second attempt's clean read is used — no fabricated None."""
+    calls = {"n": 0}
+    ok = {"main": {"assetPositions": [{"position": {"coin": "SOL", "szi": "1", "unrealizedPnl": "25.0"}}]}}
+
+    class Flaky:
+        def mcp_call(self, tool, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise TimeoutError("blip")
+            return ok
+    meta = {}
+    unreal, positions = review.fetch_open_positions(Flaky(), "0xabc", meta)
+    assert calls["n"] == 2                          # retried once
+    assert unreal == 25.0 and len(positions) == 1
+    assert not meta.get("warnings")                 # succeeded → no failure warning
+
+
+def test_fetch_open_positions_does_not_retry_definitive_failure():
+    """A definitive {success:false} is NOT retried (it's a real answer) → one call, unrealized UNKNOWN."""
+    from mcp_client import MCPError
+    calls = {"n": 0}
+
+    class Denied:
+        def mcp_call(self, tool, **kw):
+            calls["n"] += 1
+            raise MCPError("tool failed: SERR001: no access")
+    meta = {}
+    unreal, positions = review.fetch_open_positions(Denied(), "0xabc", meta)
+    assert calls["n"] == 1                           # NOT retried
+    assert unreal is None and positions == []        # UNKNOWN, never a fabricated 0
+    assert meta["warnings"]                          # a warning was recorded
+
+
 def test_last_n_caps_trade_count():
     """--last N keeps only the N most-recent closed trades (by close time). last_n=1 → only BTC (latest)."""
     res = _result(last_n=1)


### PR DESCRIPTION
Fixes the distorted (and in one spot **dangerous**) trade review we saw on M404726 — where the skill judged on a **partial ledger**, headlined a **hindsight counterfactual**, **diagnosed exit calibration on 100%-UNKNOWN attribution**, reported **"no leaks / all clear" while telemetry was down**, and **fabricated aggregates**.

## Root cause
The engine only read **closed** trades — blind to the live book's **unrealized** PnL. So it (a) called a book riding open winners a "loser," (b) leaned on the hindsight "if I'd held to now" counterfactual *because* it couldn't see the open positions, and (c) that counterfactual drove "you left $2,400 on the table / 70% premature" → implicitly *hold longer / loosen stops* on a leveraged, losing book.

## Engine (`review.py`)
- **WS1 — total ledger:** `fetch_open_book` pulls each **current** wallet's clearinghouse → `strategies[]` gain `unrealized_pnl` / `total_pnl` / `open_positions[]`; new top-level `pnl_summary {realized, unrealized, total, realized_by_book}`. Fail-open → `unrealized: None` (UNKNOWN), never a fake 0. The **open book is now the real "are winners running" evidence**, so the skill no longer relies on the counterfactual.
- **WS2 — neutral labels:** `exit_vs_hold` `beat/worse → exit_ahead/held_higher` (a model reads "worse" as "you did badly").
- **WS3 — undetermined ≠ all-clear:** new `telemetry_availability {status, streams_computed, exit_attribution}` — `streams_computed:false` when telemetry's down + `undetermined` when 0 exits attributed.
- **WS4 — anti-fabrication:** emits the `realized_by_book {current, closed}` split so the narrator quotes it (no more invented −$405).
- Wired through `run()` + the `timing`/`strategies`/`telemetry` steps (parity preserved).

## SKILL.md (binds a small model)
- **HARD RULES** block at the top (5 one-liners): lead with TOTAL PnL · counterfactual isn't a verdict · undetermined ≠ all-clear · quote engine numbers · strategy-not-user.
- **Guardrail 1 made symmetric** — a *positive* counterfactual is **not** "money left on the table," `held_higher` is **not** "premature," and the open book is the letting-winners-run evidence. **Guardrail 6** gains the undetermined rule. Output-shape / contract / quick-actions updated.

## Tests
**42/42.** +4: open-book unrealized/total; open-book-unreadable → UNKNOWN not 0; telemetry-down → `undetermined` (not all-clear); partial. Skill bump **1.1.1 → 1.2.0** (auto-upgrade; bump the external skills-manifest on merge).

**Acceptance:** re-run against M404726 and confirm the review (a) leads with **total** PnL, (b) never says "premature / left on the table," (c) reports exit-quality **UNDETERMINED** (telemetry was down), (d) all numbers reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)