### PR TITLE
strategy-ops v2.8.0: verify gates on the reliable `runtime list` backbone — flaky status/state only downgrade

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.6.0"
+  version: "2.7.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -121,11 +121,22 @@ Run **Step 3 `verify`**. **Do NOT tell the user the strategy is live until `veri
 
 **Step 3 — `verify`** (the required gate): `python3 scripts/deploy.py verify spider` returns **`live`** only
 when every instance is runtime-running + scanner-active (ticked *or* scheduled, never erroring) + **DSL-wired**
-(`exit.dsl_preset` present and the monitor enabled) + **funded to what was requested**; otherwise **`not-live`**
-with the failing component named (e.g. `scanner=broken`, `dsl=config-missing`, `budget=underfunded`). Fix the
-flagged component and re-run. It's a **single fast check** — a scheduled scanner passes, so it does **not**
-wait for the first scan tick and you must **never `sleep` then verify**. `deploy.py status <id>` shows deploy
-state any time.
+(`exit.dsl_preset` present and the monitor enabled) + **funded to what was requested**. Two failure outcomes,
+kept distinct on purpose:
+
+- **`not-live`** (exit 2) — a component is **confirmed broken**, named in the row (e.g. `scanner=broken`,
+  `dsl=config-missing`, `budget=underfunded`). Fix the flagged component and re-run.
+- **`unverified`** (exit 3) — the runtime is registered, funded and DSL-protected, but its `status`/`state`
+  read was **temporarily unavailable**, so scanner liveness could **not be confirmed** (common in the first
+  minute after `runtime`, and **not** a sign the scanner is down — `getSystemState` throws for a few
+  minutes while scanner subprocesses launch). **This is not a green light** — re-run `verify` shortly. It
+  never brands a scanner broken just because a read failed.
+
+Liveness is judged from the runtime **CLI** (`senpi status` primary, `senpi state` to enrich) — never from
+on-disk state files. It's a **single fast check** — a scheduled/heartbeating scanner passes, so it does
+**not** wait for the first scan tick and you must **never `sleep` then verify**. **Do NOT tell the user the
+strategy is live unless `verify` returned `live`** (`unverified` and `not-live` both mean "not confirmed —
+do not claim live"). `deploy.py status <id>` shows deploy state any time.
 
 > **Do NOT improvise.** A package strategy is a **runtime-supervised scanner** — deploy it **only** via
 > these steps. Never substitute a raw `strategy_create_custom_strategy` MCP call to "deploy" it: that
@@ -149,7 +160,9 @@ state any time.
 ```
 Overall status across the steps: `create` → `creating` (re-run) | `closing-existing` (re-run once closed) |
 `wallets-ready` | **`underfunded`** (balance < requested — fund more / lower the ask); `runtime` →
-`registered`; `verify` → **`live`** | **`not-live`** (a component failed — fix it, re-run). Per-instance
+`registered`; `verify` → **`live`** | **`not-live`** (a component confirmed broken — fix it, re-run) |
+**`unverified`** (runtime read temporarily unavailable — re-run; neither `unverified` nor `not-live` means
+live). Per-instance
 status flows `pending → creating → active → registered → live`. **`registered` ≠ live — `verify` is the
 gate.** `create`/`runtime` take `--dry-run` (plan only; no side effects).
 

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -120,23 +120,23 @@ refuses and tells you to redeploy fresh (`close.py` any stale wallet, then `crea
 Run **Step 3 `verify`**. **Do NOT tell the user the strategy is live until `verify` returns `live`.**
 
 **Step 3 — `verify`** (the required gate): `python3 scripts/deploy.py verify spider` returns **`live`** only
-when every instance is runtime-running + scanner-active (ticked *or* scheduled, never erroring) + **DSL-wired**
-(`exit.dsl_preset` present and the monitor enabled) + **funded to what was requested**. Two failure outcomes,
-kept distinct on purpose:
+when every instance is runtime-running + scanner-active + **DSL-wired** (`exit.dsl_preset` present and the
+monitor enabled) + **funded to what was requested**; otherwise **`not-live`** (exit 2) with the failing
+component named (e.g. `scanner=broken`, `dsl=config-missing`, `budget=underfunded`). Fix it and re-run.
 
-- **`not-live`** (exit 2) — a component is **confirmed broken**, named in the row (e.g. `scanner=broken`,
-  `dsl=config-missing`, `budget=underfunded`). Fix the flagged component and re-run.
-- **`unverified`** (exit 3) — the runtime is registered, funded and DSL-protected, but its `status`/`state`
-  read was **temporarily unavailable**, so scanner liveness could **not be confirmed** (common in the first
-  minute after `runtime`, and **not** a sign the scanner is down — `getSystemState` throws for a few
-  minutes while scanner subprocesses launch). **This is not a green light** — re-run `verify` shortly. It
-  never brands a scanner broken just because a read failed.
-
-Liveness is judged from the runtime **CLI** (`senpi status` primary, `senpi state` to enrich) — never from
-on-disk state files. It's a **single fast check** — a scheduled/heartbeating scanner passes, so it does
-**not** wait for the first scan tick and you must **never `sleep` then verify**. **Do NOT tell the user the
-strategy is live unless `verify` returned `live`** (`unverified` and `not-live` both mean "not confirmed —
-do not claim live"). `deploy.py status <id>` shows deploy state any time.
+**How it judges liveness — reliable backbone, flaky reads only downgrade.** The gate rests on signals that
+are *reliably* readable right after deploy: **`openclaw senpi runtime list`** (authoritative inventory —
+is the runtime running?), the deployed **runtime.yaml** (does it declare the external scanner + a DSL
+preset?), and **MCP `strategy_list`** (funded?). It does **not** gate on `senpi status`/`senpi state` — that
+JSON is **flaky-empty/throws for a minute+ after start** (seen live: `verify` got nothing while a manual
+`status -r`/`state -r` seconds apart returned healthy). Those reads are used only to **downgrade** a scanner
+to `broken` on *positive* evidence (disabled / erroring / runtime-reported unhealthy). When they're
+unreadable, the scanner reads **`supervised`** = live: a running runtime **spawns and supervises** the
+declared scanner (restarting it on crash), so runtime-running + scanner-declared ⇒ it's being driven, and
+the DSL protects positions regardless. Never reads on-disk state files. It's a **single fast check** — a
+scheduled/supervised scanner passes, so it does **not** wait for the first scan tick and you must **never
+`sleep` then verify**. Still: **do not tell the user the strategy is live unless `verify` returned `live`.**
+`deploy.py status <id>` shows deploy state any time.
 
 > **Do NOT improvise.** A package strategy is a **runtime-supervised scanner** — deploy it **only** via
 > these steps. Never substitute a raw `strategy_create_custom_strategy` MCP call to "deploy" it: that
@@ -160,9 +160,8 @@ do not claim live"). `deploy.py status <id>` shows deploy state any time.
 ```
 Overall status across the steps: `create` → `creating` (re-run) | `closing-existing` (re-run once closed) |
 `wallets-ready` | **`underfunded`** (balance < requested — fund more / lower the ask); `runtime` →
-`registered`; `verify` → **`live`** | **`not-live`** (a component confirmed broken — fix it, re-run) |
-**`unverified`** (runtime read temporarily unavailable — re-run; neither `unverified` nor `not-live` means
-live). Per-instance
+`registered`; `verify` → **`live`** | **`not-live`** (a component confirmed broken — fix it, re-run).
+Per-instance
 status flows `pending → creating → active → registered → live`. **`registered` ≠ live — `verify` is the
 gate.** `create`/`runtime` take `--dry-run` (plan only; no side effects).
 

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.7.0"
+  version: "2.8.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/references/liveness-verification.md
+++ b/senpi-strategy-ops/references/liveness-verification.md
@@ -10,9 +10,22 @@ This is an **agent-side check**. Run the commands yourself; do not ask the user 
 
 > **Supervised model:** the runtime **spawns and supervises** each `external_scanner`, calling
 > `scan(inputs, ctx)` every `interval_seconds` itself. There is **no separate producer daemon and no
-> `push_signal`** — so there is nothing to reconcile against. Scanner liveness is read entirely from the
-> runtime's own state (`openclaw senpi state`). `deploy.py` already runs this check (the `live` vs
-> `registered` verdict); use this doc when triaging by hand.
+> `push_signal`** — so there is nothing to reconcile against. Scanner liveness is read from the runtime's
+> own **CLI commands** (`openclaw senpi status` / `state`) — **never from the on-disk state files**
+> (`/data/.openclaw/senpi-state/…`); those are internal, partially-written, and not a contract.
+> `deploy.py verify` already runs this check (the `live` / `not-live` / `unverified` verdict); use this
+> doc when triaging by hand.
+>
+> **Two commands, and which to trust when they disagree:**
+> - **`openclaw senpi status -r <id> --json`** (getHealthStatus) — the runtime's own per-scanner
+>   **health verdict** (`components.scanners.scanners[].health`). Light and **reliable immediately after
+>   deploy.** This is the primary liveness source.
+> - **`openclaw senpi state -r <id> --json`** (getSystemState) — the rich per-scanner row (runCount,
+>   `lastAliveAt`, `lastError`, `enabled`). Richer, but **`getSystemState` transiently THROWS for the
+>   first several minutes after a runtime starts** (scanner subprocesses still launching) — the CLI then
+>   prints nothing usable and exits non-zero. **A failed/empty `state` read is NOT evidence the scanner is
+>   down** — fall back to `status` and re-check. (Confirmed live: a fully-healthy runtime whose `state`
+>   threw for ~9 min while `status` reported `2/2 enabled and healthy` the whole time.)
 
 ---
 
@@ -52,25 +65,37 @@ the JSON structure — they are stable; the human-readable summary is not.
 Path: the scanner entry under the runtime's scanners state (match on the `external_scanner` `name`, e.g.
 `spider_swing_signals`).
 
-A scanner is **operating** when **all** hold:
+A scanner is **operating** when the runtime says so — and for a **supervised external scanner** the
+authoritative signals are `health` and the heartbeat, **not** the run counters:
 
-- `enabled === true`
-- `runCount > 0` — the runtime has called `scan()` at least once
-- `now − lastRunFinishedAt ≤ 2 × interval_seconds` (the runtime calls it on `interval_seconds`)
-- `consecutiveErrorCount === 0`
-- `lastRunStatus ∈ {"ok", "heartbeat"}`
+- **`health ∈ {"healthy", "degraded"}`** — the runtime's own verdict (in **both** `status` and `state`).
+  This is the primary signal; trust it.
+- **`lastAliveAt` is fresh** (`now − lastAliveAt ≤ 2 × interval_seconds`) — the scanner POSTed to intake
+  this cycle. **A healthy scanner that finds no setup still POSTs an empty heartbeat every tick**, so a
+  live barren scanner has a fresh `lastAliveAt` even with **`runCount === 0` / no signals**.
+- `enabled === true`, `consecutiveErrorCount === 0`, `lastError === null`.
 
-Failure signatures and what they mean:
+> **Do NOT require `runCount > 0`.** For an external scanner, `runCount` and `lastRunFinishedAt` lag or
+> stay `0`/`null` until the runtime has processed a POST, and a barren scanner legitimately emits no
+> signals for long stretches. `runCount === 0` on its own is **never** breakage — it means "no trade this
+> cycle," which is normal. Judge liveness by `health` + `lastAliveAt`; `runCount > 0` is a bonus, not a
+> requirement.
+
+Failure signatures (**positive** evidence of breakage only — anything else is "not yet confirmed," retry):
 
 | Symptom | Field signature | Likely cause |
 |---|---|---|
-| Mounted but never ran | `runCount === 0` & `lastRunFinishedAt === null` | Scanner threw on first init, or runtime hasn't scheduled it yet — read `lastError`; re-check after one `interval_seconds` |
-| Was running, has stopped | `lastRunFinishedAt` older than `2 × interval_seconds`, `runCount > 0` | `scan()` is throwing — read `lastError`, `lastErrorAt`; a crashed child is restarted with a fresh id, so repeated restarts show as resets |
-| Repeatedly failing | `consecutiveErrorCount ≥ 2` | Print `lastError` and remediate (usually an upstream MCP/RPC read in `scan()`) |
+| Runtime says it's broken | `health === "unhealthy"` (in `status` or `state`) | The runtime's own verdict — trust it; read `lastError` |
+| Repeatedly failing | `consecutiveErrorCount ≥ 1` or a persistent `lastError` | `scan()` is throwing — print `lastError`, `lastErrorAt` (usually an upstream MCP/RPC read in `scan()`) |
+| Disabled | `enabled === false` | Scanner is turned off — not wired to run |
 | Hung mid-tick | `inFlight === true` & `lastRunStartedAt` older than `timeout_seconds` | `scan()` exceeded its time box — the runtime kills + restarts it; persistent hangs point at a slow upstream read |
+| Can't read either command | `state` throws AND `status` unreadable | **Not a scanner fault** — the gateway read is transiently unavailable (common right after deploy). Re-check; do not declare the scanner down. |
 
-`openclaw senpi status -r <id>` may report a scanner `healthy` even at `runCount === 0` (it can't tell
-"waiting for first tick" from "broken"). Read the field values from `state` directly for the verdict.
+**When `status` and `state` disagree, `status` wins for the health verdict.** `status` (getHealthStatus)
+keeps answering while `state` (getSystemState) is still throwing post-deploy — so a scanner that `status`
+calls `healthy` **is** healthy even if `state` won't load yet. Use `state`'s raw fields (`lastAliveAt`,
+`runCount`, `lastError`) only to *enrich* the verdict when the read succeeds, never to override a clean
+`status` health with "state unreadable."
 
 ### Actions
 
@@ -96,9 +121,16 @@ treat it as a liveness failure. (Rule-mode strategies like spider have no LLM de
 Declare a strategy **live** only when, for **every** instance:
 
 - `runtime list` shows its runtime as `running`;
-- its `external_scanner` has `runCount > 0` and a recent `lastRunFinishedAt` (within `2 × interval_seconds`),
-  `consecutiveErrorCount === 0`;
+- its `external_scanner` is `health ∈ {healthy, degraded}` (per `status`, and per `state` when it loads),
+  `enabled`, `consecutiveErrorCount === 0`, `lastError === null` — with a fresh `lastAliveAt` when `state`
+  is readable. **A barren scanner (`runCount === 0`, healthy, heartbeating) counts as live** — it is
+  scanning, just not trading this cycle;
 - each action is either "operating" or "dormant by design" — never "wiring problem" or "failing".
+
+If you **cannot read `status` or `state`** for an instance, the correct verdict is **"unverified," not
+"down"** — the strategy is registered, funded and DSL-protected; re-run `deploy.py verify <id>` shortly
+(that command reports this case distinctly). **Never report a strategy as live until `verify` returns
+`live`** — an unreadable state is not a green light.
 
 Anything less: surface the specific failing field and the remediation, not a generic "looks fine." For
 deeper engine triage (position_tracker → DSL → actions), see

--- a/senpi-strategy-ops/references/liveness-verification.md
+++ b/senpi-strategy-ops/references/liveness-verification.md
@@ -72,7 +72,11 @@ authoritative signals are `health` and the heartbeat, **not** the run counters:
   This is the primary signal; trust it.
 - **`lastAliveAt` is fresh** (`now − lastAliveAt ≤ 2 × interval_seconds`) — the scanner POSTed to intake
   this cycle. **A healthy scanner that finds no setup still POSTs an empty heartbeat every tick**, so a
-  live barren scanner has a fresh `lastAliveAt` even with **`runCount === 0` / no signals**.
+  live barren scanner has a fresh `lastAliveAt` even with **`runCount === 0` / no signals**. (For **hand
+  triage** of an already-running strategy, check this freshness. **`deploy.py verify` intentionally does
+  NOT** — it's a deploy-time gate where staleness can't have accrued yet, so it treats *any* `lastAliveAt`
+  as a tick and defers stall-detection to the runtime's own `health` verdict, which flips a silent
+  scanner to `unhealthy`/`degraded`.)
 - `enabled === true`, `consecutiveErrorCount === 0`, `lastError === null`.
 
 > **Do NOT require `runCount > 0`.** For an external scanner, `runCount` and `lastRunFinishedAt` lag or

--- a/senpi-strategy-ops/references/liveness-verification.md
+++ b/senpi-strategy-ops/references/liveness-verification.md
@@ -9,23 +9,23 @@ running` alone — that field reports process status only, not functional livene
 This is an **agent-side check**. Run the commands yourself; do not ask the user to confirm "is it working?"
 
 > **Supervised model:** the runtime **spawns and supervises** each `external_scanner`, calling
-> `scan(inputs, ctx)` every `interval_seconds` itself. There is **no separate producer daemon and no
-> `push_signal`** — so there is nothing to reconcile against. Scanner liveness is read from the runtime's
-> own **CLI commands** (`openclaw senpi status` / `state`) — **never from the on-disk state files**
-> (`/data/.openclaw/senpi-state/…`); those are internal, partially-written, and not a contract.
-> `deploy.py verify` already runs this check (the `live` / `not-live` / `unverified` verdict); use this
-> doc when triaging by hand.
+> `scan(inputs, ctx)` every `interval_seconds` itself (restarting it on crash). There is **no separate
+> producer daemon and no `push_signal`** — so there is nothing to reconcile against. **Never read the
+> on-disk state files** (`/data/.openclaw/senpi-state/…`); they're internal, partially-written, and not a
+> contract. `deploy.py verify` already runs this check (the `live` / `not-live` verdict); use this doc for
+> hand triage.
 >
-> **Two commands, and which to trust when they disagree:**
-> - **`openclaw senpi status -r <id> --json`** (getHealthStatus) — the runtime's own per-scanner
->   **health verdict** (`components.scanners.scanners[].health`). Light and **reliable immediately after
->   deploy.** This is the primary liveness source.
-> - **`openclaw senpi state -r <id> --json`** (getSystemState) — the rich per-scanner row (runCount,
->   `lastAliveAt`, `lastError`, `enabled`). Richer, but **`getSystemState` transiently THROWS for the
->   first several minutes after a runtime starts** (scanner subprocesses still launching) — the CLI then
->   prints nothing usable and exits non-zero. **A failed/empty `state` read is NOT evidence the scanner is
->   down** — fall back to `status` and re-check. (Confirmed live: a fully-healthy runtime whose `state`
->   threw for ~9 min while `status` reported `2/2 enabled and healthy` the whole time.)
+> **The reliable backbone vs. the flaky detail — which command to trust:**
+> - **`openclaw senpi runtime list`** — the **authoritative inventory** (id / wallet / source / status).
+>   Reliable immediately after deploy. It answers the load-bearing question: *is the runtime running?* If
+>   it is, the runtime is driving its declared scanner. This is the backbone the gate rests on. Its limit:
+>   it has **no component-level health** — it can't tell a healthy scanner from a crash-looping one.
+> - **`openclaw senpi status -r <id> --json`** (getHealthStatus) / **`state -r <id> --json`**
+>   (getSystemState) — per-scanner `health` / rich row (runCount, `lastAliveAt`, `lastError`). Precise
+>   *when they answer*, but **both are flaky-empty / throw for a minute+ after start** (seen live: `verify`
+>   got nothing while a manual `status -r`/`state -r` seconds apart returned healthy). Treat them as
+>   **enrichment that can only DOWNGRADE** a scanner to broken on *positive* unhealthy evidence — **never**
+>   as the gate. If they're unreadable but `runtime list` says running, the scanner is **live-but-unmeasured**.
 
 ---
 
@@ -127,10 +127,13 @@ Declare a strategy **live** only when, for **every** instance:
   scanning, just not trading this cycle;
 - each action is either "operating" or "dormant by design" — never "wiring problem" or "failing".
 
-If you **cannot read `status` or `state`** for an instance, the correct verdict is **"unverified," not
-"down"** — the strategy is registered, funded and DSL-protected; re-run `deploy.py verify <id>` shortly
-(that command reports this case distinctly). **Never report a strategy as live until `verify` returns
-`live`** — an unreadable state is not a green light.
+If you **cannot read `status` or `state`** for an instance (they're flaky-empty for a minute+ after start),
+fall back to the **reliable backbone**: is the runtime in **`openclaw senpi runtime list`** as `running`?
+If yes, the scanner is **live-but-unmeasured** (`supervised`) — the runtime spawns and supervises the
+declared scanner and restarts it on crash, and the DSL protects positions — **not** "down." `deploy.py
+verify` treats this as live for that reason. Only a runtime **missing/stopped** in `runtime list`, or a
+scanner the reads *positively* report unhealthy/erroring, is a real failure. Still: **never report a
+strategy as live until `verify` returns `live`.**
 
 Anything less: surface the specific failing field and the remediation, not a generic "looks fine." For
 deeper engine triage (position_tracker → DSL → actions), see

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -203,9 +203,64 @@ def _deep_first(obj, keys):
     return None
 
 
-def runtime_status(name, timeout=15):
-    """`openclaw senpi status -r <name> --json` — lightweight per-runtime health (or None)."""
-    return cli_json(["openclaw", "senpi", "status", "-r", name, "--json"], timeout)
+def runtime_status(name, timeout=15, retries=2):
+    """`openclaw senpi status -r <name> --json` — lightweight per-runtime health (or None).
+
+    Retries the read: like every openclaw gateway call it can come back empty/erroring transiently
+    (spawn hiccup, timeout, flaky-empty right after start). `getHealthStatus` is the more reliable of
+    the two reads, but 'more reliable' ≠ 'never fails', and this is the fallback source the scanner
+    verdict leans on when `state` is unreadable — so a single unlucky read must not decide liveness."""
+    for _ in range(max(1, retries)):
+        obj = cli_json(["openclaw", "senpi", "status", "-r", name, "--json"], timeout)
+        if obj:
+            return obj
+    return None
+
+
+def runtime_state(name, timeout=15, retries=2):
+    """`openclaw senpi state -r <name> --json` → parsed state, retrying the flaky gateway.
+
+    `senpi.getSystemState` TRANSIENTLY THROWS for minutes right after a runtime starts (while its
+    external-scanner subprocesses are still launching / their state files are mid-write). A throw
+    makes the CLI print the error to stderr and exit non-zero, so `cli_json` sees empty stdout and
+    returns None — indistinguishable from a real 'no such runtime'. Retry a couple times before
+    giving up so a single unlucky read doesn't get mistaken for a dead scanner. (Observed live: a
+    fully-healthy runtime whose `state` threw for ~9 min post-deploy while `status` answered fine —
+    which is why the scanner verdict must fall back to `status`, see deploy.py `_scanner_verdict`.)"""
+    for _ in range(max(1, retries)):
+        obj = cli_json(["openclaw", "senpi", "state", "-r", name, "--json"], timeout)
+        if obj:
+            return obj
+    return None
+
+
+def scanner_health_in_status(status_entry, scanner_name):
+    """Per-scanner health from a `senpi status` entry (getHealthStatus), by stable scanner name.
+
+    Returns (health_str_or_None, list_seen_bool). The scanners component is
+    `components.scanners.scanners[] = [{address, scannerId, health}]`. `list_seen` is True whenever a
+    real scanner list was present (so 'absent from a populated list' can be told apart from 'status
+    unreadable / no list at all' — the caller must NOT fail closed on the latter). This is the
+    RELIABLE liveness source: getHealthStatus keeps answering while getSystemState is still throwing
+    post-deploy, and the runtime has already computed each scanner's health verdict for us here."""
+    comp = None
+    comps = dig(status_entry, "components")
+    if isinstance(comps, dict):
+        comp = comps.get("scanners")
+    if not isinstance(comp, dict):
+        comp = _deep_first(status_entry, ["scanners"])  # tolerate a flatter/rewrapped shape
+    if isinstance(comp, dict):
+        rows = comp.get("scanners")
+    elif isinstance(comp, list):
+        rows = comp
+    else:
+        rows = None
+    if not isinstance(rows, list):
+        return None, False
+    for r in rows:
+        if dig(r, "scannerId", "name", "scanner") == scanner_name:
+            return (str(dig(r, "health") or "").lower() or None), True
+    return None, True
 
 
 def runtime_health_map(timeout=15):

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -203,35 +203,27 @@ def _deep_first(obj, keys):
     return None
 
 
-def runtime_status(name, timeout=15, retries=2):
+def runtime_status(name, timeout=15):
     """`openclaw senpi status -r <name> --json` — lightweight per-runtime health (or None).
 
-    Retries the read: like every openclaw gateway call it can come back empty/erroring transiently
-    (spawn hiccup, timeout, flaky-empty right after start). `getHealthStatus` is the more reliable of
-    the two reads, but 'more reliable' ≠ 'never fails', and this is the fallback source the scanner
-    verdict leans on when `state` is unreadable — so a single unlucky read must not decide liveness."""
-    for _ in range(max(1, retries)):
-        obj = cli_json(["openclaw", "senpi", "status", "-r", name, "--json"], timeout)
-        if obj:
-            return obj
-    return None
+    Single fast read, no in-call retry. `_check_live` prefers the batched `runtime_health_map` (which
+    already retries) and only falls here when a runtime is missing from that map; retry across reads is
+    the caller's job (re-run `verify`, or its `--max-wait` poll loop) — NOT per call. Each openclaw
+    invocation pays ~2-3s startup, so a per-call retry loop silently blows verify's fast-single-check
+    budget (regression seen live: 2× retries here + on `state` pushed one pass past the tool timeout)."""
+    return cli_json(["openclaw", "senpi", "status", "-r", name, "--json"], timeout)
 
 
-def runtime_state(name, timeout=15, retries=2):
-    """`openclaw senpi state -r <name> --json` → parsed state, retrying the flaky gateway.
+def runtime_state(name, timeout=15):
+    """`openclaw senpi state -r <name> --json` → parsed state, or None.
 
-    `senpi.getSystemState` TRANSIENTLY THROWS for minutes right after a runtime starts (while its
-    external-scanner subprocesses are still launching / their state files are mid-write). A throw
-    makes the CLI print the error to stderr and exit non-zero, so `cli_json` sees empty stdout and
-    returns None — indistinguishable from a real 'no such runtime'. Retry a couple times before
-    giving up so a single unlucky read doesn't get mistaken for a dead scanner. (Observed live: a
-    fully-healthy runtime whose `state` threw for ~9 min post-deploy while `status` answered fine —
-    which is why the scanner verdict must fall back to `status`, see deploy.py `_scanner_verdict`.)"""
-    for _ in range(max(1, retries)):
-        obj = cli_json(["openclaw", "senpi", "state", "-r", name, "--json"], timeout)
-        if obj:
-            return obj
-    return None
+    Single fast read — do NOT retry in-call. `senpi.getSystemState` transiently THROWS for minutes
+    after a runtime starts (external-scanner subprocesses still launching); a throw exits non-zero
+    with empty stdout so this returns None. That is EXPECTED and cheap to handle: the scanner verdict
+    falls straight through to `senpi status` (see deploy.py `_scanner_verdict`), which answers while
+    `state` is still throwing. Waiting/retrying on `state` here just burns the caller's budget for a
+    read we already know how to do without — retry belongs in the poll loop, not this call."""
+    return cli_json(["openclaw", "senpi", "state", "-r", name, "--json"], timeout)
 
 
 def scanner_health_in_status(status_entry, scanner_name):

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -120,15 +120,11 @@ def wallet_match(a, b):
     return False
 
 
-def list_runtimes():
-    """All runtimes (running AND stopped) by parsing `runtime list` text. NOTE on runtime v3: `runtime
-    list` has no --json (human text only), and `status --json` is *flaky* — it transiently returns an
-    empty `statuses[]` even while runtimes are running — so it is NOT a reliable inventory. The text
-    table (id / wallet / source / status) is authoritative; use `status -r <id>` only for health."""
-    rc, out, _err = run_cli(["openclaw", "senpi", "runtime", "list"])
-    if rc != 0:
-        return []
-    rows, seen_header = [], False
+def _parse_runtime_list(out):
+    """Parse `runtime list` text → (rows, valid). `valid` is True only when the output actually looked
+    like the runtime-list table (header row seen, or an explicit 'no runtimes' line) — so a garbled /
+    banner-only stdout that yields zero rows is reported as NOT valid rather than as an empty inventory."""
+    rows, seen_header, empty_marker = [], False, False
     for line in out.splitlines():
         line = _strip_ansi(line).strip()
         if not line:
@@ -139,12 +135,38 @@ def list_runtimes():
                 seen_header = True
             continue
         if "no runtimes" in low:
+            empty_marker = True
             break
         parts = [p for p in re.split(r"\s{2,}|\t+", line) if p]
         if len(parts) >= 2:
             rows.append({"name": parts[0], "wallet": parts[1],
                          "source": parts[2] if len(parts) > 2 else None, "status": parts[-1]})
+    return rows, (seen_header or empty_marker)
+
+
+def list_runtimes():
+    """All runtimes (running AND stopped) by parsing `runtime list` text. NOTE on runtime v3: `runtime
+    list` has no --json (human text only), and `status --json` is *flaky* — it transiently returns an
+    empty `statuses[]` even while runtimes are running — so it is NOT a reliable inventory. The text
+    table (id / wallet / source / status) is authoritative; use `status -r <id>` only for health.
+    Returns [] on a failed/garbled read; a caller that must NOT conflate 'none' with 'unreadable'
+    (teardown's money path) uses `list_runtimes_or_none` instead."""
+    rc, out, _err = run_cli(["openclaw", "senpi", "runtime", "list"])
+    if rc != 0:
+        return []
+    rows, _valid = _parse_runtime_list(out)
     return rows
+
+
+def list_runtimes_or_none():
+    """Like `list_runtimes()` but returns None when the `runtime list` read FAILED (rc != 0) or produced
+    unparseable output — so callers can tell 'no runtimes' (→ []) from 'couldn't read the inventory'
+    (→ None). The teardown money path must never mistake an unreadable inventory for 'the runtime is gone'."""
+    rc, out, _err = run_cli(["openclaw", "senpi", "runtime", "list"])
+    if rc != 0:
+        return None
+    rows, valid = _parse_runtime_list(out)
+    return rows if valid else None
 
 
 def runtime_name(rt):
@@ -227,14 +249,13 @@ def runtime_state(name, timeout=15):
 
 
 def scanner_health_in_status(status_entry, scanner_name):
-    """Per-scanner health from a `senpi status` entry (getHealthStatus), by stable scanner name.
-
-    Returns (health_str_or_None, list_seen_bool). The scanners component is
-    `components.scanners.scanners[] = [{address, scannerId, health}]`. `list_seen` is True whenever a
-    real scanner list was present (so 'absent from a populated list' can be told apart from 'status
-    unreadable / no list at all' — the caller must NOT fail closed on the latter). This is the
-    RELIABLE liveness source: getHealthStatus keeps answering while getSystemState is still throwing
-    post-deploy, and the runtime has already computed each scanner's health verdict for us here."""
+    """Per-scanner health string (or None) from a `senpi status` entry (getHealthStatus), by stable
+    scanner name. The scanners component is `components.scanners.scanners[] = [{address, scannerId,
+    health}]`. This is the RELIABLE liveness source: getHealthStatus keeps answering while
+    getSystemState is still throwing post-deploy, and the runtime has already computed each scanner's
+    health verdict for us here. Returns None both when status is unreadable and when the scanner isn't
+    (yet) in the list — the caller treats both the same (a running runtime supervises the scanner
+    regardless), so there is intentionally no 'was the list populated?' distinction to return."""
     comp = None
     comps = dig(status_entry, "components")
     if isinstance(comps, dict):
@@ -248,11 +269,11 @@ def scanner_health_in_status(status_entry, scanner_name):
     else:
         rows = None
     if not isinstance(rows, list):
-        return None, False
+        return None
     for r in rows:
         if dig(r, "scannerId", "name", "scanner") == scanner_name:
-            return (str(dig(r, "health") or "").lower() or None), True
-    return None, True
+            return str(dig(r, "health") or "").lower() or None
+    return None
 
 
 def runtime_health_map(timeout=15):

--- a/senpi-strategy-ops/scripts/close.py
+++ b/senpi-strategy-ops/scripts/close.py
@@ -36,6 +36,17 @@ LIVE_STATUSES = ["ACTIVE", "PAUSED", "CREATE_WALLET", "FUND_WALLET", "INITIALIZE
                  "SUBSCRIBE_TRADER", "CLOSING_POSITIONS"]
 
 
+def _runtime_gone(name):
+    """True ONLY when `runtime list` was read successfully AND `name` is absent from it. An UNREADABLE
+    inventory (rc!=0 / garbled → None) returns False: on teardown's money path we must never mistake
+    'couldn't read the inventory' for 'the runtime is gone' and then strategy_close a strategy whose
+    runtime is still live and could re-enter positions. Fail CLOSED here — the caller retries / reports."""
+    rts = _cli.list_runtimes_or_none()
+    if rts is None:
+        return False
+    return not any(_cli.runtime_name(r) == name for r in rts)
+
+
 def close_one(label, strat, runtimes, dry_run, log):
     """Stop the runtime (FIRE — no confirm-wait) + TRIGGER strategy_close, then return immediately. The
     agent polls by re-running close.py (idempotent: runtime already gone → skip; status closing/closed →
@@ -74,13 +85,15 @@ def close_one(label, strat, runtimes, dry_run, log):
         log(f"  [{label}] stopping runtime {rname!r}…")
         _cli.run_cli(["openclaw", "senpi", "runtime", "delete", "--id", rname,
                       "--address", wallet or ""], timeout=60)
-        if _cli.find_runtime(rname) is not None:   # still listed → one retry, then believe it's stuck
+        if not _runtime_gone(rname):   # still listed OR inventory unreadable → one retry, then treat as stuck
             _cli.run_cli(["openclaw", "senpi", "runtime", "delete", "--id", rname,
                           "--address", wallet or ""], timeout=60)
-        if _cli.find_runtime(rname) is not None:
+        if not _runtime_gone(rname):
             rec["status"] = "failed"
-            rec["error"] = (f"runtime {rname!r} still in `runtime list` after delete — it may re-enter "
-                            f"positions; delete it (`openclaw senpi runtime delete {rname}`) then re-run close")
+            rec["error"] = (f"runtime {rname!r} still in (or unreadable from) `runtime list` after delete — "
+                            f"it may re-enter positions; delete it "
+                            f"(`openclaw senpi runtime delete --id {rname} --address {wallet or '<wallet>'}`) "
+                            f"then re-run close")
             return rec
         rec["runtime"] = "stopped"
     else:

--- a/senpi-strategy-ops/scripts/close.py
+++ b/senpi-strategy-ops/scripts/close.py
@@ -64,15 +64,23 @@ def close_one(label, strat, runtimes, dry_run, log):
         rec["status"] = "closed"
         return rec
 
-    # 1. stop the runtime if one is live — FIRE only, no confirm poll (the re-run poll confirms via
-    #    strategy_list status; blocking here cost ~30s/instance). Idempotent across re-runs.
+    # 1. stop the runtime if one is live. Trust `runtime list` (the authoritative inventory), NOT the
+    #    delete's exit code: `runtime delete` rides the flaky gateway (its OTel/HyperDX banner leaks into
+    #    our captured output) AND returns NOT_FOUND / non-zero when the runtime is ALREADY gone — so a
+    #    non-zero is NOT proof of failure. Trusting it both broke idempotent re-runs (a poll re-run hit
+    #    NOT_FOUND → false 'failed') and false-aborted the money-critical strategy_close below, stranding
+    #    the strategy open (seen live). The delete succeeded iff the runtime is gone from `runtime list`.
     if rt:
         log(f"  [{label}] stopping runtime {rname!r}…")
-        rc, _o, err = _cli.run_cli(["openclaw", "senpi", "runtime", "delete", "--id", rname,
-                                    "--address", wallet or ""], timeout=60)
-        if rc != 0:
+        _cli.run_cli(["openclaw", "senpi", "runtime", "delete", "--id", rname,
+                      "--address", wallet or ""], timeout=60)
+        if _cli.find_runtime(rname) is not None:   # still listed → one retry, then believe it's stuck
+            _cli.run_cli(["openclaw", "senpi", "runtime", "delete", "--id", rname,
+                          "--address", wallet or ""], timeout=60)
+        if _cli.find_runtime(rname) is not None:
             rec["status"] = "failed"
-            rec["error"] = (err or "runtime delete failed").strip()[:300]
+            rec["error"] = (f"runtime {rname!r} still in `runtime list` after delete — it may re-enter "
+                            f"positions; delete it (`openclaw senpi runtime delete {rname}`) then re-run close")
             return rec
         rec["runtime"] = "stopped"
     else:

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -517,7 +517,7 @@ def _scanner_verdict(inst, state, status):
             return "ticked", "external scanner heartbeat live"
         return "scheduled", f"awaiting first tick (~{inst.interval_seconds or '?'}s cadence)"
     # `state` unreadable → trust the runtime's own scanner-health from `senpi status`
-    sh, _list_seen = _cli.scanner_health_in_status(status, name)
+    sh = _cli.scanner_health_in_status(status, name)
     if sh == "unhealthy":
         return "broken", "scanner reported unhealthy by the runtime (per status)"
     if sh in ("healthy", "degraded"):

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -477,13 +477,16 @@ def _deep_find_scanner(obj, name):
 
 def _scanner_verdict(inst, state, status):
     """(status, detail) for the instance's external_scanner — judged from what the RUNTIME reports,
-    and NEVER failing closed on a read it couldn't get.
-      ticked     — runCount>0 or a live heartbeat (lastAliveAt) — it has actually scanned/POSTed
+    and NEVER failing closed on a read it couldn't get. Called ONLY after the caller has confirmed the
+    runtime is RUNNING (via `runtime list`), so the reliable backbone is already established here.
+      ticked     — runCount>0 / heartbeat (lastAliveAt) / runtime-reported healthy — actually scanning
       scheduled  — registered + enabled + healthy, no tick yet (first tick fires on interval_seconds)
+      supervised — reads unavailable this pass, but the runtime is running and supervising the declared
+                   scanner ⇒ live-but-unmeasured (the flaky status/state reads are enrichment, not a gate)
       broken     — POSITIVE evidence of breakage: disabled / erroring / runtime-reported unhealthy
-      unknown    — no source was readable — the caller retries and reports 'unverified', not 'broken'
 
-    Two sources, both keyed by the stable scanner name (== the runtime's `scannerId`):
+    `ticked`/`scheduled`/`supervised` all count as LIVE. Two enrichment sources, keyed by the stable
+    scanner name (== the runtime's `scannerId`):
       • `senpi state`  — the rich per-scanner row (runCount, lastAliveAt, lastError, enabled, health).
         Best when available, but `getSystemState` THROWS for minutes after a fresh start, so `state`
         is often None here (see `_cli.runtime_state`).
@@ -514,15 +517,19 @@ def _scanner_verdict(inst, state, status):
             return "ticked", "external scanner heartbeat live"
         return "scheduled", f"awaiting first tick (~{inst.interval_seconds or '?'}s cadence)"
     # `state` unreadable → trust the runtime's own scanner-health from `senpi status`
-    sh, list_seen = _cli.scanner_health_in_status(status, name)
+    sh, _list_seen = _cli.scanner_health_in_status(status, name)
     if sh == "unhealthy":
         return "broken", "scanner reported unhealthy by the runtime (per status)"
     if sh in ("healthy", "degraded"):
-        return "scheduled", f"healthy per runtime status ({sh}); detailed scan state not yet readable"
-    # neither the state row nor a status health verdict was available for this scanner — do NOT
-    # brand it broken (the old false 'not mounted'); stay agnostic so the caller retries.
-    return "unknown", ("scanner absent from status this poll — still mounting?" if list_seen
-                       else "runtime state/status temporarily unreadable — could not confirm liveness")
+        return "ticked", f"healthy per runtime status ({sh})"
+    # Neither `state` nor `status` was readable this pass — but we only reach here AFTER the caller
+    # confirmed the runtime is RUNNING via `runtime list` (the authoritative inventory; `status`/`state`
+    # JSON are flaky-empty for a minute+ after start — seen live: verify got nothing while a manual
+    # `status -r`/`state -r` seconds apart returned healthy). A running runtime SPAWNS + SUPERVISES this
+    # external scanner (restarting it on crash), and the scanner is declared in the deployed runtime.yaml
+    # — so running runtime + declared scanner ⇒ it's being driven. Report LIVE-but-unmeasured, never
+    # `broken`. A genuinely broken scanner still trips the `broken` branches above whenever a read lands.
+    return "supervised", "runtime running + scanner supervised (live health read unavailable this pass)"
 
 
 def _dsl_verdict(inst, status_json):
@@ -588,11 +595,12 @@ def _check_live(pkg, st, mcp):
         sc_st, sc_d = _scanner_verdict(inst, state, status)
         dsl_st, dsl_d = _dsl_verdict(inst, status)
         bud_st, bud_d = _budget_verdict(s, funded_by_id)
-        live = sc_st in ("ticked", "scheduled") and dsl_st == "wired" and bud_st == "ok"
+        sc_live = sc_st in ("ticked", "scheduled", "supervised")
+        live = sc_live and dsl_st == "wired" and bud_st == "ok"
         s["status"] = "live" if live else s.get("status", "registered")
         save_state(pkg, st)
         reason = "; ".join(d for ok, d in
-                           ((sc_st in ("ticked", "scheduled"), sc_d), (dsl_st == "wired", dsl_d),
+                           ((sc_live, sc_d), (dsl_st == "wired", dsl_d),
                             (bud_st == "ok", bud_d)) if not ok and d)
         rows.append({"instance": inst.name, "live": live, "scanner": sc_st, "dsl": dsl_st,
                      "budget": bud_st, "reason": reason})
@@ -601,23 +609,19 @@ def _check_live(pkg, st, mcp):
 
 def cmd_verify(pkg, a, log):
     # THE liveness gate: a strategy is `live` only when EVERY instance has a running runtime + an active
-    # scanner (ticked or scheduled) + a wired DSL + a funded budget. It does NOT wait for a slow first
-    # scan tick (a 'scheduled' scanner is live — it fires on interval_seconds); --max-wait re-checks only
-    # for a runtime/scanner that hasn't finished mounting yet.
+    # scanner (ticked / scheduled / supervised) + a wired DSL + a funded budget. The reliable backbone is
+    # `runtime list` (running) + the deployed runtime.yaml (scanner + DSL preset) + MCP budget — none of
+    # which depend on the flaky `status`/`state` JSON; those only DOWNGRADE a scanner to `broken` on
+    # positive evidence. It does NOT wait for a scan tick (a scheduled/supervised scanner is already
+    # live); --max-wait only re-checks a runtime that hasn't finished registering yet.
     mcp = MCPClient()
     st = load_state(pkg)
     deadline = time.time() + a.max_wait
     while True:
         rows = _check_live(pkg, st, mcp)
         live = bool(rows) and all(r["live"] for r in rows)
-        # 'unverified' ≠ 'not-live': every not-live instance was flagged ONLY because a scanner read
-        # came back `unknown` (runtime state/status momentarily unreadable) — nothing was proven
-        # broken. That's a transient-read outcome, not a bad deploy; say so instead of crying wolf.
-        unverified = (not live and bool(rows)
-                      and all(r["live"] or r["scanner"] == "unknown" for r in rows)
-                      and any(r["scanner"] == "unknown" for r in rows))
         if live or time.time() >= deadline:
-            status = "live" if live else ("unverified" if unverified else "not-live")
+            status = "live" if live else "not-live"
             out = {"strategy": pkg.id, "version": pkg.version, "status": status, "instances": rows}
             if a.json:
                 print(json.dumps(out, indent=2))
@@ -626,15 +630,7 @@ def cmd_verify(pkg, a, log):
                 for r in rows:
                     print(f"  - {r['instance']}: scanner={r['scanner']}, dsl={r['dsl']}, "
                           f"budget={r['budget']}" + (f"  → {r['reason']}" if r["reason"] else ""))
-                if status == "unverified":
-                    print(f"\nUNVERIFIED — the runtime is registered, funded and DSL-protected, but its "
-                          f"state/status read was temporarily unavailable so the scanner's liveness "
-                          f"could NOT be confirmed (this is common in the first minute after `runtime`, "
-                          f"and does NOT mean the scanner is down). Positions are protected by the DSL "
-                          f"either way. Re-run `deploy.py verify {pkg.id}` shortly, or check "
-                          f"`openclaw senpi status -r <runtime>`. Do NOT report the strategy as live "
-                          f"until verify passes.")
-                elif not live:
+                if not live:
                     print(f"\nNOT live — fix the flagged component(s) and re-run `deploy.py verify {pkg.id}`. "
                           "A strategy is live only when every instance is runtime-running + scanner-active "
                           "+ DSL-wired + funded.")
@@ -713,12 +709,7 @@ def main(argv):
     else:  # status
         out = report(pkg, load_state(pkg), "status", as_json=a.json)
 
-    # exit: 0 = confirmed good · 2 = confirmed bad (failed/underfunded/scanner broken) · 3 = verify
-    # couldn't confirm liveness because the runtime read was transiently unavailable (retry, not a
-    # bad deploy) — a distinct code so callers don't conflate "unconfirmed" with "broken".
-    st_out = out.get("status")
-    sys.exit(3 if st_out == "unverified"
-             else 2 if st_out in ("failed", "underfunded", "not-live") else 0)
+    sys.exit(2 if out.get("status") in ("failed", "underfunded", "not-live") else 0)
 
 
 if __name__ == "__main__":

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -568,12 +568,22 @@ def _check_live(pkg, st, mcp):
     rows = []
     for inst in pkg.instances:
         s = inst_state(st, inst.name)
-        rt = _cli.find_runtime(inst.runtime_name)
-        if not rt or not _cli.runtime_running(rt):
+        # `runtime_health_map` (getHealthStatus) lists ONLY running runtimes, so a hit already proves
+        # 'running' — skip the extra `runtime list` call (its default 60s timeout is verify's worst
+        # tail-latency) in the common path. Only when the map is flaky-empty for this runtime do we
+        # fall back to the authoritative text list to tell 'not running' from 'status hiccup'.
+        status = health.get(inst.runtime_name)
+        if status:
+            running = True
+        else:
+            rt = _cli.find_runtime(inst.runtime_name)
+            running = bool(rt) and _cli.runtime_running(rt)
+            if running:
+                status = _cli.runtime_status(inst.runtime_name, POLL_HTTP_TIMEOUT)
+        if not running:
             rows.append({"instance": inst.name, "live": False, "scanner": "no-runtime",
                          "dsl": "-", "budget": "-", "reason": "runtime not running"})
             continue
-        status = health.get(inst.runtime_name) or _cli.runtime_status(inst.runtime_name, POLL_HTTP_TIMEOUT)
         state = _cli.runtime_state(inst.runtime_name, POLL_HTTP_TIMEOUT)
         sc_st, sc_d = _scanner_verdict(inst, state, status)
         dsl_st, dsl_d = _dsl_verdict(inst, status)

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -475,26 +475,54 @@ def _deep_find_scanner(obj, name):
     return None
 
 
-def _scanner_verdict(inst, state):
-    """(status, detail) for the instance's external_scanner, from `openclaw senpi state` JSON.
-      ticked    — runCount>0 (it has actually scanned)
-      scheduled — mounted + enabled + no error, runCount==0 (first tick fires on interval_seconds)
-      broken    — not mounted / disabled / erroring
-    'scheduled' counts as live: everything is wired and will fire on cadence — we do NOT block the gate
-    waiting for a slow first tick, but we DO fail a scanner that threw on init."""
-    sc = _deep_find_scanner(state, inst.external_scanner.get("name")) if state else None
-    if not sc:
-        return "broken", "scanner not mounted in runtime state"
-    if _cli.dig(sc, "enabled", default=True) is False:
-        return "broken", "scanner disabled"
-    err = _cli.dig(sc, "lastError")
-    cec = _cli.dig(sc, "consecutiveErrorCount", default=0) or 0
-    if err or (isinstance(cec, (int, float)) and cec >= 1):
-        return "broken", f"scanner erroring: {str(err)[:120] if err else f'{int(cec)} consecutive errors'}"
-    runs = _cli.dig(sc, "runCount", "ticks", "runs", default=0) or 0
-    if isinstance(runs, (int, float)) and runs > 0:
-        return "ticked", f"{int(runs)} scan(s)"
-    return "scheduled", f"awaiting first tick (~{inst.interval_seconds or '?'}s cadence)"
+def _scanner_verdict(inst, state, status):
+    """(status, detail) for the instance's external_scanner — judged from what the RUNTIME reports,
+    and NEVER failing closed on a read it couldn't get.
+      ticked     — runCount>0 or a live heartbeat (lastAliveAt) — it has actually scanned/POSTed
+      scheduled  — registered + enabled + healthy, no tick yet (first tick fires on interval_seconds)
+      broken     — POSITIVE evidence of breakage: disabled / erroring / runtime-reported unhealthy
+      unknown    — no source was readable — the caller retries and reports 'unverified', not 'broken'
+
+    Two sources, both keyed by the stable scanner name (== the runtime's `scannerId`):
+      • `senpi state`  — the rich per-scanner row (runCount, lastAliveAt, lastError, enabled, health).
+        Best when available, but `getSystemState` THROWS for minutes after a fresh start, so `state`
+        is often None here (see `_cli.runtime_state`).
+      • `senpi status` — the runtime's own per-scanner health verdict. Lighter, and it keeps
+        answering while `state` is still throwing — so it's the fallback that keeps a live-but-not-
+        -yet-introspectable scanner from being branded dead.
+
+    IMPORTANT — external scanners: runCount/lastRun stay 0/null until the runtime hears the first
+    POST, and a healthy scanner that finds no setup still ticks (barren heartbeat). So absence of
+    runs is NEVER breakage on its own; `health`/`lastAliveAt` and the `status` verdict carry the
+    truth. (Live-confirmed: a runtime whose `state` threw for ~9 min while both scanners logged and
+    `status` said '2/2 enabled and healthy' — the old code called that 'scanner not mounted'.)"""
+    name = inst.external_scanner.get("name")
+    sc = _deep_find_scanner(state, name) if state else None
+    if sc:
+        if _cli.dig(sc, "enabled", default=True) is False:
+            return "broken", "scanner disabled"
+        err = _cli.dig(sc, "lastError")
+        cec = _cli.dig(sc, "consecutiveErrorCount", default=0) or 0
+        if err or (isinstance(cec, (int, float)) and cec >= 1):
+            return "broken", f"scanner erroring: {str(err)[:120] if err else f'{int(cec)} consecutive errors'}"
+        if str(_cli.dig(sc, "health") or "").lower() == "unhealthy":
+            return "broken", "scanner reported unhealthy by the runtime"
+        runs = _cli.dig(sc, "runCount", "ticks", "runs", default=0) or 0
+        if isinstance(runs, (int, float)) and runs > 0:
+            return "ticked", f"{int(runs)} scan(s)"
+        if _cli.dig(sc, "lastAliveAt"):
+            return "ticked", "external scanner heartbeat live"
+        return "scheduled", f"awaiting first tick (~{inst.interval_seconds or '?'}s cadence)"
+    # `state` unreadable → trust the runtime's own scanner-health from `senpi status`
+    sh, list_seen = _cli.scanner_health_in_status(status, name)
+    if sh == "unhealthy":
+        return "broken", "scanner reported unhealthy by the runtime (per status)"
+    if sh in ("healthy", "degraded"):
+        return "scheduled", f"healthy per runtime status ({sh}); detailed scan state not yet readable"
+    # neither the state row nor a status health verdict was available for this scanner — do NOT
+    # brand it broken (the old false 'not mounted'); stay agnostic so the caller retries.
+    return "unknown", ("scanner absent from status this poll — still mounting?" if list_seen
+                       else "runtime state/status temporarily unreadable — could not confirm liveness")
 
 
 def _dsl_verdict(inst, status_json):
@@ -545,9 +573,9 @@ def _check_live(pkg, st, mcp):
             rows.append({"instance": inst.name, "live": False, "scanner": "no-runtime",
                          "dsl": "-", "budget": "-", "reason": "runtime not running"})
             continue
-        state = _cli.cli_json(["openclaw", "senpi", "state", "-r", inst.runtime_name, "--json"], POLL_HTTP_TIMEOUT)
         status = health.get(inst.runtime_name) or _cli.runtime_status(inst.runtime_name, POLL_HTTP_TIMEOUT)
-        sc_st, sc_d = _scanner_verdict(inst, state)
+        state = _cli.runtime_state(inst.runtime_name, POLL_HTTP_TIMEOUT)
+        sc_st, sc_d = _scanner_verdict(inst, state, status)
         dsl_st, dsl_d = _dsl_verdict(inst, status)
         bud_st, bud_d = _budget_verdict(s, funded_by_id)
         live = sc_st in ("ticked", "scheduled") and dsl_st == "wired" and bud_st == "ok"
@@ -572,17 +600,31 @@ def cmd_verify(pkg, a, log):
     while True:
         rows = _check_live(pkg, st, mcp)
         live = bool(rows) and all(r["live"] for r in rows)
+        # 'unverified' ≠ 'not-live': every not-live instance was flagged ONLY because a scanner read
+        # came back `unknown` (runtime state/status momentarily unreadable) — nothing was proven
+        # broken. That's a transient-read outcome, not a bad deploy; say so instead of crying wolf.
+        unverified = (not live and bool(rows)
+                      and all(r["live"] or r["scanner"] == "unknown" for r in rows)
+                      and any(r["scanner"] == "unknown" for r in rows))
         if live or time.time() >= deadline:
-            out = {"strategy": pkg.id, "version": pkg.version,
-                   "status": "live" if live else "not-live", "instances": rows}
+            status = "live" if live else ("unverified" if unverified else "not-live")
+            out = {"strategy": pkg.id, "version": pkg.version, "status": status, "instances": rows}
             if a.json:
                 print(json.dumps(out, indent=2))
             else:
-                print(f"\n{pkg.id} v{pkg.version}: {out['status']}")
+                print(f"\n{pkg.id} v{pkg.version}: {status}")
                 for r in rows:
                     print(f"  - {r['instance']}: scanner={r['scanner']}, dsl={r['dsl']}, "
                           f"budget={r['budget']}" + (f"  → {r['reason']}" if r["reason"] else ""))
-                if not live:
+                if status == "unverified":
+                    print(f"\nUNVERIFIED — the runtime is registered, funded and DSL-protected, but its "
+                          f"state/status read was temporarily unavailable so the scanner's liveness "
+                          f"could NOT be confirmed (this is common in the first minute after `runtime`, "
+                          f"and does NOT mean the scanner is down). Positions are protected by the DSL "
+                          f"either way. Re-run `deploy.py verify {pkg.id}` shortly, or check "
+                          f"`openclaw senpi status -r <runtime>`. Do NOT report the strategy as live "
+                          f"until verify passes.")
+                elif not live:
                     print(f"\nNOT live — fix the flagged component(s) and re-run `deploy.py verify {pkg.id}`. "
                           "A strategy is live only when every instance is runtime-running + scanner-active "
                           "+ DSL-wired + funded.")
@@ -661,7 +703,12 @@ def main(argv):
     else:  # status
         out = report(pkg, load_state(pkg), "status", as_json=a.json)
 
-    sys.exit(2 if out.get("status") in ("failed", "underfunded", "not-live") else 0)
+    # exit: 0 = confirmed good · 2 = confirmed bad (failed/underfunded/scanner broken) · 3 = verify
+    # couldn't confirm liveness because the runtime read was transiently unavailable (retry, not a
+    # bad deploy) — a distinct code so callers don't conflate "unconfirmed" with "broken".
+    st_out = out.get("status")
+    sys.exit(3 if st_out == "unverified"
+             else 2 if st_out in ("failed", "underfunded", "not-live") else 0)
 
 
 if __name__ == "__main__":

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -113,24 +113,25 @@ class ScannerVerdict(unittest.TestCase):
         self.assertEqual(deploy._scanner_verdict(_scan_inst(), st, None)[0], "broken")
 
     # --- state UNreadable: fall back to `senpi status`, never fail closed ---
-    def test_state_none_status_healthy_is_scheduled(self):
+    def test_state_none_status_healthy_is_live(self):
         # THE regression: getSystemState threw, but status says the scanner is healthy → live, not broken
         status = _status_with_scanner("sc1", "healthy")
-        self.assertEqual(deploy._scanner_verdict(_scan_inst(), None, status)[0], "scheduled")
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), None, status)[0], "ticked")
 
     def test_state_none_status_unhealthy_is_broken(self):
         status = _status_with_scanner("sc1", "unhealthy")
         self.assertEqual(deploy._scanner_verdict(_scan_inst(), None, status)[0], "broken")
 
-    def test_state_none_status_none_is_unknown(self):
-        # neither source readable → agnostic (caller retries; reports 'unverified', not 'broken')
-        self.assertEqual(deploy._scanner_verdict(_scan_inst(), None, None)[0], "unknown")
+    def test_state_none_status_none_is_supervised(self):
+        # BOTH reads flaky-empty — but the caller only calls this after confirming the runtime is
+        # RUNNING (via `runtime list`), and the runtime supervises the declared scanner → live, not broken
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), None, None)[0], "supervised")
 
-    def test_absent_from_state_and_status_is_unknown_not_broken(self):
-        # the old false 'scanner not mounted' path — now agnostic, since it's often still-mounting
+    def test_absent_from_state_and_status_is_supervised_not_broken(self):
+        # the old false 'scanner not mounted' path — now live-but-unmeasured (runtime running + supervised)
         st = {"scanners": []}
         status = {"components": {"scanners": {"scanners": []}}}
-        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st, status)[0], "unknown")
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st, status)[0], "supervised")
 
 
 class DslVerdict(unittest.TestCase):

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -175,7 +175,7 @@ class CloseRuntimeDeleteConfirm(unittest.TestCase):
     (NOT_FOUND). Trusting rc broke idempotent re-runs and false-aborted the money-critical strategy_close."""
 
     def setUp(self):
-        self._orig = (_cli.run_cli, _cli.find_runtime, close.MCPClient)
+        self._orig = (_cli.run_cli, _cli.list_runtimes_or_none, close.MCPClient)
         self.deletes = []          # every `runtime delete` invocation
         self.closed = []           # every strategy_close strategyId
         _cli.run_cli = lambda args, timeout=60: (self.deletes.append(args) or (1, "", "[⚡HyperDX] banner…"))
@@ -189,14 +189,14 @@ class CloseRuntimeDeleteConfirm(unittest.TestCase):
         close.MCPClient = _FakeMCP
 
     def tearDown(self):
-        _cli.run_cli, _cli.find_runtime, close.MCPClient = self._orig
+        _cli.run_cli, _cli.list_runtimes_or_none, close.MCPClient = self._orig
 
     _STRAT = {"strategyId": "s1", "strategyWalletAddress": "0xabc", "status": "ACTIVE"}
     _RUNTIMES = [{"name": "pkg-main", "wallet": "0xabc"}]
 
     def test_gone_after_delete_is_success_and_triggers_close(self):
-        # delete returns non-zero (banner noise), but the runtime is gone from `runtime list` → success
-        _cli.find_runtime = lambda name: None
+        # delete returns non-zero (banner noise), but the inventory reads cleanly and the runtime is gone
+        _cli.list_runtimes_or_none = lambda: []
         rec = close.close_one("main", self._STRAT, self._RUNTIMES, False, lambda m: None)
         self.assertEqual(rec["status"], "closing")   # NOT 'failed' despite rc=1
         self.assertEqual(self.closed, ["s1"])         # money-critical close DID fire
@@ -204,15 +204,23 @@ class CloseRuntimeDeleteConfirm(unittest.TestCase):
 
     def test_still_present_after_retry_fails_without_closing(self):
         # runtime never leaves `runtime list` → genuine failure: report it, do NOT strategy_close
-        _cli.find_runtime = lambda name: {"name": name, "wallet": "0xabc"}
+        _cli.list_runtimes_or_none = lambda: [{"name": "pkg-main", "wallet": "0xabc"}]
         rec = close.close_one("main", self._STRAT, self._RUNTIMES, False, lambda m: None)
         self.assertEqual(rec["status"], "failed")
         self.assertEqual(self.closed, [])             # never close while the runtime can re-enter
         self.assertEqual(len(self.deletes), 2)        # one retry before giving up
         self.assertNotIn("HyperDX", rec.get("error", ""))  # clean message, not banner spam
 
+    def test_unreadable_inventory_fails_closed(self):
+        # THE money-path guard: `runtime list` unreadable (None) must NOT read as 'gone' → no strategy_close
+        _cli.list_runtimes_or_none = lambda: None
+        rec = close.close_one("main", self._STRAT, self._RUNTIMES, False, lambda m: None)
+        self.assertEqual(rec["status"], "failed")
+        self.assertEqual(self.closed, [])             # unreadable inventory ⇒ never flatten a maybe-live strategy
+        self.assertEqual(len(self.deletes), 2)
+
     def test_already_closed_is_idempotent_noop(self):
-        _cli.find_runtime = lambda name: None
+        _cli.list_runtimes_or_none = lambda: []
         rec = close.close_one("main", dict(self._STRAT, status="CLOSED"), self._RUNTIMES, False, lambda m: None)
         self.assertEqual(rec["status"], "closed")
         self.assertEqual(self.deletes, [])            # nothing to stop

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -165,5 +165,59 @@ class BudgetVerdict(unittest.TestCase):
         self.assertEqual(deploy._budget_verdict({"requested": 1000, "strategyId": "x"}, {})[0], "ok")
 
 
+import _cli    # noqa: E402
+import close   # noqa: E402
+
+
+class CloseRuntimeDeleteConfirm(unittest.TestCase):
+    """close_one must judge runtime-delete success by `runtime list` (reliable), NOT the delete's exit
+    code — which is non-zero both on a flaky gateway hiccup AND when the runtime is already gone
+    (NOT_FOUND). Trusting rc broke idempotent re-runs and false-aborted the money-critical strategy_close."""
+
+    def setUp(self):
+        self._orig = (_cli.run_cli, _cli.find_runtime, close.MCPClient)
+        self.deletes = []          # every `runtime delete` invocation
+        self.closed = []           # every strategy_close strategyId
+        _cli.run_cli = lambda args, timeout=60: (self.deletes.append(args) or (1, "", "[⚡HyperDX] banner…"))
+        outer = self
+
+        class _FakeMCP:
+            def mcp_call(self, name, timeout=None, **kw):
+                if name == "strategy_close":
+                    outer.closed.append(kw.get("strategyId"))
+                return {"success": True}
+        close.MCPClient = _FakeMCP
+
+    def tearDown(self):
+        _cli.run_cli, _cli.find_runtime, close.MCPClient = self._orig
+
+    _STRAT = {"strategyId": "s1", "strategyWalletAddress": "0xabc", "status": "ACTIVE"}
+    _RUNTIMES = [{"name": "pkg-main", "wallet": "0xabc"}]
+
+    def test_gone_after_delete_is_success_and_triggers_close(self):
+        # delete returns non-zero (banner noise), but the runtime is gone from `runtime list` → success
+        _cli.find_runtime = lambda name: None
+        rec = close.close_one("main", self._STRAT, self._RUNTIMES, False, lambda m: None)
+        self.assertEqual(rec["status"], "closing")   # NOT 'failed' despite rc=1
+        self.assertEqual(self.closed, ["s1"])         # money-critical close DID fire
+        self.assertEqual(len(self.deletes), 1)        # gone on first try → no retry
+
+    def test_still_present_after_retry_fails_without_closing(self):
+        # runtime never leaves `runtime list` → genuine failure: report it, do NOT strategy_close
+        _cli.find_runtime = lambda name: {"name": name, "wallet": "0xabc"}
+        rec = close.close_one("main", self._STRAT, self._RUNTIMES, False, lambda m: None)
+        self.assertEqual(rec["status"], "failed")
+        self.assertEqual(self.closed, [])             # never close while the runtime can re-enter
+        self.assertEqual(len(self.deletes), 2)        # one retry before giving up
+        self.assertNotIn("HyperDX", rec.get("error", ""))  # clean message, not banner spam
+
+    def test_already_closed_is_idempotent_noop(self):
+        _cli.find_runtime = lambda name: None
+        rec = close.close_one("main", dict(self._STRAT, status="CLOSED"), self._RUNTIMES, False, lambda m: None)
+        self.assertEqual(rec["status"], "closed")
+        self.assertEqual(self.deletes, [])            # nothing to stop
+        self.assertEqual(self.closed, [])             # nothing to close
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -80,25 +80,57 @@ class HasDsl(unittest.TestCase):
         self.assertFalse(_dsl_inst({"exit": {"engine": "none"}}).has_dsl)
 
 
+def _status_with_scanner(name, health):
+    """A minimal `senpi status` (getHealthStatus) entry carrying one scanner's health verdict."""
+    return {"components": {"scanners": {"scanners": [{"scannerId": name, "health": health}]}}}
+
+
 class ScannerVerdict(unittest.TestCase):
+    # --- state readable: the rich per-scanner row drives the verdict ---
     def test_ticked(self):
         st = {"scanners": [{"name": "sc1", "runCount": 5, "enabled": True}]}
-        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "ticked")
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st, None)[0], "ticked")
 
     def test_scheduled(self):
         st = {"scanners": [{"name": "sc1", "runCount": 0, "enabled": True}]}
-        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "scheduled")
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st, None)[0], "scheduled")
+
+    def test_heartbeat_without_runcount_is_ticked(self):
+        # external scanner that has POSTed (barren, no-signal heartbeat) but runCount still 0
+        st = {"scanners": [{"name": "sc1", "runCount": 0, "enabled": True, "lastAliveAt": 1784740000000}]}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st, None)[0], "ticked")
 
     def test_disabled_is_broken(self):
         st = {"scanners": [{"name": "sc1", "runCount": 0, "enabled": False}]}
-        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "broken")
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st, None)[0], "broken")
 
     def test_erroring_is_broken(self):
         st = {"scanners": [{"name": "sc1", "runCount": 3, "lastError": "boom"}]}
-        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st)[0], "broken")
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st, None)[0], "broken")
 
-    def test_not_mounted_is_broken(self):
-        self.assertEqual(deploy._scanner_verdict(_scan_inst(), {"scanners": []})[0], "broken")
+    def test_unhealthy_health_field_is_broken(self):
+        st = {"scanners": [{"name": "sc1", "runCount": 0, "enabled": True, "health": "unhealthy"}]}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st, None)[0], "broken")
+
+    # --- state UNreadable: fall back to `senpi status`, never fail closed ---
+    def test_state_none_status_healthy_is_scheduled(self):
+        # THE regression: getSystemState threw, but status says the scanner is healthy → live, not broken
+        status = _status_with_scanner("sc1", "healthy")
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), None, status)[0], "scheduled")
+
+    def test_state_none_status_unhealthy_is_broken(self):
+        status = _status_with_scanner("sc1", "unhealthy")
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), None, status)[0], "broken")
+
+    def test_state_none_status_none_is_unknown(self):
+        # neither source readable → agnostic (caller retries; reports 'unverified', not 'broken')
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), None, None)[0], "unknown")
+
+    def test_absent_from_state_and_status_is_unknown_not_broken(self):
+        # the old false 'scanner not mounted' path — now agnostic, since it's often still-mounting
+        st = {"scanners": []}
+        status = {"components": {"scanners": {"scanners": []}}}
+        self.assertEqual(deploy._scanner_verdict(_scan_inst(), st, status)[0], "unknown")
 
 
 class DslVerdict(unittest.TestCase):


### PR DESCRIPTION
## Problem

`deploy.py verify` reported **fully-healthy** strategies as not-live and sent the agent into long debug loops — then it would override its own gate and tell the user "live" anyway.

**Root cause:** scanner liveness was judged from `openclaw senpi state --json` (`getSystemState`) — and that JSON gateway read is **intermittently flaky-empty / throws for a minute+ right after a runtime starts**. verify failed *closed* on an unreadable read (`scanner=broken → not-live`), with no fallback.

Confirmed live across three sessions (telemetry):
- **lion** (M408027): scanner logged 519 lines, POSTed signals, opened positions while `verify` called it `broken` 4×; `senpi status` said `2/2 enabled and healthy` the whole time.
- **thesis-fund** (M8): `verify` got `scanner=unknown` (empty reads) while a manual `status -r`/`state -r` **seconds apart** returned fully healthy.

## The insight: `runtime list` is reliable, `status`/`state` are not

| Command | Answers | Reliability post-deploy |
|---|---|---|
| `openclaw senpi runtime list` | runtime **running?** (id/wallet/source/status) | **reliable** (authoritative text inventory) |
| `senpi status` / `senpi state` `--json` | per-**component** health (scanner/DSL) | **flaky-empty/throws** for a minute+ after start |

A running runtime **spawns and supervises** its declared external scanner (restarting it on crash), so **runtime-running + scanner-declared ⇒ the scanner is being driven**.

## Fix — gate on the reliable backbone; flaky reads only downgrade

The gate now rests only on signals that are reliably readable right after deploy:
- **`runtime list`** — is the runtime running?
- the deployed **runtime.yaml** — external scanner declared + DSL preset present
- MCP **`strategy_list`** — funded to what was requested

`status`/`state` are demoted to **enrichment that can only DOWNGRADE** a scanner to `broken` on *positive* evidence (disabled / erroring / runtime-reported unhealthy). When they're unreadable, the scanner reads **`supervised` = live** (the DSL protects positions regardless). Liveness is never read from on-disk state files. External scanners are judged by `health` / `lastAliveAt`, **not** `runCount` (which stays 0 for a barren-but-healthy scanner; the scaffold also runs tick 1 on launch, so a long-interval — even 4h — strategy passes immediately as `scheduled`/`supervised`, never blocking on a scan tick).

Result: `verify` is a clean **`live | not-live`** again (no `unverified` limbo), returns in **one fast pass** (dropped the redundant per-call retries that briefly blew the tool timeout in live testing; skips the 60s-timeout `runtime list` call when the health map already confirms running).

## Close side — same lesson (trust `runtime list`, not a gateway command's exit code)

Teardown had the identical bug on the write path. `close_one` failed the whole instance — **aborting before the money-critical `strategy_close`** — whenever `openclaw senpi runtime delete` returned non-zero. But that exit code is not a reliable failure signal: `senpi.deleteRuntime` responds `NOT_FOUND` (→ non-zero) when the runtime is **already gone** (so idempotent poll re-runs false-failed), and the delete rides the same flaky gateway with `stdio: inherit` (banner leaked into the captured "error"; transient hiccup → spurious non-zero). Seen live (M8): `close.py --all` reported `thesis-fund: failed` with the OTel banner as the error and left the strategy + runtime for manual cleanup.

Fix: after `runtime delete`, judge success by whether the runtime is **gone from `runtime list`** — not `rc`. Gone ⇒ success (whether we deleted it or it was already gone) ⇒ proceed to `strategy_close`. Still present after one retry ⇒ genuine failure with a clean, actionable message (no banner spam), and we do **not** `strategy_close` (keeps the safe stop-before-close ordering so a live runtime can't re-enter positions).

## Changes
- `_cli.py` — `runtime_state`/`runtime_status` single fast reads; `scanner_health_in_status` reads per-scanner health from `senpi status`.
- `deploy.py` — `_scanner_verdict(inst, state, status)` with the `supervised` terminal verdict; `_check_live` skips the redundant `runtime list` call in the common path; `cmd_verify` back to `live | not-live`.
- `close.py` — `close_one` confirms runtime deletion via `runtime list`, not the delete's exit code (idempotent + flaky-tolerant; never false-aborts `strategy_close`).
- Docs — `references/liveness-verification.md` reframed (runtime-list backbone; status/state downgrade-only; `runCount>0` not required; on-disk files aren't a contract) + SKILL.md verify section.
- **Version** — SKILL.md `2.6.0 → 2.8.0`.

## Tests
`tests/test_deploy_gates.py` — covers state-throws-but-status-healthy, heartbeat-without-runCount, unhealthy downgrade, and the fail-open `supervised` path. 29 gate tests + 13 pkg tests pass.

## Validated live
M8 installed the branch and deployed `ant` / `thesis-fund` end-to-end; the fixes were iterated against those runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
