### PR TITLE
chore(skills): reduce SKILL.md context bloat (improve-trades + strategy-author)

### DIFF
--- a/senpi-improve-trades/SKILL.md
+++ b/senpi-improve-trades/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.5.0"
+  version: "1.6.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -418,91 +418,9 @@ run on a just-deployed book):
   not obligations** — add a complementary strategy (`senpi-strategy-discover`), or top up / adjust via ops.
   Idle embedded cash is an **opportunity to deploy more if they want**, never a "$0/day leak."
 
-## What the engine gives you — the output shape
+## What the engine gives you
 
-```
-window        { from, to, label, window_days, last_n }   # the review window
-
-trades[]      per CLOSED trade (from strategies of ALL statuses — a churned book's history is complete):
-  asset, strategy_label, strategy_status, direction, leverage, entry_px, exit_px, open_time, close_time,
-  realized_pnl,                           # strategy_status: ACTIVE|PAUSED = current book; else = HISTORY
-  price_now, price_since_exit_pct,        # subsequent action (current price only, v1)
-  if_held_delta_usd,                      # counterfactual — CONTEXT, not verdict (short-sign adjusted)
-  exit_vs_hold: exit_ahead | held_higher | flat | unknown,   # NEUTRAL context (exit_ahead=got out ahead), NOT a grade
-  exit_reason: { terminal, tier_index/tier_reached, high_water_roe, source },   # which DSL lever fired
-  source: "telemetry" | "reconstructed"   # telemetry = exit_reason came from the event log; else discovery+ratchet
-
-pnl_summary      TOTAL LEDGER — LEAD WITH THIS (realized closed + unrealized open):
-  realized, unrealized (None = UNKNOWN read, not 0), total (None when unrealized UNKNOWN),
-  realized_by_book{ current, closed },      # quote this split — never re-derive a closed-book figure
-  unrealized_coverage{ read, current_strategies },
-  unrealized_partial   # true → some wallets UNKNOWN; unrealized/total are a FLOOR ("at least $X, N of M") — HARD RULE 1
-
-telemetry_availability   the 'undetermined ≠ all-clear' signal — READ IT FIRST (guardrail 6):
-  status ∈ available | partial | undetermined | no_trades,
-  streams_computed,                          # false → leaks/blocked/execution_quality/dsl_close_reason_mix zeros are UNKNOWN, not 'none'
-  exit_attribution{ attributed, total, telemetry, ratchet, unknown }   # attributed ~0 → NO calibration diagnosis
-
-timing_summary   PROCESS-framed COUNTS (never $/week; NEUTRAL, never a grade):
-  trade_count, exits_ahead, exits_held_higher, exits_flat, exits_unknown,
-  realized_pnl_total, if_all_reclosed_now_total (CONTEXT, symmetric — see guardrail 1), by_asset_class{}
-
-dsl_close_reason_mix   "shaken out too early / how are my exits firing" (from trades[] exit_reason):
-  overall        { by_terminal{}, trade_count, premature_exits }
-  by_asset_class { crypto|equity/index: {…same…} }
-  by_strategy    { <strategy_label>: {…same…} }   # filter by label → "why is [strategy] losing"
-  premature_exit_samples[], premature_note        # premature = trailing_floor/weak_peak/max_retrace OR low-tier+small-ROE
-
-blocked_summary   "what did my own limits block" (from missed_signals[]):
-  total_blocked, by_reason_code{ no_slots|no_margin|risk_gate_*|asset_banned|… },
-  by_strategy{ <strategy_label>: { reason_code: n } }
-
-leaks   "where am I leaking" (telemetry event scan — fail-open to zeroed):
-  order_failed     { count, samples[] { asset, reason, ts, strategy_label } }   # order rejected → $ never entered
-  protection_gaps  { count, samples[] { asset, event, … } }                     # dsl.sl_sync_failed/handoff → naked leg
-  risk_halts       { count, samples[] { reason, … } }                           # runtime.paused → trading stopped
-
-execution_quality   "fees — maker vs taker" (from order.filled execution_as_maker):
-  maker_fills, taker_fills, unknown_fills, maker_ratio,   # RATE only
-  authoritative_fee_note                                  # the future ledger fee-$ hook (NOT called per-trade)
-
-book_vs_market   the "what did I miss" gap:
-  top_movers[] { asset, asset_class, pct, smart_money_pct, trader_count },
-  participation[] { asset, held, side, aligned },     # was the book on the right side?
-  gaps[]          { asset, pct, ... }                 # movers the book had NO exposure to
-  window                                              # the leaderboard's rolling window (e.g. "4h")
-
-strategies[]  the CURRENT book ONLY (status ACTIVE | PAUSED) — each judged vs ITS mandate, on TOTAL PnL:
-  { label, wallet, status, mandate, dsl, closed_trade_count, realized_pnl,
-    unrealized_pnl,           # current open positions' unrealized — None = UNKNOWN read (never a fake 0)
-    total_pnl,                # realized + unrealized (None when unrealized UNKNOWN) — JUDGE ON THIS, not realized
-    open_position_count,
-    open_positions[]{ asset, direction, unrealized_pnl, return_on_equity_pct, entry_px, position_value, leverage },
-    on_mandate_note }         # open_positions = the 'are winners running' evidence (guardrail 1)
-  # THIS is the verdict + improvement surface. Nothing here is closed.
-
-closed_strategies[]  HISTORY ONLY (CLOSED / INACTIVE / … — churned or retired redeployments):
-  { label, wallet_short, status, trade_count, realized_pnl }
-  # deliberately NO mandate / dsl / verdict / on_mandate_note. Their trades are already in trades[]
-  # (part of the timing review, attributed by label). NEVER give these a "consolidate/kill/fix" verdict,
-  # NEVER flag their absent mandate as a bug, NEVER count them as live "wallets to consolidate."
-
-meta          { warnings[], sources[], window, degraded,
-                strategy_count,             # every enumerated strategy (all statuses) — a raw total
-                current_strategy_count,     # the LIVE book — THIS is "how many strategies you run"
-                closed_strategy_count,      # churned/closed redeployments — HISTORY, not live redundancy
-                trade_count,
-                telemetry_source,           # available | partial | unavailable — how much enrichment landed
-                exit_reason_source_counts,  # { telemetry, ratchet, unknown } — where each exit_reason came from
-                missed_signal_count, leak_counts }   # quick glances at the telemetry streams
-```
-
-`exit_reason.terminal` — **when telemetry enriched it** (`source: "telemetry"`) it's the native
-`close_reason`: `tier_breach`, `max_retrace`, `trailing_floor`, `weak_peak`, `dead_weight`, `hard_timeout`,
-`manual`, `sl_hit`. **When it fell back to the ratchet record** (`source: "ratchet"`) it's `SL_TRIGGERED`,
-`MANUAL_CLOSE`, `LIQUIDATED`, `ADL`. Neither available → `UNKNOWN` (`source: "unknown"`) — say "exit mechanism
-not recorded on this build," never guess. `tier_index`/`tier_reached` = the tier that locked; `high_water_roe`
-= the peak ROE — together they tell you *which lever* to tune.
+The engine prints one JSON dict. **Lead with `pnl_summary.total`** (realized+unrealized); the PROCESS counts are in `timing_summary`; per-strategy verdicts in `strategies[]` (CURRENT book only); the telemetry streams (`dsl_close_reason_mix` / `blocked_summary` / `leaks` / `execution_quality`) are real only when `telemetry_availability.streams_computed` is true; `trades[]` is a curated outlier sample (counts from the aggregates, never `len(trades)`). **Full field-by-field catalog + the `exit_reason.terminal` enum: [`references/output-shape.md`](references/output-shape.md).**
 
 ## The output contract — what you produce
 
@@ -543,19 +461,10 @@ Never pick for the user, and never act unprompted.
 
 Don't re-implement these — call them and weave their output into the four-part contract above.
 
-## Sources today, and the one future upgrade
+## The one pending upgrade — authoritative fee $
 
-**Telemetry is a live v1 source.** The engine reads the **current book's** runtime **event log**
-(`openclaw senpi events`, ACTIVE/PAUSED strategies only — a closed strategy's ring is torn down, so it's never
-queried) to enrich each discovery trade's `exit_reason` and to produce the standalone streams — `missed_signals`,
-`leaks`, `execution_quality`. A telemetry-enriched trade reads `source: "telemetry"`; when telemetry is
-unavailable (older build / a closed strategy's ring is gone) the engine fails open to discovery + the ratchet
-record
-(`source: "reconstructed"`, `exit_reason.source` `ratchet`/`unknown`) — that's the honest fallback, not a bug.
-Discovery remains the sole owner of the onchain trade facts (list, prices, realized PnL, fees, timing).
-
-**The one authoritative-fee upgrade still pending:** `execution_quality` reports the maker-vs-taker **rate**
-today. The authoritative fee **$** lives in the ledger — `order.filled` / `position.closed` carry
-`senpi.order.id`, which joins to `execution_get_closed_position_details({closedOrderId})` → realized PnL +
-**fees** + funding. That per-order join is the future upgrade; it is intentionally **not** called per-trade
-(rate-limit risk), so until it's wired, quote the maker ratio as a fee-tier signal, never a fee dollar total.
+`execution_quality` reports the maker-vs-taker **rate** today, not fee dollars. The authoritative fee **$**
+lives in the ledger — `order.filled` / `position.closed` carry `senpi.order.id`, which joins to
+`execution_get_closed_position_details({closedOrderId})` → realized PnL + **fees** + funding. That per-order
+join is the future upgrade; it's intentionally **not** called per-trade (rate-limit risk), so until it's
+wired, quote the maker ratio as a fee-tier signal, never a fee dollar total.

--- a/senpi-improve-trades/references/output-shape.md
+++ b/senpi-improve-trades/references/output-shape.md
@@ -1,0 +1,87 @@
+# improve-trades engine output — field catalog
+
+The shape of the JSON `scripts/review.py` prints. The runtime JSON you get back is largely self-describing — read this only when a field's meaning or a guardrail-relevant nuance is unclear.
+
+```
+window        { from, to, label, window_days, last_n }   # the review window
+
+trades[]      per CLOSED trade (from strategies of ALL statuses — a churned book's history is complete):
+  asset, strategy_label, strategy_status, direction, leverage, entry_px, exit_px, open_time, close_time,
+  realized_pnl,                           # strategy_status: ACTIVE|PAUSED = current book; else = HISTORY
+  price_now, price_since_exit_pct,        # subsequent action (current price only, v1)
+  if_held_delta_usd,                      # counterfactual — CONTEXT, not verdict (short-sign adjusted)
+  exit_vs_hold: exit_ahead | held_higher | flat | unknown,   # NEUTRAL context (exit_ahead=got out ahead), NOT a grade
+  exit_reason: { terminal, tier_index/tier_reached, high_water_roe, source },   # which DSL lever fired
+  source: "telemetry" | "reconstructed"   # telemetry = exit_reason came from the event log; else discovery+ratchet
+
+pnl_summary      TOTAL LEDGER — LEAD WITH THIS (realized closed + unrealized open):
+  realized, unrealized (None = UNKNOWN read, not 0), total (None when unrealized UNKNOWN),
+  realized_by_book{ current, closed },      # quote this split — never re-derive a closed-book figure
+  unrealized_coverage{ read, current_strategies },
+  unrealized_partial   # true → some wallets UNKNOWN; unrealized/total are a FLOOR ("at least $X, N of M") — HARD RULE 1
+
+telemetry_availability   the 'undetermined ≠ all-clear' signal — READ IT FIRST (guardrail 6):
+  status ∈ available | partial | undetermined | no_trades,
+  streams_computed,                          # false → leaks/blocked/execution_quality/dsl_close_reason_mix zeros are UNKNOWN, not 'none'
+  exit_attribution{ attributed, total, telemetry, ratchet, unknown }   # attributed ~0 → NO calibration diagnosis
+
+timing_summary   PROCESS-framed COUNTS (never $/week; NEUTRAL, never a grade):
+  trade_count, exits_ahead, exits_held_higher, exits_flat, exits_unknown,
+  realized_pnl_total, if_all_reclosed_now_total (CONTEXT, symmetric — see guardrail 1), by_asset_class{}
+
+dsl_close_reason_mix   "shaken out too early / how are my exits firing" (from trades[] exit_reason):
+  overall        { by_terminal{}, trade_count, premature_exits }
+  by_asset_class { crypto|equity/index: {…same…} }
+  by_strategy    { <strategy_label>: {…same…} }   # filter by label → "why is [strategy] losing"
+  premature_exit_samples[], premature_note        # premature = trailing_floor/weak_peak/max_retrace OR low-tier+small-ROE
+
+blocked_summary   "what did my own limits block" (from missed_signals[]):
+  total_blocked, by_reason_code{ no_slots|no_margin|risk_gate_*|asset_banned|… },
+  by_strategy{ <strategy_label>: { reason_code: n } }
+
+leaks   "where am I leaking" (telemetry event scan — fail-open to zeroed):
+  order_failed     { count, samples[] { asset, reason, ts, strategy_label } }   # order rejected → $ never entered
+  protection_gaps  { count, samples[] { asset, event, … } }                     # dsl.sl_sync_failed/handoff → naked leg
+  risk_halts       { count, samples[] { reason, … } }                           # runtime.paused → trading stopped
+
+execution_quality   "fees — maker vs taker" (from order.filled execution_as_maker):
+  maker_fills, taker_fills, unknown_fills, maker_ratio,   # RATE only
+  authoritative_fee_note                                  # the future ledger fee-$ hook (NOT called per-trade)
+
+book_vs_market   the "what did I miss" gap:
+  top_movers[] { asset, asset_class, pct, smart_money_pct, trader_count },
+  participation[] { asset, held, side, aligned },     # was the book on the right side?
+  gaps[]          { asset, pct, ... }                 # movers the book had NO exposure to
+  window                                              # the leaderboard's rolling window (e.g. "4h")
+
+strategies[]  the CURRENT book ONLY (status ACTIVE | PAUSED) — each judged vs ITS mandate, on TOTAL PnL:
+  { label, wallet, status, mandate, dsl, closed_trade_count, realized_pnl,
+    unrealized_pnl,           # current open positions' unrealized — None = UNKNOWN read (never a fake 0)
+    total_pnl,                # realized + unrealized (None when unrealized UNKNOWN) — JUDGE ON THIS, not realized
+    open_position_count,
+    open_positions[]{ asset, direction, unrealized_pnl, return_on_equity_pct, entry_px, position_value, leverage },
+    on_mandate_note }         # open_positions = the 'are winners running' evidence (guardrail 1)
+  # THIS is the verdict + improvement surface. Nothing here is closed.
+
+closed_strategies[]  HISTORY ONLY (CLOSED / INACTIVE / … — churned or retired redeployments):
+  { label, wallet_short, status, trade_count, realized_pnl }
+  # deliberately NO mandate / dsl / verdict / on_mandate_note. Their trades are already in trades[]
+  # (part of the timing review, attributed by label). NEVER give these a "consolidate/kill/fix" verdict,
+  # NEVER flag their absent mandate as a bug, NEVER count them as live "wallets to consolidate."
+
+meta          { warnings[], sources[], window, degraded,
+                strategy_count,             # every enumerated strategy (all statuses) — a raw total
+                current_strategy_count,     # the LIVE book — THIS is "how many strategies you run"
+                closed_strategy_count,      # churned/closed redeployments — HISTORY, not live redundancy
+                trade_count,
+                telemetry_source,           # available | partial | unavailable — how much enrichment landed
+                exit_reason_source_counts,  # { telemetry, ratchet, unknown } — where each exit_reason came from
+                missed_signal_count, leak_counts }   # quick glances at the telemetry streams
+```
+
+`exit_reason.terminal` — **when telemetry enriched it** (`source: "telemetry"`) it's the native
+`close_reason`: `tier_breach`, `max_retrace`, `trailing_floor`, `weak_peak`, `dead_weight`, `hard_timeout`,
+`manual`, `sl_hit`. **When it fell back to the ratchet record** (`source: "ratchet"`) it's `SL_TRIGGERED`,
+`MANUAL_CLOSE`, `LIQUIDATED`, `ADL`. Neither available → `UNKNOWN` (`source: "unknown"`) — say "exit mechanism
+not recorded on this build," never guess. `tier_index`/`tier_reached` = the tier that locked; `high_water_roe`
+= the peak ROE — together they tell you *which lever* to tune.

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.5.0"
+  version: "2.6.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -60,15 +60,11 @@ never as a gate:
 > described, and you can tweak it to make it yours — or if you'd rather, we design one from scratch
 > together. Your call — what sounds better?"*
 
-**Tone — encourage without discouraging (this is the whole point):**
-- Template-first is *"the fastest way to get running,"* **never** *"the right way."* Scratch is a **peer**,
-  not a downsell.
-- **The user's choice is final.** If they pick scratch — or already gave a specific custom thesis — go
-  straight into the interview. **Never re-pitch templates, never nag.**
-- **Calibrate to the signal.** Brand-new / vague ask → lean into template-first + the fork path. Clear
-  custom thesis → surface the closest match **once** (*"heads-up, Cougar is close to this"*), then respect
-  their call and build.
-- If discover surfaces **no** close fit, say so and go straight to scratch — never force a bad-fit template.
+**Tone — encourage without discouraging:** template-first is *"the fastest way to get running,"* **never**
+*"the right way"* — scratch is a **peer**, not a downsell. **The user's choice is final**: if they pick scratch
+(or already gave a specific thesis), go straight into the interview — **never re-pitch or nag**. Calibrate to
+the signal (vague ask → lean template-first; clear custom thesis → surface the closest match **once**, then
+build). No close fit → say so and go straight to scratch; never force a bad-fit template.
 
 Everything below is the **scratch / customize** path — the interview you run once the user chooses to build
 (or to tweak a template they just deployed).


### PR DESCRIPTION
Trims the **fixed per-turn context tax** — the SKILL.md read on every invocation — as the complement to the improve-trades **v1.5.0 stdout slim** (which cut the *variable* tool-output payload 95.8%). Together they attack both halves of the samurai-pro context bloat.

**Rule for this PR: not one guardrail removed.** Guardrail adherence is the fragile thing right now (the Money-Map / counterfactual-as-verdict failures) — shaving guardrail text to save tokens would be the wrong trade. The cut is **reference material + duplication only.**

## improve-trades — v1.5.0 → 1.6.0 (561 → 470 lines, ~12.9k → ~11.2k tokens/turn)

- **Moved the 85-line field catalog** ("What the engine gives you") → `references/output-shape.md`, left a short pointer. It duplicated the runtime JSON the agent already sees — read only when a field's meaning is unclear. Better structure, not just fewer tokens.
- **Dropped the "Sources today" paragraph** that restated the current-book telemetry rule already covered by the Sources section + guardrail 6; kept the unique authoritative-fee-$ upgrade note.
- **The 5 HARD RULES and all nine guardrails are byte-for-byte unchanged.**

## strategy-author — v2.5.0 → 2.6.0 (light)

Already reference-delegated (deep mechanics live in `references/creating-a-strategy.md`), so limited safe headroom. Compressed the one clearly-repetitive block (template-vs-scratch tone bullets) into a tight paragraph — every rule preserved. Honest note: this one is a small trim, not a big cut.

## Verify

`58 passed` (improve-trades suite). Pointer resolves to the new reference; both SKILLs parse.

## Branch note

Based on **`test/deploy-flow-fixes`** (not `main`) because it stacks on the in-flight improve-trades v1.5.0 (#475) it builds the version lineage on. Merge/rebase after #475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)