### PR TITLE
verify: read state (stderr + scannerId + runCount-0) — stop false 'scanner=broken'

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.6.0"
+  version: "2.7.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -127,6 +127,17 @@ flagged component and re-run. It's a **single fast check** — a scheduled scann
 wait for the first scan tick and you must **never `sleep` then verify**. `deploy.py status <id>` shows deploy
 state any time.
 
+> **⛔ `runCount 0` / no positions ≠ broken — do NOT thrash the strategy.** A newly-deployed scanner shows
+> **`runCount = 0`, no signals, no positions until its first interval elapses** — and on a **slow clock that is
+> HOURS** (the 6h regime scanners; a from-scratch 4–6h build). That is **healthy** — `verify` reports it as
+> `scanner=scheduled` = **live**. It does **not** mean the deploy failed. **Never `close`/recreate, re-run
+> `create`, or re-`runtime` to "force a tick"** — that tears down a working strategy on a fresh wallet and, if it
+> fumbles the redeploy, leaves it closed (the confirmed **LION** incident: a slow scanner mistaken for broken,
+> thrashed for an hour, strategy destroyed). If `verify` says `scheduled` (or `create`/`runtime` already
+> succeeded), **you are done** — tell the user it's live and will scan on its interval; re-run `verify` later only
+> if they want to confirm the first tick landed. The only reasons to touch a deployed strategy again are a
+> **`broken` verdict with a real error** (`scanner erroring: …`, `dsl=…`, `budget=underfunded`), never `runCount 0`.
+
 > **Do NOT improvise.** A package strategy is a **runtime-supervised scanner** — deploy it **only** via
 > these steps. Never substitute a raw `strategy_create_custom_strategy` MCP call to "deploy" it: that
 > makes an **empty** custom-position strategy, not the running scanner. Funding is **automatic**

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.5.0"
+  version: "2.6.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -56,11 +56,15 @@ def _extract_json(text):
 
 
 def cli_json(args, timeout=60):
-    """Run a CLI command expected to emit JSON on stdout; return the parsed object or None."""
-    rc, out, _err = run_cli(args, timeout)
-    if rc != 0 or not out.strip():
+    """Run a CLI command expected to emit JSON; return the parsed object or None. Parses STDOUT first
+    (the documented stream), then falls back to STDERR — some openclaw commands (observed on
+    `senpi state -r <id> --json`) print the JSON payload to stderr, and a stdout-only read silently
+    returns None, so a healthy runtime reads as 'no state' → a FALSE `scanner=broken` in verify.
+    stdout-first keeps the normal path unchanged; the stderr fallback only fires when stdout has no JSON."""
+    rc, out, err = run_cli(args, timeout)
+    if rc != 0:
         return None
-    return _extract_json(out)
+    return _extract_json(out) or _extract_json(err)
 
 
 # ---- tolerant extraction ----

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -494,7 +494,15 @@ def _scanner_verdict(inst, state):
     runs = _cli.dig(sc, "runCount", "ticks", "runs", default=0) or 0
     if isinstance(runs, (int, float)) and runs > 0:
         return "ticked", f"{int(runs)} scan(s)"
-    return "scheduled", f"awaiting first tick (~{inst.interval_seconds or '?'}s cadence)"
+    iv = inst.interval_seconds
+    cad = f"~{iv // 3600}h" if isinstance(iv, (int, float)) and iv >= 3600 else \
+          (f"~{int(iv)}s" if isinstance(iv, (int, float)) and iv else "its interval")
+    # runCount==0 is HEALTHY, not broken: the scanner is mounted + wired and fires on its interval. On a
+    # slow clock (the 6h regime scanners) that first tick is HOURS out — say so loudly, because an
+    # impatient agent that reads this as "not working" and close+recreates DESTROYS a working strategy
+    # (the LION incident). 'scheduled' counts as LIVE in the gate above.
+    return "scheduled", (f"HEALTHY — mounted + wired, first scan due in {cad} (runCount 0 until then is "
+                         f"expected); NOT broken, do NOT redeploy/close — just re-run verify later")
 
 
 def _dsl_verdict(inst, status_json):

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -459,9 +459,13 @@ def cmd_runtime(pkg, a, log):
 # ---------- step 3: verify ticking ----------
 
 def _deep_find_scanner(obj, name):
+    # The real `openclaw senpi state --json` nests scanners at
+    # states[].components.scanners.state.scanners[], each keyed by `scannerId` (verified in prod:
+    # M408027's lion deploy) — NOT `name`. Match ANY of these id spellings so the deep search actually
+    # finds the scanner; without `scannerId` verify reports a healthy scanner as "not mounted".
     if isinstance(obj, dict):
-        if _cli.dig(obj, "name", "scanner", "scannerName") == name and any(
-                k.lower() in ("runcount", "lastrunfinishedat", "lastrunstartedat", "ticks") for k in obj):
+        if _cli.dig(obj, "name", "scanner", "scannerName", "scannerId", "id") == name and any(
+                k.lower() in ("runcount", "lastrunfinishedat", "lastrunstartedat", "ticks", "health") for k in obj):
             return obj
         for v in obj.values():
             r = _deep_find_scanner(v, name)
@@ -491,6 +495,11 @@ def _scanner_verdict(inst, state):
     cec = _cli.dig(sc, "consecutiveErrorCount", default=0) or 0
     if err or (isinstance(cec, (int, float)) and cec >= 1):
         return "broken", f"scanner erroring: {str(err)[:120] if err else f'{int(cec)} consecutive errors'}"
+    # real state carries a `health` string (not `enabled`/`lastError`) — fail only on an explicitly-bad
+    # value; unknown/transient states fall through to the runCount ticked/scheduled logic below.
+    health = str(_cli.dig(sc, "health", "status", default="") or "").lower()
+    if health in ("broken", "error", "errored", "unhealthy", "failed", "crashed", "disabled", "stopped"):
+        return "broken", f"scanner health={health}"
     runs = _cli.dig(sc, "runCount", "ticks", "runs", default=0) or 0
     if isinstance(runs, (int, float)) and runs > 0:
         return "ticked", f"{int(runs)} scan(s)"

--- a/senpi-strategy-ops/tests/test_cli.py
+++ b/senpi-strategy-ops/tests/test_cli.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""cli_json robustness — the JSON payload may land on STDOUT or STDERR.
+
+`openclaw senpi state -r <id> --json` was observed emitting its payload to stderr; the old
+stdout-only `cli_json` returned None, so a healthy runtime read as 'no state' and verify reported a
+FALSE `scanner=broken`. These lock the stdout-first / stderr-fallback behaviour.
+
+    python3 -m pytest senpi-strategy-ops/tests/
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+
+import _cli  # noqa: E402
+
+_STATE = '{"scanners":[{"name":"sc1","runCount":11,"enabled":true}]}'
+_PARSED = {"scanners": [{"name": "sc1", "runCount": 11, "enabled": True}]}
+
+
+def test_cli_json_parses_stdout(monkeypatch):
+    monkeypatch.setattr(_cli, "run_cli", lambda *a, **k: (0, _STATE, ""))
+    assert _cli.cli_json(["x"]) == _PARSED
+
+
+def test_cli_json_falls_back_to_stderr(monkeypatch):
+    """The observed failure: payload on stderr, stdout empty — must still be recovered."""
+    monkeypatch.setattr(_cli, "run_cli", lambda *a, **k: (0, "", _STATE))
+    assert _cli.cli_json(["x"]) == _PARSED
+
+
+def test_cli_json_stdout_wins_over_stderr(monkeypatch):
+    """Normal path is unchanged: when stdout has JSON it is used, stderr is ignored."""
+    monkeypatch.setattr(_cli, "run_cli", lambda *a, **k: (0, '{"a":1}', '{"b":2}'))
+    assert _cli.cli_json(["x"]) == {"a": 1}
+
+
+def test_cli_json_none_on_nonzero_rc(monkeypatch):
+    """A genuine command failure (rc!=0) still returns None even if stderr carries an error object."""
+    monkeypatch.setattr(_cli, "run_cli", lambda *a, **k: (1, "", '{"error":"nope"}'))
+    assert _cli.cli_json(["x"]) is None
+
+
+def test_cli_json_none_when_no_json_anywhere(monkeypatch):
+    monkeypatch.setattr(_cli, "run_cli", lambda *a, **k: (0, "just logs", "more logs"))
+    assert _cli.cli_json(["x"]) is None
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -100,6 +100,26 @@ class ScannerVerdict(unittest.TestCase):
     def test_not_mounted_is_broken(self):
         self.assertEqual(deploy._scanner_verdict(_scan_inst(), {"scanners": []})[0], "broken")
 
+    # ── the REAL `openclaw senpi state --json` shape (verified in prod: M408027's lion deploy) ──
+    # nested states[].components.scanners.state.scanners[], keyed by `scannerId` + `health`, NOT `name`.
+    # Before the scannerId fix, verify reported a healthy deployed scanner as "not mounted" (false broken).
+    @staticmethod
+    def _prod_state(run_count, health="healthy"):
+        return {"states": [{"components": {"scanners": {"state": {"scanners": [
+            {"scannerId": "position_tracker", "runCount": 56, "health": "healthy"},
+            {"scannerId": "sc1", "runCount": run_count, "health": health},
+        ]}}}}]}
+
+    def test_prod_schema_ticked(self):
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), self._prod_state(3))[0], "ticked")
+
+    def test_prod_schema_scheduled(self):
+        # lion-short's case: healthy scanner, runCount 0 (slow first tick) = scheduled = LIVE, not broken
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), self._prod_state(0))[0], "scheduled")
+
+    def test_prod_schema_unhealthy_is_broken(self):
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), self._prod_state(0, "broken"))[0], "broken")
+
 
 class DslVerdict(unittest.TestCase):
     def test_config_missing(self):


### PR DESCRIPTION
Fixes the **false `scanner=broken` on a healthy deployment** that makes agents thrash. **Confirmed twice in prod** — M404726 (agent close/create loop) and **M408027's LION deploy** (GLM spent ~13 min reverse-engineering `verify` before confirming a deploy that had actually succeeded). Three compounding bugs, all in the `verify` read path:

## 1. `cli_json` was blind to state on stderr
`verify` reads state via `openclaw senpi state -r <id> --json`, but that command prints its JSON to **stderr** (M408027's agent measured it: `out_len=823` log-noise vs `err_len=28735` JSON). `cli_json` parsed stdout only → `None` → false broken. **Fix:** parse stdout, fall back to stderr.

## 2. Scanner is keyed `scannerId`, not `name`
The real state nests scanners at `states[].components.scanners.state.scanners[]`, each keyed **`scannerId`** (+ `health`) — `_deep_find_scanner` searched `name`/`scanner`/`scannerName`, so **even with the JSON in hand it never found the scanner** → still false broken. **This is why fix #1 alone was insufficient.** **Fix:** also match `scannerId`/`id`; honor the `health` field (real objects carry `health`, not `enabled`/`lastError`).

## 3. `runCount 0` on a slow scanner is healthy, not broken
lion-short showed `runCount 0, health healthy` (slow first tick). `verify` already scores that `scheduled` = live; hardened the message so an agent can't misread it and thrash, plus a SKILL anti-thrash rule (never close/recreate to force a tick — cites the LION incident).

## Tests — 45 pass (incl. +3 on the **real prod state schema**: ticked / scheduled@runCount0 / unhealthy)
MINOR: strategy-ops → **2.7.0** (2.6.0 taken by #482).

> Root cause for the runtime/openclaw side (@sarvesh): `senpi state --json` should print the JSON payload to **stdout**, not stderr — then no consumer has to guess the stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)