### PR TITLE
marginPct is a PERCENT, not a fraction — fix scaffold doc + add validator guard

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.6.1"
+  version: "2.7.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-author/references/creating-a-strategy.md
+++ b/senpi-strategy-author/references/creating-a-strategy.md
@@ -41,7 +41,7 @@ whether the package is deploy-ready.
 
 Two invariants fall out of this:
 1. **`scan()` is read-only + pure + single-pass.** On *any* error, `return []` — never crash.
-2. **You emit a sizing *intent* (`marginPct`/weight), not dollars.** The runtime computes `marginUsd` from the reconciled account value. Do **not** read the clearinghouse to size — that's the runtime's job in 3.0.
+2. **You emit a sizing *intent* (`marginPct`/weight), not dollars.** The runtime computes `marginUsd` from the reconciled account value. Do **not** read the clearinghouse to size — that's the runtime's job in 3.0. **`marginPct` is a PERCENT in (0,100], NOT a fraction:** `10` = 10%; the runtime sizes `(marginPct/100) × withdrawable`. A fraction like `0.10` means 0.1% → every order lands below Hyperliquid's ~$10 min notional and is silently rejected, so the strategy funds but never trades (the recurring 0.15/0.10/0.08 slip — it's the v2 convention; 3.0 is percent).
 
 ## 4. The design space — the 7 decisions that define *any* strategy
 
@@ -114,7 +114,7 @@ def scan(inputs, ctx):
     out = [{
         "asset": p["asset"],
         "direction": p["direction"],                 # REQUIRED: LONG | SHORT
-        "marginPct": inputs.get("marginPct", 0.10),  # SIZING INTENT — runtime makes it dollars
+        "marginPct": inputs.get("marginPct", 10),    # SIZING INTENT — PERCENT in (0,100], NOT a fraction: 10 = 10%; runtime sizes (marginPct/100)×acct
         "data": {                                    # must match signal_data_schema exactly
             "score": p["score"], "direction": p["direction"], "reasons": p["reasons"],
         },
@@ -294,7 +294,7 @@ scanners:
       universe: ["xyz:SP500","xyz:NASDAQ","xyz:NVDA","xyz:AMD","xyz:MSFT","xyz:JPM","xyz:CAT","BTC","ETH"]
       minScore: 5
       breadthMin: 4
-      marginPct: 0.10
+      marginPct: 10          # PERCENT of withdrawable in (0,100] — 10 = 10%, NOT 0.10 (a fraction sizes 100× too small → every order below the ~$10 min notional, silently rejected)
       rsiMaxLong: 72
       horizonEndIso: "2026-10-01T00:00:00Z"
     signal_data_schema:
@@ -352,7 +352,7 @@ def scan(inputs, ctx):
     universe    = inputs.get("universe", [])
     min_score   = int(inputs.get("minScore", 5))
     breadth_min = int(inputs.get("breadthMin", 4))
-    base_pct    = float(inputs.get("marginPct", 0.10))
+    base_pct    = float(inputs.get("marginPct", 10))    # PERCENT in (0,100] — 10 = 10%, NOT 0.10
 
     confirmers = []
     for asset in universe:

--- a/senpi-strategy-author/references/creating-a-strategy.md
+++ b/senpi-strategy-author/references/creating-a-strategy.md
@@ -41,7 +41,7 @@ whether the package is deploy-ready.
 
 Two invariants fall out of this:
 1. **`scan()` is read-only + pure + single-pass.** On *any* error, `return []` — never crash.
-2. **You emit a sizing *intent* (`marginPct`/weight), not dollars.** The runtime computes `marginUsd` from the reconciled account value. Do **not** read the clearinghouse to size — that's the runtime's job in 3.0. **`marginPct` is a PERCENT in (0,100], NOT a fraction:** `10` = 10%; the runtime sizes `(marginPct/100) × withdrawable`. A fraction like `0.10` means 0.1% → every order lands below Hyperliquid's ~$10 min notional and is silently rejected, so the strategy funds but never trades (the recurring 0.15/0.10/0.08 slip — it's the v2 convention; 3.0 is percent).
+2. **You emit a sizing *intent* (`marginPct`/weight), not dollars.** The runtime computes `marginUsd` from the reconciled account value. Do **not** read the clearinghouse to size — that's the runtime's job in 3.0. **`marginPct` is a PERCENT in (0,100]** — `10` = 10%, sized `(marginPct/100) × withdrawable` (not a fraction: `0.10` = 0.1%).
 
 ## 4. The design space — the 7 decisions that define *any* strategy
 
@@ -114,7 +114,7 @@ def scan(inputs, ctx):
     out = [{
         "asset": p["asset"],
         "direction": p["direction"],                 # REQUIRED: LONG | SHORT
-        "marginPct": inputs.get("marginPct", 10),    # SIZING INTENT — PERCENT in (0,100], NOT a fraction: 10 = 10%; runtime sizes (marginPct/100)×acct
+        "marginPct": inputs.get("marginPct", 10),    # SIZING INTENT — PERCENT in (0,100]; 10 = 10%
         "data": {                                    # must match signal_data_schema exactly
             "score": p["score"], "direction": p["direction"], "reasons": p["reasons"],
         },
@@ -294,7 +294,7 @@ scanners:
       universe: ["xyz:SP500","xyz:NASDAQ","xyz:NVDA","xyz:AMD","xyz:MSFT","xyz:JPM","xyz:CAT","BTC","ETH"]
       minScore: 5
       breadthMin: 4
-      marginPct: 10          # PERCENT of withdrawable in (0,100] — 10 = 10%, NOT 0.10 (a fraction sizes 100× too small → every order below the ~$10 min notional, silently rejected)
+      marginPct: 10          # PERCENT of withdrawable in (0,100]; 10 = 10%
       rsiMaxLong: 72
       horizonEndIso: "2026-10-01T00:00:00Z"
     signal_data_schema:
@@ -352,7 +352,7 @@ def scan(inputs, ctx):
     universe    = inputs.get("universe", [])
     min_score   = int(inputs.get("minScore", 5))
     breadth_min = int(inputs.get("breadthMin", 4))
-    base_pct    = float(inputs.get("marginPct", 10))    # PERCENT in (0,100] — 10 = 10%, NOT 0.10
+    base_pct    = float(inputs.get("marginPct", 10))    # PERCENT in (0,100]; 10 = 10%
 
     confirmers = []
     for asset in universe:

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -25,12 +25,10 @@ _MARGIN_PCT_RE = re.compile(r"margin_?pct", re.I)
 
 
 def margin_fraction_offenders(doc, path=""):
-    """Any margin-percent key in a runtime doc whose value is a FRACTION (0,1] where a PERCENT (0,100]
-    is required. `marginPct: 0.10` (meant 10) sizes 100× too small — (0.10/100)×withdrawable → sub-$10
-    notional → EVERY order rejected, so the strategy funds but never trades. This is the recurring
-    v2-fraction-vs-3.0-percent slip (0.15/0.10/0.08 for 15/10/8). Walks the whole doc, so it catches the
-    value under `scanners[].inputs`, the runtime `strategy.margin_pct`, or a top-level emit — under any
-    key name (marginPct / marginPctBase / margin_pct). Returns [(dotted_key, value), ...]."""
+    """Margin-percent keys whose value is a fraction (0,1] where a PERCENT (0,100] is required
+    (`marginPct: 0.10` meant 10 — 100× too small). Walks the whole doc (scanners[].inputs,
+    strategy.margin_pct, or a top-level emit; any key: marginPct / marginPctBase / margin_pct).
+    Returns [(dotted_key, value), ...]."""
     out = []
     if isinstance(doc, dict):
         for k, v in doc.items():
@@ -112,14 +110,11 @@ def validate(pkg: Path) -> list:
                 errs.append(f"instance {name}: set runtime `name: {expect}` (found {rt_doc.get('name')!r})")
             if rt_doc.get("group") != sid:
                 errs.append(f"instance {name}: set runtime `group: {sid}` (found {rt_doc.get('group')!r})")
-            # marginPct/margin_pct is a PERCENT in (0,100]; a value <= 1 is the v2 FRACTION slip
-            # (0.10 meant 10) that sizes 100x too small — sub-$10 notional, every order rejected, so the
-            # strategy funds but never trades. Flag pre-deploy with the exact fix. (See scan-contract.md.)
+            # marginPct is a PERCENT in (0,100]; a value <= 1 is the fraction slip (0.10 meant 10, 100x
+            # too small). Flag it pre-deploy with the exact fix. (See scan-contract.md.)
             for kp, val in margin_fraction_offenders(rt_doc):
-                errs.append(f"instance {name}: `{kp}: {val}` looks like a FRACTION — marginPct is a "
-                            f"PERCENT in (0,100], sized as (marginPct/100)×withdrawable. Set {val * 100:g} "
-                            f"(not {val}); as-authored every order is below the ~$10 min notional and is "
-                            f"rejected, so it funds but never trades.")
+                errs.append(f"instance {name}: `{kp}` must be a PERCENT in (0,100] — set {val * 100:g} "
+                            f"(not {val})")
 
         # data_retention: Runtime 3.0 uses data_retention_seconds (integer 3600–604800);
         # the v2 data_retention_hours field is deprecated. (See senpi-trading-runtime/references/runtime-yaml.md.)

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -21,6 +21,29 @@ except ImportError:
 
 
 _VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_MARGIN_PCT_RE = re.compile(r"margin_?pct", re.I)
+
+
+def margin_fraction_offenders(doc, path=""):
+    """Any margin-percent key in a runtime doc whose value is a FRACTION (0,1] where a PERCENT (0,100]
+    is required. `marginPct: 0.10` (meant 10) sizes 100× too small — (0.10/100)×withdrawable → sub-$10
+    notional → EVERY order rejected, so the strategy funds but never trades. This is the recurring
+    v2-fraction-vs-3.0-percent slip (0.15/0.10/0.08 for 15/10/8). Walks the whole doc, so it catches the
+    value under `scanners[].inputs`, the runtime `strategy.margin_pct`, or a top-level emit — under any
+    key name (marginPct / marginPctBase / margin_pct). Returns [(dotted_key, value), ...]."""
+    out = []
+    if isinstance(doc, dict):
+        for k, v in doc.items():
+            kp = f"{path}.{k}" if path else str(k)
+            if isinstance(v, (int, float)) and not isinstance(v, bool) \
+                    and _MARGIN_PCT_RE.search(str(k)) and 0 < v <= 1:
+                out.append((kp, v))
+            else:
+                out.extend(margin_fraction_offenders(v, kp))
+    elif isinstance(doc, list):
+        for i, v in enumerate(doc):
+            out.extend(margin_fraction_offenders(v, f"{path}[{i}]"))
+    return out
 
 
 def _flat_wallet_env(pkg: Path, sid) -> str:
@@ -89,6 +112,14 @@ def validate(pkg: Path) -> list:
                 errs.append(f"instance {name}: set runtime `name: {expect}` (found {rt_doc.get('name')!r})")
             if rt_doc.get("group") != sid:
                 errs.append(f"instance {name}: set runtime `group: {sid}` (found {rt_doc.get('group')!r})")
+            # marginPct/margin_pct is a PERCENT in (0,100]; a value <= 1 is the v2 FRACTION slip
+            # (0.10 meant 10) that sizes 100x too small — sub-$10 notional, every order rejected, so the
+            # strategy funds but never trades. Flag pre-deploy with the exact fix. (See scan-contract.md.)
+            for kp, val in margin_fraction_offenders(rt_doc):
+                errs.append(f"instance {name}: `{kp}: {val}` looks like a FRACTION — marginPct is a "
+                            f"PERCENT in (0,100], sized as (marginPct/100)×withdrawable. Set {val * 100:g} "
+                            f"(not {val}); as-authored every order is below the ~$10 min notional and is "
+                            f"rejected, so it funds but never trades.")
 
         # data_retention: Runtime 3.0 uses data_retention_seconds (integer 3600–604800);
         # the v2 data_retention_hours field is deprecated. (See senpi-trading-runtime/references/runtime-yaml.md.)

--- a/senpi-strategy-author/tests/test_scaffold_margin.py
+++ b/senpi-strategy-author/tests/test_scaffold_margin.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Guards the marginPct PERCENT-not-FRACTION contract in the author scaffold + validator.
+
+`marginPct` is a PERCENT in (0,100] (Runtime 3.0 sizes `(marginPct/100) × withdrawable`). The v2
+convention was a FRACTION (0.10); the scaffold doc carried that stale form, so every from-scratch
+build that copied it shipped 100× undersized — sub-$10 notional, every order rejected, funds-but-
+never-trades. These tests lock (a) the validator that now flags it and (b) the doc that must never
+teach it again.
+
+    python3 -m pytest senpi-strategy-author/tests/
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+
+import validate_strategy as vs  # noqa: E402
+
+_DOC = os.path.join(HERE, "..", "references", "creating-a-strategy.md")
+
+
+def test_offenders_flags_fraction_passes_percent():
+    off = vs.margin_fraction_offenders
+    assert off({"scanners": [{"inputs": {"marginPct": 0.10}}]}) == [("scanners[0].inputs.marginPct", 0.10)]
+    assert off({"strategy": {"margin_pct": 0.2}}) == [("strategy.margin_pct", 0.2)]
+    assert off({"inputs": {"marginPctBase": 0.15, "marginPctCap": 25}}) == [("inputs.marginPctBase", 0.15)]
+    # legit percents + non-margin keys never flag
+    assert off({"strategy": {"margin_pct": 20}, "inputs": {"marginPctBase": 18, "marginPctCap": 25}}) == []
+    assert off({"inputs": {"minScore": 0.5, "leverage": 0.5}}) == []
+
+
+def test_scaffold_doc_teaches_percent_not_fraction():
+    """Regression on the copy-source: creating-a-strategy.md must NEVER assign a marginPct/margin_pct a
+    value <= 1 (the fraction slip that was the root cause). Percent forms like `marginPct: 10` pass."""
+    text = open(_DOC, encoding="utf-8").read()
+    bad = re.findall(r"margin_?pct[\"']?\s*[:,]\s*0*\.\d+", text, re.I)
+    assert not bad, f"fraction-form marginPct still in creating-a-strategy.md (must be a PERCENT): {bad}"
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.5.0"
+  version: "2.6.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -26,12 +26,10 @@ _MARGIN_PCT_RE = re.compile(r"margin_?pct", re.I)
 
 
 def margin_fraction_offenders(doc, path=""):
-    """Any margin-percent key whose value is a FRACTION (0,1] where a PERCENT (0,100] is required.
-    `marginPct: 0.10` (meant 10) sizes 100× too small — (0.10/100)×withdrawable → sub-$10 notional →
-    EVERY order rejected, so the strategy funds but never trades (the recurring v2-fraction slip:
-    0.15/0.10/0.08 for 15/10/8). Walks the whole runtime doc — catches `scanners[].inputs`,
-    `strategy.margin_pct`, or a top-level emit, under any key (marginPct / marginPctBase / margin_pct).
-    Mirrors senpi-strategy-author validate_strategy so author-green == deploy-green. [(key, value), ...]."""
+    """Margin-percent keys whose value is a fraction (0,1] where a PERCENT (0,100] is required
+    (`marginPct: 0.10` meant 10 — 100× too small). Walks the whole runtime doc (scanners[].inputs,
+    strategy.margin_pct, or a top-level emit; any key: marginPct / marginPctBase / margin_pct). Mirrors
+    senpi-strategy-author validate_strategy so author-green == deploy-green. [(key, value), ...]."""
     out = []
     if isinstance(doc, dict):
         for k, v in doc.items():
@@ -243,14 +241,10 @@ def validate(pkg: Package) -> list:
         expect_name = f"{pkg.id}-{inst.name}"
         if inst.runtime_name != expect_name:
             errs.append(f"{tag}: set runtime `name: {expect_name}` (found {inst.runtime_name!r})")
-        # marginPct is a PERCENT in (0,100]; a value <= 1 is the v2 FRACTION slip (0.10 meant 10) that
-        # sizes 100× too small — sub-$10 notional, every order rejected, funds-but-never-trades. Refuse
-        # to fund it here (author's validate_strategy flags it too; ops re-checks a hand-edited / fetched
-        # package). Prescriptive, like the name/group linkage errors above.
+        # marginPct is a PERCENT in (0,100]; a value <= 1 is the fraction slip (0.10 meant 10, 100x too
+        # small). Refuse to fund it (author's validate_strategy flags it too; ops re-checks fetched packages).
         for kp, val in margin_fraction_offenders(inst.runtime_doc):
-            errs.append(f"{tag}: `{kp}: {val}` looks like a FRACTION — marginPct is a PERCENT in (0,100], "
-                        f"sized as (marginPct/100)×withdrawable. Set {val * 100:g} (not {val}); as-authored "
-                        f"every order is below the ~$10 min notional and is rejected (funds but never trades).")
+            errs.append(f"{tag}: `{kp}` must be a PERCENT in (0,100] — set {val * 100:g} (not {val})")
         # wallet binding
         if not inst.wallet_env:
             errs.append(f"{tag}: missing wallet_env")

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -22,6 +22,29 @@ except ImportError:
     import _yaml as yaml  # vendored stdlib-only fallback — agent hosts may lack PyYAML / pip
 
 _VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_MARGIN_PCT_RE = re.compile(r"margin_?pct", re.I)
+
+
+def margin_fraction_offenders(doc, path=""):
+    """Any margin-percent key whose value is a FRACTION (0,1] where a PERCENT (0,100] is required.
+    `marginPct: 0.10` (meant 10) sizes 100× too small — (0.10/100)×withdrawable → sub-$10 notional →
+    EVERY order rejected, so the strategy funds but never trades (the recurring v2-fraction slip:
+    0.15/0.10/0.08 for 15/10/8). Walks the whole runtime doc — catches `scanners[].inputs`,
+    `strategy.margin_pct`, or a top-level emit, under any key (marginPct / marginPctBase / margin_pct).
+    Mirrors senpi-strategy-author validate_strategy so author-green == deploy-green. [(key, value), ...]."""
+    out = []
+    if isinstance(doc, dict):
+        for k, v in doc.items():
+            kp = f"{path}.{k}" if path else str(k)
+            if isinstance(v, (int, float)) and not isinstance(v, bool) \
+                    and _MARGIN_PCT_RE.search(str(k)) and 0 < v <= 1:
+                out.append((kp, v))
+            else:
+                out.extend(margin_fraction_offenders(v, kp))
+    elif isinstance(doc, list):
+        for i, v in enumerate(doc):
+            out.extend(margin_fraction_offenders(v, f"{path}[{i}]"))
+    return out
 
 
 class BadPackage(Exception):
@@ -220,6 +243,14 @@ def validate(pkg: Package) -> list:
         expect_name = f"{pkg.id}-{inst.name}"
         if inst.runtime_name != expect_name:
             errs.append(f"{tag}: set runtime `name: {expect_name}` (found {inst.runtime_name!r})")
+        # marginPct is a PERCENT in (0,100]; a value <= 1 is the v2 FRACTION slip (0.10 meant 10) that
+        # sizes 100× too small — sub-$10 notional, every order rejected, funds-but-never-trades. Refuse
+        # to fund it here (author's validate_strategy flags it too; ops re-checks a hand-edited / fetched
+        # package). Prescriptive, like the name/group linkage errors above.
+        for kp, val in margin_fraction_offenders(inst.runtime_doc):
+            errs.append(f"{tag}: `{kp}: {val}` looks like a FRACTION — marginPct is a PERCENT in (0,100], "
+                        f"sized as (marginPct/100)×withdrawable. Set {val * 100:g} (not {val}); as-authored "
+                        f"every order is below the ~$10 min notional and is rejected (funds but never trades).")
         # wallet binding
         if not inst.wallet_env:
             errs.append(f"{tag}: missing wallet_env")

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -181,5 +181,38 @@ def test_full_validate_catches_unresolved_placeholder(tmp_path):
     assert any("UNBOUND_THING" in e for e in errs)
 
 
+# ─────────────────────── marginPct fraction-vs-percent guard ───────────────────────
+# marginPct is a PERCENT in (0,100]; the v2 FRACTION form (0.10 meant 10) sizes 100× too small and
+# every order is rejected below the ~$10 min notional. The scaffold doc used to teach the fraction —
+# these lock the deploy-time backstop that refuses it, and that legit percents never false-positive.
+
+def test_margin_offenders_flags_fraction_passes_percent():
+    off = _pkg.margin_fraction_offenders
+    assert off({"scanners": [{"inputs": {"marginPct": 0.10}}]}) == [("scanners[0].inputs.marginPct", 0.10)]
+    assert off({"strategy": {"margin_pct": 0.2}}) == [("strategy.margin_pct", 0.2)]
+    assert off({"inputs": {"marginPctBase": 0.15, "marginPctCap": 25}}) == [("inputs.marginPctBase", 0.15)]
+    assert off({"inputs": {"marginPct": 1}}) == [("inputs.marginPct", 1)]        # 1 == the (0,1] boundary
+    # legit percents and non-margin keys never flag
+    assert off({"strategy": {"margin_pct": 20}, "inputs": {"marginPctBase": 18, "marginPctCap": 25}}) == []
+    assert off({"inputs": {"minScore": 0.5, "leverage": 0.5, "volFloorPctOfMedian": 0.2}}) == []
+
+
+def test_validate_refuses_fraction_marginpct(tmp_path):
+    """A scanner-inputs marginPct: 0.1 (the doc-copy slip) is refused pre-funding, prescribing `Set 10`."""
+    d = make_flat(tmp_path, pkg_id="fracbug")
+    rt = d / "runtime.yaml"
+    rt.write_text(rt.read_text().replace("inputs: {}", "inputs:\n      marginPct: 0.1"))
+    errs = _pkg.validate(_pkg.load(str(d)))
+    assert any("looks like a FRACTION" in e and "Set 10" in e for e in errs)
+
+
+def test_validate_accepts_percent_marginpct(tmp_path):
+    """A percent marginPct (10) validates clean — the guard has no false positive on the correct form."""
+    d = make_flat(tmp_path, pkg_id="okmargin")
+    rt = d / "runtime.yaml"
+    rt.write_text(rt.read_text().replace("inputs: {}", "inputs:\n      marginPct: 10"))
+    assert _pkg.validate(_pkg.load(str(d))) == []
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-q"]))

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -198,12 +198,12 @@ def test_margin_offenders_flags_fraction_passes_percent():
 
 
 def test_validate_refuses_fraction_marginpct(tmp_path):
-    """A scanner-inputs marginPct: 0.1 (the doc-copy slip) is refused pre-funding, prescribing `Set 10`."""
+    """A scanner-inputs marginPct: 0.1 (the doc-copy slip) is refused pre-funding, prescribing `set 10`."""
     d = make_flat(tmp_path, pkg_id="fracbug")
     rt = d / "runtime.yaml"
     rt.write_text(rt.read_text().replace("inputs: {}", "inputs:\n      marginPct: 0.1"))
     errs = _pkg.validate(_pkg.load(str(d)))
-    assert any("looks like a FRACTION" in e and "Set 10" in e for e in errs)
+    assert any("must be a PERCENT in (0,100]" in e and "set 10" in e for e in errs)
 
 
 def test_validate_accepts_percent_marginpct(tmp_path):


### PR DESCRIPTION
## What
`marginPct` is a **PERCENT in (0,100]** — `10` = 10% (the runtime sizes `(marginPct/100) × withdrawable`). The scaffold `creating-a-strategy.md` still used the old v2 **fraction** form (`marginPct: 0.10`), so from-scratch builds that copied it sized 100× too small — the recurring `0.15 / 0.10 / 0.08` slip.

## Fix
- **Doc:** `creating-a-strategy.md` `0.10 → 10` (3 spots) + a one-line percent note.
- **Validator (author + ops):** flag any `margin*pct*` value in (0,1] before funding, prescribing the fix (`set 15`). Walks `scanners[].inputs`, `strategy.margin_pct`, or a top-level emit; any key name.
- **Tests (+5):** offenders logic, deploy-time refuse/accept, doc-regression guard.

MINOR: strategy-author 2.6.1→2.7.0, strategy-ops 2.5.0→2.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)