### PR TITLE
fix(improve-trades): recover closed-strategy trades from on-chain HL fills (v1.3.0)

### DIFF
--- a/senpi-improve-trades/SKILL.md
+++ b/senpi-improve-trades/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.2.0"
+  version: "1.3.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -89,6 +89,8 @@ on-disk ring is already gone) the engine **fails open to discovery**: the trades
 recorded on this build"** (or "…this strategy's event ring is gone — it's closed") — **never** report it as a
 bug. `meta.telemetry_source` (`available` / `partial` / `unavailable`) and `meta.exit_reason_source_counts`
 tell you exactly how much enrichment landed; surface that honestly.
+
+**Closed strategies are recovered ON-CHAIN — the engine handles the trap for you.** `discovery_get_trader_history` returns **empty** once a strategy is closed/torn down — Senpi clears its own index, but the trades are **NOT gone** (Hyperliquid keys fills by wallet **address**, so they survive the close). The engine detects an empty discovery result and **falls back to on-chain HL fills**, rebuilding the real round-trips (`meta.closed_trade_source == "onchain_fills"`, wallets in `meta.onchain_recovered_wallets`); `realized_pnl` then comes from HL's own `closedPnl`. So a closed strategy's trades and realized total come back **real** — an empty discovery result is never "no trades." You do **not** hand-read `strategy_get_pnl_and_account_value_history` for this. If `trades[]` is still empty after the on-chain fallback, the book genuinely never traded (guardrail 9).
 
 ## Quick actions this skill handles
 
@@ -265,6 +267,8 @@ figure of any kind. The only dollar figures you may state are:
 The engine deliberately emits **no** per-week or projection field. If you feel the urge to annualize, weekly-ize,
 or forecast a dollar figure, stop — that urge is the exact failure mode this skill exists to kill.
 
+**Account value ≠ P&L — never narrate the value curve as trades.** The engine sources closed trades from on-chain fills, so you should not need `strategy_get_pnl_and_account_value_history` for a trade review at all. If you ever look at it: `accountValueHistory` is a series of account **snapshots**, not trades — never narrate "$135 → $133 → $143 → …" as individual round-trips. A curve ending at **`$0` after a `strategy_close` / `strategy_withdraw_funds` is capital RETURNED to the main wallet (a withdrawal), not a loss** — the realized result is realized PnL, not the value drop. If realized PnL (e.g. −$21) and the value drop (e.g. −$175) disagree, the difference **is the withdrawal** — reconcile, never report the drop as a loss.
+
 ### 4. No chasing — one window is noise; weigh mandate + turnover
 
 Do **not** recommend abandoning a strategy's mandate to buy last window's winners. A `book_vs_market.gap` (a
@@ -363,6 +367,8 @@ Concretely: if you're about to say "you have 13 wallets, kill/merge 11 of them,"
 and there is **no consolidation problem** — you're looking at redeploy history.
 
 ### 9. No trades yet? Stop cleanly — do NOT pivot to setup / config nagging
+
+**An empty `trades[]` now means the book genuinely never traded** — the engine already falls back to on-chain HL fills for closed strategies, so it is **not** a coverage gap you need to work around. Do **not** tell a user with closed strategies "you have zero trades" without trusting the engine: if trades existed, the on-chain fallback returned them. When trades were recovered that way (`meta.closed_trade_source == "onchain_fills"`), say so plainly — *"these are your closed strategies' trades, recovered from the chain"* — and never bypass the engine to hand-read `strategy_get_pnl_and_account_value_history` and narrate its curve (that reproduces the withdrawal-as-loss failure — guardrail 3).
 
 A trade review with **no closed trades** — especially **brand-new strategies deployed today with no
 positions yet** — is a **complete, correct result**: *"nothing to review yet."* Say that and stop. The

--- a/senpi-improve-trades/scripts/review.py
+++ b/senpi-improve-trades/scripts/review.py
@@ -45,6 +45,8 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 CLOSED_HISTORY_PULL = 100    # closed positions to pull per wallet before the window filter
 WINDOW_DEFAULT_DAYS = 7      # the default review window
 TOP_MOVERS_CAP = 12          # cap the book-vs-market movers surfaced
+HL_INFO_URL = "https://api.hyperliquid.xyz/info"   # public, no-auth — durable closed-trade recovery
+HL_FILLS_CAP = 2000          # userFills returns the most recent N fills; ample for any review window
 
 # The runtime registers every deployed strategy in installed_runtimes.json in the state dir — the
 # UNIVERSAL source of a strategy's mandate (the runtime.yaml `description`) + its DSL ladder. Reused
@@ -697,24 +699,113 @@ def _direction(rec, szi, entry_px, exit_px, pnl):
     return None
 
 
+# ───────────────────── on-chain fill recovery (durable across strategy_close) ─────────────────────
+def _hl_info(payload, meta, client=None, timeout=12):
+    """POST the Hyperliquid Info API (public, no auth) — the same transport the DSL scripts use. Recovers a
+    CLOSED strategy's trades that Senpi's discovery index has dropped: HL keys fills by wallet ADDRESS, so
+    they survive a `strategy_close` (which only clears Senpi's own record). Offline/fixture-aware for tests
+    (`_FixtureClient` serves a recorded `hl::<type>::<wallet>` entry). Fails OPEN → None."""
+    if client is not None and hasattr(client, "_r"):          # _FixtureClient — serve recorded HL response
+        u = str(payload.get("user", "")).lower()
+        return client._r.get(f"hl::{payload.get('type')}::{u}") or client._r.get(f"hl::{payload.get('type')}")
+    try:
+        p = subprocess.run(
+            ["curl", "-s", "-m", str(timeout), "-X", "POST", HL_INFO_URL,
+             "-H", "Content-Type: application/json", "-d", json.dumps(payload)],
+            capture_output=True, text=True, timeout=timeout + 3)
+        if p.returncode != 0 or not (p.stdout or "").strip():
+            return None
+        return json.loads(p.stdout)
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"hl_info {payload.get('type')} failed: {e}")
+        return None
+
+
+def _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap):
+    """Rebuild round-trip CLOSED trades from raw HL fills — the durable, close-independent source. HL gives
+    per-fill `dir` ('Open/Close Long/Short'), px, sz, closedPnl, fee, time, oid. Walk fills per coin
+    oldest→newest, FIFO-match each Close against prior Opens, and emit one trade per closed chunk with a
+    size-weighted entry price. `realized_pnl` = HL's own closedPnl (authoritative — correct even when the
+    matching open predates the window). Same trade shape as discovery, tagged source='onchain_fills'."""
+    if not isinstance(fills, list):
+        return []
+    import collections
+    fl = sorted((f for f in fills if isinstance(f, dict)), key=lambda f: _num(f.get("time")) or 0)
+    lots = collections.defaultdict(collections.deque)   # coin -> deque of open lots {px, sz, time}
+    trades = []
+    for f in fl:
+        coin = f.get("coin")
+        d = str(f.get("dir") or "")
+        sz = abs(_num(f.get("sz")) or 0.0)
+        px = _num(f.get("px"))
+        t = _ms(f.get("time"))
+        if not coin or sz <= 0:
+            continue
+        if d.startswith("Open"):
+            lots[coin].append({"px": px, "sz": sz, "time": t})
+        elif d.startswith("Close"):
+            side = "long" if "Long" in d else ("short" if "Short" in d else None)
+            remaining, entry_notional, matched, open_time = sz, 0.0, 0.0, t
+            q = lots[coin]
+            while remaining > 1e-9 and q:                # FIFO-match the closed size against open lots
+                lot = q[0]
+                take = min(remaining, lot["sz"])
+                entry_notional += take * (lot["px"] or 0.0)
+                matched += take
+                open_time = lot["time"] or open_time
+                lot["sz"] -= take
+                remaining -= take
+                if lot["sz"] <= 1e-9:
+                    q.popleft()
+            trades.append({
+                "asset": coin,
+                "direction": side,
+                "size": sz,
+                "leverage": None,                        # not carried on HL fills
+                "entry_px": (entry_notional / matched) if matched > 0 else None,
+                "exit_px": px,
+                "realized_pnl": round(_num(f.get("closedPnl")) or 0.0, 2),   # HL's own realized — authoritative
+                "margin_used": None,
+                "open_time": open_time,
+                "close_time": t,
+                "closed_order_id": f.get("oid"),
+                "fee": _num(f.get("fee")),
+                "source": "onchain_fills",
+            })
+    out = []
+    for tr in trades:
+        ct = tr["close_time"]
+        if since_ms is not None and ct is not None and ct < since_ms:
+            continue
+        if until_ms is not None and ct is not None and ct > until_ms:
+            continue
+        out.append(tr)
+    out.sort(key=lambda t: _num(t.get("close_time")) or 0, reverse=True)
+    return out[:cap] if cap else out
+
+
 def fetch_closed_trades(client, wallet, since_ms, until_ms, cap, meta):
-    """Read-guarded closed-position ledger for one strategy wallet, filtered to the review window. Lifts
-    portfolio.py's fetch_closed extraction (the real discovery_get_trader_history shape: closedPositions[]
-    of coin, signed szi, string realizedPnl, Unix-ms openTime/closeTime, entryPx/exitPx). `since_ms`
-    filters by closeTime; `cap` (optional) keeps only the last N by close time. Fails OPEN → []."""
+    """Read-guarded closed-trade list for one strategy wallet, filtered to the review window.
+
+    PRIMARY: `discovery_get_trader_history` (closedPositions[] round-trips — works for CURRENT strategies).
+    FALLBACK — the closed-strategy trap: `strategy_close` clears Senpi's discovery index, so a CLOSED
+    strategy returns EMPTY here even though it traded. The fills still exist ON-CHAIN (HL keys them by
+    wallet ADDRESS, not by Senpi's strategy record), so on an empty discovery result we recover the real
+    round-trips from HL `userFills` and tag them source='onchain_fills'. `realized_pnl` then comes from HL's
+    own closedPnl — so a closed book is never misread as "no trades" or "drained to $0" (that $0 is the
+    withdrawal on close). Empty HL fills too ⇒ genuinely no trades. Fails OPEN → []."""
     try:
         h = _ok(client.mcp_call("discovery_get_trader_history", trader_address=wallet,
                                 sort_by="CLOSED_TIME", sort_direction="DESC",
                                 limit=CLOSED_HISTORY_PULL, timeout=12))
     except Exception as e:  # noqa
         meta.setdefault("warnings", []).append(f"trader_history {wallet[:8]} failed: {e}")
-        return []
-    if h is None:
-        meta.setdefault("warnings", []).append(f"trader_history {wallet[:8]} returned no data")
-        return []
-    rows = h if isinstance(h, list) else _field(h, "closedPositions", "closed_positions", "positions", default=[])
-    if not isinstance(rows, list):
-        rows = []
+        h = None
+    rows = []
+    if h is not None:
+        rows = h if isinstance(h, list) else _field(h, "closedPositions", "closed_positions", "positions", default=[])
+        if not isinstance(rows, list):
+            rows = []
     trades = []
     for p in rows:
         if not isinstance(p, dict):
@@ -741,11 +832,20 @@ def fetch_closed_trades(client, wallet, since_ms, until_ms, cap, meta):
             "open_time": _ms(_field(p, "openTime", "open_time")),
             "close_time": close_ms,
             "closed_order_id": _field(p, "closedOrderId", "closed_order_id"),
+            "source": "discovery",
         })
-    trades.sort(key=lambda t: _num(t.get("close_time")) or 0, reverse=True)
-    if cap:
-        trades = trades[:cap]
-    return trades
+    if trades:
+        trades.sort(key=lambda t: _num(t.get("close_time")) or 0, reverse=True)
+        return trades[:cap] if cap else trades
+
+    # DISCOVERY EMPTY → recover on-chain. This is the closed-strategy trap: the trades exist, just not in
+    # Senpi's index. Empty HL fills too ⇒ genuinely no trades (a brand-new book) → [].
+    fills = _hl_info({"type": "userFills", "user": wallet}, meta, client)
+    recon = _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap)
+    if recon:
+        meta.setdefault("onchain_recovered_wallets", []).append(wallet)
+        meta["closed_trade_source"] = "onchain_fills"
+    return recon
 
 
 # ──────────────────────────────────────────────────────────────── current price (market_get_asset_data)

--- a/senpi-improve-trades/tests/test_review.py
+++ b/senpi-improve-trades/tests/test_review.py
@@ -803,6 +803,66 @@ def test_default_state_path_uses_tempdir_and_window_key():
     assert review._default_state_path(30.0, 20).endswith("state-30d-last20.json")
 
 
+# ── on-chain fill recovery (closed-strategy trap: discovery clears on close, HL fills persist) ──
+def test_reconstruct_closed_from_fills_fifo_direction_pnl():
+    base = 1784000000000
+    fills = [
+        {"coin": "HYPE", "dir": "Open Long",   "sz": "2",  "px": "100", "closedPnl": "0",   "fee": "0.1",  "time": base + 1000, "oid": 1},
+        {"coin": "HYPE", "dir": "Open Long",   "sz": "1",  "px": "110", "closedPnl": "0",   "fee": "0.05", "time": base + 2000, "oid": 2},
+        {"coin": "HYPE", "dir": "Close Long",  "sz": "2",  "px": "120", "closedPnl": "40",  "fee": "0.12", "time": base + 3000, "oid": 3},
+        {"coin": "HYPE", "dir": "Close Long",  "sz": "1",  "px": "130", "closedPnl": "20",  "fee": "0.06", "time": base + 4000, "oid": 4},
+        {"coin": "SOL",  "dir": "Open Short",  "sz": "10", "px": "200", "closedPnl": "0",   "fee": "0.2",  "time": base + 1500, "oid": 5},
+        {"coin": "SOL",  "dir": "Close Short", "sz": "10", "px": "190", "closedPnl": "100", "fee": "0.19", "time": base + 9000, "oid": 6},
+    ]
+    tr = review._reconstruct_closed_from_fills(fills, None, None, None)
+    assert len(tr) == 3
+    by = {(t["asset"], t["exit_px"]): t for t in tr}
+    # FIFO: first HYPE close (2) matches the 2@100 lot; the second (1) matches the 1@110 lot
+    assert by[("HYPE", 120.0)]["entry_px"] == 100.0 and by[("HYPE", 120.0)]["direction"] == "long"
+    assert by[("HYPE", 130.0)]["entry_px"] == 110.0
+    assert by[("SOL", 190.0)]["direction"] == "short" and by[("SOL", 190.0)]["entry_px"] == 200.0
+    assert round(sum(t["realized_pnl"] for t in tr), 2) == 160.0    # HL closedPnl — authoritative
+    assert all(t["source"] == "onchain_fills" for t in tr)
+    assert tr[0]["asset"] == "SOL"                                  # newest close first
+    assert [t["asset"] for t in review._reconstruct_closed_from_fills(fills, base + 5000, None, None)] == ["SOL"]
+    assert review._reconstruct_closed_from_fills(fills, None, None, 1)[0]["asset"] == "SOL"
+    assert review._reconstruct_closed_from_fills(None, None, None, None) == []
+
+
+def test_closed_strategy_falls_back_to_onchain_fills():
+    """The bug this fixes: CLOSED strategy → discovery empty → recover REAL trades on-chain; never report
+    'no trades', and realized PnL comes from HL closedPnl (the $0-after-close is a withdrawal, not a loss)."""
+    w = "0xclosed00000000000000000000000000000closed"
+    fills = [
+        {"coin": "SMSN", "dir": "Open Long",  "sz": "1", "px": "180", "closedPnl": "0",  "time": 1784000001000, "oid": 11},
+        {"coin": "SMSN", "dir": "Close Long", "sz": "1", "px": "188", "closedPnl": "8",  "time": 1784000002000, "oid": 12},
+        {"coin": "SOL",  "dir": "Open Long",  "sz": "1", "px": "78",  "closedPnl": "0",  "time": 1784000003000, "oid": 13},
+        {"coin": "SOL",  "dir": "Close Long", "sz": "1", "px": "77",  "closedPnl": "-1", "time": 1784000004000, "oid": 14},
+    ]
+    client = review._FixtureClient({
+        f"discovery_get_trader_history::{w.lower()}": {"closedPositions": []},   # Senpi index cleared on close
+        f"hl::userFills::{w.lower()}": fills,                                     # HL retains fills by address
+    })
+    meta = {}
+    trades = review.fetch_closed_trades(client, w, None, None, None, meta)
+    assert len(trades) == 2                                     # real trades recovered, not "zero"
+    assert round(sum(t["realized_pnl"] for t in trades), 2) == 7.0
+    assert meta.get("closed_trade_source") == "onchain_fills"
+    assert w in meta.get("onchain_recovered_wallets", [])
+
+
+def test_no_trades_when_both_sources_empty():
+    """Empty discovery AND empty on-chain fills ⇒ genuinely no trades (a brand-new book) → []."""
+    w = "0xbrandnew0000000000000000000000000000new"
+    client = review._FixtureClient({
+        f"discovery_get_trader_history::{w.lower()}": {"closedPositions": []},
+        f"hl::userFills::{w.lower()}": [],
+    })
+    meta = {}
+    assert review.fetch_closed_trades(client, w, None, None, None, meta) == []
+    assert "closed_trade_source" not in meta
+
+
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     for fn in fns:


### PR DESCRIPTION
## The bug (live)
User: *"Improve my last 10 trades. Did I sell too early or late?"* — on an account whose **Lion strategies were closed**. The agent answered *"there are zero closed trades to review… the question can't be answered."* Pushed, it read a `$0` account-value curve as *"the account drained to $0 — grinding losses,"* but `$0` was the **user closing the strategy (funds returned)**, and the strategies had **real winning trades**.

## Root cause (in the engine)
`review.py` sourced closed trades **only** from `discovery_get_trader_history`, which returns **empty** once a strategy is closed/torn down (Senpi clears its own index). Empty `trades[]` → the agent says "zero trades," then hand-reads `strategy_get_pnl_and_account_value_history` and narrates the withdrawal as a loss. The SKILL.md even claimed discovery "fails open" and still lists closed trades — **it does not.**

## The fix — recover on-chain (don't concede)
The trades **aren't gone**: Hyperliquid keys fills by wallet **address**, so they persist through `strategy_close`. `fetch_closed_trades` now:
- discovery first (unchanged for current strategies);
- on an **empty** result, falls back to **HL `userFills`** and rebuilds real round-trips (FIFO entry match; `realized_pnl` from HL's own `closedPnl` — authoritative);
- tags provenance (`meta.closed_trade_source="onchain_fills"`, `meta.onchain_recovered_wallets`).

So a closed book is never "no trades" or "drained to $0," and *"too early/late"* is answerable again. Transport = the same public HL Info curl the DSL scripts already use (reachable from the agent box).

**Verified on the two real closed Lion wallets** from the incident: 31 and 73 round-trips recovered with per-trade entry/exit and realized totals (−$15.27, −$75.70) — including the `xyz:SKHX` +$23 / `xyz:SMSN` +$20 winners the "grinding losses" narrative erased.

## Guardrails (the correct half of the closed #473)
- Sources note corrected: closed strategies are recovered on-chain; empty discovery ≠ no trades.
- **Account value ≠ P&L** — `$0` after a close is a **withdrawal**, not a loss; reconcile realized vs the value drop.
- Guardrail 9: empty `trades[]` now means genuinely no trades (the engine already tried on-chain).

## Tests
`51 passed` — adds FIFO/direction/pnl/window/cap reconstruction, the closed-strategy on-chain fallback, and the both-sources-empty ⇒ no-trades case.

Supersedes **#473** (closed — guardrails-only, and it wrongly conceded that per-trade detail is "genuinely gone"). Version 1.2.0 → 1.3.0 (MINOR — manifest auto-upgrades users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
