### PR TITLE
strategy deploy: gated create→runtime→verify loop + honor requested budget

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.4.2"
+  version: "2.5.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -238,8 +238,20 @@ Same references; usually no rebuild: tune `runtime.yaml` `inputs` (universe/thre
 the `dsl_preset`, adjust `risk.guard_rails`, or change the `scoring.py` math. Re-validate, then
 re-smoke-test if you touched `scan.py`/`runtime.yaml`.
 
-## Handoff
+## Handoff & the live gate — "done" means the deploy is verified LIVE, not "package built"
 
-Authoring produces the package only. **Deploy/monitor/close is `senpi-strategy-ops`** — hand off the
-`id` once the smoke test is green. Attribution (`skillName`/`skillVersion`) is set by ops from
-`strategy.yaml` `id`/`version`.
+Authoring produces the package; a strategy is only **live** once **`senpi-strategy-ops` deploys it AND
+`deploy.py verify` passes**. Walk the full loop every time, and never skip the gate:
+
+1. **Build** — stages 1–9 above (spec → scoring → scan → runtime.yaml → strategy.yaml → unit-test →
+   `validate_strategy.py` → `validate_universe.py` → smoke-test). Every ticker verified; a DSL preset in.
+2. **Deploy** (hand the `id` to `senpi-strategy-ops`): `deploy.py create <id> --budget <the user's exact
+   amount>` → `deploy.py runtime <id>`. The budget is a **hard target** — if the live balance can't cover
+   it, create halts `underfunded`; fund/confirm, never silently fund less.
+3. **GATE — `deploy.py verify <id>`**: the strategy is **live** only when *every* instance is
+   **runtime-running + scanner-active + DSL-wired + funded**. If verify returns `not-live` (e.g.
+   `scanner=broken`, `dsl=config-missing`, `budget=underfunded`), **the strategy is NOT live** — fix the
+   flagged component and re-run. **Never tell the user it's live until `verify` returns `live`.**
+
+**If any step of the loop is incomplete, the strategy is not live — say exactly which step failed.**
+Attribution (`skillName`/`skillVersion`) is set by ops from `strategy.yaml` `id`/`version`.

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.5.0"
+  version: "2.6.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -37,6 +37,19 @@ much risk). Your job is to draw those out, one question at a time, and compile t
 > no name). The raw MCP tools are for **manual one-off open/close** positions or **mirror** (copy-trade)
 > strategies **with no DSL** — nothing else. If protection is anywhere in the ask, you're in the right
 > skill; author it.
+
+> **Opening a position for the user is a FORK — ASK, never assume.** When the user asks to *open* a
+> position (or a set) — "go long HYPE", "buy BTC 5x", "short SOFTBANK" — do **not** just place it. Ask which
+> of two different products they want:
+> - **(A) A DSL-protected strategy** — a named, supervised Runtime 3.0 strategy that manages a trailing stop
+>   + profit-lock ladder. → **author it here.** The path for anything the user wants *managed* or persistent.
+> - **(B) A plain position with a standard take-profit / stop-loss** — a one-off via raw `create_position`
+>   (it carries `stopLoss` / `takeProfit`), placed in a **discretionary wallet, NOT a strategy wallet.**
+>
+> **Either way, NEVER open into an existing scanner-managed strategy's wallet.** A hand-placed position in a
+> wallet a deployed strategy runs is reconciled as *foreign* and **DSL-flattened within minutes** — the order
+> "succeeds," the position is gone, and the user eats the round-trip. If the user hasn't said which of
+> (A)/(B) they want, **ask before placing anything** — and never route (B) into a managed wallet to save a step.
 
 ## Start here — offer the fast path before building from scratch
 

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.3.0"
+  version: "2.4.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -36,8 +36,8 @@ tool call — wallet funding and the first scan tick are slow, so they must not 
 
 ```
 python3 senpi-strategy-ops/scripts/deploy.py create  <id> --budget <usd>   # 1. create wallets & fund them
-python3 senpi-strategy-ops/scripts/deploy.py runtime <id>                  # 2. set up autonomous trading (DONE after this)
-python3 senpi-strategy-ops/scripts/deploy.py verify  <id>                  # optional: confirm a scan fired (only if asked)
+python3 senpi-strategy-ops/scripts/deploy.py runtime <id>                  # 2. register the runtime(s)
+python3 senpi-strategy-ops/scripts/deploy.py verify  <id>                  # 3. GATE — confirm LIVE (runtime+scanner+DSL+budget)
 python3 senpi-strategy-ops/scripts/status.py                               # what am I running? (+ health)
 python3 senpi-strategy-ops/scripts/close.py          <id>                  # teardown one strategy
 python3 senpi-strategy-ops/scripts/close.py          --all                 # teardown EVERY open strategy
@@ -50,7 +50,12 @@ fetched from the remote if not on disk. The scripts call MCP directly (`scripts/
 `SENPI_AUTH_TOKEN`) + drive `openclaw senpi runtime …`. Mechanics + state machine:
 [`references/lifecycle.md`](references/lifecycle.md). Manifest: [`references/strategy-yaml-schema.md`](references/strategy-yaml-schema.md).
 
-## Deploy — two steps (then it's autonomously trading; `verify` is optional)
+## Deploy — three steps: create → runtime → verify (NOT live until `verify` passes)
+
+> **The loop is a gate, not a suggestion.** A strategy is LIVE only when `verify` returns `live` — every
+> instance **runtime-running + scanner-active + DSL-wired + funded to what was requested**. If any step is
+> incomplete, the strategy is **not live**; say so and fix the flagged component. Never report "live" off
+> `registered` alone.
 
 **Step 0 — resolve which strategy.** The user's word ("spider") is a strategy **`id`**. To confirm it
 exists, check the registry; no match → hand to **senpi-strategy-discover**:
@@ -72,9 +77,13 @@ is still created (unnamed) rather than failing the deploy. It records the `strat
 `strategy_list` to **ACTIVE** — **bounded** (~150s). If it prints
 **`creating`** (wallets still funding), just **re-run the same `create` command** — it resumes and
 **never re-creates** a wallet. It prints **`wallets-ready`** when done. `create` is **self-healing**: it
-reconciles recorded wallets against the backend (drops any CLOSED/FAILED and recreates) and **sizes each
-wallet to your live balance minus a fee buffer**. So **never hand-edit `.deploy-state.json` and never
-lower `--budget` to dodge a rounding/funding error** — just re-run `create`.
+reconciles recorded wallets against the backend (drops any CLOSED/FAILED and recreates). The `--budget` is
+a **hard target**: create funds exactly what you ask (split by `funding_share`, $100/wallet floor). If your
+live balance can't cover it, create **HALTS with `underfunded`** and the exact shortfall — it will **NEVER
+silently fund less** (the "$1,000 → $100" failure). Fund more USDC / free some from another strategy, or
+confirm a smaller amount with the user, then re-run. **Never hand-edit `.deploy-state.json`.** When the user
+names a budget per strategy ("$1k on X, $2k on Y"), deploy each with its own `--budget` and **confirm the
+split before funding**.
 
 **Step 2 — setting up the autonomous trading strategy** (`runtime`, fast): `python3 scripts/deploy.py
 runtime spider` renders each instance's runtime.yaml with its wallet and runs `openclaw senpi runtime create`.
@@ -82,23 +91,23 @@ runtime spider` renders each instance's runtime.yaml with its wallet and runs `o
 (different/CLOSED wallet, e.g. orphaned by an earlier close) it's deleted and recreated. Prints
 `registered`. `--decision-model` only for a `decision_mode: llm` action (rule-mode strategies need none).
 
-**Once Step 2 prints `registered`, deployment is DONE — the strategy is live and trading autonomously.**
-It scans on its own schedule and opens positions when *its* signals fire (spider swing ~300s, scalp ~60s
-cadence). Tell the user it's set up and running; **do NOT sleep/poll waiting for the first scan tick** —
-that's normal strategy behavior, not part of deploy.
+**Once Step 2 prints `registered`, the runtime is wired — but the strategy is NOT confirmed live yet.**
+Run **Step 3 `verify`**. **Do NOT tell the user the strategy is live until `verify` returns `live`.**
 
-**Optional — `verify`** (only if the user asks "is it actually scanning / live yet?"): `python3
-scripts/deploy.py verify spider` checks each `external_scanner` once. The first `scan()` only fires on its
-`interval_seconds`, so right after `runtime` it reports `registered` (not ticked yet) — expected, not a
-failure; re-run after the interval to see `live`. `deploy.py status <id>` shows current state any time.
-Do not run `verify` (and never `sleep` then verify) as a default step.
+**Step 3 — `verify`** (the required gate): `python3 scripts/deploy.py verify spider` returns **`live`** only
+when every instance is runtime-running + scanner-active (ticked *or* scheduled, never erroring) + **DSL-wired**
+(`exit.dsl_preset` present and the monitor enabled) + **funded to what was requested**; otherwise **`not-live`**
+with the failing component named (e.g. `scanner=broken`, `dsl=config-missing`, `budget=underfunded`). Fix the
+flagged component and re-run. It's a **single fast check** — a scheduled scanner passes, so it does **not**
+wait for the first scan tick and you must **never `sleep` then verify**. `deploy.py status <id>` shows deploy
+state any time.
 
 > **Do NOT improvise.** A package strategy is a **runtime-supervised scanner** — deploy it **only** via
 > these steps. Never substitute a raw `strategy_create_custom_strategy` MCP call to "deploy" it: that
 > makes an **empty** custom-position strategy, not the running scanner. Funding is **automatic**
-> (Hyperliquid perps → HL spot → EVM bridge). If `create` reports insufficient USDC / `available: 0`, the
-> wallet genuinely lacks accessible funds (often locked in other strategies) — have the user fund/free
-> USDC, then **re-run `create`**. Do not switch tools. If `create` **refuses** with "existing strategies
+> (Hyperliquid perps → HL spot → EVM bridge). If `create` reports **`underfunded`** (or insufficient USDC /
+> `available: 0`), the balance can't cover the requested budget (often locked in other strategies) — have
+> the user fund/free USDC or confirm a lower amount, then **re-run `create`**. Do not switch tools. If `create` **refuses** with "existing strategies
 > not in deploy state", a prior run was interrupted — `close.py <id>` the strays first, then `create`.
 
 **Report** from the structured output, not raw logs (then always close with the **How it runs** block below):
@@ -108,10 +117,11 @@ Do not run `verify` (and never `sleep` then verify) as a default step.
   "instances":[ { "instance":"swing","runtime_id":"spider-swing","wallet":"0x…","status":"live" },
                 { "instance":"scalp","runtime_id":"spider-scalp","wallet":"0x…","status":"live" } ] }
 ```
-Overall status across the steps: `create` → `creating` (re-run) | `wallets-ready`; `runtime` →
-`registered`; `verify` → `live` (scanner ticked) | `registered` (re-run verify). Per-instance status
-flows `pending → creating → active → registered → live`. **`registered` ≠ ticking.** `create`/`runtime`
-take `--dry-run` (plan only; no side effects).
+Overall status across the steps: `create` → `creating` (re-run) | `wallets-ready` | **`underfunded`**
+(balance < requested — fund more / lower the ask); `runtime` → `registered`; `verify` → **`live`** |
+**`not-live`** (a component failed — fix it, re-run). Per-instance status flows
+`pending → creating → active → registered → live`. **`registered` ≠ live — `verify` is the gate.**
+`create`/`runtime` take `--dry-run` (plan only; no side effects).
 
 ### Final step — tell the user HOW each strategy runs (REQUIRED on every deploy)
 
@@ -125,12 +135,12 @@ Keep it to ~3 short lines per strategy. Multi-instance packages whose legs diffe
 
 ### Worked example — "install spider"
 ```
-user: "deploy spider with $200"
-1. resolve → id = spider (two instances: swing 60% / scalp 40%; $200 → swing ~$120, scalp $100 min)
-2. create → python3 scripts/deploy.py create spider --budget 200
-            → wallets-ready  (if "creating", re-run the same command until wallets-ready)
+user: "deploy spider with $300"
+1. resolve → id = spider (two instances: swing 60% / scalp 40%; $300 → swing $180, scalp $120)
+2. create → python3 scripts/deploy.py create spider --budget 300
+            → wallets-ready  (if "creating", re-run until wallets-ready; if "underfunded", fund more / lower)
 3. runtime → python3 scripts/deploy.py runtime spider          → registered (spider-swing + spider-scalp)
-4. verify  → python3 scripts/deploy.py verify spider           → live  (re-run if a slow instance hasn't ticked)
+4. verify  → python3 scripts/deploy.py verify spider           → live  (runtime+scanner+DSL+budget all green)
 5. confirm → "🕷️ Spider is live (swing + scalp)." + the required How it runs block, e.g.:
    • Cadence — scans every 5 min (swing) / 5 min (scalp).
    • Scoring — grades tech/AI names on 4h/1h trend + smart-money consensus; opens above its score bar,

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -69,6 +69,19 @@ class Instance:
         return self.external_scanner.get("interval_seconds")
 
     @property
+    def exit_block(self):
+        ex = (self.runtime_doc or {}).get("exit")
+        return ex if isinstance(ex, dict) else {}
+
+    @property
+    def has_dsl(self):
+        """True iff the runtime.yaml ships a DSL exit block (`exit:` with a preset or `engine: dsl`) —
+        the built-in trailing stop. A deployed strategy WITHOUT one runs its positions naked (the
+        funded-but-no-DSL hole). Mirrors the author-side validate_strategy exit-block requirement."""
+        ex = self.exit_block
+        return bool(ex) and (bool(ex.get("dsl_preset")) or str(ex.get("engine", "")).lower() == "dsl")
+
+    @property
     def needs_model(self):
         """True iff any action runs decision_mode: llm (then a decision-model env must be injected)."""
         for a in (self.runtime_doc or {}).get("actions", []) or []:
@@ -189,6 +202,13 @@ def validate(pkg: Package) -> list:
             ep = inst.runtime_path.parent / sub / es.get("entrypoint", "scan.py")
             if not ep.is_file():
                 errs.append(f"{tag}: scanner entrypoint {ep.name!r} not found at {ep.parent}")
+        # Protection is not optional — a deployed strategy with no DSL exit runs every position naked
+        # (the funded-but-no-DSL hole). Refuse to deploy it. (author's validate_strategy checks this too;
+        # ops re-checks so a hand-edited or fetched package can't slip a naked strategy past deploy.)
+        if not inst.has_dsl:
+            errs.append(f"{tag}: runtime {inst.runtime_rel!r} has no DSL exit block "
+                        f"(exit.dsl_preset / engine: dsl) — every deployed strategy must ship "
+                        f"built-in protection")
         if inst.funding_share is None:
             errs.append(f"{tag}: missing funding_share")
         # llm actions need a model env declared

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -104,17 +104,23 @@ def available_usd(mcp):
 
 
 def plan_funding(need, budget, available):
-    """Per-instance initialBudget for the instances still needing a wallet. Splits the requested
-    budget by funding_share, but caps the TOTAL at the live available balance minus a per-wallet fee
-    buffer (so sequential funding + creation fees can't leave a later instance $1 short). Floors at MIN_WALLET."""
+    """Per-instance initialBudget for the instances still needing a wallet, split by funding_share and
+    floored at MIN_WALLET. Returns (amounts, shortfall).
+
+    The requested budget is a HARD TARGET, not a suggestion: if the live balance can't cover it (minus a
+    per-wallet fee buffer) we return a `shortfall` dict and the caller HALTS — we never silently fund
+    LESS than asked. The old behaviour scaled every wallet down to fit `available`, which quietly turned
+    a "$1,000 / $2,000" request into two $100 floor wallets; that silent under-funding is the bug this
+    removes. (`available` unreadable → shortfall stays None → proceed; create would fail loudly anyway.)"""
     raw = {i.name: max(MIN_WALLET, round((budget or 0) * (i.funding_share or (1.0 / len(need))), 2)) for i in need}
-    total = sum(raw.values())
+    total = round(sum(raw.values()), 2)
+    shortfall = None
     if available is not None:
-        cap = max(0.0, available - FEE_BUFFER * len(need))
-        if total > cap and total > 0:
-            scale = cap / total
-            raw = {n: max(MIN_WALLET, round(a * scale, 2)) for n, a in raw.items()}
-    return raw
+        usable = max(0.0, round(available - FEE_BUFFER * len(need), 2))
+        if total > usable:
+            shortfall = {"requested": total, "available": round(float(available), 2),
+                         "usable": usable, "short_by": round(total - usable, 2), "wallets": len(need)}
+    return raw, shortfall
 
 
 def report(pkg, st, overall, note=None, as_json=False):
@@ -127,6 +133,7 @@ def report(pkg, st, overall, note=None, as_json=False):
         print(f"\n{pkg.id} v{pkg.version}: {overall}")
         for r in insts:
             print(f"  - {r['instance']}: {r['status']}"
+                  + (f"  requested=${r['requested']:g}" if r.get("requested") else "")
                   + (f"  wallet={r['wallet']}" if r.get("wallet") else "")
                   + (f"  ({r['error']})" if r.get("error") else ""))
         if note:
@@ -195,9 +202,18 @@ def cmd_create(pkg, a, log):
             f"(likely an interrupted run). Close them first to avoid duplicate funded wallets:\n"
             f"  python3 {Path(__file__).with_name('close.py')} {pkg.id}")
 
-    # size the to-create instances against the LIVE available balance (minus a per-wallet fee buffer),
-    # so sequential funding + creation fees can't leave a later instance short.
-    amounts = plan_funding(need, a.budget, available_usd(mcp)) if need else {}
+    # Size the to-create instances against the LIVE available balance. The requested --budget is a HARD
+    # TARGET: if the balance can't cover it, HALT with the shortfall (fund more / lower the ask) rather
+    # than silently funding the $100 floor. Nothing is created on this path.
+    amounts, shortfall = plan_funding(need, a.budget, available_usd(mcp)) if need else ({}, None)
+    if shortfall:
+        return report(pkg, st, "underfunded", note=(
+            f"Requested ${shortfall['requested']:g} across {shortfall['wallets']} wallet(s) "
+            f"(min ${MIN_WALLET:g}/wallet), but only ${shortfall['available']:g} is accessible "
+            f"(${shortfall['usable']:g} after fees) — short by ${shortfall['short_by']:g}. "
+            f"NOT funding; no wallet was created. Add USDC (or free some from another strategy), or "
+            f"confirm a lower amount with the user and re-run `create` with --budget ≤ ${shortfall['usable']:g}."),
+            as_json=a.json)
 
     # create any instance that has no strategyId yet — record the id IMMEDIATELY (before polling),
     # so an interrupted run resumes instead of re-creating.
@@ -206,6 +222,7 @@ def cmd_create(pkg, a, log):
         if s.get("strategyId"):
             continue
         amt = amounts.get(inst.name, max(MIN_WALLET, round((a.budget or 0) * (inst.funding_share or 1.0), 2)))
+        s["requested"] = amt  # remember what the user asked to fund → reconciled against actual at verify
         # Name each wallet for its role in the strategy (matches the pkg-instance runtime naming),
         # so wallets are legible in the app / balances / notifications instead of a bare 0x address.
         # e.g. a WhaleHunter deploy → "whalehunter-long", "whalehunter-short". Sanitized to the
@@ -326,9 +343,9 @@ def cmd_runtime(pkg, a, log):
     failed = [i.name for i in pkg.instances if inst_state(st, i.name).get("error")]
     overall = "failed" if failed else "registered"
     note = ("Some instances failed to register — see errors above." if failed else
-            "Done — " + pkg.id + " is deployed and trading autonomously (it scans on its own cadence and "
-            "opens positions when its signals fire). No need to wait for the first tick. "
-            "Optional: `deploy.py verify " + pkg.id + "` only if you want to confirm a scan has fired.")
+            "Registered — now confirm it's actually live: run `deploy.py verify " + pkg.id + "`. "
+            "That gate checks every instance is runtime-running + scanner-active + DSL-wired + funded; "
+            "the strategy is NOT live until it passes. (verify does not wait for the first scan tick.)")
     return report(pkg, st, overall, note=note, as_json=a.json)
 
 
@@ -351,48 +368,121 @@ def _deep_find_scanner(obj, name):
     return None
 
 
-def _check_ticks(pkg, st):
-    """One pass: mark each instance live if its external_scanner has ticked. Returns the list of
-    instances not yet live as (name, reason)."""
-    pending = []
+def _scanner_verdict(inst, state):
+    """(status, detail) for the instance's external_scanner, from `openclaw senpi state` JSON.
+      ticked    — runCount>0 (it has actually scanned)
+      scheduled — mounted + enabled + no error, runCount==0 (first tick fires on interval_seconds)
+      broken    — not mounted / disabled / erroring
+    'scheduled' counts as live: everything is wired and will fire on cadence — we do NOT block the gate
+    waiting for a slow first tick, but we DO fail a scanner that threw on init."""
+    sc = _deep_find_scanner(state, inst.external_scanner.get("name")) if state else None
+    if not sc:
+        return "broken", "scanner not mounted in runtime state"
+    if _cli.dig(sc, "enabled", default=True) is False:
+        return "broken", "scanner disabled"
+    err = _cli.dig(sc, "lastError")
+    cec = _cli.dig(sc, "consecutiveErrorCount", default=0) or 0
+    if err or (isinstance(cec, (int, float)) and cec >= 1):
+        return "broken", f"scanner erroring: {str(err)[:120] if err else f'{int(cec)} consecutive errors'}"
+    runs = _cli.dig(sc, "runCount", "ticks", "runs", default=0) or 0
+    if isinstance(runs, (int, float)) and runs > 0:
+        return "ticked", f"{int(runs)} scan(s)"
+    return "scheduled", f"awaiting first tick (~{inst.interval_seconds or '?'}s cadence)"
+
+
+def _dsl_verdict(inst, status_json):
+    """(status, detail) for DSL protection. The STATIC check — the deployed runtime.yaml has an
+    `exit.dsl_preset` — is load-bearing (it closes the funded-but-no-DSL hole); the runtime monitor's
+    `enabled` flag (from `senpi status`) confirms it wired. If status is unreadable we trust the static
+    config — never fail the gate on an unreadable status alone."""
+    if not inst.has_dsl:
+        return "config-missing", "runtime.yaml has no exit.dsl_preset — positions would run naked"
+    dsl = _cli._deep_first(status_json, ["dsl"]) if status_json else None
+    if isinstance(dsl, dict) and _cli.dig(dsl, "enabled") is False:
+        return "monitor-down", "DSL configured but its monitor is disabled in the runtime"
+    return "wired", "exit.dsl_preset present; DSL monitor active"
+
+
+def _budget_verdict(s, funded_by_id):
+    """(status, detail) comparing the wallet's ACTUAL funded USDC to what was requested. Best-effort: if
+    we can't read the funded amount we don't block (the create-time shortfall halt is the primary guard;
+    this reconciliation also catches a backend partial-fund)."""
+    req = s.get("requested")
+    funded = funded_by_id.get(s.get("strategyId"))
+    if not req or funded is None:
+        return "ok", (f"${funded:g}" if isinstance(funded, (int, float)) else "")
+    if funded < req * 0.9:
+        return "underfunded", f"funded ${funded:g} of requested ${req:g}"
+    return "ok", f"${funded:g} (asked ${req:g})"
+
+
+def _check_live(pkg, st, mcp):
+    """One pass over every instance → the composite live verdict: runtime running AND scanner active AND
+    DSL wired AND budget funded. Returns a list of per-instance rows."""
+    # one strategy_list read → actual funded amount per strategyId (best-effort budget reconciliation)
+    funded_by_id = {}
+    try:
+        for m in _cli.strategies_for(mcp, skill_name=pkg.id, timeout=POLL_HTTP_TIMEOUT):
+            fid = _cli.strategy_id_of(m)
+            fv = _cli.dig(_cli.strategy_obj(m), "totalFunded", "netFunded", "initialBudget")
+            if fid and isinstance(fv, (int, float)):
+                funded_by_id[fid] = float(fv)
+    except Exception:  # noqa: BLE001 — a read hiccup must not fail the gate; budget stays best-effort
+        pass
+    health = _cli.runtime_health_map()  # one status --json for all runtimes' DSL/health lines
+    rows = []
     for inst in pkg.instances:
         s = inst_state(st, inst.name)
-        if s.get("status") == "live":
-            continue
         rt = _cli.find_runtime(inst.runtime_name)
         if not rt or not _cli.runtime_running(rt):
-            pending.append((inst.name, "no live runtime"))
+            rows.append({"instance": inst.name, "live": False, "scanner": "no-runtime",
+                         "dsl": "-", "budget": "-", "reason": "runtime not running"})
             continue
         state = _cli.cli_json(["openclaw", "senpi", "state", "-r", inst.runtime_name, "--json"], POLL_HTTP_TIMEOUT)
-        sc = _deep_find_scanner(state, inst.external_scanner.get("name")) if state else None
-        runs = _cli.dig(sc or {}, "runCount", "ticks", "runs", default=0) or 0
-        if isinstance(runs, (int, float)) and runs > 0:
-            s["status"] = "live"
-            save_state(pkg, st)
-        else:
-            pending.append((inst.name, f"awaiting first tick (~{inst.interval_seconds or '?'}s cadence)"))
-    return pending
+        status = health.get(inst.runtime_name) or _cli.runtime_status(inst.runtime_name, POLL_HTTP_TIMEOUT)
+        sc_st, sc_d = _scanner_verdict(inst, state)
+        dsl_st, dsl_d = _dsl_verdict(inst, status)
+        bud_st, bud_d = _budget_verdict(s, funded_by_id)
+        live = sc_st in ("ticked", "scheduled") and dsl_st == "wired" and bud_st == "ok"
+        s["status"] = "live" if live else s.get("status", "registered")
+        save_state(pkg, st)
+        reason = "; ".join(d for ok, d in
+                           ((sc_st in ("ticked", "scheduled"), sc_d), (dsl_st == "wired", dsl_d),
+                            (bud_st == "ok", bud_d)) if not ok and d)
+        rows.append({"instance": inst.name, "live": live, "scanner": sc_st, "dsl": dsl_st,
+                     "budget": bud_st, "reason": reason})
+    return rows
 
 
 def cmd_verify(pkg, a, log):
-    # Single fast check by default — the first scan() tick is gated by the scanner's interval_seconds
-    # (e.g. spider swing = 300s), so blocking here would just burn the tool budget. Report liveness or
-    # the expected cadence and let the agent re-run when it's worth re-checking. `--max-wait S` opts
-    # into a bounded poll for fast instances.
+    # THE liveness gate: a strategy is `live` only when EVERY instance has a running runtime + an active
+    # scanner (ticked or scheduled) + a wired DSL + a funded budget. It does NOT wait for a slow first
+    # scan tick (a 'scheduled' scanner is live — it fires on interval_seconds); --max-wait re-checks only
+    # for a runtime/scanner that hasn't finished mounting yet.
+    mcp = MCPClient()
     st = load_state(pkg)
     deadline = time.time() + a.max_wait
     while True:
-        pending = _check_ticks(pkg, st)
-        if not pending:
-            out = report(pkg, st, "live", as_json=a.json)
-            delete_state(pkg)  # deploy complete → state is ephemeral; next deploy starts clean
+        rows = _check_live(pkg, st, mcp)
+        live = bool(rows) and all(r["live"] for r in rows)
+        if live or time.time() >= deadline:
+            out = {"strategy": pkg.id, "version": pkg.version,
+                   "status": "live" if live else "not-live", "instances": rows}
+            if a.json:
+                print(json.dumps(out, indent=2))
+            else:
+                print(f"\n{pkg.id} v{pkg.version}: {out['status']}")
+                for r in rows:
+                    print(f"  - {r['instance']}: scanner={r['scanner']}, dsl={r['dsl']}, "
+                          f"budget={r['budget']}" + (f"  → {r['reason']}" if r["reason"] else ""))
+                if not live:
+                    print(f"\nNOT live — fix the flagged component(s) and re-run `deploy.py verify {pkg.id}`. "
+                          "A strategy is live only when every instance is runtime-running + scanner-active "
+                          "+ DSL-wired + funded.")
+            if live:
+                delete_state(pkg)  # deploy complete → state is ephemeral; next deploy starts clean
             return out
-        if time.time() >= deadline:
-            note = "Not ticking yet — each instance's first scan() fires on its interval_seconds:\n  " + \
-                   "\n  ".join(f"{n}: {why}" for n, why in pending) + \
-                   f"\nRe-run `deploy.py verify {pkg.id}` after that to confirm `live`."
-            return report(pkg, st, "registered", note=note, as_json=a.json)
-        log(f"  waiting on {', '.join(n for n, _ in pending)}…")
+        log("  re-checking liveness…")
         time.sleep(POLL_EVERY)
 
 
@@ -447,7 +537,7 @@ def main(argv):
     else:  # status
         out = report(pkg, load_state(pkg), "status", as_json=a.json)
 
-    sys.exit(2 if out.get("status") == "failed" else 0)
+    sys.exit(2 if out.get("status") in ("failed", "underfunded", "not-live") else 0)
 
 
 if __name__ == "__main__":

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Hermetic unit tests for the deploy liveness + budget gates.
+
+No MCP, no openclaw, no network — every input is a plain dict/stub. Run:
+    python3 senpi-strategy-ops/tests/test_deploy_gates.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import types
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import _pkg    # noqa: E402
+import deploy  # noqa: E402
+
+
+def _inst(name, share):
+    return types.SimpleNamespace(name=name, funding_share=share)
+
+
+def _dsl_inst(runtime_doc):
+    """A bare _pkg.Instance with only runtime_doc set — enough for the exit_block/has_dsl properties."""
+    i = _pkg.Instance.__new__(_pkg.Instance)
+    i.runtime_doc = runtime_doc
+    return i
+
+
+def _scan_inst():
+    return types.SimpleNamespace(external_scanner={"name": "sc1"}, interval_seconds=300)
+
+
+class PlanFunding(unittest.TestCase):
+    def test_fits(self):
+        amounts, short = deploy.plan_funding([_inst("a", 0.6), _inst("b", 0.4)], 1000, 1100)
+        self.assertEqual(amounts, {"a": 600.0, "b": 400.0})
+        self.assertIsNone(short)
+
+    def test_incident_single_wallet_underfunded(self):
+        # the M-incident: user asked $1000, only $100 available → HALT, never silently fund the floor
+        _amounts, short = deploy.plan_funding([_inst("only", 1.0)], 1000, 100)
+        self.assertIsNotNone(short)
+        self.assertEqual(short["requested"], 1000.0)
+        self.assertGreater(short["short_by"], 800)
+
+    def test_floor_covered_by_balance_is_not_short(self):
+        # $200 across 60/40 floors the small leg to $100 → $220 total; $300 available covers it, no halt
+        amounts, short = deploy.plan_funding([_inst("a", 0.6), _inst("b", 0.4)], 200, 300)
+        self.assertEqual(amounts, {"a": 120.0, "b": 100.0})
+        self.assertIsNone(short)
+
+    def test_floor_over_balance_is_short(self):
+        _amounts, short = deploy.plan_funding([_inst("a", 0.6), _inst("b", 0.4)], 200, 200)
+        self.assertIsNotNone(short)
+
+    def test_available_unknown_never_halts(self):
+        _amounts, short = deploy.plan_funding([_inst("a", 1.0)], 1000, None)
+        self.assertIsNone(short)
+
+
+class HasDsl(unittest.TestCase):
+    def test_full_preset(self):
+        self.assertTrue(_dsl_inst({"exit": {"engine": "dsl", "dsl_preset": {"phase1": {}}}}).has_dsl)
+
+    def test_engine_only(self):
+        self.assertTrue(_dsl_inst({"exit": {"engine": "dsl"}}).has_dsl)
+
+    def test_preset_only(self):
+        self.assertTrue(_dsl_inst({"exit": {"dsl_preset": {"phase1": {}}}}).has_dsl)
+
+    def test_empty_exit_is_naked(self):
+        self.assertFalse(_dsl_inst({"exit": {}}).has_dsl)
+
+    def test_no_exit_is_naked(self):
+        self.assertFalse(_dsl_inst({}).has_dsl)
+
+    def test_non_dsl_engine_no_preset_is_naked(self):
+        self.assertFalse(_dsl_inst({"exit": {"engine": "none"}}).has_dsl)
+
+
+class ScannerVerdict(unittest.TestCase):
+    def test_ticked(self):
+        st = {"scanners": [{"name": "sc1", "runCount": 5, "enabled": True}]}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "ticked")
+
+    def test_scheduled(self):
+        st = {"scanners": [{"name": "sc1", "runCount": 0, "enabled": True}]}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "scheduled")
+
+    def test_disabled_is_broken(self):
+        st = {"scanners": [{"name": "sc1", "runCount": 0, "enabled": False}]}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "broken")
+
+    def test_erroring_is_broken(self):
+        st = {"scanners": [{"name": "sc1", "runCount": 3, "lastError": "boom"}]}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "broken")
+
+    def test_not_mounted_is_broken(self):
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), {"scanners": []})[0], "broken")
+
+
+class DslVerdict(unittest.TestCase):
+    def test_config_missing(self):
+        v = deploy._dsl_verdict(types.SimpleNamespace(has_dsl=False), {"dsl": {"enabled": True}})
+        self.assertEqual(v[0], "config-missing")
+
+    def test_wired_when_status_unreadable(self):
+        self.assertEqual(deploy._dsl_verdict(types.SimpleNamespace(has_dsl=True), None)[0], "wired")
+
+    def test_monitor_down(self):
+        v = deploy._dsl_verdict(types.SimpleNamespace(has_dsl=True), {"dsl": {"enabled": False}})
+        self.assertEqual(v[0], "monitor-down")
+
+    def test_wired(self):
+        v = deploy._dsl_verdict(types.SimpleNamespace(has_dsl=True), {"dsl": {"enabled": True}})
+        self.assertEqual(v[0], "wired")
+
+
+class BudgetVerdict(unittest.TestCase):
+    def test_ok(self):
+        self.assertEqual(deploy._budget_verdict({"requested": 1000, "strategyId": "x"}, {"x": 1000.0})[0], "ok")
+
+    def test_underfunded(self):
+        self.assertEqual(deploy._budget_verdict({"requested": 1000, "strategyId": "x"}, {"x": 100.0})[0], "underfunded")
+
+    def test_no_requested_is_ok(self):
+        self.assertEqual(deploy._budget_verdict({"strategyId": "x"}, {"x": 100.0})[0], "ok")
+
+    def test_funded_unreadable_is_ok(self):
+        self.assertEqual(deploy._budget_verdict({"requested": 1000, "strategyId": "x"}, {})[0], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem
Two deploy gaps behind recent incidents:
1. **A strategy could be \`registered\` but not actually live.** \`verify\` only checked the scanner had ticked — nothing confirmed the **DSL was wired** or the **budget landed**. Funded-but-no-DSL and FAILED/idle deploys slipped through (M404726).
2. **\`create\` silently under-funded.** \`plan_funding\` scaled every wallet down to the live balance, floored at $100 — so a "$1,000 / $2,000" request could quietly become two $100 wallets and still report success.

## Solution — clean rework of #462/#464 (~350 lines vs #462's ~1,750)
- **\`verify\` is now THE liveness gate.** \`live\` only when *every* instance is **runtime-running + scanner-active (ticked or scheduled, never erroring) + DSL-wired (\`exit.dsl_preset\` present AND monitor enabled) + funded to request**. It does **not** wait for a slow first tick (a \`scheduled\` scanner passes) — a fast required step, not an optional poll. Returns \`not-live\` naming the failing component (\`scanner=broken\`, \`dsl=config-missing\`, \`budget=underfunded\`).
- **\`create\` honors \`--budget\` as a hard target.** If the balance can't cover it, it **HALTS \`underfunded\`** with the exact shortfall (fund more / lower the ask) — never silently funds less. Records the requested amount; reconciles against actual funded at verify.
- **\`_pkg.validate\` refuses a DSL-less package** (defense-in-depth vs funded-but-no-DSL). **83/83** existing templates still pass.
- **SKILLs** (strategy-ops, strategy-author) document the mandatory **create → runtime → verify** loop — *not live until verify passes*.

## Testing
- \`tests/test_deploy_gates.py\` — 24 hermetic tests (funding halt, has_dsl, scanner/dsl/budget verdicts). All pass.
- Regression: 83/83 packages pass the new DSL gate; 0 false-fails.

## Merge checklist
- Bump external **skills-manifest**: \`senpi-strategy-ops\` → 2.4.0, \`senpi-strategy-author\` → 2.5.0 (MINOR = auto-upgrade).
- Supersedes #462 + #464 (being closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)