### PR TITLE
fix(spider): cap emit to maxSlots — stop max_items_exceeded signal drops

### DIFF
--- a/strategies/spider/scalp/scanners/scan.py
+++ b/strategies/spider/scalp/scanners/scan.py
@@ -178,8 +178,15 @@ def scan(inputs, ctx):
 
     candidates.sort(key=lambda x: x["score"], reverse=True)
 
+    # Cap the emitted batch. The runtime opens up to maxSlots positions, and the /signals intake caps items
+    # per POST — emitting the whole gated basket (up to xyzMaxNames names on a broad day) overflows that cap
+    # and the runtime drops the ENTIRE batch (max_items_exceeded → silently missed entries). Emit only the
+    # top-scoring maxEmit (default maxSlots); the runtime picks its slots from these. Overridable via inputs.maxEmit.
+    emit_cap = max(1, int(inputs.get("maxEmit") or inputs.get("maxSlots") or 4))
     out = []
     for th in candidates:
+        if len(out) >= emit_cap:
+            break
         leverage = scoring.clamp_leverage(leg_max_lev, th["_meta"].get("max_leverage"))
         notional = margin_usd * leverage
         if leverage <= 0 or notional < min_notional:

--- a/strategies/spider/strategy.yaml
+++ b/strategies/spider/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: spider                  # == package dir name; == every leg's runtime.yaml `group`
-version: "6.0.0"            # single source for catalog + MCP attribution (skillName/skillVersion)
+version: "6.0.1"            # single source for catalog + MCP attribution (skillName/skillVersion)
 
 catalog:                    # discovery surface. `group` here is the discovery TAXONOMY bucket —
                             # distinct from each runtime.yaml's `group: spider` linkage key.

--- a/strategies/spider/swing/scanners/scan.py
+++ b/strategies/spider/swing/scanners/scan.py
@@ -294,8 +294,15 @@ def scan(inputs, ctx):
 
     candidates.sort(key=lambda x: x["score"], reverse=True)
 
+    # Cap the emitted batch. The runtime opens up to maxSlots positions, and the /signals intake caps items
+    # per POST — emitting the whole gated basket (up to xyzMaxNames names on a broad day) overflows that cap
+    # and the runtime drops the ENTIRE batch (max_items_exceeded → silently missed entries). Emit only the
+    # top-scoring maxEmit (default maxSlots); the runtime picks its slots from these. Overridable via inputs.maxEmit.
+    emit_cap = max(1, int(inputs.get("maxEmit") or inputs.get("maxSlots") or 3))
     out = []
     for th in candidates:
+        if len(out) >= emit_cap:
+            break
         leverage = scoring.clamp_leverage(leg_max_lev, th["_meta"].get("max_leverage"))
         notional = margin_usd * leverage
         if leverage <= 0 or notional < min_notional:


### PR DESCRIPTION
**Answers "is the bug in our strategy file?" → yes, the oversized batch is ours; the reject-whole-batch is runtime.**

`spider/swing` + `spider/scalp` `scan()` returned the **entire gated basket** in one call (`for th in candidates:` with no count cap) — up to `xyzMaxNames` (~20) names on a broad AI/tech day. The runtime POSTs that as one batch → exceeds the `/signals` intake `max_items` cap → the runtime rejects the **whole** batch (`max_items_exceeded`, logged at `info`), so those positions silently never open. Confirmed across multiple spider users in HyperDX.

## Fix (our part, #2)
Spider only holds `maxSlots` (swing 3, scalp 4), so emitting ~20 is the cause *and* waste. Cap the emit to the top-scoring **`maxEmit` (default `maxSlots`)**, overridable via `inputs.maxEmit`:
```python
emit_cap = max(1, int(inputs.get("maxEmit") or inputs.get("maxSlots") or 3))
for th in candidates:
    if len(out) >= emit_cap:
        break
    ...
```
Default = `maxSlots` is safe under **any** intake cap; if Rachin raises the cap (#3), bump `maxEmit` per-deploy without a code change. (The scan's own docstring already claimed it emitted "at most `min(open_slots, affordable)`" — this restores that.)

## Not here (runtime / Rachin)
The intake rejecting the **whole** batch instead of truncating (fix #1) is the real systemic guard — ~15 other scanners fleet-wide use the same emit-all pattern; per-scanner caps don't scale. That stays a runtime change.

## Verified (offline, stubbed data)
- swing: 20 candidates → **3** emitted (cap `maxSlots`); `maxEmit=6` → 6
- scalp: 20 → **4** (cap `maxSlots`); `maxEmit=2` → 2

Package `6.0.0 → 6.0.1`. Existing spider deploys pick it up on redeploy; the runtime fix (#1) covers them in the meantime.

**Verify in HyperDX after deploy:** `signal.rejected … max_items_exceeded` for `spider_swing_signals` → ~0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)