### PR TITLE
strategy-ops v2.8.1: note the ~20-40s live-runtime close teardown (launch async / allow ≥60s)

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.8.0"
+  version: "2.8.1"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -241,6 +241,15 @@ python3 scripts/close.py --all           # close EVERY open strategy (all packag
 Per strategy: **stop the runtime** (if live) → **trigger `strategy_close`** (flattens **all** positions
 + closes the strategy, funds returned). `strategy_close` is **async**, so the script **does not wait** —
 it returns `closing` and hands polling to you: **re-run `close.py spider`** until it reports `closed`.
+
+> **Give it time — stopping a live runtime is a synchronous teardown.** Deleting a *live* runtime tears
+> it down (stop scanner + DSL monitor) before the call returns — so a first `close.py <id>` on a running
+> strategy can take **~20-40s** (openclaw cold-start + teardown + a cold gateway). **Launch it in the
+> background and poll, or allow ≥ 60s** — do **not** run it with a ~30s timeout, or the first attempt gets
+> SIGTERM'd mid-teardown. It's safe to kill and re-run (idempotent), but a killed attempt just wastes a
+> round-trip; the confirm step already treats an unreadable `runtime list` as "still live → retry", never
+> as "gone".
+
 Re-runs are idempotent (runtime already gone → skip; already closing/closed → no re-submit). Strategies
 are discovered from `strategy_list` (`skillName==<id>`), so close also cleans up **orphaned** wallets
 that have no runtime. `--instance <name>` scopes an instance (needs its live runtime to map; else omit to close


### PR DESCRIPTION
## What

Docs-only follow-up to #486 (merged). Adds a note to the `senpi-strategy-ops` SKILL.md **Close** section that closing a **live** strategy runs a synchronous runtime teardown and can take **~20-40s** — so agents should launch `close.py <id>` in the background (or allow ≥60s) and poll, not run it with a ~30s timeout.

## Why

Live teardown of `remora` (user M8) SIGTERM'd the **first** `close.py remora` at ~32s: deleting a live runtime tears it down (stop scanner + DSL monitor) before the call returns, so the first close on a running strategy runs ~20-40s (openclaw cold-start + teardown + a cold gateway). The idempotent re-run recovered cleanly (`closing` → `closed`, funds returned — `totalWithdrawn 197.80` of `200`), but the agent burned a killed attempt first because nothing signalled that close can be slow.

This is expected behavior, not a regression — the synchronous teardown is the safety property (stop the runtime before `strategy_close` so it can't re-enter positions). The note just sets the right expectation so agents stop getting SIGTERM'd on the first try.

## Change
- `SKILL.md` Close section — one guidance note (launch async / allow ≥60s; idempotent to kill+re-run).
- Version `2.8.0 → 2.8.1` (patch; docs only).

No code change; 33 gate + 13 pkg tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)