### PR TITLE
W4a: opening a position is a fork — ask DSL-strategy vs plain TP/SL, never a managed wallet

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.5.0"
+  version: "2.6.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -37,6 +37,20 @@ much risk). Your job is to draw those out, one question at a time, and compile t
 > no name). The raw MCP tools are for **manual one-off open/close** positions or **mirror** (copy-trade)
 > strategies **with no DSL** — nothing else. If protection is anywhere in the ask, you're in the right
 > skill; author it.
+
+> **Opening a position for the user is a FORK — ASK, never assume.** When the user asks to *open* a
+> position (or a set) — "go long HYPE", "buy BTC 5x", "short SOFTBANK" — do **not** just place it. Ask which
+> of two different products they want:
+> - **(A) A DSL-protected strategy** — a named, supervised Runtime 3.0 strategy that manages a trailing stop
+>   + profit-lock ladder. → **author it here.** The path for anything the user wants *managed* or persistent.
+> - **(B) A plain position with a standard take-profit / stop-loss** — a one-off via raw `create_position`
+>   (it carries `stopLoss` / `takeProfit`), placed in a **discretionary wallet, NOT a strategy wallet.**
+>
+> **Either way, NEVER open into an existing scanner-managed strategy's wallet.** A hand-placed position in a
+> wallet a deployed strategy runs is reconciled as *foreign* and **DSL-flattened within minutes** — the order
+> "succeeds," the position is gone, and the user eats the round-trip (the **M405775** loss: discretionary
+> opens injected into scanner-managed wallets, wrong-way, flattened, ~$376). If the user hasn't said which of
+> (A)/(B) they want, **ask before placing anything** — and never route (B) into a managed wallet to save a step.
 
 ## Start here — offer the fast path before building from scratch
 

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -48,8 +48,7 @@ much risk). Your job is to draw those out, one question at a time, and compile t
 >
 > **Either way, NEVER open into an existing scanner-managed strategy's wallet.** A hand-placed position in a
 > wallet a deployed strategy runs is reconciled as *foreign* and **DSL-flattened within minutes** — the order
-> "succeeds," the position is gone, and the user eats the round-trip (the **M405775** loss: discretionary
-> opens injected into scanner-managed wallets, wrong-way, flattened, ~$376). If the user hasn't said which of
+> "succeeds," the position is gone, and the user eats the round-trip. If the user hasn't said which of
 > (A)/(B) they want, **ask before placing anything** — and never route (B) into a managed wallet to save a step.
 
 ## Start here — offer the fast path before building from scratch


### PR DESCRIPTION
**W4** skills-side rule (stacked on #467 — same `strategy-author` SKILL; auto-retargets to `main` on merge).

Per the product decision: on a discretionary open the agent **asks the user** which of two products they want, and never touches a managed wallet.

## The rule (in strategy-author's DSL-boundary block)
When the user asks to *open* a position — "go long HYPE", "buy BTC 5x", "short SOFTBANK" — **do not just place it. Ask:**
- **(A) A DSL-protected strategy** → author a Runtime 3.0 strategy (managed trailing stop + profit ladder).
- **(B) A plain position with a standard take-profit / stop-loss** → raw `create_position` (carries `stopLoss`/`takeProfit`) into a **discretionary wallet, not a strategy wallet.**

**Either way, NEVER open into an existing scanner-managed strategy's wallet** — a foreign position there is reconciled and DSL-flattened within minutes (the M405775 loss: discretionary opens into scanner-managed wallets, wrong-way, flattened, ~$376).

## Scope
This is the **skills-side documentation** of the fork (the injected authority for the DSL-vs-raw decision). The **hard enforcement is the W4b MCP/runtime spec** (separate): block `create_position`/`close_position` against a wallet with an active registered runtime, and implement the discretionary-wallet routing for path (B). A skill rule guides; the backend block guarantees.

Docs-only. Bump external skills-manifest: `senpi-strategy-author` → 2.6.0 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)