### PR TITLE
Temporary template-only deploy gate (while we harden the custom builder)

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.6.1"
+  version: "2.7.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -52,6 +52,37 @@ much risk). Your job is to draw those out, one question at a time, and compile t
 > (A)/(B) they want, **ask before placing anything** — and never route (B) into a managed wallet to save a step.
 
 ## Start here — offer the fast path before building from scratch
+
+<!-- ══════════════════════════════════════════════════════════════════════════════════════════════
+     TEMPORARY — TEMPLATE-ONLY MODE.  While we harden the from-scratch builder/compiler, do NOT run
+     the from-scratch interview (option 3 below): steer the user to a proven template instead. The
+     deployer enforces the same rule (deploy.py refuses to FUND a non-catalog package), so beginning a
+     scratch build here only burns the user's time before it hits that wall.
+     ⟳ TO RESTORE full from-scratch building: delete this one comment block — the 3-path "Start here"
+       below is intact and governs again. (Pair with `TEMPLATE_ONLY_MODE = False` in strategy-ops
+       deploy.py.)
+     ══════════════════════════════════════════════════════════════════════════════════════════════ -->
+> ### ⏸ Custom (from-scratch) building is paused for a few days — start from a proven template
+>
+> Here's what most tools hide from you: **every Senpi strategy is real code.** Behind the name is a
+> Python **scanner**, the **scoring math** that ranks candidates, a **runtime spec**, and a supervised
+> **DSL exit engine** — Senpi writes and compiles all of it for you. That's genuine quant engineering,
+> and we're **upgrading the builder/compiler that generates it right now.**
+>
+> While we do, you launch from one of our **90+ proven templates** — each is code that's already been
+> validated and battle-tested end-to-end, so you start from something that *works* and you're live in a
+> single step. Pick the closest to your thesis and make it yours: editing a template's universe /
+> thresholds / sizing / DSL is fully open (you inherit working code — that's the reliable way to
+> customize today).
+>
+> **So while this block is here:**
+> - **Any "build from scratch" / "design my own" ask →** don't run the interview. Hand the user's
+>   thesis words to **`senpi-strategy-discover`**, name the closest one or two templates, and offer to
+>   deploy + tailor. Frame it warmly and honestly: *custom from-scratch is paused for a few days while
+>   we make it rock-solid — here's the proven template closest to what you want, and we can tune it.*
+> - **Template + edits** (option 2 below) is how to "customize" right now — it inherits working code
+>   and deploys clean.
+> - **Ignore option 3 (from-scratch) below** until this block is removed.
 
 Building from scratch is powerful, but it's the **slow** path (the full interview + compile + smoke-test).
 Most users — especially new ones — are best served by starting from a **proven template** and tweaking it

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.5.0"
+  version: "2.6.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -55,6 +55,13 @@ real errors and is never silently replaced by a remote fetch. The scripts call M
 (`scripts/mcp_client.py`, reads
 `SENPI_AUTH_TOKEN`) + drive `openclaw senpi runtime …`. Mechanics + state machine:
 [`references/lifecycle.md`](references/lifecycle.md). Manifest: [`references/strategy-yaml-schema.md`](references/strategy-yaml-schema.md).
+
+> **⏸ Template-only mode (temporary).** While the from-scratch builder is being hardened, `deploy.py
+> create` refuses to fund a package whose id isn't a **catalog template** (the ones
+> `senpi-strategy-discover` offers) — a custom/from-scratch build is turned away *before any wallet is
+> funded*, with a pointer to the template path. Deploying a real catalog template is unaffected.
+> Internal fleet/CI deploying a new, not-yet-catalogued strategy: set `SENPI_ALLOW_CUSTOM_DEPLOY=1`.
+> Reversible in one line — `TEMPLATE_ONLY_MODE = False` in `deploy.py`.
 
 ## Deploy — three steps: create → runtime → verify (NOT live until `verify` passes)
 

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -24,6 +24,7 @@ on first use if it isn't on disk.
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import argparse
 import json
+import os
 import re
 import sys
 import time
@@ -43,6 +44,71 @@ POLL_EVERY = 10
 FEE_BUFFER = 1.5        # USDC reserved per wallet for the creation fee (observed ~$1)
 MIN_WALLET = 100.0      # platform minimum per strategy wallet
 ORDER = ("pending", "creating", "active", "registered", "live")
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# TEMPORARY — template-only mode.  While we harden the from-scratch strategy builder/compiler,
+# deploys are limited to the proven catalog templates (what senpi-strategy-discover offers). A
+# custom/from-scratch package — an id NOT in the catalog — is refused HERE, before any wallet is
+# funded, with a warm pointer to the template path. The strategy-author SKILL is the primary gate
+# (it steers users to templates); this is the backstop for an agent that scaffolds anyway.
+#
+#   ⟳ TO RE-ENABLE CUSTOM DEPLOYS when the builder is ready:  flip TEMPLATE_ONLY_MODE = False
+#     (one line) — or delete this block together with the `_template_only_guard(...)` call in main().
+#   • SENPI_ALLOW_CUSTOM_DEPLOY=1 overrides per-invocation (internal fleet / CI deploys of new,
+#     not-yet-catalogued strategies).
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+TEMPLATE_ONLY_MODE = True
+
+_TEMPLATE_ONLY_MSG = """\
+error: custom (from-scratch) strategies are paused for a few days while we harden the builder.
+
+Here's what most tools hide: every Senpi strategy is real quant engineering — a Python scanner,
+scoring math, a runtime spec, and a supervised DSL exit engine — that Senpi compiles and runs for
+you. We're upgrading that builder/compiler right now, so {id!r} (not one of our catalog templates)
+can't deploy just yet.
+
+Meanwhile, launch from one of our 90+ proven templates — you start from code that's already been
+validated and battle-tested end-to-end, and you're live in a single step:
+  → browse them with senpi-strategy-discover, pick the closest to your thesis, and deploy.
+
+Custom building is coming back shortly — it's a one-line switch on our side.
+(internal: set SENPI_ALLOW_CUSTOM_DEPLOY=1 to deploy a non-catalog package.)"""
+
+_CATALOG_IDS = None  # cached per-process: the set of deployable template ids
+
+
+def _catalog_template_ids():
+    """The allow-list — ids in strategies/catalog.json on the deploy ref, fetched from the public repo
+    (same channel as package fetch) and cached. Returns None if the catalog can't be read; the guard
+    treats None as 'can't verify → don't block' (fail-open). That's safe: funding a wallet needs the
+    network anyway, so a fail-open here can't let an offline scratch deploy actually complete."""
+    global _CATALOG_IDS
+    if _CATALOG_IDS is not None:
+        return _CATALOG_IDS
+    try:
+        status, body = _fetch._get("raw.githubusercontent.com",
+                                   f"/{_fetch.REPO}/{_fetch.REF}/strategies/catalog.json", "*/*", 15)
+        if status != 200:
+            return None
+        skills = json.loads(body).get("skills", [])
+        _CATALOG_IDS = {s["id"] for s in skills if isinstance(s, dict) and s.get("id")}
+        return _CATALOG_IDS
+    except Exception:  # noqa: BLE001 — any failure → can't verify → fail open (see docstring)
+        return None
+
+
+def _template_only_guard(pkg, cmd):
+    """Backstop for TEMPLATE_ONLY_MODE: refuse to FUND a package whose id isn't a catalog template.
+    Gates `create` only (the funding step); with no wallet, runtime/verify can't proceed anyway."""
+    if not TEMPLATE_ONLY_MODE or cmd != "create":
+        return
+    if os.environ.get("SENPI_ALLOW_CUSTOM_DEPLOY"):
+        return
+    ids = _catalog_template_ids()
+    if ids is None or pkg.id in ids:  # can't verify → don't block;  in catalog → allow
+        return
+    raise SystemExit(_TEMPLATE_ONLY_MSG.format(id=pkg.id))
+# ══════════════════════════════════════════════════════════════════════════════════════════════
 
 
 # ---------- package + state ----------
@@ -632,6 +698,7 @@ def main(argv):
     log = (lambda m: None) if a.json else (lambda m: print(m))
 
     pkg = ensure_pkg(a.package, a.ref, log)
+    _template_only_guard(pkg, a.cmd)  # TEMPORARY template-only mode — remove with the block above
 
     # `validate` is the standalone, side-effect-free preflight; `create` runs the SAME full check
     # before funding any wallet; runtime/verify/status keep the structural gate.

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -6,6 +6,7 @@ bake-off (Samurai/Qwen, Gemini, GLM), where every model tripped on the same auth
     python3 -m pytest senpi-strategy-ops/tests/
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import json
 import os
 import sys
 
@@ -179,6 +180,97 @@ def test_full_validate_catches_unresolved_placeholder(tmp_path):
     pkg = _pkg.load(str(d))
     errs = deploy.full_validate(pkg)
     assert any("UNBOUND_THING" in e for e in errs)
+
+
+# ─────────────────────────── template-only mode (temporary gate) ───────────────────────────
+# While the from-scratch builder is being hardened, deploy.py refuses to FUND a package whose id
+# isn't a catalog template. These lock in the four behaviours that keep it safe + reversible:
+# blocks scratch, allows templates, honours the override, and never touches non-`create` commands.
+from types import SimpleNamespace  # noqa: E402
+
+
+def test_template_only_blocks_non_catalog_create(monkeypatch):
+    """A from-scratch id (not in the catalog) is refused at `create` — before any wallet is funded —
+    with the warm template pointer, not a stack trace."""
+    deploy = _import_deploy()
+    monkeypatch.setattr(deploy, "TEMPLATE_ONLY_MODE", True)
+    monkeypatch.setattr(deploy, "_catalog_template_ids", lambda: {"raven", "wolf"})
+    monkeypatch.delenv("SENPI_ALLOW_CUSTOM_DEPLOY", raising=False)
+    with pytest.raises(SystemExit) as ei:
+        deploy._template_only_guard(SimpleNamespace(id="my-scratch-idea"), "create")
+    msg = str(ei.value)
+    assert "my-scratch-idea" in msg and "senpi-strategy-discover" in msg
+
+
+def test_template_only_allows_catalog_template(monkeypatch):
+    """A real catalog template deploys unimpeded (and a re-deploy of an already-fetched template is
+    NOT falsely blocked — membership is by id, not by whether it's cached on disk)."""
+    deploy = _import_deploy()
+    monkeypatch.setattr(deploy, "TEMPLATE_ONLY_MODE", True)
+    monkeypatch.setattr(deploy, "_catalog_template_ids", lambda: {"raven", "wolf"})
+    monkeypatch.delenv("SENPI_ALLOW_CUSTOM_DEPLOY", raising=False)
+    deploy._template_only_guard(SimpleNamespace(id="raven"), "create")  # no raise
+
+
+def test_template_only_override_env_lets_internal_deploys_through(monkeypatch):
+    """SENPI_ALLOW_CUSTOM_DEPLOY=1 is the internal escape hatch — fleet/CI can still deploy a new,
+    not-yet-catalogued strategy from scratch."""
+    deploy = _import_deploy()
+    monkeypatch.setattr(deploy, "TEMPLATE_ONLY_MODE", True)
+    monkeypatch.setattr(deploy, "_catalog_template_ids", lambda: {"raven"})
+    monkeypatch.setenv("SENPI_ALLOW_CUSTOM_DEPLOY", "1")
+    deploy._template_only_guard(SimpleNamespace(id="brand-new-fleet-agent"), "create")  # no raise
+
+
+def test_template_only_ignores_non_create_commands(monkeypatch):
+    """validate/status/runtime/verify are never gated — a user can still VALIDATE a scratch package
+    (and get feedback); only funding is blocked."""
+    deploy = _import_deploy()
+    monkeypatch.setattr(deploy, "TEMPLATE_ONLY_MODE", True)
+    monkeypatch.setattr(deploy, "_catalog_template_ids", lambda: {"raven"})
+    monkeypatch.delenv("SENPI_ALLOW_CUSTOM_DEPLOY", raising=False)
+    for cmd in ("validate", "status", "runtime", "verify"):
+        deploy._template_only_guard(SimpleNamespace(id="my-scratch-idea"), cmd)  # no raise
+
+
+def test_template_only_fails_open_when_catalog_unreadable(monkeypatch):
+    """If the catalog can't be fetched (None), the guard does NOT block — funding needs the network
+    anyway, so failing open here can't let an offline scratch deploy complete."""
+    deploy = _import_deploy()
+    monkeypatch.setattr(deploy, "TEMPLATE_ONLY_MODE", True)
+    monkeypatch.setattr(deploy, "_catalog_template_ids", lambda: None)
+    monkeypatch.delenv("SENPI_ALLOW_CUSTOM_DEPLOY", raising=False)
+    deploy._template_only_guard(SimpleNamespace(id="my-scratch-idea"), "create")  # no raise
+
+
+def test_template_only_mode_off_is_a_clean_noop(monkeypatch):
+    """Flipping TEMPLATE_ONLY_MODE = False fully restores custom deploys — the one-line switch back."""
+    deploy = _import_deploy()
+    monkeypatch.setattr(deploy, "TEMPLATE_ONLY_MODE", False)
+    monkeypatch.delenv("SENPI_ALLOW_CUSTOM_DEPLOY", raising=False)
+    deploy._template_only_guard(SimpleNamespace(id="my-scratch-idea"), "create")  # no raise
+
+
+def test_catalog_ids_parses_skills_and_caches(monkeypatch):
+    """_catalog_template_ids extracts skills[].id from the fetched catalog.json and caches per run
+    (one network hit); an HTTP error or exception fails open to None (→ guard won't block)."""
+    deploy = _import_deploy()
+    monkeypatch.setattr(deploy, "_CATALOG_IDS", None)
+    body = json.dumps({"skills": [{"id": "raven"}, {"id": "wolf"}, {"no_id": 1}]}).encode()
+    calls = {"n": 0}
+
+    def _fake_get(host, path, accept, timeout):
+        calls["n"] += 1
+        assert "catalog.json" in path
+        return 200, body
+    monkeypatch.setattr(deploy._fetch, "_get", _fake_get)
+    assert deploy._catalog_template_ids() == {"raven", "wolf"}
+    assert deploy._catalog_template_ids() == {"raven", "wolf"}  # cached
+    assert calls["n"] == 1
+
+    monkeypatch.setattr(deploy, "_CATALOG_IDS", None)
+    monkeypatch.setattr(deploy._fetch, "_get", lambda *a, **k: (404, b""))
+    assert deploy._catalog_template_ids() is None  # HTTP error → fail open
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
>90% of from-scratch (Qwen) strategy-author attempts currently fail to deploy runtimes/scanners. Until the builder/compiler is hardened, limit user deploys to the **91 proven catalog templates** — the code that's already validated end-to-end — while keeping our own fleet builds unrestricted.

## What
Two layers, one flag, fully reversible.

1. **`strategy-author` SKILL — the steer (primary gate).** Any "build from scratch / design my own" ask is routed to the closest proven template via `senpi-strategy-discover`, with warm, power-user framing (*every strategy is real quant engineering — scanner + scoring + runtime + DSL exit — that we're upgrading right now; start from proven code*). The original 3-path interview is **kept intact below** a single comment block.

2. **`deploy.py` — the backstop (enforcement).** `create` refuses to **fund** a package whose id isn't a catalog template, *before any wallet is created*, with the same warm pointer. Membership is checked **by catalog id** (survives fetch-caching, so a re-deployed template is never falsely blocked). **Fail-open** if the catalog is unreachable — safe, because funding needs the network anyway, so a fail-open can't complete an offline scratch deploy.

## Reversibility (by design)
- Flip **`TEMPLATE_ONLY_MODE = False`** in `deploy.py` — one line, custom deploys return instantly.
- Delete the one comment block in the author SKILL — the 3-path "Start here" governs again.
- **`SENPI_ALLOW_CUSTOM_DEPLOY=1`** overrides per-invocation (internal fleet / CI deploying a new, not-yet-catalogued strategy).

## Scope decision
**Strict template-only** (blocks scratch *and* fork-to-new-id): matches "only allow launching from templates," simplest to enforce, and a stopgap — editing a template's config (universe/thresholds/sizing/DSL) stays fully open and is the reliable way to customize today.

## Note
#476 (merged) already targets the deploy-contract failures behind most of that >90%. Recommend **re-running the bake-off on current main** to re-measure before deciding how long this stays on — this is the safety net while confidence rebuilds, likely short-lived.

## Tests
+7 (block scratch / allow template / override / non-create / fail-open / flag-off / catalog parse+cache). Full ops suite: **41 passed**. Live-verified against the real catalog (91 templates, raven allowed, scratch blocked with pointer, validate not gated).

MINOR bumps: strategy-ops 2.5.0→2.6.0, strategy-author 2.6.1→2.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)