### PR TITLE
strategy-ops: fresh wallet on every deploy — both steps never reuse an old wallet (2.4.0)

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -81,10 +81,16 @@ So **never hand-edit `.deploy-state.json` and never lower `--budget` to dodge a 
 just re-run `create`.
 
 **Step 2 — setting up the autonomous trading strategy** (`runtime`, fast): `python3 scripts/deploy.py
-runtime spider` renders each instance's runtime.yaml with its wallet and runs `openclaw senpi runtime create`.
-**Self-healing**: if a runtime already exists on the right ACTIVE wallet it's skipped; if it's stale
-(different/CLOSED wallet, e.g. orphaned by an earlier close) it's deleted and recreated. Prints
-`registered`. `--decision-model` only for a `decision_mode: llm` action (rule-mode strategies need none).
+runtime spider` renders each instance's runtime.yaml **fresh from its `${WALLET_ENV}` template with the
+wallet Step 1 created** and runs `openclaw senpi runtime create`. **Never reuses an old wallet:** the
+runtime is always (re)built from scratch on the fresh wallet — if a same-name runtime already exists on a
+**different/old** wallet it is **deleted and recreated**, never `runtime update`d in place; only an exact
+same-wallet match is an idempotent skip. **Self-heals a lost deploy state:** if Step 1 succeeded but its
+`.deploy-state.json` was lost (a sub-agent died before persisting), `runtime` **re-resolves the fresh
+wallet from the live ACTIVE `<id>` strategy** instead of dead-ending — so you never hand-register a runtime
+onto an old wallet. It **won't guess**: if the backend is ambiguous (0 or >1 ACTIVE `<id>` wallets) it
+refuses and tells you to redeploy fresh (`close.py` any stale wallet, then `create`). Prints `registered`.
+`--decision-model` only for a `decision_mode: llm` action (rule-mode strategies need none).
 
 **Once Step 2 prints `registered`, deployment is DONE — the strategy is live and trading autonomously.**
 It scans on its own schedule and opens positions when *its* signals fire (spider swing ~300s, scalp ~60s
@@ -105,7 +111,9 @@ Do not run `verify` (and never `sleep` then verify) as a default step.
 > USDC, then **re-run `create`**. Do not switch tools. If `create` reports **`closing-existing`**, it's
 > closing a runtime-less `<id>` wallet to recover funds so it can deploy fresh — re-run `create` once it's
 > closed. If it **refuses** "already deployed AND running", a live `<id>` strategy exists — `close.py <id>`
-> first to redeploy on a fresh wallet.
+> first to redeploy on a fresh wallet. If **`runtime`** says "wallet(s) not ready and not safely
+> recoverable", **never hand-register a runtime onto an old wallet** (no manual `runtime create`/`update`
+> with a wallet from a leftover yaml) — `close.py <id>` any stale wallet, then re-run `create` → `runtime`.
 
 **Report** from the structured output, not raw logs (then always close with the **How it runs** block below):
 ```jsonc

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.3.0"
+  version: "2.4.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -71,10 +71,14 @@ and notifications. Naming is best-effort: if the backend rejects a name (conflic
 is still created (unnamed) rather than failing the deploy. It records the `strategyId`, and polls
 `strategy_list` to **ACTIVE** — **bounded** (~150s). If it prints
 **`creating`** (wallets still funding), just **re-run the same `create` command** — it resumes and
-**never re-creates** a wallet. It prints **`wallets-ready`** when done. `create` is **self-healing**: it
-reconciles recorded wallets against the backend (drops any CLOSED/FAILED and recreates) and **sizes each
-wallet to your live balance minus a fee buffer**. So **never hand-edit `.deploy-state.json` and never
-lower `--budget` to dodge a rounding/funding error** — just re-run `create`.
+**never re-creates** a wallet. It prints **`wallets-ready`** when done. **`create` never reuses an existing wallet — every deploy gets a
+FRESH one.** If an existing `<id>` strategy is found: a **runtime-less** one (funded but never got a
+runtime — the reuse trap an agent keeps landing back on) is **closed to recover its funds**, then a new
+wallet is created (prints **`closing-existing`**; re-run `create` once it's closed and funds are back); a
+**live, running** one is left untouched — `create` **refuses** so it can't silently flatten a real book
+(`close.py <id>` first to redeploy). It still sizes each wallet to your live balance minus a fee buffer.
+So **never hand-edit `.deploy-state.json` and never lower `--budget` to dodge a rounding/funding error** —
+just re-run `create`.
 
 **Step 2 — setting up the autonomous trading strategy** (`runtime`, fast): `python3 scripts/deploy.py
 runtime spider` renders each instance's runtime.yaml with its wallet and runs `openclaw senpi runtime create`.
@@ -98,8 +102,10 @@ Do not run `verify` (and never `sleep` then verify) as a default step.
 > makes an **empty** custom-position strategy, not the running scanner. Funding is **automatic**
 > (Hyperliquid perps → HL spot → EVM bridge). If `create` reports insufficient USDC / `available: 0`, the
 > wallet genuinely lacks accessible funds (often locked in other strategies) — have the user fund/free
-> USDC, then **re-run `create`**. Do not switch tools. If `create` **refuses** with "existing strategies
-> not in deploy state", a prior run was interrupted — `close.py <id>` the strays first, then `create`.
+> USDC, then **re-run `create`**. Do not switch tools. If `create` reports **`closing-existing`**, it's
+> closing a runtime-less `<id>` wallet to recover funds so it can deploy fresh — re-run `create` once it's
+> closed. If it **refuses** "already deployed AND running", a live `<id>` strategy exists — `close.py <id>`
+> first to redeploy on a fresh wallet.
 
 **Report** from the structured output, not raw logs (then always close with the **How it runs** block below):
 ```jsonc
@@ -108,7 +114,7 @@ Do not run `verify` (and never `sleep` then verify) as a default step.
   "instances":[ { "instance":"swing","runtime_id":"spider-swing","wallet":"0x…","status":"live" },
                 { "instance":"scalp","runtime_id":"spider-scalp","wallet":"0x…","status":"live" } ] }
 ```
-Overall status across the steps: `create` → `creating` (re-run) | `wallets-ready`; `runtime` →
+Overall status across the steps: `create` → `creating` (re-run) | `closing-existing` (re-run once closed) | `wallets-ready`; `runtime` →
 `registered`; `verify` → `live` (scanner ticked) | `registered` (re-run verify). Per-instance status
 flows `pending → creating → active → registered → live`. **`registered` ≠ ticking.** `create`/`runtime`
 take `--dry-run` (plan only; no side effects).

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -289,6 +289,12 @@ def strategy_wallet(s):
     return dig(strategy_obj(s), "strategyWalletAddress", "walletAddress", "wallet", "address")
 
 
+def strategy_name(s):
+    """The strategyName a strategy was created under (create sets it to <id> or <id>-<instance>).
+    Lets a lost-state redeploy match a backend strategy back to its package instance."""
+    return dig(strategy_obj(s), "strategyName", "tradingStrategyName", "name")
+
+
 def strategy_skill(s):
     """The package id a strategy was created under. Lives in strategyMetadata.skillName (set by
     strategy_create_custom_strategy's skillName arg); falls back to tradingStrategyName."""

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -181,19 +181,45 @@ def cmd_create(pkg, a, log):
             st["instances"][inst.name] = {"status": "pending"}
     save_state(pkg, st)
 
-    # Safety: refuse if there are skillName==id strategies we never recorded (interrupted run) — do
-    # NOT blindly fund duplicates. The operator must close the strays first.
-    recorded = {inst_state(st, i.name).get("strategyId") for i in pkg.instances}
-    recorded.discard(None)
-    existing = _cli.strategies_for(mcp, skill_name=pkg.id)
-    # only OPEN, unrecorded strategies indicate an interrupted run — closed/failed history is harmless
-    untracked = [s for s in existing if _cli.strategy_open(s) and _cli.strategy_id_of(s) not in recorded]
-    need = [i for i in pkg.instances if not inst_state(st, i.name).get("strategyId")]
-    if untracked and need:
+    # NEVER reuse an existing strategy's wallet. Re-using a funded, runtime-less wallet is the trap an
+    # agent keeps falling into (creates <id>, never deploys the runtime, keeps landing back on the same
+    # dead wallet); creating a second alongside it double-funds. So every `create` deploys on a FRESH
+    # wallet, resolving any existing OPEN <id> strategy first:
+    #   • RUNNING runtime → a live, working deploy: REFUSE to silently flatten it; redeploy is explicit
+    #     (close.py first). Protects a real book from an accidental `create`.
+    #   • no running runtime → the funded-but-stuck trap: CLOSE it (recovers its funds), then this deploy
+    #     creates a fresh wallet. strategy_close is async, so hand off and re-run `create` once it's closed.
+    runtimes = _cli.list_runtimes()
+    existing_open = [s for s in _cli.strategies_for(mcp, skill_name=pkg.id) if _cli.strategy_open(s)]
+
+    def _has_running_runtime(s):
+        rt = _cli.find_runtime_by_wallet(_cli.strategy_wallet(s))
+        return bool(rt) and _cli.runtime_running(rt)
+
+    live = [s for s in existing_open if _has_running_runtime(s)]
+    if live:
         raise SystemExit(
-            f"error: found {len(untracked)} existing {pkg.id} strateg(y/ies) not in this deploy's state "
-            f"(likely an interrupted run). Close them first to avoid duplicate funded wallets:\n"
-            f"  python3 {Path(__file__).with_name('close.py')} {pkg.id}")
+            f"error: {pkg.id} is already deployed AND running ({len(live)} live wallet(s)) — `create` will not "
+            f"silently close a live strategy. To redeploy on a fresh wallet, close it first:\n"
+            f"  python3 {Path(__file__).with_name('close.py')} {pkg.id}\n"
+            f"Or just re-check it:  python3 {Path(__file__).name} verify {pkg.id}")
+
+    if existing_open:  # open but NOT running → the runtime-less trap: close (recover funds) → fresh wallet
+        import close as _close  # noqa: E402 — sibling module, lazy import
+        for s in existing_open:
+            _close.close_one(pkg.id, s, runtimes, False, log)
+        for inst in pkg.instances:  # forget the old ids so the re-run makes NEW wallets, never resumes them
+            prev = inst_state(st, inst.name)
+            st["instances"][inst.name] = ({"status": "pending", "requested": prev["requested"]}
+                                          if prev.get("requested") else {"status": "pending"})
+        save_state(pkg, st)
+        return report(pkg, st, "closing-existing", note=(
+            f"Found {len(existing_open)} existing {pkg.id} strateg(y/ies) with NO running runtime — closing "
+            f"them (recovering funds) so this deploys on a FRESH wallet, never reusing the runtime-less one. "
+            f"strategy_close is async; re-run `python3 {Path(__file__).name} create {pkg.id} --budget "
+            f"{a.budget:g}` once they're CLOSED and the funds are back."), as_json=a.json)
+
+    need = [i for i in pkg.instances if not inst_state(st, i.name).get("strategyId")]
 
     # size the to-create instances against the LIVE available balance (minus a per-wallet fee buffer),
     # so sequential funding + creation fees can't leave a later instance short.

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -78,13 +78,22 @@ def save_state(pkg, st):
     _state_path(pkg).write_text(json.dumps(st, indent=2) + "\n")
 
 
-def delete_state(pkg):
-    """Remove the ephemeral deploy state — called once a deploy is fully live, or on close."""
-    p = _state_path(pkg)
+def _safe_unlink(p):
+    """Delete a file, ignoring if it's already gone."""
     try:
-        p.unlink()
+        Path(p).unlink()
     except OSError:
         pass
+
+
+def delete_state(pkg):
+    """Remove the ephemeral deploy state — called once a deploy is fully live, or on close. Also sweeps
+    any rendered `<inst>.deploy.runtime.yaml` build artifacts: they carry a baked-in wallet, and a stale
+    one left on disk is exactly what a lost-state manual redeploy wrongly picks up (the reuse trap)."""
+    _safe_unlink(_state_path(pkg))
+    for inst in pkg.instances:
+        if inst.runtime_path:
+            _safe_unlink(inst.runtime_path.with_name(f"{inst.name}.deploy.runtime.yaml"))
 
 
 def inst_state(st, name):
@@ -301,12 +310,54 @@ def cmd_create(pkg, a, log):
 
 # ---------- step 2: deploy runtimes ----------
 
+def _recover_wallet(pkg, inst, active):
+    """Re-resolve one instance's FRESH wallet from the live ACTIVE <id> strategies when the deploy
+    state was lost (the sub-agent died before persisting it). Returns (wallet, error).
+
+    NEVER guesses: if the backend is ambiguous (0, or >1 candidate wallets for the instance) it
+    returns an error so cmd_runtime refuses rather than binding a runtime to the wrong/old wallet —
+    the exact reuse trap (agent hand-registers onto a stale wallet from a leftover rendered yaml)."""
+    if len(pkg.instances) > 1:  # multi-instance: match by the name create assigned each wallet
+        cands = [s for s in active if _cli.strategy_name(s) == f"{pkg.id}-{inst.name}"]
+    else:  # single-instance: the lone ACTIVE <id> strategy is this instance
+        cands = list(active)
+    wallets = {str(_cli.strategy_wallet(s)).lower() for s in cands if _cli.strategy_wallet(s)}
+    if cands and len(wallets) == 1:
+        return _cli.strategy_wallet(cands[0]), None
+    if not cands:
+        return None, f"no ACTIVE {pkg.id} wallet on the backend for instance {inst.name!r}"
+    return None, f"{len(cands)} ACTIVE {pkg.id} wallets match instance {inst.name!r} — ambiguous, won't guess"
+
+
 def cmd_runtime(pkg, a, log):
     st = load_state(pkg)
-    not_ready = [i.name for i in pkg.instances
-                 if not inst_state(st, i.name).get("wallet")]
-    if not_ready and not a.dry_run:
-        raise SystemExit(f"error: wallets not ready for {', '.join(not_ready)} — run `deploy.py create {pkg.id}` first")
+
+    # Self-heal a lost/partial deploy state: if `create` succeeded but its state file was lost (the
+    # sub-agent died before persisting), re-resolve each instance's FRESH wallet from the live ACTIVE
+    # <id> strategies instead of dead-ending. Otherwise the agent improvises a manual `runtime update`
+    # onto an OLD wallet baked into a leftover rendered yaml / a pre-existing same-name runtime — the
+    # reuse trap. We never guess: an ambiguous backend refuses with a redeploy-fresh instruction.
+    missing = [i for i in pkg.instances if not inst_state(st, i.name).get("wallet")]
+    if missing and not a.dry_run:
+        active = _cli.strategies_for(MCPClient(), skill_name=pkg.id, statuses=["ACTIVE"])
+        recovered, unresolved = [], []
+        for inst in missing:
+            w, err = _recover_wallet(pkg, inst, active)
+            if w:
+                inst_state(st, inst.name).update(wallet=w, status="active")
+                recovered.append(inst.name)
+            else:
+                unresolved.append((inst.name, err))
+        if recovered:
+            save_state(pkg, st)
+            log(f"  deploy-state was lost — recovered fresh wallet(s) from the backend for: {', '.join(recovered)}")
+        if unresolved:
+            lines = "\n".join(f"    - {n}: {why}" for n, why in unresolved)
+            raise SystemExit(
+                f"error: wallet(s) not ready and not safely recoverable:\n{lines}\n"
+                f"Do NOT hand-register a runtime on an old wallet. Redeploy on a fresh wallet:\n"
+                f"  python3 {Path(__file__).with_name('close.py')} {pkg.id}   # if a stale {pkg.id} wallet is lingering\n"
+                f"  python3 {Path(__file__).name} create {pkg.id} --budget <usd>")
     if pkg.any_needs_model and not a.decision_model and not a.dry_run:
         raise SystemExit("error: a runtime has a decision_mode: llm action — pass --decision-model <bare-model>")
 
@@ -325,16 +376,20 @@ def cmd_runtime(pkg, a, log):
             s["plan"] = f"openclaw senpi runtime create -p {build} --runtime-id {inst.runtime_name}"
             save_state(pkg, st)
             continue
-        # Reconcile an existing runtime of this id: same+correct wallet → already deployed (skip);
-        # stale (wallet differs, or its wallet is CLOSED — e.g. orphaned by a prior close) → delete it
-        # and recreate. Self-heals the "already exists" / "wallet CLOSED" collisions.
+        # Reconcile an existing runtime of this id. The runtime is ALWAYS (re)built from scratch on the
+        # freshly-resolved wallet — we never reuse an old wallet a same-name runtime is still bound to:
+        #   same + correct wallet → already deployed on this wallet (idempotent skip);
+        #   wallet differs / unreadable / its wallet is CLOSED (orphaned by a prior close) → DELETE the
+        #   old runtime and recreate on the fresh wallet (never `runtime update` it in place).
         existing = _cli.find_runtime(inst.runtime_name)
         if existing:
             if _cli.wallet_match(_cli.runtime_wallet(existing), wallet):
                 s.update(status="registered", error=None)
                 save_state(pkg, st)
+                _safe_unlink(build)  # runtime owns its config now — drop the rendered yaml so no stale wallet lingers
                 continue
-            log(f"  [{inst.name}] stale runtime {inst.runtime_name!r} (wallet mismatch) — deleting")
+            log(f"  [{inst.name}] existing runtime {inst.runtime_name!r} is on a different/old wallet "
+                f"— deleting and recreating on the fresh wallet (never reusing the old one)")
             _cli.run_cli(["openclaw", "senpi", "runtime", "delete", inst.runtime_name], timeout=60)
         build.write_text(text)
         log(f"  [{inst.name}] runtime create…")
@@ -343,9 +398,10 @@ def cmd_runtime(pkg, a, log):
         if rc != 0:
             s.update(error=(err or "runtime create failed").strip()[:300])
             save_state(pkg, st)
-            continue
+            continue  # keep the rendered yaml on failure for debugging
         s.update(status="registered", error=None)
         save_state(pkg, st)
+        _safe_unlink(build)  # registered — the runtime holds its own config; remove the rendered wallet-bearing yaml
 
     if a.dry_run:
         return report(pkg, st, "planned", as_json=a.json)


### PR DESCRIPTION
## Problem

An agent created the **Gibbon** strategy but never completed a clean deploy, and kept **re-using the same funded wallet** — falling into the same trap each time. It fails in **both** deploy steps:

- **Step 1 (`create`)** — re-running `create` resumed onto the same funded, runtime-less wallet instead of a fresh one.
- **Step 2 (`runtime`)** — `create` made a fresh wallet, then the `.deploy-state.json` was **lost** (sub-agent died before persisting). `runtime` dead-ended ("run create first"), so the agent went **manual** — found the **old** wallet baked into a leftover rendered `gibbon-main.deploy.runtime.yaml` + the pre-existing `gibbon-main` runtime, and `runtime update`d it in place onto the old wallet.

## Fix — fresh wallet guaranteed at every step

### Step 1 `create` — resolve any existing OPEN `<id>` before deploying
| Existing `<id>` state | Behavior |
|---|---|
| **Running runtime** (live book) | **Refuse** — won't silently flatten a live strategy; `close.py <id>` first. |
| **Open, no running runtime** (funded-but-stuck trap) | **Close it** (recovers funds) → deploy a **fresh wallet**. Async close → reports `closing-existing`; re-run `create` once closed. |
| **None open** | Deploy fresh, unchanged. |

### Step 2 `runtime` — self-heal lost state, never reuse an old wallet
- **Lost/partial deploy-state → re-resolve the FRESH wallet from the live ACTIVE `<id>` strategy** instead of dead-ending, so the agent never hand-registers onto an old wallet. **Never guesses:** ambiguous backend (0 or >1 ACTIVE `<id>` wallets) → refuses with a redeploy-fresh instruction.
- Runtime is **always (re)built from scratch on the fresh wallet**; a same-name runtime on a different/old wallet is **deleted + recreated**, never `runtime update`d in place. Exact same-wallet match = idempotent skip.
- **Removes the rendered `<inst>.deploy.runtime.yaml` on success** (and `delete_state` sweeps any leftover), so no stale wallet-bearing yaml lingers to be picked up by a manual redeploy.

Guarantees across both steps: **never reuses a wallet**, **never double-funds** (close recovers funds before any fresh create; `create` never funds while an open `<id>` exists), **never strands**, **never hand-registers onto an old wallet**.

## Changes
- `scripts/deploy.py` — `cmd_create` resolve-then-fresh; `cmd_runtime` lost-state recovery (`_recover_wallet`) + delete-and-recreate-from-scratch + build-artifact cleanup; `delete_state` sweeps rendered yamls.
- `scripts/_cli.py` — `strategy_name` helper (match a backend strategy back to its package instance).
- `SKILL.md` — create + runtime behavior, `closing-existing` status, never-hand-register callout, version **2.3.0 → 2.4.0**.

## Notes for review
- **Version collision with #467** (also bumps ops to 2.4.0). Whichever merges second → 2.5.0 + skills-manifest sync. Independent changes, no code overlap.
- **Smoke-test before merge:** the close→fresh and lost-state→recover paths hit live MCP + `openclaw runtime`. Recommend one real Gibbon-style redeploy (incl. deleting the state file mid-deploy to exercise Step-2 recovery).
- Recovery logic is unit-tested (single/multi-instance match, ambiguous-refuse, none). `py_compile` clean.
- **Known edge (safe):** an interrupted *mid-funding* re-run of `create` resolves by close+recreate rather than resume — minor fee cost, no fund loss, no double-fund.

🤖 Generated with [Claude Code](https://claude.com/claude-code)