### PR TITLE
fleet-new: 4 strategies — raven, starling, ant (deployable) + crane (blocked) + catalog gen skip

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.4.0"
+  version: "2.5.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-06-17",
+  "_updated": "2026-07-13",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -1608,6 +1608,53 @@
       "sort_order": 1
     },
     {
+      "id": "ant",
+      "name": "Ant — Funding Harvester",
+      "emoji": "🐜",
+      "tagline": "Finds the most heavily-traded perps where longs are paying shorts a rich funding rate, and — only when that crowd of longs looks tired (overbought and rolling over, not still charging) — shorts them to collect the funding, hour after hour. Low leverage, a tight stop in case of a squeeze, and it rotates daily, dropping names once the funding dries up.",
+      "belief_plain": "When too many traders pile long into a perp, the funding rate turns positive — longs literally pay shorts every hour to hold. Ant gets on the receiving side of that payment by shorting those names, but it's careful: it only shorts when the long crowd is already exhausted, so it's fading a tired move rather than standing in front of a freight train. It keeps size and leverage modest because the money is in the funding, not in calling the direction, and a tight trailing stop caps the damage if a name squeezes.",
+      "version": "1.0.0",
+      "thesis": "Perpetual funding is a harvestable yield: sustained positive funding pays shorts. True cash-and-carry hedges the short with long spot for delta-neutral carry, but Senpi is perps-only (no HyperEVM spot execution), so ant runs the DIRECTIONAL half — short the funding-payer — and manages the price risk with an exhaustion entry gate (RSI/structure), low leverage, a tight DSL squeeze-stop, and a 24h rotation. It ranks the top-OI names, requires annualized funding >= targetApr with multi-hour persistence, and never shorts a name still in a fresh uptrend. Not delta-neutral — the missing spot leg is the residual risk (NOTES.md).",
+      "tags": [
+        "funding",
+        "carry",
+        "harvest",
+        "cash-and-carry",
+        "basis",
+        "short",
+        "contrarian",
+        "exhaustion",
+        "perps-only",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "funding_extreme",
+      "sub_style_label": "Fades extreme funding rates.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "short_only",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 1
+    },
+    {
       "id": "chimp",
       "name": "Chimp — Regime Allocator (Daily)",
       "emoji": "🐒",
@@ -1654,7 +1701,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 1
+      "sort_order": 2
     },
     {
       "id": "gibbon",
@@ -1702,7 +1749,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 2
+      "sort_order": 3
     },
     {
       "id": "gorilla",
@@ -1751,7 +1798,7 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 3
+      "sort_order": 4
     },
     {
       "id": "mantis",
@@ -1797,7 +1844,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "octopus",
@@ -1841,7 +1888,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "orangutan",
@@ -1889,7 +1936,102 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 6
+      "sort_order": 7
+    },
+    {
+      "id": "raven",
+      "name": "Raven — Self-Calibrating Momentum",
+      "emoji": "🐦‍⬛",
+      "tagline": "Runs a momentum book across the most liquid names and gets smarter about ITSELF: twice a day it reads its own closed trades, and if it's been losing it becomes more selective and trades smaller, while if it's been winning it loosens up and presses. You don't tune it — it tunes itself, inside guardrails, and a trailing stop does all the exiting.",
+      "belief_plain": "A momentum strategy's edge drifts with the regime — what worked last week can bleed this week. Raven opens positions on the same proven momentum signal every time, but it watches its OWN results: after a cold streak it raises the bar for what it'll trade and cuts its size; after a hot streak it leans back in. It never manually closes — a ratchet stop protects and exits every position — and a hard drawdown halt is the backstop if the self-tuning isn't enough.",
+      "version": "1.0.0",
+      "thesis": "Momentum entry quality is regime-dependent, and a fixed score threshold is right only some of the time. Raven treats its realized track record (win-rate, profit-factor, losing streak over the last N closed trades) as a live control signal: it ratchets the entry floor up/down and scales conviction sizing between bounded rails on a slow clock. The momentum thesis itself is Bison's validated weighted scorer, ported verbatim; the novelty is the closed-loop self-calibration on top. DSL owns exits; the runtime drawdown_halt is the equity backstop.",
+      "tags": [
+        "momentum",
+        "adaptive",
+        "self-tuning",
+        "self-calibrating",
+        "feedback",
+        "universe",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "adaptive",
+      "sub_style_label": "Self-tunes its thresholds from its own track record.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities",
+        "commodities"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 1800,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 6,
+      "branch": "main",
+      "sort_order": 8
+    },
+    {
+      "id": "starling",
+      "name": "Starling — Smart-Money Rotation Follower",
+      "emoji": "🐦",
+      "tagline": "Watches a flock of the most profitable wallets on Hyperliquid and moves when they do — the instant several of them start piling into the SAME trade in the SAME direction at the SAME time, it buys (or shorts) alongside them, betting more the more of them agree. It only acts on a rotation that's just forming, not a crowd that's been standing in a name for hours, and it never sells manually — a trailing stop does all the exiting, so last week's follows wind down on their own as the flock rotates into the next name.",
+      "belief_plain": "The proven winners on Hyperliquid tend to rotate into the same trades at the same time, and the freshest edge is the moment that agreement is FORMING — not once everyone can already see it. Starling keeps a live shortlist of the wallets with the best all-time track record, watches what they're opening, and when enough of them freshly line up on one name in one direction it opens with them, sizing up when the agreement is strongest. It never manually closes — a ratchet stop protects and exits every position, so the book rotates as the smart money does, and a hard drawdown halt is the backstop.",
+      "version": "1.0.0",
+      "thesis": "Cohort copiers average a pool's standing net bias (already priced); Starling instead trades the DERIVATIVE of that bias — the snapshot-to-snapshot change. Each tick it counts, per name and direction, how many proven wallets hold it, and fires only when that count has just crossed the consensus bar or is still rising (newly-formed / growing), never on a stale standing consensus. Conviction sizing scales with the agreement count. It force-closes nothing — turnover is set by the market via DSL (rotate-by-attrition), the same never-close discipline as the gibbon/orangutan rotation riders.",
+      "tags": [
+        "smart-money",
+        "copy-trading",
+        "consensus",
+        "rotation",
+        "cohort",
+        "follows-traders",
+        "long-short",
+        "universe",
+        "no-close",
+        "dsl-only"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "sm_rotation",
+      "sub_style_label": "Follows where smart money is rotating across asset classes — long the crowded-into, short the fled.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities",
+        "commodities"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 6,
+      "branch": "main",
+      "sort_order": 9
     },
     {
       "id": "asia-ai",
@@ -2621,7 +2763,7 @@
       "emoji": "🕷️",
       "tagline": "An AI/Tech momentum long book plus a macro/majors mean-reversion book — two legs, two wallets, one package.",
       "belief_plain": "AI/tech equities and crypto majors trend over days, while majors and energy snap back from short-term extremes — run both books side by side.",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "thesis": null,
       "tags": [
         "ai",

--- a/senpi-trading-runtime/scripts/gen_catalog.py
+++ b/senpi-trading-runtime/scripts/gen_catalog.py
@@ -204,6 +204,13 @@ def build(updated, branch):
         m = yaml.safe_load(open(man_path)) or {}
         c = m.get("catalog", {}) or {}
         sid = m.get("id", os.path.dirname(man_path))
+        # The catalog is the DEPLOYABLE-package registry. A package flagged non-deployable
+        # (e.g. blocked on a missing runtime capability) is tracked + tested in the repo but
+        # must NOT surface to users as installable — skip it (loudly).
+        if c.get("status") == "blocked" or c.get("deployable") is False:
+            print(f"  · skipping non-deployable package: {sid} "
+                  f"(catalog.status={c.get('status')!r})", file=sys.stderr)
+            continue
         instances = m.get("instances", []) or []
         instance_count = len(instances)
 

--- a/strategies/ant/NOTES.md
+++ b/strategies/ant/NOTES.md
@@ -46,9 +46,14 @@ funding dropped. Ant approximates the intent:
 
 This is a daily rotation, not an instant funding-threshold close.
 
-## Precision on the numbers
-Hyperliquid funds **hourly**, not on an 8h cycle. `funding_apr = rate_hourly × 24 ×
-365`. `targetApr: 30` means ~0.00342%/hr. Set thresholds in HL's hourly terms.
+## Funding source + the numbers
+Ant reads funding from **`market_get_funding_history`** using the exact call + parse
+a live strategy (pangolin) uses: args are `{"asset": <bare>}` only (the tool has no
+`dex` param), and each row carries `annualized_pct`, `funding_direction` (which side
+COLLECTS — SHORT when longs pay), `persistence_hours`, and `trend`. Ant gates on
+`funding_direction == "SHORT"` + `annualized_pct >= targetApr` + `persistence_hours`
++ `trend != "DECAYING"`, and uses `annualized_pct` **directly** — no rate→APR
+recompute, so the hourly-vs-8h question never arises. `targetApr: 30` = 30% annualized.
 
 ## What would make it the *real* (delta-neutral) strategy
 Same primitives crane needs, plus spot:

--- a/strategies/ant/NOTES.md
+++ b/strategies/ant/NOTES.md
@@ -1,0 +1,63 @@
+# Ant — Funding Harvester: what it is, what it isn't
+
+Ant is the **best cash-and-carry Senpi can run today**. It is deployable and tested,
+but you should understand exactly what it does and does not give you.
+
+## The request vs. what's achievable
+The original ask was true **delta-neutral cash-and-carry**: buy spot on HyperEVM +
+short the perp at equal notional, collect funding with ~no price risk, exit when
+funding decays, rebalance daily. Mapping it to Senpi:
+
+| Step | Senpi | Notes |
+|---|---|---|
+| Rank top perps by open interest | ✅ | volume shortlist → `market_get_asset_data` OI |
+| Funding > threshold (longs pay shorts) | ✅ | `market_get_funding_history` |
+| **Buy spot on HyperEVM** | ❌ | **no spot execution primitive** — the delta-neutral leg |
+| Short the perp | ✅ | perp `SHORT` signal |
+| Target 30% APR | ✅ | funding-APR gate |
+| Exit when funding < 0.002% | ⚠️ | approximated (24h hard-timeout + no-reopen); no funding-triggered close |
+| Rebalance daily | ⚠️ | approximated by the 24h rotation; no delta-rebalance action |
+
+Senpi automates **perps**; it can bridge USDC to HyperEVM but cannot swap it into a
+spot token. So the hedge that makes cash-and-carry riskless is exactly what it can't
+place.
+
+## What ant actually is
+A **directional funding-carry short with an exhaustion gate.** It shorts high-OI
+perps paying rich positive funding, **but only when the long crowd is exhausted**
+(overbought RSI, 4h structure rolling over, 1h momentum fading) — never a name still
+ripping (that's the steamroller a naive funding short gets flattened by). It collects
+the hourly funding while a tight Phase-1 stop (8%) and low leverage (2–4×) bound the
+squeeze risk.
+
+**The residual risk you are NOT hedged against:** the perp going *up*. Positive
+funding often clusters on names that squeeze; the exhaustion gate + tight stop reduce
+this but do not remove it the way a long-spot leg would. Size accordingly — the
+harvestable yield is real but it is **gross funding minus directional PnL minus
+fees**, not the riskless basis of a true carry.
+
+## How "exit on funding decay" and "rebalance daily" are handled
+The runtime's exit engine is price-action DSL — it can't close a position because
+funding dropped. Ant approximates the intent:
+- **24h `hard_timeout`** force-closes every position daily.
+- On re-scan, a name is only re-shorted if it **still clears the APR + persistence +
+  exhaustion gates** — so a decayed-funding name simply isn't re-opened (rotate-by-
+  attrition). Freed slots go to the current best funding-payers.
+
+This is a daily rotation, not an instant funding-threshold close.
+
+## Precision on the numbers
+Hyperliquid funds **hourly**, not on an 8h cycle. `funding_apr = rate_hourly × 24 ×
+365`. `targetApr: 30` means ~0.00342%/hr. Set thresholds in HL's hourly terms.
+
+## What would make it the *real* (delta-neutral) strategy
+Same primitives crane needs, plus spot:
+1. **Spot execution** — buy/sell spot (HyperEVM swap or HL-native spot) from the
+   scanner/runtime, so the long-spot hedge can be placed.
+2. **Cross-venue joint position + coordinated close** — manage `{spot long, perp
+   short}` as one delta-neutral unit and close both on funding decay.
+3. **Funding/delta-triggered rebalance action** — a non-price-action exit/rebalance.
+
+With (1)–(3), ant's `build_signal` (which already selects the names and directions)
+feeds a true delta-neutral carry unchanged. Until then, this is the harvestable,
+honestly-labeled directional version.

--- a/strategies/ant/main/runtime.yaml
+++ b/strategies/ant/main/runtime.yaml
@@ -1,0 +1,135 @@
+# ── ANT · Funding Harvester ──────────────────────────────────────────────────
+# The best Senpi-achievable cash-and-carry. Senpi is perps-only (no spot on
+# HyperEVM), so ant cannot place the long-spot hedge that makes true cash-and-carry
+# delta-neutral. It harvests funding the one way the runtime allows — SHORTING perps
+# that pay positive funding (longs pay shorts) — and gates every short behind an
+# EXHAUSTION filter so it fades tired, overcrowded longs, never a name still ripping.
+#
+# ⚠️ DIRECTIONAL, NOT delta-neutral: you collect the funding but carry perp price
+# risk. Leverage is deliberately low and the DSL stop is tight. See ant/NOTES.md.
+# The daily rotation / "exit when funding decays" is a 24h hard-timeout + no-reopen
+# of names that no longer clear the APR gate (a true funding-triggered close needs
+# the coordinated-close primitive crane also needs).
+name: ant-main
+group: ant
+version: 1.0.0
+description: >
+  ANT — Funding Harvester. Ranks the most-liquid perps by open interest, and shorts
+  the ones paying high positive funding (annualized ≥ targetApr) WHEN the long crowd
+  looks exhausted (overbought / rolling over), collecting the hourly funding. Low
+  leverage, tight DSL squeeze-stop, 24h rotation. Directional funding carry, not
+  delta-neutral (Senpi has no spot leg). Up to 5 concurrent shorts.
+
+strategy:
+  wallet: "${ANT_WALLET}"
+  slots: 5
+  margin_pct: 8
+  default_leverage: 2
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: ant_scanner
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300             # 5m — funding is slow; rotation is driven by the 24h timeout
+    timeout_seconds: 300
+    default_signal_validity_seconds: 3600
+    state_history_max_count: 200
+    inputs:
+      # ── universe: top-N by open interest ──
+      includeXyz: false               # funding carry lives on crypto perps
+      universeVolFloorUsd: 25000000
+      shortlistByVol: 20              # volume shortlist (cheap) …
+      topOiCount: 10                  # … then the true top-10 by open interest
+      maxSlots: 5
+      recentSignalTtlSeconds: 21600
+      # ── funding gate ──
+      targetApr: 30                   # annualized funding %; HL funds HOURLY (apr = rate×24×365)
+      minPersistHours: 6              # funding must have been positive ≥ this many hours
+      oiBonusUsd: 50000000            # OI above this earns a liquidity bonus point
+      # ── exhaustion gate (never short fresh strength) ──
+      minExhaustion: 1                # require ≥ this much exhaustion evidence to short
+      # ── scoring / sizing (LOW leverage — the edge is the carry) ──
+      apexScore: 7
+      goodScore: 5
+      leverageTiers: { apex: 4, good: 3, base: 2 }
+      marginPctTiers: { apex: 12, good: 9, base: 6 }
+      maxLeverage: 4
+      maxMarginPct: 20
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      band: { type: string, required: false }
+      fundingApr: { type: number, required: false }
+      oiUsd: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: ant_open
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [ant_scanner]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: ant_scanner
+  # NO CLOSE_POSITION action — DSL + the 24h hard-timeout own every exit.
+
+# EXIT — DSL only. Funding-carry shorts squeeze violently, so Phase 1 is TIGHT and
+# Phase 2 locks profit early. hard_timeout forces the daily rotation (a name whose
+# funding has decayed is closed at 24h and only re-opened if it still clears the gate).
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true
+      interval_in_minutes: 1440        # 24h — the daily rotation / funding-decay drop-off
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 720         # 12h — cut a stalled short that isn't paying its way
+      min_value: 2.0
+    phase1:
+      enabled: true
+      max_loss_pct: 8.0                 # tight — a squeeze is cut fast
+      retrace_threshold: 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 6,  lock_hw_pct: 0 }
+        - { trigger_pct: 12, lock_hw_pct: 40 }
+        - { trigger_pct: 20, lock_hw_pct: 60 }
+        - { trigger_pct: 35, lock_hw_pct: 75 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 8
+    max_entries_per_day: 5
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 900
+    per_asset_cooldown_seconds: 43200   # 12h — don't re-short the same name on a whipsaw
+    drawdown_halt_pct: 15
+    drawdown_reset_on_day_rollover: true

--- a/strategies/ant/main/scanners/scan.py
+++ b/strategies/ant/main/scanners/scan.py
@@ -1,0 +1,193 @@
+"""ANT — Funding Harvester. The single supervised scanner.
+
+The best Senpi-achievable cash-and-carry: perps-only, so it harvests funding by
+SHORTING perps that pay positive funding (longs pay shorts), gated so it only fades
+an EXHAUSTED long crowd — never a name still ripping. Directional (not delta-neutral;
+Senpi can't place the spot hedge — see ant/NOTES.md). Each tick:
+  1) Rank the liquid universe by real open interest (volume shortlist → asset_data
+     OI) and take the top-N by OI.
+  2) For each, read funding (current + recent history) + candles; keep names whose
+     annualized funding ≥ targetApr, has persisted, and whose tape shows exhaustion.
+  3) Short the best-scoring, up to free slots. NEVER closes — the DSL owns exits;
+     a 24h hard-timeout forces the daily rotation / funding-decay drop-off.
+
+Read-only + single-pass. marginPct is a PERCENT in (0,100]. No daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
+        print(f"[ant.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _dex_of(name):
+    return "xyz" if str(name).lower().startswith("xyz:") else ""
+
+
+def _instrument_rows(ctx, dex):
+    data = _read(ctx, "market_list_instruments", ({"dex": dex} if dex else {}),
+                 f"market_list_instruments({dex or 'main'})")
+    if data is None:
+        return None
+    insts = data.get("instruments", data.get("universe", data)) if isinstance(data, dict) else data
+    if not isinstance(insts, list):
+        return None
+    rows = []
+    for inst in insts:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        c = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        rows.append({"name": str(name), "vol": scoring._f(c.get("dayNtlVlm")),
+                     "venue_max": c.get("max_leverage", c.get("maxLeverage")), "dex": _dex_of(name)})
+    return rows
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["1h", "4h"],
+        "include_funding": True, "include_order_book": False, "dex": _dex_of(name),
+    }, f"market_get_asset_data({name})")
+
+
+def _oi_of(md):
+    ctx_ = (md or {}).get("asset_context") or (md or {}).get("assetContext") or {}
+    oi = scoring._num(ctx_.get("openInterest") or ctx_.get("open_interest"))
+    mark = scoring._num(ctx_.get("markPx") or ctx_.get("midPx"))
+    if oi is None:
+        return 0.0
+    return oi * mark if (mark and oi < 1e7) else oi   # coin-units × price → USD; else already USD-ish
+
+
+def _funding_series(ctx, name):
+    """(current_rate_hourly, [recent rates]) from market_get_funding_history.
+    Tolerates the double-nested data.data shape and several rate spellings."""
+    d = _read(ctx, "market_get_funding_history", {"asset": name, "dex": _dex_of(name)},
+              f"market_get_funding_history({name})")
+    rows = d.get("data") if isinstance(d, dict) and isinstance(d.get("data"), list) else d
+    if not isinstance(rows, list) or not rows:
+        return None, []
+    rates = []
+    for e in rows:
+        if isinstance(e, dict):
+            r = scoring._num(e.get("fundingRate") or e.get("funding_rate")
+                             or e.get("rate") or e.get("premium"))
+            if r is not None:
+                rates.append(r)
+        else:
+            r = scoring._num(e)
+            if r is not None:
+                rates.append(r)
+    cur = rates[-1] if rates else None
+    return cur, rates[-24:]                           # last ~24h for persistence
+
+
+def _held(ctx):
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = set()
+    for e in d.get("assetPositions", d.get("asset_positions", [])) or []:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def _top_by_oi(ctx, inputs):
+    """Volume shortlist → asset_data OI → the top-N names by real open interest.
+    Returns [(name, oi_usd, venue_max, md)] or None if instruments unreadable."""
+    main = _instrument_rows(ctx, "")
+    if main is None:
+        return None
+    rows = list(main)
+    if bool(inputs.get("includeXyz", False)):
+        rows += (_instrument_rows(ctx, "xyz") or [])
+    vfloor = scoring._f(inputs.get("universeVolFloorUsd"), 25_000_000)
+    rows = [r for r in rows if r["vol"] >= vfloor]
+    rows.sort(key=lambda r: r["vol"], reverse=True)
+    shortlist = rows[: int(scoring._f(inputs.get("shortlistByVol"), 20))]
+
+    scored = []
+    for r in shortlist:
+        md = _asset_data(ctx, r["name"])
+        if not md:
+            continue
+        scored.append((r["name"], _oi_of(md), r.get("venue_max"), md))
+    scored.sort(key=lambda t: t[1], reverse=True)
+    return scored[: int(scoring._f(inputs.get("topOiCount"), 10))]
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 5))
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 21600)
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    recent = dict(st.get("recent", {}) or {})
+
+    held = _held(ctx)
+    if held is None:
+        return []
+    free = max_slots - len(held)
+
+    out = []
+    if free > 0:
+        top = _top_by_oi(ctx, inputs)
+        if top is None:
+            print("[ant.scan] instruments unreadable — no opens this tick", file=sys.stderr)
+        else:
+            cands = []
+            for name, oi, venue_max, md in top:
+                bare = str(name).split(":", 1)[-1].upper()
+                if bare in held or (recent.get(bare) and (now - scoring._f(recent[bare])) < ttl):
+                    continue
+                cur, rates = _funding_series(ctx, name)
+                candles = md.get("candles", {}) or {}
+                th = scoring.build_signal(name, cur, rates, oi,
+                                          candles.get("1h", []), candles.get("4h", []), inputs)
+                if th:
+                    cands.append((th, venue_max))
+            cands.sort(key=lambda c: c[0]["score"], reverse=True)
+            for th, venue_max in cands:
+                if free <= 0:
+                    break
+                bare = str(th["coin"]).split(":", 1)[-1].upper()
+                band = scoring.band_for(th["score"], inputs)
+                lev, mgn = scoring.sizing_for(band, inputs, venue_max)
+                recent[bare] = now
+                free -= 1
+                out.append({
+                    "asset": th["coin"], "direction": "SHORT", "marginPct": mgn, "leverage": lev,
+                    "data": {"score": th["score"], "leverage": lev, "direction": "SHORT",
+                             "band": band, "fundingApr": th["apr"], "oiUsd": round(th["oi_usd"]),
+                             "reasons": th["reasons"]},
+                })
+                print(f"[ant.scan] SHORT {th['coin']}: apr={th['apr']:.0f}% score={th['score']} "
+                      f"band={band} {lev}x {mgn}% | {', '.join(th['reasons'][:3])}", file=sys.stderr)
+
+    if not out:
+        print(f"[ant.scan] no shorts: held={len(held)}/{max_slots} free={free}", file=sys.stderr)
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"recent": recent,
+                              "result": {"ts": now, "opened": len(out), "held": len(held)}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[ant.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/ant/main/scanners/scan.py
+++ b/strategies/ant/main/scanners/scan.py
@@ -72,27 +72,23 @@ def _oi_of(md):
     return oi * mark if (mark and oi < 1e7) else oi   # coin-units × price → USD; else already USD-ish
 
 
-def _funding_series(ctx, name):
-    """(current_rate_hourly, [recent rates]) from market_get_funding_history.
-    Tolerates the double-nested data.data shape and several rate spellings."""
-    d = _read(ctx, "market_get_funding_history", {"asset": name, "dex": _dex_of(name)},
-              f"market_get_funding_history({name})")
-    rows = d.get("data") if isinstance(d, dict) and isinstance(d.get("data"), list) else d
+def _funding(ctx, name):
+    """This asset's funding row from market_get_funding_history — the call + parse are
+    ported from pangolin (a LIVE strategy): args are `{"asset": <bare>}` ONLY (the tool
+    has no `dex` param), and the payload is double-nested `data.data = [{asset,
+    annualized_pct, funding_direction, persistence_hours, trend}, ...]`. Returns that
+    row dict for this asset, or None. (`_read` already unwraps the outer `data`.)"""
+    bare = str(name).split(":", 1)[-1]
+    d = _read(ctx, "market_get_funding_history", {"asset": bare},
+              f"market_get_funding_history({bare})")
+    rows = d.get("data") if isinstance(d, dict) else d
     if not isinstance(rows, list) or not rows:
-        return None, []
-    rates = []
-    for e in rows:
-        if isinstance(e, dict):
-            r = scoring._num(e.get("fundingRate") or e.get("funding_rate")
-                             or e.get("rate") or e.get("premium"))
-            if r is not None:
-                rates.append(r)
-        else:
-            r = scoring._num(e)
-            if r is not None:
-                rates.append(r)
-    cur = rates[-1] if rates else None
-    return cur, rates[-24:]                           # last ~24h for persistence
+        return None
+    up = bare.upper()
+    for row in rows:
+        if isinstance(row, dict) and str(row.get("asset", "")).split(":", 1)[-1].upper() == up:
+            return row
+    return rows[0] if isinstance(rows[0], dict) else None   # asset-filtered call → single row
 
 
 def _held(ctx):
@@ -157,9 +153,9 @@ def scan(inputs, ctx):
                 bare = str(name).split(":", 1)[-1].upper()
                 if bare in held or (recent.get(bare) and (now - scoring._f(recent[bare])) < ttl):
                     continue
-                cur, rates = _funding_series(ctx, name)
+                funding = _funding(ctx, name)
                 candles = md.get("candles", {}) or {}
-                th = scoring.build_signal(name, cur, rates, oi,
+                th = scoring.build_signal(name, funding, oi,
                                           candles.get("1h", []), candles.get("4h", []), inputs)
                 if th:
                     cands.append((th, venue_max))

--- a/strategies/ant/main/scanners/scoring.py
+++ b/strategies/ant/main/scanners/scoring.py
@@ -18,17 +18,17 @@ still-accelerating name is a steamroller; ant skips it.
 
 Pure halves:
   1. INDICATORS — trend_structure / calc_rsi / price_momentum (ported from bison).
-  2. FUNDING + EXHAUSTION — funding_apr, exhaustion_ok/exhaustion_score, and
-     build_signal (short-only, funding-APR gate ∧ persistence ∧ not-still-ripping).
+  2. FUNDING + EXHAUSTION — funding_signal, exhaustion_score, and build_signal
+     (short-only, funding gate ∧ persistence ∧ not-still-ripping).
 
-NOTE: funding + OI payload shapes were NOT live-verified (auth token invalid when
-written). funding_rate is treated as the per-HOUR fraction Hyperliquid returns
-(HL funds hourly, not 8h); funding_apr = rate × 24 × 365. Verify the rate's unit
-and sign against a real market_get_funding_history / asset_context before funding.
+FUNDING SOURCE: the funding fields (annualized_pct, funding_direction,
+persistence_hours, trend) come straight from `market_get_funding_history` — the
+call + parse are ported from pangolin (a live strategy), so ant uses the tool's
+NATIVE annualized % and its LONG/SHORT collecting-side flag rather than recomputing
+an APR from a raw rate (avoids the hourly-vs-8h ambiguity entirely). OI shape from
+asset_context is still best-effort tolerant.
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
-
-HOURS_PER_YEAR = 24 * 365
 
 
 def _f(v, d=0.0):
@@ -109,23 +109,39 @@ def calc_rsi(closes, period=14):
     return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
 
 
-# ── funding ──
+# ── funding (fields straight from market_get_funding_history — pangolin's proven
+# parse: each row carries annualized_pct, funding_direction, persistence_hours, trend) ──
 
-def funding_apr(rate_hourly):
-    """Annualized funding % from HL's per-HOUR funding fraction (positive ⇒ longs
-    pay shorts ⇒ a short RECEIVES it). rate 0.0000342/hr ≈ 30% APR."""
-    r = _num(rate_hourly)
-    return None if r is None else r * HOURS_PER_YEAR * 100.0
-
-
-def funding_persistent(recent_rates, min_hours):
-    """True iff funding has been positive for at least `min_hours` of the recent
-    window (filters a one-hour spike). `recent_rates` newest-last or -first, sign
-    is all that matters. Empty/short → False (need evidence of persistence)."""
-    vals = [r for r in (_num(x) for x in (recent_rates or [])) if r is not None]
-    if len(vals) < int(min_hours):
-        return False
-    return sum(1 for r in vals if r > 0) >= int(min_hours)
+def funding_signal(funding, inputs):
+    """Is this funding row a harvestable SHORT, and how rich? `funding` is one
+    market_get_funding_history row (see scan._funding). Uses the tool's NATIVE fields —
+    no rate→APR recompute, no hourly-vs-8h ambiguity:
+      • funding_direction == "SHORT"  (the SHORT side COLLECTS ⇒ longs pay us to short)
+      • annualized_pct >= targetApr
+      • persistence_hours >= minPersistHours   (not a one-hour spike)
+      • trend != "DECAYING"                     (funding isn't already drying up)
+    Returns (apr, persistence_hours, reasons) or None."""
+    if not isinstance(funding, dict):
+        return None
+    direction = str(funding.get("funding_direction") or "").upper()
+    apr = _num(funding.get("annualized_pct"))
+    if apr is None:
+        return None
+    apr = abs(apr)                                 # magnitude is the yield; direction gates the side
+    persist = _f(funding.get("persistence_hours"), 0.0)
+    trend = str(funding.get("trend") or "").upper()
+    if direction != "SHORT":                       # ant harvests by SHORTING the funding-payer
+        return None
+    if apr < _f(inputs.get("targetApr"), 30.0):
+        return None
+    if persist < _f(inputs.get("minPersistHours"), 6):
+        return None
+    if trend == "DECAYING":
+        return None
+    reasons = [f"funding_apr_{apr:.0f}%", f"persist_{persist:.0f}h"]
+    if trend:
+        reasons.append(f"funding_{trend.lower()}")
+    return apr, persist, reasons
 
 
 # ── exhaustion gate (never short a crowd that is still ripping) ──
@@ -160,22 +176,16 @@ def exhaustion_score(candles_1h, candles_4h):
 
 # ── the signal (short-only funding harvest) ──
 
-def build_signal(coin, rate_hourly, recent_rates, oi_usd, candles_1h, candles_4h, inputs):
-    """Return a SHORT signal thesis dict or None. None ⟺ insufficient candles,
-    funding not positive / below the APR target, not persistent, or the crowd is
-    still ripping (exhaustion gate). Score blends funding APR + exhaustion + size."""
+def build_signal(coin, funding, oi_usd, candles_1h, candles_4h, inputs):
+    """Return a SHORT signal thesis dict or None. None ⟺ insufficient candles, the
+    funding isn't a harvestable SHORT (direction / APR / persistence / decay), or the
+    crowd is still ripping (exhaustion gate). Score blends funding APR + exhaustion + OI."""
     if len(candles_1h) < 8 or len(candles_4h) < 4:
         return None
-    apr = funding_apr(rate_hourly)
-    if apr is None or apr <= 0:
+    fs = funding_signal(funding, inputs)
+    if not fs:
         return None
-
-    target = _f(inputs.get("targetApr"), 30.0)
-    min_persist = int(_f(inputs.get("minPersistHours"), 6))
-    if apr < target:
-        return None
-    if not funding_persistent(recent_rates, min_persist):
-        return None
+    apr, _persist, freasons = fs
 
     ex, ex_reasons, still_ripping = exhaustion_score(candles_1h, candles_4h)
     if still_ripping:
@@ -184,10 +194,11 @@ def build_signal(coin, rate_hourly, recent_rates, oi_usd, candles_1h, candles_4h
         return None                               # not exhausted enough to fade
 
     # score: APR headroom over target (capped) + exhaustion + OI liquidity bonus
+    target = _f(inputs.get("targetApr"), 30.0)
     apr_pts = min(5.0, (apr - target) / max(1.0, target) * 3.0)
     oi_pts = 1.0 if _f(oi_usd) >= _f(inputs.get("oiBonusUsd"), 50_000_000) else 0.0
     score = round(apr_pts + ex + oi_pts, 2)
-    reasons = [f"funding_apr_{apr:.0f}%", f"oi_${_f(oi_usd) / 1e6:.0f}M"] + ex_reasons
+    reasons = freasons + [f"oi_${_f(oi_usd) / 1e6:.0f}M"] + ex_reasons
     return {"coin": coin, "direction": "SHORT", "score": score, "apr": round(apr, 1),
             "exhaustion": ex, "oi_usd": _f(oi_usd), "reasons": reasons}
 

--- a/strategies/ant/main/scanners/scoring.py
+++ b/strategies/ant/main/scanners/scoring.py
@@ -1,0 +1,213 @@
+"""ANT — Funding Harvester engine (pure: no I/O, no MCP, no clock).
+
+The best Senpi-achievable version of a cash-and-carry funding trade. Senpi is
+perps-only (no spot execution on HyperEVM), so ant cannot place the long-spot hedge
+that makes true cash-and-carry delta-neutral. Instead it harvests funding the one
+way the runtime allows — by SHORTING perps that pay positive funding (longs pay
+shorts) — and it manages the resulting DIRECTIONAL price risk with an exhaustion
+gate + a tight DSL stop.
+
+⚠️ This is a DIRECTIONAL funding carry, NOT delta-neutral. You collect the funding
+but you are short the perp; if the name squeezes up, the loss can dwarf the carry.
+That risk is the price of the missing spot leg — see ant/NOTES.md.
+
+The edge that makes it more than a naive funding short: ant only shorts a
+high-funding name when the long crowd looks EXHAUSTED (overbought / rolling over /
+not making fresh highs), never a name that is still ripping. High funding on a
+still-accelerating name is a steamroller; ant skips it.
+
+Pure halves:
+  1. INDICATORS — trend_structure / calc_rsi / price_momentum (ported from bison).
+  2. FUNDING + EXHAUSTION — funding_apr, exhaustion_ok/exhaustion_score, and
+     build_signal (short-only, funding-APR gate ∧ persistence ∧ not-still-ripping).
+
+NOTE: funding + OI payload shapes were NOT live-verified (auth token invalid when
+written). funding_rate is treated as the per-HOUR fraction Hyperliquid returns
+(HL funds hourly, not 8h); funding_apr = rate × 24 × 365. Verify the rate's unit
+and sign against a real market_get_funding_history / asset_context before funding.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+
+HOURS_PER_YEAR = 24 * 365
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+# ── candle accessors + indicators (ported from bison/scoring.py) ──
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def price_momentum(candles, n_bars=1):
+    if len(candles) < n_bars + 1:
+        return 0.0
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    return ((new - old) / old) * 100 if old else 0.0
+
+
+def trend_structure(candles, lookback=6):
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def calc_rsi(closes, period=14):
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0.0, d))
+        losses.append(max(0.0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── funding ──
+
+def funding_apr(rate_hourly):
+    """Annualized funding % from HL's per-HOUR funding fraction (positive ⇒ longs
+    pay shorts ⇒ a short RECEIVES it). rate 0.0000342/hr ≈ 30% APR."""
+    r = _num(rate_hourly)
+    return None if r is None else r * HOURS_PER_YEAR * 100.0
+
+
+def funding_persistent(recent_rates, min_hours):
+    """True iff funding has been positive for at least `min_hours` of the recent
+    window (filters a one-hour spike). `recent_rates` newest-last or -first, sign
+    is all that matters. Empty/short → False (need evidence of persistence)."""
+    vals = [r for r in (_num(x) for x in (recent_rates or [])) if r is not None]
+    if len(vals) < int(min_hours):
+        return False
+    return sum(1 for r in vals if r > 0) >= int(min_hours)
+
+
+# ── exhaustion gate (never short a crowd that is still ripping) ──
+
+def exhaustion_score(candles_1h, candles_4h):
+    """0..~5 — how EXHAUSTED the long crowd looks (higher ⇒ safer to short).
+    Overbought RSI only counts as exhaustion when the move is ALSO stalling — a
+    vertical rip has RSI ~100 and is the most dangerous thing to short, so high RSI
+    alone earns nothing. Rewards overbought-AND-stalling, a rolling-over 4h
+    structure, and fading 1h momentum. Returns (score, reasons, still_ripping)."""
+    closes_1h = [_close(c) for c in candles_1h]
+    rsi = calc_rsi(closes_1h)
+    trend_4h, _ = trend_structure(candles_4h)
+    mom_1h = price_momentum(candles_1h, 2)
+    stalling = mom_1h <= 0.0                       # not pushing up right now
+
+    score, reasons = 0.0, []
+    if rsi >= 70 and stalling:
+        score += 2; reasons.append(f"overbought_stalling_rsi{rsi:.0f}")
+    if trend_4h == "BEARISH":
+        score += 2; reasons.append("4h_rolling_over")
+    elif trend_4h == "NEUTRAL":
+        score += 1; reasons.append("4h_stalled")
+    if mom_1h <= -0.3:
+        score += 1; reasons.append(f"1h_fading_{mom_1h:+.2f}%")
+
+    # still ripping = a bullish 4h structure that is STILL pushing up right now →
+    # never short an active uptrend, no matter how rich the funding or how high RSI.
+    still_ripping = (trend_4h == "BULLISH" and mom_1h > 0.5)
+    return score, reasons, still_ripping
+
+
+# ── the signal (short-only funding harvest) ──
+
+def build_signal(coin, rate_hourly, recent_rates, oi_usd, candles_1h, candles_4h, inputs):
+    """Return a SHORT signal thesis dict or None. None ⟺ insufficient candles,
+    funding not positive / below the APR target, not persistent, or the crowd is
+    still ripping (exhaustion gate). Score blends funding APR + exhaustion + size."""
+    if len(candles_1h) < 8 or len(candles_4h) < 4:
+        return None
+    apr = funding_apr(rate_hourly)
+    if apr is None or apr <= 0:
+        return None
+
+    target = _f(inputs.get("targetApr"), 30.0)
+    min_persist = int(_f(inputs.get("minPersistHours"), 6))
+    if apr < target:
+        return None
+    if not funding_persistent(recent_rates, min_persist):
+        return None
+
+    ex, ex_reasons, still_ripping = exhaustion_score(candles_1h, candles_4h)
+    if still_ripping:
+        return None                               # never short fresh strength
+    if ex < _f(inputs.get("minExhaustion"), 1):
+        return None                               # not exhausted enough to fade
+
+    # score: APR headroom over target (capped) + exhaustion + OI liquidity bonus
+    apr_pts = min(5.0, (apr - target) / max(1.0, target) * 3.0)
+    oi_pts = 1.0 if _f(oi_usd) >= _f(inputs.get("oiBonusUsd"), 50_000_000) else 0.0
+    score = round(apr_pts + ex + oi_pts, 2)
+    reasons = [f"funding_apr_{apr:.0f}%", f"oi_${_f(oi_usd) / 1e6:.0f}M"] + ex_reasons
+    return {"coin": coin, "direction": "SHORT", "score": score, "apr": round(apr, 1),
+            "exhaustion": ex, "oi_usd": _f(oi_usd), "reasons": reasons}
+
+
+def band_for(score, inputs):
+    if score >= _f(inputs.get("apexScore"), 7):
+        return "apex"
+    if score >= _f(inputs.get("goodScore"), 5):
+        return "good"
+    return "base"
+
+
+def sizing_for(band, inputs, venue_max=None):
+    """(leverage, marginPct). Funding-carry shorts squeeze violently, so leverage is
+    DELIBERATELY LOW (the edge is the carry, not directional conviction)."""
+    lev_tiers = inputs.get("leverageTiers") or {"apex": 4, "good": 3, "base": 2}
+    mgn_tiers = inputs.get("marginPctTiers") or {"apex": 12, "good": 9, "base": 6}
+    cap = int(_f(inputs.get("maxLeverage"), 4))
+    if venue_max:
+        cap = min(cap, int(_f(venue_max, cap)))
+    lev = max(1, min(int(_f(lev_tiers.get(band), 2)), cap))
+    mgn = max(1.0, min(_f(mgn_tiers.get(band), 6), _f(inputs.get("maxMarginPct"), 20)))
+    return lev, round(mgn, 2)

--- a/strategies/ant/strategy.yaml
+++ b/strategies/ant/strategy.yaml
@@ -1,0 +1,42 @@
+# Ant — Funding Harvester. The best Senpi-achievable cash-and-carry: perps-only,
+# so it harvests funding by SHORTING high-positive-funding perps behind an exhaustion
+# gate (never fades fresh strength). DIRECTIONAL, not delta-neutral — Senpi has no
+# spot leg to hedge with. See ant/NOTES.md for the full limitation writeup + the
+# path to a true delta-neutral version.
+schema_version: 1
+
+id: ant
+version: "1.0.0"
+
+catalog:
+  name: "Ant — Funding Harvester"
+  emoji: "🐜"
+  tagline: "Finds the most heavily-traded perps where longs are paying shorts a rich funding rate, and — only when that crowd of longs looks tired (overbought and rolling over, not still charging) — shorts them to collect the funding, hour after hour. Low leverage, a tight stop in case of a squeeze, and it rotates daily, dropping names once the funding dries up."
+  belief_plain: "When too many traders pile long into a perp, the funding rate turns positive — longs literally pay shorts every hour to hold. Ant gets on the receiving side of that payment by shorting those names, but it's careful: it only shorts when the long crowd is already exhausted, so it's fading a tired move rather than standing in front of a freight train. It keeps size and leverage modest because the money is in the funding, not in calling the direction, and a tight trailing stop caps the damage if a name squeezes."
+  thesis: "Perpetual funding is a harvestable yield: sustained positive funding pays shorts. True cash-and-carry hedges the short with long spot for delta-neutral carry, but Senpi is perps-only (no HyperEVM spot execution), so ant runs the DIRECTIONAL half — short the funding-payer — and manages the price risk with an exhaustion entry gate (RSI/structure), low leverage, a tight DSL squeeze-stop, and a 24h rotation. It ranks the top-OI names, requires annualized funding >= targetApr with multi-hour persistence, and never shorts a name still in a fresh uptrend. Not delta-neutral — the missing spot leg is the residual risk (NOTES.md)."
+  group: multi-asset-universe
+  archetype: contrarian_fade
+  sub_style: funding_extreme
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: universe
+  direction: short_only
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 4
+  max_slots: 5
+  min_budget: 100
+  assets: []                 # DERIVED live: top-N perps by open interest
+  tags: [funding, carry, harvest, cash-and-carry, basis, short, contrarian, exhaustion, perps-only, dsl-only, no-close]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name ant-main, group ant
+    wallet_env: ANT_WALLET
+    funding_share: 1.0

--- a/strategies/ant/tests/test_engine.py
+++ b/strategies/ant/tests/test_engine.py
@@ -1,5 +1,7 @@
 """Ant funding-harvester tests. Pure/deterministic + a scan() smoke against a fake
-ctx. Run: python3 strategies/ant/tests/test_engine.py"""
+ctx. Funding uses the REAL market_get_funding_history row shape (pangolin-proven:
+{asset, funding_direction, annualized_pct, persistence_hours, trend}).
+Run: python3 strategies/ant/tests/test_engine.py"""
 import os
 import sys
 
@@ -14,52 +16,55 @@ def _c(seq):
 
 def _blowoff(n=14):
     """Rip up then roll over: elevated RSI, non-bullish structure, negative late momentum."""
-    up = [100 + 3 * i for i in range(n - 4)]      # strong rise
+    up = [100 + 3 * i for i in range(n - 4)]
     top = up[-1]
-    roll = [top - 2, top - 4, top - 6, top - 8]   # lower highs, falling
+    roll = [top - 2, top - 4, top - 6, top - 8]
     return _c(up + roll)
 
 
 def _gentle_up(n=14):
-    """Clean, actively-rising uptrend: bullish structure + positive momentum right
-    now ⇒ 'still ripping' (must NOT be shorted, whatever the funding)."""
+    """Clean, actively-rising uptrend → 'still ripping' (must NOT be shorted)."""
     return _c([100 + 1.5 * i for i in range(n)])
 
 
-def test_funding_apr_hourly():
-    assert scoring.funding_apr(0) == 0
-    apr = scoring.funding_apr(0.0000342)          # ~30% APR at HL's hourly cadence
-    assert 29 < apr < 31
-    assert scoring.funding_apr(None) is None
+def _fund(direction="SHORT", apr=44.0, persist=8.0, trend="STABLE", asset="BTC"):
+    """One market_get_funding_history row (the pangolin/live shape)."""
+    return {"asset": asset, "funding_direction": direction, "annualized_pct": apr,
+            "persistence_hours": persist, "trend": trend}
 
 
-def test_funding_persistent():
-    assert scoring.funding_persistent([0.00003] * 6, 6) is True
-    assert scoring.funding_persistent([0.00003] * 4, 6) is False        # too short
-    assert scoring.funding_persistent([0.00003, -0.00001] * 3, 6) is False  # not all positive
+def test_funding_signal_gates():
+    inp = {"targetApr": 30, "minPersistHours": 6}
+    fs = scoring.funding_signal(_fund(), inp)                              # SHORT collects, rich, persistent
+    assert fs and fs[0] == 44 and fs[1] == 8
+    assert scoring.funding_signal(_fund(direction="LONG"), inp) is None    # shorts would PAY → not for ant
+    assert scoring.funding_signal(_fund(apr=20), inp) is None              # below target APR
+    assert scoring.funding_signal(_fund(persist=3), inp) is None           # one-hour spike, not persistent
+    assert scoring.funding_signal(_fund(trend="DECAYING"), inp) is None    # funding drying up
+    assert scoring.funding_signal(None, inp) is None                       # fails closed
+    assert scoring.funding_signal({}, inp) is None
 
 
 def test_exhaustion_and_still_ripping():
     ex, _, ripping = scoring.exhaustion_score(_blowoff(), _blowoff(8))
     assert ex >= 1 and ripping is False           # tired crowd → shortable
-    ex2, _, ripping2 = scoring.exhaustion_score(_gentle_up(), _gentle_up(8))
+    _, _, ripping2 = scoring.exhaustion_score(_gentle_up(), _gentle_up(8))
     assert ripping2 is True                        # still charging → do NOT short
 
 
 def test_build_signal_gates():
     inp = {"targetApr": 30, "minPersistHours": 6, "minExhaustion": 1}
-    good_rates = [0.00005] * 8                      # ~44% APR, persistent
-    # qualifying: high APR + persistent + exhausted → SHORT
-    th = scoring.build_signal("BTC", 0.00005, good_rates, 8e8, _blowoff(), _blowoff(8), inp)
+    # qualifying: harvestable SHORT funding + exhausted crowd → SHORT
+    th = scoring.build_signal("BTC", _fund(), 8e8, _blowoff(), _blowoff(8), inp)
     assert th and th["direction"] == "SHORT" and th["score"] > 0 and th["apr"] > 30
-    # APR below target → None
-    assert scoring.build_signal("BTC", 0.000001, [0.000001] * 8, 8e8, _blowoff(), _blowoff(8), inp) is None
-    # not persistent → None
-    assert scoring.build_signal("BTC", 0.00005, [0.00005, -0.001] * 4, 8e8, _blowoff(), _blowoff(8), inp) is None
+    # LONG-collecting funding (shorts pay) → None
+    assert scoring.build_signal("BTC", _fund(direction="LONG"), 8e8, _blowoff(), _blowoff(8), inp) is None
+    # below target APR → None
+    assert scoring.build_signal("BTC", _fund(apr=20), 8e8, _blowoff(), _blowoff(8), inp) is None
     # still ripping (fresh strength) → None even with rich funding
-    assert scoring.build_signal("BTC", 0.00005, good_rates, 8e8, _gentle_up(), _gentle_up(8), inp) is None
-    # negative funding (shorts would PAY) → None
-    assert scoring.build_signal("BTC", -0.00005, [-0.00005] * 8, 8e8, _blowoff(), _blowoff(8), inp) is None
+    assert scoring.build_signal("BTC", _fund(), 8e8, _gentle_up(), _gentle_up(8), inp) is None
+    # no funding row → None (fails closed)
+    assert scoring.build_signal("BTC", None, 8e8, _blowoff(), _blowoff(8), inp) is None
 
 
 def test_sizing_is_low_leverage_and_capped():
@@ -84,11 +89,14 @@ class _MCP:
                 {"name": "BTC", "context": {"dayNtlVlm": 9e8, "maxLeverage": 10}},
                 {"name": "ETH", "context": {"dayNtlVlm": 8e8, "maxLeverage": 10}}]}}
         if tool == "market_get_asset_data":
-            b = _blowoff()
-            return {"data": {"candles": {"1h": b, "4h": _blowoff(8)},
+            return {"data": {"candles": {"1h": _blowoff(), "4h": _blowoff(8)},
                              "asset_context": {"openInterest": 6e8, "markPx": 1.0}}}
-        if tool == "market_get_funding_history":
-            return {"data": {"data": [{"fundingRate": 0.00005} for _ in range(10)]}}
+        if tool == "market_get_funding_history":            # real shape: data.data list of rows
+            return {"data": {"data": [
+                {"asset": "BTC", "funding_direction": "SHORT", "annualized_pct": 44.0,
+                 "persistence_hours": 8.0, "trend": "STABLE"},
+                {"asset": "ETH", "funding_direction": "SHORT", "annualized_pct": 44.0,
+                 "persistence_hours": 8.0, "trend": "STABLE"}]}}
         if tool == "strategy_get_clearinghouse_state":
             return {"data": {"assetPositions": []}}
         return {}
@@ -104,7 +112,7 @@ def test_scan_smoke_shorts_only_and_valid():
     ctx = _Ctx()
     out = scan.scan({"maxSlots": 5, "targetApr": 30, "minPersistHours": 6, "shortlistByVol": 20,
                      "topOiCount": 10, "universeVolFloorUsd": 1e6, "maxLeverage": 4}, ctx)
-    assert isinstance(out, list)
+    assert isinstance(out, list) and out, "smoke should emit at least one short"
     for s in out:
         assert s["direction"] == "SHORT"
         assert 0 < s["marginPct"] <= 20 and 1 <= s["leverage"] <= 4

--- a/strategies/ant/tests/test_engine.py
+++ b/strategies/ant/tests/test_engine.py
@@ -1,0 +1,119 @@
+"""Ant funding-harvester tests. Pure/deterministic + a scan() smoke against a fake
+ctx. Run: python3 strategies/ant/tests/test_engine.py"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "main", "scanners"))
+import scoring  # noqa: E402
+
+
+def _c(seq):
+    """closes → OHLC candles (high=close+.5, low=close-.5)."""
+    return [{"open": p, "high": p + 0.5, "low": p - 0.5, "close": p, "volume": 1000} for p in seq]
+
+
+def _blowoff(n=14):
+    """Rip up then roll over: elevated RSI, non-bullish structure, negative late momentum."""
+    up = [100 + 3 * i for i in range(n - 4)]      # strong rise
+    top = up[-1]
+    roll = [top - 2, top - 4, top - 6, top - 8]   # lower highs, falling
+    return _c(up + roll)
+
+
+def _gentle_up(n=14):
+    """Clean, actively-rising uptrend: bullish structure + positive momentum right
+    now ⇒ 'still ripping' (must NOT be shorted, whatever the funding)."""
+    return _c([100 + 1.5 * i for i in range(n)])
+
+
+def test_funding_apr_hourly():
+    assert scoring.funding_apr(0) == 0
+    apr = scoring.funding_apr(0.0000342)          # ~30% APR at HL's hourly cadence
+    assert 29 < apr < 31
+    assert scoring.funding_apr(None) is None
+
+
+def test_funding_persistent():
+    assert scoring.funding_persistent([0.00003] * 6, 6) is True
+    assert scoring.funding_persistent([0.00003] * 4, 6) is False        # too short
+    assert scoring.funding_persistent([0.00003, -0.00001] * 3, 6) is False  # not all positive
+
+
+def test_exhaustion_and_still_ripping():
+    ex, _, ripping = scoring.exhaustion_score(_blowoff(), _blowoff(8))
+    assert ex >= 1 and ripping is False           # tired crowd → shortable
+    ex2, _, ripping2 = scoring.exhaustion_score(_gentle_up(), _gentle_up(8))
+    assert ripping2 is True                        # still charging → do NOT short
+
+
+def test_build_signal_gates():
+    inp = {"targetApr": 30, "minPersistHours": 6, "minExhaustion": 1}
+    good_rates = [0.00005] * 8                      # ~44% APR, persistent
+    # qualifying: high APR + persistent + exhausted → SHORT
+    th = scoring.build_signal("BTC", 0.00005, good_rates, 8e8, _blowoff(), _blowoff(8), inp)
+    assert th and th["direction"] == "SHORT" and th["score"] > 0 and th["apr"] > 30
+    # APR below target → None
+    assert scoring.build_signal("BTC", 0.000001, [0.000001] * 8, 8e8, _blowoff(), _blowoff(8), inp) is None
+    # not persistent → None
+    assert scoring.build_signal("BTC", 0.00005, [0.00005, -0.001] * 4, 8e8, _blowoff(), _blowoff(8), inp) is None
+    # still ripping (fresh strength) → None even with rich funding
+    assert scoring.build_signal("BTC", 0.00005, good_rates, 8e8, _gentle_up(), _gentle_up(8), inp) is None
+    # negative funding (shorts would PAY) → None
+    assert scoring.build_signal("BTC", -0.00005, [-0.00005] * 8, 8e8, _blowoff(), _blowoff(8), inp) is None
+
+
+def test_sizing_is_low_leverage_and_capped():
+    lev, mgn = scoring.sizing_for("apex", {"maxLeverage": 4, "maxMarginPct": 20}, venue_max=10)
+    assert 1 <= lev <= 4 and 0 < mgn <= 20         # funding shorts stay low-lev
+    lev2, _ = scoring.sizing_for("apex", {"maxLeverage": 4}, venue_max=2)
+    assert lev2 == 2                                # venue cap wins
+
+
+# ── scan() smoke against a fake ctx ──
+
+class _State:
+    def __init__(self): self._l = []
+    def last(self): return self._l[-1] if self._l else None
+    def append(self, d): self._l.append(d)
+
+
+class _MCP:
+    def call_tool(self, tool, args):
+        if tool == "market_list_instruments":
+            return {"data": {"instruments": [
+                {"name": "BTC", "context": {"dayNtlVlm": 9e8, "maxLeverage": 10}},
+                {"name": "ETH", "context": {"dayNtlVlm": 8e8, "maxLeverage": 10}}]}}
+        if tool == "market_get_asset_data":
+            b = _blowoff()
+            return {"data": {"candles": {"1h": b, "4h": _blowoff(8)},
+                             "asset_context": {"openInterest": 6e8, "markPx": 1.0}}}
+        if tool == "market_get_funding_history":
+            return {"data": {"data": [{"fundingRate": 0.00005} for _ in range(10)]}}
+        if tool == "strategy_get_clearinghouse_state":
+            return {"data": {"assetPositions": []}}
+        return {}
+
+
+class _Ctx:
+    wallet = "0xabc"
+    def __init__(self): self.state = _State(); self.senpi_mcp = _MCP()
+
+
+def test_scan_smoke_shorts_only_and_valid():
+    import scan
+    ctx = _Ctx()
+    out = scan.scan({"maxSlots": 5, "targetApr": 30, "minPersistHours": 6, "shortlistByVol": 20,
+                     "topOiCount": 10, "universeVolFloorUsd": 1e6, "maxLeverage": 4}, ctx)
+    assert isinstance(out, list)
+    for s in out:
+        assert s["direction"] == "SHORT"
+        assert 0 < s["marginPct"] <= 20 and 1 <= s["leverage"] <= 4
+        assert s["data"]["fundingApr"] > 30
+    assert ctx.state.last() is not None
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn(); print(f"ok  {fn.__name__}")
+    print(f"\nALL {len(fns)} ANT TESTS PASS")

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-06-17",
+  "_updated": "2026-07-13",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -1608,6 +1608,53 @@
       "sort_order": 1
     },
     {
+      "id": "ant",
+      "name": "Ant — Funding Harvester",
+      "emoji": "🐜",
+      "tagline": "Finds the most heavily-traded perps where longs are paying shorts a rich funding rate, and — only when that crowd of longs looks tired (overbought and rolling over, not still charging) — shorts them to collect the funding, hour after hour. Low leverage, a tight stop in case of a squeeze, and it rotates daily, dropping names once the funding dries up.",
+      "belief_plain": "When too many traders pile long into a perp, the funding rate turns positive — longs literally pay shorts every hour to hold. Ant gets on the receiving side of that payment by shorting those names, but it's careful: it only shorts when the long crowd is already exhausted, so it's fading a tired move rather than standing in front of a freight train. It keeps size and leverage modest because the money is in the funding, not in calling the direction, and a tight trailing stop caps the damage if a name squeezes.",
+      "version": "1.0.0",
+      "thesis": "Perpetual funding is a harvestable yield: sustained positive funding pays shorts. True cash-and-carry hedges the short with long spot for delta-neutral carry, but Senpi is perps-only (no HyperEVM spot execution), so ant runs the DIRECTIONAL half — short the funding-payer — and manages the price risk with an exhaustion entry gate (RSI/structure), low leverage, a tight DSL squeeze-stop, and a 24h rotation. It ranks the top-OI names, requires annualized funding >= targetApr with multi-hour persistence, and never shorts a name still in a fresh uptrend. Not delta-neutral — the missing spot leg is the residual risk (NOTES.md).",
+      "tags": [
+        "funding",
+        "carry",
+        "harvest",
+        "cash-and-carry",
+        "basis",
+        "short",
+        "contrarian",
+        "exhaustion",
+        "perps-only",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "funding_extreme",
+      "sub_style_label": "Fades extreme funding rates.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "short_only",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 1
+    },
+    {
       "id": "chimp",
       "name": "Chimp — Regime Allocator (Daily)",
       "emoji": "🐒",
@@ -1654,7 +1701,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 1
+      "sort_order": 2
     },
     {
       "id": "gibbon",
@@ -1702,7 +1749,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 2
+      "sort_order": 3
     },
     {
       "id": "gorilla",
@@ -1751,7 +1798,7 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 3
+      "sort_order": 4
     },
     {
       "id": "mantis",
@@ -1797,7 +1844,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "octopus",
@@ -1841,7 +1888,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "orangutan",
@@ -1889,7 +1936,102 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 6
+      "sort_order": 7
+    },
+    {
+      "id": "raven",
+      "name": "Raven — Self-Calibrating Momentum",
+      "emoji": "🐦‍⬛",
+      "tagline": "Runs a momentum book across the most liquid names and gets smarter about ITSELF: twice a day it reads its own closed trades, and if it's been losing it becomes more selective and trades smaller, while if it's been winning it loosens up and presses. You don't tune it — it tunes itself, inside guardrails, and a trailing stop does all the exiting.",
+      "belief_plain": "A momentum strategy's edge drifts with the regime — what worked last week can bleed this week. Raven opens positions on the same proven momentum signal every time, but it watches its OWN results: after a cold streak it raises the bar for what it'll trade and cuts its size; after a hot streak it leans back in. It never manually closes — a ratchet stop protects and exits every position — and a hard drawdown halt is the backstop if the self-tuning isn't enough.",
+      "version": "1.0.0",
+      "thesis": "Momentum entry quality is regime-dependent, and a fixed score threshold is right only some of the time. Raven treats its realized track record (win-rate, profit-factor, losing streak over the last N closed trades) as a live control signal: it ratchets the entry floor up/down and scales conviction sizing between bounded rails on a slow clock. The momentum thesis itself is Bison's validated weighted scorer, ported verbatim; the novelty is the closed-loop self-calibration on top. DSL owns exits; the runtime drawdown_halt is the equity backstop.",
+      "tags": [
+        "momentum",
+        "adaptive",
+        "self-tuning",
+        "self-calibrating",
+        "feedback",
+        "universe",
+        "long-short",
+        "dsl-only",
+        "no-close"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "adaptive",
+      "sub_style_label": "Self-tunes its thresholds from its own track record.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities",
+        "commodities"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 1800,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 6,
+      "branch": "main",
+      "sort_order": 8
+    },
+    {
+      "id": "starling",
+      "name": "Starling — Smart-Money Rotation Follower",
+      "emoji": "🐦",
+      "tagline": "Watches a flock of the most profitable wallets on Hyperliquid and moves when they do — the instant several of them start piling into the SAME trade in the SAME direction at the SAME time, it buys (or shorts) alongside them, betting more the more of them agree. It only acts on a rotation that's just forming, not a crowd that's been standing in a name for hours, and it never sells manually — a trailing stop does all the exiting, so last week's follows wind down on their own as the flock rotates into the next name.",
+      "belief_plain": "The proven winners on Hyperliquid tend to rotate into the same trades at the same time, and the freshest edge is the moment that agreement is FORMING — not once everyone can already see it. Starling keeps a live shortlist of the wallets with the best all-time track record, watches what they're opening, and when enough of them freshly line up on one name in one direction it opens with them, sizing up when the agreement is strongest. It never manually closes — a ratchet stop protects and exits every position, so the book rotates as the smart money does, and a hard drawdown halt is the backstop.",
+      "version": "1.0.0",
+      "thesis": "Cohort copiers average a pool's standing net bias (already priced); Starling instead trades the DERIVATIVE of that bias — the snapshot-to-snapshot change. Each tick it counts, per name and direction, how many proven wallets hold it, and fires only when that count has just crossed the consensus bar or is still rising (newly-formed / growing), never on a stale standing consensus. Conviction sizing scales with the agreement count. It force-closes nothing — turnover is set by the market via DSL (rotate-by-attrition), the same never-close discipline as the gibbon/orangutan rotation riders.",
+      "tags": [
+        "smart-money",
+        "copy-trading",
+        "consensus",
+        "rotation",
+        "cohort",
+        "follows-traders",
+        "long-short",
+        "universe",
+        "no-close",
+        "dsl-only"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "sm_rotation",
+      "sub_style_label": "Follows where smart money is rotating across asset classes — long the crowded-into, short the fled.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities",
+        "commodities"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 6,
+      "branch": "main",
+      "sort_order": 9
     },
     {
       "id": "asia-ai",
@@ -2621,7 +2763,7 @@
       "emoji": "🕷️",
       "tagline": "An AI/Tech momentum long book plus a macro/majors mean-reversion book — two legs, two wallets, one package.",
       "belief_plain": "AI/tech equities and crypto majors trend over days, while majors and energy snap back from short-term extremes — run both books side by side.",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "thesis": null,
       "tags": [
         "ai",

--- a/strategies/crane/DESIGN.md
+++ b/strategies/crane/DESIGN.md
@@ -1,0 +1,80 @@
+# Crane — Managed Pairs / Stat-Arb (BLOCKED on a runtime capability)
+
+**Status: engine complete + unit-tested; NOT deployable.** Crane needs coordinated
+multi-leg close, which the current Runtime 3.0 scanner contract does not expose.
+This doc records the design, the exact gap, and how to wire it when the capability
+lands. The scanner ships **disarmed** (`inputs.armed: false`) so it can never open a
+pair it cannot manage.
+
+## What it does
+Market-neutral. For a correlated pair `(A, B)` it tracks the log price spread
+`ln(A/B)`, z-scores it over a rolling window, and trades the **spread**:
+- `|z| ≥ entryZ` → short the rich leg, long the cheap leg (equal notional).
+- `|z| ≤ exitZ` → revert: close both legs.
+- `|z| ≥ stopZ` → blowout: close both legs.
+- The two legs are **one position** — they open together and close together.
+
+The alpha is in `main/scanners/scoring.py` (pure, `test_engine.py` green): spread,
+z-score (guards a full window + non-zero dispersion), the pair state machine, entry
+directions, z-scaled sizing.
+
+## The safety core — why DSL-only cannot do this
+A pair with only one leg left is a **naked directional bet**. If the two legs exit
+independently (which is what per-position DSL does), the first leg to hit its stop
+leaves the other fully directional until something notices. That is the exact
+naked-position failure mode the fleet guards against everywhere.
+
+`decide_pair_action` encodes the rule: **exactly one leg held ⇒ `CLOSE_NAKED`,
+unconditionally, before any other branch.** Crane is only safe if it can flatten
+the survivor immediately. It cannot, today.
+
+## The gap (verified against the runtime references)
+1. **Scan signals are open-only.** `scan-contract.md`: the returned signal dict is
+   `{asset, direction, marginPct, leverage, data}` — there is no close/reduce
+   intent. A scanner cannot express "close this position."
+2. **Scan cannot mutate.** `close_position` / `strategy_close_positions` /
+   `strategy_close` raise `PermissionError` inside `scan`.
+3. **`CLOSE_POSITION` exists but is unreachable from a scanner.** It is a valid
+   `action_type` in `runtime-yaml.md`, but only `OPEN_POSITION` execution params
+   are documented, **no fleet strategy uses it**, and the scanner-driven-close
+   approach was tried and scrapped previously (per fleet notes). There is no
+   documented contract for how a scanner tells a `CLOSE_POSITION` action *what* to
+   close.
+4. **DSL is per-position.** It trails/stops each leg independently — it has no
+   concept of "these two legs are one unit; if one dies, kill the other."
+
+Net: the runtime has no primitive for a **joint multi-leg position** or a
+**scanner-driven coordinated close**. Every deployable fleet strategy is
+open-on-scanner + exit-on-DSL, which structurally cannot express a managed pair.
+
+## What would unblock it (the ask for the runtime team)
+Any **one** of these is sufficient:
+- **A close-signal contract** for the scan return value — e.g. a signal with
+  `intent: "close"` (or a `reduce_only`/`close: true` flag) that a `CLOSE_POSITION`
+  action consumes, with the scanner naming the asset(s) to flatten. Crane's
+  `scoring.decide_pair_action` already emits `CLOSE_BOTH` / `CLOSE_NAKED`; it just
+  needs an execution path.
+- **A joint/basket position type** the runtime opens and exits atomically (both
+  legs fill or neither; either leg's stop closes both).
+- **A "linked positions" DSL mode** — tag two positions as a group; the exit engine
+  closes the group when any member exits or on a group-level spread rule.
+
+The first (a scanner close-signal + working `CLOSE_POSITION`) is the smallest change
+and also unlocks other tier-3 strategies (rebalancers, follow-them-out copiers).
+
+## Wiring when it lands
+1. Flip `inputs.armed: true`.
+2. Route `scan`'s `CLOSE_BOTH` / `CLOSE_NAKED` decisions to the close path (emit
+   close-intent signals for the named legs instead of just logging them).
+3. Add the `CLOSE_POSITION` action to `runtime.yaml` subscribed to `crane_scanner`
+   (the reference wiring is stubbed there, commented).
+4. Keep the single-scanner design — the pair's rolling spread state lives in one
+   `ctx.state`; splitting open/close across two scanners would fracture it.
+
+## Connection to the Strategy-Spec proposal
+This is concrete evidence for the coverage-gap point on Duncan's Path-B plan: his
+four Phase-2 stateful primitives (snapshot-diff, rolling-window, derived-universe,
+adaptive-threshold) all assume **independent single-asset emits**. A managed pair
+needs a **fifth** capability — joint multi-leg positions / coordinated close — that
+is missing from both the spec *and* the current runtime. Market-neutral is the
+highest-value category that neither covers yet.

--- a/strategies/crane/main/runtime.yaml
+++ b/strategies/crane/main/runtime.yaml
@@ -1,0 +1,125 @@
+# ── CRANE · Managed Pairs / Stat-Arb ────────────────────────────────────────
+# ⚠️ NOT DEPLOYABLE AS-IS — BLOCKED on a runtime capability (coordinated multi-leg
+# close). See crane/DESIGN.md. The scanner is DISARMED (inputs.armed: false) so it
+# cannot open a pair it cannot manage. This runtime.yaml is the REFERENCE wiring;
+# the CLOSE_POSITION action a managed pair needs is stubbed in comments below,
+# pending a scanner close-signal contract.
+#
+# Market-neutral: tracks the log spread ln(A/B) of each configured pair, z-scores
+# it, shorts the rich leg / longs the cheap leg on dislocation, and manages both
+# legs as one position (open together, close together, never a naked single leg).
+name: crane-main
+group: crane
+version: 1.0.0
+description: >
+  CRANE — Managed Pairs / Stat-Arb (market-neutral). Trades the log-spread z-score
+  of correlated pairs: short the rich leg, long the cheap leg, close both on
+  reversion or a blowout stop, and flatten a survivor instantly if one leg dies.
+  BLOCKED pending coordinated multi-leg close — ships disarmed with a tested engine.
+
+strategy:
+  wallet: "${CRANE_WALLET}"
+  slots: 8                            # 4 pairs × 2 legs
+  margin_pct: 8
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: crane_scanner
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300             # 5m — spread z-score is not high-frequency
+    timeout_seconds: 120
+    default_signal_validity_seconds: 900
+    state_history_max_count: 300      # holds the rolling spread series per pair
+    inputs:
+      armed: false                    # ⚠️ keep false until coordinated close exists
+      pairs:                          # identity-basket correlated pairs (same-dex)
+        - ["BTC", "ETH"]
+        - ["SOL", "AVAX"]
+        - ["xyz:NVDA", "xyz:AMD"]
+        - ["xyz:MSFT", "xyz:GOOGL"]
+      zWindow: 60
+      entryZ: 2.0
+      exitZ: 0.5
+      stopZ: 3.5
+      legMarginPct: 8
+      maxLegMarginPct: 12
+      legLeverage: 3
+      maxLeverage: 5
+    signal_data_schema:
+      pair: { type: string }
+      z: { type: number, required: false }
+      direction: { type: string }
+      leverage: { type: number }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: crane_open
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [crane_scanner]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: crane_scanner
+
+  # ── REQUIRED to make crane safe, pending runtime support (see DESIGN.md) ──
+  # A managed pair must close both legs together. This needs a scanner close-signal
+  # contract that CLOSE_POSITION consumes. Uncomment + wire when it exists:
+  # - name: crane_close
+  #   action_type: CLOSE_POSITION
+  #   decision_mode: rule
+  #   scanners: [crane_scanner]        # same scanner → shared pair/spread state
+  #   context:
+  #     - type: signal
+  #       scanner: crane_scanner
+
+# EXIT — DSL is only a per-leg BACKSTOP here (it cannot coordinate the two legs).
+# The real exit is the manager's CLOSE_BOTH / CLOSE_NAKED, which is why crane is
+# blocked. Tight hard stop so a runaway leg is bounded while disarmed.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    phase1:
+      enabled: true
+      max_loss_pct: 10.0
+      retrace_threshold: 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 6, lock_hw_pct: 0 }
+        - { trigger_pct: 12, lock_hw_pct: 45 }
+        - { trigger_pct: 25, lock_hw_pct: 70 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 8
+    max_entries_per_day: 8
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 900
+    per_asset_cooldown_seconds: 3600
+    drawdown_halt_pct: 15
+    drawdown_reset_on_day_rollover: true

--- a/strategies/crane/main/scanners/scan.py
+++ b/strategies/crane/main/scanners/scan.py
@@ -1,0 +1,131 @@
+"""CRANE — Managed Pairs / Stat-Arb. The single supervised scanner.
+
+⚠️ NOT DEPLOYABLE AS-IS — BLOCKED ON A RUNTIME CAPABILITY (see crane/DESIGN.md).
+A managed pair must close BOTH legs together (on reversion, on a blowout stop, or
+the instant one leg goes missing). The Runtime 3.0 scan contract emits OPEN-only
+signals and blocks close mutations; CLOSE_POSITION has no scanner-signal path. So
+crane cannot flatten a pair, and a DSL-only pair would leave a naked directional
+leg the moment one side's stop fires. Until coordinated multi-leg close exists,
+this scanner is DISARMED: `scan` returns [] unless `inputs.armed` is true, and it
+logs every close it WOULD issue so the gap is observable. The alpha engine
+(scoring.py) is complete and unit-tested, ready to wire when the capability lands.
+
+Each tick: update each configured pair's rolling log-spread in ctx.state, z-score
+it, and run the pair state machine. Read-only, single-pass, no daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[crane.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _prices(ctx, assets):
+    """{ASSET_UPPER: price} for the requested assets (tolerant)."""
+    d = _read(ctx, "market_get_prices", {"assets": assets}, "market_get_prices")
+    out = {}
+    rows = d if isinstance(d, list) else (d.get("prices", d) if isinstance(d, dict) else [])
+    if isinstance(rows, dict):
+        for k, v in rows.items():
+            p = scoring._num(v if not isinstance(v, dict) else v.get("price", v.get("markPx")))
+            if p is not None:
+                out[str(k).split(":", 1)[-1].upper()] = p
+    elif isinstance(rows, list):
+        for r in rows:
+            if isinstance(r, dict):
+                name = r.get("asset") or r.get("coin") or r.get("name")
+                p = scoring._num(r.get("price", r.get("markPx", r.get("mid"))))
+                if name and p is not None:
+                    out[str(name).split(":", 1)[-1].upper()] = p
+    return out
+
+
+def _held_map(ctx):
+    """{ASSET_UPPER: 'LONG'|'SHORT'} for open positions, or None on read failure."""
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = {}
+    for e in d.get("assetPositions", d.get("asset_positions", [])) or []:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        szi = scoring._f(pos.get("szi"))
+        if coin and szi != 0:
+            out[coin.split(":", 1)[-1].upper()] = "LONG" if szi > 0 else "SHORT"
+    return out
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    armed = bool(inputs.get("armed", False))
+    window = int(scoring._f(inputs.get("zWindow"), 60))
+    pairs = [{"a": str(p[0]).upper(), "b": str(p[1]).upper()}
+             for p in (inputs.get("pairs") or []) if isinstance(p, (list, tuple)) and len(p) == 2]
+    if not pairs:
+        print("[crane.scan] no pairs configured — nothing to do", file=sys.stderr)
+        return []
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    spreads = dict(st.get("spreads", {}) or {})     # {pairKey: [history]}
+
+    legs = sorted({p["a"] for p in pairs} | {p["b"] for p in pairs})
+    prices = _prices(ctx, legs)
+    held = _held_map(ctx)
+    if held is None:
+        print("[crane.scan] clearinghouse unreadable — act next tick", file=sys.stderr)
+        return []
+
+    out, close_needed, suppressed_open = [], [], False
+    for p in pairs:
+        key = f"{p['a']}/{p['b']}"
+        spread = scoring.log_spread(prices.get(p["a"]), prices.get(p["b"]))
+        spreads[key] = scoring.push_spread(spreads.get(key, []), spread, window)
+        z = scoring.zscore(spreads[key], window)
+        a_held, b_held = p["a"] in held, p["b"] in held
+        action, reason = scoring.decide_pair_action(z, a_held, b_held, inputs)
+        print(f"[crane.scan] {key}: z={'NA' if z is None else round(z,2)} held=({a_held},{b_held}) "
+              f"→ {action} ({reason})", file=sys.stderr)
+
+        if action in (scoring.CLOSE_BOTH, scoring.CLOSE_NAKED):
+            # Cannot execute a close from a scanner in the current runtime — record the gap.
+            close_needed.append((key, action, reason))
+            print(f"[crane.scan] ⚠️ {action} REQUIRED for {key} but the runtime exposes no "
+                  f"scanner-driven close — see crane/DESIGN.md", file=sys.stderr)
+        elif action == scoring.OPEN_BOTH and not a_held and not b_held:
+            if not armed:
+                suppressed_open = True
+                continue
+            lev, mgn = scoring.leg_sizing(z, inputs)
+            for leg in scoring.entry_legs(z, p):
+                out.append({
+                    "asset": leg["asset"], "direction": leg["direction"],
+                    "marginPct": mgn, "leverage": lev,
+                    "data": {"pair": key, "z": round(z, 3), "leverage": lev,
+                             "direction": leg["direction"], "reasons": [reason]},
+                })
+            print(f"[crane.scan] OPEN pair {key}: {lev}x {mgn}%/leg | {reason}", file=sys.stderr)
+
+    if suppressed_open:
+        print("[crane.scan] DISARMED (inputs.armed=false) — opens suppressed; arm only once "
+              "coordinated multi-leg close exists (crane/DESIGN.md)", file=sys.stderr)
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"spreads": spreads,
+                              "result": {"ts": now, "opened": len(out),
+                                         "close_needed": [c[0] for c in close_needed]}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[crane.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/crane/main/scanners/scoring.py
+++ b/strategies/crane/main/scanners/scoring.py
@@ -1,0 +1,138 @@
+"""CRANE — Managed Pairs / Stat-Arb engine (pure: no I/O, no MCP, no clock).
+
+Market-neutral. For a correlated pair (A, B) it tracks the log price spread
+ln(A/B), z-scores it over a rolling window, and trades the SPREAD: when the pair
+dislocates it shorts the rich leg / longs the cheap leg (equal notional), and it
+manages the two legs as ONE position — they open together and MUST close together
+on reversion, on a blowout stop, or the instant one leg goes missing.
+
+That last rule is the safety core: a pair with only one leg left is a naked
+directional bet. `decide_pair_action` returns CLOSE_NAKED whenever exactly one leg
+is held, so the manager can flatten the survivor immediately.
+
+⚠️ BLOCKED ON A RUNTIME CAPABILITY — see crane/DESIGN.md. The Runtime 3.0 scan
+contract emits OPEN-only signals (no close/reduce intent) and blocks close
+mutations, and CLOSE_POSITION has no scanner-signal path. So CLOSE_BOTH /
+CLOSE_NAKED cannot currently be executed — which is exactly why crane ships as a
+tested engine + design, NOT a deployable package. This module is complete and
+unit-tested so it is ready to wire the moment coordinated multi-leg close exists.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import math
+
+# action verbs returned by decide_pair_action
+OPEN_BOTH = "OPEN_BOTH"
+CLOSE_BOTH = "CLOSE_BOTH"
+CLOSE_NAKED = "CLOSE_NAKED"
+HOLD = "HOLD"
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def log_spread(px_a, px_b):
+    """ln(A/B). None if either price is non-positive/unreadable."""
+    a, b = _num(px_a), _num(px_b)
+    if a is None or b is None or a <= 0 or b <= 0:
+        return None
+    return math.log(a / b)
+
+
+def _mean(xs):
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _std(xs):
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    m = _mean(xs)
+    return math.sqrt(sum((x - m) ** 2 for x in xs) / (n - 1))
+
+
+def zscore(history, window):
+    """z-score of the LAST spread vs the trailing `window`. None until the window
+    is full and dispersion is non-degenerate (guards a divide-by-zero blowup)."""
+    w = int(window)
+    hist = [h for h in (history or []) if isinstance(h, (int, float))]
+    if len(hist) < w:
+        return None
+    ref = hist[-w:]
+    sd = _std(ref)
+    if sd <= 0:
+        return None
+    return (hist[-1] - _mean(ref)) / sd
+
+
+def decide_pair_action(z, a_held, b_held, inputs):
+    """The pair state machine. Returns (action, reason).
+
+    SAFETY: exactly-one-leg-held ⇒ CLOSE_NAKED, unconditionally and before any
+    other branch — never leave a single directional leg. Both-held ⇒ CLOSE_BOTH on
+    reversion (|z|≤exitZ) or blowout (|z|≥stopZ), else HOLD. Neither-held ⇒
+    OPEN_BOTH when |z|≥entryZ (needs a valid z, i.e. a full window), else HOLD."""
+    entry_z = _f(inputs.get("entryZ"), 2.0)
+    exit_z = _f(inputs.get("exitZ"), 0.5)
+    stop_z = _f(inputs.get("stopZ"), 3.5)
+
+    if a_held != b_held:                      # exactly one leg — NAKED
+        return CLOSE_NAKED, "one leg missing — flatten survivor (never hold a naked leg)"
+
+    if a_held and b_held:                     # in a pair
+        if z is None:
+            return HOLD, "z unavailable — hold managed pair"
+        az = abs(z)
+        if az <= exit_z:
+            return CLOSE_BOTH, f"reverted |z|={az:.2f}≤{exit_z:g}"
+        if az >= stop_z:
+            return CLOSE_BOTH, f"blowout |z|={az:.2f}≥{stop_z:g} — stop"
+        return HOLD, f"managed |z|={az:.2f}"
+
+    # neither leg held — look for an entry
+    if z is None:
+        return HOLD, "z unavailable (window not full)"
+    if abs(z) >= entry_z:
+        return OPEN_BOTH, f"dislocated |z|={abs(z):.2f}≥{entry_z:g}"
+    return HOLD, f"in-band |z|={abs(z):.2f}"
+
+
+def entry_legs(z, pair):
+    """Given a dislocation z and a pair {a, b}, the two legs to open (equal
+    notional). z>0 ⇒ A rich vs B ⇒ SHORT A / LONG B; z<0 ⇒ LONG A / SHORT B."""
+    a, b = pair["a"], pair["b"]
+    if z > 0:
+        return [{"asset": a, "direction": "SHORT"}, {"asset": b, "direction": "LONG"}]
+    return [{"asset": a, "direction": "LONG"}, {"asset": b, "direction": "SHORT"}]
+
+
+def leg_sizing(z, inputs):
+    """(leverage, marginPct) applied to EACH leg — equal notional per side. z-scaled
+    conviction within fleet caps; marginPct is a PERCENT of withdrawable per leg."""
+    base = _f(inputs.get("legMarginPct"), 8)
+    cap = _f(inputs.get("maxLegMarginPct"), 12)
+    stretch = _f(inputs.get("entryZ"), 2.0)
+    mgn = base * (1.0 + min(0.5, max(0.0, (abs(z) - stretch) / stretch))) if z else base
+    mgn = max(1.0, min(mgn, cap))
+    lev = int(_f(inputs.get("legLeverage"), 3))
+    lev = max(1, min(lev, int(_f(inputs.get("maxLeverage"), 5))))
+    return lev, round(mgn, 2)
+
+
+def push_spread(history, spread, window):
+    """Append a spread sample to the bounded rolling history (keep ~3×window)."""
+    h = list(history or [])
+    if spread is not None:
+        h.append(spread)
+    keep = max(4, int(window) * 3)
+    return h[-keep:]

--- a/strategies/crane/strategy.yaml
+++ b/strategies/crane/strategy.yaml
@@ -1,0 +1,42 @@
+# Crane — Managed Pairs / Stat-Arb (market-neutral). ⚠️ NOT DEPLOYABLE AS-IS:
+# blocked on a runtime capability (coordinated multi-leg close). Ships as a tested
+# engine + reference wiring, disarmed. See crane/DESIGN.md for the exact gap and
+# how to wire it when the capability lands.
+schema_version: 1
+
+id: crane
+version: "1.0.0"
+
+catalog:
+  name: "Crane — Managed Pairs / Stat-Arb"
+  emoji: "🕊️"
+  tagline: "Market-neutral: it finds a correlated pair that has stretched apart, shorts the expensive one and buys the cheap one in equal size, and profits when they converge — with little exposure to whether the whole market goes up or down. It manages the two sides as a single trade: they go on together and come off together, and if one side ever gets closed on its own it flattens the other immediately."
+  belief_plain: "Two closely-related names (e.g. two AI-chip stocks) usually move together; when they temporarily diverge, that gap tends to close. Crane sells the one that ran ahead and buys the one that lagged, sized so the market direction roughly cancels out, and takes profit as they reconverge. It's built to be balanced at all times — never left holding just one leg."
+  thesis: "Cross-sectional mean-reversion on the log-spread of correlated pairs, z-scored over a rolling window: enter on dislocation (|z|≥entryZ), exit on reversion (|z|≤exitZ) or a blowout stop (|z|≥stopZ), equal notional per leg. The defining requirement is coordinated two-leg exit — a half-closed pair is a naked directional bet — which the current runtime cannot express (open-only scan signals, no scanner-driven close). Crane is therefore a validated engine awaiting a joint-position / coordinated-close primitive."
+  group: multi-asset-universe
+  archetype: structural_neutral
+  sub_style: pairs_rv
+  asset_classes: [btc_eth, major_alts, xyz_equities]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 8
+  min_budget: 200
+  assets: []                 # configured correlated pairs (identity baskets)
+  status: blocked            # ⚠️ not deployable — see crane/DESIGN.md
+  tags: [pairs, stat-arb, market-neutral, mean-reversion, spread, z-score, hedged, blocked, not-deployable]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name crane-main, group crane
+    wallet_env: CRANE_WALLET
+    funding_share: 1.0

--- a/strategies/crane/tests/test_engine.py
+++ b/strategies/crane/tests/test_engine.py
@@ -1,0 +1,73 @@
+"""Crane pair-engine tests. Pure/deterministic. The centerpiece is the naked-leg
+safety invariant. Run: python3 strategies/crane/tests/test_engine.py"""
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "main", "scanners"))
+import scoring  # noqa: E402
+
+
+def test_log_spread_and_guard():
+    assert abs(scoring.log_spread(110, 100) - math.log(1.1)) < 1e-9
+    assert scoring.log_spread(0, 100) is None      # non-positive price guarded
+    assert scoring.log_spread(100, None) is None
+
+
+def test_zscore_needs_full_window_and_dispersion():
+    assert scoring.zscore([0.0] * 5, 10) is None    # window not full
+    assert scoring.zscore([1.0] * 10, 10) is None    # zero dispersion → None (no div/0)
+    hist = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3]
+    z = scoring.zscore(hist, 10)
+    assert z is not None and z > 2                    # last point is a clear outlier
+
+
+def test_naked_leg_always_closes_first():
+    inp = {"entryZ": 2, "exitZ": 0.5, "stopZ": 3.5}
+    # exactly one leg held → CLOSE_NAKED regardless of z (even a "fine" z)
+    for z in (0.0, 1.0, 2.5, None):
+        act, _ = scoring.decide_pair_action(z, a_held=True, b_held=False, inputs=inp)
+        assert act == scoring.CLOSE_NAKED, f"naked leg not flattened at z={z}"
+        act2, _ = scoring.decide_pair_action(z, a_held=False, b_held=True, inputs=inp)
+        assert act2 == scoring.CLOSE_NAKED
+
+
+def test_pair_state_machine():
+    inp = {"entryZ": 2, "exitZ": 0.5, "stopZ": 3.5}
+    # neither held: open only when dislocated and z known
+    assert scoring.decide_pair_action(2.4, False, False, inp)[0] == scoring.OPEN_BOTH
+    assert scoring.decide_pair_action(1.0, False, False, inp)[0] == scoring.HOLD
+    assert scoring.decide_pair_action(None, False, False, inp)[0] == scoring.HOLD
+    # both held: reversion and blowout both close; in-between holds
+    assert scoring.decide_pair_action(0.3, True, True, inp)[0] == scoring.CLOSE_BOTH   # reverted
+    assert scoring.decide_pair_action(3.9, True, True, inp)[0] == scoring.CLOSE_BOTH   # blowout stop
+    assert scoring.decide_pair_action(1.5, True, True, inp)[0] == scoring.HOLD
+
+
+def test_entry_legs_direction():
+    pair = {"a": "BTC", "b": "ETH"}
+    hi = scoring.entry_legs(2.5, pair)     # A rich → short A / long B
+    assert hi[0] == {"asset": "BTC", "direction": "SHORT"}
+    assert hi[1] == {"asset": "ETH", "direction": "LONG"}
+    lo = scoring.entry_legs(-2.5, pair)
+    assert lo[0]["direction"] == "LONG" and lo[1]["direction"] == "SHORT"
+
+
+def test_leg_sizing_caps():
+    lev, mgn = scoring.leg_sizing(5.0, {"legMarginPct": 8, "maxLegMarginPct": 12,
+                                        "entryZ": 2, "legLeverage": 3, "maxLeverage": 5})
+    assert 1 <= lev <= 5 and 0 < mgn <= 12
+
+
+def test_push_spread_bounded():
+    h = []
+    for i in range(100):
+        h = scoring.push_spread(h, float(i), window=10)
+    assert len(h) <= 30 and h[-1] == 99.0        # bounded to ~3×window, newest kept
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn(); print(f"ok  {fn.__name__}")
+    print(f"\nALL {len(fns)} CRANE ENGINE TESTS PASS")

--- a/strategies/raven/main/runtime.yaml
+++ b/strategies/raven/main/runtime.yaml
@@ -1,0 +1,142 @@
+# ── RAVEN · Self-Calibrating Momentum ───────────────────────────────────────
+# A momentum book that learns from its OWN realized track record. Every position
+# is opened by the same weighted-momentum thesis (ported from Bison); what changes
+# over time is HOW SELECTIVE and HOW BIG it is. On a slow clock the scanner reads
+# this wallet's own closed trades, rolls up win-rate / profit-factor / losing
+# streak, and ratchets two knobs within bounded rails: the entry score floor
+# (tighter after a cold streak, looser after a hot one) and a conviction size
+# scale (smaller when the record is poor, bigger when it's strong). NEVER closes —
+# DSL owns every exit and the drawdown_halt is the equity backstop.
+name: raven-main
+group: raven
+version: 1.0.0
+description: >
+  RAVEN — Self-Calibrating Momentum. A universe momentum book (main + xyz derived,
+  vol floor + top-N) that opens conviction-banded, tape-confirmed positions, and
+  auto-tunes its OWN entry selectivity + sizing from its realized track record:
+  raises the score floor and cuts size after a losing streak, presses after a
+  winning one — all bounded. Up to 6 positions, leverage clamped to venue max.
+  DSL is the ONLY exit (15% Phase 1, granular profit-lock ladder to +90%, 24h weak-peak).
+
+strategy:
+  wallet: "${RAVEN_WALLET}"
+  slots: 6
+  margin_pct: 10
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: raven_scanner
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 1800            # wake every 30m; self-calibration gated to recalibrationHours
+    timeout_seconds: 300
+    default_signal_validity_seconds: 3600
+    state_history_max_count: 200
+    inputs:
+      # ── universe ──
+      includeXyz: true
+      universeVolFloorUsd: 25000000
+      xyzVolFloorUsd: 3000000
+      maxUniverse: 40
+      maxSlots: 6
+      recentSignalTtlSeconds: 21600
+      # ── momentum thesis knobs (bison-ported) ──
+      minVolTrendPct: 10
+      rsiMaxLong: 72
+      rsiMinShort: 28
+      apexScore: 12
+      goodScore: 10
+      leverageTiers: { apex: 5, good: 4, base: 3 }
+      marginPctTiers: { apex: 14, good: 10, base: 7 }
+      maxLeverage: 5
+      maxMarginPct: 25
+      # ── self-calibration rails ──
+      recalibrationHours: 12          # re-read own record twice a day
+      historyTrades: 40               # roll up the most-recent N closed trades
+      initialMinScore: 8              # score floor — the LOWER bound (most permissive)
+      maxMinScore: 12                 # score floor ceiling (most selective)
+      minTrades: 8                    # below this, HOLD — never tune on noise
+      hotWinRate: 0.55
+      coldWinRate: 0.40
+      hotProfitFactor: 1.5
+      coldProfitFactor: 1.0
+      coldStreak: 4                   # N consecutive losers ⇒ force tighten
+      scoreStep: 0.5                  # per-recal ratchet on the floor
+      sizeStep: 0.15                  # per-recal ratchet on the size scale
+      minSizeScale: 0.5
+      maxSizeScale: 1.5
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      band: { type: string, required: false }
+      sizeScale: { type: number, required: false }
+      minScore: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: raven_open
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [raven_scanner]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: raven_scanner
+  # NO CLOSE_POSITION action — DSL is the only exit.
+
+# EXIT — DSL only. Granular breakeven-first ladder (no back-loaded gap): locks
+# early and ramps smoothly so a modest winner isn't given all the way back.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 1440        # 24h — a stalled momentum name frees its slot
+      min_value: 2.5
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 0 }
+        - { trigger_pct: 15, lock_hw_pct: 35 }
+        - { trigger_pct: 25, lock_hw_pct: 52 }
+        - { trigger_pct: 40, lock_hw_pct: 65 }
+        - { trigger_pct: 60, lock_hw_pct: 77 }
+        - { trigger_pct: 90, lock_hw_pct: 86 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 6
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 900
+    per_asset_cooldown_seconds: 21600
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true

--- a/strategies/raven/main/scanners/scan.py
+++ b/strategies/raven/main/scanners/scan.py
@@ -1,0 +1,221 @@
+"""RAVEN — Self-Calibrating Momentum. The single supervised scanner.
+
+A momentum book that reads its OWN realized track record and adapts. Each tick:
+  1) Load the standing calibration (current_min_score, size_scale) from ctx.state.
+  2) SLOW CLOCK: when the recalibration window elapses, read this wallet's own
+     closed-trade history (discovery_get_trader_history), roll up win-rate /
+     profit-factor / losing-streak, and ratchet the two knobs within bounded rails
+     (scoring.adapt). No-op below minTrades — never tunes on noise.
+  3) Read held positions; fill any FREE slots with universe candidates whose
+     momentum thesis clears the CURRENT adaptive floor, sized by conviction ×
+     size_scale. NEVER closes — DSL owns every exit; the runtime's drawdown_halt
+     is the equity backstop.
+
+Read-only + single-pass. marginPct is a PERCENT in (0,100]. No daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
+        print(f"[raven.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _dex_of(name):
+    return "xyz" if str(name).lower().startswith("xyz:") else ""
+
+
+def _instrument_rows(ctx, dex):
+    data = _read(ctx, "market_list_instruments", ({"dex": dex} if dex else {}),
+                 f"market_list_instruments({dex or 'main'})")
+    if data is None:
+        return None
+    insts = data.get("instruments", data.get("universe", data)) if isinstance(data, dict) else data
+    if not isinstance(insts, list):
+        return None
+    rows = []
+    for inst in insts:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        c = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        vol = scoring._f(c.get("dayNtlVlm"))
+        venue = c.get("max_leverage", c.get("maxLeverage")) or inst.get("max_leverage")
+        rows.append({"name": str(name), "vol": vol, "venue_max": venue, "dex": _dex_of(name)})
+    return rows
+
+
+def _derive_universe(ctx, inputs):
+    """Live top-N liquid names, main (+ xyz iff enabled), over the vol floor."""
+    main = _instrument_rows(ctx, "")
+    if main is None:
+        return None
+    rows = list(main)
+    if bool(inputs.get("includeXyz", True)):
+        rows += (_instrument_rows(ctx, "xyz") or [])
+    vfloor = scoring._f(inputs.get("universeVolFloorUsd"), 25_000_000)
+    xfloor = scoring._f(inputs.get("xyzVolFloorUsd"), 3_000_000)
+    keep = [r for r in rows if r["vol"] >= (xfloor if r["dex"] == "xyz" else vfloor)]
+    keep.sort(key=lambda r: r["vol"], reverse=True)
+    cap = int(scoring._f(inputs.get("maxUniverse"), 40))
+    return keep[:cap]
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["15m", "1h", "4h"],
+        "include_funding": True, "include_order_book": False, "dex": _dex_of(name),
+    }, f"market_get_asset_data({name})")
+
+
+def _funding_of(md):
+    """Current funding rate as a float (tolerant; 0.0 if absent)."""
+    for k in ("funding", "funding_rate", "fundingRate", "current_funding"):
+        v = scoring._num((md or {}).get(k))
+        if v is not None:
+            return v
+    fh = (md or {}).get("funding") if isinstance((md or {}).get("funding"), dict) else None
+    if isinstance(fh, dict):
+        return scoring._f(fh.get("rate", fh.get("current")))
+    return 0.0
+
+
+def _held(ctx):
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = set()
+    for e in d.get("assetPositions", d.get("asset_positions", [])) or []:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def _own_closed(ctx, inputs):
+    """This wallet's own closed trades, newest-first, for self-calibration."""
+    n = int(scoring._f(inputs.get("historyTrades"), 40))
+    d = _read(ctx, "discovery_get_trader_history",
+              {"trader_address": ctx.wallet, "limit": n,
+               "sort_by": "CLOSED_TIME", "sort_direction": "DESC"},
+              "discovery_get_trader_history(self)")
+    if d is None:
+        return None
+    if isinstance(d, list):
+        return d
+    for k in ("closedPositions", "closed_positions", "positions", "history", "trades", "data", "results"):
+        v = d.get(k) if isinstance(d, dict) else None
+        if isinstance(v, list):
+            return v
+    return []
+
+
+def _recalibrate(ctx, inputs, state, now):
+    """Read own history → adapt the knobs. Returns (min_score, size_scale, stats, note)."""
+    closed = _own_closed(ctx, inputs)
+    if closed is None:                       # read failed — keep current calibration
+        cur_min = scoring._f(state.get("current_min_score"), scoring._f(inputs.get("initialMinScore"), 8))
+        cur_scale = scoring._f(state.get("size_scale"), 1.0)
+        return cur_min, cur_scale, {"n": -1}, "history unreadable — holding calibration"
+    stats = scoring.track_record(closed, scoring._f(inputs.get("historyTrades"), 40))
+    if stats.get("n", 0) == 0:
+        print("[raven.scan] WARNING: 0 closed trades parsed from history — holding "
+              "(verify discovery_get_trader_history payload shape)", file=sys.stderr)
+    min_score, size_scale, note = scoring.adapt(stats, state, inputs)
+    return min_score, size_scale, stats, note
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    recal_s = scoring._f(inputs.get("recalibrationHours"), 12.0) * 3600.0
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 6))
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 21600)
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    floor = scoring._f(inputs.get("initialMinScore"), 8)
+    min_score = scoring._f(st.get("current_min_score"), floor)
+    size_scale = scoring._f(st.get("size_scale"), 1.0)
+    last_recal = scoring._f(st.get("last_recal"), 0.0)
+    recent = dict(st.get("recent", {}) or {})
+    stats = st.get("stats", {}) or {}
+
+    # ── SLOW CLOCK: self-calibrate only when due (or first tick) ──
+    if last_recal == 0.0 or (now - last_recal) >= recal_s:
+        min_score, size_scale, stats, note = _recalibrate(ctx, inputs, st, now)
+        last_recal = now
+        print(f"[raven.scan] SELF-TUNE: {note} | floor now {min_score:g}, size ×{size_scale:.2f}",
+              file=sys.stderr)
+
+    held = _held(ctx)
+    if held is None:
+        return []                                    # clearinghouse unreadable — act next tick
+    free = max_slots - len(held)
+
+    out = []
+    if free > 0:
+        universe = _derive_universe(ctx, inputs)
+        if universe is None:
+            print("[raven.scan] instruments unreadable — no opens this tick", file=sys.stderr)
+        else:
+            looked = 0
+            for row in universe:
+                if free <= 0 or looked >= max(12, free * 4):
+                    break
+                name = row["name"]
+                bare = str(name).split(":", 1)[-1].upper()
+                if bare in held:
+                    continue
+                if recent.get(bare) is not None and (now - recent[bare]) < ttl:
+                    continue
+                looked += 1
+                md = _asset_data(ctx, name)
+                if not md:
+                    continue
+                candles = md.get("candles", {}) or {}
+                th = scoring.build_thesis(name, candles.get("15m", []), candles.get("1h", []),
+                                          candles.get("4h", []), _funding_of(md), (None, 0), inputs)
+                if not th or th["score"] < min_score:
+                    continue
+                band = scoring.band_for(th["score"], inputs)
+                lev, mgn = scoring.sizing_for(band, size_scale, inputs, row.get("venue_max"))
+                recent[bare] = now
+                free -= 1
+                out.append({
+                    "asset": name, "direction": th["direction"], "marginPct": mgn, "leverage": lev,
+                    "data": {"score": th["score"], "leverage": lev, "direction": th["direction"],
+                             "band": band, "sizeScale": round(size_scale, 3),
+                             "minScore": round(min_score, 3), "reasons": th["reasons"]},
+                })
+                print(f"[raven.scan] OPEN {th['direction']} {name}: score={th['score']} "
+                      f"band={band} {lev}x {mgn}% (floor {min_score:g}, size ×{size_scale:.2f})",
+                      file=sys.stderr)
+
+    if not out:
+        print(f"[raven.scan] no opens: held={len(held)}/{max_slots} free={free} "
+              f"floor={min_score:g} size=×{size_scale:.2f} n={stats.get('n', '?')}", file=sys.stderr)
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({
+                "current_min_score": min_score, "size_scale": size_scale,
+                "last_recal": last_recal, "recent": recent, "stats": stats,
+                "result": {"ts": now, "opened": len(out), "held": len(held),
+                           "floor": min_score, "size_scale": size_scale},
+            })
+        except Exception as exc:  # noqa: BLE001
+            print(f"[raven.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/raven/main/scanners/scoring.py
+++ b/strategies/raven/main/scanners/scoring.py
@@ -1,0 +1,358 @@
+"""RAVEN — pure thesis math + self-calibration (no I/O, no MCP, no clock).
+
+Two halves, both pure and unit-testable:
+
+  1. MOMENTUM ENGINE — the indicator math + direction-waterfall + weighted score
+     are ported VERBATIM from bison/scoring.py (a validated Runtime 3.0 scorer).
+     Kept byte-faithful so a fidelity harness can diff raven's entries against
+     bison's on the same candles; behaviour-preserving quirks carry bison's
+     `# v2-quirk` flags. Raven's edge is NOT a new indicator — it is the layer below.
+
+  2. SELF-CALIBRATION — raven reads its OWN realized track record (the caller
+     fetches closed trades via discovery_get_trader_history and passes the list
+     in) and ratchets two knobs within bounded rails:
+        • current_min_score  — RAISE after a cold streak (more selective),
+                                LOWER toward the floor after a hot streak.
+        • size_scale         — CUT conviction sizing when the record is poor,
+                                PRESS it when the record is strong.
+     The DSL still owns every exit and the runtime's drawdown_halt is the equity
+     backstop; self-calibration only moves ENTRY selectivity + sizing. Bounded,
+     monotone-step, and a no-op below `minTrades` so it can never tune on noise.
+
+NOTE: the discovery_get_trader_history payload shape was NOT live-verified when
+this was written (auth token was invalid) — `realized_of` tries every realized-PnL
+spelling the corpus uses and `track_record` returns n=0 loudly if it parses none,
+which holds thresholds. Verify against a real payload before trusting the tuner.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _num(v):
+    """Float or None (distinguishes a real 0.0 from a missing field)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# Ported verbatim from bison/scoring.py.
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── indicators (ported verbatim from bison/scoring.py) ──
+
+def price_momentum(candles, n_bars=1):
+    if len(candles) < n_bars + 1:
+        return 0
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    if old == 0:
+        return 0
+    return ((new - old) / old) * 100
+
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim from bison.
+    v2-quirk: STRICT (>) counting, gate `>= total * 0.6`, total = lookback - 1."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def volume_trend(candles, lookback=6):
+    if len(candles) < lookback + 2:
+        return 0
+    vols = [_vol(c) for c in candles[-(lookback + 2):]]
+    half = lookback // 2
+    recent = sum(vols[-half:]) / half if half > 0 else 1
+    earlier = sum(vols[:half]) / half if half > 0 else 1
+    if earlier == 0:
+        return 0
+    return ((recent - earlier) / earlier) * 100
+
+
+def calc_rsi(closes, period=14):
+    """Trailing-window RSI. Verbatim from bison (uses gains[-period:])."""
+    if len(closes) < period + 1:
+        return 50
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── the thesis (direction waterfall + weighted score), ported from bison ──
+
+def build_thesis(coin, candles_15m, candles_1h, candles_4h, funding, sm, inputs):
+    """Port of bison build_thesis. Returns a thesis dict (with `score`) or None.
+    None ⟺ insufficient history (len(c1h) < 8 or len(c4h) < 4) OR no direction
+    resolves. minScore is applied by the CALLER (scan.py) using the ADAPTED floor."""
+    min_vol_trend = _f(inputs.get("minVolTrendPct", 10))
+    rsi_max_long = _f(inputs.get("rsiMaxLong", 72))
+    rsi_min_short = _f(inputs.get("rsiMinShort", 28))
+
+    if len(candles_1h) < 8 or len(candles_4h) < 4:
+        return None
+
+    price = _close(candles_15m[-1]) if candles_15m else _close(candles_1h[-1])
+
+    trend_4h, trend_strength = trend_structure(candles_4h)
+    trend_1h, _ = trend_structure(candles_1h)
+    sm_dir, sm_pct = sm if sm else (None, 0)
+    mom_1h = price_momentum(candles_1h, 2)
+
+    direction = None
+    if trend_4h == "BULLISH":
+        direction = "LONG"
+    elif trend_4h == "BEARISH":
+        direction = "SHORT"
+    elif sm_dir and sm_dir != "NEUTRAL":
+        direction = sm_dir
+    elif mom_1h > 0.5:
+        direction = "LONG"
+    elif mom_1h < -0.5:
+        direction = "SHORT"
+    if direction is None:
+        return None
+
+    score = 0
+    reasons = []
+
+    if trend_4h != "NEUTRAL":
+        if (direction == "LONG") == (trend_4h == "BULLISH"):
+            score += 3; reasons.append(f"4h_{trend_4h.lower()}_{trend_strength:.0%}")
+        else:
+            score -= 1; reasons.append(f"4h_opposing_{trend_4h.lower()}")
+
+    if trend_1h != "NEUTRAL":
+        if (direction == "LONG") == (trend_1h == "BULLISH"):
+            score += 2; reasons.append(f"1h_confirms_{trend_1h.lower()}")
+        else:
+            score -= 1; reasons.append(f"1h_opposing_{trend_1h.lower()}")
+
+    if direction == "LONG":
+        if mom_1h >= 1.0:
+            score += 2; reasons.append(f"1h_strong_momentum_{mom_1h:+.2f}%")
+        elif mom_1h >= 0.5:
+            score += 1; reasons.append(f"1h_momentum_{mom_1h:+.2f}%")
+        elif mom_1h < -0.5:
+            score -= 1; reasons.append(f"1h_counter_{mom_1h:+.2f}%")
+    else:
+        if mom_1h <= -1.0:
+            score += 2; reasons.append(f"1h_strong_momentum_{mom_1h:+.2f}%")
+        elif mom_1h <= -0.5:
+            score += 1; reasons.append(f"1h_momentum_{mom_1h:+.2f}%")
+        elif mom_1h > 0.5:
+            score -= 1; reasons.append(f"1h_counter_{mom_1h:+.2f}%")
+
+    if sm_dir == direction and sm_dir:
+        score += 2; reasons.append(f"sm_aligned_{_f(sm_pct):.0f}%")
+    elif sm_dir and sm_dir != "NEUTRAL" and sm_dir != direction:
+        score -= 2; reasons.append(f"sm_opposing_{sm_dir}")
+
+    if (direction == "LONG" and funding < 0) or (direction == "SHORT" and funding > 0):
+        score += 2; reasons.append(f"funding_aligned_{funding:+.4f}")
+    elif (direction == "LONG" and funding > 0.01) or (direction == "SHORT" and funding < -0.005):
+        score -= 1; reasons.append("funding_crowded")
+
+    vol_1h = volume_trend(candles_1h)
+    if vol_1h > min_vol_trend:
+        score += 1; reasons.append(f"vol_rising_{vol_1h:+.0f}%")
+
+    vol_recent = sum(_vol(c) for c in candles_1h[-3:])
+    vol_earlier = sum(_vol(c) for c in candles_1h[-6:-3])
+    oi_proxy = ((vol_recent - vol_earlier) / vol_earlier * 100) if vol_earlier > 0 else 0
+    if oi_proxy > 10:
+        score += 1; reasons.append(f"oi_growing_{oi_proxy:+.0f}%")
+
+    closes_1h = [_close(c) for c in candles_1h]
+    rsi = calc_rsi(closes_1h)
+    if direction == "LONG" and rsi > rsi_max_long:
+        score -= 1; reasons.append(f"rsi_overbought_{rsi:.0f}")
+    elif direction == "SHORT" and rsi < rsi_min_short:
+        score -= 1; reasons.append(f"rsi_oversold_{rsi:.0f}")
+    elif (direction == "LONG" and rsi < 55) or (direction == "SHORT" and rsi > 45):
+        score += 1; reasons.append(f"rsi_room_{rsi:.0f}")
+
+    mom_4h = price_momentum(candles_4h, 1)
+    if abs(mom_4h) > 1.5 and ((direction == "LONG") == (mom_4h > 0)):
+        score += 1; reasons.append(f"4h_momentum_{mom_4h:+.1f}%")
+
+    return {"coin": coin, "direction": direction, "score": score, "reasons": reasons,
+            "price": price, "rsi": round(rsi, 1), "momentum_1h": round(mom_1h, 3)}
+
+
+def band_for(score, inputs):
+    """Conviction band from the score, relative to the CURRENT adaptive floor."""
+    apex = _f(inputs.get("apexScore"), 12)
+    good = _f(inputs.get("goodScore"), 10)
+    if score >= apex:
+        return "apex"
+    if score >= good:
+        return "good"
+    return "base"
+
+
+def sizing_for(band, size_scale, inputs, venue_max=None):
+    """(leverage, marginPct). marginPct is a PERCENT in (0,100]; scaled by the
+    self-calibrated `size_scale` and clamped to fleet + venue leverage caps."""
+    lev_tiers = inputs.get("leverageTiers") or {"apex": 5, "good": 4, "base": 3}
+    mgn_tiers = inputs.get("marginPctTiers") or {"apex": 14, "good": 10, "base": 7}
+    cap = int(_f(inputs.get("maxLeverage"), 5))
+    lev = int(_f(lev_tiers.get(band), 3))
+    if venue_max:
+        cap = min(cap, int(_f(venue_max, cap)))
+    lev = max(1, min(lev, cap))
+    mgn = _f(mgn_tiers.get(band), 7) * _f(size_scale, 1.0)
+    mgn = max(1.0, min(mgn, _f(inputs.get("maxMarginPct"), 25)))
+    return lev, round(mgn, 2)
+
+
+# ── self-calibration (the centerpiece) — pure, operates on the closed-trade list ──
+
+# realized-PnL spellings observed across the corpus; tried in order. (Shape not
+# live-verified — see module docstring.)
+_REALIZED_KEYS = ("realizedPnl", "realized_pnl", "realizedProfitAndLoss",
+                  "realized_profit_and_loss", "closedPnl", "closed_pnl", "netPnl", "pnl")
+
+
+def realized_of(pos):
+    """Realized PnL of one closed-position record, or None if no spelling matches."""
+    if not isinstance(pos, dict):
+        return None
+    for k in _REALIZED_KEYS:
+        if k in pos:
+            v = _num(pos[k])
+            if v is not None:
+                return v
+    return None
+
+
+def track_record(closed, max_trades):
+    """Roll up the most-recent `max_trades` closed positions into health stats.
+    `closed` is assumed newest-first (discovery_get_trader_history default sort).
+    Returns n=0 when nothing parses (caller then HOLDS thresholds — never tunes on noise)."""
+    rows = [p for p in (closed or []) if isinstance(p, dict)][: max(1, int(max_trades))]
+    pnls = [r for r in (realized_of(p) for p in rows) if r is not None]
+    n = len(pnls)
+    if n == 0:
+        return {"n": 0}
+    wins = [p for p in pnls if p > 0]
+    gross_win = sum(wins)
+    gross_loss = -sum(p for p in pnls if p < 0)   # positive magnitude
+    # trailing losing streak, from the newest end
+    streak = 0
+    for p in pnls:
+        if p < 0:
+            streak += 1
+        else:
+            break
+    return {
+        "n": n,
+        "win_rate": len(wins) / n,
+        "profit_factor": (gross_win / gross_loss) if gross_loss > 0 else (float("inf") if gross_win > 0 else 0.0),
+        "sum_pnl": sum(pnls),
+        "avg_pnl": sum(pnls) / n,
+        "loss_streak": streak,
+    }
+
+
+def adapt(stats, state, inputs):
+    """Ratchet (current_min_score, size_scale) from the track record, bounded.
+    Returns (min_score, size_scale, note). A no-op (holds) below `minTrades`."""
+    floor = _f(inputs.get("initialMinScore"), 8)
+    ceil = _f(inputs.get("maxMinScore"), 12)
+    min_n = int(_f(inputs.get("minTrades"), 8))
+    hi_wr = _f(inputs.get("hotWinRate"), 0.55)
+    lo_wr = _f(inputs.get("coldWinRate"), 0.40)
+    hi_pf = _f(inputs.get("hotProfitFactor"), 1.5)
+    lo_pf = _f(inputs.get("coldProfitFactor"), 1.0)
+    step = _f(inputs.get("scoreStep"), 0.5)
+    sstep = _f(inputs.get("sizeStep"), 0.15)
+    smin = _f(inputs.get("minSizeScale"), 0.5)
+    smax = _f(inputs.get("maxSizeScale"), 1.5)
+    cold_streak = int(_f(inputs.get("coldStreak"), 4))
+
+    cur_min = _f((state or {}).get("current_min_score"), floor)
+    cur_scale = _f((state or {}).get("size_scale"), 1.0)
+
+    n = int(stats.get("n", 0))
+    if n < min_n:
+        return (max(floor, min(cur_min, ceil)), max(smin, min(cur_scale, smax)),
+                f"hold (only {n}/{min_n} trades — no tune)")
+
+    wr = _f(stats.get("win_rate"))
+    pf = _f(stats.get("profit_factor"))
+    streak = int(stats.get("loss_streak", 0))
+
+    hot = wr >= hi_wr and pf >= hi_pf
+    cold = (wr <= lo_wr) or (pf <= lo_pf) or (streak >= cold_streak)
+
+    if cold and not hot:
+        new_min = min(ceil, cur_min + step)
+        new_scale = max(smin, cur_scale - sstep)
+        note = f"COLD wr={wr:.0%} pf={pf:.2f} streak={streak} → tighten min {cur_min:g}→{new_min:g}, size {cur_scale:.2f}→{new_scale:.2f}"
+    elif hot:
+        new_min = max(floor, cur_min - step)
+        new_scale = min(smax, cur_scale + sstep)
+        note = f"HOT wr={wr:.0%} pf={pf:.2f} → loosen min {cur_min:g}→{new_min:g}, size {cur_scale:.2f}→{new_scale:.2f}"
+    else:
+        # neutral — let size drift back toward 1.0, leave the score floor put
+        new_min = cur_min
+        new_scale = cur_scale + max(-sstep / 2, min(sstep / 2, 1.0 - cur_scale))
+        note = f"neutral wr={wr:.0%} pf={pf:.2f} → hold min {cur_min:g}, size →{new_scale:.2f}"
+
+    return round(max(floor, min(new_min, ceil)), 3), round(max(smin, min(new_scale, smax)), 3), note

--- a/strategies/raven/strategy.yaml
+++ b/strategies/raven/strategy.yaml
@@ -1,0 +1,42 @@
+# Raven — Self-Calibrating Momentum. Single-wallet PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/ (momentum engine ported from Bison;
+# scoring.py adds the self-calibration that reads Raven's OWN realized track
+# record and ratchets entry selectivity + sizing within bounded rails). NEVER
+# closes — DSL owns every exit.
+schema_version: 1
+
+id: raven
+version: "1.0.0"
+
+catalog:
+  name: "Raven — Self-Calibrating Momentum"
+  emoji: "🐦‍⬛"
+  tagline: "Runs a momentum book across the most liquid names and gets smarter about ITSELF: twice a day it reads its own closed trades, and if it's been losing it becomes more selective and trades smaller, while if it's been winning it loosens up and presses. You don't tune it — it tunes itself, inside guardrails, and a trailing stop does all the exiting."
+  belief_plain: "A momentum strategy's edge drifts with the regime — what worked last week can bleed this week. Raven opens positions on the same proven momentum signal every time, but it watches its OWN results: after a cold streak it raises the bar for what it'll trade and cuts its size; after a hot streak it leans back in. It never manually closes — a ratchet stop protects and exits every position — and a hard drawdown halt is the backstop if the self-tuning isn't enough."
+  thesis: "Momentum entry quality is regime-dependent, and a fixed score threshold is right only some of the time. Raven treats its realized track record (win-rate, profit-factor, losing streak over the last N closed trades) as a live control signal: it ratchets the entry floor up/down and scales conviction sizing between bounded rails on a slow clock. The momentum thesis itself is Bison's validated weighted scorer, ported verbatim; the novelty is the closed-loop self-calibration on top. DSL owns exits; the runtime drawdown_halt is the equity backstop."
+  group: multi-asset-universe
+  archetype: trend_following
+  sub_style: adaptive
+  asset_classes: [btc_eth, major_alts, xyz_equities, commodities]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 6
+  min_budget: 100
+  assets: []                 # DERIVED live from both dexes (vol floor + top-N)
+  tags: [momentum, adaptive, self-tuning, self-calibrating, feedback, universe, long-short, dsl-only, no-close]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name raven-main, group raven
+    wallet_env: RAVEN_WALLET
+    funding_share: 1.0

--- a/strategies/raven/tests/test_engine.py
+++ b/strategies/raven/tests/test_engine.py
@@ -1,0 +1,131 @@
+"""Raven engine + self-calibration tests. Pure/deterministic; plus a scan() smoke
+run against a fake ctx (no network). Run: python3 -m pytest strategies/raven/tests -q
+or plain `python3 strategies/raven/tests/test_engine.py`."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "main", "scanners"))
+import scoring  # noqa: E402
+
+
+def _synth_candles(n, step, start=100.0):
+    """Monotone series (step>0 → higher-lows/bullish, step<0 → bearish)."""
+    out, p = [], start
+    for _ in range(n):
+        out.append({"open": p, "high": p + abs(step), "low": p - abs(step) / 2,
+                    "close": p + step, "volume": 1000})
+        p += step
+    return out
+
+
+def test_track_record_basic():
+    # newest-first: two losers then wins — loss_streak counts from the newest end
+    closed = [{"realizedPnl": -5}, {"realizedPnl": -3}, {"realizedPnl": 10}, {"realizedPnl": 4}]
+    s = scoring.track_record(closed, 40)
+    assert s["n"] == 4
+    assert s["win_rate"] == 0.5
+    assert round(s["profit_factor"], 3) == round(14 / 8, 3)
+    assert s["loss_streak"] == 2
+    assert s["sum_pnl"] == 6
+
+
+def test_track_record_tolerant_keys_and_empty():
+    assert scoring.track_record([{"realized_profit_and_loss": 7}], 40)["n"] == 1
+    assert scoring.track_record([{"nope": 1}], 40)["n"] == 0     # unparseable → n=0 (caller holds)
+    assert scoring.track_record([], 40)["n"] == 0
+
+
+def test_adapt_cold_tightens_hot_loosens_and_holds():
+    inp = {"initialMinScore": 8, "maxMinScore": 12, "minTrades": 8}
+    st = {"current_min_score": 8, "size_scale": 1.0}
+    # cold: low win-rate → floor up, size down
+    cold = {"n": 10, "win_rate": 0.2, "profit_factor": 0.6, "loss_streak": 1}
+    m, sc, _ = scoring.adapt(cold, st, inp)
+    assert m > 8 and sc < 1.0
+    # hot: strong → floor down (already at floor, stays), size up
+    hot = {"n": 10, "win_rate": 0.7, "profit_factor": 2.0, "loss_streak": 0}
+    m2, sc2, _ = scoring.adapt(hot, {"current_min_score": 10, "size_scale": 1.0}, inp)
+    assert m2 < 10 and sc2 > 1.0
+    # insufficient trades → hold exactly
+    m3, sc3, note = scoring.adapt({"n": 3}, st, inp)
+    assert m3 == 8 and sc3 == 1.0 and "hold" in note
+    # cold streak alone forces tighten even with ok win-rate
+    streaky = {"n": 10, "win_rate": 0.5, "profit_factor": 1.2, "loss_streak": 5}
+    m4, sc4, _ = scoring.adapt(streaky, st, inp)
+    assert m4 > 8
+
+
+def test_adapt_respects_bounds():
+    inp = {"initialMinScore": 8, "maxMinScore": 12, "minTrades": 8}
+    hot = {"n": 20, "win_rate": 0.9, "profit_factor": 5, "loss_streak": 0}
+    # already at ceilings — must clamp, not overshoot
+    m, sc, _ = scoring.adapt(hot, {"current_min_score": 8, "size_scale": 1.5}, inp)
+    assert m == 8 and sc == 1.5
+
+
+def test_build_thesis_direction_and_insufficient():
+    up1h, up4h = _synth_candles(12, 1.0), _synth_candles(6, 2.0)
+    th = scoring.build_thesis("BTC", up1h[-3:], up1h, up4h, funding=-0.01, sm=(None, 0), inputs={})
+    assert th and th["direction"] == "LONG" and th["score"] > 0
+    assert scoring.build_thesis("X", [], up1h[:4], up4h[:2], 0, (None, 0), {}) is None  # too few candles
+
+
+def test_sizing_caps():
+    lev, mgn = scoring.sizing_for("apex", 1.5, {"maxLeverage": 5, "maxMarginPct": 25}, venue_max=3)
+    assert lev == 3            # clamped to venue max
+    assert 0 < mgn <= 25       # margin capped
+
+
+# ── scan() smoke against a fake ctx (no network) ──
+
+class _State:
+    def __init__(self): self._log = []
+    def last(self): return self._log[-1] if self._log else None
+    def append(self, d): self._log.append(d)
+
+
+class _MCP:
+    def __init__(self, up):
+        self.up = up
+    def call_tool(self, tool, args):
+        if tool == "market_list_instruments":
+            return {"data": {"instruments": [
+                {"name": "BTC", "context": {"dayNtlVlm": 5e8, "maxLeverage": 5}},
+                {"name": "ETH", "context": {"dayNtlVlm": 4e8, "maxLeverage": 5}}]}}
+        if tool == "market_get_asset_data":
+            return {"data": {"candles": {"15m": self.up[-3:], "1h": self.up, "4h": self.up},
+                             "funding": -0.01}}
+        if tool == "strategy_get_clearinghouse_state":
+            return {"data": {"assetPositions": []}}
+        if tool == "discovery_get_trader_history":
+            return {"data": {"closedPositions": [{"realizedPnl": 5}, {"realizedPnl": -2}]}}
+        return {}
+
+
+class _Ctx:
+    def __init__(self, up):
+        self.wallet = "0xabc"
+        self.state = _State()
+        self.senpi_mcp = _MCP(up)
+
+
+def test_scan_smoke_returns_valid_signals():
+    import scan
+    up = _synth_candles(14, 1.0)
+    ctx = _Ctx(up)
+    inputs = {"maxSlots": 6, "initialMinScore": 0, "minTrades": 8, "includeXyz": False,
+              "universeVolFloorUsd": 1e6, "maxUniverse": 10}
+    out = scan.scan(inputs, ctx)
+    assert isinstance(out, list)
+    for s in out:
+        assert set(("asset", "direction", "marginPct", "leverage", "data")) <= set(s)
+        assert 0 < s["marginPct"] <= 25 and 1 <= s["leverage"] <= 5
+        assert s["direction"] in ("LONG", "SHORT")
+    assert ctx.state.last() is not None            # state persisted
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn(); print(f"ok  {fn.__name__}")
+    print(f"\nALL {len(fns)} RAVEN TESTS PASS")

--- a/strategies/starling/main/runtime.yaml
+++ b/strategies/starling/main/runtime.yaml
@@ -1,0 +1,127 @@
+# ── STARLING · Smart-Money Rotation Follower ─────────────────────────────────
+# Follows a cohort of proven-profitable Hyperliquid wallets and opens WITH them
+# only when SEVERAL are FRESHLY piling into the same name in the same direction at
+# the same time (consensus forming = a rotation) — not a name that has stood at
+# consensus for a while. It reads the cohort's live books every 10 minutes, diffs
+# this snapshot against the last, and sizes each entry by how many wallets agree.
+# NEVER closes — a rotation change only changes what it opens next; prior positions
+# retire on their own DSL trailing stops (rotate-by-attrition, exactly like gibbon).
+name: starling-main
+group: starling
+version: 1.0.0
+description: >
+  STARLING — Smart-Money Rotation Follower. Tracks a cohort of the most
+  profitable Hyperliquid wallets (all-time realized) and opens with them the
+  moment several are FRESHLY buying/shorting the same name together — the
+  snapshot-to-snapshot diff catches consensus FORMING, not a stale standing
+  crowd. Conviction/size scales with how many wallets agree (base/good/apex).
+  One wallet, up to 6 positions, leverage clamped to venue max. DSL is the ONLY
+  exit (15% Phase 1, granular profit-lock ladder to +90%, 48h weak-peak).
+
+strategy:
+  wallet: "${STARLING_WALLET}"
+  slots: 6
+  margin_pct: 10
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: starling_scanner
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 600             # wake every 10m — consensus forms over minutes/hours
+    timeout_seconds: 300
+    default_signal_validity_seconds: 3600
+    state_history_max_count: 200
+    inputs:
+      # ── cohort derivation (SLOW clock) ──
+      cohortRefreshHours: 12          # re-derive the smart cohort twice a day
+      smartMinRealizedUsd: 1000000    # proven = >= $1M all-time realized PnL
+      cohortCap: 120                  # cap the cohort size
+      pageSize: 1000
+      maxPages: 6
+      stateBatch: 50                  # discovery_get_trader_state addresses per call
+      # ── consensus bands ──
+      minConsensus: 3                 # >= this many freshly-agreeing wallets to open
+      goodConsensus: 4
+      apexConsensus: 6
+      # ── slots + sizing ──
+      maxSlots: 6
+      recentSignalTtlSeconds: 21600   # 6h per-name signal debounce
+      leverageTiers: { apex: 5, good: 4, base: 3 }
+      marginPctTiers: { apex: 14, good: 10, base: 7 }
+      maxLeverage: 5
+      maxMarginPct: 25
+    signal_data_schema:
+      consensusCount: { type: number }
+      band: { type: string, required: false }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      leverage: { type: number }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: starling_open
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [starling_scanner]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: starling_scanner
+  # NO CLOSE_POSITION action — DSL is the only exit (rotate-by-attrition).
+
+# EXIT — DSL only. Granular breakeven-first ladder (raven's): locks early and ramps
+# smoothly so a modest winner isn't given all the way back. A follower holds longer
+# than a momentum book, so the weak-peak cut is 48h (not 24h).
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 2880        # 48h — a stalled follow frees its slot
+      min_value: 2.5
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 0 }
+        - { trigger_pct: 15, lock_hw_pct: 35 }
+        - { trigger_pct: 25, lock_hw_pct: 52 }
+        - { trigger_pct: 40, lock_hw_pct: 65 }
+        - { trigger_pct: 60, lock_hw_pct: 77 }
+        - { trigger_pct: 90, lock_hw_pct: 86 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 6
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 900
+    per_asset_cooldown_seconds: 21600
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true

--- a/strategies/starling/main/scanners/scan.py
+++ b/strategies/starling/main/scanners/scan.py
@@ -1,0 +1,214 @@
+"""STARLING — Smart-Money Rotation Follower. The single supervised scanner.
+
+Follows a cohort of proven-profitable Hyperliquid wallets and opens WITH them only
+when several are FRESHLY piling into the same name in the same direction at the same
+time (consensus forming = rotation) — not a name that has stood at consensus for a
+while. Conviction/size scales with how many cohort wallets agree. NEVER closes — the
+DSL owns every exit (rotate-by-attrition, exactly like gibbon).
+
+Each tick:
+  1) SLOW CLOCK — refresh the smart cohort every cohortRefreshHours (or first tick):
+     paginated discovery_get_top_traders (ALL_TIME, realized), wallets with realized
+     PnL >= smartMinRealizedUsd, capped at cohortCap. If derivation returns empty,
+     KEEP the prior cohort (never wipe).
+  2) Snapshot every cohort wallet's OPEN positions (discovery_get_trader_state,
+     batched) -> current consensus counts (distinct wallets per asset/direction).
+  3) DIFF this snapshot against the previous one -> fresh picks (consensus newly
+     formed or still rising). For each fresh pick not already held and not signalled
+     within recentSignalTtlSeconds, size by the agreement band and emit an OPEN.
+  4) Persist cohort + snapshot + recent. NEVER closes.
+
+Read-only + single-pass. marginPct is a PERCENT in (0,100]. No daemon.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
+        print(f"[starling.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _cohort(ctx, inputs):
+    """Derive the SMART cohort: paginated discovery_get_top_traders (ALL_TIME, sorted
+    by realized PnL desc), keeping wallets with realized PnL >= smartMinRealizedUsd,
+    capped at cohortCap. Returns a list of lower-cased addresses ([] on total failure —
+    the caller then keeps the prior cohort). Ported verbatim-in-spirit from gibbon."""
+    smin = scoring._f(inputs.get("smartMinRealizedUsd"), 1_000_000)
+    cap = int(scoring._f(inputs.get("cohortCap"), 120))
+    psize = int(scoring._f(inputs.get("pageSize"), 1000))
+    pages = int(scoring._f(inputs.get("maxPages"), 6))
+
+    smart, seen = [], set()
+    for page in range(pages):
+        d = _read(ctx, "discovery_get_top_traders",
+                  {"time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
+                   "open_position_filter": False, "limit": psize, "offset": page * psize},
+                  f"discovery_get_top_traders(p{page})")
+        rows = scoring.traders_of(d)
+        if not rows:
+            break
+        top = None
+        for t in rows:
+            if not isinstance(t, dict):
+                continue
+            a = scoring.trader_address(t)
+            if not a or a in seen:
+                continue
+            rp = scoring.realized(t)
+            top = rp if top is None else max(top, rp)
+            if rp >= smin and len(smart) < cap:
+                smart.append(a)
+                seen.add(a)
+        if len(smart) >= cap:
+            break
+        if top is not None and top < smin:   # sorted desc by realized — past the floor, stop
+            break
+    return smart
+
+
+def _snapshot_states(ctx, cohort, inputs):
+    """discovery_get_trader_state in batches of stateBatch -> a flat list of trader-state
+    dicts. Returns None iff EVERY batch read failed (unreadable — the caller then holds
+    the prior snapshot and emits nothing, rather than treating it as 'cohort flat')."""
+    batch = int(scoring._f(inputs.get("stateBatch"), 50))
+    states, any_ok = [], False
+    for i in range(0, len(cohort), batch):
+        d = _read(ctx, "discovery_get_trader_state",
+                  {"trader_addresses": cohort[i:i + batch]},
+                  f"discovery_get_trader_state(b{i // batch})")
+        if d is None:
+            continue
+        any_ok = True
+        states.extend(scoring.traders_of(d))
+    return states if any_ok else None
+
+
+def _held(ctx):
+    """Bare-uppercase set of coins with an open position on this wallet, or None on
+    read failure. Ported verbatim from raven (clearinghouse assetPositions unwrap)."""
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = set()
+    for e in d.get("assetPositions", d.get("asset_positions", [])) or []:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def _prune_recent(recent, ttl, now):
+    """Drop recent-signal entries older than 4x TTL so the map stays bounded."""
+    cutoff = now - (ttl * 4)
+    return {k: v for k, v in (recent or {}).items() if scoring._f(v) >= cutoff}
+
+
+def _persist(ctx, cohort, cohort_ts, snapshot, recent, now, opened, held_n):
+    if ctx.state is None:
+        return
+    try:
+        ctx.state.append({
+            "cohort": cohort, "cohort_ts": cohort_ts,
+            "last_snapshot": snapshot, "recent": recent,
+            "result": {"ts": now, "opened": opened, "held": held_n,
+                       "cohort_size": len(cohort), "consensus_names": len(snapshot or {})},
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[starling.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    refresh_s = scoring._f(inputs.get("cohortRefreshHours"), 12.0) * 3600.0
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 6))
+    min_c = int(scoring._f(inputs.get("minConsensus"), 3))
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 21600)
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    cohort = list(st.get("cohort", []) or [])
+    cohort_ts = scoring._f(st.get("cohort_ts"), 0.0)
+    prev = dict(st.get("last_snapshot", {}) or {})
+    recent = _prune_recent(st.get("recent", {}) or {}, ttl, now)
+
+    # ── SLOW CLOCK: refresh the cohort only when due (or first tick / empty) ──
+    if cohort_ts == 0.0 or (now - cohort_ts) >= refresh_s or not cohort:
+        fresh_cohort = _cohort(ctx, inputs)
+        if fresh_cohort:
+            cohort, cohort_ts = fresh_cohort, now
+            print(f"[starling.scan] COHORT refreshed: {len(cohort)} smart wallets "
+                  f"(realized >= ${scoring._f(inputs.get('smartMinRealizedUsd'), 1e6):,.0f})",
+                  file=sys.stderr)
+        else:
+            print(f"[starling.scan] cohort derivation empty — keeping prior cohort "
+                  f"({len(cohort)} wallets)", file=sys.stderr)
+
+    if not cohort:
+        print("[starling.scan] no cohort yet — nothing to follow this tick", file=sys.stderr)
+        _persist(ctx, cohort, cohort_ts, prev, recent, now, 0, 0)
+        return []
+
+    # ── snapshot the cohort's live books -> current consensus ──
+    states = _snapshot_states(ctx, cohort, inputs)
+    if states is None:
+        print("[starling.scan] cohort states unreadable — holding prior snapshot", file=sys.stderr)
+        _persist(ctx, cohort, cohort_ts, prev, recent, now, 0, None)
+        return []
+    cur = scoring.consensus_counts(states)
+    names = scoring.name_map(states)               # BARE -> raw coin (preserves xyz: prefix)
+    fresh = scoring.fresh_picks(cur, prev, inputs)
+
+    held = _held(ctx)
+    if held is None:
+        # clearinghouse unreadable — do NOT advance the snapshot (keep the fresh
+        # consensus actionable next tick), emit nothing this tick.
+        print("[starling.scan] clearinghouse unreadable — no opens this tick", file=sys.stderr)
+        _persist(ctx, cohort, cohort_ts, prev, recent, now, 0, None)
+        return []
+    free = max_slots - len(held)
+
+    out = []
+    if free > 0 and fresh:
+        for pick in fresh:
+            if free <= 0:
+                break
+            bare = pick["asset"]
+            direction = pick["direction"]
+            count = int(pick["count"])
+            if bare in held:
+                continue
+            if recent.get(bare) is not None and (now - scoring._f(recent[bare])) < ttl:
+                continue
+            asset = names.get(bare, bare)          # emit the tradeable (prefixed) name
+            band = scoring.band_for(count, inputs)
+            lev, mgn = scoring.sizing_for(band, inputs, None)
+            recent[bare] = now
+            free -= 1
+            reasons = [f"{count}_smart_wallets_{direction}"]
+            out.append({
+                "asset": asset, "direction": direction, "marginPct": mgn, "leverage": lev,
+                "data": {"consensusCount": count, "band": band, "direction": direction,
+                         "reasons": reasons, "leverage": lev},
+            })
+            print(f"[starling.scan] OPEN {direction} {asset}: {count} smart wallets "
+                  f"agree (band {band}) {lev}x {mgn}%", file=sys.stderr)
+
+    if not out:
+        n_consensus = sum(1 for a, dirs in cur.items()
+                          for dv in (dirs or {}).values() if int(scoring._f(dv)) >= min_c)
+        print(f"[starling.scan] no opens: cohort={len(cohort)} held={len(held)}/{max_slots} "
+              f"free={free} names_at_consensus={n_consensus} fresh={len(fresh)}", file=sys.stderr)
+
+    _persist(ctx, cohort, cohort_ts, cur, recent, now, len(out), len(held))
+    return out

--- a/strategies/starling/main/scanners/scoring.py
+++ b/strategies/starling/main/scanners/scoring.py
@@ -1,0 +1,214 @@
+"""STARLING — pure consensus engine (no I/O, no MCP, no clock).
+
+Smart-Money Rotation Follower. All the tunable/decidable logic lives here so it is
+unit-testable without a network. scan.py does the MCP orchestration and calls into
+these pure functions.
+
+The edge: a cohort of proven-profitable Hyperliquid wallets is snapshotted every
+tick; when SEVERAL of them are NEWLY, freshly piling into the same name in the same
+direction at the same time (consensus FORMING = a rotation), Starling opens with
+them — bigger when more of them agree. It fires on the snapshot-to-snapshot DIFF
+(consensus forming / rising), NOT on a name that has been at consensus for a while
+(stale standing consensus is already priced). It NEVER closes — the DSL owns every
+exit (rotate-by-attrition, exactly like gibbon).
+
+Two pure halves:
+  1. COHORT / STATE EXTRACTION — `traders_of` / `realized` (cohort derivation, ported
+     verbatim-in-spirit from gibbon/_cohorts) and the tolerant position readers that
+     turn a batch of discovery_get_trader_state payloads into consensus counts.
+  2. THE DIFF + SIZING — `consensus_counts` (distinct wallets per asset/direction),
+     `fresh_picks` (the newly-formed/rising snapshot diff), and band → leverage/margin.
+
+NOTE: the discovery_get_trader_state / discovery_get_top_traders payload SHAPES were
+NOT live-verified when this was written (the auth token was invalid), so extraction
+tries every spelling the deployed corpus uses (gibbon/oxpecker/albatross patterns):
+trader address under traderAddress|trader_address|address|wallet; open positions under
+openPositions|open_positions|positions; coin under coin|asset; direction from the
+`szi` sign. Verify against a real payload before trusting the counts.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _num(v):
+    """Float or None (distinguishes a real 0.0 from a missing / unparseable field)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bare_upper(name):
+    """Bare, upper-cased asset key: strips any venue prefix (e.g. 'xyz:NVDA' -> 'NVDA')."""
+    return str(name).split(":", 1)[-1].upper()
+
+
+# ── COHORT DERIVATION — tolerant readers (ported verbatim-in-spirit from gibbon) ──
+
+def traders_of(d):
+    """Unwrap a discovery_* list from a bare list or a {traders|data|results: [...]} dict."""
+    if isinstance(d, list):
+        return d
+    if isinstance(d, dict):
+        for k in ("traders", "data", "results"):
+            if isinstance(d.get(k), list):
+                return d[k]
+    return []
+
+
+def realized(t):
+    """Realized PnL of one top-trader record, trying every spelling in the corpus."""
+    for k in ("realizedProfitAndLoss", "realized_profit_and_loss",
+              "profit_and_loss_realized", "realizedPnl", "realized_pnl"):
+        v = _num((t or {}).get(k))
+        if v is not None:
+            return v
+    return 0.0
+
+
+def trader_address(t):
+    """Wallet address of a top-trader record, lower-cased ('' if none)."""
+    return str((t or {}).get("address") or (t or {}).get("trader_address")
+               or (t or {}).get("wallet") or "").lower()
+
+
+# ── TRADER-STATE EXTRACTION — one cohort wallet's open book -> positions ──
+
+def _state_wallet(st):
+    return str((st or {}).get("traderAddress") or (st or {}).get("trader_address")
+               or (st or {}).get("address") or (st or {}).get("wallet") or "").lower()
+
+
+def _positions_of(st):
+    """The open-position list for one trader state (tolerant of the corpus spellings)."""
+    if not isinstance(st, dict):
+        return []
+    pos = (st.get("openPositions") or st.get("open_positions") or st.get("positions") or [])
+    return pos if isinstance(pos, list) else []
+
+
+def _coin_raw(pos):
+    """Raw coin string of one position (carries any venue prefix, e.g. 'xyz:NVDA')."""
+    return (pos or {}).get("coin") or (pos or {}).get("asset")
+
+
+def direction_of(pos):
+    """LONG / SHORT from the szi sign; None when flat or undeterminable.
+    Falls back to an explicit side/direction string only when szi is absent."""
+    szi = _num((pos or {}).get("szi"))
+    if szi is not None:
+        if szi > 0:
+            return "LONG"
+        if szi < 0:
+            return "SHORT"
+        return None  # explicit flat
+    s = str((pos or {}).get("direction") or (pos or {}).get("side") or "").upper()
+    if s in ("LONG", "BUY", "B"):
+        return "LONG"
+    if s in ("SHORT", "SELL", "A", "S"):
+        return "SHORT"
+    return None
+
+
+def consensus_counts(trader_states):
+    """{ASSET: {"LONG": n, "SHORT": n}} — DISTINCT cohort wallets holding each
+    (bare-upper asset, direction). One position per coin per wallet in practice;
+    a (wallet, asset, direction) seen-set makes the count robust to duplicate
+    states across overlapping batches. PURE — no I/O."""
+    counts = {}
+    seen = set()
+    for st in trader_states or []:
+        if not isinstance(st, dict):
+            continue
+        wallet = _state_wallet(st)
+        for pos in _positions_of(st):
+            if not isinstance(pos, dict):
+                continue
+            coin = _coin_raw(pos)
+            direction = direction_of(pos)
+            if not coin or direction is None:
+                continue
+            asset = _bare_upper(coin)
+            # dedup by wallet when known; anonymous positions always count
+            wkey = wallet or f"_anon_{id(pos)}"
+            key = (wkey, asset, direction)
+            if key in seen:
+                continue
+            seen.add(key)
+            rec = counts.setdefault(asset, {"LONG": 0, "SHORT": 0})
+            rec[direction] += 1
+    return counts
+
+
+def name_map(trader_states):
+    """{BARE_UPPER: representative RAW coin string} across the snapshot, so scan.py
+    can emit signal.asset with the venue prefix the DEX requires (xyz: markets
+    reject a bare name). Prefers a prefixed spelling if one is ever seen. PURE."""
+    out = {}
+    for st in trader_states or []:
+        if not isinstance(st, dict):
+            continue
+        for pos in _positions_of(st):
+            if not isinstance(pos, dict):
+                continue
+            coin = _coin_raw(pos)
+            if not coin:
+                continue
+            bare = _bare_upper(coin)
+            if bare not in out or (":" in str(coin) and ":" not in str(out[bare])):
+                out[bare] = str(coin)
+    return out
+
+
+# ── THE DIFF — fire on newly-formed / rising consensus, never on stale standing ──
+
+def fresh_picks(cur, prev, inputs):
+    """Snapshot diff. A candidate (asset, direction) qualifies iff:
+        cur >= minConsensus  AND  (prev < minConsensus  OR  cur > prev)
+    i.e. consensus has just reached the bar (newly formed) or is still rising —
+    NEVER a name that was already at/above the bar and hasn't grown (prev == cur
+    >= minConsensus => no pick: stale standing consensus is already priced in).
+    Returns [{asset, direction, count}] sorted by count desc. PURE."""
+    min_c = int(_f(inputs.get("minConsensus"), 3))
+    picks = []
+    for asset, dirs in (cur or {}).items():
+        for direction in ("LONG", "SHORT"):
+            c = int(_f((dirs or {}).get(direction), 0))
+            if c < min_c:
+                continue
+            pc = int(_f(((prev or {}).get(asset) or {}).get(direction), 0))
+            if pc < min_c or c > pc:
+                picks.append({"asset": asset, "direction": direction, "count": c})
+    picks.sort(key=lambda p: p["count"], reverse=True)
+    return picks
+
+
+# ── SIZING — conviction band from the agreement count -> leverage / marginPct ──
+
+def band_for(count, inputs):
+    """Conviction band from how many cohort wallets agree."""
+    if count >= _f(inputs.get("apexConsensus"), 6):
+        return "apex"
+    if count >= _f(inputs.get("goodConsensus"), 4):
+        return "good"
+    return "base"
+
+
+def sizing_for(band, inputs, venue_max=None):
+    """(leverage, marginPct). marginPct is a PERCENT in (0,100]; both clamped to the
+    fleet caps (maxLeverage / maxMarginPct) and leverage additionally to venue max."""
+    lev_tiers = inputs.get("leverageTiers") or {"apex": 5, "good": 4, "base": 3}
+    mgn_tiers = inputs.get("marginPctTiers") or {"apex": 14, "good": 10, "base": 7}
+    cap = int(_f(inputs.get("maxLeverage"), 5))
+    if venue_max:
+        cap = min(cap, int(_f(venue_max, cap)))
+    lev = max(1, min(int(_f(lev_tiers.get(band), 3)), cap))
+    mgn = _f(mgn_tiers.get(band), 7)
+    mgn = max(1.0, min(mgn, _f(inputs.get("maxMarginPct"), 25)))
+    return lev, round(mgn, 2)

--- a/strategies/starling/strategy.yaml
+++ b/strategies/starling/strategy.yaml
@@ -1,0 +1,43 @@
+# Starling — Smart-Money Rotation Follower. Single-wallet PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/ (scan.py does the MCP orchestration;
+# scoring.py is the pure consensus engine — cohort derivation, the snapshot diff,
+# and sizing). Follows a cohort of proven-profitable wallets and opens WITH them only
+# when several are FRESHLY agreeing on the same name/direction (consensus forming =
+# rotation), sized by how many agree. NEVER closes — the DSL owns every exit.
+schema_version: 1
+
+id: starling
+version: "1.0.0"
+
+catalog:
+  name: "Starling — Smart-Money Rotation Follower"
+  emoji: "🐦"
+  tagline: "Watches a flock of the most profitable wallets on Hyperliquid and moves when they do — the instant several of them start piling into the SAME trade in the SAME direction at the SAME time, it buys (or shorts) alongside them, betting more the more of them agree. It only acts on a rotation that's just forming, not a crowd that's been standing in a name for hours, and it never sells manually — a trailing stop does all the exiting, so last week's follows wind down on their own as the flock rotates into the next name."
+  belief_plain: "The proven winners on Hyperliquid tend to rotate into the same trades at the same time, and the freshest edge is the moment that agreement is FORMING — not once everyone can already see it. Starling keeps a live shortlist of the wallets with the best all-time track record, watches what they're opening, and when enough of them freshly line up on one name in one direction it opens with them, sizing up when the agreement is strongest. It never manually closes — a ratchet stop protects and exits every position, so the book rotates as the smart money does, and a hard drawdown halt is the backstop."
+  thesis: "Cohort copiers average a pool's standing net bias (already priced); Starling instead trades the DERIVATIVE of that bias — the snapshot-to-snapshot change. Each tick it counts, per name and direction, how many proven wallets hold it, and fires only when that count has just crossed the consensus bar or is still rising (newly-formed / growing), never on a stale standing consensus. Conviction sizing scales with the agreement count. It force-closes nothing — turnover is set by the market via DSL (rotate-by-attrition), the same never-close discipline as the gibbon/orangutan rotation riders."
+  group: multi-asset-universe
+  archetype: copy_trading
+  sub_style: sm_rotation
+  asset_classes: [btc_eth, major_alts, xyz_equities, commodities]
+  asset_scope: follows_traders
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 6
+  min_budget: 100
+  assets: []                 # DERIVED live from the cohort's freshly-forming consensus
+  tags: [smart-money, copy-trading, consensus, rotation, cohort, follows-traders, long-short, universe, no-close, dsl-only]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name starling-main, group starling
+    wallet_env: STARLING_WALLET
+    funding_share: 1.0

--- a/strategies/starling/tests/test_engine.py
+++ b/strategies/starling/tests/test_engine.py
@@ -1,0 +1,214 @@
+"""Starling consensus-engine tests. Pure/deterministic; plus a scan() smoke run
+against a fake ctx (no network). Run: python3 -m pytest strategies/starling/tests -q
+or plain `python3 strategies/starling/tests/test_engine.py`."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "main", "scanners"))
+import scoring  # noqa: E402
+
+
+# ── (a) consensus_counts: DISTINCT wallets per (asset, direction) ──
+
+def test_consensus_counts_distinct_wallets_and_tolerant_shapes():
+    states = [
+        {"traderAddress": "0xa", "openPositions": [{"coin": "BTC", "szi": 1.0}]},
+        {"traderAddress": "0xb", "openPositions": [{"coin": "BTC", "szi": 2.0},
+                                                   {"coin": "ETH", "szi": -1.0}]},
+        {"traderAddress": "0xc", "openPositions": [{"coin": "xyz:NVDA", "szi": 3.0},
+                                                   {"coin": "BTC", "szi": 0.5}]},
+        {"trader_address": "0xd", "open_positions": [{"asset": "ETH", "szi": -2.0}]},  # alt keys
+        {"traderAddress": "0xa", "openPositions": [{"coin": "BTC", "szi": 1.0}]},  # DUP wallet
+        {"traderAddress": "0xe", "openPositions": [{"coin": "BTC", "szi": 0.0}]},  # flat -> ignored
+    ]
+    c = scoring.consensus_counts(states)
+    assert c["BTC"]["LONG"] == 3      # a, b, c ; dup a not double-counted ; flat e ignored
+    assert c["BTC"]["SHORT"] == 0
+    assert c["ETH"]["SHORT"] == 2     # b, d (via alt spellings open_positions/asset)
+    assert c["ETH"]["LONG"] == 0
+    assert c["NVDA"]["LONG"] == 1     # bare-upper strips the xyz: prefix for counting
+    assert scoring.consensus_counts([]) == {}
+    assert scoring.consensus_counts(None) == {}
+
+
+def test_name_map_preserves_venue_prefix():
+    states = [{"traderAddress": "0xc", "openPositions": [
+        {"coin": "xyz:NVDA", "szi": 3.0}, {"coin": "BTC", "szi": 1.0}]}]
+    nm = scoring.name_map(states)
+    assert nm["NVDA"] == "xyz:NVDA"   # emit the tradeable prefixed name, not bare
+    assert nm["BTC"] == "BTC"
+
+
+def test_direction_of_from_szi_then_side_fallback():
+    assert scoring.direction_of({"szi": 5}) == "LONG"
+    assert scoring.direction_of({"szi": -5}) == "SHORT"
+    assert scoring.direction_of({"szi": 0}) is None
+    assert scoring.direction_of({"side": "SELL"}) == "SHORT"   # fallback only when szi absent
+    assert scoring.direction_of({"direction": "long"}) == "LONG"
+    assert scoring.direction_of({}) is None
+
+
+# ── (b) fresh_picks: fires on newly-formed / rising, NOT on stale standing ──
+
+def test_fresh_picks_forming_growing_and_stale():
+    inp = {"minConsensus": 3}
+    cur = {"BTC": {"LONG": 3, "SHORT": 0}}
+    # newly FORMED (prev absent) -> fires
+    assert scoring.fresh_picks(cur, {}, inp) == [{"asset": "BTC", "direction": "LONG", "count": 3}]
+    # STALE standing consensus (prev == cur >= min) -> NO pick  (the core guarantee)
+    assert scoring.fresh_picks(cur, {"BTC": {"LONG": 3, "SHORT": 0}}, inp) == []
+    # GROWING (prev 3 -> cur 5) -> fires
+    grew = scoring.fresh_picks({"BTC": {"LONG": 5}}, {"BTC": {"LONG": 3}}, inp)
+    assert grew == [{"asset": "BTC", "direction": "LONG", "count": 5}]
+    # crossing the bar from below (prev 2 < min -> cur 4) -> fires
+    assert scoring.fresh_picks({"BTC": {"LONG": 4}}, {"BTC": {"LONG": 2}}, inp)[0]["count"] == 4
+    # below the bar -> never
+    assert scoring.fresh_picks({"BTC": {"LONG": 2}}, {}, inp) == []
+    # SHRINKING but still above bar (prev 5 -> cur 4) -> NO pick (not rising)
+    assert scoring.fresh_picks({"BTC": {"LONG": 4}}, {"BTC": {"LONG": 5}}, inp) == []
+
+
+def test_fresh_picks_sorted_by_count_desc():
+    inp = {"minConsensus": 3}
+    cur = {"BTC": {"LONG": 4, "SHORT": 0}, "ETH": {"LONG": 0, "SHORT": 7}, "SOL": {"LONG": 3}}
+    picks = scoring.fresh_picks(cur, {}, inp)
+    assert [p["count"] for p in picks] == [7, 4, 3]      # apex ETH first
+    assert picks[0] == {"asset": "ETH", "direction": "SHORT", "count": 7}
+
+
+# ── band + sizing (fleet caps) ──
+
+def test_band_and_sizing_caps():
+    inp = {"apexConsensus": 6, "goodConsensus": 4, "minConsensus": 3,
+           "leverageTiers": {"apex": 5, "good": 4, "base": 3},
+           "marginPctTiers": {"apex": 14, "good": 10, "base": 7},
+           "maxLeverage": 5, "maxMarginPct": 25}
+    assert scoring.band_for(6, inp) == "apex"
+    assert scoring.band_for(5, inp) == "good"
+    assert scoring.band_for(4, inp) == "good"
+    assert scoring.band_for(3, inp) == "base"
+    lev, mgn = scoring.sizing_for("apex", inp)
+    assert lev == 5 and mgn == 14
+    lev, mgn = scoring.sizing_for("apex", inp, venue_max=3)
+    assert lev == 3                                        # clamped to venue max
+    lev, mgn = scoring.sizing_for("base", inp)
+    assert 1 <= lev <= 5 and 0 < mgn <= 25
+    # oversized tier clamps to fleet caps, never overshoots
+    lev, mgn = scoring.sizing_for("apex", {"leverageTiers": {"apex": 99},
+                                           "marginPctTiers": {"apex": 999},
+                                           "maxLeverage": 5, "maxMarginPct": 25})
+    assert lev == 5 and mgn == 25
+
+
+def test_traders_of_and_realized_tolerant():
+    assert scoring.traders_of([1, 2]) == [1, 2]
+    assert scoring.traders_of({"traders": [1]}) == [1]
+    assert scoring.traders_of({"data": [2]}) == [2]
+    assert scoring.traders_of({"results": [3]}) == [3]
+    assert scoring.traders_of({"nope": 1}) == []
+    assert scoring.realized({"realizedPnl": 5}) == 5.0
+    assert scoring.realized({"realized_profit_and_loss": 7}) == 7.0
+    assert scoring.realized({"nope": 1}) == 0.0
+    assert scoring.trader_address({"address": "0xAbC"}) == "0xabc"
+    assert scoring.trader_address({"trader_address": "0xDeF"}) == "0xdef"
+    assert scoring.trader_address({}) == ""
+
+
+# ── (c) scan() smoke against a fake ctx (no network) ──
+
+class _State:
+    def __init__(self):
+        self._log = []
+
+    def last(self):
+        return self._log[-1] if self._log else None
+
+    def append(self, d):
+        self._log.append(d)
+
+
+class _MCP:
+    """Canned: 4 proven traders; 3 of them freshly long BTC, 1 short ETH, 1 long SOL."""
+    def call_tool(self, tool, args):
+        if tool == "discovery_get_top_traders":
+            if (args or {}).get("offset", 0) > 0:
+                return {"data": {"traders": []}}           # end pagination
+            return {"data": {"traders": [
+                {"address": "0xa", "realizedPnl": 5_000_000},
+                {"address": "0xb", "realizedPnl": 3_000_000},
+                {"address": "0xc", "realizedPnl": 2_000_000},
+                {"address": "0xd", "realizedPnl": 1_500}]}}
+        if tool == "discovery_get_trader_state":
+            return {"data": {"traders": [
+                {"traderAddress": "0xa", "openPositions": [{"coin": "BTC", "szi": 1.2}]},
+                {"traderAddress": "0xb", "openPositions": [{"coin": "BTC", "szi": 3.0}]},
+                {"traderAddress": "0xc", "openPositions": [{"coin": "BTC", "szi": 0.4},
+                                                           {"coin": "ETH", "szi": -2.0}]},
+                {"traderAddress": "0xd", "openPositions": [{"coin": "SOL", "szi": 9.0}]}]}}
+        if tool == "strategy_get_clearinghouse_state":
+            return {"data": {"assetPositions": []}}
+        return {}
+
+
+class _EmptyMCP:
+    def call_tool(self, tool, args):
+        if tool == "discovery_get_top_traders":
+            return {"data": {"traders": []}}
+        return {"data": {"assetPositions": []}}
+
+
+class _Ctx:
+    def __init__(self, mcp=None):
+        self.wallet = "0xstarling"
+        self.state = _State()
+        self.senpi_mcp = mcp or _MCP()
+
+
+_INPUTS = {
+    "cohortRefreshHours": 12, "smartMinRealizedUsd": 1000, "cohortCap": 120,
+    "pageSize": 1000, "maxPages": 6, "stateBatch": 50,
+    "minConsensus": 3, "goodConsensus": 4, "apexConsensus": 6,
+    "maxSlots": 6, "recentSignalTtlSeconds": 21600,
+    "leverageTiers": {"apex": 5, "good": 4, "base": 3},
+    "marginPctTiers": {"apex": 14, "good": 10, "base": 7},
+    "maxLeverage": 5, "maxMarginPct": 25,
+}
+
+
+def test_scan_smoke_returns_valid_signals_and_persists():
+    import scan
+    ctx = _Ctx()
+    out = scan.scan(dict(_INPUTS), ctx)
+    assert isinstance(out, list)
+    assert len(out) == 1                                   # only BTC has >=3 fresh agreeing wallets
+    s = out[0]
+    assert set(("asset", "direction", "marginPct", "leverage", "data")) <= set(s)
+    assert s["asset"] == "BTC" and s["direction"] == "LONG"
+    assert 0 < s["marginPct"] <= 25 and 1 <= s["leverage"] <= 5
+    assert s["data"]["consensusCount"] == 3 and s["data"]["band"] == "base"
+    assert s["data"]["reasons"] == ["3_smart_wallets_LONG"]
+    # state persisted: cohort + snapshot + recent
+    last = ctx.state.last()
+    assert last is not None and len(last["cohort"]) == 4
+    assert last["last_snapshot"]["BTC"]["LONG"] == 3
+    assert "BTC" in last["recent"]
+
+    # second tick: identical snapshot -> STALE standing consensus (+ recent debounce) -> no new opens
+    out2 = scan.scan(dict(_INPUTS), ctx)
+    assert out2 == []
+
+
+def test_scan_degrades_when_cohort_empty():
+    import scan
+    ctx = _Ctx(mcp=_EmptyMCP())
+    out = scan.scan(dict(_INPUTS), ctx)
+    assert out == []                                       # nothing to follow -> empty, no crash
+    assert ctx.state.last() is not None                    # still persists (cohort stays empty)
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\nALL {len(fns)} STARLING TESTS PASS")


### PR DESCRIPTION
Four new strategy packages on the tier-3 (imperative/stateful) frontier, plus a generator upgrade so non-deployable packages stay out of the user catalog. Each is a self-contained package (`strategy.yaml` + `main/runtime.yaml` + `scanners/{scan,scoring}.py` + `tests/`), fleet-standard throughout (marginPct sizing, leverage caps, mandatory DSL, drawdown gate, read-only single-pass scanners).

## Deployable (in catalog · tested · `_pkg.validate` ✓)

**`raven` — Self-Calibrating Momentum** (7 tests)
Bison's momentum engine (ported verbatim) under a self-tuner: on a slow clock it reads its **own** closed-trade record (`discovery_get_trader_history`), rolls up win-rate / profit-factor / losing-streak, and ratchets the entry-score floor + a conviction size-scale within bounded rails. **Holds below `minTrades`** — never tunes on noise. Uses the granular DSL ladder (breakeven-first, no back-loaded gap).

**`starling` — Smart-Money Rotation Follower** (9 tests)
Derives a proven-profitable cohort (paginated top-traders ≥ $1M realized), snapshots their books, and opens **only on fresh/rising consensus** (a true snapshot-diff — never stale standing consensus), sized by agreement count. Open-only + DSL exit; held + recent-signal dedup prevent churn as consensus climbs. Preserves the `xyz:` venue prefix on emitted names.

**`ant` — Funding Harvester** (6 tests)
The best Senpi-achievable cash-and-carry. Senpi is perps-only (no HyperEVM spot), so ant runs the achievable half: **short** top-OI names paying high positive funding — but **only when the long crowd is exhausted** (overbought *and* stalling / rolling over), never a name still ripping. Low leverage (2–4×), tight 8% squeeze-stop, 24h rotation. **Directional, not delta-neutral** — the missing spot hedge is the residual risk, documented in [`ant/NOTES.md`](strategies/ant/NOTES.md).

## Not deployable — tracked + tested, excluded from the catalog

**`crane` — Managed Pairs / Stat-Arb** (7 tests)
Market-neutral alpha engine is complete and tested (log-spread → z-score → pair state machine, with `CLOSE_NAKED` as the unconditional first branch), but it **ships disarmed**: the runtime has no coordinated multi-leg close, so a DSL-only pair would leave a **naked directional leg** when one side stops first. [`crane/DESIGN.md`](strategies/crane/DESIGN.md) documents the exact gap and the one primitive that unblocks it. Concrete evidence that market-neutral needs a capability neither the runtime nor the strategy-spec proposal covers yet.

## Manifest / generator
- `gen_catalog.py` now **skips packages flagged `catalog.status: blocked`** — the catalog is the *deployable* registry, so crane is tracked/tested in-repo but never surfaces as installable.
- `catalog.json` regenerated (both locations). Also **syncs a pre-existing stale entry**: `spider` 6.0.0 → 6.0.1 (its `strategy.yaml` was already 6.0.1; the committed catalog hadn't been regenerated). Purely additive otherwise — `raven`/`starling`/`ant` added, nothing removed, only `sort_order` renumbering on existing entries.
- All declared catalog terms reuse **existing** glossary vocabulary — zero new warnings.

## Verification
`raven` 7 · `starling` 9 · `ant` 6 · `crane` 7 engine tests — all pass; `py_compile` clean; `_pkg.validate` ✓ for all four; catalog regenerates warning-clean.

**One caveat before funding any of these:** the self-tune / cohort / funding reads (`discovery_get_trader_history`, `discovery_get_trader_state`/`top_traders`, `market_get_funding_history`) use tolerant multi-key extraction + hold-on-zero, but their payload shapes **weren't live-verified** (the prod token went invalid mid-build). Worth one real-payload check before funding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)