### PR TITLE
New template: Kingfisher — Classic Indicators (RSI + MACD)

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.6.0"
+  version: "2.7.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-07-13",
+  "_updated": "2026-06-17",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -1012,6 +1012,64 @@
       "sort_order": 8
     },
     {
+      "id": "kingfisher",
+      "name": "Kingfisher — Classic Indicators (RSI + MACD)",
+      "emoji": "🐦",
+      "tagline": "The textbook RSI + MACD setup, supervised: a MACD signal-line crossover (12/26/9) on 1h candles triggers the entry, RSI(14) confirms (room above 50 for longs, below 50 for shorts) and vetoes it at the overbought/oversold extreme, 4h trend structure adds context. Trades a liquid-majors basket (BTC/ETH/SOL/BNB/XRP/AVAX/LINK/DOGE) long & short at 3-5x with a balanced DSL that locks profit from +8% ROE.",
+      "belief_plain": "The two indicators everyone knows, run for you the way the textbook says. It waits for MACD to cross its signal line, checks that RSI agrees and isn't already stretched, prefers trades that line up with the 4-hour trend, then trails a stop that starts protecting profit once you're up ~8%. Classic technical analysis on the big, liquid coins — no black box.",
+      "version": "1.0.0",
+      "thesis": "RSI and MACD are the single most-requested retail build ('a strategy based on RSI and MACD'), yet no template was positioned as one. Kingfisher is that on-ramp: a faithful, well-labelled crossover-plus-confirmation strategy on names deep enough to size into, with the runtime owning execution, sizing, slots, and a disciplined trailing exit — so a familiar chart setup becomes a supervised, always-on strategy instead of a manual watch.",
+      "tags": [
+        "rsi",
+        "macd",
+        "indicators",
+        "technical-analysis",
+        "crossover",
+        "oscillator",
+        "classic-ta",
+        "momentum",
+        "beginner",
+        "btc",
+        "eth",
+        "sol",
+        "multi-asset",
+        "long-short"
+      ],
+      "group": "momentum",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "indicator_crossover",
+      "sub_style_label": "Textbook technical setup: a MACD signal-line crossover triggers the entry, RSI confirms momentum, higher-timeframe trend adds context.",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "BNB",
+        "XRP",
+        "AVAX",
+        "LINK",
+        "DOGE"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 900,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "main",
+      "sort_order": 9
+    },
+    {
       "id": "lemur",
       "name": "Lemur — Pre-IPO Perpetual Trend Follower",
       "emoji": "🦤",
@@ -1055,7 +1113,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "lynx",
@@ -1106,7 +1164,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "meerkat",
@@ -1150,7 +1208,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "orca",
@@ -1193,7 +1251,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "otter",
@@ -1237,7 +1295,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "piranha",
@@ -1289,7 +1347,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "python",
@@ -1333,7 +1391,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 15
+      "sort_order": 16
     },
     {
       "id": "sailfish",
@@ -1383,7 +1441,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 16
+      "sort_order": 17
     },
     {
       "id": "salamander",
@@ -1433,7 +1491,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 17
+      "sort_order": 18
     },
     {
       "id": "sheep",
@@ -1486,7 +1544,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 18
+      "sort_order": 19
     },
     {
       "id": "jaguar",

--- a/senpi-strategy-discover/references/glossary.yaml
+++ b/senpi-strategy-discover/references/glossary.yaml
@@ -65,6 +65,7 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   conviction_hold_hedged: { gloss: "Single-asset conviction hold paired with a basket hedge sleeve." }
   trend_continuation: { gloss: "Enters in the direction of an established, still-intact trend." }
   accumulation: { gloss: "Detects persistent institutional accumulation — relative-strength decoupling from the market on rising volume with shallow, bought dips — from the tape, no catalyst feed needed." }
+  indicator_crossover: { gloss: "Textbook technical setup: a MACD signal-line crossover triggers the entry, RSI confirms momentum, higher-timeframe trend adds context." }
   # contrarian_fade
   sm_crowding:   { gloss: "Fades the crowded smart-money side once price stops following." }
   funding_extreme: { gloss: "Fades extreme funding rates." }

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-07-13",
+  "_updated": "2026-06-17",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -1012,6 +1012,64 @@
       "sort_order": 8
     },
     {
+      "id": "kingfisher",
+      "name": "Kingfisher — Classic Indicators (RSI + MACD)",
+      "emoji": "🐦",
+      "tagline": "The textbook RSI + MACD setup, supervised: a MACD signal-line crossover (12/26/9) on 1h candles triggers the entry, RSI(14) confirms (room above 50 for longs, below 50 for shorts) and vetoes it at the overbought/oversold extreme, 4h trend structure adds context. Trades a liquid-majors basket (BTC/ETH/SOL/BNB/XRP/AVAX/LINK/DOGE) long & short at 3-5x with a balanced DSL that locks profit from +8% ROE.",
+      "belief_plain": "The two indicators everyone knows, run for you the way the textbook says. It waits for MACD to cross its signal line, checks that RSI agrees and isn't already stretched, prefers trades that line up with the 4-hour trend, then trails a stop that starts protecting profit once you're up ~8%. Classic technical analysis on the big, liquid coins — no black box.",
+      "version": "1.0.0",
+      "thesis": "RSI and MACD are the single most-requested retail build ('a strategy based on RSI and MACD'), yet no template was positioned as one. Kingfisher is that on-ramp: a faithful, well-labelled crossover-plus-confirmation strategy on names deep enough to size into, with the runtime owning execution, sizing, slots, and a disciplined trailing exit — so a familiar chart setup becomes a supervised, always-on strategy instead of a manual watch.",
+      "tags": [
+        "rsi",
+        "macd",
+        "indicators",
+        "technical-analysis",
+        "crossover",
+        "oscillator",
+        "classic-ta",
+        "momentum",
+        "beginner",
+        "btc",
+        "eth",
+        "sol",
+        "multi-asset",
+        "long-short"
+      ],
+      "group": "momentum",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "indicator_crossover",
+      "sub_style_label": "Textbook technical setup: a MACD signal-line crossover triggers the entry, RSI confirms momentum, higher-timeframe trend adds context.",
+      "asset_classes": [
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "BNB",
+        "XRP",
+        "AVAX",
+        "LINK",
+        "DOGE"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 900,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "main",
+      "sort_order": 9
+    },
+    {
       "id": "lemur",
       "name": "Lemur — Pre-IPO Perpetual Trend Follower",
       "emoji": "🦤",
@@ -1055,7 +1113,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "lynx",
@@ -1106,7 +1164,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "meerkat",
@@ -1150,7 +1208,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "orca",
@@ -1193,7 +1251,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "otter",
@@ -1237,7 +1295,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "piranha",
@@ -1289,7 +1347,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "python",
@@ -1333,7 +1391,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 15
+      "sort_order": 16
     },
     {
       "id": "sailfish",
@@ -1383,7 +1441,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 16
+      "sort_order": 17
     },
     {
       "id": "salamander",
@@ -1433,7 +1491,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 17
+      "sort_order": 18
     },
     {
       "id": "sheep",
@@ -1486,7 +1544,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 18
+      "sort_order": 19
     },
     {
       "id": "jaguar",

--- a/strategies/kingfisher/main/runtime.yaml
+++ b/strategies/kingfisher/main/runtime.yaml
@@ -1,0 +1,142 @@
+# ── KINGFISHER · single instance — Classic Indicators (RSI + MACD) ────────────
+# A textbook indicator-crossover swing strategy on a liquid-majors basket. MACD
+# signal-line crossover is the entry trigger, RSI(14) confirms/vetoes, 4h trend
+# structure is context. Moderate leverage (3-5x), conviction-tiered margin, a
+# balanced DSL ladder (locks profit earlier than a conviction holder). Retail-
+# recognisable "RSI + MACD" — the highest-frequency organic build request.
+name: kingfisher-main
+group: kingfisher
+version: 1.0.0
+description: >
+  KINGFISHER — Classic Indicators (RSI + MACD) on a liquid-majors basket
+  (BTC/ETH/SOL/BNB/XRP/AVAX/LINK/DOGE). The entry TRIGGER is a MACD signal-line
+  crossover (12/26/9) on 1h candles; RSI(14) CONFIRMS momentum (a long needs RSI
+  above 50, a short below 50) — a true extreme (>=78 / <=22) is a mild caution, not
+  a fade, since a strong MACD trend runs RSI hot; 4h trend structure adds context. Emits
+  every name clearing the conviction floor, best-first, sized 10% base margin
+  (x1.25 / x1.5 by score) at 3-5x. Exits are DSL-only: a balanced ratchet that
+  locks profit from +8% ROE while a real trend still breathes. Long & short.
+
+strategy:
+  wallet: "${KINGFISHER_WALLET}"
+  slots: 3
+  margin_pct: 10                          # baseline %; scan emits the conviction-tier marginPct per signal
+  default_leverage: 4                     # fallback; scan emits 3-5x per signal
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: kingfisher_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900                  # 15m: re-check the 1h MACD/RSI, catch fresh crossovers promptly
+    timeout_seconds: 180                   # up to ~1 candle read per basket name + account
+    default_signal_validity_seconds: 1800  # 2x tick; rule action, a fresh re-score arrives next tick
+    state_history_max_count: 100           # crossover dedup map + per-tick scan-results history
+    inputs:
+      allowedAssets: ["BTC", "ETH", "SOL", "BNB", "XRP", "AVAX", "LINK", "DOGE"]  # liquid HL majors
+      minScore: 6                          # MACD cross (4) + RSI confirm (2); continuation alone won't clear
+      marginPctBase: 10                    # PERCENT of withdrawable (0,100]; tiered x1.25 (>=6) / x1.5 (>=8)
+      maxSlots: 3
+      leverageDefault: 4                   # clamped to [leverageMin, leverageMax]
+      leverageMin: 3
+      leverageMax: 5
+      macdFast: 12
+      macdSlow: 26
+      macdSignal: 9
+      rsiPeriod: 14
+      rsiOverbought: 78                    # true-extreme caution for longs (not a mean-reversion fade)
+      rsiOversold: 22                      # true-extreme caution for shorts
+      histStrengthPct: 0.03                # |histogram|/price %% to count as a strong crossover
+      recentSignalTtlSeconds: 3600         # one crossover per name per hour (race-window dedup)
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      directionSource: { type: string, required: false }
+      reasons: { type: array, required: false }
+      rsi: { type: number, required: false }
+      macd: { type: number, required: false }
+      signal: { type: number, required: false }
+      hist: { type: number, required: false }
+      trend4h: { type: string, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: kingfisher_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied every filter (crossover + RSI + trend)
+    scanners: [kingfisher_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # taker fallback: a maker-only entry rests and silently misses
+                                           # the fill on a fast crossover move (CREATE_ORDER_RESTING).
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: kingfisher_main_signals
+
+# ── EXIT (DSL — balanced swing ladder) ───────────────────────────────────────
+# A crossover swing takes profit on the move, so this locks earlier than a
+# conviction holder (first lock at +8% ROE) while still letting a real trend run.
+# Time-cuts off (exits are price-action, not clock); weak_peak_cut kept as a
+# self-limiting thesis-validity check. Phase 1 max_loss 20%. Closes MUST happen —
+# taker fallback on.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 240
+    weak_peak_cut:
+      enabled: true                        # self-limiting: fires only if peak ROE never clears 2.0 in 60m
+      interval_in_minutes: 60
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # balanced: FIRST lock at +8% ROE, tighten as it runs
+        - { trigger_pct: 8, lock_hw_pct: 0 }
+        - { trigger_pct: 15, lock_hw_pct: 25 }
+        - { trigger_pct: 25, lock_hw_pct: 45 }
+        - { trigger_pct: 40, lock_hw_pct: 60 }
+        - { trigger_pct: 60, lock_hw_pct: 75 }
+
+# ── RISK guard rails (moderate) ──
+risk:
+  data_retention_seconds: 259200           # 72h
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 5                  # a basket scanner across 8 names
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 1800                  # post-loss cooldown 30m
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 3600        # 1h — matches the 1h signal timeframe
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/kingfisher/main/scanners/scan.py
+++ b/strategies/kingfisher/main/scanners/scan.py
@@ -1,0 +1,152 @@
+"""KINGFISHER — supervised scanner: RSI + MACD classic-indicator crossover on a liquid-majors basket.
+
+Per tick:
+  - reads account + held positions (dual-DEX equity via max(), never sum; corrupt-read sanity guard),
+  - iterates the configured `allowedAssets` basket (held + recently-signalled filtered first),
+  - fetches 1h + 4h candles and scores each via pure `scoring.build_thesis` (MACD crossover trigger +
+    RSI confirmation + 4h trend context),
+  - emits EVERY candidate at/above `minScore`, best-first up to the open slots, sized by a conviction
+    margin tier; the runtime applies the slots ceiling, sizes the dollars, owns cooldowns/risk gates,
+    and trails the DSL exit.
+
+Read-only + single-pass. Emits a `marginPct` INTENT (PERCENT in (0,100]) + `leverage`; no daemon, no
+push_signal, no create_position. Candle values are strings keyed o/h/l/c/v — scoring._close/_f coerce.
+"""
+
+import sys
+import time
+
+import scoring
+
+_ALLOWED_ASSETS_DEFAULT = ["BTC", "ETH", "SOL", "BNB", "XRP", "AVAX", "LINK", "DOGE"]
+_DEFAULT_RECENT_TTL = 3600     # don't re-fire the same crossover within an hour (1h timeframe)
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position dicts]) from strategy_get_clearinghouse_state — dual-DEX equity via
+    max() (never sum), plus the corrupt-read sanity guard. Read-guarded (a read error skips the tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the tick
+        print(f"[kingfisher.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)), abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""), "margin": scoring._f(pos.get("marginUsed", 0))})
+    if used > 1.0 and not positions:   # corrupt read: margin in use but empty positions — skip tick
+        print("[kingfisher.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _candles(ctx, coin):
+    """{'1h':[...], '4h':[...]} for `coin` or None. Read-guarded."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin, "candle_intervals": ["1h", "4h"],
+            "include_funding": False, "include_order_book": False, "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[kingfisher.scan] market_get_asset_data({coin}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md or (isinstance(md, dict) and md.get("success") is False):
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    return d.get("candles", {}) if isinstance(d, dict) else None
+
+
+def _load_signaled(ctx):
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    sig = (ctx.state.last() or {}).get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    allowed = inputs.get("allowedAssets", _ALLOWED_ASSETS_DEFAULT)
+    min_score = float(inputs.get("minScore", 6))
+    base_margin_pct = float(inputs.get("marginPctBase", 10))   # PERCENT in (0,100]
+    max_slots = int(inputs.get("maxSlots", 3))
+    lev_default = int(inputs.get("leverageDefault", 4))
+    lev_min = int(inputs.get("leverageMin", 3))
+    lev_max = int(inputs.get("leverageMax", 5))
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[kingfisher.scan] WAITING — no account value / corrupt read", file=sys.stderr)
+        return []
+    held = {p["coin"].upper() for p in positions if p.get("coin")}
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        print(f"[kingfisher.scan] slots full ({len(held)}/{max_slots}) — DSL manages exits", file=sys.stderr)
+        return []
+
+    signaled = {k: v for k, v in _load_signaled(ctx).items() if (now - v) < ttl * 4}
+
+    candidates, scanned = [], 0
+    for coin in allowed:
+        if not coin or coin.lower().startswith("xyz:"):
+            continue
+        cu = coin.upper()
+        if cu in held:
+            continue
+        if (now - signaled.get(cu, 0)) < ttl:
+            continue
+        scanned += 1
+        candles = _candles(ctx, coin)
+        if not candles:
+            continue
+        th = scoring.build_thesis(coin, candles.get("1h", []), candles.get("4h", []), inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    leverage = max(lev_min, min(lev_default, lev_max))
+    out = []
+    for th in candidates[:open_slots]:
+        margin_pct = round(scoring.margin_tier_pct(th["score"], base_margin_pct), 4)
+        signaled[th["coin"].upper()] = now
+        out.append({
+            "asset": th["coin"],
+            "direction": th["direction"],
+            "marginPct": margin_pct,      # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,
+            "data": {
+                "score": th["score"], "leverage": leverage, "direction": th["direction"],
+                "directionSource": th["directionSource"], "reasons": th["reasons"][:8],
+                "rsi": th["rsi"], "macd": th["macd"], "signal": th["signal"], "hist": th["hist"],
+                "trend4h": th["trend_4h"], "heldAssets": sorted(held),
+            },
+        })
+
+    print(f"[kingfisher.scan] {'EMIT' if out else 'WAITING'} scanned={scanned} emitted={len(out)} "
+          f"min_score={min_score:.0f} held={sorted(held)}", file=sys.stderr)
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"signaled": signaled,
+                              "result": {"ts": now, "scanned": scanned, "emitted": len(out)}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[kingfisher.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/kingfisher/main/scanners/scoring.py
+++ b/strategies/kingfisher/main/scanners/scoring.py
@@ -1,0 +1,204 @@
+"""KINGFISHER — pure thesis math: RSI + MACD classic-indicator crossover (no I/O, no MCP, no clock).
+
+Two textbook indicators, combined the way retail traders actually use them:
+  - MACD (EMA fast/slow, signal EMA, histogram) is the DIRECTIONAL trigger — a fresh signal-line
+    crossover (the histogram flips sign) is the entry; an already-crossed, still-expanding histogram
+    is a weaker continuation.
+  - RSI(14) CONFIRMS: a long wants RSI with room above 50 (momentum, not yet overbought); a short
+    wants RSI below 50 (not yet oversold). RSI at the opposite extreme vetoes the crossover.
+  - 4h trend structure is a context bonus/penalty.
+
+Pure + single-pass + unit-testable on plain candle lists. Candles are keyed o/h/l/c/v with STRING
+values — `_close`/`_f` handle both the short key and the string coercion.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+# ── indicators ──
+
+def _ema(vals, period):
+    """EMA series seeded with the SMA of the first `period` values (k = 2/(period+1)).
+    Length = len(vals) - period + 1; empty if too short."""
+    if len(vals) < period:
+        return []
+    k = 2.0 / (period + 1)
+    ema = [sum(vals[:period]) / period]
+    for v in vals[period:]:
+        ema.append(v * k + ema[-1] * (1.0 - k))
+    return ema
+
+
+def calc_macd(closes, fast=12, slow=26, signal=9):
+    """Classic MACD. Returns (macd_line, signal_line, histogram) as EQUAL-LENGTH tail series (aligned
+    to where the signal EMA exists), or (None, None, None) if history is too short.
+    macd = EMA(fast) - EMA(slow); signal = EMA(macd, signal); histogram = macd - signal."""
+    if len(closes) < slow + signal:
+        return None, None, None
+    ema_fast, ema_slow = _ema(closes, fast), _ema(closes, slow)
+    n = len(ema_slow)                       # ema_slow is the shorter series (slow > fast)
+    fast_tail = ema_fast[-n:]
+    macd_line = [fast_tail[i] - ema_slow[i] for i in range(n)]
+    sig = _ema(macd_line, signal)
+    if not sig:
+        return None, None, None
+    m = len(sig)
+    macd_tail = macd_line[-m:]
+    hist = [macd_tail[i] - sig[i] for i in range(m)]
+    return macd_tail, sig, hist
+
+
+def calc_rsi(closes, period=14):
+    """Trailing-window RSI (last `period` gains/losses). 50 when history is too short."""
+    if len(closes) < period + 1:
+        return 50.0
+    gains, losses = [], []
+    for i in range(1, len(closes)):
+        d = closes[i] - closes[i - 1]
+        gains.append(max(0.0, d))
+        losses.append(max(0.0, -d))
+    g, l = gains[-period:], losses[-period:]
+    avg_g, avg_l = sum(g) / period, sum(l) / period
+    if avg_l == 0:
+        return 100.0
+    return 100.0 - (100.0 / (1.0 + avg_g / avg_l))
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows = BULLISH / lower-highs = BEARISH — the 4h context bonus. (BULLISH|BEARISH|NEUTRAL, strength)."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if total and higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if total and lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+# ── conviction-scaled margin PERCENT ──
+
+def margin_tier_pct(score, base_pct):
+    """marginPct (PERCENT in (0,100]) scaled by conviction: score>=8 -> base*1.5, >=6 -> base*1.25,
+    else base. The runtime sizes (marginPct/100) x withdrawable."""
+    if score >= 8:
+        return base_pct * 1.5
+    if score >= 6:
+        return base_pct * 1.25
+    return base_pct
+
+
+# ── the thesis: MACD crossover trigger + RSI confirmation + 4h trend context ──
+
+def build_thesis(coin, candles_1h, candles_4h, inputs):
+    """Returns a thesis dict (with `score`) or None. None when history is insufficient or no MACD
+    direction resolves. `minScore` is applied by the CALLER (scan.py)."""
+    fast = int(inputs.get("macdFast", 12))
+    slow = int(inputs.get("macdSlow", 26))
+    sig_p = int(inputs.get("macdSignal", 9))
+    rsi_p = int(inputs.get("rsiPeriod", 14))
+    rsi_ob = float(inputs.get("rsiOverbought", 70))
+    rsi_os = float(inputs.get("rsiOversold", 30))
+    hist_min_pct = float(inputs.get("histStrengthPct", 0.03))
+
+    closes = [_close(c) for c in candles_1h]
+    if len(closes) < slow + sig_p + 2:
+        return None
+
+    macd_line, sig_line, hist = calc_macd(closes, fast, slow, sig_p)
+    if hist is None or len(hist) < 2:
+        return None
+    rsi = calc_rsi(closes, rsi_p)
+    hist_now, hist_prev, macd_now = hist[-1], hist[-2], macd_line[-1]
+
+    # MACD state = which side of its signal line the MACD line sits on (the sign of the histogram).
+    # Being on-side is a valid signal; a FRESH crossover this bar (the histogram just flipped sign) is
+    # the strongest trigger and scores higher. Exactly flat -> no signal.
+    if hist_now > 0:
+        direction, fresh = "LONG", hist_prev <= 0
+    elif hist_now < 0:
+        direction, fresh = "SHORT", hist_prev >= 0
+    else:
+        return None
+    core = 4 if fresh else 2
+    source = f"macd_{'bull' if direction == 'LONG' else 'bear'}_{'cross' if fresh else 'state'}"
+
+    score, reasons = core, [source]
+
+    # MACD zero-line context (+1 when the histogram side agrees with the MACD line's sign)
+    if (direction == "LONG" and macd_now > 0) or (direction == "SHORT" and macd_now < 0):
+        score += 1
+        reasons.append("macd_" + ("above" if macd_now > 0 else "below") + "_zero")
+
+    # RSI as MOMENTUM confirmation (not a mean-reversion fade): a long wants RSI above 50, a short
+    # below 50 — that CONFIRMS the MACD direction. Only a TRUE extreme (>= rsi_overbought /
+    # <= rsi_oversold) is a mild caution, because a strong MACD trend legitimately runs RSI hot.
+    if direction == "LONG":
+        if rsi >= rsi_ob:
+            score -= 1; reasons.append(f"rsi_extreme_{rsi:.0f}")
+        elif rsi >= 50:
+            score += 2; reasons.append(f"rsi_confirms_{rsi:.0f}")
+        else:
+            reasons.append(f"rsi_weak_{rsi:.0f}")
+    else:
+        if rsi <= rsi_os:
+            score -= 1; reasons.append(f"rsi_extreme_{rsi:.0f}")
+        elif rsi <= 50:
+            score += 2; reasons.append(f"rsi_confirms_{rsi:.0f}")
+        else:
+            reasons.append(f"rsi_weak_{rsi:.0f}")
+
+    # histogram strength, normalised by price (+1)
+    price = closes[-1]
+    hist_pct = (hist_now / price * 100.0) if price else 0.0
+    if abs(hist_pct) >= hist_min_pct:
+        score += 1
+        reasons.append(f"hist_{hist_pct:+.3f}pct")
+
+    # 4h trend structure context (+2 aligned / -1 opposing)
+    trend_4h, ts = trend_structure(candles_4h)
+    if trend_4h != "NEUTRAL":
+        if (direction == "LONG" and trend_4h == "BULLISH") or (direction == "SHORT" and trend_4h == "BEARISH"):
+            score += 2; reasons.append(f"4h_{trend_4h.lower()}_{ts:.0%}")
+        else:
+            score -= 1; reasons.append(f"4h_opposing_{trend_4h.lower()}")
+
+    return {
+        "coin": coin, "direction": direction, "score": score, "reasons": reasons,
+        "directionSource": source, "rsi": round(rsi, 1),
+        "macd": round(macd_now, 6), "signal": round(sig_line[-1], 6), "hist": round(hist_now, 6),
+        "trend_4h": trend_4h, "price": price,
+    }

--- a/strategies/kingfisher/strategy.yaml
+++ b/strategies/kingfisher/strategy.yaml
@@ -1,0 +1,40 @@
+# Kingfisher — Classic Indicators (RSI + MACD). A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. The most-recognised retail
+# technical setup (MACD signal-line crossover, RSI confirmation) as a supervised
+# Runtime 3.0 strategy on a liquid-majors basket. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: kingfisher
+version: "1.0.0"
+
+catalog:
+  name: "Kingfisher — Classic Indicators (RSI + MACD)"
+  emoji: "🐦"
+  tagline: "The textbook RSI + MACD setup, supervised: a MACD signal-line crossover (12/26/9) on 1h candles triggers the entry, RSI(14) confirms (room above 50 for longs, below 50 for shorts) and vetoes it at the overbought/oversold extreme, 4h trend structure adds context. Trades a liquid-majors basket (BTC/ETH/SOL/BNB/XRP/AVAX/LINK/DOGE) long & short at 3-5x with a balanced DSL that locks profit from +8% ROE."
+  belief_plain: "The two indicators everyone knows, run for you the way the textbook says. It waits for MACD to cross its signal line, checks that RSI agrees and isn't already stretched, prefers trades that line up with the 4-hour trend, then trails a stop that starts protecting profit once you're up ~8%. Classic technical analysis on the big, liquid coins — no black box."
+  thesis: "RSI and MACD are the single most-requested retail build ('a strategy based on RSI and MACD'), yet no template was positioned as one. Kingfisher is that on-ramp: a faithful, well-labelled crossover-plus-confirmation strategy on names deep enough to size into, with the runtime owning execution, sizing, slots, and a disciplined trailing exit — so a familiar chart setup becomes a supervised, always-on strategy instead of a manual watch."
+  group: momentum
+  archetype: trend_following
+  sub_style: indicator_crossover
+  asset_classes: [major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: starter
+  leverage_max: 5
+  max_slots: 3
+  min_budget: 200
+  assets: ["BTC", "ETH", "SOL", "BNB", "XRP", "AVAX", "LINK", "DOGE"]
+  tags: [rsi, macd, indicators, technical-analysis, crossover, oscillator, classic-ta, momentum, beginner, btc, eth, sol, multi-asset, long-short]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: KINGFISHER_WALLET
+    funding_share: 1.0


### PR DESCRIPTION
## Why
"Create a strategy based on RSI and MACD" is the single highest-frequency **organic** build request in the 72h prompt telemetry, and the catalog had **no template positioned as one** (0 MACD; RSI only buried inside mean-reversion strategies).

## What
**Kingfisher — Classic Indicators (RSI + MACD)** · starter tier · long & short on a liquid-majors basket (BTC/ETH/SOL/BNB/XRP/AVAX/LINK/DOGE):
- **MACD signal-line crossover** (12/26/9) on 1h candles is the entry trigger — a fresh cross scores higher than an established on-side state;
- **RSI(14) confirms momentum** (>50 long / <50 short); a true extreme (≥78 / ≤22) is a mild caution, **not a fade** — a strong MACD trend legitimately runs RSI hot;
- **4h trend structure** adds context; conviction-tiered margin (10% base ×1.25/×1.5), 3-5x, balanced DSL that locks profit from +8% ROE.

## Validation
- Clones bison's plumbing (dual-DEX account read, **string-safe candle accessors**, crossover dedup); `scoring.py` is new MACD/RSI math **validated on real live BTC candles end-to-end** (RSI 67.5, MACD/signal computed, a sensible *selective* score — it declined a conflicted BTC setup).
- **Deploy-ready** — author `validate_strategy` + ops `deploy.py validate` both green; all 8 tickers live; scanner imports clean.
- Catalog regenerated (both locations, 92 strategies); **ranks #1 for "rsi macd"** (theme_score 27 vs next-best 9). Discover suite green.

MINOR: strategy-discover 2.6.0 → 2.7.0 (catalog change). New strategy — **not deployed**, catalog-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)