### PR TITLE
fleet-new: 5 demand-driven strategies — viper, ram, salmon, gecko, armadillo

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.5.0"
+  version: "2.6.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1655,6 +1655,50 @@
       "sort_order": 1
     },
     {
+      "id": "armadillo",
+      "name": "Armadillo — Capital Preservation",
+      "emoji": "🛡️",
+      "tagline": "A sleep-at-night strategy that trades only the biggest, most liquid coins, at low leverage (1-2x), with small position sizes and a high bar for entering — so it makes few, careful trades and protects your money first. Tight stops cut losers fast and lock in gains early, and a hard drawdown halt is the backstop. Built to NOT lose money, not to swing for the fences.",
+      "belief_plain": "This is the conservative, capital-preservation option. It sticks to the majors (the deepest, most liquid markets), uses low leverage and small sizes, and only opens a position when a real, strong trend lines up — so most of the time it's patient and does nothing. When it is in a trade, a tight trailing stop protects it: it cuts losers quickly and starts locking in profit early instead of giving gains back. A hard 10% drawdown halt stops everything if things go wrong. It won't shoot the lights out — that's the point.",
+      "version": "1.0.0",
+      "thesis": "Most users who ask for 'low risk' don't want the highest return — they want to not lose money and to sleep at night. Armadillo is built for exactly that: restricting to the most liquid majors removes the thin-coin blow-up risk, low leverage (1-2x) and small margin cap the downside on any single trade, and a demanding score floor means it only acts on the strongest setups (few, high-quality entries, low turnover so fees don't bleed it). The momentum entry is Bison's validated multi-factor scorer, ported verbatim; the conservatism is entirely in the configuration — a high entry bar and low sizing — not in new, unproven math. The DSL owns every exit with a tight floor and an early profit-lock ladder, and the runtime drawdown_halt is the equity backstop.",
+      "tags": [
+        "conservative",
+        "capital-preservation",
+        "low-risk",
+        "low-leverage",
+        "defensive",
+        "majors",
+        "sleep-at-night",
+        "dsl-only"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "conviction_holder",
+      "sub_style_label": "High-conviction multi-factor holder; sizes up as more signals agree, then holds the move.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "conservative",
+      "tier": "starter",
+      "leverage_max": 2,
+      "time_horizon": "swing",
+      "cadence_seconds": 900,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 4,
+      "branch": "main",
+      "sort_order": 2
+    },
+    {
       "id": "chimp",
       "name": "Chimp — Regime Allocator (Daily)",
       "emoji": "🐒",
@@ -1701,7 +1745,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 2
+      "sort_order": 3
     },
     {
       "id": "gibbon",
@@ -1749,7 +1793,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 3
+      "sort_order": 4
     },
     {
       "id": "gorilla",
@@ -1798,7 +1842,7 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "mantis",
@@ -1844,7 +1888,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "octopus",
@@ -1888,7 +1932,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 6
+      "sort_order": 7
     },
     {
       "id": "orangutan",
@@ -1936,7 +1980,7 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 7
+      "sort_order": 8
     },
     {
       "id": "raven",
@@ -1983,7 +2027,50 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
+    },
+    {
+      "id": "salmon",
+      "name": "Salmon — RSI Mean-Reversion",
+      "emoji": "🐟",
+      "tagline": "Buys the bounce, not the falling knife. It watches the RSI on liquid majors and only steps in when an oversold coin has actually turned back up — a real cross off the lows with the candle confirming — going long the recovery (or short an overbought coin rolling over). It bets price snaps back to its average, sizes moderately because these turns fail fast, and lets a tight trailing stop do all the exiting.",
+      "belief_plain": "Trades the big liquid coins by their RSI. When one gets oversold it waits for it to actually turn back up before buying — not while it's still dropping — and when one gets overbought and starts rolling over it shorts the fade. It's betting the price springs back toward its average, keeps size moderate because these bounces can fail quickly, and never closes by hand: a tight stop protects and exits every trade.",
+      "version": "1.0.0",
+      "thesis": "Stretched moves revert. When a liquid major gets pushed to an oversold extreme and then genuinely turns — RSI crossing back up through the line while the last candle confirms — the snap back toward the mean is the trade; the symmetric overbought roll-over is the short. The discipline is refusing to catch a falling knife: a low RSI alone is not a signal, only the confirmed cross-back is. Because reversions fail fast, leverage stays moderate and the DSL exit is tight — lock early, cut small.",
+      "tags": [
+        "mean-reversion",
+        "rsi",
+        "oversold",
+        "dip-buy",
+        "contrarian",
+        "reversion",
+        "dsl-only"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "mean_reversion",
+      "sub_style_label": "Buys oversold / sells overbought, betting price reverts to its mean (works in chop, not just trends).",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 10
     },
     {
       "id": "starling",
@@ -2031,7 +2118,53 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 11
+    },
+    {
+      "id": "viper",
+      "name": "Viper — SMC/ICT Structure Trader",
+      "emoji": "🐍",
+      "tagline": "Reads a chart the way a smart-money trader does. It marks the recent peaks and troughs, then waits for price to actually break structure — punch through a prior high (or low) — and only takes the trade when the break is backed by a stop-hunt wick that grabbed liquidity and snapped back, a price gap that shows one-sided pressure, and the bigger-picture 4h trend pointing the same way. A trailing stop does all the exiting; Viper never sells manually.",
+      "belief_plain": "Markets move from one pool of resting stop orders to the next, and the honest tell is structure: a 'Break of Structure' is price closing past the last swing high or low in the trend's direction (it's continuing), and a 'Change of Character' is the first close through the OPPOSITE swing (the trend may be flipping). Viper enters on those breaks — but only the high-quality ones, where a liquidity sweep (a wick that runs the stops just past a prior swing then closes back inside) and a fair-value gap (a 3-candle imbalance where price left a gap it tends to revisit) agree with it, and the 4h structure confirms. It never manually closes — a ratchet stop protects and exits every position, and a hard drawdown halt is the backstop.",
+      "version": "1.0.0",
+      "thesis": "Price is delivered between liquidity pools, and market structure — not an oscillator — is the cleanest read on which pool is next. Viper maps confirmed swing pivots, classifies each close through the most-recent swing as a Break of Structure (continuation) or Change of Character (reversal), and requires SMC/ICT confluence before committing: a liquidity sweep of a prior swing that closes back inside (the stop-hunt / Wyckoff spring), a 3-candle Fair Value Gap in the break direction, and higher-timeframe (4h) structure agreement. Confluence is scored, conviction-banded, and gated to a minimum; sizing scales with conviction and leverage is clamped to the venue max. The edge is entry QUALITY on structure; the DSL owns exits and the runtime drawdown_halt is the equity backstop.",
+      "tags": [
+        "smc",
+        "ict",
+        "wyckoff",
+        "market-structure",
+        "liquidity-sweep",
+        "fvg",
+        "bos",
+        "choch"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "market_structure",
+      "sub_style_label": "Trades SMC/ICT/Wyckoff structure: break-of-structure, liquidity sweeps, fair-value gaps.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities",
+        "commodities"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 900,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 6,
+      "branch": "main",
+      "sort_order": 12
     },
     {
       "id": "asia-ai",
@@ -3253,6 +3386,51 @@
       "sort_order": 3
     },
     {
+      "id": "gecko",
+      "name": "Gecko — Any-Coin Confluence",
+      "emoji": "🦎",
+      "tagline": "Point it at any liquid coin you name and it trades just that one: it scores trend structure, momentum and funding into a single confluence read on that name, goes long or short when enough signals line up — sizing conviction to the strength of the setup — and trails a stop instead of guessing the exit.",
+      "belief_plain": "You pick the coin; Gecko trades only that coin. It waits until the 1-hour and 4-hour trend, momentum and funding all point the same way, then goes in — harder when more of them agree — and never guesses the exit: a trailing stop does all the closing. One coin, one position, done well.",
+      "version": "1.0.0",
+      "thesis": "Most people don't want a scattergun across the whole market — they want their coin traded properly. Gecko is bison's validated confluence scorer pointed at a single user-named asset: trend structure (1h/4h), momentum, RSI and funding are summed into one conviction score, direction resolves from the timeframe waterfall, and leverage/margin scale to the score. One asset, one high-conviction slot; the DSL owns every exit and the drawdown_halt is the backstop. It fills the long tail of 'make me a strategy for <my coin>' without a bespoke build each time.",
+      "tags": [
+        "configurable",
+        "any-asset",
+        "confluence",
+        "single-asset",
+        "custom",
+        "dsl-only"
+      ],
+      "group": "single-asset",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "confluence_sniper",
+      "sub_style_label": "Fires only when multiple timeframes/factors line up.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "BTC"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "main",
+      "sort_order": 4
+    },
+    {
       "id": "grizzly",
       "name": "Grizzly — BTC Alpha Hunter",
       "emoji": "🐻",
@@ -3294,7 +3472,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "heron",
@@ -3337,7 +3515,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "hummingbird",
@@ -3380,7 +3558,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 6
+      "sort_order": 7
     },
     {
       "id": "iguana",
@@ -3428,7 +3606,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 7
+      "sort_order": 8
     },
     {
       "id": "koala",
@@ -3473,7 +3651,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
     },
     {
       "id": "kodiak",
@@ -3516,7 +3694,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "polar",
@@ -3560,7 +3738,51 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 11
+    },
+    {
+      "id": "ram",
+      "name": "Ram — Gold Specialist",
+      "emoji": "🐏",
+      "tagline": "A single-asset gold (xyz:GOLD) specialist: goes long when gold's trend lines up across the 1h and 4h and momentum agrees — and leans in harder when the market turns risk-off and money is looking for a safe haven — and can short a clean downtrend. Holds one position at a time and trails a stop instead of guessing the exit.",
+      "belief_plain": "Trades only gold. It buys when gold is trending up and, especially, when the market gets defensive and flows into safe havens; it can short a clear downtrend. It never picks a top or bottom by hand — a trailing stop does all the exiting. Gold trades around the clock, weekends included.",
+      "version": "1.0.0",
+      "thesis": "Gold is the market's safe-haven anchor: it trends on real-rate and risk-regime shifts and gets bid hardest when risk assets wobble. An agent that watches only gold can read its 1h/4h trend structure, momentum and RSI far more tightly than a broad scanner, and add a safe-haven tilt when a risk-off funding regime shows up — catching the defensive bid early and locking profit as the move matures. Concentration by conviction on one asset, with the DSL owning every exit.",
+      "tags": [
+        "gold",
+        "xau",
+        "metals",
+        "safe-haven",
+        "commodity",
+        "single-asset",
+        "dsl-only"
+      ],
+      "group": "single-asset",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "commodity",
+      "sub_style_label": "Trades a commodity (oil/metals).",
+      "asset_classes": [
+        "commodities"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "xyz:GOLD"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "main",
+      "sort_order": 12
     },
     {
       "id": "stag",
@@ -3608,7 +3830,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 13
     },
     {
       "id": "wolverine",
@@ -3653,7 +3875,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 14
     },
     {
       "id": "hydra",

--- a/senpi-strategy-discover/references/glossary.yaml
+++ b/senpi-strategy-discover/references/glossary.yaml
@@ -91,6 +91,8 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   # breakout_momentum
   range_break:   { gloss: "Buys/sells the break of a multi-day range." }
   pullback:      { gloss: "Buys the dip within an uptrend." }
+  mean_reversion: { gloss: "Buys oversold / sells overbought, betting price reverts to its mean (works in chop, not just trends)." }
+  market_structure: { gloss: "Trades SMC/ICT/Wyckoff structure: break-of-structure, liquidity sweeps, fair-value gaps." }
   rank_jump:     { gloss: "Catches leaderboard rank-jumps early." }
   momentum_event: { gloss: "Snipes fresh momentum events the instant they fire." }
   liquidation_cascade: { gloss: "Rides liquidation cascades / forced flow." }

--- a/senpi-strategy-discover/scripts/discover.py
+++ b/senpi-strategy-discover/scripts/discover.py
@@ -57,6 +57,7 @@ ASSET_SYN = {**{t: t for t in CLASS_TAGS},
              "everything": "universe_crypto", "scan": "universe_crypto", "all": "universe_crypto", "universe": "universe_crypto",
              "stocks": "xyz_equities", "stock": "xyz_equities", "equities": "xyz_equities", "equity": "xyz_equities", "tech": "xyz_equities",
              "oil": "commodities", "gold": "commodities", "silver": "commodities", "metals": "commodities", "commodity": "commodities",
+             "xauusd": "commodities", "xau": "commodities", "xagusd": "commodities",
              "index": "indices", "sp500": "indices", "nasdaq": "indices",
              "pre-ipo": "pre_ipo", "preipo": "pre_ipo", "ipo": "pre_ipo", "spacex": "pre_ipo"}
 DIRECTION_SYN = {"long_only": "long_only", "long-only": "long_only", "longonly": "long_only", "long": "long_only",
@@ -179,6 +180,14 @@ def asset_matches(named, assets):
     return False
 
 
+def _configurable(r):
+    """A user-parameterized single-asset template (e.g. gecko) trades ANY liquid coin the
+    user sets at deploy, so a named-asset intent must NOT filter it out — it's precisely the
+    answer when no fixed-asset template covers the coin. Flagged by a catalog tag."""
+    tags = [str(t).lower() for t in (r.get("tags") or [])]
+    return "configurable" in tags or "any-asset" in tags
+
+
 def infer_class_for_named(named):
     n = named.upper().replace("XYZ:", "")
     if named.upper().startswith("XYZ:"):
@@ -197,7 +206,7 @@ def _hard_reject(r, intent):
         if ud and sd and ud.isdisjoint(sd):
             return True
     named = [v for k, v in intent["assets"] if k == "named"]
-    if named and not any(asset_matches(n, r.get("assets")) for n in named):
+    if named and not _configurable(r) and not any(asset_matches(n, r.get("assets")) for n in named):
         if not intent.get("_broadened_classes"):
             return True
         if not (set(intent["_broadened_classes"]) & set(r.get("asset_classes") or [])):
@@ -240,7 +249,10 @@ def _caveats(r, intent):
     """Fixed-string honesty caveats — concrete only (no soft scoring). Surfaced verbatim by the LLM."""
     cav = []
     user_classes = [v for k, v in intent["assets"] if k == "class"]
+    named = [v for k, v in intent["assets"] if k == "named"]
     acs = set(r.get("asset_classes") or [])
+    if named and _configurable(r) and not any(asset_matches(x, r.get("assets")) for x in named):
+        cav.append(f"Configurable — set it to trade {named[0]} (or any liquid coin) at deploy.")
     if "btc_eth" in user_classes and "btc_eth" not in acs and (acs & CRYPTO_CLASSES):
         cav.append("Trades alts beyond just BTC/ETH.")
     if intent["direction"] == "long_only" and r.get("direction") == "long_short":

--- a/senpi-strategy-discover/tests/test_new_strategy_discoverability.py
+++ b/senpi-strategy-discover/tests/test_new_strategy_discoverability.py
@@ -1,0 +1,71 @@
+"""Regression guard: the demand-driven strategies must surface for the way users
+actually prompt for them (from senpi-strategy-creation-prompts-2026-07-13.csv).
+Each is expected at rank 1 among the theme-ranked survivors; the bar asserted here
+is top-3 (leaves headroom for future catalog growth). Runs offline on the bundled
+catalog — no MCP. See discover.py `_configurable` (gecko) + ASSET_SYN (gold/xauusd)."""
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+import discover  # noqa: E402
+
+_CATALOG = os.path.join(HERE, "..", "catalog.json")
+_RECORDS = json.load(open(_CATALOG))["skills"]
+
+
+def _intent(assets=None, direction=None, exclude=None):
+    return {"direction": direction, "assets": assets or [], "exclude": exclude or [],
+            "budget": None, "_broadened_classes": None}
+
+
+def _rank(target, itn, theme):
+    res = discover.match(itn, _RECORDS)
+    if theme:
+        discover.apply_theme(res, theme)
+    ids = [c["id"] for c in res.get("candidates", [])]
+    return (ids.index(target) + 1) if target in ids else None
+
+
+# (target, intent, theme) mirroring the real user prompts
+_CASES = [
+    ("viper",     _intent(), "smc ict market structure"),                      # M174126
+    ("salmon",    _intent(), "mean reversion rsi oversold buy the dip"),       # M210373 / M272040
+    ("armadillo", _intent(), "low risk capital preservation conservative"),    # M264525 / M287260
+    ("starling",  _intent(), "follow smart money rotation"),                   # M279357 / M196406
+    ("ant",       _intent(), "funding carry cash and carry harvest"),          # M242529
+    ("raven",     _intent(), "adaptive self tuning momentum learns"),
+    ("ram",       _intent(assets=[("class", "commodities")]), "gold xauusd metals"),  # M207348 / M197292
+    ("gecko",     _intent(assets=[("named", "VVV")]), "any coin"),             # M279357 (VVV) / M199951 ($LIT)
+]
+
+
+def test_each_new_strategy_ranks_top3_for_its_prompt():
+    for target, itn, theme in _CASES:
+        rank = _rank(target, itn, theme)
+        assert rank is not None, f"{target} was filtered OUT for its own query"
+        assert rank <= 3, f"{target} ranked {rank} (>3) for its query — discoverability regressed"
+
+
+def test_gecko_survives_any_named_asset():
+    # gecko is the configurable catch-all: it must survive a named-asset filter for a coin
+    # no fixed template covers, rather than being hard-rejected.
+    for coin in ("VVV", "LIT", "WIF", "PEPE"):
+        res = discover.match(_intent(assets=[("named", coin)]), _RECORDS)
+        ids = [c["id"] for c in res.get("candidates", [])]
+        assert "gecko" in ids, f"gecko filtered out for named {coin} — configurability broken"
+
+
+def test_gold_resolves_from_gold_and_xauusd():
+    w = []
+    assert ("class", "commodities") in discover._norm_assets("gold", w)
+    assert ("class", "commodities") in discover._norm_assets("xauusd", w)
+    assert ("class", "commodities") in discover._norm_assets("XAU", w)
+
+
+if __name__ == "__main__":
+    test_each_new_strategy_ranks_top3_for_its_prompt()
+    test_gecko_survives_any_named_asset()
+    test_gold_resolves_from_gold_and_xauusd()
+    print("ALL DISCOVERABILITY TESTS PASS")

--- a/strategies/armadillo/main/runtime.yaml
+++ b/strategies/armadillo/main/runtime.yaml
@@ -1,0 +1,136 @@
+# ── ARMADILLO · Capital-Preservation / Low-Vol ───────────────────────────────
+# The "sleep at night" strategy. For users asking for low-risk / conservative /
+# capital-preservation / impervious-to-volatility. Trades ONLY the most liquid
+# majors (main DEX, HIGH volume floor, top-N), at LOW leverage (1-2x), small
+# per-trade margin (4-8%), behind a HIGH conviction bar (few, high-quality
+# entries) and low turnover (12h dedup). Its job is to NOT lose money, not to
+# maximize. The momentum thesis is Bison's validated weighted scorer, ported
+# verbatim; the conservatism is entirely in the CONFIG (high minScore + low
+# sizing caps). NEVER closes — the DSL owns every exit (TIGHT), and the runtime
+# drawdown_halt is the equity backstop.
+name: armadillo-main
+group: armadillo
+version: 1.0.0
+description: >
+  ARMADILLO — Capital Preservation / Low-Vol. The sleep-at-night book: a
+  conservative majors-only momentum strategy (main DEX, high volume floor, top-8
+  most-liquid) that opens few, high-conviction, LOW-leverage positions (1-2x,
+  4-8% margin) only when a 9-factor thesis clears a HIGH score floor (11). Low
+  turnover (12h dedup), tight capital-preservation DSL, and a hard 10% drawdown
+  halt. Up to 4 positions, leverage clamped to 2x AND venue max. DSL is the ONLY
+  exit — tight Phase 1 (6% floor), early profit-lock ladder, 24h weak-peak cut.
+
+strategy:
+  wallet: "${ARMADILLO_WALLET}"
+  slots: 4
+  margin_pct: 6                           # baseline %; scan emits the per-signal LOW marginPct (4-8%)
+  default_leverage: 2                     # fallback; scan emits 1-2x per signal (clamped to venue max)
+  trading_risk: conservative
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: armadillo_scanner
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900                  # slow, low-turnover clock (15m)
+    timeout_seconds: 180                   # up to ~8 asset reads + instruments + clearinghouse
+    default_signal_validity_seconds: 1800  # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 200           # dedup map + per-tick scan-results history
+    inputs:
+      # ── universe (majors only) ──
+      includeXyz: false                    # main DEX only — deepest books
+      universeVolFloorUsd: 50000000        # HIGH floor — only the most liquid names survive
+      maxUniverse: 8                       # top-8 most-liquid = majors
+      maxSlots: 4
+      recentSignalTtlSeconds: 43200        # 12h — low churn
+      # ── conviction gate (HIGH bar) ──
+      minScore: 11                         # only the strongest setups clear
+      apexScore: 13
+      goodScore: 12
+      # ── LOW sizing caps (capital preservation) ──
+      leverageTiers: { apex: 2, good: 2, base: 1 }
+      marginPctTiers: { apex: 8, good: 6, base: 4 }
+      maxLeverage: 2
+      maxMarginPct: 10
+      # ── momentum thesis knobs (bison-ported) ──
+      minVolTrendPct: 10
+      rsiMaxLong: 72
+      rsiMinShort: 28
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      band: { type: string, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: armadillo_open
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter
+    scanners: [armadillo_scanner]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # low-turnover book — take the fill, then DSL attaches
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: armadillo_scanner
+  # NO CLOSE_POSITION action — DSL is the only exit.
+
+# ── EXIT — DSL only. Capital preservation is TIGHT: a shallow Phase 1 floor,
+# an EARLY profit-lock ladder (first lock at +12% locks 45% of the high-water
+# gain — protect gains fast), and a 24h weak-peak cut that frees a slot from a
+# stalled name. order_type FEE_OPTIMIZED_LIMIT, taker fallback on (closes MUST
+# happen). interval_seconds 30 (responsive protection).
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true        # closes MUST happen — taker fallback safety floor
+    execution_timeout_seconds: 60
+  dsl_preset:
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 1440            # 24h — a stalled name frees its slot
+      min_value: 2.0
+    phase1:
+      enabled: true
+      max_loss_pct: 6.0                    # TIGHT floor — protect capital first
+      retrace_threshold: 5
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # lock profit EARLY
+        - { trigger_pct: 6,  lock_hw_pct: 0 }
+        - { trigger_pct: 12, lock_hw_pct: 45 }
+        - { trigger_pct: 20, lock_hw_pct: 65 }
+        - { trigger_pct: 35, lock_hw_pct: 80 }
+
+# ── RISK guard rails — conservative, tight ──
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 5
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 1800                 # post-loss cooldown 30m
+    per_asset_cooldown_seconds: 43200      # 12h — do not re-enter the same name quickly
+    drawdown_halt_pct: 10                  # hard equity backstop
+    drawdown_reset_on_day_rollover: true
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/armadillo/main/scanners/scan.py
+++ b/strategies/armadillo/main/scanners/scan.py
@@ -1,0 +1,197 @@
+"""ARMADILLO — Capital-Preservation / Low-Vol. The single supervised scanner.
+
+The "sleep at night" book: trades ONLY the most liquid majors, at LOW leverage
+(1-2x), small per-trade margin, with a HIGH conviction bar (few, high-quality
+entries), low turnover, and a tight drawdown circuit-breaker. Its job is to NOT
+lose money, not to maximize. Each tick:
+  1) Read held positions (free slots = maxSlots - held).
+  2) If any slot is free, derive the MAJORS-ONLY universe (main DEX, HIGH volume
+     floor, top-N most-liquid), and for each non-held / non-recently-signaled
+     candidate score the bison momentum thesis and gate on a HIGH `minScore`.
+  3) Emit at most (free) opens, sized LOW (band → 1-2x, 4-8% margin, hard-capped).
+  NEVER closes — the DSL owns every exit (tight), and the runtime's drawdown_halt
+  is the equity backstop.
+
+Read-only + single-pass. marginPct is a PERCENT in (0,100]. No daemon, no
+push_signal, no create_position — the runtime sizes the dollars and trails exits.
+
+NOTE: MCP payload shapes (market_list_instruments / market_get_asset_data /
+strategy_get_clearinghouse_state) were NOT live-verified when this was written
+(auth token invalid). Every read is tolerant (tries the spellings the corpus uses)
+and degrades to "no opens this tick" rather than raising — a capital-preservation
+book must fail CLOSED (do nothing), never fail into a bad trade.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
+        print(f"[armadillo.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _dex_of(name):
+    return "xyz" if str(name).lower().startswith("xyz:") else ""
+
+
+def _instrument_rows(ctx, dex):
+    data = _read(ctx, "market_list_instruments", ({"dex": dex} if dex else {}),
+                 f"market_list_instruments({dex or 'main'})")
+    if data is None:
+        return None
+    insts = data.get("instruments", data.get("universe", data)) if isinstance(data, dict) else data
+    if not isinstance(insts, list):
+        return None
+    rows = []
+    for inst in insts:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        c = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        vol = scoring._f(c.get("dayNtlVlm"))
+        venue = c.get("max_leverage", c.get("maxLeverage")) or inst.get("max_leverage")
+        rows.append({"name": str(name), "vol": vol, "venue_max": venue, "dex": _dex_of(name)})
+    return rows
+
+
+def _derive_universe(ctx, inputs):
+    """Live top-N MOST-LIQUID names over a HIGH volume floor — majors only.
+
+    Capital preservation trades only the deepest books, so this is main-DEX only
+    (includeXyz defaults OFF) with a HIGH vol floor and a small cap (top 8). The
+    high floor + small cap IS the 'majors only' filter: sorting the whole live
+    board by 24h notional and keeping the top few leaves BTC/ETH/SOL/HYPE-class
+    names and nothing thin."""
+    main = _instrument_rows(ctx, "")
+    if main is None:
+        return None
+    rows = list(main)
+    if bool(inputs.get("includeXyz", False)):          # default OFF — majors only
+        rows += (_instrument_rows(ctx, "xyz") or [])
+    vfloor = scoring._f(inputs.get("universeVolFloorUsd"), 50_000_000)
+    xfloor = scoring._f(inputs.get("xyzVolFloorUsd"), vfloor)
+    keep = [r for r in rows if r["vol"] >= (xfloor if r["dex"] == "xyz" else vfloor)]
+    keep.sort(key=lambda r: r["vol"], reverse=True)
+    cap = int(scoring._f(inputs.get("maxUniverse"), 8))
+    return keep[:cap]
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["15m", "1h", "4h"],
+        "include_funding": True, "include_order_book": False, "dex": _dex_of(name),
+    }, f"market_get_asset_data({name})")
+
+
+def _funding_of(md):
+    """Current funding rate as a float (tolerant; 0.0 if absent)."""
+    for k in ("funding", "funding_rate", "fundingRate", "current_funding"):
+        v = scoring._num((md or {}).get(k))
+        if v is not None:
+            return v
+    fh = (md or {}).get("funding") if isinstance((md or {}).get("funding"), dict) else None
+    if isinstance(fh, dict):
+        return scoring._f(fh.get("rate", fh.get("current")))
+    return 0.0
+
+
+def _held(ctx):
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = set()
+    # dual-shape: {assetPositions:[...]} OR sub-DEX sections {main:{assetPositions}, xyz:{...}}
+    buckets = []
+    if isinstance(d.get("assetPositions"), list) or isinstance(d.get("asset_positions"), list):
+        buckets.append(d)
+    for section in ("main", "xyz"):
+        s = d.get(section)
+        if isinstance(s, dict):
+            buckets.append(s)
+    for b in buckets:
+        for e in b.get("assetPositions", b.get("asset_positions", [])) or []:
+            pos = e.get("position", e) if isinstance(e, dict) else {}
+            coin = str(pos.get("coin", "")).strip()
+            if coin and scoring._f(pos.get("szi")) != 0:
+                out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 4))
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 43200)
+    min_score = scoring._f(inputs.get("minScore"), 11)
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    recent = dict(st.get("recent", {}) or {})
+
+    held = _held(ctx)
+    if held is None:
+        print("[armadillo.scan] clearinghouse unreadable — no opens this tick (fail closed)",
+              file=sys.stderr)
+        return []                                        # fail CLOSED — never trade on a bad read
+    free = max_slots - len(held)
+
+    out = []
+    if free > 0:
+        universe = _derive_universe(ctx, inputs)
+        if universe is None:
+            print("[armadillo.scan] instruments unreadable — no opens this tick", file=sys.stderr)
+        else:
+            looked = 0
+            for row in universe:
+                if free <= 0 or looked >= max(12, free * 4):
+                    break
+                name = row["name"]
+                bare = str(name).split(":", 1)[-1].upper()
+                if bare in held:
+                    continue
+                if recent.get(bare) is not None and (now - recent[bare]) < ttl:
+                    continue                             # low turnover: long TTL dedup
+                looked += 1
+                md = _asset_data(ctx, name)
+                if not md:
+                    continue
+                candles = md.get("candles", {}) or {}
+                th = scoring.build_thesis(name, candles.get("15m", []), candles.get("1h", []),
+                                          candles.get("4h", []), _funding_of(md), (None, 0), inputs)
+                if not th or th["score"] < min_score:     # HIGH bar — only the strongest setups
+                    continue
+                band = scoring.band_for(th["score"], inputs)
+                lev, mgn = scoring.sizing_for(band, inputs, row.get("venue_max"))
+                recent[bare] = now
+                free -= 1
+                out.append({
+                    "asset": name, "direction": th["direction"], "marginPct": mgn, "leverage": lev,
+                    "data": {"score": th["score"], "leverage": lev, "direction": th["direction"],
+                             "band": band, "reasons": th["reasons"]},
+                })
+                print(f"[armadillo.scan] OPEN {th['direction']} {name}: score={th['score']} "
+                      f"band={band} {lev}x {mgn}% (min {min_score:g})", file=sys.stderr)
+
+    if not out:
+        print(f"[armadillo.scan] no opens: held={len(held)}/{max_slots} free={free} "
+              f"min={min_score:g}", file=sys.stderr)
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({
+                "recent": recent,
+                "result": {"ts": now, "opened": len(out), "held": len(held), "min_score": min_score},
+            })
+        except Exception as exc:  # noqa: BLE001
+            print(f"[armadillo.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/armadillo/main/scanners/scoring.py
+++ b/strategies/armadillo/main/scanners/scoring.py
@@ -1,0 +1,312 @@
+"""ARMADILLO — pure thesis math (no I/O, no MCP, no clock).
+
+Capital-Preservation / Low-Vol scorer. The multi-factor MOMENTUM ENGINE (indicator
+math + direction-waterfall + weighted score) is ported VERBATIM from bison/scoring.py
+(a validated Runtime 3.0 scorer) so a fidelity harness can diff armadillo's thesis
+against bison's on the same candles; behaviour-preserving quirks carry bison's
+`# v2-quirk` flags. Armadillo adds NO new indicator — its conservatism lives entirely
+in the CONFIG (a HIGH minScore floor applied by the caller, and LOW leverage/margin
+tiers via band_for + sizing_for below). The DSL owns every exit.
+
+Multi-asset, single-pass, unit-testable on plain candle lists. `sm` (smart-money
+lean) is passed in as (None, 0) by armadillo's caller — armadillo trades only the
+tape, so the SM contributor never fires — keeping this module pure.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# Ported verbatim from bison/scoring.py. v2 read dicts only; the list branch is
+# defensive and never fires on dict candles, so it does not change v2 behaviour.
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _num(v):
+    """Float or None (distinguishes a real 0.0 from a missing field). Used by the
+    scanner's tolerant funding extraction; not part of the verbatim bison port."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── indicators (ported verbatim from bison/scoring.py) ──
+
+def price_momentum(candles, n_bars=1):
+    """% change over the last n_bars. Verbatim from bison price_momentum."""
+    if len(candles) < n_bars + 1:
+        return 0
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    if old == 0:
+        return 0
+    return ((new - old) / old) * 100
+
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim from bison.
+
+    v2-quirk: thresholds are STRICT (>) for higher-lows / lower-highs counting,
+    and the BULLISH/BEARISH gate is `>= total * 0.6` where total = lookback - 1.
+    Reproduced exactly — do NOT switch to >= counting (Kodiak's variant uses >=,
+    Bison uses strict >). The strength returned is higher_lows/total (BULLISH) or
+    lower_highs/total (BEARISH)."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-half vs earlier-half average volume, % change. Verbatim from bison."""
+    if len(candles) < lookback + 2:
+        return 0
+    vols = [_vol(c) for c in candles[-(lookback + 2):]]
+    half = lookback // 2
+    recent = sum(vols[-half:]) / half if half > 0 else 1
+    earlier = sum(vols[:half]) / half if half > 0 else 1
+    if earlier == 0:
+        return 0
+    return ((recent - earlier) / earlier) * 100
+
+
+def calc_rsi(closes, period=14):
+    """RSI. Verbatim from bison calc_rsi.
+
+    v2-quirk: uses the LAST `period` gains/losses (gains[-period:]) — the more
+    conventional trailing-window RSI. Reproduced exactly."""
+    if len(closes) < period + 1:
+        return 50
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── the thesis (direction waterfall + 9-component score), ported verbatim from bison ──
+
+def build_thesis(coin, candles_15m, candles_1h, candles_4h, funding, sm, inputs):
+    """Port of bison build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned ONLY when:
+      - insufficient candle history (len(c1h) < 8 or len(c4h) < 4), OR
+      - the direction waterfall resolves no direction.
+    minScore is NOT applied here — the caller (scan.py) gates on thesis['score']
+    using armadillo's HIGH floor. `sm` is (direction, pct) or (None, 0); armadillo
+    always passes (None, 0), so the SM contributor is inert."""
+    min_vol_trend = float(inputs.get("minVolTrendPct", 10))
+    rsi_max_long = float(inputs.get("rsiMaxLong", 72))
+    rsi_min_short = float(inputs.get("rsiMinShort", 28))
+
+    if len(candles_1h) < 8 or len(candles_4h) < 4:
+        return None
+
+    price = _close(candles_15m[-1]) if candles_15m else 0
+
+    trend_4h, trend_strength = trend_structure(candles_4h)
+    trend_1h, trend_1h_strength = trend_structure(candles_1h)
+    sm_dir, sm_pct = sm if sm else (None, 0)
+    mom_1h = price_momentum(candles_1h, 2)
+
+    # Direction waterfall: 4H trend -> SM direction -> 1H momentum (verbatim)
+    direction = None
+    direction_source = None
+    if trend_4h == "BULLISH":
+        direction = "LONG"
+        direction_source = "4h_trend"
+    elif trend_4h == "BEARISH":
+        direction = "SHORT"
+        direction_source = "4h_trend"
+    elif sm_dir and sm_dir != "NEUTRAL":
+        direction = sm_dir
+        direction_source = "sm_direction"
+    elif mom_1h > 0.5:
+        direction = "LONG"
+        direction_source = "1h_momentum"
+    elif mom_1h < -0.5:
+        direction = "SHORT"
+        direction_source = "1h_momentum"
+
+    if direction is None:
+        return None
+
+    score = 0
+    reasons = []
+
+    # 4H trend structure (+3 / -1)
+    if trend_4h != "NEUTRAL":
+        if (direction == "LONG" and trend_4h == "BULLISH") or (direction == "SHORT" and trend_4h == "BEARISH"):
+            score += 3
+            reasons.append(f"4h_{trend_4h.lower()}_{trend_strength:.0%}")
+        else:
+            score -= 1
+            reasons.append(f"4h_opposing_{trend_4h.lower()}")
+
+    # 1H trend agreement (+2 / -1)
+    if trend_1h != "NEUTRAL":
+        if (direction == "LONG" and trend_1h == "BULLISH") or (direction == "SHORT" and trend_1h == "BEARISH"):
+            score += 2
+            reasons.append(f"1h_confirms_{trend_1h.lower()}")
+        else:
+            score -= 1
+            reasons.append(f"1h_opposing_{trend_1h.lower()}")
+
+    # 1H momentum (+2 / +1 / -1)
+    if direction == "LONG":
+        if mom_1h >= 1.0:
+            score += 2; reasons.append(f"1h_strong_momentum_{mom_1h:+.2f}%")
+        elif mom_1h >= 0.5:
+            score += 1; reasons.append(f"1h_momentum_{mom_1h:+.2f}%")
+        elif mom_1h < -0.5:
+            score -= 1; reasons.append(f"1h_counter_momentum_{mom_1h:+.2f}%")
+    else:
+        if mom_1h <= -1.0:
+            score += 2; reasons.append(f"1h_strong_momentum_{mom_1h:+.2f}%")
+        elif mom_1h <= -0.5:
+            score += 1; reasons.append(f"1h_momentum_{mom_1h:+.2f}%")
+        elif mom_1h > 0.5:
+            score -= 1; reasons.append(f"1h_counter_momentum_{mom_1h:+.2f}%")
+
+    # SM alignment (+-2) — inert for armadillo (sm always (None, 0))
+    if sm_dir == direction:
+        score += 2
+        reasons.append(f"sm_aligned_{sm_pct:.0f}%")
+    elif sm_dir and sm_dir != "NEUTRAL" and sm_dir != direction:
+        score -= 2
+        reasons.append(f"sm_opposing_{sm_dir}")
+
+    # Funding alignment (+2 / -1)
+    if (direction == "LONG" and funding < 0) or (direction == "SHORT" and funding > 0):
+        score += 2
+        reasons.append(f"funding_aligned_{funding:+.4f}")
+    elif (direction == "LONG" and funding > 0.01) or (direction == "SHORT" and funding < -0.005):
+        score -= 1
+        reasons.append("funding_crowded")
+
+    # Volume trend (+1)
+    vol_1h = volume_trend(candles_1h)
+    if vol_1h > min_vol_trend:
+        score += 1
+        reasons.append(f"vol_rising_{vol_1h:+.0f}%")
+
+    # OI proxy (+1) — recent-3 vs earlier-3 1h volume delta (verbatim)
+    vol_recent = sum(_vol(c) for c in candles_1h[-3:])
+    vol_earlier = sum(_vol(c) for c in candles_1h[-6:-3])
+    oi_proxy = ((vol_recent - vol_earlier) / vol_earlier * 100) if vol_earlier > 0 else 0
+    if oi_proxy > 10:
+        score += 1
+        reasons.append(f"oi_growing_{oi_proxy:+.0f}%")
+
+    # RSI (+1 / -1)
+    closes_1h = [_close(c) for c in candles_1h]
+    rsi = calc_rsi(closes_1h)
+    if direction == "LONG" and rsi > rsi_max_long:
+        score -= 1
+        reasons.append(f"rsi_overbought_{rsi:.0f}")
+    elif direction == "SHORT" and rsi < rsi_min_short:
+        score -= 1
+        reasons.append(f"rsi_oversold_{rsi:.0f}")
+    elif (direction == "LONG" and rsi < 55) or (direction == "SHORT" and rsi > 45):
+        score += 1
+        reasons.append(f"rsi_room_{rsi:.0f}")
+
+    # 4H momentum (+1)
+    mom_4h = price_momentum(candles_4h, 1)
+    if abs(mom_4h) > 1.5:
+        if (direction == "LONG" and mom_4h > 0) or (direction == "SHORT" and mom_4h < 0):
+            score += 1
+            reasons.append(f"4h_momentum_{mom_4h:+.1f}%")
+
+    return {
+        "coin": coin, "direction": direction, "score": score, "reasons": reasons,
+        "directionSource": direction_source,
+        "price": price, "trend_4h": trend_4h, "trend_1h": trend_1h,
+        "momentum_1h": round(mom_1h, 3), "momentum_4h": round(mom_4h, 3),
+        "sm_direction": sm_dir, "sm_pct": _f(sm_pct), "funding": funding,
+        "rsi": round(rsi, 1), "volume_trend": round(vol_1h, 2), "oi_proxy": round(oi_proxy, 2),
+    }
+
+
+# ── conviction band + LOW-cap sizing (armadillo's conservatism, raven-shaped) ──
+# NOT ported from bison's margin_tier_pct — armadillo replaces conviction-scaled
+# margin with a hard LOW ceiling. The whole point is few, small, low-leverage bets.
+
+def band_for(score, inputs):
+    """Conviction band from the score, relative to the HIGH capital-preservation
+    floor. apex/good default well above a typical thesis so only the strongest
+    setups earn even the (still tiny) apex sizing."""
+    apex = _f(inputs.get("apexScore"), 13)
+    good = _f(inputs.get("goodScore"), 12)
+    if score >= apex:
+        return "apex"
+    if score >= good:
+        return "good"
+    return "base"
+
+
+def sizing_for(band, inputs, venue_max=None):
+    """(leverage, marginPct) for a conviction band. marginPct is a PERCENT in
+    (0,100]. Capital-preservation LOW caps: leverage clamped to maxLeverage (2)
+    AND the venue max; marginPct clamped to maxMarginPct (10). Even an apex score
+    can never exceed 2x / 10% — the ceiling is structural, not adaptive."""
+    lev_tiers = inputs.get("leverageTiers") or {"apex": 2, "good": 2, "base": 1}
+    mgn_tiers = inputs.get("marginPctTiers") or {"apex": 8, "good": 6, "base": 4}
+    cap = int(_f(inputs.get("maxLeverage"), 2))
+    lev = int(_f(lev_tiers.get(band), 1))
+    if venue_max:
+        cap = min(cap, int(_f(venue_max, cap)))
+    lev = max(1, min(lev, cap))
+    mgn = _f(mgn_tiers.get(band), 4)
+    mgn = max(1.0, min(mgn, _f(inputs.get("maxMarginPct"), 10)))
+    return lev, round(mgn, 2)

--- a/strategies/armadillo/strategy.yaml
+++ b/strategies/armadillo/strategy.yaml
@@ -1,0 +1,43 @@
+# Armadillo — Capital Preservation / Low-Vol. Single-wallet PACKAGE: this manifest
+# + one self-contained runtime.yaml + scanners/ (Bison's validated multi-factor
+# momentum scorer, ported VERBATIM). The "sleep at night" strategy: trades ONLY
+# the most liquid majors, at LOW leverage (1-2x), small margin, behind a HIGH
+# conviction bar, with low turnover and a tight drawdown circuit-breaker. Its job
+# is to NOT lose money. NEVER closes — DSL owns every exit (tight).
+schema_version: 1
+
+id: armadillo
+version: "1.0.0"
+
+catalog:
+  name: "Armadillo — Capital Preservation"
+  emoji: "🛡️"
+  tagline: "A sleep-at-night strategy that trades only the biggest, most liquid coins, at low leverage (1-2x), with small position sizes and a high bar for entering — so it makes few, careful trades and protects your money first. Tight stops cut losers fast and lock in gains early, and a hard drawdown halt is the backstop. Built to NOT lose money, not to swing for the fences."
+  belief_plain: "This is the conservative, capital-preservation option. It sticks to the majors (the deepest, most liquid markets), uses low leverage and small sizes, and only opens a position when a real, strong trend lines up — so most of the time it's patient and does nothing. When it is in a trade, a tight trailing stop protects it: it cuts losers quickly and starts locking in profit early instead of giving gains back. A hard 10% drawdown halt stops everything if things go wrong. It won't shoot the lights out — that's the point."
+  thesis: "Most users who ask for 'low risk' don't want the highest return — they want to not lose money and to sleep at night. Armadillo is built for exactly that: restricting to the most liquid majors removes the thin-coin blow-up risk, low leverage (1-2x) and small margin cap the downside on any single trade, and a demanding score floor means it only acts on the strongest setups (few, high-quality entries, low turnover so fees don't bleed it). The momentum entry is Bison's validated multi-factor scorer, ported verbatim; the conservatism is entirely in the configuration — a high entry bar and low sizing — not in new, unproven math. The DSL owns every exit with a tight floor and an early profit-lock ladder, and the runtime drawdown_halt is the equity backstop."
+  group: multi-asset-universe
+  archetype: trend_following
+  sub_style: conviction_holder
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: universe
+  direction: long_short
+  risk_level: conservative
+  tier: starter
+  time_horizon: swing
+  leverage_max: 2
+  max_slots: 4
+  min_budget: 100
+  assets: []                 # DERIVED live from the main DEX (high vol floor + top-N)
+  tags: [conservative, capital-preservation, low-risk, low-leverage, defensive, majors, sleep-at-night, dsl-only]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name armadillo-main, group armadillo
+    wallet_env: ARMADILLO_WALLET
+    funding_share: 1.0

--- a/strategies/armadillo/tests/test_engine.py
+++ b/strategies/armadillo/tests/test_engine.py
@@ -1,0 +1,146 @@
+"""Armadillo engine tests. Pure/deterministic thesis + LOW-cap sizing checks, plus
+a scan() smoke run against a fake ctx (no network). Run:
+  python3 -m pytest strategies/armadillo/tests -q
+or plain `python3 strategies/armadillo/tests/test_engine.py`."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "main", "scanners"))
+import scoring  # noqa: E402
+
+
+def _synth_candles(n, step, start=100.0):
+    """Monotone series (step>0 → higher-lows/bullish, step<0 → bearish)."""
+    out, p = [], start
+    for _ in range(n):
+        out.append({"open": p, "high": p + abs(step), "low": p - abs(step) / 2,
+                    "close": p + step, "volume": 1000})
+        p += step
+    return out
+
+
+# ── the thesis scorer (bison-ported): clean trend → thesis, thin history → None ──
+
+def test_build_thesis_clean_trend_and_insufficient():
+    up1h, up4h = _synth_candles(12, 1.0), _synth_candles(6, 2.0)
+    th = scoring.build_thesis("BTC", up1h[-3:], up1h, up4h, funding=-0.01, sm=(None, 0), inputs={})
+    assert th and th["direction"] == "LONG" and th["score"] > 0
+    # a bearish series resolves SHORT (direction waterfall, opposite sign)
+    dn1h, dn4h = _synth_candles(12, -1.0), _synth_candles(6, -2.0)
+    ths = scoring.build_thesis("ETH", dn1h[-3:], dn1h, dn4h, funding=0.01, sm=(None, 0), inputs={})
+    assert ths and ths["direction"] == "SHORT"
+    # insufficient candles → None (len(c1h) < 8 or len(c4h) < 4)
+    assert scoring.build_thesis("X", [], up1h[:4], up4h[:2], 0, (None, 0), {}) is None
+    assert scoring.build_thesis("Y", up1h, up1h, up4h[:3], 0, (None, 0), {}) is None
+
+
+# ── band + LOW-cap sizing: leverage ≤2, marginPct ≤10 even for an APEX score ──
+
+def test_band_and_sizing_enforce_low_caps():
+    inp = {"apexScore": 13, "goodScore": 12,
+           "leverageTiers": {"apex": 2, "good": 2, "base": 1},
+           "marginPctTiers": {"apex": 8, "good": 6, "base": 4},
+           "maxLeverage": 2, "maxMarginPct": 10}
+    assert scoring.band_for(15, inp) == "apex"      # only the strongest earn apex
+    assert scoring.band_for(12, inp) == "good"
+    assert scoring.band_for(9, inp) == "base"       # a mediocre score is only 'base'
+
+    # apex band still tops out at the LOW caps
+    lev, mgn = scoring.sizing_for("apex", inp)
+    assert lev == 2 and 0 < mgn <= 10
+    lev_b, mgn_b = scoring.sizing_for("base", inp)
+    assert lev_b == 1 and 0 < mgn_b <= 10
+
+    # a config that TRIED to size big is still hard-clamped to the ceilings
+    hot = {"leverageTiers": {"apex": 50}, "marginPctTiers": {"apex": 99},
+           "maxLeverage": 2, "maxMarginPct": 10}
+    lev2, mgn2 = scoring.sizing_for("apex", hot)
+    assert lev2 == 2 and mgn2 == 10                 # clamped, never overshoots
+
+    # a venue max BELOW the fleet cap wins (defensive against thin-book leverage)
+    lev3, _ = scoring.sizing_for("apex", inp, venue_max=1)
+    assert lev3 == 1
+
+
+# ── scan() smoke against a fake ctx (no network) ──
+
+class _State:
+    def __init__(self): self._log = []
+    def last(self): return self._log[-1] if self._log else None
+    def append(self, d): self._log.append(d)
+
+
+class _MCP:
+    def __init__(self, up):
+        self.up = up
+    def call_tool(self, tool, args):
+        if tool == "market_list_instruments":
+            return {"data": {"instruments": [
+                {"name": "BTC", "context": {"dayNtlVlm": 5e8, "maxLeverage": 5}},
+                {"name": "ETH", "context": {"dayNtlVlm": 4e8, "maxLeverage": 5}}]}}
+        if tool == "market_get_asset_data":
+            return {"data": {"candles": {"15m": self.up[-3:], "1h": self.up, "4h": self.up},
+                             "funding": -0.01}}
+        if tool == "strategy_get_clearinghouse_state":
+            return {"data": {"assetPositions": []}}
+        return {}
+
+
+class _Ctx:
+    def __init__(self, up):
+        self.wallet = "0xabc"
+        self.state = _State()
+        self.senpi_mcp = _MCP(up)
+
+
+def test_scan_high_minscore_gate_rejects_mediocre():
+    """The clean synthetic uptrend scores ~8 — below the HIGH minScore floor (11),
+    so the gate emits NOTHING. (Proves the high bar; state still persists.)"""
+    import scan
+    ctx = _Ctx(_synth_candles(14, 1.0))
+    inputs = {"maxSlots": 4, "minScore": 11, "includeXyz": False,
+              "universeVolFloorUsd": 1e6, "maxUniverse": 10}
+    out = scan.scan(inputs, ctx)
+    assert out == []                                # mediocre score rejected by high gate
+    assert ctx.state.last() is not None             # state still persisted
+
+
+def test_scan_smoke_emits_low_capped_signal():
+    """With the gate dropped, the same setup emits — and every emitted signal
+    obeys the LOW caps: leverage∈[1,2], marginPct∈(0,10], valid direction."""
+    import scan
+    ctx = _Ctx(_synth_candles(14, 1.0))
+    inputs = {"maxSlots": 4, "minScore": 0, "includeXyz": False,
+              "universeVolFloorUsd": 1e6, "maxUniverse": 10}
+    out = scan.scan(inputs, ctx)
+    assert isinstance(out, list) and len(out) >= 1   # at least one open on a clean trend
+    for s in out:
+        assert set(("asset", "direction", "marginPct", "leverage", "data")) <= set(s)
+        assert 1 <= s["leverage"] <= 2               # LOW leverage cap
+        assert 0 < s["marginPct"] <= 10              # LOW margin cap
+        assert s["direction"] in ("LONG", "SHORT")
+        assert s["data"]["band"] in ("apex", "good", "base")
+    assert ctx.state.last() is not None              # state persisted
+
+
+def test_scan_fails_closed_on_bad_clearinghouse():
+    """A capital-preservation book must fail CLOSED: an unreadable clearinghouse
+    yields NO opens (never trades on a bad read)."""
+    import scan
+
+    class _BadMCP(_MCP):
+        def call_tool(self, tool, args):
+            if tool == "strategy_get_clearinghouse_state":
+                return {"data": "garbage"}           # not a dict → _held returns None
+            return super().call_tool(tool, args)
+
+    ctx = _Ctx(_synth_candles(14, 1.0))
+    ctx.senpi_mcp = _BadMCP(_synth_candles(14, 1.0))
+    assert scan.scan({"maxSlots": 4, "minScore": 0}, ctx) == []
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn(); print(f"ok  {fn.__name__}")
+    print(f"\nALL {len(fns)} ARMADILLO TESTS PASS")

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1655,6 +1655,50 @@
       "sort_order": 1
     },
     {
+      "id": "armadillo",
+      "name": "Armadillo — Capital Preservation",
+      "emoji": "🛡️",
+      "tagline": "A sleep-at-night strategy that trades only the biggest, most liquid coins, at low leverage (1-2x), with small position sizes and a high bar for entering — so it makes few, careful trades and protects your money first. Tight stops cut losers fast and lock in gains early, and a hard drawdown halt is the backstop. Built to NOT lose money, not to swing for the fences.",
+      "belief_plain": "This is the conservative, capital-preservation option. It sticks to the majors (the deepest, most liquid markets), uses low leverage and small sizes, and only opens a position when a real, strong trend lines up — so most of the time it's patient and does nothing. When it is in a trade, a tight trailing stop protects it: it cuts losers quickly and starts locking in profit early instead of giving gains back. A hard 10% drawdown halt stops everything if things go wrong. It won't shoot the lights out — that's the point.",
+      "version": "1.0.0",
+      "thesis": "Most users who ask for 'low risk' don't want the highest return — they want to not lose money and to sleep at night. Armadillo is built for exactly that: restricting to the most liquid majors removes the thin-coin blow-up risk, low leverage (1-2x) and small margin cap the downside on any single trade, and a demanding score floor means it only acts on the strongest setups (few, high-quality entries, low turnover so fees don't bleed it). The momentum entry is Bison's validated multi-factor scorer, ported verbatim; the conservatism is entirely in the configuration — a high entry bar and low sizing — not in new, unproven math. The DSL owns every exit with a tight floor and an early profit-lock ladder, and the runtime drawdown_halt is the equity backstop.",
+      "tags": [
+        "conservative",
+        "capital-preservation",
+        "low-risk",
+        "low-leverage",
+        "defensive",
+        "majors",
+        "sleep-at-night",
+        "dsl-only"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "conviction_holder",
+      "sub_style_label": "High-conviction multi-factor holder; sizes up as more signals agree, then holds the move.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "conservative",
+      "tier": "starter",
+      "leverage_max": 2,
+      "time_horizon": "swing",
+      "cadence_seconds": 900,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 4,
+      "branch": "main",
+      "sort_order": 2
+    },
+    {
       "id": "chimp",
       "name": "Chimp — Regime Allocator (Daily)",
       "emoji": "🐒",
@@ -1701,7 +1745,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 2
+      "sort_order": 3
     },
     {
       "id": "gibbon",
@@ -1749,7 +1793,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 3
+      "sort_order": 4
     },
     {
       "id": "gorilla",
@@ -1798,7 +1842,7 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "mantis",
@@ -1844,7 +1888,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "octopus",
@@ -1888,7 +1932,7 @@
       ],
       "max_slots": 8,
       "branch": "main",
-      "sort_order": 6
+      "sort_order": 7
     },
     {
       "id": "orangutan",
@@ -1936,7 +1980,7 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 7
+      "sort_order": 8
     },
     {
       "id": "raven",
@@ -1983,7 +2027,50 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
+    },
+    {
+      "id": "salmon",
+      "name": "Salmon — RSI Mean-Reversion",
+      "emoji": "🐟",
+      "tagline": "Buys the bounce, not the falling knife. It watches the RSI on liquid majors and only steps in when an oversold coin has actually turned back up — a real cross off the lows with the candle confirming — going long the recovery (or short an overbought coin rolling over). It bets price snaps back to its average, sizes moderately because these turns fail fast, and lets a tight trailing stop do all the exiting.",
+      "belief_plain": "Trades the big liquid coins by their RSI. When one gets oversold it waits for it to actually turn back up before buying — not while it's still dropping — and when one gets overbought and starts rolling over it shorts the fade. It's betting the price springs back toward its average, keeps size moderate because these bounces can fail quickly, and never closes by hand: a tight stop protects and exits every trade.",
+      "version": "1.0.0",
+      "thesis": "Stretched moves revert. When a liquid major gets pushed to an oversold extreme and then genuinely turns — RSI crossing back up through the line while the last candle confirms — the snap back toward the mean is the trade; the symmetric overbought roll-over is the short. The discipline is refusing to catch a falling knife: a low RSI alone is not a signal, only the confirmed cross-back is. Because reversions fail fast, leverage stays moderate and the DSL exit is tight — lock early, cut small.",
+      "tags": [
+        "mean-reversion",
+        "rsi",
+        "oversold",
+        "dip-buy",
+        "contrarian",
+        "reversion",
+        "dsl-only"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "contrarian_fade",
+      "archetype_label": "Contrarian / Fade",
+      "sub_style": "mean_reversion",
+      "sub_style_label": "Buys oversold / sells overbought, betting price reverts to its mean (works in chop, not just trends).",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 4,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 10
     },
     {
       "id": "starling",
@@ -2031,7 +2118,53 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 11
+    },
+    {
+      "id": "viper",
+      "name": "Viper — SMC/ICT Structure Trader",
+      "emoji": "🐍",
+      "tagline": "Reads a chart the way a smart-money trader does. It marks the recent peaks and troughs, then waits for price to actually break structure — punch through a prior high (or low) — and only takes the trade when the break is backed by a stop-hunt wick that grabbed liquidity and snapped back, a price gap that shows one-sided pressure, and the bigger-picture 4h trend pointing the same way. A trailing stop does all the exiting; Viper never sells manually.",
+      "belief_plain": "Markets move from one pool of resting stop orders to the next, and the honest tell is structure: a 'Break of Structure' is price closing past the last swing high or low in the trend's direction (it's continuing), and a 'Change of Character' is the first close through the OPPOSITE swing (the trend may be flipping). Viper enters on those breaks — but only the high-quality ones, where a liquidity sweep (a wick that runs the stops just past a prior swing then closes back inside) and a fair-value gap (a 3-candle imbalance where price left a gap it tends to revisit) agree with it, and the 4h structure confirms. It never manually closes — a ratchet stop protects and exits every position, and a hard drawdown halt is the backstop.",
+      "version": "1.0.0",
+      "thesis": "Price is delivered between liquidity pools, and market structure — not an oscillator — is the cleanest read on which pool is next. Viper maps confirmed swing pivots, classifies each close through the most-recent swing as a Break of Structure (continuation) or Change of Character (reversal), and requires SMC/ICT confluence before committing: a liquidity sweep of a prior swing that closes back inside (the stop-hunt / Wyckoff spring), a 3-candle Fair Value Gap in the break direction, and higher-timeframe (4h) structure agreement. Confluence is scored, conviction-banded, and gated to a minimum; sizing scales with conviction and leverage is clamped to the venue max. The edge is entry QUALITY on structure; the DSL owns exits and the runtime drawdown_halt is the equity backstop.",
+      "tags": [
+        "smc",
+        "ict",
+        "wyckoff",
+        "market-structure",
+        "liquidity-sweep",
+        "fvg",
+        "bos",
+        "choch"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "market_structure",
+      "sub_style_label": "Trades SMC/ICT/Wyckoff structure: break-of-structure, liquidity sweeps, fair-value gaps.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities",
+        "commodities"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 900,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 6,
+      "branch": "main",
+      "sort_order": 12
     },
     {
       "id": "asia-ai",
@@ -3253,6 +3386,51 @@
       "sort_order": 3
     },
     {
+      "id": "gecko",
+      "name": "Gecko — Any-Coin Confluence",
+      "emoji": "🦎",
+      "tagline": "Point it at any liquid coin you name and it trades just that one: it scores trend structure, momentum and funding into a single confluence read on that name, goes long or short when enough signals line up — sizing conviction to the strength of the setup — and trails a stop instead of guessing the exit.",
+      "belief_plain": "You pick the coin; Gecko trades only that coin. It waits until the 1-hour and 4-hour trend, momentum and funding all point the same way, then goes in — harder when more of them agree — and never guesses the exit: a trailing stop does all the closing. One coin, one position, done well.",
+      "version": "1.0.0",
+      "thesis": "Most people don't want a scattergun across the whole market — they want their coin traded properly. Gecko is bison's validated confluence scorer pointed at a single user-named asset: trend structure (1h/4h), momentum, RSI and funding are summed into one conviction score, direction resolves from the timeframe waterfall, and leverage/margin scale to the score. One asset, one high-conviction slot; the DSL owns every exit and the drawdown_halt is the backstop. It fills the long tail of 'make me a strategy for <my coin>' without a bespoke build each time.",
+      "tags": [
+        "configurable",
+        "any-asset",
+        "confluence",
+        "single-asset",
+        "custom",
+        "dsl-only"
+      ],
+      "group": "single-asset",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "confluence_sniper",
+      "sub_style_label": "Fires only when multiple timeframes/factors line up.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "xyz_equities"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "BTC"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 600,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "main",
+      "sort_order": 4
+    },
+    {
       "id": "grizzly",
       "name": "Grizzly — BTC Alpha Hunter",
       "emoji": "🐻",
@@ -3294,7 +3472,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "heron",
@@ -3337,7 +3515,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "hummingbird",
@@ -3380,7 +3558,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 6
+      "sort_order": 7
     },
     {
       "id": "iguana",
@@ -3428,7 +3606,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 7
+      "sort_order": 8
     },
     {
       "id": "koala",
@@ -3473,7 +3651,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
     },
     {
       "id": "kodiak",
@@ -3516,7 +3694,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "polar",
@@ -3560,7 +3738,51 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 11
+    },
+    {
+      "id": "ram",
+      "name": "Ram — Gold Specialist",
+      "emoji": "🐏",
+      "tagline": "A single-asset gold (xyz:GOLD) specialist: goes long when gold's trend lines up across the 1h and 4h and momentum agrees — and leans in harder when the market turns risk-off and money is looking for a safe haven — and can short a clean downtrend. Holds one position at a time and trails a stop instead of guessing the exit.",
+      "belief_plain": "Trades only gold. It buys when gold is trending up and, especially, when the market gets defensive and flows into safe havens; it can short a clear downtrend. It never picks a top or bottom by hand — a trailing stop does all the exiting. Gold trades around the clock, weekends included.",
+      "version": "1.0.0",
+      "thesis": "Gold is the market's safe-haven anchor: it trends on real-rate and risk-regime shifts and gets bid hardest when risk assets wobble. An agent that watches only gold can read its 1h/4h trend structure, momentum and RSI far more tightly than a broad scanner, and add a safe-haven tilt when a risk-off funding regime shows up — catching the defensive bid early and locking profit as the move matures. Concentration by conviction on one asset, with the DSL owning every exit.",
+      "tags": [
+        "gold",
+        "xau",
+        "metals",
+        "safe-haven",
+        "commodity",
+        "single-asset",
+        "dsl-only"
+      ],
+      "group": "single-asset",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "commodity",
+      "sub_style_label": "Trades a commodity (oil/metals).",
+      "asset_classes": [
+        "commodities"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "xyz:GOLD"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "main",
+      "sort_order": 12
     },
     {
       "id": "stag",
@@ -3608,7 +3830,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 13
     },
     {
       "id": "wolverine",
@@ -3653,7 +3875,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 14
     },
     {
       "id": "hydra",

--- a/strategies/gecko/main/runtime.yaml
+++ b/strategies/gecko/main/runtime.yaml
@@ -1,0 +1,124 @@
+# ── GECKO · Configurable Single-Asset Confluence — "trade the coin I name." ──
+# One instance, one user-named asset (inputs.asset, default BTC), one position. The
+# scanner points bison's validated confluence scorer (trend structure 1h/4h +
+# momentum + RSI + funding) at that ONE name and opens a single conviction-sized
+# position when the score clears minScore. Fills the long tail of "make me a
+# strategy for <my coin>". NEVER closes — the DSL owns every exit and the
+# drawdown_halt is the equity backstop. Set inputs.asset (with `xyz:` for HIP-3
+# instruments) to retarget; everything else is the same proven engine.
+name: gecko-main
+group: gecko
+version: 1.0.0
+description: >
+  GECKO — Configurable Single-Asset Confluence. Point it at any one liquid coin
+  (inputs.asset, default BTC; `xyz:` prefix for HIP-3 instruments): it runs bison's
+  validated multi-signal confluence scorer — 1h/4h trend structure + 1h/4h momentum
+  + RSI + funding alignment — on that single name and opens ONE conviction-banded
+  LONG/SHORT (5x/4x/3x, 20/15/10% margin, clamped to venue max) when the score clears
+  minScore. Single slot, never stacks, NEVER closes — DSL is the ONLY exit (15% Phase 1,
+  breakeven-first profit-lock ladder to +90%, 24h weak-peak); drawdown_halt is the backstop.
+
+strategy:
+  wallet: "${GECKO_WALLET}"
+  slots: 1                                  # single asset, single position
+  margin_pct: 10                            # fallback; scan emits per-signal 10/15/20 by band
+  default_leverage: 3                       # fallback; scan emits per-signal 3/4/5 by band
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: gecko_scanner
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 600                    # wake every 10m — swing-horizon single asset
+    timeout_seconds: 120                     # 2 MCP reads/tick (clearinghouse + asset_data)
+    default_signal_validity_seconds: 3600
+    state_history_max_count: 100
+    inputs:
+      # ── the one thing a user sets ──
+      asset: "BTC"                           # the coin to trade; `xyz:` prefix for HIP-3 instruments
+      # ── confluence thesis knobs (bison-ported) ──
+      minScore: 6                            # entry floor — open only when confluence clears this
+      apexScore: 12                          # >= -> apex band (5x / 20%)
+      goodScore: 10                          # >= -> good band (4x / 15%)
+      minVolTrendPct: 10
+      rsiMaxLong: 72
+      rsiMinShort: 28
+      # ── single high-conviction sizing slot ──
+      leverageTiers: { apex: 5, good: 4, base: 3 }
+      marginPctTiers: { apex: 20, good: 15, base: 10 }
+      maxLeverage: 5
+      maxMarginPct: 25
+      recentSignalTtlSeconds: 7200           # 120m — mirror the per-asset cooldown (anti re-fire)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      band: { type: string, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: gecko_open
+    action_type: OPEN_POSITION
+    decision_mode: rule                      # the scan already applied every filter
+    scanners: [gecko_scanner]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: gecko_scanner
+  # NO CLOSE_POSITION action — DSL is the only exit.
+
+# EXIT — DSL only. Single-asset family pattern: time cuts DISABLED (Phase 1 + Phase 2
+# own all exits via price action); weak_peak_cut kept as a 24h stall-out. Granular
+# breakeven-first profit-lock ladder (no back-loaded gap): locks early, ramps smoothly.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 1440              # 24h — a stalled name frees the single slot
+      min_value: 2.5
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 0 }
+        - { trigger_pct: 15, lock_hw_pct: 35 }
+        - { trigger_pct: 25, lock_hw_pct: 52 }
+        - { trigger_pct: 40, lock_hw_pct: 65 }
+        - { trigger_pct: 60, lock_hw_pct: 77 }
+        - { trigger_pct: 90, lock_hw_pct: 86 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 900
+    per_asset_cooldown_seconds: 7200
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true

--- a/strategies/gecko/main/scanners/scan.py
+++ b/strategies/gecko/main/scanners/scan.py
@@ -1,0 +1,164 @@
+"""GECKO — Configurable Single-Asset Confluence. "Trade the coin I name."
+
+One user-named asset (inputs.asset, default "BTC"), one position, one supervised
+scanner. Each tick:
+  1) Resolve the asset + its dex from the string (xyz:* -> the HIP-3 xyz DEX, else main).
+  2) Signal-dedup: if a fresh signal fired within recentSignalTtlSeconds, hold.
+  3) If we ALREADY hold the asset -> emit nothing (DSL owns the exit; never stack).
+  4) Else read its candles (15m/1h/4h) + funding, run bison's confluence thesis
+     (trend structure 1h/4h + momentum + RSI + funding; sm=(None,0)), and emit ONE
+     LONG/SHORT signal at conviction sizing when score >= minScore.
+
+NEVER closes — the runtime DSL owns every exit; the drawdown_halt is the equity
+backstop. Read-only + single-pass; marginPct is a PERCENT in (0,100]. No daemon,
+no push_signal. The asset string is emitted WITH its prefix (xyz: preserved).
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, tool, args, label):
+    """READ-GUARD: a read error must never crash the tick. Returns the inner data
+    (unwrapping a {'data': ...} envelope) or None (degrade — never raise)."""
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
+        print(f"[gecko.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _dex_of(name):
+    return "xyz" if str(name).lower().startswith("xyz:") else ""
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["15m", "1h", "4h"],
+        "include_funding": True, "include_order_book": False, "dex": _dex_of(name),
+    }, f"market_get_asset_data({name})")
+
+
+def _funding_of(md):
+    """Current funding rate as a float (tolerant; 0.0 if absent)."""
+    for k in ("funding", "funding_rate", "fundingRate", "current_funding"):
+        v = scoring._num((md or {}).get(k))
+        if v is not None:
+            return v
+    fh = (md or {}).get("funding") if isinstance((md or {}).get("funding"), dict) else None
+    if isinstance(fh, dict):
+        return scoring._f(fh.get("rate", fh.get("current")))
+    return 0.0
+
+
+def _venue_max_of(md):
+    """Best-effort venue max leverage from asset_data (tolerant; None if absent).
+    Lets gecko respect a low-leverage instrument's own cap on top of maxLeverage —
+    important for the any-coin use case (e.g. a low-max xyz equity). Degrades to
+    None (then only the maxLeverage input caps). Payload shape NOT live-verified —
+    tries asset_context/context.{max_leverage,maxLeverage}."""
+    for key in ("asset_context", "context"):
+        c = (md or {}).get(key)
+        if isinstance(c, dict):
+            for k in ("max_leverage", "maxLeverage"):
+                v = scoring._num(c.get(k))
+                if v is not None and v > 0:
+                    return v
+    return None
+
+
+def _held(ctx):
+    """Set of bare (prefix-stripped, upper) coins currently held, or None if the
+    clearinghouse is unreadable (caller then defers this tick — never blind-opens)."""
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = set()
+    for e in d.get("assetPositions", d.get("asset_positions", [])) or []:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def _append(ctx, recent, result):
+    """Persist the dedup map + this tick's result (self-trims at state_history_max_count)."""
+    if ctx.state is None:
+        return
+    try:
+        ctx.state.append({"recent": recent, "result": result})
+    except Exception as exc:  # noqa: BLE001
+        print(f"[gecko.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+
+def scan(inputs, ctx):
+    asset = str(inputs.get("asset") or "BTC")
+    min_score = scoring._f(inputs.get("minScore"), 6)
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 7200)
+    now = time.time()
+    bare = asset.split(":", 1)[-1].upper()
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    recent = dict(st.get("recent", {}) or {})
+
+    # ── signal-dedup (defence-in-depth alongside the runtime per-asset cooldown) ──
+    last = recent.get(bare)
+    if last is not None and (now - last) < ttl:
+        print(f"[gecko.scan] {asset} HOLD: recent signal within {ttl:g}s ttl", file=sys.stderr)
+        _append(ctx, recent, {"ts": now, "asset": asset, "emitted": False, "gate": "recent_ttl"})
+        return []
+
+    # ── single-asset dedup: already holding -> emit nothing (DSL owns the exit) ──
+    held = _held(ctx)
+    if held is None:
+        print("[gecko.scan] clearinghouse unreadable — act next tick", file=sys.stderr)
+        return []                                    # no state write — retry cleanly next tick
+    if bare in held:
+        print(f"[gecko.scan] {asset} HOLD: already holding", file=sys.stderr)
+        _append(ctx, recent, {"ts": now, "asset": asset, "emitted": False, "gate": "already_held"})
+        return []
+
+    md = _asset_data(ctx, asset)
+    if not md:
+        print(f"[gecko.scan] {asset} asset_data unreadable — no open this tick", file=sys.stderr)
+        return []
+    candles = md.get("candles", {}) or {}
+    th = scoring.build_thesis(asset, candles.get("15m", []), candles.get("1h", []),
+                              candles.get("4h", []), _funding_of(md), (None, 0), inputs)
+
+    out = []
+    if not th:
+        print(f"[gecko.scan] {asset} HOLD: no direction / insufficient candles", file=sys.stderr)
+        result = {"ts": now, "asset": asset, "emitted": False, "gate": "no_thesis"}
+    elif th["score"] < min_score:
+        print(f"[gecko.scan] {asset} HOLD: score={th['score']}<{min_score:g} "
+              f"{th['direction']} | {th['reasons']}", file=sys.stderr)
+        result = {"ts": now, "asset": asset, "emitted": False, "gate": "score_low",
+                  "score": th["score"], "direction": th["direction"]}
+    else:
+        band = scoring.band_for(th["score"], inputs)
+        lev, mgn = scoring.sizing_for(band, inputs, _venue_max_of(md))
+        recent[bare] = now
+        out = [{
+            "asset": asset,                          # WITH prefix (xyz: preserved)
+            "direction": th["direction"],
+            "marginPct": mgn,                        # PERCENT of withdrawable — runtime sizes
+            "leverage": lev,                         # conviction-tiered; runtime applies it
+            "data": {"score": th["score"], "leverage": lev, "direction": th["direction"],
+                     "band": band, "reasons": th["reasons"]},
+        }]
+        result = {"ts": now, "asset": asset, "emitted": True, "gate": "pass",
+                  "score": th["score"], "direction": th["direction"],
+                  "band": band, "leverage": lev, "marginPct": mgn}
+        print(f"[gecko.scan] {asset} EMIT {th['direction']}: score={th['score']} band={band} "
+              f"{lev}x {mgn}% | {th['reasons']}", file=sys.stderr)
+
+    _append(ctx, recent, result)
+    return out

--- a/strategies/gecko/main/scanners/scoring.py
+++ b/strategies/gecko/main/scanners/scoring.py
@@ -1,0 +1,311 @@
+"""GECKO — pure thesis math + conviction sizing (no I/O, no MCP, no clock).
+
+Configurable single-asset confluence: "trade the coin I name." The MOMENTUM /
+CONFLUENCE ENGINE — indicator math, direction waterfall and the 9-component
+weighted score — is ported VERBATIM from bison/scoring.py (a validated Runtime 3.0
+scorer). Kept byte-faithful so a fidelity harness can diff gecko's entries against
+bison's on the same candles; behaviour-preserving quirks carry bison's `# v2-quirk`
+flags. Gecko is NOT a new indicator — it is bison's confluence scorer pointed at ONE
+user-named asset (inputs.asset), with a single high-conviction sizing slot on top.
+
+`sm` (smart-money lean) is fetched by the caller and passed in — gecko always passes
+`(None, 0)` (no leaderboard cohort), so this module stays pure and single-asset.
+
+The DSL owns every exit; gecko never closes. `band_for`/`sizing_for` map the score
+to a single conviction slot (apex/good/base) → leverage + marginPct, clamped to the
+fleet caps (maxLeverage / maxMarginPct) and an optional venue leverage cap.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# v2 read dicts only; the list branch is defensive and never fires on dict candles,
+# so it does not change v2 behaviour. Ported verbatim from bison/scoring.py.
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _num(v):
+    """Float or None (distinguishes a real 0.0 from a missing field)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── indicators (ported verbatim from v2 bison-producer.py) ──
+
+def price_momentum(candles, n_bars=1):
+    """% change over the last n_bars. Verbatim from v2 price_momentum."""
+    if len(candles) < n_bars + 1:
+        return 0
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    if old == 0:
+        return 0
+    return ((new - old) / old) * 100
+
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim from v2.
+
+    v2-quirk: thresholds are STRICT (>) for higher-lows / lower-highs counting,
+    and the BULLISH/BEARISH gate is `>= total * 0.6` where total = lookback - 1.
+    Reproduced exactly — do NOT switch to >= counting (Kodiak's variant uses >=,
+    Bison uses strict >). The strength returned is higher_lows/total (BULLISH) or
+    lower_highs/total (BEARISH)."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def volume_trend(candles, lookback=6):
+    """Recent-half vs earlier-half average volume, % change. Verbatim from v2."""
+    if len(candles) < lookback + 2:
+        return 0
+    vols = [_vol(c) for c in candles[-(lookback + 2):]]
+    half = lookback // 2
+    recent = sum(vols[-half:]) / half if half > 0 else 1
+    earlier = sum(vols[:half]) / half if half > 0 else 1
+    if earlier == 0:
+        return 0
+    return ((recent - earlier) / earlier) * 100
+
+
+def calc_rsi(closes, period=14):
+    """RSI. Verbatim from v2 calc_rsi.
+
+    v2-quirk: uses the LAST `period` gains/losses (gains[-period:]), unlike
+    Kodiak's port which uses the FIRST period+1 closes. Bison's is the more
+    conventional trailing-window RSI. Reproduced exactly."""
+    if len(closes) < period + 1:
+        return 50
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── the thesis (direction waterfall + 9-component score), ported verbatim ──
+
+def build_thesis(coin, candles_15m, candles_1h, candles_4h, funding, sm, inputs):
+    """Port of v2 build_thesis. Returns a thesis dict (with `score`) or None.
+
+    None is returned ONLY when:
+      - insufficient candle history (len(c1h) < 8 or len(c4h) < 4), OR
+      - the direction waterfall resolves no direction.
+    minScore is NOT applied here — the caller gates on thesis['score'].
+
+    `sm` is the smart-money tuple (direction, pct) or (None, 0) — gecko always
+    passes (None, 0) (single-asset, no leaderboard cohort)."""
+    min_vol_trend = float(inputs.get("minVolTrendPct", 10))
+    rsi_max_long = float(inputs.get("rsiMaxLong", 72))
+    rsi_min_short = float(inputs.get("rsiMinShort", 28))
+
+    if len(candles_1h) < 8 or len(candles_4h) < 4:
+        return None
+
+    price = _close(candles_15m[-1]) if candles_15m else 0
+
+    trend_4h, trend_strength = trend_structure(candles_4h)
+    trend_1h, trend_1h_strength = trend_structure(candles_1h)
+    sm_dir, sm_pct = sm if sm else (None, 0)
+    mom_1h = price_momentum(candles_1h, 2)
+
+    # Direction waterfall: 4H trend -> SM direction -> 1H momentum (verbatim)
+    direction = None
+    direction_source = None
+    if trend_4h == "BULLISH":
+        direction = "LONG"
+        direction_source = "4h_trend"
+    elif trend_4h == "BEARISH":
+        direction = "SHORT"
+        direction_source = "4h_trend"
+    elif sm_dir and sm_dir != "NEUTRAL":
+        direction = sm_dir
+        direction_source = "sm_direction"
+    elif mom_1h > 0.5:
+        direction = "LONG"
+        direction_source = "1h_momentum"
+    elif mom_1h < -0.5:
+        direction = "SHORT"
+        direction_source = "1h_momentum"
+
+    if direction is None:
+        return None
+
+    score = 0
+    reasons = []
+
+    # 4H trend structure (+3 / -1)
+    if trend_4h != "NEUTRAL":
+        if (direction == "LONG" and trend_4h == "BULLISH") or (direction == "SHORT" and trend_4h == "BEARISH"):
+            score += 3
+            reasons.append(f"4h_{trend_4h.lower()}_{trend_strength:.0%}")
+        else:
+            score -= 1
+            reasons.append(f"4h_opposing_{trend_4h.lower()}")
+
+    # 1H trend agreement (+2 / -1)
+    if trend_1h != "NEUTRAL":
+        if (direction == "LONG" and trend_1h == "BULLISH") or (direction == "SHORT" and trend_1h == "BEARISH"):
+            score += 2
+            reasons.append(f"1h_confirms_{trend_1h.lower()}")
+        else:
+            score -= 1
+            reasons.append(f"1h_opposing_{trend_1h.lower()}")
+
+    # 1H momentum (+2 / +1 / -1)
+    if direction == "LONG":
+        if mom_1h >= 1.0:
+            score += 2; reasons.append(f"1h_strong_momentum_{mom_1h:+.2f}%")
+        elif mom_1h >= 0.5:
+            score += 1; reasons.append(f"1h_momentum_{mom_1h:+.2f}%")
+        elif mom_1h < -0.5:
+            score -= 1; reasons.append(f"1h_counter_momentum_{mom_1h:+.2f}%")
+    else:
+        if mom_1h <= -1.0:
+            score += 2; reasons.append(f"1h_strong_momentum_{mom_1h:+.2f}%")
+        elif mom_1h <= -0.5:
+            score += 1; reasons.append(f"1h_momentum_{mom_1h:+.2f}%")
+        elif mom_1h > 0.5:
+            score -= 1; reasons.append(f"1h_counter_momentum_{mom_1h:+.2f}%")
+
+    # SM alignment (+-2)
+    if sm_dir == direction:
+        score += 2
+        reasons.append(f"sm_aligned_{sm_pct:.0f}%")
+    elif sm_dir and sm_dir != "NEUTRAL" and sm_dir != direction:
+        score -= 2
+        reasons.append(f"sm_opposing_{sm_dir}")
+
+    # Funding alignment (+2 / -1)
+    if (direction == "LONG" and funding < 0) or (direction == "SHORT" and funding > 0):
+        score += 2
+        reasons.append(f"funding_aligned_{funding:+.4f}")
+    elif (direction == "LONG" and funding > 0.01) or (direction == "SHORT" and funding < -0.005):
+        score -= 1
+        reasons.append("funding_crowded")
+
+    # Volume trend (+1)
+    vol_1h = volume_trend(candles_1h)
+    if vol_1h > min_vol_trend:
+        score += 1
+        reasons.append(f"vol_rising_{vol_1h:+.0f}%")
+
+    # OI proxy (+1) — recent-3 vs earlier-3 1h volume delta (verbatim)
+    vol_recent = sum(_vol(c) for c in candles_1h[-3:])
+    vol_earlier = sum(_vol(c) for c in candles_1h[-6:-3])
+    oi_proxy = ((vol_recent - vol_earlier) / vol_earlier * 100) if vol_earlier > 0 else 0
+    if oi_proxy > 10:
+        score += 1
+        reasons.append(f"oi_growing_{oi_proxy:+.0f}%")
+
+    # RSI (+1 / -1)
+    closes_1h = [_close(c) for c in candles_1h]
+    rsi = calc_rsi(closes_1h)
+    if direction == "LONG" and rsi > rsi_max_long:
+        score -= 1
+        reasons.append(f"rsi_overbought_{rsi:.0f}")
+    elif direction == "SHORT" and rsi < rsi_min_short:
+        score -= 1
+        reasons.append(f"rsi_oversold_{rsi:.0f}")
+    elif (direction == "LONG" and rsi < 55) or (direction == "SHORT" and rsi > 45):
+        score += 1
+        reasons.append(f"rsi_room_{rsi:.0f}")
+
+    # 4H momentum (+1)
+    mom_4h = price_momentum(candles_4h, 1)
+    if abs(mom_4h) > 1.5:
+        if (direction == "LONG" and mom_4h > 0) or (direction == "SHORT" and mom_4h < 0):
+            score += 1
+            reasons.append(f"4h_momentum_{mom_4h:+.1f}%")
+
+    return {
+        "coin": coin, "direction": direction, "score": score, "reasons": reasons,
+        "directionSource": direction_source,
+        "price": price, "trend_4h": trend_4h, "trend_1h": trend_1h,
+        "momentum_1h": round(mom_1h, 3), "momentum_4h": round(mom_4h, 3),
+        "sm_direction": sm_dir, "sm_pct": _f(sm_pct), "funding": funding,
+        "rsi": round(rsi, 1), "volume_trend": round(vol_1h, 2), "oi_proxy": round(oi_proxy, 2),
+    }
+
+
+# ── conviction sizing — single high-conviction slot (raven band_for/sizing_for) ──
+
+def band_for(score, inputs):
+    """Conviction band from the score. apex >= apexScore, good >= goodScore, else base."""
+    apex = _f(inputs.get("apexScore"), 12)
+    good = _f(inputs.get("goodScore"), 10)
+    if score >= apex:
+        return "apex"
+    if score >= good:
+        return "good"
+    return "base"
+
+
+def sizing_for(band, inputs, venue_max=None):
+    """(leverage, marginPct) for the single slot. marginPct is a PERCENT in (0,100],
+    clamped to the fleet caps (maxLeverage / maxMarginPct) and an optional venue
+    leverage cap. No self-calibration — gecko sizes purely by conviction band."""
+    lev_tiers = inputs.get("leverageTiers") or {"apex": 5, "good": 4, "base": 3}
+    mgn_tiers = inputs.get("marginPctTiers") or {"apex": 20, "good": 15, "base": 10}
+    cap = int(_f(inputs.get("maxLeverage"), 5))
+    lev = int(_f(lev_tiers.get(band), 3))
+    if venue_max:
+        cap = min(cap, int(_f(venue_max, cap)))
+    lev = max(1, min(lev, cap))
+    mgn = _f(mgn_tiers.get(band), 10)
+    mgn = max(1.0, min(mgn, _f(inputs.get("maxMarginPct"), 25)))
+    return lev, round(mgn, 2)

--- a/strategies/gecko/strategy.yaml
+++ b/strategies/gecko/strategy.yaml
@@ -1,0 +1,44 @@
+# Gecko — Configurable Single-Asset Confluence ("trade the coin I name"). A single-
+# instance PACKAGE: this manifest + one self-contained runtime.yaml + scanners/. A
+# user sets inputs.asset (default BTC) and gecko runs bison's validated multi-signal
+# confluence scorer (trend structure 1h/4h + momentum + RSI + funding) on that ONE
+# asset, opening ONE conviction-sized position. Fills the long tail of "make me a
+# strategy for <my coin>". NEVER closes — DSL owns every exit. Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: gecko
+version: "1.0.0"
+
+catalog:
+  name: "Gecko — Any-Coin Confluence"
+  emoji: "🦎"
+  tagline: "Point it at any liquid coin you name and it trades just that one: it scores trend structure, momentum and funding into a single confluence read on that name, goes long or short when enough signals line up — sizing conviction to the strength of the setup — and trails a stop instead of guessing the exit."
+  belief_plain: "You pick the coin; Gecko trades only that coin. It waits until the 1-hour and 4-hour trend, momentum and funding all point the same way, then goes in — harder when more of them agree — and never guesses the exit: a trailing stop does all the closing. One coin, one position, done well."
+  thesis: "Most people don't want a scattergun across the whole market — they want their coin traded properly. Gecko is bison's validated confluence scorer pointed at a single user-named asset: trend structure (1h/4h), momentum, RSI and funding are summed into one conviction score, direction resolves from the timeframe waterfall, and leverage/margin scale to the score. One asset, one high-conviction slot; the DSL owns every exit and the drawdown_halt is the backstop. It fills the long tail of 'make me a strategy for <my coin>' without a bespoke build each time."
+  group: single-asset
+  archetype: single_market
+  sub_style: confluence_sniper
+  asset_classes: [btc_eth, major_alts, xyz_equities]
+  asset_scope: single
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 100
+  assets: ["BTC"]            # DEFAULT; configurable — the user sets inputs.asset to any liquid coin
+  tags: [configurable, any-asset, confluence, single-asset, custom, dsl-only]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name gecko-main, group gecko
+    wallet_env: GECKO_WALLET
+    funding_share: 1.0

--- a/strategies/gecko/tests/test_engine.py
+++ b/strategies/gecko/tests/test_engine.py
@@ -1,0 +1,136 @@
+"""Gecko engine + scanner tests. Pure/deterministic engine checks, plus a scan()
+smoke run against a fake ctx (no network). Run:
+    python3 -m pytest strategies/gecko/tests -q
+or plain:
+    python3 strategies/gecko/tests/test_engine.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "main", "scanners"))
+import scoring  # noqa: E402
+
+
+def _synth_candles(n, step, start=100.0):
+    """Monotone series (step>0 → higher-lows/bullish, step<0 → lower-highs/bearish)."""
+    out, p = [], start
+    for _ in range(n):
+        out.append({"open": p, "high": p + abs(step), "low": p - abs(step) / 2,
+                    "close": p + step, "volume": 1000})
+        p += step
+    return out
+
+
+# ── pure engine ──
+
+def test_build_thesis_direction_and_insufficient():
+    # clean uptrend → LONG with positive confluence
+    up1h, up4h = _synth_candles(12, 1.0), _synth_candles(6, 2.0)
+    long_th = scoring.build_thesis("BTC", up1h[-3:], up1h, up4h, -0.01, (None, 0), {})
+    assert long_th and long_th["direction"] == "LONG" and long_th["score"] > 0
+    # clean downtrend → SHORT with positive confluence
+    dn1h, dn4h = _synth_candles(12, -1.0), _synth_candles(6, -2.0)
+    short_th = scoring.build_thesis("BTC", dn1h[-3:], dn1h, dn4h, 0.02, (None, 0), {})
+    assert short_th and short_th["direction"] == "SHORT" and short_th["score"] > 0
+    # insufficient candle history → None (len(c1h) < 8 or len(c4h) < 4)
+    assert scoring.build_thesis("X", [], up1h[:4], up4h[:2], 0, (None, 0), {}) is None
+
+
+def test_band_and_sizing_caps():
+    inp = {"apexScore": 12, "goodScore": 10,
+           "leverageTiers": {"apex": 5, "good": 4, "base": 3},
+           "marginPctTiers": {"apex": 20, "good": 15, "base": 10},
+           "maxLeverage": 5, "maxMarginPct": 25}
+    assert scoring.band_for(13, inp) == "apex"
+    assert scoring.band_for(10, inp) == "good"
+    assert scoring.band_for(6, inp) == "base"
+    # apex sizes to the fleet caps
+    lev, mgn = scoring.sizing_for("apex", inp)
+    assert lev == 5 and mgn == 20
+    # a venue leverage cap clamps below the fleet max
+    lev2, _ = scoring.sizing_for("apex", inp, venue_max=3)
+    assert lev2 == 3
+    # marginPct hard-capped at maxMarginPct even if a tier over-asks
+    _, mgn3 = scoring.sizing_for("apex", {**inp, "marginPctTiers": {"apex": 40}})
+    assert 0 < mgn3 <= 25
+    # leverage floored at 1 even for a degenerate tier
+    lev4, _ = scoring.sizing_for("base", {**inp, "leverageTiers": {"base": 0}})
+    assert lev4 >= 1
+
+
+# ── scan() against a fake ctx (no network) ──
+
+class _State:
+    def __init__(self): self._log = []
+    def last(self): return self._log[-1] if self._log else None
+    def append(self, d): self._log.append(d)
+
+
+class _MCP:
+    def __init__(self, candles, held=None, funding=-0.01):
+        self.candles = candles
+        self.held = held                # coin string currently held (bare or prefixed), or None
+        self.funding = funding
+        self.calls = []
+    def call_tool(self, tool, args):
+        self.calls.append((tool, args))
+        if tool == "market_get_asset_data":
+            return {"data": {"candles": {"15m": self.candles[-3:], "1h": self.candles,
+                                         "4h": self.candles}, "funding": self.funding}}
+        if tool == "strategy_get_clearinghouse_state":
+            aps = [{"position": {"coin": self.held, "szi": 1.0}}] if self.held else []
+            return {"data": {"assetPositions": aps}}
+        return {}
+
+
+class _Ctx:
+    def __init__(self, candles, held=None, funding=-0.01):
+        self.wallet = "0xabc"
+        self.state = _State()
+        self.senpi_mcp = _MCP(candles, held, funding)
+
+
+def test_scan_honors_asset_and_prefix():
+    import scan
+    up = _synth_candles(14, 1.0)
+    ctx = _Ctx(up)
+    out = scan.scan({"asset": "xyz:TSLA", "minScore": 0}, ctx)
+    assert len(out) == 1
+    assert out[0]["asset"] == "xyz:TSLA"                  # emits THAT asset, prefix preserved
+    assert out[0]["direction"] == "LONG"
+    # the asset_data read derived the xyz dex from the prefix
+    md_calls = [a for (t, a) in ctx.senpi_mcp.calls if t == "market_get_asset_data"]
+    assert md_calls and md_calls[0]["dex"] == "xyz" and md_calls[0]["asset"] == "xyz:TSLA"
+
+
+def test_scan_emits_nothing_when_held():
+    import scan
+    up = _synth_candles(14, 1.0)
+    # already holding the named asset (bare coin in clearinghouse) → no signal
+    assert scan.scan({"asset": "xyz:TSLA", "minScore": 0}, _Ctx(up, held="TSLA")) == []
+    # also holds when the clearinghouse reports the prefixed coin
+    assert scan.scan({"asset": "xyz:TSLA", "minScore": 0}, _Ctx(up, held="xyz:TSLA")) == []
+    # and for a main-dex name held bare
+    assert scan.scan({"asset": "BTC", "minScore": 0}, _Ctx(up, held="BTC")) == []
+
+
+def test_scan_smoke_returns_single_valid_signal():
+    import scan
+    up = _synth_candles(14, 1.0)
+    ctx = _Ctx(up)                                       # empty clearinghouse, in-memory state
+    out = scan.scan({"asset": "BTC", "minScore": 0}, ctx)
+    assert len(out) == 1
+    s = out[0]
+    assert set(("asset", "direction", "marginPct", "leverage", "data")) <= set(s)
+    assert s["asset"] == "BTC"
+    assert 0 < s["marginPct"] <= 25 and 1 <= s["leverage"] <= 5
+    assert s["direction"] in ("LONG", "SHORT")
+    assert ctx.state.last() is not None                  # state persisted
+    assert ctx.state.last()["result"]["emitted"] is True
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn(); print(f"ok  {fn.__name__}")
+    print(f"\nALL {len(fns)} GECKO TESTS PASS")

--- a/strategies/ram/main/runtime.yaml
+++ b/strategies/ram/main/runtime.yaml
@@ -1,0 +1,124 @@
+# ── RAM · single instance — GOLD XYZ specialist (safe-haven + momentum) ──────────
+# The precious-metals analogue of DIRE (BRENTOIL). One asset: xyz:GOLD (Hyperliquid
+# HIP-3 DEX). Bison's validated momentum engine narrowed to a single instrument
+# (4h trend structure -> 1h confirmation -> momentum / RSI / funding), plus a metals
+# SAFE-HAVEN tilt: a small bounded bonus to a LONG when a risk-off regime is detected
+# (gold is bid when the market turns defensive). Holds ONE position; conviction-banded
+# leverage/margin; DSL-only exits. xyz:GOLD trades 24/7 incl. weekends — NO market-hours
+# gate. xyz:GOLD uses ISOLATED margin (the runtime defaults xyz -> ISOLATED; not overridden).
+name: ram-main
+group: ram
+version: 1.0.0
+description: >
+  RAM — single-asset GOLD (xyz:GOLD, HIP-3) specialist. Goes LONG when the 4h trend
+  structure, 1h confirmation and momentum align — and harder still in a risk-off
+  (safe-haven) regime — and can SHORT a clean downtrend. Bison's weighted momentum
+  scorer (trend + momentum + RSI room + funding), narrowed to one instrument, plus a
+  bounded safe-haven tilt to longs. Conviction-banded sizing (base/good/apex ->
+  3x/4x/5x, 10%/15%/20% margin), one slot, leverage clamped to 5x. DSL is the ONLY
+  exit — breakeven-first ladder (12% Phase 1, profit-lock to +60%, 48h weak-peak);
+  time cuts DISABLED (single-asset family; metals move slower than crypto).
+
+strategy:
+  wallet: "${RAM_WALLET}"
+  slots: 1                                # single asset, single position
+  default_leverage: 3                     # fallback; scan emits per-signal 3/4/5 by band
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: ram_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # 5 min — metals move slower than crypto
+    timeout_seconds: 150                   # up to 3 guarded MCP reads/tick (clearinghouse + asset_data + funding_regime)
+    default_signal_validity_seconds: 3600
+    state_history_max_count: 100           # dedup map + per-tick result history
+    inputs:
+      asset: "xyz:GOLD"
+      dex: "xyz"                           # HIP-3 DEX — xyz: prefix mandatory
+      minScore: 5                          # entry floor (composite score)
+      apexScore: 9                         # -> apex band (5x / 20%)
+      goodScore: 7                         # -> good band (4x / 15%)
+      leverageTiers: { apex: 5, good: 4, base: 3 }
+      marginPctTiers: { apex: 20, good: 15, base: 10 }
+      maxLeverage: 5                       # venue-safe cap for a single high-conviction slot
+      maxMarginPct: 25                     # PERCENT of withdrawable — hard sizing ceiling
+      recentSignalTtlSeconds: 3600         # 60m — anti re-fire (mirrors per-asset cooldown half)
+      # ── momentum engine knobs (bison-ported) ──
+      minVolTrendPct: 10                   # volume-trend bonus threshold
+      rsiMaxLong: 72                       # long RSI-overbought penalty
+      rsiMinShort: 28                      # short RSI-oversold penalty
+      # ── safe-haven tilt ──
+      useFundingRegime: true               # read market_get_funding_regime for the risk-off flag
+      safeHavenBonusLong: 2                # bounded bonus added to a LONG in a risk-off regime
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      band: { type: string, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: ram_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter
+    scanners: [ram_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # trend entry must fill — taker fallback (xyz spreads narrow)
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: ram_main_signals
+  # NO CLOSE_POSITION action — DSL is the only exit.
+
+# EXIT — DSL only. Gold is lower-vol than crypto, so the ladder is WIDER: a breakeven-
+# first Phase 2 (T0 locks nothing at +8%, first real lock only at +18%) that ramps
+# smoothly, and a 12% Phase 1 backstop. Time cuts DISABLED (single-asset family:
+# Phase 1 + Phase 2 own all exits via price action); weak_peak_cut KEPT (a stalled
+# metals name frees its single slot after 48h).
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 2880            # 48h — a stalled gold position frees its slot
+      min_value: 2.5
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0
+      retrace_threshold: 7
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 0 }    # T0 — breakeven arm (locks nothing yet)
+        - { trigger_pct: 18, lock_hw_pct: 40 }   # T1 — first real profit lock
+        - { trigger_pct: 35, lock_hw_pct: 62 }   # T2
+        - { trigger_pct: 60, lock_hw_pct: 80 }   # T3 — parabolic extension
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 3                  # single asset, low churn
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 900
+    per_asset_cooldown_seconds: 14400       # 4h — GOLD re-entry throttle
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true

--- a/strategies/ram/main/scanners/scan.py
+++ b/strategies/ram/main/scanners/scan.py
@@ -1,0 +1,201 @@
+"""RAM — supervised scanner. Single-asset GOLD (xyz:GOLD) specialist.
+
+The precious-metals analogue of DIRE (BRENTOIL). One instrument, one position, no
+universe scan. Each tick:
+  1) Single-position guard — if we already hold GOLD, emit nothing (the DSL owns the
+     exit; RAM never opens a second slot).
+  2) Signal dedup — refuse to re-emit within recentSignalTtlSeconds (defence-in-depth
+     alongside the runtime's per-asset cooldown).
+  3) Read GOLD candles (1h/4h) + funding; derive a risk-off (safe-haven) flag from
+     market_get_funding_regime; score the pure `scoring.build_thesis`; emit ONE
+     conviction-banded LONG/SHORT signal iff it clears minScore. NEVER closes.
+
+Read-only + single-pass; never raises (every MCP read is guarded and degrades to
+"no action this tick"). marginPct is a PERCENT in (0,100]. No daemon, no push_signal.
+
+XYZ / gold notes (fleet rules — do NOT redesign):
+  - asset = xyz:GOLD, dex = "xyz" — the xyz: prefix is mandatory (HIP-3 DEX) and is
+    emitted verbatim in the signal.
+  - xyz:GOLD trades 24/7 incl. weekends — NO market-hours gating anywhere.
+  - xyz:GOLD uses ISOLATED margin; the runtime defaults xyz -> ISOLATED (not overridden).
+
+PAYLOAD-SHAPE ASSUMPTIONS (auth token was invalid — not live-verified; tolerant like
+raven/dire):
+  - market_get_asset_data -> {"data": {"candles": {"1h":[...],"4h":[...]},
+    "funding": <rate|dict>, ...}} — candles are dicts {open/high/low/close/volume} or
+    [t,o,h,l,c,v] lists; funding via `_funding_of` (every spelling the corpus uses).
+  - strategy_get_clearinghouse_state -> handled for BOTH the flat `assetPositions`
+    shape (raven) AND the main/xyz sub-DEX sections shape (dire/HIP-3).
+  - market_get_funding_regime -> parsed by scoring.risk_off_from_regime (categorical/
+    boolean only; unknown -> neutral). Verify all three against real payloads.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
+        print(f"[ram.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _dex_for(asset, inputs):
+    dex = inputs.get("dex")
+    if dex is not None:
+        return dex
+    return "xyz" if str(asset).lower().startswith("xyz:") else ""
+
+
+def _asset_data(ctx, asset, dex):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": asset, "candle_intervals": ["1h", "4h"],
+        "include_funding": True, "include_order_book": False, "dex": dex,
+    }, f"market_get_asset_data({asset})")
+
+
+def _funding_of(md):
+    """Current funding rate as a float (tolerant; 0.0 if absent -> funding factor
+    neutralised). XYZ funding presence is not guaranteed; 0.0 is the safe default."""
+    for k in ("funding", "funding_rate", "fundingRate", "current_funding"):
+        v = scoring._num((md or {}).get(k))
+        if v is not None:
+            return v
+    fh = (md or {}).get("funding") if isinstance((md or {}).get("funding"), dict) else None
+    if isinstance(fh, dict):
+        return scoring._f(fh.get("rate", fh.get("current")))
+    return 0.0
+
+
+def _held(ctx):
+    """Bare-name set of currently-held coins, or None if the read fails / is
+    unusable. Robust to BOTH clearinghouse shapes in the corpus: the flat top-level
+    `assetPositions` (raven) AND the main/xyz sub-DEX sections (dire, HIP-3). Returns
+    None (not an empty set) on a failed read so the caller defers to the next tick
+    rather than risk a double-open."""
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = set()
+
+    def _collect(container):
+        for e in (container or []):
+            pos = e.get("position", e) if isinstance(e, dict) else {}
+            coin = str(pos.get("coin", "")).strip()
+            if coin and scoring._f(pos.get("szi")) != 0:
+                out.add(coin.split(":", 1)[-1].upper())
+
+    _collect(d.get("assetPositions", d.get("asset_positions", [])))
+    for section in ("main", "xyz"):
+        s = d.get(section)
+        if isinstance(s, dict):
+            _collect(s.get("assetPositions", s.get("asset_positions", [])))
+    return out
+
+
+def _risk_off(ctx, inputs):
+    """Safe-haven (risk-off) flag from market_get_funding_regime. Tolerant + safe:
+    True ONLY on an explicit risk-off label/flag; any read failure / unknown shape ->
+    False (neutral, tilt off). Disable the read entirely with useFundingRegime:false."""
+    if not bool(inputs.get("useFundingRegime", True)):
+        return False
+    data = _read(ctx, "market_get_funding_regime", {}, "market_get_funding_regime")
+    if data is None:
+        return False
+    try:
+        return scoring.risk_off_from_regime(data)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[ram.scan] funding-regime parse failed (neutral): {exc!r}", file=sys.stderr)
+        return False
+
+
+def scan(inputs, ctx):
+    asset = inputs.get("asset", "xyz:GOLD") or "xyz:GOLD"
+    dex = _dex_for(asset, inputs)
+    min_score = scoring._f(inputs.get("minScore"), 5)
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 3600)
+    now = time.time()
+    bare = str(asset).split(":", 1)[-1].upper()
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    recent = dict(st.get("recent", {}) or {})
+
+    def _persist(result):
+        if ctx.state is not None:
+            try:
+                ctx.state.append({"recent": recent, "result": result})
+            except Exception as exc:  # noqa: BLE001
+                print(f"[ram.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    # ── 1) single-position guard: already holding gold? ──
+    held = _held(ctx)
+    if held is None:
+        print("[ram.scan] clearinghouse unreadable — no action this tick", file=sys.stderr)
+        return []                                     # do NOT persist a bogus result; act next tick
+    if bare in held:
+        print(f"[ram.scan] {asset} HOLD: already holding {bare} (single slot; DSL owns exit)",
+              file=sys.stderr)
+        _persist({"ts": now, "asset": asset, "emitted": False, "gate": "already_held"})
+        return []
+
+    # ── 2) signal dedup (defence-in-depth vs the runtime per-asset cooldown) ──
+    last = recent.get(bare)
+    if last is not None and (now - last) < ttl:
+        print(f"[ram.scan] {asset} HOLD: recent signal {int(now - last)}s < ttl {int(ttl)}s",
+              file=sys.stderr)
+        _persist({"ts": now, "asset": asset, "emitted": False, "gate": "recent_signal"})
+        return []
+
+    # ── 3) fetch + thesis ──
+    md = _asset_data(ctx, asset, dex)
+    if not md:
+        print(f"[ram.scan] {asset} asset_data unreadable — no action this tick", file=sys.stderr)
+        _persist({"ts": now, "asset": asset, "emitted": False, "gate": "no_data"})
+        return []
+    candles = md.get("candles", {}) or {}
+    funding = _funding_of(md)
+    risk_off = _risk_off(ctx, inputs)
+
+    th = scoring.build_thesis(asset, candles.get("1h", []), candles.get("4h", []),
+                              funding, (None, 0), risk_off, inputs)
+    if not th:
+        print(f"[ram.scan] {asset} HOLD: no thesis (insufficient candles / no direction)",
+              file=sys.stderr)
+        _persist({"ts": now, "asset": asset, "emitted": False, "gate": "no_thesis"})
+        return []
+    if th["score"] < min_score:
+        print(f"[ram.scan] {asset} HOLD: score={th['score']}<{min_score:g} {th['direction']} "
+              f"risk_off={risk_off} | {th['reasons']}", file=sys.stderr)
+        _persist({"ts": now, "asset": asset, "emitted": False, "gate": "score_low",
+                  "score": th["score"], "direction": th["direction"]})
+        return []
+
+    band = scoring.band_for(th["score"], inputs)
+    lev, mgn = scoring.sizing_for(band, inputs)
+    recent[bare] = now
+    sig = {
+        "asset": asset,                     # WITH xyz: prefix — mandatory for the HIP-3 DEX
+        "direction": th["direction"],
+        "marginPct": mgn,                   # PERCENT of withdrawable — runtime sizes (marginPct/100)*withdrawable
+        "leverage": lev,                    # conviction-banded 3/4/5; runtime applies it (ISOLATED on xyz)
+        "data": {
+            "score": float(th["score"]),
+            "leverage": float(lev),
+            "direction": th["direction"],
+            "band": band,
+            "reasons": th["reasons"],       # safe_haven_bid appears here when the risk-off tilt fired
+        },
+    }
+    print(f"[ram.scan] {asset} EMIT {th['direction']} score={th['score']} band={band} "
+          f"{lev}x {mgn}% risk_off={risk_off} | {th['reasons']}", file=sys.stderr)
+    _persist({"ts": now, "asset": asset, "emitted": True, "gate": "pass", "score": th["score"],
+              "direction": th["direction"], "band": band, "leverage": lev, "marginPct": mgn})
+    return [sig]

--- a/strategies/ram/main/scanners/scoring.py
+++ b/strategies/ram/main/scanners/scoring.py
@@ -1,0 +1,336 @@
+"""RAM — pure thesis math (no I/O, no MCP, no clock).
+
+RAM is the single-asset GOLD (xyz:GOLD) specialist — the precious-metals analogue
+of DIRE (BRENTOIL). Safe-haven + momentum: it goes LONG gold when trend and (in a
+risk-off regime) safe-haven demand align, can SHORT a clean downtrend, and holds
+ONE position. NEVER closes — the DSL owns every exit.
+
+Two halves, both pure and unit-testable:
+
+  1. MOMENTUM ENGINE — the indicator math (_close/_high/_low/_vol, trend_structure,
+     price_momentum, calc_rsi, volume_trend) and the direction-waterfall + weighted
+     score are ported VERBATIM from bison/scoring.py (a validated Runtime 3.0 scorer),
+     so a fidelity harness can diff RAM's entries against bison's on the same candles.
+     Behaviour-preserving quirks carry bison's `# v2-quirk` flags. RAM's engine is
+     bison's momentum thesis, narrowed to one instrument (1h/4h only, no 15m) and no
+     smart-money cohort source (gold has none — the `sm` rung is kept for fidelity but
+     the caller passes (None, 0), leaving it inert exactly as in bison).
+
+  2. SAFE-HAVEN TILT — the single metals-specific addition. When the caller detects a
+     risk-off regime (from market_get_funding_regime), it passes risk_off=True and a
+     small bounded bonus (`safeHavenBonusLong`) is added to a LONG thesis only — gold
+     is bid when the market turns defensive. A SHORT is never given the tilt.
+
+NOTE: the market_get_funding_regime payload shape was NOT live-verified when this was
+written (auth token invalid). `risk_off_from_regime` derives the flag ONLY from an
+explicit categorical/boolean field and defaults to False (neutral) on any unknown or
+mis-shaped payload — it never infers risk-off from a numeric funding sign, so a bad
+payload can never inject a wrong-way bias into a live long. Verify against a real
+payload and extend the key/word lists before trusting the tilt.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _num(v):
+    """Float or None (distinguishes a real 0.0 from a missing field)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# Ported verbatim from bison/scoring.py.
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── indicators (ported verbatim from bison/scoring.py) ──
+
+def price_momentum(candles, n_bars=1):
+    if len(candles) < n_bars + 1:
+        return 0
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    if old == 0:
+        return 0
+    return ((new - old) / old) * 100
+
+
+def trend_structure(candles, lookback=6):
+    """Higher lows = BULLISH, lower highs = BEARISH. Verbatim from bison.
+    v2-quirk: STRICT (>) counting, gate `>= total * 0.6`, total = lookback - 1."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    elif lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0
+
+
+def volume_trend(candles, lookback=6):
+    if len(candles) < lookback + 2:
+        return 0
+    vols = [_vol(c) for c in candles[-(lookback + 2):]]
+    half = lookback // 2
+    recent = sum(vols[-half:]) / half if half > 0 else 1
+    earlier = sum(vols[:half]) / half if half > 0 else 1
+    if earlier == 0:
+        return 0
+    return ((recent - earlier) / earlier) * 100
+
+
+def calc_rsi(closes, period=14):
+    """Trailing-window RSI. Verbatim from bison (uses gains[-period:])."""
+    if len(closes) < period + 1:
+        return 50
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── the thesis (direction waterfall + weighted score) — bison's engine, narrowed
+#    to one instrument (1h/4h, no 15m) with the metals safe-haven tilt appended ──
+
+def build_thesis(coin, candles_1h, candles_4h, funding, sm, risk_off, inputs):
+    """Port of bison build_thesis for a single metals instrument. Returns a thesis
+    dict (with `score`) or None. None ⟺ insufficient history (len(c1h) < 8 or
+    len(c4h) < 4) OR no direction resolves. minScore is applied by the CALLER
+    (scan.py).
+
+    Differences from bison (all behaviour-preserving except the tilt):
+      • no 15m timeframe — RAM fetches 1h/4h only; price comes from the 1h close.
+      • `sm` (smart-money lean) is kept for bison-fidelity but gold has no cohort
+        source, so the caller passes (None, 0); the sm waterfall rung and sm score
+        component are then inert exactly as in bison when sm is absent.
+      • SAFE-HAVEN TILT: +`safeHavenBonusLong` added to a LONG when risk_off is set
+        (gold bid in risk-off regimes). A SHORT is never given the tilt.
+    """
+    min_vol_trend = _f(inputs.get("minVolTrendPct", 10))
+    rsi_max_long = _f(inputs.get("rsiMaxLong", 72))
+    rsi_min_short = _f(inputs.get("rsiMinShort", 28))
+    sh_bonus = _f(inputs.get("safeHavenBonusLong", 2))
+
+    if len(candles_1h) < 8 or len(candles_4h) < 4:
+        return None
+
+    price = _close(candles_1h[-1]) if candles_1h else 0
+
+    trend_4h, trend_strength = trend_structure(candles_4h)
+    trend_1h, _ = trend_structure(candles_1h)
+    sm_dir, sm_pct = sm if sm else (None, 0)
+    mom_1h = price_momentum(candles_1h, 2)
+
+    # Direction waterfall: 4H trend -> SM direction -> 1H momentum (verbatim from bison)
+    direction = None
+    if trend_4h == "BULLISH":
+        direction = "LONG"
+    elif trend_4h == "BEARISH":
+        direction = "SHORT"
+    elif sm_dir and sm_dir != "NEUTRAL":
+        direction = sm_dir
+    elif mom_1h > 0.5:
+        direction = "LONG"
+    elif mom_1h < -0.5:
+        direction = "SHORT"
+    if direction is None:
+        return None
+
+    score = 0
+    reasons = []
+
+    # 4H trend structure (+3 / -1)
+    if trend_4h != "NEUTRAL":
+        if (direction == "LONG") == (trend_4h == "BULLISH"):
+            score += 3; reasons.append(f"4h_{trend_4h.lower()}_{trend_strength:.0%}")
+        else:
+            score -= 1; reasons.append(f"4h_opposing_{trend_4h.lower()}")
+
+    # 1H trend agreement (+2 / -1)
+    if trend_1h != "NEUTRAL":
+        if (direction == "LONG") == (trend_1h == "BULLISH"):
+            score += 2; reasons.append(f"1h_confirms_{trend_1h.lower()}")
+        else:
+            score -= 1; reasons.append(f"1h_opposing_{trend_1h.lower()}")
+
+    # 1H momentum (+2 / +1 / -1)
+    if direction == "LONG":
+        if mom_1h >= 1.0:
+            score += 2; reasons.append(f"1h_strong_momentum_{mom_1h:+.2f}%")
+        elif mom_1h >= 0.5:
+            score += 1; reasons.append(f"1h_momentum_{mom_1h:+.2f}%")
+        elif mom_1h < -0.5:
+            score -= 1; reasons.append(f"1h_counter_{mom_1h:+.2f}%")
+    else:
+        if mom_1h <= -1.0:
+            score += 2; reasons.append(f"1h_strong_momentum_{mom_1h:+.2f}%")
+        elif mom_1h <= -0.5:
+            score += 1; reasons.append(f"1h_momentum_{mom_1h:+.2f}%")
+        elif mom_1h > 0.5:
+            score -= 1; reasons.append(f"1h_counter_{mom_1h:+.2f}%")
+
+    # SM alignment (+-2) — inert when sm is (None, 0), as in bison
+    if sm_dir == direction and sm_dir:
+        score += 2; reasons.append(f"sm_aligned_{_f(sm_pct):.0f}%")
+    elif sm_dir and sm_dir != "NEUTRAL" and sm_dir != direction:
+        score -= 2; reasons.append(f"sm_opposing_{sm_dir}")
+
+    # Funding alignment (+2 / -1)
+    if (direction == "LONG" and funding < 0) or (direction == "SHORT" and funding > 0):
+        score += 2; reasons.append(f"funding_aligned_{funding:+.4f}")
+    elif (direction == "LONG" and funding > 0.01) or (direction == "SHORT" and funding < -0.005):
+        score -= 1; reasons.append("funding_crowded")
+
+    # Volume trend (+1)
+    vol_1h = volume_trend(candles_1h)
+    if vol_1h > min_vol_trend:
+        score += 1; reasons.append(f"vol_rising_{vol_1h:+.0f}%")
+
+    # OI proxy (+1) — recent-3 vs earlier-3 1h volume delta (verbatim)
+    vol_recent = sum(_vol(c) for c in candles_1h[-3:])
+    vol_earlier = sum(_vol(c) for c in candles_1h[-6:-3])
+    oi_proxy = ((vol_recent - vol_earlier) / vol_earlier * 100) if vol_earlier > 0 else 0
+    if oi_proxy > 10:
+        score += 1; reasons.append(f"oi_growing_{oi_proxy:+.0f}%")
+
+    # RSI room (+1 / -1)
+    closes_1h = [_close(c) for c in candles_1h]
+    rsi = calc_rsi(closes_1h)
+    if direction == "LONG" and rsi > rsi_max_long:
+        score -= 1; reasons.append(f"rsi_overbought_{rsi:.0f}")
+    elif direction == "SHORT" and rsi < rsi_min_short:
+        score -= 1; reasons.append(f"rsi_oversold_{rsi:.0f}")
+    elif (direction == "LONG" and rsi < 55) or (direction == "SHORT" and rsi > 45):
+        score += 1; reasons.append(f"rsi_room_{rsi:.0f}")
+
+    # 4H momentum (+1)
+    mom_4h = price_momentum(candles_4h, 1)
+    if abs(mom_4h) > 1.5 and ((direction == "LONG") == (mom_4h > 0)):
+        score += 1; reasons.append(f"4h_momentum_{mom_4h:+.1f}%")
+
+    # ── SAFE-HAVEN TILT (metals-specific; LONG only) ──
+    if risk_off and direction == "LONG":
+        score += sh_bonus; reasons.append(f"safe_haven_bid_+{sh_bonus:g}")
+
+    return {"coin": coin, "direction": direction, "score": score, "reasons": reasons,
+            "price": price, "trend_4h": trend_4h, "trend_1h": trend_1h,
+            "rsi": round(rsi, 1), "momentum_1h": round(mom_1h, 3),
+            "funding": funding, "risk_off": bool(risk_off)}
+
+
+# ── conviction band + sizing (raven-shaped; single high-conviction slot) ──
+
+def band_for(score, inputs):
+    """Conviction band from the score."""
+    apex = _f(inputs.get("apexScore"), 9)
+    good = _f(inputs.get("goodScore"), 7)
+    if score >= apex:
+        return "apex"
+    if score >= good:
+        return "good"
+    return "base"
+
+
+def sizing_for(band, inputs, venue_max=None):
+    """(leverage, marginPct). marginPct is a PERCENT in (0,100], clamped to the
+    fleet + venue leverage caps and to maxMarginPct. Single high-conviction slot —
+    no self-calibration size_scale (RAM does not adapt its own sizing)."""
+    lev_tiers = inputs.get("leverageTiers") or {"apex": 5, "good": 4, "base": 3}
+    mgn_tiers = inputs.get("marginPctTiers") or {"apex": 20, "good": 15, "base": 10}
+    cap = int(_f(inputs.get("maxLeverage"), 5))
+    lev = int(_f(lev_tiers.get(band), 3))
+    if venue_max:
+        cap = min(cap, int(_f(venue_max, cap)))
+    lev = max(1, min(lev, cap))
+    mgn = _f(mgn_tiers.get(band), 10)
+    mgn = max(1.0, min(mgn, _f(inputs.get("maxMarginPct"), 25)))
+    return lev, round(mgn, 2)
+
+
+# ── safe-haven / risk-off derivation (pure parse of a funding-regime payload) ──
+
+# categorical spellings a funding-regime payload might use. Shape UNVERIFIED — extend
+# once a real market_get_funding_regime response is captured.
+_RISK_OFF_WORDS = ("risk_off", "risk-off", "riskoff", "defensive", "bearish", "fear",
+                   "flight_to_safety", "flight-to-safety", "capitulation")
+_RISK_ON_WORDS = ("risk_on", "risk-on", "riskon", "bullish", "greed", "aggressive",
+                  "euphoria")
+_REGIME_KEYS = ("regime", "funding_regime", "fundingRegime", "label", "state",
+                "classification", "sentiment", "mode", "risk_regime", "riskRegime")
+_RISK_OFF_FLAGS = ("risk_off", "riskOff", "is_risk_off", "isRiskOff",
+                   "safe_haven", "safeHaven", "risk_off_regime")
+
+
+def risk_off_from_regime(data):
+    """Tolerant, PURE parse of a market_get_funding_regime payload into a risk-off
+    bool. Categorical / boolean ONLY — never inferred from a numeric funding sign
+    (guessing the sign could inject a wrong-way bias into a live long). Any unknown,
+    absent, or mis-shaped payload → False (neutral; the safe-haven tilt stays off).
+    Shape NOT live-verified — see the module docstring."""
+    d = data.get("data", data) if isinstance(data, dict) else data
+    if not isinstance(d, dict):
+        return False
+    # explicit boolean flag
+    for k in _RISK_OFF_FLAGS:
+        v = d.get(k)
+        if isinstance(v, bool) and v:
+            return True
+    # categorical label — risk-off words win; risk-on words explicitly clear it
+    for k in _REGIME_KEYS:
+        v = d.get(k)
+        if isinstance(v, str):
+            s = v.strip().lower()
+            if any(w in s for w in _RISK_OFF_WORDS):
+                return True
+            if any(w in s for w in _RISK_ON_WORDS):
+                return False
+    return False

--- a/strategies/ram/strategy.yaml
+++ b/strategies/ram/strategy.yaml
@@ -1,0 +1,43 @@
+# Ram — GOLD XYZ specialist. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. The precious-metals analogue of Dire
+# (single-commodity BRENTOIL specialist): one hardcoded asset (xyz:GOLD, Hyperliquid
+# HIP-3 DEX), one position, safe-haven + momentum. Bison's validated momentum engine
+# narrowed to a single instrument, plus a risk-off safe-haven tilt to longs. NEVER
+# closes — DSL owns every exit. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: ram
+version: "1.0.0"
+
+catalog:
+  name: "Ram — Gold Specialist"
+  emoji: "🐏"
+  tagline: "A single-asset gold (xyz:GOLD) specialist: goes long when gold's trend lines up across the 1h and 4h and momentum agrees — and leans in harder when the market turns risk-off and money is looking for a safe haven — and can short a clean downtrend. Holds one position at a time and trails a stop instead of guessing the exit."
+  belief_plain: "Trades only gold. It buys when gold is trending up and, especially, when the market gets defensive and flows into safe havens; it can short a clear downtrend. It never picks a top or bottom by hand — a trailing stop does all the exiting. Gold trades around the clock, weekends included."
+  thesis: "Gold is the market's safe-haven anchor: it trends on real-rate and risk-regime shifts and gets bid hardest when risk assets wobble. An agent that watches only gold can read its 1h/4h trend structure, momentum and RSI far more tightly than a broad scanner, and add a safe-haven tilt when a risk-off funding regime shows up — catching the defensive bid early and locking profit as the move matures. Concentration by conviction on one asset, with the DSL owning every exit."
+  group: single-asset
+  archetype: single_market
+  sub_style: commodity
+  asset_classes: [commodities]
+  asset_scope: single
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 100
+  assets: ["xyz:GOLD"]
+  tags: [gold, xau, metals, safe-haven, commodity, single-asset, dsl-only]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml           # → runtime name ram-main, group ram
+    wallet_env: RAM_WALLET
+    funding_share: 1.0

--- a/strategies/ram/tests/test_engine.py
+++ b/strategies/ram/tests/test_engine.py
@@ -1,0 +1,185 @@
+"""RAM engine tests. Pure/deterministic scorer + safe-haven tilt + sizing caps,
+plus a scan() smoke run against a fake ctx (no network). Run:
+  python3 -m pytest strategies/ram/tests -q
+  python3 strategies/ram/tests/test_engine.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "main", "scanners"))
+import scoring  # noqa: E402
+
+
+def _synth_candles(n, step, start=100.0):
+    """Monotone series (step>0 → higher-lows/bullish, step<0 → lower-highs/bearish)."""
+    out, p = [], start
+    for _ in range(n):
+        out.append({"open": p, "high": p + abs(step), "low": p - abs(step) / 2,
+                    "close": p + step, "volume": 1000})
+        p += step
+    return out
+
+
+# ── thesis: direction + insufficient-history guard ──
+
+def test_build_thesis_uptrend_is_long_downtrend_is_short():
+    up1h, up4h = _synth_candles(14, 1.0), _synth_candles(6, 2.0)
+    th = scoring.build_thesis("GOLD", up1h, up4h, funding=-0.01, sm=(None, 0),
+                              risk_off=False, inputs={})
+    assert th and th["direction"] == "LONG" and th["score"] > 0
+
+    dn1h, dn4h = _synth_candles(14, -1.0), _synth_candles(6, -2.0)
+    th_s = scoring.build_thesis("GOLD", dn1h, dn4h, funding=0.01, sm=(None, 0),
+                                risk_off=False, inputs={})
+    assert th_s and th_s["direction"] == "SHORT" and th_s["score"] > 0
+
+
+def test_build_thesis_none_on_insufficient_candles():
+    up = _synth_candles(14, 1.0)
+    # < 8 1h candles → None
+    assert scoring.build_thesis("GOLD", up[:4], up, 0, (None, 0), False, {}) is None
+    # < 4 4h candles → None
+    assert scoring.build_thesis("GOLD", up, up[:3], 0, (None, 0), False, {}) is None
+
+
+# ── safe-haven tilt: adds to LONG when risk_off, never to SHORT ──
+
+def test_safe_haven_tilt_adds_to_long_only():
+    up1h, up4h = _synth_candles(14, 1.0), _synth_candles(6, 2.0)
+    base = scoring.build_thesis("GOLD", up1h, up4h, -0.01, (None, 0), False,
+                                {"safeHavenBonusLong": 2})
+    tilted = scoring.build_thesis("GOLD", up1h, up4h, -0.01, (None, 0), True,
+                                  {"safeHavenBonusLong": 2})
+    assert tilted["direction"] == "LONG"
+    assert tilted["score"] == base["score"] + 2
+    assert any("safe_haven" in r for r in tilted["reasons"])
+    assert not any("safe_haven" in r for r in base["reasons"])
+
+    # a SHORT is never given the safe-haven tilt
+    dn1h, dn4h = _synth_candles(14, -1.0), _synth_candles(6, -2.0)
+    s_base = scoring.build_thesis("GOLD", dn1h, dn4h, 0.01, (None, 0), False,
+                                  {"safeHavenBonusLong": 2})
+    s_tilt = scoring.build_thesis("GOLD", dn1h, dn4h, 0.01, (None, 0), True,
+                                  {"safeHavenBonusLong": 2})
+    assert s_base["direction"] == "SHORT" and s_tilt["score"] == s_base["score"]
+
+
+# ── risk-off derivation (pure, tolerant, categorical-only) ──
+
+def test_risk_off_from_regime_categorical_and_safe_default():
+    assert scoring.risk_off_from_regime({"regime": "risk_off"}) is True
+    assert scoring.risk_off_from_regime({"regime": "RISK-OFF (extreme)"}) is True
+    assert scoring.risk_off_from_regime({"label": "defensive"}) is True
+    assert scoring.risk_off_from_regime({"is_risk_off": True}) is True
+    assert scoring.risk_off_from_regime({"data": {"regime": "flight_to_safety"}}) is True
+    # risk-on / neutral / unknown / mis-shaped → False (safe default, tilt off)
+    assert scoring.risk_off_from_regime({"regime": "risk_on"}) is False
+    assert scoring.risk_off_from_regime({"regime": "neutral"}) is False
+    assert scoring.risk_off_from_regime({"avg_funding": -0.05}) is False   # never inferred from a number
+    assert scoring.risk_off_from_regime({}) is False
+    assert scoring.risk_off_from_regime(None) is False
+    assert scoring.risk_off_from_regime("nope") is False
+
+
+# ── band + sizing caps ──
+
+def test_band_for_thresholds():
+    inp = {"apexScore": 9, "goodScore": 7}
+    assert scoring.band_for(9, inp) == "apex"
+    assert scoring.band_for(7, inp) == "good"
+    assert scoring.band_for(6, inp) == "base"
+
+
+def test_sizing_caps_and_venue_clamp():
+    inp = {"leverageTiers": {"apex": 5, "good": 4, "base": 3},
+           "marginPctTiers": {"apex": 20, "good": 15, "base": 10},
+           "maxLeverage": 5, "maxMarginPct": 25}
+    lev, mgn = scoring.sizing_for("apex", inp)
+    assert lev == 5 and 0 < mgn <= 25 and mgn == 20
+    lev2, mgn2 = scoring.sizing_for("base", inp)
+    assert lev2 == 3 and mgn2 == 10
+    # venue max clamps leverage below the fleet cap
+    lev3, _ = scoring.sizing_for("apex", inp, venue_max=3)
+    assert lev3 == 3
+    # marginPct is hard-capped at maxMarginPct
+    _, mgn4 = scoring.sizing_for("apex", {"marginPctTiers": {"apex": 40}, "maxMarginPct": 25})
+    assert mgn4 == 25
+
+
+# ── scan() smoke against a fake ctx (no network) ──
+
+class _State:
+    def __init__(self): self._log = []
+    def last(self): return self._log[-1] if self._log else None
+    def append(self, d): self._log.append(d)
+
+
+class _MCP:
+    def __init__(self, candles, held=False, regime=None):
+        self.candles = candles
+        self.held = held
+        self.regime = regime
+
+    def call_tool(self, tool, args):
+        if tool == "market_get_asset_data":
+            return {"data": {"candles": {"1h": self.candles, "4h": self.candles},
+                             "asset_context": {"markPx": 2400.0}, "funding": -0.01}}
+        if tool == "strategy_get_clearinghouse_state":
+            if self.held:
+                return {"data": {"assetPositions": [
+                    {"position": {"coin": "GOLD", "szi": 1.5}}]}}
+            return {"data": {"assetPositions": []}}
+        if tool == "market_get_funding_regime":
+            return {"data": self.regime} if self.regime is not None else {}
+        return {}
+
+
+class _Ctx:
+    def __init__(self, candles, held=False, regime=None):
+        self.wallet = "0xram"
+        self.state = _State()
+        self.senpi_mcp = _MCP(candles, held=held, regime=regime)
+
+
+_INPUTS = {"asset": "xyz:GOLD", "minScore": 5, "apexScore": 9, "goodScore": 7,
+           "leverageTiers": {"apex": 5, "good": 4, "base": 3},
+           "marginPctTiers": {"apex": 20, "good": 15, "base": 10},
+           "maxLeverage": 5, "maxMarginPct": 25, "recentSignalTtlSeconds": 3600}
+
+
+def test_scan_smoke_returns_one_valid_gold_signal():
+    import scan
+    ctx = _Ctx(_synth_candles(14, 1.0), held=False, regime={"regime": "risk_off"})
+    out = scan.scan(dict(_INPUTS), ctx)
+    assert isinstance(out, list) and len(out) == 1
+    s = out[0]
+    assert set(("asset", "direction", "marginPct", "leverage", "data")) <= set(s)
+    assert s["asset"] == "xyz:GOLD"                    # emitted WITH the xyz: prefix
+    assert s["direction"] in ("LONG", "SHORT")
+    assert 0 < s["marginPct"] <= 25
+    assert 1 <= s["leverage"] <= 5
+    d = s["data"]
+    assert set(("score", "leverage", "direction", "band", "reasons")) <= set(d)
+    assert ctx.state.last() is not None                # state persisted
+
+
+def test_scan_emits_nothing_when_gold_already_held():
+    import scan
+    ctx = _Ctx(_synth_candles(14, 1.0), held=True, regime={"regime": "risk_off"})
+    out = scan.scan(dict(_INPUTS), ctx)
+    assert out == []                                   # single slot — no second open
+
+
+def test_scan_holds_below_min_score():
+    import scan
+    ctx = _Ctx(_synth_candles(14, 1.0), held=False)
+    inp = dict(_INPUTS); inp["minScore"] = 99          # unreachable floor
+    out = scan.scan(inp, ctx)
+    assert out == []
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn(); print(f"ok  {fn.__name__}")
+    print(f"\nALL {len(fns)} RAM TESTS PASS")

--- a/strategies/salmon/main/runtime.yaml
+++ b/strategies/salmon/main/runtime.yaml
@@ -1,0 +1,126 @@
+# ── SALMON · RSI Mean-Reversion / Dip-Buyer ──────────────────────────────────
+# Buys oversold BOUNCES and sells overbought FADES on liquid crypto majors. Every
+# 10 minutes the scanner derives the live main-DEX universe (vol floor + top-N) and,
+# for each free slot, looks for an RSI(14) CROSS back through a band: LONG when RSI
+# dipped below the oversold line and has crossed back UP while rising with an up
+# bar; SHORT on the symmetric overbought case. It is a mean-reversion play (bets
+# price reverts to its mean), deliberately NOT a falling-knife catcher — a still-
+# falling RSI below the line does NOT trigger. NEVER closes — the DSL owns every
+# exit, kept TIGHT because reversions fail fast, with the drawdown_halt as backstop.
+name: salmon-main
+group: salmon
+version: 1.0.0
+description: >
+  SALMON — RSI Mean-Reversion / Dip-Buyer. A universe reversion book (main-DEX only,
+  vol floor + top-N liquid crypto majors) that goes LONG on an oversold RSI(14)
+  cross-back-UP and SHORT on an overbought cross-back-DOWN, each requiring the cross
+  + a rising/falling RSI + a price-reversal bar (anti-falling-knife). Conviction-
+  banded sizing to a moderate cap (leverage <= 4, margin <= 20%). Up to 5 positions.
+  DSL is the ONLY exit — tight because reversions fail fast (8% Phase 1, early
+  profit-lock ladder to +50%, 12h weak-peak).
+
+strategy:
+  wallet: "${SALMON_WALLET}"
+  slots: 5
+  margin_pct: 6
+  default_leverage: 2
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: salmon_scanner
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 600              # wake every 10m — reversion signals decay fast
+    timeout_seconds: 300
+    default_signal_validity_seconds: 1800
+    state_history_max_count: 200
+    inputs:
+      # ── universe (main-only; reversion is cleanest on liquid crypto majors) ──
+      includeXyz: false
+      universeVolFloorUsd: 30000000
+      maxUniverse: 25
+      maxSlots: 5
+      recentSignalTtlSeconds: 14400     # 4h — don't re-fire the same name into the same swing
+      # ── RSI mean-reversion cross knobs ──
+      oversoldLevel: 30
+      overboughtLevel: 70
+      crossLookback: 5                  # bars to look back for the dip/pop before the cross
+      # ── conviction band cutoffs + tiered sizing ──
+      apexScore: 7
+      goodScore: 5
+      leverageTiers: { apex: 4, good: 3, base: 2 }
+      marginPctTiers: { apex: 12, good: 9, base: 6 }
+      maxLeverage: 4
+      maxMarginPct: 20
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      band: { type: string, required: false }
+      rsi: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: salmon_open
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [salmon_scanner]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: salmon_scanner
+  # NO CLOSE_POSITION action — DSL is the only exit.
+
+# EXIT — DSL only, TIGHT (reversions fail fast). Locks profit early and ramps so a
+# reversion that works isn't given back, and caps the loss well short of a rout.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 720          # 12h — a stalled reversion frees its slot
+      min_value: 2.0
+    phase1:
+      enabled: true
+      max_loss_pct: 8.0
+      retrace_threshold: 6
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 6,  lock_hw_pct: 0 }
+        - { trigger_pct: 12, lock_hw_pct: 40 }
+        - { trigger_pct: 20, lock_hw_pct: 60 }
+        - { trigger_pct: 35, lock_hw_pct: 75 }
+        - { trigger_pct: 50, lock_hw_pct: 85 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 5
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 900
+    per_asset_cooldown_seconds: 14400
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true

--- a/strategies/salmon/main/scanners/scan.py
+++ b/strategies/salmon/main/scanners/scan.py
@@ -1,0 +1,161 @@
+"""SALMON — RSI Mean-Reversion / Dip-Buyer. The single supervised scanner.
+
+Buys oversold BOUNCES and sells overbought FADES on liquid crypto majors. Each tick:
+  1) Read held positions; compute FREE slots (never re-enters a held name).
+  2) Derive the live MAIN-DEX universe (vol floor + top-N by 24h notional volume;
+     XYZ excluded — mean-reversion is cleanest on liquid crypto majors).
+  3) For each non-held, non-recently-signaled candidate, fetch 1h candles and run
+     the pure `scoring.oversold_bounce` CROSS detector. Emit a conviction-banded,
+     capped signal for every confirmed cross (LONG on an oversold cross-up, SHORT
+     on an overbought cross-down), sized by band. NEVER closes — the DSL owns every
+     exit (tight, because reversions fail fast).
+
+Read-only + single-pass — emits `marginPct` (a PERCENT in (0,100]) + `leverage`
+intents; the runtime sizes the dollars, owns cooldowns/risk gates, and trails the
+DSL exit. No daemon, no push_signal, no create_position.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
+        print(f"[salmon.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _dex_of(name):
+    return "xyz" if str(name).lower().startswith("xyz:") else ""
+
+
+def _instrument_rows(ctx, dex):
+    data = _read(ctx, "market_list_instruments", ({"dex": dex} if dex else {}),
+                 f"market_list_instruments({dex or 'main'})")
+    if data is None:
+        return None
+    insts = data.get("instruments", data.get("universe", data)) if isinstance(data, dict) else data
+    if not isinstance(insts, list):
+        return None
+    rows = []
+    for inst in insts:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        c = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        vol = scoring._f(c.get("dayNtlVlm"))
+        venue = c.get("max_leverage", c.get("maxLeverage")) or inst.get("max_leverage")
+        rows.append({"name": str(name), "vol": vol, "venue_max": venue, "dex": _dex_of(name)})
+    return rows
+
+
+def _derive_universe(ctx, inputs):
+    """Live top-N liquid MAIN-DEX names over the vol floor. XYZ is excluded by
+    default (includeXyz defaults False) — mean-reversion is cleanest on liquid
+    crypto majors; an operator can still opt XYZ in explicitly."""
+    main = _instrument_rows(ctx, "")
+    if main is None:
+        return None
+    rows = list(main)
+    if bool(inputs.get("includeXyz", False)):
+        rows += (_instrument_rows(ctx, "xyz") or [])
+    vfloor = scoring._f(inputs.get("universeVolFloorUsd"), 30_000_000)
+    xfloor = scoring._f(inputs.get("xyzVolFloorUsd"), 3_000_000)
+    keep = [r for r in rows if r["vol"] >= (xfloor if r["dex"] == "xyz" else vfloor)]
+    keep.sort(key=lambda r: r["vol"], reverse=True)
+    cap = int(scoring._f(inputs.get("maxUniverse"), 25))
+    return keep[:cap]
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["1h"],
+        "include_funding": False, "include_order_book": False, "dex": _dex_of(name),
+    }, f"market_get_asset_data({name})")
+
+
+def _held(ctx):
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = set()
+    for e in d.get("assetPositions", d.get("asset_positions", [])) or []:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 5))
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 14400)
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    recent = dict(st.get("recent", {}) or {})
+
+    held = _held(ctx)
+    if held is None:
+        return []                                    # clearinghouse unreadable — act next tick
+    free = max_slots - len(held)
+
+    out = []
+    if free > 0:
+        universe = _derive_universe(ctx, inputs)
+        if universe is None:
+            print("[salmon.scan] instruments unreadable — no opens this tick", file=sys.stderr)
+        else:
+            looked = 0
+            for row in universe:
+                if free <= 0 or looked >= max(12, free * 4):
+                    break
+                name = row["name"]
+                bare = str(name).split(":", 1)[-1].upper()
+                if bare in held:
+                    continue
+                if recent.get(bare) is not None and (now - recent[bare]) < ttl:
+                    continue
+                looked += 1
+                md = _asset_data(ctx, name)
+                if not md:
+                    continue
+                candles_1h = (md.get("candles", {}) or {}).get("1h", [])
+                sig = scoring.oversold_bounce(candles_1h, inputs)
+                if not sig:
+                    continue
+                band = scoring.band_for(sig["score"], inputs)
+                lev, mgn = scoring.sizing_for(band, inputs, row.get("venue_max"))
+                recent[bare] = now
+                free -= 1
+                out.append({
+                    "asset": name, "direction": sig["direction"], "marginPct": mgn, "leverage": lev,
+                    "data": {"score": sig["score"], "leverage": lev, "direction": sig["direction"],
+                             "band": band, "rsi": sig["rsi"], "reasons": sig["reasons"]},
+                })
+                print(f"[salmon.scan] OPEN {sig['direction']} {name}: score={sig['score']} "
+                      f"band={band} rsi={sig['rsi']} {lev}x {mgn}% | {sig['reasons'][:4]}",
+                      file=sys.stderr)
+
+    if not out:
+        print(f"[salmon.scan] no opens: held={len(held)}/{max_slots} free={free}", file=sys.stderr)
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({
+                "recent": recent,
+                "result": {"ts": now, "opened": len(out), "held": len(held), "free": free},
+            })
+        except Exception as exc:  # noqa: BLE001
+            print(f"[salmon.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/salmon/main/scanners/scoring.py
+++ b/strategies/salmon/main/scanners/scoring.py
@@ -1,0 +1,206 @@
+"""SALMON — pure RSI mean-reversion math (no I/O, no MCP, no clock).
+
+Dip-buyer / overbought-fader. Goes LONG when RSI(14) has dipped BELOW an oversold
+line and then CROSSES BACK UP through it while rising, with the last close
+confirming the turn; SHORT on the symmetric overbought case. It is deliberately
+NOT a falling-knife catcher: a still-falling RSI below the line does NOT trigger —
+the signal requires the cross back + a rising RSI + a price-reversal bar. It bets
+price reverts to its mean, which works in chop as well as trends.
+
+The indicator primitives (`_close`/`_high`/`_low`/`_vol`, `calc_rsi`,
+`price_momentum`) are ported VERBATIM from bison/scoring.py (a validated Runtime
+3.0 scorer) so the RSI math is byte-faithful. `rsi_series` reuses `calc_rsi` at
+each bar to expose the trailing-window RSI history the CROSS detector needs.
+`band_for`/`sizing_for` clone raven's conviction bands, clamped to salmon's tighter
+caps (leverage <= 4, margin <= 20%) — reversions fail fast, so moderate size.
+
+DSL owns every exit; this module only shapes ENTRY. Pure and unit-testable on
+plain candle lists — no network, no state, no clock.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# Ported VERBATIM from bison/scoring.py.
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── indicators (ported VERBATIM from bison/scoring.py) ──
+
+def price_momentum(candles, n_bars=1):
+    """% change over the last n_bars. Verbatim from bison price_momentum."""
+    if len(candles) < n_bars + 1:
+        return 0
+    old = _close(candles[-(n_bars + 1)])
+    new = _close(candles[-1])
+    if old == 0:
+        return 0
+    return ((new - old) / old) * 100
+
+
+def calc_rsi(closes, period=14):
+    """Trailing-window RSI. Verbatim from bison (uses gains[-period:])."""
+    if len(closes) < period + 1:
+        return 50
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0, d))
+        losses.append(max(0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+# ── RSI series (reuses calc_rsi at each bar to expose the trailing-window history) ──
+
+def rsi_series(closes, period=14):
+    """RSI at each bar, computed on the trailing window ending at that bar. Reuses
+    `calc_rsi` VERBATIM, so bars without enough history (< period+1 preceding
+    closes) return its neutral 50. The returned list is index-aligned to `closes`
+    so the caller can slice the last N bars to detect a CROSS back through a level.
+    """
+    return [calc_rsi(closes[: i + 1], period) for i in range(len(closes))]
+
+
+# ── the mean-reversion cross detector (the centerpiece) — pure ──
+
+def _reversion_score(depth, turn, pm):
+    """Discrete conviction score (+ reason tags) for a confirmed reversion cross.
+    Higher when the RSI went DEEPER past the line (`depth` = how far past the
+    oversold/overbought level the extreme reached), turned back HARDER (`turn` =
+    RSI reversal magnitude between the last two bars), and the price bar confirms
+    more strongly (|pm| = last-bar % move). Range 1..8."""
+    score, reasons = 0, []
+    if depth >= 18:
+        score += 4; reasons.append(f"depth_{depth:.0f}")
+    elif depth >= 12:
+        score += 3; reasons.append(f"depth_{depth:.0f}")
+    elif depth >= 6:
+        score += 2; reasons.append(f"depth_{depth:.0f}")
+    else:
+        score += 1; reasons.append(f"depth_{depth:.0f}")
+    if turn >= 10:
+        score += 2; reasons.append(f"turn_{turn:.0f}")
+    elif turn >= 4:
+        score += 1; reasons.append(f"turn_{turn:.0f}")
+    apm = abs(pm)
+    if apm >= 1.0:
+        score += 2; reasons.append(f"px_{pm:+.2f}%")
+    elif apm >= 0.3:
+        score += 1; reasons.append(f"px_{pm:+.2f}%")
+    return score, reasons
+
+
+def oversold_bounce(candles, inputs):
+    """Detect an RSI mean-reversion CROSS on a 1h candle list. Returns a signal dict
+    {direction, score, reasons, rsi} or None.
+
+    LONG iff — over the last `crossLookback` bars — RSI dipped BELOW `oversoldLevel`
+    (default 30) AND the CURRENT RSI is back at/above it AND rising (rsi[-1] > rsi[-2])
+    AND the last close > the prior close (price-reversal confirmation). SHORT is the
+    symmetric case around `overboughtLevel` (default 70). None if neither.
+
+    This is the anti-falling-knife gate: a still-FALLING RSI below the oversold line
+    does NOT trigger — it needs the cross back up + the rising RSI + the up bar.
+    Score scales with how deep the extreme went and the strength of the confirmation."""
+    period = int(_f(inputs.get("rsiPeriod"), 14))
+    oversold = _f(inputs.get("oversoldLevel"), 30)
+    overbought = _f(inputs.get("overboughtLevel"), 70)
+    cross_lb = int(_f(inputs.get("crossLookback"), 5))
+
+    closes = [_close(c) for c in candles]
+    if len(closes) < period + cross_lb + 1:          # need real RSI across the lookback
+        return None
+    rsi = rsi_series(closes, period)
+    cur, prev = rsi[-1], rsi[-2]
+    window = rsi[-(cross_lb + 1):-1]                  # the `cross_lb` bars BEFORE current
+    if not window:
+        return None
+    last_close, prior_close = _close(candles[-1]), _close(candles[-2])
+
+    # LONG — dipped below oversold, now crossed back up, RSI rising, price confirms
+    min_recent = min(window)
+    if min_recent < oversold and cur >= oversold and cur > prev and last_close > prior_close:
+        depth, turn, pm = oversold - min_recent, cur - prev, price_momentum(candles, 1)
+        score, comp = _reversion_score(depth, turn, pm)
+        return {"direction": "LONG", "score": score, "rsi": round(cur, 1),
+                "reasons": [f"rsi_cross_up_{prev:.0f}->{cur:.0f}", f"min_rsi_{min_recent:.0f}"] + comp}
+
+    # SHORT — popped above overbought, now crossed back down, RSI falling, price confirms
+    max_recent = max(window)
+    if max_recent > overbought and cur <= overbought and cur < prev and last_close < prior_close:
+        depth, turn, pm = max_recent - overbought, prev - cur, price_momentum(candles, 1)
+        score, comp = _reversion_score(depth, turn, pm)
+        return {"direction": "SHORT", "score": score, "rsi": round(cur, 1),
+                "reasons": [f"rsi_cross_down_{prev:.0f}->{cur:.0f}", f"max_rsi_{max_recent:.0f}"] + comp}
+
+    return None
+
+
+# ── conviction band + sizing (cloned from raven; salmon's tighter caps) ──
+
+def band_for(score, inputs):
+    """Conviction band from the reversion score."""
+    apex = _f(inputs.get("apexScore"), 7)
+    good = _f(inputs.get("goodScore"), 5)
+    if score >= apex:
+        return "apex"
+    if score >= good:
+        return "good"
+    return "base"
+
+
+def sizing_for(band, inputs, venue_max=None):
+    """(leverage, marginPct). marginPct is a PERCENT in (0,100]; clamped to salmon's
+    caps: leverage <= maxLeverage (default 4) and <= the venue max; margin <=
+    maxMarginPct (default 20). Reversions fail fast — moderate leverage by design."""
+    lev_tiers = inputs.get("leverageTiers") or {"apex": 4, "good": 3, "base": 2}
+    mgn_tiers = inputs.get("marginPctTiers") or {"apex": 12, "good": 9, "base": 6}
+    cap = int(_f(inputs.get("maxLeverage"), 4))
+    lev = int(_f(lev_tiers.get(band), 2))
+    if venue_max:
+        cap = min(cap, int(_f(venue_max, cap)))
+    lev = max(1, min(lev, cap))
+    mgn = _f(mgn_tiers.get(band), 6)
+    mgn = max(1.0, min(mgn, _f(inputs.get("maxMarginPct"), 20)))
+    return lev, round(mgn, 2)

--- a/strategies/salmon/strategy.yaml
+++ b/strategies/salmon/strategy.yaml
@@ -1,0 +1,44 @@
+# Salmon — RSI Mean-Reversion / Dip-Buyer. A single-instance PACKAGE: this manifest
+# + one self-contained runtime.yaml + scanners/. Buys oversold BOUNCES and sells
+# overbought FADES on liquid crypto majors via an RSI(14) CROSS-back detector
+# (dip below 30 -> cross back up rising -> LONG; symmetric around 70 -> SHORT).
+# The RSI/indicator math is ported verbatim from Bison; the edge is the cross-back +
+# reversal confirmation that makes it a mean-reversion play, NOT a falling-knife
+# catcher. NEVER closes — DSL owns every exit (tight, because reversions fail fast).
+schema_version: 1
+
+id: salmon
+version: "1.0.0"
+
+catalog:
+  name: "Salmon — RSI Mean-Reversion"
+  emoji: "🐟"
+  tagline: "Buys the bounce, not the falling knife. It watches the RSI on liquid majors and only steps in when an oversold coin has actually turned back up — a real cross off the lows with the candle confirming — going long the recovery (or short an overbought coin rolling over). It bets price snaps back to its average, sizes moderately because these turns fail fast, and lets a tight trailing stop do all the exiting."
+  belief_plain: "Trades the big liquid coins by their RSI. When one gets oversold it waits for it to actually turn back up before buying — not while it's still dropping — and when one gets overbought and starts rolling over it shorts the fade. It's betting the price springs back toward its average, keeps size moderate because these bounces can fail quickly, and never closes by hand: a tight stop protects and exits every trade."
+  thesis: "Stretched moves revert. When a liquid major gets pushed to an oversold extreme and then genuinely turns — RSI crossing back up through the line while the last candle confirms — the snap back toward the mean is the trade; the symmetric overbought roll-over is the short. The discipline is refusing to catch a falling knife: a low RSI alone is not a signal, only the confirmed cross-back is. Because reversions fail fast, leverage stays moderate and the DSL exit is tight — lock early, cut small."
+  group: multi-asset-universe
+  archetype: contrarian_fade
+  sub_style: mean_reversion
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 4
+  max_slots: 5
+  min_budget: 100
+  assets: []                 # DERIVED live from the main DEX (vol floor + top-N liquid majors)
+  tags: [mean-reversion, rsi, oversold, dip-buy, contrarian, reversion, dsl-only]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name salmon-main, group salmon
+    wallet_env: SALMON_WALLET
+    funding_share: 1.0

--- a/strategies/salmon/tests/test_engine.py
+++ b/strategies/salmon/tests/test_engine.py
@@ -1,0 +1,168 @@
+"""Salmon engine tests — pure/deterministic RSI mean-reversion detector, plus a
+scan() smoke run against a fake ctx (no network). Run:
+  python3 -m pytest strategies/salmon/tests -q
+  python3 strategies/salmon/tests/test_engine.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "main", "scanners"))
+import scoring  # noqa: E402
+
+
+def _candles_from_closes(closes):
+    """Minimal OHLCV candle dicts from a close series (RSI/momentum use close)."""
+    return [{"open": c, "high": c + 1, "low": c - 1, "close": c, "volume": 1000} for c in closes]
+
+
+def _long_bounce_closes():
+    """Long decline (RSI -> 0) then a 3-bar rally that crosses RSI back up through 30
+    while still rising, with the final close up. min RSI over the lookback is ~0."""
+    down = [100 - 2 * i for i in range(21)]     # 100,98,...,60  → RSI pinned near 0
+    up = [64, 68, 72]                            # +4/bar → RSI recovers up through 30
+    return down + up
+
+
+def _short_fade_closes():
+    """Symmetric: long rally (RSI -> 100) then a 3-bar drop that crosses RSI back down
+    through 70 while still falling, with the final close down."""
+    up = [40 + 2 * i for i in range(21)]         # 40,42,...,80  → RSI pinned near 100
+    down = [76, 72, 68]                          # -4/bar → RSI rolls down through 70
+    return up + down
+
+
+def _still_falling_closes():
+    """Strictly decreasing — RSI sits at 0 and is NOT rising. Anti-falling-knife: a
+    low RSI that has not turned must NOT trigger a LONG."""
+    return [100 - 2 * i for i in range(24)]
+
+
+# ── rsi_series: index-aligned + verbatim reuse of calc_rsi ──
+
+def test_rsi_series_aligned_and_reuses_calc_rsi():
+    closes = [100 - i for i in range(20)]        # strictly down
+    s = scoring.rsi_series(closes)
+    assert len(s) == len(closes)                 # index-aligned to closes
+    assert s[0] == 50                            # < period+1 history → calc_rsi's neutral 50
+    assert s[-1] == 0.0                          # pure downtrend → RSI 0
+    assert s[-1] == scoring.calc_rsi(closes)     # last bar == full-series calc_rsi (verbatim)
+
+
+# ── oversold_bounce: LONG cross-up, anti-falling-knife None, SHORT symmetric ──
+
+def test_oversold_bounce_long_on_confirmed_cross_up():
+    sig = scoring.oversold_bounce(_candles_from_closes(_long_bounce_closes()), {})
+    assert sig is not None
+    assert sig["direction"] == "LONG"
+    assert sig["score"] > 0
+    assert sig["rsi"] >= 30                       # current RSI is back above the oversold line
+    assert any("cross_up" in r for r in sig["reasons"])
+
+
+def test_oversold_bounce_none_when_still_falling():
+    # RSI is deep below 30 but STILL FALLING (not crossed back up) → no signal.
+    sig = scoring.oversold_bounce(_candles_from_closes(_still_falling_closes()), {})
+    assert sig is None                            # anti-falling-knife gate
+
+
+def test_oversold_bounce_short_on_overbought_symmetric():
+    sig = scoring.oversold_bounce(_candles_from_closes(_short_fade_closes()), {})
+    assert sig is not None
+    assert sig["direction"] == "SHORT"
+    assert sig["score"] > 0
+    assert sig["rsi"] <= 70                       # current RSI is back below the overbought line
+    assert any("cross_down" in r for r in sig["reasons"])
+
+
+def test_oversold_bounce_none_on_short_history():
+    # Fewer than period + crossLookback + 1 bars → cannot resolve a cross → None.
+    sig = scoring.oversold_bounce(_candles_from_closes(_long_bounce_closes()[:12]), {})
+    assert sig is None
+
+
+def test_oversold_bounce_respects_custom_levels():
+    # Tightening the oversold line to 20 makes the shallow cross emit differently;
+    # a symmetric-config sanity check that inputs are honored (no crash, valid dict).
+    sig = scoring.oversold_bounce(_candles_from_closes(_long_bounce_closes()),
+                                  {"oversoldLevel": 30, "overboughtLevel": 70, "crossLookback": 5})
+    assert sig and sig["direction"] == "LONG"
+
+
+# ── band_for + sizing_for: conviction bands and salmon's caps (leverage <= 4) ──
+
+def test_band_and_sizing_caps():
+    inp = {"apexScore": 7, "goodScore": 5,
+           "leverageTiers": {"apex": 4, "good": 3, "base": 2},
+           "marginPctTiers": {"apex": 12, "good": 9, "base": 6},
+           "maxLeverage": 4, "maxMarginPct": 20}
+    assert scoring.band_for(8, inp) == "apex"
+    assert scoring.band_for(5, inp) == "good"
+    assert scoring.band_for(3, inp) == "base"
+
+    lev, mgn = scoring.sizing_for("apex", inp, venue_max=10)
+    assert lev == 4 and 0 < mgn <= 20            # leverage capped at maxLeverage 4
+    lev2, _ = scoring.sizing_for("apex", inp, venue_max=3)
+    assert lev2 == 3                             # clamped further to the venue max
+    assert scoring.sizing_for("base", inp)[0] == 2
+    # a mis-tiered margin can never exceed the cap
+    _, mgn3 = scoring.sizing_for("apex", {"marginPctTiers": {"apex": 50}, "maxMarginPct": 20})
+    assert mgn3 == 20
+
+
+# ── scan() smoke against a fake ctx (no network) ──
+
+class _State:
+    def __init__(self): self._log = []
+    def last(self): return self._log[-1] if self._log else None
+    def append(self, d): self._log.append(d)
+
+
+class _MCP:
+    def __init__(self, candles):
+        self.candles = candles
+    def call_tool(self, tool, args):
+        if tool == "market_list_instruments":
+            return {"data": {"instruments": [
+                {"name": "BTC", "context": {"dayNtlVlm": 5e8, "maxLeverage": 5}},
+                {"name": "ETH", "context": {"dayNtlVlm": 4e8, "maxLeverage": 5}}]}}
+        if tool == "market_get_asset_data":
+            return {"data": {"candles": {"1h": self.candles}}}
+        if tool == "strategy_get_clearinghouse_state":
+            return {"data": {"assetPositions": []}}
+        return {}
+
+
+class _Ctx:
+    def __init__(self, candles):
+        self.wallet = "0xabc"
+        self.state = _State()
+        self.senpi_mcp = _MCP(candles)
+
+
+def test_scan_smoke_returns_valid_signals():
+    import scan
+    ctx = _Ctx(_candles_from_closes(_long_bounce_closes()))
+    inputs = {"maxSlots": 5, "includeXyz": False, "universeVolFloorUsd": 1e6, "maxUniverse": 10,
+              "recentSignalTtlSeconds": 14400, "oversoldLevel": 30, "overboughtLevel": 70,
+              "crossLookback": 5, "apexScore": 7, "goodScore": 5,
+              "leverageTiers": {"apex": 4, "good": 3, "base": 2},
+              "marginPctTiers": {"apex": 12, "good": 9, "base": 6},
+              "maxLeverage": 4, "maxMarginPct": 20}
+    out = scan.scan(inputs, ctx)
+    assert isinstance(out, list) and len(out) >= 1        # BTC + ETH both bounce
+    for s in out:
+        assert set(("asset", "direction", "marginPct", "leverage", "data")) <= set(s)
+        assert 0 < s["marginPct"] <= 20                   # PERCENT within salmon's cap
+        assert 1 <= s["leverage"] <= 4                    # moderate leverage cap
+        assert s["direction"] in ("LONG", "SHORT")
+        assert s["data"]["band"] in ("apex", "good", "base")
+        assert "rsi" in s["data"] and "score" in s["data"]
+    assert ctx.state.last() is not None                   # state persisted
+    assert "recent" in ctx.state.last()
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn(); print(f"ok  {fn.__name__}")
+    print(f"\nALL {len(fns)} SALMON TESTS PASS")

--- a/strategies/viper/main/runtime.yaml
+++ b/strategies/viper/main/runtime.yaml
@@ -1,0 +1,126 @@
+# ── VIPER · SMC/ICT + Wyckoff Structure Trader ───────────────────────────────
+# Trades market structure the way a smart-money-concepts trader reads a chart. On a
+# derived universe (main + xyz, vol floor + top-N) it maps swing highs/lows, then
+# enters on a Break of Structure (BOS, continuation) or Change of Character (CHoCH,
+# reversal) that lines up with a liquidity sweep (a wick that runs stops past a prior
+# swing then closes back inside), a Fair Value Gap (3-candle imbalance), and an
+# agreeing 4h structure. Conviction-banded sizing, leverage clamped to venue max.
+# NEVER closes — the DSL owns every exit and the drawdown_halt is the equity backstop.
+name: viper-main
+group: viper
+version: 1.0.0
+description: >
+  VIPER — SMC/ICT + Wyckoff Structure Trader. A universe structure book (main + xyz
+  derived, vol floor + top-N) that maps swing highs/lows and enters in the structure
+  direction when a Break of Structure or Change of Character lines up with a liquidity
+  sweep, a Fair Value Gap, and an agreeing higher timeframe. Up to 6 conviction-banded
+  positions, leverage clamped to venue max. DSL is the ONLY exit (15% Phase 1, granular
+  profit-lock ladder to +90%, 24h weak-peak).
+
+strategy:
+  wallet: "${VIPER_WALLET}"
+  slots: 6
+  margin_pct: 10
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+
+  - name: viper_scanner
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900             # wake every 15m; map structure, fill free slots
+    timeout_seconds: 300
+    default_signal_validity_seconds: 3600
+    state_history_max_count: 200
+    inputs:
+      # ── universe ──
+      includeXyz: true
+      universeVolFloorUsd: 25000000
+      xyzVolFloorUsd: 3000000
+      maxUniverse: 40
+      maxSlots: 6
+      recentSignalTtlSeconds: 21600
+      # ── structure engine ──
+      minScore: 5                     # entry floor on the composite structure score
+      apexScore: 9                    # conviction bands
+      goodScore: 7
+      swingLeft: 2                    # fractal pivot confirmation (bars before)
+      swingRight: 2                   # fractal pivot confirmation (bars after)
+      # ── sizing ──
+      leverageTiers: { apex: 5, good: 4, base: 3 }
+      marginPctTiers: { apex: 14, good: 10, base: 7 }
+      maxLeverage: 5
+      maxMarginPct: 25
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      band: { type: string, required: false }
+      structure: { type: string, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+
+  - name: viper_open
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [viper_scanner]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: viper_scanner
+  # NO CLOSE_POSITION action — DSL is the only exit.
+
+# EXIT — DSL only. Granular breakeven-first ladder (no back-loaded gap): locks
+# early and ramps smoothly so a modest winner isn't given all the way back.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 1440        # 24h — a stalled structure name frees its slot
+      min_value: 2.5
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 0 }
+        - { trigger_pct: 15, lock_hw_pct: 35 }
+        - { trigger_pct: 25, lock_hw_pct: 52 }
+        - { trigger_pct: 40, lock_hw_pct: 65 }
+        - { trigger_pct: 60, lock_hw_pct: 77 }
+        - { trigger_pct: 90, lock_hw_pct: 86 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 6
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 900
+    per_asset_cooldown_seconds: 21600
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true

--- a/strategies/viper/main/scanners/scan.py
+++ b/strategies/viper/main/scanners/scan.py
@@ -1,0 +1,161 @@
+"""VIPER — SMC/ICT + Wyckoff Structure Trader. The single supervised scanner.
+
+A market-structure book that trades the tape the way smart-money-concepts traders
+do. Each tick:
+  1) Read held positions; free = maxSlots − held. NEVER closes — the DSL owns every
+     exit and the runtime's drawdown_halt is the equity backstop.
+  2) Derive the live universe (main + xyz, vol floor + top-N by volume, like raven).
+  3) For each candidate with a free slot, fetch 1h + 4h candles and run the pure
+     structure engine (scoring.score_structure): a Break of Structure / Change of
+     Character on 1h sets the direction; a liquidity sweep, a Fair Value Gap, and an
+     agreeing 4h structure stack confluence into the score. Gate on minScore, size by
+     conviction band (venue-clamped), emit.
+  4) recent + TTL dedup so a just-signalled name isn't re-fired; persist {recent, result}.
+
+Read-only + single-pass. marginPct is a PERCENT in (0,100]. No daemon; never raises.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001 — degrade, never crash the tick
+        print("[viper.scan] %s read failed: %r" % (label, exc), file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _dex_of(name):
+    return "xyz" if str(name).lower().startswith("xyz:") else ""
+
+
+def _instrument_rows(ctx, dex):
+    data = _read(ctx, "market_list_instruments", ({"dex": dex} if dex else {}),
+                 "market_list_instruments(%s)" % (dex or "main"))
+    if data is None:
+        return None
+    insts = data.get("instruments", data.get("universe", data)) if isinstance(data, dict) else data
+    if not isinstance(insts, list):
+        return None
+    rows = []
+    for inst in insts:
+        if not isinstance(inst, dict) or inst.get("is_delisted"):
+            continue
+        name = inst.get("name") or (inst.get("context", {}) or {}).get("coin")
+        if not name:
+            continue
+        c = inst.get("context", {}) if isinstance(inst.get("context"), dict) else {}
+        vol = scoring._f(c.get("dayNtlVlm"))
+        venue = c.get("max_leverage", c.get("maxLeverage")) or inst.get("max_leverage")
+        rows.append({"name": str(name), "vol": vol, "venue_max": venue, "dex": _dex_of(name)})
+    return rows
+
+
+def _derive_universe(ctx, inputs):
+    """Live top-N liquid names, main (+ xyz iff enabled), over the vol floor."""
+    main = _instrument_rows(ctx, "")
+    if main is None:
+        return None
+    rows = list(main)
+    if bool(inputs.get("includeXyz", True)):
+        rows += (_instrument_rows(ctx, "xyz") or [])
+    vfloor = scoring._f(inputs.get("universeVolFloorUsd"), 25_000_000)
+    xfloor = scoring._f(inputs.get("xyzVolFloorUsd"), 3_000_000)
+    keep = [r for r in rows if r["vol"] >= (xfloor if r["dex"] == "xyz" else vfloor)]
+    keep.sort(key=lambda r: r["vol"], reverse=True)
+    cap = int(scoring._f(inputs.get("maxUniverse"), 40))
+    return keep[:cap]
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["1h", "4h"],
+        "include_funding": False, "include_order_book": False, "dex": _dex_of(name),
+    }, "market_get_asset_data(%s)" % name)
+
+
+def _held(ctx):
+    d = _read(ctx, "strategy_get_clearinghouse_state",
+              {"strategy_wallet": ctx.wallet}, "strategy_get_clearinghouse_state")
+    if not isinstance(d, dict):
+        return None
+    out = set()
+    for e in d.get("assetPositions", d.get("asset_positions", [])) or []:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 6))
+    min_score = scoring._f(inputs.get("minScore"), 5)
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 21600)
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    recent = dict(st.get("recent", {}) or {})
+
+    held = _held(ctx)
+    if held is None:
+        return []                                    # clearinghouse unreadable — act next tick
+    free = max_slots - len(held)
+
+    out = []
+    if free > 0:
+        universe = _derive_universe(ctx, inputs)
+        if universe is None:
+            print("[viper.scan] instruments unreadable — no opens this tick", file=sys.stderr)
+        else:
+            looked = 0
+            for row in universe:
+                if free <= 0 or looked >= max(12, free * 4):
+                    break
+                name = row["name"]
+                bare = str(name).split(":", 1)[-1].upper()
+                if bare in held:
+                    continue
+                if recent.get(bare) is not None and (now - recent[bare]) < ttl:
+                    continue
+                looked += 1
+                md = _asset_data(ctx, name)
+                if not md:
+                    continue
+                candles = md.get("candles", {}) or {}
+                th = scoring.score_structure(candles.get("1h", []), candles.get("4h", []), inputs)
+                if not th or th["score"] < min_score:
+                    continue
+                band = scoring.band_for(th["score"], inputs)
+                lev, mgn = scoring.sizing_for(band, inputs, row.get("venue_max"))
+                recent[bare] = now
+                free -= 1
+                out.append({
+                    "asset": name, "direction": th["direction"], "marginPct": mgn, "leverage": lev,
+                    "data": {"score": th["score"], "leverage": lev, "direction": th["direction"],
+                             "band": band, "structure": th["structure"], "reasons": th["reasons"]},
+                })
+                print("[viper.scan] OPEN %s %s: score=%s struct=%s band=%s %sx %s%% (minScore %g)"
+                      % (th["direction"], name, th["score"], th["structure"], band, lev, mgn, min_score),
+                      file=sys.stderr)
+
+    if not out:
+        print("[viper.scan] no opens: held=%d/%d free=%d minScore=%g"
+              % (len(held), max_slots, free, min_score), file=sys.stderr)
+
+    if ctx.state is not None:
+        try:
+            ctx.state.append({
+                "recent": recent,
+                "result": {"ts": now, "opened": len(out), "held": len(held), "free": free},
+            })
+        except Exception as exc:  # noqa: BLE001
+            print("[viper.scan] WARNING: state append failed: %r" % (exc,), file=sys.stderr)
+    return out

--- a/strategies/viper/main/scanners/scoring.py
+++ b/strategies/viper/main/scanners/scoring.py
@@ -1,0 +1,286 @@
+"""VIPER — pure market-structure math (no I/O, no MCP, no clock).
+
+Smart-Money-Concepts / ICT + Wyckoff STRUCTURE engine, entirely unit-testable on
+plain candle lists. Nothing here reaches the network; scan.py does all the MCP
+orchestration and passes candle lists in.
+
+The pipeline maps the tape the way an SMC/ICT trader reads it:
+
+  1. swings()          — confirmed swing-high / swing-low pivots (fractal: a high
+                         that exceeds `left` bars before AND `right` bars after).
+  2. structure()       — Break of Structure (BOS, trend continuation) vs Change of
+                         Character (CHoCH, the first close through the OPPOSING swing
+                         = a reversal). Direction is set by which side breaks.
+  3. liquidity_sweep() — a wick that runs stops PAST a prior swing then closes back
+                         inside (above a swing high → bearish; below a swing low →
+                         bullish). The classic stop-hunt / spring.
+  4. fvg()             — a 3-candle Fair Value Gap (imbalance): candle[i-1].high <
+                         candle[i+1].low is a bullish gap; candle[i-1].low >
+                         candle[i+1].high is a bearish gap.
+  5. score_structure() — direction comes from the 1h structure break; the score
+                         stacks confluence (sweep aligned, FVG aligned, 4h structure
+                         agreeing) and is gated to minScore by the CALLER (scan.py).
+
+band_for / sizing_for are cloned from raven (conviction tiers, clamped to the fleet
++ venue leverage caps). VIPER never closes — the DSL owns every exit.
+
+NOTE: the market_get_asset_data candle payload shape was NOT live-verified when this
+was written (auth token was invalid). The candle accessors below are dual-shape
+(dict {high|h,…} OR list [t,o,h,l,c,v]), ported verbatim from bison, so a real payload
+in either shape reads correctly; scan.py extracts candles tolerantly.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _num(v):
+    """Float or None (distinguishes a real 0.0 from a missing field)."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+# ── candle accessors (dual-shape: dict {close|c} OR list [t,o,h,l,c,v]) ──
+# Ported VERBATIM from bison/scoring.py — do not diverge (a fidelity harness
+# diffs viper's structure reads against bison's on the same candles).
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", c.get("vlm", 0))))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── 1. swings — confirmed fractal pivots ──────────────────────────────────────
+
+def swings(candles, left=2, right=2):
+    """Confirmed swing pivots. A pivot HIGH at i has _high(i) strictly greater than
+    the `left` bars before AND the `right` bars after; a pivot LOW is the mirror on
+    _low. The last `right` bars can never be pivots (unconfirmed), so every returned
+    pivot is 'prior' to the forming edge. Returns a list of
+    {"idx","price","kind":"high"|"low"} in index order (never raises)."""
+    out = []
+    n = len(candles)
+    left = max(1, int(left))
+    right = max(1, int(right))
+    if n < left + right + 1:
+        return out
+    for i in range(left, n - right):
+        hi = _high(candles[i])
+        lo = _low(candles[i])
+        is_high = (all(hi > _high(candles[j]) for j in range(i - left, i)) and
+                   all(hi > _high(candles[j]) for j in range(i + 1, i + right + 1)))
+        is_low = (all(lo < _low(candles[j]) for j in range(i - left, i)) and
+                  all(lo < _low(candles[j]) for j in range(i + 1, i + right + 1)))
+        if is_high:
+            out.append({"idx": i, "price": hi, "kind": "high"})
+        if is_low:
+            out.append({"idx": i, "price": lo, "kind": "low"})
+    return out
+
+
+def _highs(pivots):
+    return [p for p in pivots if p["kind"] == "high"]
+
+
+def _lows(pivots):
+    return [p for p in pivots if p["kind"] == "low"]
+
+
+def _bias(highs, lows):
+    """Structural bias from the last two swing highs + lows.
+    Higher-high AND higher-low → BULLISH; lower-high AND lower-low → BEARISH;
+    anything mixed / too few pivots → NEUTRAL."""
+    if len(highs) >= 2 and len(lows) >= 2:
+        hh = highs[-1]["price"] > highs[-2]["price"]
+        lh = highs[-1]["price"] < highs[-2]["price"]
+        hl = lows[-1]["price"] > lows[-2]["price"]
+        ll = lows[-1]["price"] < lows[-2]["price"]
+        if hh and hl:
+            return "BULLISH"
+        if lh and ll:
+            return "BEARISH"
+    return "NEUTRAL"
+
+
+# ── 2. structure — BOS vs CHoCH ───────────────────────────────────────────────
+
+def structure(candles, left=2, right=2):
+    """(direction, kind). direction ∈ {"LONG","SHORT",None}; kind ∈ {"BOS","CHoCH","NONE"}.
+
+    Reads the last close against the MOST-RECENT confirmed swing high / low:
+      • close > most-recent swing high → bullish break (LONG)
+      • close < most-recent swing low  → bearish break (SHORT)
+    A break that CONTINUES the standing bias is a BOS; the first close through the
+    OPPOSING swing (breaking up while the bias was bearish, or down while bullish)
+    is a CHoCH — the reversal tell. Neutral bias + a break = BOS (a fresh breakout).
+    Returns (None,"NONE") when there is no swing high/low to reference."""
+    piv = swings(candles, left, right)
+    highs, lows = _highs(piv), _lows(piv)
+    if not candles or not highs or not lows:
+        return (None, "NONE")
+    sh = highs[-1]["price"]
+    sl = lows[-1]["price"]
+    c = _close(candles[-1])
+    bias = _bias(highs, lows)
+    if c > sh:
+        return ("LONG", "CHoCH" if bias == "BEARISH" else "BOS")
+    if c < sl:
+        return ("SHORT", "CHoCH" if bias == "BULLISH" else "BOS")
+    return (None, "NONE")
+
+
+# ── 3. liquidity sweep — stop-hunt wick that closes back inside ────────────────
+
+def liquidity_sweep(candles, left=2, right=2):
+    """(swept, dir). The last bar runs liquidity beyond a PRIOR swing then closes
+    back inside:
+      • wick ABOVE the most-recent swing high but close back BELOW it → bearish (SHORT)
+      • wick BELOW the most-recent swing low  but close back ABOVE it → bullish (LONG)
+    Returns (False, None) when neither fires (never raises)."""
+    if not candles:
+        return (False, None)
+    piv = swings(candles, left, right)
+    highs, lows = _highs(piv), _lows(piv)
+    last = candles[-1]
+    h, l, c = _high(last), _low(last), _close(last)
+    if highs:
+        sh = highs[-1]["price"]
+        if h > sh and c < sh:
+            return (True, "SHORT")
+    if lows:
+        sl = lows[-1]["price"]
+        if l < sl and c > sl:
+            return (True, "LONG")
+    return (False, None)
+
+
+# ── 4. fair value gap — 3-candle imbalance in the last few bars ────────────────
+
+def fvg(candles, lookback=5):
+    """(present, dir). Scans the last `lookback` 3-candle windows, newest-first, for
+    an imbalance around the middle bar i:
+      • bullish gap: high(i-1) < low(i+1)   → LONG
+      • bearish gap: low(i-1)  > high(i+1)  → SHORT
+    Returns the most-recent gap found, else (False, None) (never raises)."""
+    n = len(candles)
+    if n < 3:
+        return (False, None)
+    lo_i = max(1, n - 1 - int(max(1, lookback)))
+    for i in range(n - 2, lo_i - 1, -1):        # middle index, newest window first
+        if i < 1 or i + 1 > n - 1:
+            continue
+        if _high(candles[i - 1]) < _low(candles[i + 1]):
+            return (True, "LONG")
+        if _low(candles[i - 1]) > _high(candles[i + 1]):
+            return (True, "SHORT")
+    return (False, None)
+
+
+# ── 5. score — direction from 1h structure, confluence stacked on top ──────────
+
+def score_structure(candles_1h, candles_4h, inputs):
+    """Compose the structure read into {direction, score, reasons, structure} or None.
+
+    Direction is set by the 1h structure break (None ⇒ no trade this tick, return None).
+    Score stacks confluence (minScore is applied by the CALLER, scan.py):
+        BOS +3 / CHoCH +2
+        liquidity sweep aligned with the break  +2
+        Fair Value Gap aligned with the break    +1
+        4h structure agrees +2  /  opposes −2
+    """
+    left = int(_f((inputs or {}).get("swingLeft"), 2))
+    right = int(_f((inputs or {}).get("swingRight"), 2))
+
+    d1, kind = structure(candles_1h, left, right)
+    if d1 is None:
+        return None
+
+    reasons = []
+    score = 3 if kind == "BOS" else 2
+    reasons.append("1h_%s_%s" % (kind.lower(), d1.lower()))
+
+    swept, sdir = liquidity_sweep(candles_1h, left, right)
+    if swept and sdir == d1:
+        score += 2
+        reasons.append("sweep_aligned_%s" % sdir.lower())
+    elif swept and sdir is not None:
+        reasons.append("sweep_opposing_%s" % sdir.lower())
+
+    present, fdir = fvg(candles_1h)
+    if present and fdir == d1:
+        score += 1
+        reasons.append("fvg_aligned_%s" % fdir.lower())
+    elif present and fdir is not None:
+        reasons.append("fvg_opposing_%s" % fdir.lower())
+
+    d4, kind4 = structure(candles_4h, left, right)
+    if d4 == d1:
+        score += 2
+        reasons.append("4h_agrees_%s" % kind4.lower())
+    elif d4 is not None:
+        score -= 2
+        reasons.append("4h_opposes_%s" % d4.lower())
+
+    return {"direction": d1, "score": score, "reasons": reasons, "structure": kind}
+
+
+# ── conviction band + sizing (cloned from raven — tiers, venue-clamped) ────────
+
+def band_for(score, inputs):
+    """Conviction band from the composite score."""
+    apex = _f((inputs or {}).get("apexScore"), 9)
+    good = _f((inputs or {}).get("goodScore"), 7)
+    if score >= apex:
+        return "apex"
+    if score >= good:
+        return "good"
+    return "base"
+
+
+def sizing_for(band, inputs, venue_max=None):
+    """(leverage, marginPct). marginPct is a PERCENT in (0,100]; leverage is clamped
+    to the fleet cap (maxLeverage) AND the venue's max_leverage, floored at 1x."""
+    inputs = inputs or {}
+    lev_tiers = inputs.get("leverageTiers") or {"apex": 5, "good": 4, "base": 3}
+    mgn_tiers = inputs.get("marginPctTiers") or {"apex": 14, "good": 10, "base": 7}
+    cap = int(_f(inputs.get("maxLeverage"), 5))
+    lev = int(_f(lev_tiers.get(band), 3))
+    if venue_max:
+        cap = min(cap, int(_f(venue_max, cap)))
+    lev = max(1, min(lev, cap))
+    mgn = _f(mgn_tiers.get(band), 7)
+    mgn = max(1.0, min(mgn, _f(inputs.get("maxMarginPct"), 25)))
+    return lev, round(mgn, 2)

--- a/strategies/viper/strategy.yaml
+++ b/strategies/viper/strategy.yaml
@@ -1,0 +1,41 @@
+# Viper — SMC/ICT + Wyckoff Structure Trader. Single-wallet PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/ (a pure market-structure engine: swing
+# mapping, Break of Structure / Change of Character, liquidity sweeps, Fair Value Gaps).
+# Universe-derived like raven, single-instance `main`. NEVER closes — DSL owns every exit.
+schema_version: 1
+
+id: viper
+version: "1.0.0"
+
+catalog:
+  name: "Viper — SMC/ICT Structure Trader"
+  emoji: "🐍"
+  tagline: "Reads a chart the way a smart-money trader does. It marks the recent peaks and troughs, then waits for price to actually break structure — punch through a prior high (or low) — and only takes the trade when the break is backed by a stop-hunt wick that grabbed liquidity and snapped back, a price gap that shows one-sided pressure, and the bigger-picture 4h trend pointing the same way. A trailing stop does all the exiting; Viper never sells manually."
+  belief_plain: "Markets move from one pool of resting stop orders to the next, and the honest tell is structure: a 'Break of Structure' is price closing past the last swing high or low in the trend's direction (it's continuing), and a 'Change of Character' is the first close through the OPPOSITE swing (the trend may be flipping). Viper enters on those breaks — but only the high-quality ones, where a liquidity sweep (a wick that runs the stops just past a prior swing then closes back inside) and a fair-value gap (a 3-candle imbalance where price left a gap it tends to revisit) agree with it, and the 4h structure confirms. It never manually closes — a ratchet stop protects and exits every position, and a hard drawdown halt is the backstop."
+  thesis: "Price is delivered between liquidity pools, and market structure — not an oscillator — is the cleanest read on which pool is next. Viper maps confirmed swing pivots, classifies each close through the most-recent swing as a Break of Structure (continuation) or Change of Character (reversal), and requires SMC/ICT confluence before committing: a liquidity sweep of a prior swing that closes back inside (the stop-hunt / Wyckoff spring), a 3-candle Fair Value Gap in the break direction, and higher-timeframe (4h) structure agreement. Confluence is scored, conviction-banded, and gated to a minimum; sizing scales with conviction and leverage is clamped to the venue max. The edge is entry QUALITY on structure; the DSL owns exits and the runtime drawdown_halt is the equity backstop."
+  group: multi-asset-universe
+  archetype: breakout_momentum
+  sub_style: market_structure
+  asset_classes: [btc_eth, major_alts, xyz_equities, commodities]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 6
+  min_budget: 100
+  assets: []                 # DERIVED live from both dexes (vol floor + top-N)
+  tags: [smc, ict, wyckoff, market-structure, liquidity-sweep, fvg, bos, choch]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml         # → runtime name viper-main, group viper
+    wallet_env: VIPER_WALLET
+    funding_share: 1.0

--- a/strategies/viper/tests/test_engine.py
+++ b/strategies/viper/tests/test_engine.py
@@ -1,0 +1,204 @@
+"""Viper structure-engine tests. Pure/deterministic (swings, BOS/CHoCH, liquidity
+sweep, FVG, scoring, sizing) + a scan() smoke run against a fake ctx (no network).
+Run: python3 -m pytest strategies/viper/tests -q   OR   python3 strategies/viper/tests/test_engine.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "main", "scanners"))
+import scoring  # noqa: E402
+
+
+def _c(h, l, c, v=1000):
+    """One candle dict (open irrelevant to the structure math)."""
+    return {"open": c, "high": h, "low": l, "close": c, "volume": v}
+
+
+def _up(n, step=2, start=100.0):
+    """Strictly monotone-up series → NO interior pivots (clean 'nothing happening')."""
+    out, p = [], start
+    for _ in range(n):
+        out.append(_c(p + step + 1, p - 1, p + step))
+        p += step
+    return out
+
+
+def _flat(n):
+    return [_c(100, 99, 99.5) for _ in range(n)]
+
+
+# Clean bullish setup: a confirmed swing high (idx5=110) + swing low (idx7=101);
+# the last bar closes 114 (> swing high → BOS LONG), wicks to 100 (< swing low 101,
+# closes back above → bullish liquidity sweep), and a bullish FVG sits at bars 8-9-10
+# (high[8]=107 < low[10]=108). Hand-verified.
+BOS = [
+    _c(101, 99, 100),   # 0
+    _c(102, 98, 99),    # 1
+    _c(100, 95, 96),    # 2  swing low = 95
+    _c(103, 97, 102),   # 3
+    _c(106, 100, 105),  # 4
+    _c(110, 104, 108),  # 5  swing high = 110
+    _c(108, 102, 104),  # 6
+    _c(106, 101, 103),  # 7  swing low = 101 (most recent)
+    _c(107, 103, 106),  # 8
+    _c(109, 105, 108),  # 9
+    _c(112, 108, 111),  # 10 (low 108 opens a bullish FVG vs high[8]=107)
+    _c(116, 100, 114),  # 11 last: close>swing-high AND wick<swing-low, closes back above
+]
+
+# Bullish bias (higher-high 108→113, higher-low 96→100) then the last close (96)
+# breaks BELOW the most-recent swing low (100) → SHORT CHoCH (reversal). Hand-verified.
+CHOCH = [
+    _c(101, 99, 100),   # 0
+    _c(103, 100, 102),  # 1
+    _c(100, 96, 97),    # 2  swing low = 96
+    _c(105, 99, 104),   # 3
+    _c(108, 102, 107),  # 4  swing high = 108
+    _c(106, 101, 103),  # 5
+    _c(104, 100, 102),  # 6  swing low = 100 (higher low)
+    _c(110, 104, 109),  # 7
+    _c(113, 107, 112),  # 8  swing high = 113 (higher high, most recent)
+    _c(111, 105, 107),  # 9
+    _c(108, 103, 104),  # 10
+    _c(106, 100, 102),  # 11
+    _c(104, 98, 100),   # 12
+    _c(101, 95, 96),    # 13 last: close 96 < swing low 100 → break down
+]
+
+
+def test_swings_finds_confirmed_pivots():
+    piv = scoring.swings(BOS, left=2, right=2)
+    highs = [p for p in piv if p["kind"] == "high"]
+    lows = [p for p in piv if p["kind"] == "low"]
+    assert any(p["idx"] == 5 and p["price"] == 110 for p in highs)      # swing high
+    assert any(p["idx"] == 2 and p["price"] == 95 for p in lows)        # swing low
+    assert any(p["idx"] == 7 and p["price"] == 101 for p in lows)       # most-recent low
+    # the last `right` bars can never be confirmed pivots
+    assert all(p["idx"] <= len(BOS) - 1 - 2 for p in piv)
+    assert scoring.swings(_up(3), 2, 2) == []                           # too few bars → none
+    assert scoring.swings(_up(20)) == []                                # monotone → no pivots
+
+
+def test_structure_bos_and_choch():
+    assert scoring.structure(BOS) == ("LONG", "BOS")
+    assert scoring.structure(CHOCH) == ("SHORT", "CHoCH")
+    assert scoring.structure(_flat(10)) == (None, "NONE")              # no pivots → no read
+    assert scoring.structure([]) == (None, "NONE")                     # empty → safe
+
+
+def test_liquidity_sweep_true_and_false():
+    # bearish sweep: wick above a confirmed swing high (108), close back below
+    swept_series = [_c(100, 98, 99), _c(101, 99, 100), _c(108, 103, 106),
+                    _c(104, 100, 102), _c(103, 99, 101), _c(110, 104, 105)]
+    assert scoring.liquidity_sweep(swept_series) == (True, "SHORT")
+    # BOS series' last bar sweeps the swing low (100 < 101) and closes back above
+    assert scoring.liquidity_sweep(BOS) == (True, "LONG")
+    # clean monotone series: no swing to sweep
+    assert scoring.liquidity_sweep(_up(12)) == (False, None)
+    assert scoring.liquidity_sweep([]) == (False, None)
+
+
+def test_fvg_true_and_false():
+    bull = [_c(101, 99, 100), _c(105, 100, 103), _c(110, 106, 108)]     # high[0]=101 < low[2]=106
+    bear = [_c(110, 106, 108), _c(104, 100, 102), _c(99, 95, 97)]       # low[0]=106 > high[2]=99
+    none = [_c(105, 100, 102), _c(106, 101, 103), _c(107, 102, 104)]    # overlapping — no gap
+    assert scoring.fvg(bull) == (True, "LONG")
+    assert scoring.fvg(bear) == (True, "SHORT")
+    assert scoring.fvg(none) == (False, None)
+    assert scoring.fvg([_c(1, 1, 1)]) == (False, None)                  # < 3 bars → safe
+
+
+def test_score_structure_directional_and_none():
+    # clean BOS + aligned sweep + aligned FVG + agreeing 4h → LONG, high score
+    th = scoring.score_structure(BOS, BOS, {"swingLeft": 2, "swingRight": 2})
+    assert th is not None
+    assert th["direction"] == "LONG"
+    assert th["structure"] == "BOS"
+    assert th["score"] >= 5                                             # 3 BOS +2 sweep +1 fvg +2 4h = 8
+    joined = " ".join(th["reasons"])
+    assert "sweep_aligned" in joined and "fvg_aligned" in joined and "4h_agrees" in joined
+    # CHoCH short with agreeing 4h resolves a directional SHORT
+    ths = scoring.score_structure(CHOCH, CHOCH, {})
+    assert ths is not None and ths["direction"] == "SHORT" and ths["structure"] == "CHoCH"
+    # no structure → None (not a zero-score signal)
+    assert scoring.score_structure(_flat(10), _flat(10), {}) is None
+    assert scoring.score_structure([], [], {}) is None
+
+
+def test_score_structure_4h_opposes_penalizes():
+    aligned = scoring.score_structure(BOS, BOS, {})["score"]
+    opposed = scoring.score_structure(BOS, CHOCH, {})["score"]          # 4h is SHORT vs 1h LONG
+    assert opposed == aligned - 4                                       # +2 agree flips to −2
+
+
+def test_band_and_sizing_caps():
+    inp = {"apexScore": 9, "goodScore": 7, "maxLeverage": 5, "maxMarginPct": 25,
+           "leverageTiers": {"apex": 5, "good": 4, "base": 3},
+           "marginPctTiers": {"apex": 30, "good": 10, "base": 7}}      # apex margin over cap
+    assert scoring.band_for(9, inp) == "apex"
+    assert scoring.band_for(7, inp) == "good"
+    assert scoring.band_for(3, inp) == "base"
+    lev, mgn = scoring.sizing_for("apex", inp, venue_max=3)
+    assert lev == 3                                                    # clamped to venue max (< fleet 5)
+    assert 0 < mgn <= 25                                               # margin capped to maxMarginPct
+    lev2, _ = scoring.sizing_for("base", inp, venue_max=None)
+    assert 1 <= lev2 <= 5
+
+
+# ── scan() smoke against a fake ctx (no network) ──
+
+class _State:
+    def __init__(self):
+        self._log = []
+
+    def last(self):
+        return self._log[-1] if self._log else None
+
+    def append(self, d):
+        self._log.append(d)
+
+
+class _MCP:
+    def call_tool(self, tool, args):
+        if tool == "market_list_instruments":
+            return {"data": {"instruments": [
+                {"name": "BTC", "context": {"dayNtlVlm": 5e8, "maxLeverage": 5}},
+                {"name": "ETH", "context": {"dayNtlVlm": 4e8, "maxLeverage": 5}}]}}
+        if tool == "market_get_asset_data":
+            return {"data": {"candles": {"1h": BOS, "4h": BOS}}}
+        if tool == "strategy_get_clearinghouse_state":
+            return {"data": {"assetPositions": []}}
+        return {}
+
+
+class _Ctx:
+    def __init__(self):
+        self.wallet = "0xabc"
+        self.state = _State()
+        self.senpi_mcp = _MCP()
+
+
+def test_scan_smoke_returns_valid_signals():
+    import scan
+    ctx = _Ctx()
+    inputs = {"maxSlots": 6, "minScore": 0, "includeXyz": False,
+              "universeVolFloorUsd": 1e6, "maxUniverse": 10}
+    out = scan.scan(inputs, ctx)
+    assert isinstance(out, list)
+    assert len(out) >= 1                                               # BOS series clears minScore 0
+    for s in out:
+        assert set(("asset", "direction", "marginPct", "leverage", "data")) <= set(s)
+        assert 0 < s["marginPct"] <= 25
+        assert 1 <= s["leverage"] <= 5
+        assert s["direction"] in ("LONG", "SHORT")
+        assert isinstance(s["data"].get("reasons"), list)
+    assert ctx.state.last() is not None                               # state persisted
+    assert "recent" in ctx.state.last()
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print("ok  %s" % fn.__name__)
+    print("\nALL %d VIPER TESTS PASS" % len(fns))


### PR DESCRIPTION
Five new strategy packages built from a **gap analysis of 105 real organic strategy-creation prompts** (2026-07-13) against the existing catalog. The key finding: copy/mirror (9 templates) and HYPE (17) are already well-covered *despite* high prompt volume — a discovery problem, not a template gap. These five fill **verified, unmet gaps**.

> **Stacked on #471.** Base is `fleet-new/raven-starling-ant-crane` so this diff shows only the 5 new packages; it auto-retargets to `main` once #471 merges. (Stacked because both regenerate `catalog.json` — this keeps them consistent instead of conflicting.)

## The five (all deployable · in catalog · `_pkg.validate` ✓)

| Strategy | Fills | Tests |
|---|---|---|
| **viper** — SMC/ICT + Wyckoff Structure Trader | No market-structure style existed; large retail cohort (M174126, M364811) | 8 |
| **ram** — Gold / Precious-Metals Specialist | Gold was only in baskets, no single-market specialist (M207348, M197292×2) | 9 |
| **salmon** — RSI Mean-Reversion / Dip-Buyer | Matches a fully-backtested user spec (M210373); no clean oversold-bounce existed | 8 |
| **gecko** — Configurable Single-Asset Confluence | The "trade the coin I name" long tail (VVV, $LIT, aave…) | 5 |
| **armadillo** — Capital-Preservation / Low-Vol | Recurring "low-risk / sleep-at-night" demand (M264525, M287260, M191917) | 5 |

## What to scrutinize (the novel engines — I read both myself)
- **viper** (`scoring.py`): `swings` (fractal pivots), `structure` (BOS vs **CHoCH** — correctly flags a break *against* the prevailing bias as the reversal tell), `liquidity_sweep` (wick past a swing that closes back inside), `fvg` (3-candle imbalance). Confluence-scored, gated by minScore.
- **salmon** (`oversold_bounce`): the **anti-falling-knife gate** — fires only when RSI *dipped below* the line in the lookback **AND crossed back above AND is rising AND the price bar confirms**. A still-falling RSI below 30 does **not** trigger.
- ram / gecko / armadillo reuse bison's `build_thesis` **verbatim**; the differentiation is config (safe-haven tilt, parameterized asset, low caps + fail-closed).

## Notes
- **Glossary:** +2 sub_styles (`market_structure`, `mean_reversion`); everything else reuses existing vocab. Tiers corrected to the real glossary values (`starter`/`advanced` only — there is no `intermediate`). Catalog regenerated, **warning-clean**.
- **Fleet-standard throughout:** marginPct sizing, leverage caps enforced in `sizing_for`, mandatory DSL, drawdown gate, read-only single-pass scanners, no CLOSE action.
- **Same go-live caveat as #471:** the funding / regime / market reads use tolerant multi-key extraction (token was invalid mid-build) — worth one real-payload check before funding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)