### PR TITLE
strategy-author: document candle schema + lint the close-key silent bug

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.7.0"
+  version: "2.8.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-author/references/creating-a-strategy.md
+++ b/senpi-strategy-author/references/creating-a-strategy.md
@@ -81,6 +81,9 @@ grep `strategies/catalog.json` by its `archetype` field (a closed set; every pac
 
 ### `scoring.py` — pure math (the edge)
 No I/O, no MCP, no clock, no state — just functions over candles/numbers, so it unit-tests without mocks.
+
+> **Candle schema (from `market_get_asset_data`) — read it from the source, don't guess.** Each candle is keyed **`t,o,h,l,c,v`** (+ `T,s,i,n`) — short OHLCV, and the values are **strings**. Close is `c`; read every field as `float(candle["c"])`. It is **not** `candle["close"]` (that key doesn't exist → always `None` → the scan silently emits nothing).
+
 ```python
 def score(asset, candles, extra, inputs):    # candles/numbers in, thesis dict out
     if not _qualifies(...): return None

--- a/senpi-strategy-author/references/creating-a-strategy.md
+++ b/senpi-strategy-author/references/creating-a-strategy.md
@@ -82,7 +82,7 @@ grep `strategies/catalog.json` by its `archetype` field (a closed set; every pac
 ### `scoring.py` — pure math (the edge)
 No I/O, no MCP, no clock, no state — just functions over candles/numbers, so it unit-tests without mocks.
 
-> **Candle schema (from `market_get_asset_data`) — read it from the source, don't guess.** Each candle is keyed **`t,o,h,l,c,v`** (+ `T,s,i,n`) — short OHLCV, and the values are **strings**. Close is `c`; read every field as `float(candle["c"])`. It is **not** `candle["close"]` (that key doesn't exist → always `None` → the scan silently emits nothing).
+> **Candle schema (`market_get_asset_data`):** each candle is keyed `t,o,h,l,c,v` (+ `T,s,i,n`) — short OHLCV, **string** values. Close is `c`; read fields as `float(candle["c"])`, not `candle["close"]` (no such key).
 
 ```python
 def score(asset, candles, extra, inputs):    # candles/numbers in, thesis dict out

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -44,12 +44,10 @@ def margin_fraction_offenders(doc, path=""):
     return out
 
 
-# OHLC candle keys — `market_get_asset_data` returns candles keyed `o/h/l/c/v` (string values); the long
-# forms (open/high/low/close) don't exist, so `candle.get("close")` is always None → the scan silently
-# emits nothing. The working idiom keeps a short-key access (direct `c["c"]`, or the
-# `c.get("close", c.get("c", 0))` fallback); a file that reads a LONG key with NO short-form counterpart
-# anywhere is the bug (0 false positives fleet-wide). `volume`/`v` is deliberately EXCLUDED — scanners
-# legitimately read a `volume` field from leaderboard/market rows (not candles), so it isn't a clean signal.
+# Candles (market_get_asset_data) are keyed o/h/l/c/v; the long forms (open/high/low/close) don't exist,
+# so `candle.get("close")` is always None → the scan silently emits nothing. A file that reads a long key
+# with NO short-form counterpart anywhere is the bug (0 fleet false positives). volume/v is EXCLUDED —
+# scanners legitimately read a `volume` field from market rows.
 _OHLCV_LONG = {"open": "o", "high": "h", "low": "l", "close": "c"}
 _CANDLE_ACCESS = {k: re.compile(r"""(?:\.get\(|\[)\s*['"]%s['"]""" % k)
                   for k in list(_OHLCV_LONG) + list(_OHLCV_LONG.values())}
@@ -208,9 +206,8 @@ def validate(pkg: Path) -> list:
         except SyntaxError as e:
             errs.append(f"{py.name}: syntax error ({e})")
         for lng, sht in candle_key_bug(src):
-            errs.append(f"{py.name}: reads candles by `{lng}` — Senpi candles (market_get_asset_data) are "
-                        f"keyed `o/h/l/c/v` (string values); use `float(candle['{sht}'])`. `{lng}` doesn't "
-                        f"exist → always None → the scan silently emits nothing.")
+            errs.append(f"{py.name}: candles are keyed `o/h/l/c/v` — use `candle['{sht}']`, not `{lng}` "
+                        f"(no such key → always None → the scan emits nothing).")
     for f in pkg.rglob("*"):
         if f.is_file() and f.suffix in (".py", ".yaml", ".md"):
             t = f.read_text(errors="ignore")

--- a/senpi-strategy-author/scripts/validate_strategy.py
+++ b/senpi-strategy-author/scripts/validate_strategy.py
@@ -44,6 +44,24 @@ def margin_fraction_offenders(doc, path=""):
     return out
 
 
+# OHLC candle keys — `market_get_asset_data` returns candles keyed `o/h/l/c/v` (string values); the long
+# forms (open/high/low/close) don't exist, so `candle.get("close")` is always None → the scan silently
+# emits nothing. The working idiom keeps a short-key access (direct `c["c"]`, or the
+# `c.get("close", c.get("c", 0))` fallback); a file that reads a LONG key with NO short-form counterpart
+# anywhere is the bug (0 false positives fleet-wide). `volume`/`v` is deliberately EXCLUDED — scanners
+# legitimately read a `volume` field from leaderboard/market rows (not candles), so it isn't a clean signal.
+_OHLCV_LONG = {"open": "o", "high": "h", "low": "l", "close": "c"}
+_CANDLE_ACCESS = {k: re.compile(r"""(?:\.get\(|\[)\s*['"]%s['"]""" % k)
+                  for k in list(_OHLCV_LONG) + list(_OHLCV_LONG.values())}
+
+
+def candle_key_bug(text):
+    """Long-form OHLCV keys accessed on a dict with NO short-form counterpart in the file — the silent
+    candle-key bug (`candle.get("close")` where Senpi candles are keyed `c`). Returns [(long, short), ...]."""
+    return [(lng, sht) for lng, sht in _OHLCV_LONG.items()
+            if _CANDLE_ACCESS[lng].search(text) and not _CANDLE_ACCESS[sht].search(text)]
+
+
 def _flat_wallet_env(pkg: Path, sid) -> str:
     """Mirror the deployer's flat-instance synthesis: bind wallet_env to the ${...} the flat
     runtime.yaml already uses for its wallet, falling back to <ID>_WALLET."""
@@ -182,12 +200,17 @@ def validate(pkg: Path) -> list:
     if len(man.get("instances", [])) > 1 and len(seen_wallet_envs) < len(man["instances"]):
         errs.append("multi-instance strategy must declare a distinct wallet_env per instance")
 
-    # scanner present + parses; no '@senpi/runtime' without -ai anywhere
+    # scanner present + parses; candle-key sanity; no '@senpi/runtime' without -ai anywhere
     for py in pkg.rglob("*.py"):
+        src = py.read_text()
         try:
-            ast.parse(py.read_text())
+            ast.parse(src)
         except SyntaxError as e:
             errs.append(f"{py.name}: syntax error ({e})")
+        for lng, sht in candle_key_bug(src):
+            errs.append(f"{py.name}: reads candles by `{lng}` — Senpi candles (market_get_asset_data) are "
+                        f"keyed `o/h/l/c/v` (string values); use `float(candle['{sht}'])`. `{lng}` doesn't "
+                        f"exist → always None → the scan silently emits nothing.")
     for f in pkg.rglob("*"):
         if f.is_file() and f.suffix in (".py", ".yaml", ".md"):
             t = f.read_text(errors="ignore")

--- a/senpi-strategy-author/tests/test_scaffold_margin.py
+++ b/senpi-strategy-author/tests/test_scaffold_margin.py
@@ -40,6 +40,25 @@ def test_scaffold_doc_teaches_percent_not_fraction():
     assert not bad, f"fraction-form marginPct still in creating-a-strategy.md (must be a PERCENT): {bad}"
 
 
+def test_candle_key_bug_flags_long_without_short():
+    b = vs.candle_key_bug
+    # the reported bug: candle close read by the long key with no `c` access anywhere
+    assert b('[c.get("close", 0) for c in candles if c.get("close") is not None]') == [("close", "c")]
+    assert b('hi = row["high"]') == [("high", "h")]
+    # working idioms are NOT flagged
+    assert b('float(c.get("close", c.get("c", 0)) or 0)') == []   # fallback keeps a `c` access
+    assert b('float(candle["c"])') == []                          # direct short key
+    # volume is excluded — scanners read a `volume` field from market/leaderboard rows, not candles
+    assert b('vol = market["volume"]') == []
+    assert b('n = m.get("avg_volume_6h", 0)') == []
+
+
+def test_scaffold_doc_documents_candle_c_key():
+    """The scaffold must state the candle schema so agents don't guess `close` (the root cause)."""
+    text = open(_DOC, encoding="utf-8").read()
+    assert 'candle["c"]' in text
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Candles from `market_get_asset_data` are keyed `o/h/l/c/v` (string values) — close is `c`, no `"close"` key. The scaffold never showed candle-field access, so a from-scratch build guessed `c.get("close")` → always `None` → the scan emits nothing (silent, same class as marginPct).

- **Doc:** scoring section now states the schema + the `float(candle["c"])` idiom.
- **Lint:** flag a scanner `.py` reading a long OHLC key (`open/high/low/close`) with no short-form counterpart. `volume/v` excluded (legit market-row `volume`). 0 FPs across 253 fleet scanners.
- **Tests:** +2 (lint logic, doc regression).

Author-only, `2.7.0 → 2.8.0`. Ops deploy-gate mirror = follow-up after #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)