### PR TITLE
strategy deploy — consolidated: accept-flat + validate + fresh-wallet + live-gate (folds #470, #467)

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.4.2"
+  version: "2.5.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -238,8 +238,20 @@ Same references; usually no rebuild: tune `runtime.yaml` `inputs` (universe/thre
 the `dsl_preset`, adjust `risk.guard_rails`, or change the `scoring.py` math. Re-validate, then
 re-smoke-test if you touched `scan.py`/`runtime.yaml`.
 
-## Handoff
+## Handoff & the live gate — "done" means the deploy is verified LIVE, not "package built"
 
-Authoring produces the package only. **Deploy/monitor/close is `senpi-strategy-ops`** — hand off the
-`id` once the smoke test is green. Attribution (`skillName`/`skillVersion`) is set by ops from
-`strategy.yaml` `id`/`version`.
+Authoring produces the package; a strategy is only **live** once **`senpi-strategy-ops` deploys it AND
+`deploy.py verify` passes**. Walk the full loop every time, and never skip the gate:
+
+1. **Build** — stages 1–9 above (spec → scoring → scan → runtime.yaml → strategy.yaml → unit-test →
+   `validate_strategy.py` → `validate_universe.py` → smoke-test). Every ticker verified; a DSL preset in.
+2. **Deploy** (hand the `id` to `senpi-strategy-ops`): `deploy.py create <id> --budget <the user's exact
+   amount>` → `deploy.py runtime <id>`. The budget is a **hard target** — if the live balance can't cover
+   it, create halts `underfunded`; fund/confirm, never silently fund less.
+3. **GATE — `deploy.py verify <id>`**: the strategy is **live** only when *every* instance is
+   **runtime-running + scanner-active + DSL-wired + funded**. If verify returns `not-live` (e.g.
+   `scanner=broken`, `dsl=config-missing`, `budget=underfunded`), **the strategy is NOT live** — fix the
+   flagged component and re-run. **Never tell the user it's live until `verify` returns `live`.**
+
+**If any step of the loop is incomplete, the strategy is not live — say exactly which step failed.**
+Attribution (`skillName`/`skillVersion`) is set by ops from `strategy.yaml` `id`/`version`.

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -146,7 +146,9 @@ For each: ask the question, offer the options as plain choices, then map the ans
    `let_winners_run` (wide; rides to +100%, protect both sides) · `balanced` (default) ·
    `mean_reversion` (tight, locks early — for faders) · `scalp` (HFT) · `parabolic_runner` (scalpel).
    Then set guard rails (`drawdown_halt_pct`, `daily_loss_limit_pct`) sized to the style, and cadence
-   (`interval_seconds`). **Never hand-roll stops — copy a preset from `references/dsl-presets.yaml`.**
+   (`interval_seconds`). **Never hand-roll stops — copy a preset from
+   `senpi-strategy-author/references/dsl-presets.yaml`** (full path — it lives in THIS skill, not the
+   runtime package).
 
 ## After the 7 — build it in STAGES, narrating as you go
 
@@ -167,10 +169,15 @@ the catalog entry, then unit-test → validate → hand to smoke-test."* Then ti
 2. **Scaffold.** Match the idea to an archetype row in `references/creating-a-strategy.md`, create the
    package dirs, and state the archetype + file plan. → *"Matched the cohort-rotation archetype; scaffolding
    `strategies/<id>/…`."* This lets the user catch a wrong archetype/universe **before** you write code.
+   **Layout: single-instance = FLAT** — `strategy.yaml` + `runtime.yaml` + `scanners/` at the package
+   root, **no `instances:` list, no `main/` dir** (the deployer synthesizes the `main` instance).
+   Multi-instance (e.g. a long book + a short book) = one `<instance>/` dir each + an explicit
+   `instances:` list in `strategy.yaml`.
 3. **`scoring.py`** (pure math). Write it → one line on what it scores. → *"scoring.py in — ranks the cohort
    by 3-day relative strength."*
-4. **`<instance>/scanners/scan.py`** (read-only, emits `marginPct` intent). Write it → one line on what it
-   emits.
+4. **`scanners/scan.py`** (read-only, emits `marginPct` intent) — at the package **root** for a flat
+   single-instance strategy; under `<instance>/scanners/` only for multi-instance. Write it → one line
+   on what it emits.
 5. **`runtime.yaml`** — the plain-language **`description`** of the thesis + how it works (the runtime
    registers it and senpi-portfolio reads it back as the mandate) plus inputs, entry action, DSL preset,
    risk gates. Write it → one line on the thesis + DSL + risk posture.
@@ -178,11 +185,16 @@ the catalog entry, then unit-test → validate → hand to smoke-test."* Then ti
    `references/strategy-yaml-schema.md`; what each facet does for matching:
    `references/discovery-catalog-fields.md`). Write it → *"catalog entry in."*
 7. **Unit-test `scoring.py`** on sample candles (pure — no mocks). Run it → report pass/fail as its own beat.
-8. **Validate** → `python3 senpi-strategy-author/scripts/validate_strategy.py strategies/<id>` (0 errors),
-   then the **universe gate** → `python3 senpi-strategy-ops/scripts/validate_universe.py strategies/<id>`
-   — every hardcoded ticker must be a live HL instrument (`deploy.py create` also runs this as a preflight
-   and refuses to fund a bad universe; derived-universe strategies pass trivially). Run each, report the
-   result. **If validation fails, narrate the fix and re-run — don't go silent while you debug.**
+8. **Validate — three gates, all before any wallet exists:**
+   (a) **code-level** → `python3 senpi-strategy-author/scripts/validate_strategy.py strategies/<id>`
+   (0 errors — scan/scoring shape, DSL exit present, mandate description, retention/cooldown bounds);
+   (b) **universe gate** → `python3 senpi-strategy-ops/scripts/validate_universe.py strategies/<id>`
+   — every hardcoded ticker must be a live HL instrument (derived-universe strategies pass trivially);
+   (c) **deploy contract** → `python3 senpi-strategy-ops/scripts/deploy.py validate strategies/<id>`
+   — the deployer's own one-pass preflight (structure, linkage, render; **no side effects**). Green
+   here means `create` will not reject the package. (`deploy.py create` re-runs (b)+(c) itself and
+   refuses to fund on failure.) Run each, report the result. **If validation fails, narrate the fix
+   and re-run — don't go silent while you debug.**
 9. **Smoke-test (hand to `senpi-strategy-ops`):** dry-run → run `scan()` once on live read-only MCP →
    tiny deploy → confirm the runtime **accepted** a signal (`openclaw senpi state -r <id>-<inst>
    --json`), not just that it ticked. **Green = `scan` → signal → runtime-accepted, end to end.**
@@ -248,7 +260,9 @@ built and validated:
 2. **Preflight** — `python3 senpi-strategy-ops/scripts/deploy.py validate <id>` — reports every fix in
    **one pass**, no side effects. The deployer **accepts the flat package you built** (it synthesizes
    the `main` instance), so you do **not** restructure into `main/` or hand-write `.deploy-state.json`.
-3. **Deploy** — `deploy.py create <id> --budget <N>` → `deploy.py runtime <id>`. Done.
+3. **Deploy** — `deploy.py create <id> --budget <N>` → `deploy.py runtime <id>`. Done. (Already
+   smoke-deployed a tiny wallet in step 9? `create` self-heals to that existing wallet and will NOT
+   add the difference — top it up to the user's budget with `strategy_top_up` instead of re-creating.)
 
 **NEVER deploy an authored strategy with `strategy_create_custom_strategy` / `create_position`.** Those
 raw MCP tools fund a wallet with **no runtime** — a naked funded wallet: no scanner, no DSL, no

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.5.0"
+  version: "2.6.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -37,6 +37,19 @@ much risk). Your job is to draw those out, one question at a time, and compile t
 > no name). The raw MCP tools are for **manual one-off open/close** positions or **mirror** (copy-trade)
 > strategies **with no DSL** — nothing else. If protection is anywhere in the ask, you're in the right
 > skill; author it.
+
+> **Opening a position for the user is a FORK — ASK, never assume.** When the user asks to *open* a
+> position (or a set) — "go long HYPE", "buy BTC 5x", "short SOFTBANK" — do **not** just place it. Ask which
+> of two different products they want:
+> - **(A) A DSL-protected strategy** — a named, supervised Runtime 3.0 strategy that manages a trailing stop
+>   + profit-lock ladder. → **author it here.** The path for anything the user wants *managed* or persistent.
+> - **(B) A plain position with a standard take-profit / stop-loss** — a one-off via raw `create_position`
+>   (it carries `stopLoss` / `takeProfit`), placed in a **discretionary wallet, NOT a strategy wallet.**
+>
+> **Either way, NEVER open into an existing scanner-managed strategy's wallet.** A hand-placed position in a
+> wallet a deployed strategy runs is reconciled as *foreign* and **DSL-flattened within minutes** — the order
+> "succeeds," the position is gone, and the user eats the round-trip. If the user hasn't said which of
+> (A)/(B) they want, **ask before placing anything** — and never route (B) into a managed wallet to save a step.
 
 ## Start here — offer the fast path before building from scratch
 

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.4.2"
+  version: "2.5.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -238,8 +238,21 @@ Same references; usually no rebuild: tune `runtime.yaml` `inputs` (universe/thre
 the `dsl_preset`, adjust `risk.guard_rails`, or change the `scoring.py` math. Re-validate, then
 re-smoke-test if you touched `scan.py`/`runtime.yaml`.
 
-## Handoff
+## Handoff — deploy is `senpi-strategy-ops`, NEVER raw MCP
 
-Authoring produces the package only. **Deploy/monitor/close is `senpi-strategy-ops`** — hand off the
-`id` once the smoke test is green. Attribution (`skillName`/`skillVersion`) is set by ops from
-`strategy.yaml` `id`/`version`.
+Authoring produces the **package** only; going live is a **separate, gated step**. Once the package is
+built and validated:
+
+1. **Confirm with the user** — budget + "ready to deploy?" Funding a wallet is real money and one-way,
+   so this is an explicit yes, not an assumption.
+2. **Preflight** — `python3 senpi-strategy-ops/scripts/deploy.py validate <id>` — reports every fix in
+   **one pass**, no side effects. The deployer **accepts the flat package you built** (it synthesizes
+   the `main` instance), so you do **not** restructure into `main/` or hand-write `.deploy-state.json`.
+3. **Deploy** — `deploy.py create <id> --budget <N>` → `deploy.py runtime <id>`. Done.
+
+**NEVER deploy an authored strategy with `strategy_create_custom_strategy` / `create_position`.** Those
+raw MCP tools fund a wallet with **no runtime** — a naked funded wallet: no scanner, no DSL, no
+guard-rails (the recurring failure that stranded real money). A "created" strategy with no runtime **is
+the bug**, not the deploy. The only path to live is `senpi-strategy-ops deploy.py`.
+
+Attribution (`skillName`/`skillVersion`) is set by ops from `strategy.yaml` `id`/`version`.

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -257,12 +257,17 @@ built and validated:
 
 1. **Confirm with the user** — budget + "ready to deploy?" Funding a wallet is real money and one-way,
    so this is an explicit yes, not an assumption.
-2. **Preflight** — `python3 senpi-strategy-ops/scripts/deploy.py validate <id>` — reports every fix in
-   **one pass**, no side effects. The deployer **accepts the flat package you built** (it synthesizes
-   the `main` instance), so you do **not** restructure into `main/` or hand-write `.deploy-state.json`.
-3. **Deploy** — `deploy.py create <id> --budget <N>` → `deploy.py runtime <id>`. Done. (Already
-   smoke-deployed a tiny wallet in step 9? `create` self-heals to that existing wallet and will NOT
-   add the difference — top it up to the user's budget with `strategy_top_up` instead of re-creating.)
+2. **Preflight** — `python3 senpi-strategy-ops/scripts/deploy.py validate <path-to-package>` — reports
+   every fix in **one pass**, no side effects. The deployer **accepts the flat package you built** (it
+   synthesizes the `main` instance), so you do **not** restructure into `main/` or hand-write
+   `.deploy-state.json`. **Pass the package DIRECTORY you authored** (absolute path is safest, e.g.
+   `/data/workspace/strategies/<id>`) — a **bare id** is resolved relative to your CWD and, failing
+   that, treated as a **catalog id and fetched from remote**, which is never what you want for a
+   package you just wrote.
+3. **Deploy** — `deploy.py create <path-to-package> --budget <N>` → `deploy.py runtime
+   <path-to-package>`. Done. (Already smoke-deployed a tiny wallet in step 9? `create` self-heals to
+   that existing wallet and will NOT add the difference — top it up to the user's budget with
+   `strategy_top_up` instead of re-creating.)
 
 **NEVER deploy an authored strategy with `strategy_create_custom_strategy` / `create_position`.** Those
 raw MCP tools fund a wallet with **no runtime** — a naked funded wallet: no scanner, no DSL, no

--- a/senpi-strategy-author/references/creating-a-strategy.md
+++ b/senpi-strategy-author/references/creating-a-strategy.md
@@ -23,6 +23,12 @@ strategies/<id>/
 ```
 One instance binds to one wallet. A long book + a short book, or a swing + a scalp leg, = **multiple instances**.
 
+**Single-instance? Build it FLAT** — `strategy.yaml` + `runtime.yaml` + `scanners/` at the package root,
+no `instances:` list and no `<instance>/` dir: the deployer (strategy-ops v2.4.0+) synthesizes the
+canonical `main` instance for you. The nested `<instance>/` layout above is only *required* for
+multi-instance strategies. Either way, `deploy.py validate strategies/<id>` tells you in one pass
+whether the package is deploy-ready.
+
 ## 3. Division of labor — memorize this
 
 | **You own** | **Runtime 3.0 owns** |

--- a/senpi-strategy-author/references/strategy-yaml-schema.md
+++ b/senpi-strategy-author/references/strategy-yaml-schema.md
@@ -18,8 +18,12 @@ strategies/<id>/                # all strategy packages live under strategies/
   <instance2>/ …                # one subdir per instance (multi-runtime, e.g. spider swing + scalp)
 ```
 
-A single-instance strategy has one `<instance>/` dir; a multi-instance one (spider) has several, **each
-on its own wallet** (a runtime binds to exactly one wallet).
+A single-instance strategy may use the **FLAT layout** instead — `runtime.yaml` + `scanners/` at the
+package root with **no `instances:` list at all**: the deployer (strategy-ops v2.4.0+) synthesizes the
+canonical `main` instance, binding `wallet_env` to the `${...}` the runtime already uses. A
+multi-instance strategy (spider) has one `<instance>/` dir per runtime, **each on its own wallet** (a
+runtime binds to exactly one wallet), and declares them in `instances:`. `deploy.py validate <id>`
+confirms either form is deploy-ready.
 
 ## Schema
 

--- a/senpi-strategy-author/scripts/_yaml.py
+++ b/senpi-strategy-author/scripts/_yaml.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Tiny stdlib-only YAML safe-loader — the subset the strategy.yaml + runtime.yaml packages use.
+
+Why: the deploy/close scripts run on agent hosts that may not have PyYAML (or pip). `_pkg` uses real
+PyYAML when importable and falls back to this. It is NOT a general YAML parser — it covers exactly what
+our packages use: block maps + sequences, nested blocks, flow `[...]`/`{...}`, scalars (str/int/float/
+bool/null), single/double quotes, `#` comments, and `>`/`|` block scalars (captured loosely as text —
+we don't interpret descriptions). Validated for byte-equality against PyYAML on the example packages.
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import re
+
+_INT_RE = re.compile(r"^[-+]?\d+$")
+_FLOAT_RE = re.compile(r"^[-+]?(\d+\.\d*|\.\d+|\d+)([eE][-+]?\d+)?$")
+
+
+class YAMLError(Exception):
+    pass
+
+
+# ---------- scalars + comments ----------
+
+def _strip_comment(s):
+    """Remove a trailing ` # comment` at depth 0 outside quotes (YAML: # starts a comment at col 0 or
+    after whitespace)."""
+    depth = 0
+    q = None
+    for i, c in enumerate(s):
+        if q:
+            if c == q:
+                q = None
+        elif c in "\"'":
+            q = c
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == "#" and depth == 0 and (i == 0 or s[i - 1] in " \t"):
+            return s[:i].rstrip()
+    return s.rstrip()
+
+
+def _scalar(tok):
+    tok = tok.strip()
+    if tok == "" or tok == "~" or tok.lower() == "null":
+        return None
+    if len(tok) >= 2 and tok[0] == tok[-1] and tok[0] in "\"'":
+        return tok[1:-1]
+    low = tok.lower()
+    if low == "true":
+        return True
+    if low == "false":
+        return False
+    if _INT_RE.match(tok):
+        return int(tok)
+    if _FLOAT_RE.match(tok):
+        return float(tok)
+    return tok
+
+
+# ---------- flow [...] / {...} ----------
+
+def _split_top(s):
+    """Split a flow body on top-level commas (respecting nesting + quotes)."""
+    out, depth, q, start = [], 0, None, 0
+    for i, c in enumerate(s):
+        if q:
+            if c == q:
+                q = None
+        elif c in "\"'":
+            q = c
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == "," and depth == 0:
+            out.append(s[start:i])
+            start = i + 1
+    tail = s[start:]
+    if tail.strip() or out:
+        out.append(tail)
+    return out
+
+
+def _split_kv(item):
+    """Split a flow-map entry on the first top-level ':'."""
+    depth, q = 0, None
+    for i, c in enumerate(item):
+        if q:
+            if c == q:
+                q = None
+        elif c in "\"'":
+            q = c
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ":" and depth == 0:
+            return item[:i], item[i + 1:]
+    return item, None
+
+
+def _parse_flow(s):
+    s = s.strip()
+    if s.startswith("["):
+        if not s.endswith("]"):
+            raise YAMLError(f"unterminated flow sequence: {s!r}")
+        inner = s[1:-1].strip()
+        return [_parse_flow(x) for x in _split_top(inner)] if inner else []
+    if s.startswith("{"):
+        if not s.endswith("}"):
+            raise YAMLError(f"unterminated flow mapping: {s!r}")
+        inner = s[1:-1].strip()
+        d = {}
+        for item in (_split_top(inner) if inner else []):
+            if not item.strip():
+                continue
+            k, v = _split_kv(item)
+            if v is None:
+                raise YAMLError(f"bad flow mapping entry: {item!r}")
+            d[str(_scalar(k))] = _parse_flow(v)
+        return d
+    return _scalar(s)
+
+
+def _value(s):
+    """A value that may be a flow collection or a plain scalar."""
+    s = _strip_comment(s).strip()
+    if s[:1] in "[{":
+        return _parse_flow(s)
+    return _scalar(s)
+
+
+# ---------- block parser ----------
+
+def _indent(line):
+    return len(line) - len(line.lstrip(" "))
+
+
+def _key_split(content):
+    """Split a block-mapping line into (key, rest) on the first ': ' / trailing ':' at depth 0 outside
+    quotes/flow. Returns (None, None) if it is not a mapping line."""
+    depth, q = 0, None
+    for i, c in enumerate(content):
+        if q:
+            if c == q:
+                q = None
+        elif c in "\"'":
+            q = c
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ":" and depth == 0 and (i + 1 == len(content) or content[i + 1] in " \t"):
+            return content[:i].strip(), content[i + 1:]
+    return None, None
+
+
+class _P:
+    def __init__(self, text):
+        self.lines = text.split("\n")
+        self.i = 0
+
+    def _skip(self):
+        while self.i < len(self.lines):
+            s = self.lines[self.i].strip()
+            if s == "" or s.startswith("#"):
+                self.i += 1
+            else:
+                return
+
+    def parse_node(self, indent):
+        self._skip()
+        if self.i >= len(self.lines):
+            return None
+        ci = _indent(self.lines[self.i])
+        if ci < indent:
+            return None
+        content = self.lines[self.i].strip()
+        if content[:1] in "[{":
+            self.i += 1
+            return _value(content)
+        if content == "-" or content.startswith("- "):
+            return self.parse_seq(ci)
+        key, _rest = _key_split(content)
+        if key is not None:
+            return self.parse_map(ci)
+        self.i += 1
+        return _value(content)
+
+    def parse_map(self, indent):
+        d = {}
+        while True:
+            self._skip()
+            if self.i >= len(self.lines):
+                break
+            ci = _indent(self.lines[self.i])
+            if ci != indent:
+                break
+            content = self.lines[self.i].strip()
+            key, rest = _key_split(content)
+            if key is None:
+                break
+            self.i += 1
+            rest = (rest or "").strip()
+            stripped = _strip_comment(rest).strip()
+            if stripped in (">", "|", ">-", "|-", ">+", "|+"):
+                d[str(_scalar(key))] = self._block_scalar(indent)
+            elif rest == "" or _strip_comment(rest).strip() == "":
+                d[str(_scalar(key))] = self.parse_node(indent + 1)
+            else:
+                d[str(_scalar(key))] = _value(rest)
+        return d
+
+    def parse_seq(self, indent):
+        items = []
+        while True:
+            self._skip()
+            if self.i >= len(self.lines):
+                break
+            line = self.lines[self.i]
+            if _indent(line) != indent:
+                break
+            stripped = line.strip()
+            if stripped != "-" and not stripped.startswith("- "):
+                break
+            # rewrite the leading '-' to a space so the item content sits at indent+2 and reparse
+            self.lines[self.i] = line[:indent] + " " + line[indent + 1:]
+            if stripped == "-":
+                self.i += 1
+                items.append(self.parse_node(indent + 1))
+            else:
+                items.append(self.parse_node(indent + 2))
+        return items
+
+    def _block_scalar(self, key_indent):
+        """Capture a `>`/`|` block as text (folded loosely). We never interpret these, just consume."""
+        out = []
+        while self.i < len(self.lines):
+            line = self.lines[self.i]
+            if line.strip() == "":
+                out.append("")
+                self.i += 1
+                continue
+            if _indent(line) <= key_indent:
+                break
+            out.append(line.strip())
+            self.i += 1
+        return " ".join(x for x in out if x).strip()
+
+
+def safe_load(text):
+    if text is None:
+        return None
+    p = _P(text)
+    p._skip()
+    if p.i >= len(p.lines):
+        return None
+    return p.parse_node(_indent(p.lines[p.i]))

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -13,9 +13,11 @@ import sys
 from pathlib import Path
 
 try:
-    import yaml
+    import yaml  # prefer PyYAML when present
 except ImportError:
-    sys.exit("PyYAML required: pip install pyyaml")
+    # Agent hosts may lack PyYAML AND pip (externally-managed Python) — never make the author
+    # pip-install just to validate. Same vendored stdlib-only fallback _pkg.py (strategy-ops) uses.
+    import _yaml as yaml
 
 
 _VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -18,6 +18,22 @@ except ImportError:
     sys.exit("PyYAML required: pip install pyyaml")
 
 
+_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _flat_wallet_env(pkg: Path, sid) -> str:
+    """Mirror the deployer's flat-instance synthesis: bind wallet_env to the ${...} the flat
+    runtime.yaml already uses for its wallet, falling back to <ID>_WALLET."""
+    try:
+        doc = yaml.safe_load((pkg / "runtime.yaml").read_text()) or {}
+        m = _VAR_RE.search(str((doc.get("strategy") or {}).get("wallet") or ""))
+        if m:
+            return m.group(1)
+    except Exception:  # noqa: BLE001 — best-effort; the binding check below flags a miss
+        pass
+    return re.sub(r"[^A-Za-z0-9]", "_", str(sid or "")).upper().strip("_") + "_WALLET"
+
+
 def validate(pkg: Path) -> list:
     errs = []
     man_path = pkg / "strategy.yaml"
@@ -34,7 +50,16 @@ def validate(pkg: Path) -> list:
     if not man.get("version"):
         errs.append("missing version (single source for catalog + attribution)")
     if not man.get("instances"):
-        errs.append("no instances[]")
+        # FLAT single-instance package — the layout agents naturally scaffold; the deployer accepts
+        # it (strategy-ops v2.4.0+) by synthesizing the canonical `main` instance. Synthesize the SAME
+        # instance here so every code-level check below still runs — a red author validator on a
+        # package the deployer would accept is exactly the author↔ops drift this file must not have.
+        if (pkg / "runtime.yaml").is_file():
+            man = dict(man)
+            man["instances"] = [{"name": "main", "runtime": "runtime.yaml",
+                                 "wallet_env": _flat_wallet_env(pkg, sid)}]
+        else:
+            errs.append("no instances[] (and no flat root runtime.yaml to synthesize one from)")
 
     seen_wallet_envs = set()
     for inst in man.get("instances", []):
@@ -47,6 +72,21 @@ def validate(pkg: Path) -> list:
             errs.append(f"instance {name}: runtime {rt_rel!r} not found")
             continue
         rt_text = rt.read_text()
+
+        # Linkage convention — the deployer + runtime engine key on these, and it was the #1
+        # tripwire in the 3-model deploy bake-off (every model wrote `name: <id>`): the runtime's
+        # `name:` must be `<id>-<instance>` and `group:` must be `<id>`. Same prescriptive wording
+        # as strategy-ops `_pkg.validate`, so author-green ≈ deploy-green.
+        try:
+            rt_doc = yaml.safe_load(rt_text) or {}
+        except Exception:  # noqa: BLE001 — unparseable YAML surfaces via the checks below
+            rt_doc = None
+        if isinstance(rt_doc, dict):
+            expect = f"{sid}-{name}"
+            if rt_doc.get("name") != expect:
+                errs.append(f"instance {name}: set runtime `name: {expect}` (found {rt_doc.get('name')!r})")
+            if rt_doc.get("group") != sid:
+                errs.append(f"instance {name}: set runtime `group: {sid}` (found {rt_doc.get('group')!r})")
 
         # data_retention: Runtime 3.0 uses data_retention_seconds (integer 3600–604800);
         # the v2 data_retention_hours field is deprecated. (See senpi-trading-runtime/references/runtime-yaml.md.)
@@ -145,7 +185,9 @@ def main(argv):
                 print(f"    - {e}")
         else:
             man = yaml.safe_load((pkg / "strategy.yaml").read_text())
-            print(f"✓ {pkg.name} v{man.get('version')} ({len(man.get('instances', []))} instance(s))")
+            n = len(man.get("instances") or [])
+            label = f"{n} instance(s)" if n else "flat single-instance"
+            print(f"✓ {pkg.name} v{man.get('version')} ({label})")
     sys.exit(1 if bad else 0)
 
 

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -81,10 +81,16 @@ So **never hand-edit `.deploy-state.json` and never lower `--budget` to dodge a 
 just re-run `create`.
 
 **Step 2 — setting up the autonomous trading strategy** (`runtime`, fast): `python3 scripts/deploy.py
-runtime spider` renders each instance's runtime.yaml with its wallet and runs `openclaw senpi runtime create`.
-**Self-healing**: if a runtime already exists on the right ACTIVE wallet it's skipped; if it's stale
-(different/CLOSED wallet, e.g. orphaned by an earlier close) it's deleted and recreated. Prints
-`registered`. `--decision-model` only for a `decision_mode: llm` action (rule-mode strategies need none).
+runtime spider` renders each instance's runtime.yaml **fresh from its `${WALLET_ENV}` template with the
+wallet Step 1 created** and runs `openclaw senpi runtime create`. **Never reuses an old wallet:** the
+runtime is always (re)built from scratch on the fresh wallet — if a same-name runtime already exists on a
+**different/old** wallet it is **deleted and recreated**, never `runtime update`d in place; only an exact
+same-wallet match is an idempotent skip. **Self-heals a lost deploy state:** if Step 1 succeeded but its
+`.deploy-state.json` was lost (a sub-agent died before persisting), `runtime` **re-resolves the fresh
+wallet from the live ACTIVE `<id>` strategy** instead of dead-ending — so you never hand-register a runtime
+onto an old wallet. It **won't guess**: if the backend is ambiguous (0 or >1 ACTIVE `<id>` wallets) it
+refuses and tells you to redeploy fresh (`close.py` any stale wallet, then `create`). Prints `registered`.
+`--decision-model` only for a `decision_mode: llm` action (rule-mode strategies need none).
 
 **Once Step 2 prints `registered`, deployment is DONE — the strategy is live and trading autonomously.**
 It scans on its own schedule and opens positions when *its* signals fire (spider swing ~300s, scalp ~60s
@@ -105,7 +111,9 @@ Do not run `verify` (and never `sleep` then verify) as a default step.
 > USDC, then **re-run `create`**. Do not switch tools. If `create` reports **`closing-existing`**, it's
 > closing a runtime-less `<id>` wallet to recover funds so it can deploy fresh — re-run `create` once it's
 > closed. If it **refuses** "already deployed AND running", a live `<id>` strategy exists — `close.py <id>`
-> first to redeploy on a fresh wallet.
+> first to redeploy on a fresh wallet. If **`runtime`** says "wallet(s) not ready and not safely
+> recoverable", **never hand-register a runtime onto an old wallet** (no manual `runtime create`/`update`
+> with a wallet from a leftover yaml) — `close.py <id>` any stale wallet, then re-run `create` → `runtime`.
 
 **Report** from the structured output, not raw logs (then always close with the **How it runs** block below):
 ```jsonc

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -46,8 +46,13 @@ python3 senpi-strategy-ops/scripts/close.py          --all                 # tea
 **Always tear down through `close.py`** (one `<id>` or `--all`) — it deletes the runtime *and* closes the
 strategy. A raw `strategy_close` MCP call closes the strategy but **leaves the runtime registered**, which
 collides on the next deploy. "close all strategies / return funds to main" → `close.py --all`.
-Pass the **strategy `id`** (what `senpi-strategy-discover` hands over, e.g. `spider`); the package is
-fetched from the remote if not on disk. The scripts call MCP directly (`scripts/mcp_client.py`, reads
+Pass the **strategy `id`** for a CATALOG strategy (what `senpi-strategy-discover` hands over, e.g.
+`spider`) — it's fetched from the remote if not on disk. For a **locally-authored package, pass its
+DIRECTORY path** (absolute is safest, e.g. `/data/workspace/strategies/<id>`): a bare id only resolves
+locally relative to your CWD, so from anywhere else it becomes a remote catalog fetch — never what you
+want for a package you just wrote. An on-disk package is authoritative; an invalid one surfaces its
+real errors and is never silently replaced by a remote fetch. The scripts call MCP directly
+(`scripts/mcp_client.py`, reads
 `SENPI_AUTH_TOKEN`) + drive `openclaw senpi runtime …`. Mechanics + state machine:
 [`references/lifecycle.md`](references/lifecycle.md). Manifest: [`references/strategy-yaml-schema.md`](references/strategy-yaml-schema.md).
 

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.3.0"
+  version: "2.4.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -35,6 +35,7 @@ sizing/execution, the two-phase DSL exit, risk guard-rails. **There is no separa
 tool call — wallet funding and the first scan tick are slow, so they must not block one long call):
 
 ```
+python3 senpi-strategy-ops/scripts/deploy.py validate <id>                 # 0. preflight — deploy-ready? (no side effects)
 python3 senpi-strategy-ops/scripts/deploy.py create  <id> --budget <usd>   # 1. create wallets & fund them
 python3 senpi-strategy-ops/scripts/deploy.py runtime <id>                  # 2. set up autonomous trading (DONE after this)
 python3 senpi-strategy-ops/scripts/deploy.py verify  <id>                  # optional: confirm a scan fired (only if asked)
@@ -58,8 +59,17 @@ exists, check the registry; no match → hand to **senpi-strategy-discover**:
 curl -s https://raw.githubusercontent.com/Senpi-ai/senpi-skills/refs/heads/main/strategies/catalog.json
 ```
 
+**Step 0.5 — preflight (recommended).** `deploy.py validate <id>` reports every structural + render
+issue in **one pass**, with **no side effects**, before you fund anything. The deployer **accepts the
+flat single-instance layout** agents naturally scaffold — one `runtime.yaml` + `scanners/` at the
+package root — by synthesizing the canonical `main` instance, so there's **no need to restructure into
+`main/`**. Any remaining fix is named prescriptively (e.g. `set runtime name: <id>-main`). A package
+that exists **on disk is authoritative** — an invalid local package surfaces its real error and is
+never silently replaced by a stale remote fetch.
+
 **Step 1 — creating wallets & funding them** (`create`; one fresh wallet per instance; budget splits by
-`funding_share`, **min $100 each** — confirm with the user first):
+`funding_share`, **min $100 each** — confirm with the user first). `create` runs the same full preflight
+first, so it refuses **before funding** if the package isn't deploy-ready:
 ```
 python3 scripts/deploy.py create spider --budget 200
 ```

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.3.0"
+  version: "2.4.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -36,8 +36,8 @@ tool call — wallet funding and the first scan tick are slow, so they must not 
 
 ```
 python3 senpi-strategy-ops/scripts/deploy.py create  <id> --budget <usd>   # 1. create wallets & fund them
-python3 senpi-strategy-ops/scripts/deploy.py runtime <id>                  # 2. set up autonomous trading (DONE after this)
-python3 senpi-strategy-ops/scripts/deploy.py verify  <id>                  # optional: confirm a scan fired (only if asked)
+python3 senpi-strategy-ops/scripts/deploy.py runtime <id>                  # 2. register the runtime(s)
+python3 senpi-strategy-ops/scripts/deploy.py verify  <id>                  # 3. GATE — confirm LIVE (runtime+scanner+DSL+budget)
 python3 senpi-strategy-ops/scripts/status.py                               # what am I running? (+ health)
 python3 senpi-strategy-ops/scripts/close.py          <id>                  # teardown one strategy
 python3 senpi-strategy-ops/scripts/close.py          --all                 # teardown EVERY open strategy
@@ -50,7 +50,12 @@ fetched from the remote if not on disk. The scripts call MCP directly (`scripts/
 `SENPI_AUTH_TOKEN`) + drive `openclaw senpi runtime …`. Mechanics + state machine:
 [`references/lifecycle.md`](references/lifecycle.md). Manifest: [`references/strategy-yaml-schema.md`](references/strategy-yaml-schema.md).
 
-## Deploy — two steps (then it's autonomously trading; `verify` is optional)
+## Deploy — three steps: create → runtime → verify (NOT live until `verify` passes)
+
+> **The loop is a gate, not a suggestion.** A strategy is LIVE only when `verify` returns `live` — every
+> instance **runtime-running + scanner-active + DSL-wired + funded to what was requested**. If any step is
+> incomplete, the strategy is **not live**; say so and fix the flagged component. Never report "live" off
+> `registered` alone.
 
 **Step 0 — resolve which strategy.** The user's word ("spider") is a strategy **`id`**. To confirm it
 exists, check the registry; no match → hand to **senpi-strategy-discover**:
@@ -72,9 +77,13 @@ is still created (unnamed) rather than failing the deploy. It records the `strat
 `strategy_list` to **ACTIVE** — **bounded** (~150s). If it prints
 **`creating`** (wallets still funding), just **re-run the same `create` command** — it resumes and
 **never re-creates** a wallet. It prints **`wallets-ready`** when done. `create` is **self-healing**: it
-reconciles recorded wallets against the backend (drops any CLOSED/FAILED and recreates) and **sizes each
-wallet to your live balance minus a fee buffer**. So **never hand-edit `.deploy-state.json` and never
-lower `--budget` to dodge a rounding/funding error** — just re-run `create`.
+reconciles recorded wallets against the backend (drops any CLOSED/FAILED and recreates). The `--budget` is
+a **hard target**: create funds exactly what you ask (split by `funding_share`, $100/wallet floor). If your
+live balance can't cover it, create **HALTS with `underfunded`** and the exact shortfall — it will **NEVER
+silently fund less** (the "$1,000 → $100" failure). Fund more USDC / free some from another strategy, or
+confirm a smaller amount with the user, then re-run. **Never hand-edit `.deploy-state.json`.** When the user
+names a budget per strategy ("$1k on X, $2k on Y"), deploy each with its own `--budget` and **confirm the
+split before funding**.
 
 **Step 2 — setting up the autonomous trading strategy** (`runtime`, fast): `python3 scripts/deploy.py
 runtime spider` renders each instance's runtime.yaml with its wallet and runs `openclaw senpi runtime create`.
@@ -82,23 +91,23 @@ runtime spider` renders each instance's runtime.yaml with its wallet and runs `o
 (different/CLOSED wallet, e.g. orphaned by an earlier close) it's deleted and recreated. Prints
 `registered`. `--decision-model` only for a `decision_mode: llm` action (rule-mode strategies need none).
 
-**Once Step 2 prints `registered`, deployment is DONE — the strategy is live and trading autonomously.**
-It scans on its own schedule and opens positions when *its* signals fire (spider swing ~300s, scalp ~60s
-cadence). Tell the user it's set up and running; **do NOT sleep/poll waiting for the first scan tick** —
-that's normal strategy behavior, not part of deploy.
+**Once Step 2 prints `registered`, the runtime is wired — but the strategy is NOT confirmed live yet.**
+Run **Step 3 `verify`**. **Do NOT tell the user the strategy is live until `verify` returns `live`.**
 
-**Optional — `verify`** (only if the user asks "is it actually scanning / live yet?"): `python3
-scripts/deploy.py verify spider` checks each `external_scanner` once. The first `scan()` only fires on its
-`interval_seconds`, so right after `runtime` it reports `registered` (not ticked yet) — expected, not a
-failure; re-run after the interval to see `live`. `deploy.py status <id>` shows current state any time.
-Do not run `verify` (and never `sleep` then verify) as a default step.
+**Step 3 — `verify`** (the required gate): `python3 scripts/deploy.py verify spider` returns **`live`** only
+when every instance is runtime-running + scanner-active (ticked *or* scheduled, never erroring) + **DSL-wired**
+(`exit.dsl_preset` present and the monitor enabled) + **funded to what was requested**; otherwise **`not-live`**
+with the failing component named (e.g. `scanner=broken`, `dsl=config-missing`, `budget=underfunded`). Fix the
+flagged component and re-run. It's a **single fast check** — a scheduled scanner passes, so it does **not**
+wait for the first scan tick and you must **never `sleep` then verify**. `deploy.py status <id>` shows deploy
+state any time.
 
 > **Do NOT improvise.** A package strategy is a **runtime-supervised scanner** — deploy it **only** via
 > these steps. Never substitute a raw `strategy_create_custom_strategy` MCP call to "deploy" it: that
 > makes an **empty** custom-position strategy, not the running scanner. Funding is **automatic**
-> (Hyperliquid perps → HL spot → EVM bridge). If `create` reports insufficient USDC / `available: 0`, the
-> wallet genuinely lacks accessible funds (often locked in other strategies) — have the user fund/free
-> USDC, then **re-run `create`**. Do not switch tools. If `create` **refuses** with "existing strategies
+> (Hyperliquid perps → HL spot → EVM bridge). If `create` reports **`underfunded`** (or insufficient USDC /
+> `available: 0`), the balance can't cover the requested budget (often locked in other strategies) — have
+> the user fund/free USDC or confirm a lower amount, then **re-run `create`**. Do not switch tools. If `create` **refuses** with "existing strategies
 > not in deploy state", a prior run was interrupted — `close.py <id>` the strays first, then `create`.
 
 **Report** from the structured output, not raw logs (then always close with the **How it runs** block below):
@@ -108,10 +117,11 @@ Do not run `verify` (and never `sleep` then verify) as a default step.
   "instances":[ { "instance":"swing","runtime_id":"spider-swing","wallet":"0x…","status":"live" },
                 { "instance":"scalp","runtime_id":"spider-scalp","wallet":"0x…","status":"live" } ] }
 ```
-Overall status across the steps: `create` → `creating` (re-run) | `wallets-ready`; `runtime` →
-`registered`; `verify` → `live` (scanner ticked) | `registered` (re-run verify). Per-instance status
-flows `pending → creating → active → registered → live`. **`registered` ≠ ticking.** `create`/`runtime`
-take `--dry-run` (plan only; no side effects).
+Overall status across the steps: `create` → `creating` (re-run) | `wallets-ready` | **`underfunded`**
+(balance < requested — fund more / lower the ask); `runtime` → `registered`; `verify` → **`live`** |
+**`not-live`** (a component failed — fix it, re-run). Per-instance status flows
+`pending → creating → active → registered → live`. **`registered` ≠ live — `verify` is the gate.**
+`create`/`runtime` take `--dry-run` (plan only; no side effects).
 
 ### Final step — tell the user HOW each strategy runs (REQUIRED on every deploy)
 
@@ -125,12 +135,12 @@ Keep it to ~3 short lines per strategy. Multi-instance packages whose legs diffe
 
 ### Worked example — "install spider"
 ```
-user: "deploy spider with $200"
-1. resolve → id = spider (two instances: swing 60% / scalp 40%; $200 → swing ~$120, scalp $100 min)
-2. create → python3 scripts/deploy.py create spider --budget 200
-            → wallets-ready  (if "creating", re-run the same command until wallets-ready)
+user: "deploy spider with $300"
+1. resolve → id = spider (two instances: swing 60% / scalp 40%; $300 → swing $180, scalp $120)
+2. create → python3 scripts/deploy.py create spider --budget 300
+            → wallets-ready  (if "creating", re-run until wallets-ready; if "underfunded", fund more / lower)
 3. runtime → python3 scripts/deploy.py runtime spider          → registered (spider-swing + spider-scalp)
-4. verify  → python3 scripts/deploy.py verify spider           → live  (re-run if a slow instance hasn't ticked)
+4. verify  → python3 scripts/deploy.py verify spider           → live  (runtime+scanner+DSL+budget all green)
 5. confirm → "🕷️ Spider is live (swing + scalp)." + the required How it runs block, e.g.:
    • Cadence — scans every 5 min (swing) / 5 min (scalp).
    • Scoring — grades tech/AI names on 4h/1h trend + smart-money consensus; opens above its score bar,

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.3.0"
+  version: "2.4.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -71,10 +71,14 @@ and notifications. Naming is best-effort: if the backend rejects a name (conflic
 is still created (unnamed) rather than failing the deploy. It records the `strategyId`, and polls
 `strategy_list` to **ACTIVE** — **bounded** (~150s). If it prints
 **`creating`** (wallets still funding), just **re-run the same `create` command** — it resumes and
-**never re-creates** a wallet. It prints **`wallets-ready`** when done. `create` is **self-healing**: it
-reconciles recorded wallets against the backend (drops any CLOSED/FAILED and recreates) and **sizes each
-wallet to your live balance minus a fee buffer**. So **never hand-edit `.deploy-state.json` and never
-lower `--budget` to dodge a rounding/funding error** — just re-run `create`.
+**never re-creates** a wallet. It prints **`wallets-ready`** when done. **`create` never reuses an existing wallet — every deploy gets a
+FRESH one.** If an existing `<id>` strategy is found: a **runtime-less** one (funded but never got a
+runtime — the reuse trap an agent keeps landing back on) is **closed to recover its funds**, then a new
+wallet is created (prints **`closing-existing`**; re-run `create` once it's closed and funds are back); a
+**live, running** one is left untouched — `create` **refuses** so it can't silently flatten a real book
+(`close.py <id>` first to redeploy). It still sizes each wallet to your live balance minus a fee buffer.
+So **never hand-edit `.deploy-state.json` and never lower `--budget` to dodge a rounding/funding error** —
+just re-run `create`.
 
 **Step 2 — setting up the autonomous trading strategy** (`runtime`, fast): `python3 scripts/deploy.py
 runtime spider` renders each instance's runtime.yaml with its wallet and runs `openclaw senpi runtime create`.
@@ -98,8 +102,10 @@ Do not run `verify` (and never `sleep` then verify) as a default step.
 > makes an **empty** custom-position strategy, not the running scanner. Funding is **automatic**
 > (Hyperliquid perps → HL spot → EVM bridge). If `create` reports insufficient USDC / `available: 0`, the
 > wallet genuinely lacks accessible funds (often locked in other strategies) — have the user fund/free
-> USDC, then **re-run `create`**. Do not switch tools. If `create` **refuses** with "existing strategies
-> not in deploy state", a prior run was interrupted — `close.py <id>` the strays first, then `create`.
+> USDC, then **re-run `create`**. Do not switch tools. If `create` reports **`closing-existing`**, it's
+> closing a runtime-less `<id>` wallet to recover funds so it can deploy fresh — re-run `create` once it's
+> closed. If it **refuses** "already deployed AND running", a live `<id>` strategy exists — `close.py <id>`
+> first to redeploy on a fresh wallet.
 
 **Report** from the structured output, not raw logs (then always close with the **How it runs** block below):
 ```jsonc
@@ -108,7 +114,7 @@ Do not run `verify` (and never `sleep` then verify) as a default step.
   "instances":[ { "instance":"swing","runtime_id":"spider-swing","wallet":"0x…","status":"live" },
                 { "instance":"scalp","runtime_id":"spider-scalp","wallet":"0x…","status":"live" } ] }
 ```
-Overall status across the steps: `create` → `creating` (re-run) | `wallets-ready`; `runtime` →
+Overall status across the steps: `create` → `creating` (re-run) | `closing-existing` (re-run once closed) | `wallets-ready`; `runtime` →
 `registered`; `verify` → `live` (scanner ticked) | `registered` (re-run verify). Per-instance status
 flows `pending → creating → active → registered → live`. **`registered` ≠ ticking.** `create`/`runtime`
 take `--dry-run` (plan only; no side effects).

--- a/senpi-strategy-ops/references/strategy-yaml-schema.md
+++ b/senpi-strategy-ops/references/strategy-yaml-schema.md
@@ -18,8 +18,12 @@ strategies/<id>/                # all strategy packages live under strategies/
   <instance2>/ …                # one subdir per instance (multi-runtime, e.g. spider swing + scalp)
 ```
 
-A single-instance strategy has one `<instance>/` dir; a multi-instance one (spider) has several, **each
-on its own wallet** (a runtime binds to exactly one wallet).
+A single-instance strategy may use the **FLAT layout** instead — `runtime.yaml` + `scanners/` at the
+package root with **no `instances:` list at all**: the deployer (strategy-ops v2.4.0+) synthesizes the
+canonical `main` instance, binding `wallet_env` to the `${...}` the runtime already uses. A
+multi-instance strategy (spider) has one `<instance>/` dir per runtime, **each on its own wallet** (a
+runtime binds to exactly one wallet), and declares them in `instances:`. `deploy.py validate <id>`
+confirms either form is deploy-ready.
 
 ## Schema
 

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -289,6 +289,12 @@ def strategy_wallet(s):
     return dig(strategy_obj(s), "strategyWalletAddress", "walletAddress", "wallet", "address")
 
 
+def strategy_name(s):
+    """The strategyName a strategy was created under (create sets it to <id> or <id>-<instance>).
+    Lets a lost-state redeploy match a backend strategy back to its package instance."""
+    return dig(strategy_obj(s), "strategyName", "tradingStrategyName", "name")
+
+
 def strategy_skill(s):
     """The package id a strategy was created under. Lives in strategyMetadata.skillName (set by
     strategy_create_custom_strategy's skillName arg); falls back to tradingStrategyName."""

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -69,6 +69,19 @@ class Instance:
         return self.external_scanner.get("interval_seconds")
 
     @property
+    def exit_block(self):
+        ex = (self.runtime_doc or {}).get("exit")
+        return ex if isinstance(ex, dict) else {}
+
+    @property
+    def has_dsl(self):
+        """True iff the runtime.yaml ships a DSL exit block (`exit:` with a preset or `engine: dsl`) —
+        the built-in trailing stop. A deployed strategy WITHOUT one runs its positions naked (the
+        funded-but-no-DSL hole). Mirrors the author-side validate_strategy exit-block requirement."""
+        ex = self.exit_block
+        return bool(ex) and (bool(ex.get("dsl_preset")) or str(ex.get("engine", "")).lower() == "dsl")
+
+    @property
     def needs_model(self):
         """True iff any action runs decision_mode: llm (then a decision-model env must be injected)."""
         for a in (self.runtime_doc or {}).get("actions", []) or []:
@@ -189,6 +202,13 @@ def validate(pkg: Package) -> list:
             ep = inst.runtime_path.parent / sub / es.get("entrypoint", "scan.py")
             if not ep.is_file():
                 errs.append(f"{tag}: scanner entrypoint {ep.name!r} not found at {ep.parent}")
+        # Protection is not optional — a deployed strategy with no DSL exit runs every position naked
+        # (the funded-but-no-DSL hole). Refuse to deploy it. (author's validate_strategy checks this too;
+        # ops re-checks so a hand-edited or fetched package can't slip a naked strategy past deploy.)
+        if not inst.has_dsl:
+            errs.append(f"{tag}: runtime {inst.runtime_rel!r} has no DSL exit block "
+                        f"(exit.dsl_preset / engine: dsl) — every deployed strategy must ship "
+                        f"built-in protection")
         if inst.funding_share is None:
             errs.append(f"{tag}: missing funding_share")
         # llm actions need a model env declared

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -126,6 +126,31 @@ def resolve_pkg_dir(arg):
     return p  # let load() raise the BadPackage with the original arg
 
 
+_DEFAULT_INSTANCE = "main"
+
+
+def _flat_instance(pkg_dir, pkg_id):
+    """Synthesize the manifest entry for a FLAT single-instance package (one `runtime.yaml` at the
+    package root + `scanners/`) — the layout agents naturally scaffold. Binds `wallet_env` to the
+    `${...}` the flat runtime already uses for its wallet, so render substitutes correctly; falls back
+    to `<ID>_WALLET` when the runtime declares none (validate then flags the missing binding, rather
+    than the deploy failing opaquely). The synthesized instance flows through validate/render/deploy
+    identically to a declared one."""
+    wallet_env = None
+    try:
+        doc = yaml.safe_load((pkg_dir / "runtime.yaml").read_text()) or {}
+        wallet_ref = (doc.get("strategy") or {}).get("wallet") if isinstance(doc, dict) else None
+        m = _VAR_RE.search(str(wallet_ref or ""))
+        if m:
+            wallet_env = m.group(1)
+    except Exception:  # noqa — best-effort detection; validate catches a bad/absent binding
+        pass
+    if not wallet_env:
+        wallet_env = re.sub(r"[^A-Za-z0-9]", "_", str(pkg_id or "")).upper().strip("_") + "_WALLET"
+    return {"name": _DEFAULT_INSTANCE, "runtime": "runtime.yaml",
+            "wallet_env": wallet_env, "funding_share": 1.0}
+
+
 def load(pkg_dir) -> Package:
     """Parse strategy.yaml into a Package. Accepts a path or a bare id (resolved to strategies/<id>).
     Raises BadPackage if it can't be modelled at all."""
@@ -143,7 +168,15 @@ def load(pkg_dir) -> Package:
     if not man.get("id"):
         raise BadPackage("strategy.yaml: missing 'id'")
     if not isinstance(man.get("instances"), list) or not man["instances"]:
-        raise BadPackage("strategy.yaml: 'instances' must be a non-empty list")
+        # Accept a FLAT single-instance package — synthesize the canonical `main` instance when there
+        # IS a root runtime.yaml to point it at. A package with neither instances nor a root
+        # runtime.yaml is genuinely unusable.
+        if (pkg / "runtime.yaml").is_file():
+            man = dict(man)
+            man["instances"] = [_flat_instance(pkg, man.get("id"))]
+        else:
+            raise BadPackage("strategy.yaml: 'instances' must be a non-empty list "
+                             "(or ship a single flat runtime.yaml at the package root)")
     return Package(pkg, man)
 
 
@@ -167,12 +200,13 @@ def validate(pkg: Package) -> list:
         if inst.runtime_doc is None:
             errs.append(f"{tag}: runtime {inst.runtime_rel!r} is not valid YAML")
             continue
-        # linkage convention
+        # linkage convention — messages are PRESCRIPTIVE (the exact value to set), since every model
+        # in the bake-off tripped on `name: <id>` vs the required `<id>-<instance>`.
         if inst.group != pkg.id:
-            errs.append(f"{tag}: runtime group {inst.group!r} != strategy id {pkg.id!r}")
+            errs.append(f"{tag}: set runtime `group: {pkg.id}` (found {inst.group!r})")
         expect_name = f"{pkg.id}-{inst.name}"
         if inst.runtime_name != expect_name:
-            errs.append(f"{tag}: runtime name {inst.runtime_name!r} != {expect_name!r}")
+            errs.append(f"{tag}: set runtime `name: {expect_name}` (found {inst.runtime_name!r})")
         # wallet binding
         if not inst.wallet_env:
             errs.append(f"{tag}: missing wallet_env")
@@ -189,6 +223,13 @@ def validate(pkg: Package) -> list:
             ep = inst.runtime_path.parent / sub / es.get("entrypoint", "scan.py")
             if not ep.is_file():
                 errs.append(f"{tag}: scanner entrypoint {ep.name!r} not found at {ep.parent}")
+            # the runtime engine requires a non-empty signal_data_schema MAP on the external_scanner,
+            # as a sibling of `inputs` (not nested inside it) — the other bake-off tripwire. Surface it
+            # here, pre-funding, instead of at runtime-create after the wallet is already funded.
+            sds = es.get("signal_data_schema")
+            if not isinstance(sds, dict) or not sds:
+                errs.append(f"{tag}: external_scanner needs a non-empty `signal_data_schema` map "
+                            f"(a sibling of `inputs`, not nested inside it)")
         if inst.funding_share is None:
             errs.append(f"{tag}: missing funding_share")
         # llm actions need a model env declared

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -181,19 +181,45 @@ def cmd_create(pkg, a, log):
             st["instances"][inst.name] = {"status": "pending"}
     save_state(pkg, st)
 
-    # Safety: refuse if there are skillName==id strategies we never recorded (interrupted run) — do
-    # NOT blindly fund duplicates. The operator must close the strays first.
-    recorded = {inst_state(st, i.name).get("strategyId") for i in pkg.instances}
-    recorded.discard(None)
-    existing = _cli.strategies_for(mcp, skill_name=pkg.id)
-    # only OPEN, unrecorded strategies indicate an interrupted run — closed/failed history is harmless
-    untracked = [s for s in existing if _cli.strategy_open(s) and _cli.strategy_id_of(s) not in recorded]
-    need = [i for i in pkg.instances if not inst_state(st, i.name).get("strategyId")]
-    if untracked and need:
+    # NEVER reuse an existing strategy's wallet. Re-using a funded, runtime-less wallet is the trap an
+    # agent keeps falling into (creates <id>, never deploys the runtime, keeps landing back on the same
+    # dead wallet); creating a second alongside it double-funds. So every `create` deploys on a FRESH
+    # wallet, resolving any existing OPEN <id> strategy first:
+    #   • RUNNING runtime → a live, working deploy: REFUSE to silently flatten it; redeploy is explicit
+    #     (close.py first). Protects a real book from an accidental `create`.
+    #   • no running runtime → the funded-but-stuck trap: CLOSE it (recovers its funds), then this deploy
+    #     creates a fresh wallet. strategy_close is async, so hand off and re-run `create` once it's closed.
+    runtimes = _cli.list_runtimes()
+    existing_open = [s for s in _cli.strategies_for(mcp, skill_name=pkg.id) if _cli.strategy_open(s)]
+
+    def _has_running_runtime(s):
+        rt = _cli.find_runtime_by_wallet(_cli.strategy_wallet(s))
+        return bool(rt) and _cli.runtime_running(rt)
+
+    live = [s for s in existing_open if _has_running_runtime(s)]
+    if live:
         raise SystemExit(
-            f"error: found {len(untracked)} existing {pkg.id} strateg(y/ies) not in this deploy's state "
-            f"(likely an interrupted run). Close them first to avoid duplicate funded wallets:\n"
-            f"  python3 {Path(__file__).with_name('close.py')} {pkg.id}")
+            f"error: {pkg.id} is already deployed AND running ({len(live)} live wallet(s)) — `create` will not "
+            f"silently close a live strategy. To redeploy on a fresh wallet, close it first:\n"
+            f"  python3 {Path(__file__).with_name('close.py')} {pkg.id}\n"
+            f"Or just re-check it:  python3 {Path(__file__).name} verify {pkg.id}")
+
+    if existing_open:  # open but NOT running → the runtime-less trap: close (recover funds) → fresh wallet
+        import close as _close  # noqa: E402 — sibling module, lazy import
+        for s in existing_open:
+            _close.close_one(pkg.id, s, runtimes, False, log)
+        for inst in pkg.instances:  # forget the old ids so the re-run makes NEW wallets, never resumes them
+            prev = inst_state(st, inst.name)
+            st["instances"][inst.name] = ({"status": "pending", "requested": prev["requested"]}
+                                          if prev.get("requested") else {"status": "pending"})
+        save_state(pkg, st)
+        return report(pkg, st, "closing-existing", note=(
+            f"Found {len(existing_open)} existing {pkg.id} strateg(y/ies) with NO running runtime — closing "
+            f"them (recovering funds) so this deploys on a FRESH wallet, never reusing the runtime-less one. "
+            f"strategy_close is async; re-run `python3 {Path(__file__).name} create {pkg.id} --budget "
+            f"{a.budget:g}` once they're CLOSED and the funds are back."), as_json=a.json)
+
+    need = [i for i in pkg.instances if not inst_state(st, i.name).get("strategyId")]
 
     # size the to-create instances against the LIVE available balance (minus a per-wallet fee buffer),
     # so sequential funding + creation fees can't leave a later instance short.

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -48,16 +48,36 @@ ORDER = ("pending", "creating", "active", "registered", "live")
 # ---------- package + state ----------
 
 def ensure_pkg(arg, ref, log):
-    try:
+    # A package that EXISTS on disk is authoritative — load it and let any BadPackage surface as the
+    # real, fixable error. NEVER fall through to a (possibly stale) remote fetch just because a local
+    # package is invalid: that silently deploys the wrong version and discards the author's local fixes.
+    # Only a bare id that isn't a local directory triggers the catalog fetch from remote.
+    if (_pkg.resolve_pkg_dir(arg) / "strategy.yaml").is_file():
         return _pkg.load(arg)
-    except _pkg.BadPackage as e:
-        sid = Path(arg).name
-        log(f"package not on disk — fetching {sid} from remote…")
+    sid = Path(arg).name
+    log(f"package {sid!r} not on disk — fetching from remote…")
+    try:
+        _fetch.fetch_package(sid, "strategies", ref=ref)
+        return _pkg.load(sid)
+    except (_fetch.FetchError, _pkg.BadPackage) as e:
+        raise SystemExit(f"error: {e}")
+
+
+def full_validate(pkg):
+    """Every error deploy.py can see, in ONE pass, with NO side effects: structural (`_pkg.validate`)
+    plus a render dry-run per instance (unresolved `${...}`, a `decision_mode: llm` with no model). Lets
+    `validate` and the `create` preflight report everything BEFORE a wallet is funded. (Runtime-engine
+    schema errors still surface at `runtime`, but everything modellable here is caught first.)"""
+    errs = list(_pkg.validate(pkg))
+    for inst in pkg.instances:
+        if inst.runtime_doc is None:
+            continue  # already reported by _pkg.validate
         try:
-            _fetch.fetch_package(sid, "strategies", ref=ref)
-            return _pkg.load(sid)
-        except (_fetch.FetchError, _pkg.BadPackage):
-            raise SystemExit(f"error: {e}")
+            inst.render("0x0000000000000000000000000000000000000000",
+                        model_env=pkg.model_env, model="validation-model")
+        except _pkg.BadPackage as e:
+            errs.append(str(e))
+    return errs
 
 
 def _state_path(pkg):
@@ -427,14 +447,31 @@ def main(argv):
     ps = sub.add_parser("status", help="Show the deploy state.")
     common(ps)
 
+    pval = sub.add_parser("validate",
+                          help="Preflight: is the package deploy-ready? (structural + render — no side effects)")
+    common(pval)
+
     a = ap.parse_args(argv[1:])
     log = (lambda m: None) if a.json else (lambda m: print(m))
 
     pkg = ensure_pkg(a.package, a.ref, log)
-    errs = _pkg.validate(pkg)
-    if errs:
-        print(f"✗ {pkg.id}: invalid package", file=sys.stderr)
-        for e in errs:
+
+    # `validate` is the standalone, side-effect-free preflight; `create` runs the SAME full check
+    # before funding any wallet; runtime/verify/status keep the structural gate.
+    gate = full_validate(pkg) if a.cmd in ("validate", "create") else _pkg.validate(pkg)
+    if a.cmd == "validate":
+        if a.json:
+            print(json.dumps({"status": "valid" if not gate else "invalid", "id": pkg.id, "errors": gate}))
+        elif gate:
+            print(f"✗ {pkg.id}: {len(gate)} issue(s) to fix before deploy:", file=sys.stderr)
+            for e in gate:
+                print(f"    - {e}", file=sys.stderr)
+        else:
+            print(f"✓ {pkg.id}: deploy-ready ({len(pkg.instances)} instance(s))")
+        sys.exit(2 if gate else 0)
+    if gate:
+        print(f"✗ {pkg.id}: {len(gate)} issue(s) to fix before deploy:", file=sys.stderr)
+        for e in gate:
             print(f"    - {e}", file=sys.stderr)
         sys.exit(1)
 

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -60,7 +60,12 @@ def ensure_pkg(arg, ref, log):
         _fetch.fetch_package(sid, "strategies", ref=ref)
         return _pkg.load(sid)
     except (_fetch.FetchError, _pkg.BadPackage) as e:
-        raise SystemExit(f"error: {e}")
+        raise SystemExit(
+            f"error: {e}\n"
+            f"  {arg!r} is not a package on disk (tried {arg!r} and 'strategies/{arg}' relative to the "
+            f"current directory) and could not be fetched as a catalog id.\n"
+            f"  Deploying a locally-authored package? Pass its DIRECTORY path instead of a bare id, "
+            f"e.g.: deploy.py validate /data/workspace/strategies/{sid}")
 
 
 def full_validate(pkg):

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -78,13 +78,22 @@ def save_state(pkg, st):
     _state_path(pkg).write_text(json.dumps(st, indent=2) + "\n")
 
 
-def delete_state(pkg):
-    """Remove the ephemeral deploy state — called once a deploy is fully live, or on close."""
-    p = _state_path(pkg)
+def _safe_unlink(p):
+    """Delete a file, ignoring if it's already gone."""
     try:
-        p.unlink()
+        Path(p).unlink()
     except OSError:
         pass
+
+
+def delete_state(pkg):
+    """Remove the ephemeral deploy state — called once a deploy is fully live, or on close. Also sweeps
+    any rendered `<inst>.deploy.runtime.yaml` build artifacts: they carry a baked-in wallet, and a stale
+    one left on disk is exactly what a lost-state manual redeploy wrongly picks up (the reuse trap)."""
+    _safe_unlink(_state_path(pkg))
+    for inst in pkg.instances:
+        if inst.runtime_path:
+            _safe_unlink(inst.runtime_path.with_name(f"{inst.name}.deploy.runtime.yaml"))
 
 
 def inst_state(st, name):
@@ -301,12 +310,54 @@ def cmd_create(pkg, a, log):
 
 # ---------- step 2: deploy runtimes ----------
 
+def _recover_wallet(pkg, inst, active):
+    """Re-resolve one instance's FRESH wallet from the live ACTIVE <id> strategies when the deploy
+    state was lost (the sub-agent died before persisting it). Returns (wallet, error).
+
+    NEVER guesses: if the backend is ambiguous (0, or >1 candidate wallets for the instance) it
+    returns an error so cmd_runtime refuses rather than binding a runtime to the wrong/old wallet —
+    the exact reuse trap (agent hand-registers onto a stale wallet from a leftover rendered yaml)."""
+    if len(pkg.instances) > 1:  # multi-instance: match by the name create assigned each wallet
+        cands = [s for s in active if _cli.strategy_name(s) == f"{pkg.id}-{inst.name}"]
+    else:  # single-instance: the lone ACTIVE <id> strategy is this instance
+        cands = list(active)
+    wallets = {str(_cli.strategy_wallet(s)).lower() for s in cands if _cli.strategy_wallet(s)}
+    if cands and len(wallets) == 1:
+        return _cli.strategy_wallet(cands[0]), None
+    if not cands:
+        return None, f"no ACTIVE {pkg.id} wallet on the backend for instance {inst.name!r}"
+    return None, f"{len(cands)} ACTIVE {pkg.id} wallets match instance {inst.name!r} — ambiguous, won't guess"
+
+
 def cmd_runtime(pkg, a, log):
     st = load_state(pkg)
-    not_ready = [i.name for i in pkg.instances
-                 if not inst_state(st, i.name).get("wallet")]
-    if not_ready and not a.dry_run:
-        raise SystemExit(f"error: wallets not ready for {', '.join(not_ready)} — run `deploy.py create {pkg.id}` first")
+
+    # Self-heal a lost/partial deploy state: if `create` succeeded but its state file was lost (the
+    # sub-agent died before persisting), re-resolve each instance's FRESH wallet from the live ACTIVE
+    # <id> strategies instead of dead-ending. Otherwise the agent improvises a manual `runtime update`
+    # onto an OLD wallet baked into a leftover rendered yaml / a pre-existing same-name runtime — the
+    # reuse trap. We never guess: an ambiguous backend refuses with a redeploy-fresh instruction.
+    missing = [i for i in pkg.instances if not inst_state(st, i.name).get("wallet")]
+    if missing and not a.dry_run:
+        active = _cli.strategies_for(MCPClient(), skill_name=pkg.id, statuses=["ACTIVE"])
+        recovered, unresolved = [], []
+        for inst in missing:
+            w, err = _recover_wallet(pkg, inst, active)
+            if w:
+                inst_state(st, inst.name).update(wallet=w, status="active")
+                recovered.append(inst.name)
+            else:
+                unresolved.append((inst.name, err))
+        if recovered:
+            save_state(pkg, st)
+            log(f"  deploy-state was lost — recovered fresh wallet(s) from the backend for: {', '.join(recovered)}")
+        if unresolved:
+            lines = "\n".join(f"    - {n}: {why}" for n, why in unresolved)
+            raise SystemExit(
+                f"error: wallet(s) not ready and not safely recoverable:\n{lines}\n"
+                f"Do NOT hand-register a runtime on an old wallet. Redeploy on a fresh wallet:\n"
+                f"  python3 {Path(__file__).with_name('close.py')} {pkg.id}   # if a stale {pkg.id} wallet is lingering\n"
+                f"  python3 {Path(__file__).name} create {pkg.id} --budget <usd>")
     if pkg.any_needs_model and not a.decision_model and not a.dry_run:
         raise SystemExit("error: a runtime has a decision_mode: llm action — pass --decision-model <bare-model>")
 
@@ -325,16 +376,20 @@ def cmd_runtime(pkg, a, log):
             s["plan"] = f"openclaw senpi runtime create -p {build} --runtime-id {inst.runtime_name}"
             save_state(pkg, st)
             continue
-        # Reconcile an existing runtime of this id: same+correct wallet → already deployed (skip);
-        # stale (wallet differs, or its wallet is CLOSED — e.g. orphaned by a prior close) → delete it
-        # and recreate. Self-heals the "already exists" / "wallet CLOSED" collisions.
+        # Reconcile an existing runtime of this id. The runtime is ALWAYS (re)built from scratch on the
+        # freshly-resolved wallet — we never reuse an old wallet a same-name runtime is still bound to:
+        #   same + correct wallet → already deployed on this wallet (idempotent skip);
+        #   wallet differs / unreadable / its wallet is CLOSED (orphaned by a prior close) → DELETE the
+        #   old runtime and recreate on the fresh wallet (never `runtime update` it in place).
         existing = _cli.find_runtime(inst.runtime_name)
         if existing:
             if _cli.wallet_match(_cli.runtime_wallet(existing), wallet):
                 s.update(status="registered", error=None)
                 save_state(pkg, st)
+                _safe_unlink(build)  # runtime owns its config now — drop the rendered yaml so no stale wallet lingers
                 continue
-            log(f"  [{inst.name}] stale runtime {inst.runtime_name!r} (wallet mismatch) — deleting")
+            log(f"  [{inst.name}] existing runtime {inst.runtime_name!r} is on a different/old wallet "
+                f"— deleting and recreating on the fresh wallet (never reusing the old one)")
             _cli.run_cli(["openclaw", "senpi", "runtime", "delete", inst.runtime_name], timeout=60)
         build.write_text(text)
         log(f"  [{inst.name}] runtime create…")
@@ -343,9 +398,10 @@ def cmd_runtime(pkg, a, log):
         if rc != 0:
             s.update(error=(err or "runtime create failed").strip()[:300])
             save_state(pkg, st)
-            continue
+            continue  # keep the rendered yaml on failure for debugging
         s.update(status="registered", error=None)
         save_state(pkg, st)
+        _safe_unlink(build)  # registered — the runtime holds its own config; remove the rendered wallet-bearing yaml
 
     if a.dry_run:
         return report(pkg, st, "planned", as_json=a.json)

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -104,17 +104,23 @@ def available_usd(mcp):
 
 
 def plan_funding(need, budget, available):
-    """Per-instance initialBudget for the instances still needing a wallet. Splits the requested
-    budget by funding_share, but caps the TOTAL at the live available balance minus a per-wallet fee
-    buffer (so sequential funding + creation fees can't leave a later instance $1 short). Floors at MIN_WALLET."""
+    """Per-instance initialBudget for the instances still needing a wallet, split by funding_share and
+    floored at MIN_WALLET. Returns (amounts, shortfall).
+
+    The requested budget is a HARD TARGET, not a suggestion: if the live balance can't cover it (minus a
+    per-wallet fee buffer) we return a `shortfall` dict and the caller HALTS — we never silently fund
+    LESS than asked. The old behaviour scaled every wallet down to fit `available`, which quietly turned
+    a "$1,000 / $2,000" request into two $100 floor wallets; that silent under-funding is the bug this
+    removes. (`available` unreadable → shortfall stays None → proceed; create would fail loudly anyway.)"""
     raw = {i.name: max(MIN_WALLET, round((budget or 0) * (i.funding_share or (1.0 / len(need))), 2)) for i in need}
-    total = sum(raw.values())
+    total = round(sum(raw.values()), 2)
+    shortfall = None
     if available is not None:
-        cap = max(0.0, available - FEE_BUFFER * len(need))
-        if total > cap and total > 0:
-            scale = cap / total
-            raw = {n: max(MIN_WALLET, round(a * scale, 2)) for n, a in raw.items()}
-    return raw
+        usable = max(0.0, round(available - FEE_BUFFER * len(need), 2))
+        if total > usable:
+            shortfall = {"requested": total, "available": round(float(available), 2),
+                         "usable": usable, "short_by": round(total - usable, 2), "wallets": len(need)}
+    return raw, shortfall
 
 
 def report(pkg, st, overall, note=None, as_json=False):
@@ -127,6 +133,7 @@ def report(pkg, st, overall, note=None, as_json=False):
         print(f"\n{pkg.id} v{pkg.version}: {overall}")
         for r in insts:
             print(f"  - {r['instance']}: {r['status']}"
+                  + (f"  requested=${r['requested']:g}" if r.get("requested") else "")
                   + (f"  wallet={r['wallet']}" if r.get("wallet") else "")
                   + (f"  ({r['error']})" if r.get("error") else ""))
         if note:
@@ -195,9 +202,18 @@ def cmd_create(pkg, a, log):
             f"(likely an interrupted run). Close them first to avoid duplicate funded wallets:\n"
             f"  python3 {Path(__file__).with_name('close.py')} {pkg.id}")
 
-    # size the to-create instances against the LIVE available balance (minus a per-wallet fee buffer),
-    # so sequential funding + creation fees can't leave a later instance short.
-    amounts = plan_funding(need, a.budget, available_usd(mcp)) if need else {}
+    # Size the to-create instances against the LIVE available balance. The requested --budget is a HARD
+    # TARGET: if the balance can't cover it, HALT with the shortfall (fund more / lower the ask) rather
+    # than silently funding the $100 floor. Nothing is created on this path.
+    amounts, shortfall = plan_funding(need, a.budget, available_usd(mcp)) if need else ({}, None)
+    if shortfall:
+        return report(pkg, st, "underfunded", note=(
+            f"Requested ${shortfall['requested']:g} across {shortfall['wallets']} wallet(s) "
+            f"(min ${MIN_WALLET:g}/wallet), but only ${shortfall['available']:g} is accessible "
+            f"(${shortfall['usable']:g} after fees) — short by ${shortfall['short_by']:g}. "
+            f"NOT funding; no wallet was created. Add USDC (or free some from another strategy), or "
+            f"confirm a lower amount with the user and re-run `create` with --budget ≤ ${shortfall['usable']:g}."),
+            as_json=a.json)
 
     # create any instance that has no strategyId yet — record the id IMMEDIATELY (before polling),
     # so an interrupted run resumes instead of re-creating.
@@ -206,6 +222,7 @@ def cmd_create(pkg, a, log):
         if s.get("strategyId"):
             continue
         amt = amounts.get(inst.name, max(MIN_WALLET, round((a.budget or 0) * (inst.funding_share or 1.0), 2)))
+        s["requested"] = amt  # remember what the user asked to fund → reconciled against actual at verify
         # Name each wallet for its role in the strategy (matches the pkg-instance runtime naming),
         # so wallets are legible in the app / balances / notifications instead of a bare 0x address.
         # e.g. a WhaleHunter deploy → "whalehunter-long", "whalehunter-short". Sanitized to the
@@ -326,9 +343,9 @@ def cmd_runtime(pkg, a, log):
     failed = [i.name for i in pkg.instances if inst_state(st, i.name).get("error")]
     overall = "failed" if failed else "registered"
     note = ("Some instances failed to register — see errors above." if failed else
-            "Done — " + pkg.id + " is deployed and trading autonomously (it scans on its own cadence and "
-            "opens positions when its signals fire). No need to wait for the first tick. "
-            "Optional: `deploy.py verify " + pkg.id + "` only if you want to confirm a scan has fired.")
+            "Registered — now confirm it's actually live: run `deploy.py verify " + pkg.id + "`. "
+            "That gate checks every instance is runtime-running + scanner-active + DSL-wired + funded; "
+            "the strategy is NOT live until it passes. (verify does not wait for the first scan tick.)")
     return report(pkg, st, overall, note=note, as_json=a.json)
 
 
@@ -351,48 +368,121 @@ def _deep_find_scanner(obj, name):
     return None
 
 
-def _check_ticks(pkg, st):
-    """One pass: mark each instance live if its external_scanner has ticked. Returns the list of
-    instances not yet live as (name, reason)."""
-    pending = []
+def _scanner_verdict(inst, state):
+    """(status, detail) for the instance's external_scanner, from `openclaw senpi state` JSON.
+      ticked    — runCount>0 (it has actually scanned)
+      scheduled — mounted + enabled + no error, runCount==0 (first tick fires on interval_seconds)
+      broken    — not mounted / disabled / erroring
+    'scheduled' counts as live: everything is wired and will fire on cadence — we do NOT block the gate
+    waiting for a slow first tick, but we DO fail a scanner that threw on init."""
+    sc = _deep_find_scanner(state, inst.external_scanner.get("name")) if state else None
+    if not sc:
+        return "broken", "scanner not mounted in runtime state"
+    if _cli.dig(sc, "enabled", default=True) is False:
+        return "broken", "scanner disabled"
+    err = _cli.dig(sc, "lastError")
+    cec = _cli.dig(sc, "consecutiveErrorCount", default=0) or 0
+    if err or (isinstance(cec, (int, float)) and cec >= 1):
+        return "broken", f"scanner erroring: {str(err)[:120] if err else f'{int(cec)} consecutive errors'}"
+    runs = _cli.dig(sc, "runCount", "ticks", "runs", default=0) or 0
+    if isinstance(runs, (int, float)) and runs > 0:
+        return "ticked", f"{int(runs)} scan(s)"
+    return "scheduled", f"awaiting first tick (~{inst.interval_seconds or '?'}s cadence)"
+
+
+def _dsl_verdict(inst, status_json):
+    """(status, detail) for DSL protection. The STATIC check — the deployed runtime.yaml has an
+    `exit.dsl_preset` — is load-bearing (it closes the funded-but-no-DSL hole); the runtime monitor's
+    `enabled` flag (from `senpi status`) confirms it wired. If status is unreadable we trust the static
+    config — never fail the gate on an unreadable status alone."""
+    if not inst.has_dsl:
+        return "config-missing", "runtime.yaml has no exit.dsl_preset — positions would run naked"
+    dsl = _cli._deep_first(status_json, ["dsl"]) if status_json else None
+    if isinstance(dsl, dict) and _cli.dig(dsl, "enabled") is False:
+        return "monitor-down", "DSL configured but its monitor is disabled in the runtime"
+    return "wired", "exit.dsl_preset present; DSL monitor active"
+
+
+def _budget_verdict(s, funded_by_id):
+    """(status, detail) comparing the wallet's ACTUAL funded USDC to what was requested. Best-effort: if
+    we can't read the funded amount we don't block (the create-time shortfall halt is the primary guard;
+    this reconciliation also catches a backend partial-fund)."""
+    req = s.get("requested")
+    funded = funded_by_id.get(s.get("strategyId"))
+    if not req or funded is None:
+        return "ok", (f"${funded:g}" if isinstance(funded, (int, float)) else "")
+    if funded < req * 0.9:
+        return "underfunded", f"funded ${funded:g} of requested ${req:g}"
+    return "ok", f"${funded:g} (asked ${req:g})"
+
+
+def _check_live(pkg, st, mcp):
+    """One pass over every instance → the composite live verdict: runtime running AND scanner active AND
+    DSL wired AND budget funded. Returns a list of per-instance rows."""
+    # one strategy_list read → actual funded amount per strategyId (best-effort budget reconciliation)
+    funded_by_id = {}
+    try:
+        for m in _cli.strategies_for(mcp, skill_name=pkg.id, timeout=POLL_HTTP_TIMEOUT):
+            fid = _cli.strategy_id_of(m)
+            fv = _cli.dig(_cli.strategy_obj(m), "totalFunded", "netFunded", "initialBudget")
+            if fid and isinstance(fv, (int, float)):
+                funded_by_id[fid] = float(fv)
+    except Exception:  # noqa: BLE001 — a read hiccup must not fail the gate; budget stays best-effort
+        pass
+    health = _cli.runtime_health_map()  # one status --json for all runtimes' DSL/health lines
+    rows = []
     for inst in pkg.instances:
         s = inst_state(st, inst.name)
-        if s.get("status") == "live":
-            continue
         rt = _cli.find_runtime(inst.runtime_name)
         if not rt or not _cli.runtime_running(rt):
-            pending.append((inst.name, "no live runtime"))
+            rows.append({"instance": inst.name, "live": False, "scanner": "no-runtime",
+                         "dsl": "-", "budget": "-", "reason": "runtime not running"})
             continue
         state = _cli.cli_json(["openclaw", "senpi", "state", "-r", inst.runtime_name, "--json"], POLL_HTTP_TIMEOUT)
-        sc = _deep_find_scanner(state, inst.external_scanner.get("name")) if state else None
-        runs = _cli.dig(sc or {}, "runCount", "ticks", "runs", default=0) or 0
-        if isinstance(runs, (int, float)) and runs > 0:
-            s["status"] = "live"
-            save_state(pkg, st)
-        else:
-            pending.append((inst.name, f"awaiting first tick (~{inst.interval_seconds or '?'}s cadence)"))
-    return pending
+        status = health.get(inst.runtime_name) or _cli.runtime_status(inst.runtime_name, POLL_HTTP_TIMEOUT)
+        sc_st, sc_d = _scanner_verdict(inst, state)
+        dsl_st, dsl_d = _dsl_verdict(inst, status)
+        bud_st, bud_d = _budget_verdict(s, funded_by_id)
+        live = sc_st in ("ticked", "scheduled") and dsl_st == "wired" and bud_st == "ok"
+        s["status"] = "live" if live else s.get("status", "registered")
+        save_state(pkg, st)
+        reason = "; ".join(d for ok, d in
+                           ((sc_st in ("ticked", "scheduled"), sc_d), (dsl_st == "wired", dsl_d),
+                            (bud_st == "ok", bud_d)) if not ok and d)
+        rows.append({"instance": inst.name, "live": live, "scanner": sc_st, "dsl": dsl_st,
+                     "budget": bud_st, "reason": reason})
+    return rows
 
 
 def cmd_verify(pkg, a, log):
-    # Single fast check by default — the first scan() tick is gated by the scanner's interval_seconds
-    # (e.g. spider swing = 300s), so blocking here would just burn the tool budget. Report liveness or
-    # the expected cadence and let the agent re-run when it's worth re-checking. `--max-wait S` opts
-    # into a bounded poll for fast instances.
+    # THE liveness gate: a strategy is `live` only when EVERY instance has a running runtime + an active
+    # scanner (ticked or scheduled) + a wired DSL + a funded budget. It does NOT wait for a slow first
+    # scan tick (a 'scheduled' scanner is live — it fires on interval_seconds); --max-wait re-checks only
+    # for a runtime/scanner that hasn't finished mounting yet.
+    mcp = MCPClient()
     st = load_state(pkg)
     deadline = time.time() + a.max_wait
     while True:
-        pending = _check_ticks(pkg, st)
-        if not pending:
-            out = report(pkg, st, "live", as_json=a.json)
-            delete_state(pkg)  # deploy complete → state is ephemeral; next deploy starts clean
+        rows = _check_live(pkg, st, mcp)
+        live = bool(rows) and all(r["live"] for r in rows)
+        if live or time.time() >= deadline:
+            out = {"strategy": pkg.id, "version": pkg.version,
+                   "status": "live" if live else "not-live", "instances": rows}
+            if a.json:
+                print(json.dumps(out, indent=2))
+            else:
+                print(f"\n{pkg.id} v{pkg.version}: {out['status']}")
+                for r in rows:
+                    print(f"  - {r['instance']}: scanner={r['scanner']}, dsl={r['dsl']}, "
+                          f"budget={r['budget']}" + (f"  → {r['reason']}" if r["reason"] else ""))
+                if not live:
+                    print(f"\nNOT live — fix the flagged component(s) and re-run `deploy.py verify {pkg.id}`. "
+                          "A strategy is live only when every instance is runtime-running + scanner-active "
+                          "+ DSL-wired + funded.")
+            if live:
+                delete_state(pkg)  # deploy complete → state is ephemeral; next deploy starts clean
             return out
-        if time.time() >= deadline:
-            note = "Not ticking yet — each instance's first scan() fires on its interval_seconds:\n  " + \
-                   "\n  ".join(f"{n}: {why}" for n, why in pending) + \
-                   f"\nRe-run `deploy.py verify {pkg.id}` after that to confirm `live`."
-            return report(pkg, st, "registered", note=note, as_json=a.json)
-        log(f"  waiting on {', '.join(n for n, _ in pending)}…")
+        log("  re-checking liveness…")
         time.sleep(POLL_EVERY)
 
 
@@ -447,7 +537,7 @@ def main(argv):
     else:  # status
         out = report(pkg, load_state(pkg), "status", as_json=a.json)
 
-    sys.exit(2 if out.get("status") == "failed" else 0)
+    sys.exit(2 if out.get("status") in ("failed", "underfunded", "not-live") else 0)
 
 
 if __name__ == "__main__":

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Hermetic unit tests for the deploy liveness + budget gates.
+
+No MCP, no openclaw, no network — every input is a plain dict/stub. Run:
+    python3 senpi-strategy-ops/tests/test_deploy_gates.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import types
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import _pkg    # noqa: E402
+import deploy  # noqa: E402
+
+
+def _inst(name, share):
+    return types.SimpleNamespace(name=name, funding_share=share)
+
+
+def _dsl_inst(runtime_doc):
+    """A bare _pkg.Instance with only runtime_doc set — enough for the exit_block/has_dsl properties."""
+    i = _pkg.Instance.__new__(_pkg.Instance)
+    i.runtime_doc = runtime_doc
+    return i
+
+
+def _scan_inst():
+    return types.SimpleNamespace(external_scanner={"name": "sc1"}, interval_seconds=300)
+
+
+class PlanFunding(unittest.TestCase):
+    def test_fits(self):
+        amounts, short = deploy.plan_funding([_inst("a", 0.6), _inst("b", 0.4)], 1000, 1100)
+        self.assertEqual(amounts, {"a": 600.0, "b": 400.0})
+        self.assertIsNone(short)
+
+    def test_incident_single_wallet_underfunded(self):
+        # the M-incident: user asked $1000, only $100 available → HALT, never silently fund the floor
+        _amounts, short = deploy.plan_funding([_inst("only", 1.0)], 1000, 100)
+        self.assertIsNotNone(short)
+        self.assertEqual(short["requested"], 1000.0)
+        self.assertGreater(short["short_by"], 800)
+
+    def test_floor_covered_by_balance_is_not_short(self):
+        # $200 across 60/40 floors the small leg to $100 → $220 total; $300 available covers it, no halt
+        amounts, short = deploy.plan_funding([_inst("a", 0.6), _inst("b", 0.4)], 200, 300)
+        self.assertEqual(amounts, {"a": 120.0, "b": 100.0})
+        self.assertIsNone(short)
+
+    def test_floor_over_balance_is_short(self):
+        _amounts, short = deploy.plan_funding([_inst("a", 0.6), _inst("b", 0.4)], 200, 200)
+        self.assertIsNotNone(short)
+
+    def test_available_unknown_never_halts(self):
+        _amounts, short = deploy.plan_funding([_inst("a", 1.0)], 1000, None)
+        self.assertIsNone(short)
+
+
+class HasDsl(unittest.TestCase):
+    def test_full_preset(self):
+        self.assertTrue(_dsl_inst({"exit": {"engine": "dsl", "dsl_preset": {"phase1": {}}}}).has_dsl)
+
+    def test_engine_only(self):
+        self.assertTrue(_dsl_inst({"exit": {"engine": "dsl"}}).has_dsl)
+
+    def test_preset_only(self):
+        self.assertTrue(_dsl_inst({"exit": {"dsl_preset": {"phase1": {}}}}).has_dsl)
+
+    def test_empty_exit_is_naked(self):
+        self.assertFalse(_dsl_inst({"exit": {}}).has_dsl)
+
+    def test_no_exit_is_naked(self):
+        self.assertFalse(_dsl_inst({}).has_dsl)
+
+    def test_non_dsl_engine_no_preset_is_naked(self):
+        self.assertFalse(_dsl_inst({"exit": {"engine": "none"}}).has_dsl)
+
+
+class ScannerVerdict(unittest.TestCase):
+    def test_ticked(self):
+        st = {"scanners": [{"name": "sc1", "runCount": 5, "enabled": True}]}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "ticked")
+
+    def test_scheduled(self):
+        st = {"scanners": [{"name": "sc1", "runCount": 0, "enabled": True}]}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "scheduled")
+
+    def test_disabled_is_broken(self):
+        st = {"scanners": [{"name": "sc1", "runCount": 0, "enabled": False}]}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "broken")
+
+    def test_erroring_is_broken(self):
+        st = {"scanners": [{"name": "sc1", "runCount": 3, "lastError": "boom"}]}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "broken")
+
+    def test_not_mounted_is_broken(self):
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), {"scanners": []})[0], "broken")
+
+
+class DslVerdict(unittest.TestCase):
+    def test_config_missing(self):
+        v = deploy._dsl_verdict(types.SimpleNamespace(has_dsl=False), {"dsl": {"enabled": True}})
+        self.assertEqual(v[0], "config-missing")
+
+    def test_wired_when_status_unreadable(self):
+        self.assertEqual(deploy._dsl_verdict(types.SimpleNamespace(has_dsl=True), None)[0], "wired")
+
+    def test_monitor_down(self):
+        v = deploy._dsl_verdict(types.SimpleNamespace(has_dsl=True), {"dsl": {"enabled": False}})
+        self.assertEqual(v[0], "monitor-down")
+
+    def test_wired(self):
+        v = deploy._dsl_verdict(types.SimpleNamespace(has_dsl=True), {"dsl": {"enabled": True}})
+        self.assertEqual(v[0], "wired")
+
+
+class BudgetVerdict(unittest.TestCase):
+    def test_ok(self):
+        self.assertEqual(deploy._budget_verdict({"requested": 1000, "strategyId": "x"}, {"x": 1000.0})[0], "ok")
+
+    def test_underfunded(self):
+        self.assertEqual(deploy._budget_verdict({"requested": 1000, "strategyId": "x"}, {"x": 100.0})[0], "underfunded")
+
+    def test_no_requested_is_ok(self):
+        self.assertEqual(deploy._budget_verdict({"strategyId": "x"}, {"x": 100.0})[0], "ok")
+
+    def test_funded_unreadable_is_ok(self):
+        self.assertEqual(deploy._budget_verdict({"requested": 1000, "strategyId": "x"}, {})[0], "ok")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Offline tests for the deploy package model — accept-flat, prescriptive validation, and the
+`ensure_pkg` local-authoritative fix. No network, no wallets. Motivated by the 3-model deploy
+bake-off (Samurai/Qwen, Gemini, GLM), where every model tripped on the same author↔ops gap.
+
+    python3 -m pytest senpi-strategy-ops/tests/
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import os
+import sys
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+
+import _pkg  # noqa: E402
+
+RUNTIME_TMPL = """\
+name: {name}
+group: {group}
+strategy:
+  wallet: "${{{wallet_env}}}"
+  slots: 1
+  margin_pct: 20
+scanners:
+  - type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900
+    inputs: {{}}
+{sds}
+"""
+
+_SDS = "    signal_data_schema:\n      score:\n        type: float\n"
+
+
+def _runtime(name, group, wallet_env, with_sds=True):
+    return RUNTIME_TMPL.format(name=name, group=group, wallet_env=wallet_env,
+                               sds=(_SDS if with_sds else ""))
+
+
+def _write(root, rel, text):
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+    return p
+
+
+def make_flat(tmp_path, pkg_id="tech-breakout", name=None, group=None,
+              wallet_env="TECHBREAKOUT_WALLET", with_sds=True, version="1.0.0"):
+    """A FLAT package — the layout agents naturally scaffold: strategy.yaml (NO instances) + a root
+    runtime.yaml + scanners/. `name`/`group` default to the CORRECT values; pass wrong ones to test
+    the prescriptive validators."""
+    d = tmp_path / pkg_id
+    strat = f"id: {pkg_id}\nversion: \"{version}\"\n" if version else f"id: {pkg_id}\n"
+    _write(d, "strategy.yaml", strat)
+    _write(d, "runtime.yaml", _runtime(name or f"{pkg_id}-main", group or pkg_id, wallet_env, with_sds))
+    _write(d, "scanners/scan.py", "def scan(inputs, ctx):\n    return []\n")
+    return d
+
+
+def make_nested(tmp_path, pkg_id="lion", wallet_env="LION_WALLET"):
+    """A NESTED multi-field package with an explicit single instance under main/ — the canonical form
+    the deployer has always accepted. Guards that accept-flat is purely ADDITIVE."""
+    d = tmp_path / pkg_id
+    _write(d, "strategy.yaml",
+           f"id: {pkg_id}\nversion: \"1.0.0\"\n"
+           f"instances:\n  - name: main\n    runtime: main/runtime.yaml\n"
+           f"    wallet_env: {wallet_env}\n    funding_share: 1.0\n")
+    _write(d, "main/runtime.yaml", _runtime(f"{pkg_id}-main", pkg_id, wallet_env))
+    _write(d, "main/scanners/scan.py", "def scan(inputs, ctx):\n    return []\n")
+    return d
+
+
+# ───────────────────────────────── accept flat ─────────────────────────────────
+
+def test_flat_package_loads_with_synthesized_main_instance(tmp_path):
+    """A flat package (no `instances`) loads — the deployer synthesizes the canonical single `main`
+    instance. This is the #1 error all three bake-off models hit ('instances must be non-empty')."""
+    pkg = _pkg.load(str(make_flat(tmp_path)))
+    assert len(pkg.instances) == 1
+    inst = pkg.instances[0]
+    assert inst.name == "main"
+    assert inst.runtime_rel == "runtime.yaml"          # points at the ROOT runtime, no main/ nesting
+    assert inst.funding_share == 1.0
+
+
+def test_flat_wallet_env_detected_from_runtime(tmp_path):
+    """The synthesized instance binds `wallet_env` to the `${...}` the flat runtime already uses — so
+    render substitutes correctly with zero agent effort."""
+    pkg = _pkg.load(str(make_flat(tmp_path, wallet_env="VECTOR_WALLET")))
+    assert pkg.instances[0].wallet_env == "VECTOR_WALLET"
+
+
+def test_flat_package_validates_clean(tmp_path):
+    """A flat package with the correct name/group/binding is DEPLOY-READY as authored — validate
+    returns no errors (the deployer meets the agent where it builds)."""
+    pkg = _pkg.load(str(make_flat(tmp_path)))
+    assert _pkg.validate(pkg) == []
+
+
+def test_flat_missing_instances_and_no_runtime_raises(tmp_path):
+    """No instances AND no root runtime.yaml is genuinely unusable — still a BadPackage (with the
+    updated message pointing at either fix)."""
+    d = tmp_path / "empty"
+    _write(d, "strategy.yaml", "id: empty\nversion: \"1.0.0\"\n")
+    with pytest.raises(_pkg.BadPackage) as ei:
+        _pkg.load(str(d))
+    assert "instances" in str(ei.value)
+
+
+def test_nested_package_unchanged(tmp_path):
+    """Accept-flat is ADDITIVE: an explicit nested single-instance package still loads with its
+    declared instance and validates clean (Lion/Cougar multi-instance path is untouched)."""
+    pkg = _pkg.load(str(make_nested(tmp_path)))
+    assert len(pkg.instances) == 1 and pkg.instances[0].runtime_rel == "main/runtime.yaml"
+    assert _pkg.validate(pkg) == []
+
+
+# ─────────────────────────── prescriptive validation ───────────────────────────
+
+def test_validate_prescriptive_name(tmp_path):
+    """The recurring bake-off tripwire: a flat runtime named `<id>` instead of `<id>-main`. The error
+    now PRESCRIBES the exact value to set, not just 'X != Y'."""
+    pkg = _pkg.load(str(make_flat(tmp_path, pkg_id="vector", name="vector")))
+    errs = _pkg.validate(pkg)
+    assert any("set runtime `name: vector-main`" in e for e in errs)
+
+
+def test_validate_requires_signal_data_schema(tmp_path):
+    """external_scanner with no signal_data_schema → a clear, pre-funding error naming the map and its
+    placement (Gemma nested it inside `inputs`; Gemini omitted it)."""
+    pkg = _pkg.load(str(make_flat(tmp_path, with_sds=False)))
+    errs = _pkg.validate(pkg)
+    assert any("signal_data_schema" in e and "sibling of `inputs`" in e for e in errs)
+
+
+def test_validate_flags_missing_version(tmp_path):
+    """Sanity: an existing invariant still fires (version required)."""
+    pkg = _pkg.load(str(make_flat(tmp_path, version=None)))
+    assert any("version" in e for e in _pkg.validate(pkg))
+
+
+# ─────────────────────────── ensure_pkg / full_validate (deploy.py) ───────────────────────────
+
+def _import_deploy():
+    try:
+        import deploy  # noqa
+        return deploy
+    except Exception as e:  # noqa — mcp_client deps may be absent in a bare test env
+        pytest.skip(f"deploy.py not importable in this env ({e})")
+
+
+def test_ensure_pkg_local_invalid_never_fetches_remote(tmp_path, monkeypatch):
+    """The GLM footgun: an invalid LOCAL package must surface its real error, NOT silently fall back to
+    a (stale) remote fetch. ensure_pkg must not call the remote fetcher when the path is on disk."""
+    deploy = _import_deploy()
+    called = {"fetch": False}
+    monkeypatch.setattr(deploy._fetch, "fetch_package",
+                        lambda *a, **k: called.__setitem__("fetch", True))
+    d = tmp_path / "broken"
+    _write(d, "strategy.yaml", "id: broken\nversion: \"1.0.0\"\n")   # on disk, but invalid (no runtime)
+    with pytest.raises(_pkg.BadPackage):
+        deploy.ensure_pkg(str(d), None, lambda m: None)
+    assert called["fetch"] is False                                  # never reached the remote
+
+
+def test_full_validate_catches_unresolved_placeholder(tmp_path):
+    """The render dry-run in full_validate surfaces an unresolved `${...}` (a runtime that references
+    an env the manifest doesn't bind) BEFORE any wallet is funded."""
+    deploy = _import_deploy()
+    d = make_flat(tmp_path, pkg_id="leaky", wallet_env="LEAKY_WALLET")
+    # inject a second placeholder (valid top-level key) the render step can't resolve
+    rt = d / "runtime.yaml"
+    rt.write_text(rt.read_text() + "note: \"${UNBOUND_THING}\"\n")
+    pkg = _pkg.load(str(d))
+    errs = deploy.full_validate(pkg)
+    assert any("UNBOUND_THING" in e for e in errs)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/strategies/magpie/pre_listing/runtime.yaml
+++ b/strategies/magpie/pre_listing/runtime.yaml
@@ -1,5 +1,5 @@
 # ── MAGPIE · PRE-LISTING book — accumulate pre-IPO perpetuals (IPOPs) into the IPO ──
-name: magpie-pre-listing
+name: magpie-pre_listing
 group: magpie
 version: 3.0.0
 description: >

--- a/strategies/wolf/risk_off/runtime.yaml
+++ b/strategies/wolf/risk_off/runtime.yaml
@@ -1,5 +1,5 @@
 # ── WOLF · RISK-OFF book — LONG defensives + SHORT risk in a confirmed RISK-OFF regime ──
-name: wolf-risk-off
+name: wolf-risk_off
 group: wolf
 version: 3.0.0
 description: >

--- a/strategies/wolf/risk_on/runtime.yaml
+++ b/strategies/wolf/risk_on/runtime.yaml
@@ -1,5 +1,5 @@
 # ── WOLF · RISK-ON book — LONG beaten-down beta in a confirmed RISK-ON regime ──
-name: wolf-risk-on
+name: wolf-risk_on
 group: wolf
 version: 3.0.0
 description: >


### PR DESCRIPTION
**Consolidated deploy PR.** Folds three overlapping, *complementary* strategy-ops PRs into one coherent flow so the team merges once instead of resolving a three-way conflict. Backed by the 4-model deploy bake-off (Samurai/Qwen, Gemini, Gemma, GLM).

| Source | Concern | What it adds |
|---|---|---|
| **#476** (this) | Package acceptance | Accept the **flat** package agents build · one-pass `deploy.py validate` (before funding) · on-disk authoritative (no stale-remote) · **author↔ops validator parity** · gated deploy + never-raw-`strategy_create_custom_strategy` · no-PyYAML fallback · path-vs-bare-id guidance · **wolf/magpie latent fleet bug** |
| **#470** (folded) | Wallet lifecycle | **Never reuse a wallet** — fresh every deploy; runtime-less → close+recover funds (`closing-existing`); live → refuse; lost-state recovery in `runtime` |
| **#467** (folded) | Live gate | `verify` is the GATE (runtime-running + scanner-active + DSL-wired + funded); **`--budget` a hard target** (`create` HALTS `underfunded`, never silently funds less); `_pkg.validate` **refuses a no-DSL package** (naked-strategy block) |

### Conflict resolutions — both behaviors preserved
- **`_pkg.validate`:** kept #476's `signal_data_schema` check **and** #467's `has_dsl` refusal — both fire.
- **ops SKILL `create` prose:** states fresh-wallet (#470) **and** budget-hard-target/`underfunded` (#467); status line lists `closing-existing | underfunded` and `verify → live | not-live`.
- **author SKILL Handoff:** one gated loop — confirm → validate (accept-flat, path guidance, never-raw-MCP) → create/runtime (budget hard target, fresh wallet) → **verify GATE**. **Removed a cross-PR contradiction:** #476's old "smoke-deployed? `create` self-heals to that wallet + `strategy_top_up`" line — #470's fresh-wallet semantics *close and recover* that wallet, so the advice was now wrong.
- **Test fixtures:** added a `dsl_preset` block — #467's new `has_dsl` check correctly failed the DSL-less unit fixtures (real packages always ship DSL).

### Verify
**34/34** ops tests (`test_pkg` + `test_deploy_gates`). Fleet validators clean (author + ops). Versions: strategy-ops **2.3.0 → 2.5.0**, strategy-author **2.4.2 → 2.6.0**.

### Action for the team
**Merge this one; close #470 and #467 as folded-in** (their commits are preserved here via merge, authorship intact). Also in flight: #475 (improve-trades telemetry+slim) and #479 (SKILL bloat) — independent of this, merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)