### PR TITLE
strategy-ops: cli_json falls back to stderr (salvaged from #483)

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.8.0"
+  version: "2.9.1"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -56,11 +56,20 @@ def _extract_json(text):
 
 
 def cli_json(args, timeout=60):
-    """Run a CLI command expected to emit JSON on stdout; return the parsed object or None."""
-    rc, out, _err = run_cli(args, timeout)
-    if rc != 0 or not out.strip():
+    """Run a CLI command expected to emit JSON; return the parsed object or None.
+
+    Reads STDOUT first, then falls back to STDERR. `openclaw senpi state --json` exits 0 but
+    writes its payload to stderr while stdout carries only banner/log noise (measured on a live
+    lion deploy: 823B of noise on stdout vs 28,735B of JSON on stderr). Parsing stdout alone
+    therefore returned None for a read that had in fact SUCCEEDED, which permanently hid the rich
+    per-scanner row (runCount / lastAliveAt / lastError / consecutiveErrorCount) that only `state`
+    carries — so `_scanner_verdict` could never reach its downgrade evidence and always fell
+    through to `status`. Fail-open is the right default for liveness, but it should be the
+    fallback, not the only reachable branch."""
+    rc, out, err = run_cli(args, timeout)
+    if rc != 0:
         return None
-    return _extract_json(out)
+    return _extract_json(out) or _extract_json(err)
 
 
 # ---- tolerant extraction ----

--- a/senpi-strategy-ops/tests/test_cli_json.py
+++ b/senpi-strategy-ops/tests/test_cli_json.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""cli_json stream handling.
+
+`openclaw senpi state --json` exits 0 but writes its JSON payload to STDERR while
+stdout carries only banner/log noise. Reading stdout alone returned None for a read
+that had SUCCEEDED — permanently hiding the rich per-scanner row (runCount /
+lastAliveAt / lastError / consecutiveErrorCount) that only `state` carries.
+
+Run:
+    python3 senpi-strategy-ops/tests/test_cli_json.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import _cli  # noqa: E402
+
+# abridged from a live lion deploy (M408027): stdout = banner noise, stderr = the payload
+NOISE = "[openclaw] connecting to gateway…\n[openclaw] senpi state -r lion-main\n"
+PAYLOAD = ('{"states":[{"components":{"scanners":{"state":{"scanners":['
+           '{"scannerId":"lion_scan","runCount":3,"health":"healthy"}]}}}}]}')
+
+
+class CliJsonStreams(unittest.TestCase):
+    def _run(self, rc, out, err):
+        orig = _cli.run_cli
+        _cli.run_cli = lambda *_a, **_k: (rc, out, err)
+        try:
+            return _cli.cli_json(["openclaw", "senpi", "state", "--json"])
+        finally:
+            _cli.run_cli = orig
+
+    def test_payload_on_stdout(self):
+        self.assertIsNotNone(self._run(0, PAYLOAD, ""))
+
+    def test_payload_on_stderr_with_noisy_stdout(self):
+        """The real shape — this returned None before the fix."""
+        got = self._run(0, NOISE, PAYLOAD)
+        self.assertIsNotNone(got, "JSON on stderr must be parsed when stdout has no JSON")
+        scanners = got["states"][0]["components"]["scanners"]["state"]["scanners"]
+        self.assertEqual(scanners[0]["scannerId"], "lion_scan")
+
+    def test_payload_on_stderr_with_empty_stdout(self):
+        self.assertIsNotNone(self._run(0, "", PAYLOAD))
+
+    def test_stdout_wins_when_both_carry_json(self):
+        got = self._run(0, PAYLOAD, '{"states":[{"decoy":true}]}')
+        self.assertNotIn("decoy", got["states"][0])
+
+    def test_nonzero_exit_is_none(self):
+        """A genuine throw stays unreadable — the verdict then fails OPEN, by design."""
+        self.assertIsNone(self._run(1, "", PAYLOAD))
+
+    def test_no_json_anywhere_is_none(self):
+        self.assertIsNone(self._run(0, NOISE, "Error: getSystemState threw"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The one piece of #483 that **#486 did not subsume**. #483 is now closed; this is its salvage, rebased onto current main.

### The bug
`openclaw senpi state --json` **exits 0** but writes its JSON payload to **stderr**, while stdout carries only banner/log noise. Measured on M408027's lion deploy: **823B of noise on stdout vs 28,735B of JSON on stderr.**

`cli_json` read stdout only, so `_extract_json(out)` found nothing and returned `None` — for a read that had actually *succeeded*.

### Why it matters after #486
#486 correctly made `status`/`state` **downgrade-only enrichment** behind a fail-open gate. But `state` is the only source of the rich per-scanner row — `runCount`, `lastAliveAt`, `lastError`, `consecutiveErrorCount`. With it permanently unreadable, `_scanner_verdict` never reaches its downgrade evidence and always falls through to `senpi status`.

Failing open is the right default for a liveness gate. It should be the **fallback**, not the only reachable branch — otherwise verify can never catch a genuinely broken scanner.

### The fix
Try stdout, then stderr. A non-zero exit still returns `None`, so a genuine `getSystemState` throw stays unreadable and the verdict fails open exactly as #486 intends.

```python
rc, out, err = run_cli(args, timeout)
if rc != 0:
    return None
return _extract_json(out) or _extract_json(err)
```

### Verification
6 tests pinned to the real stream shape, including stdout-wins-when-both-carry-JSON and the non-zero-exit fail-open case. The noisy-stdout case returns `None` against `origin/main`.

### Notes
- **Durable fix is runtime-side:** send the `--json` payload to stdout. This is a client-side workaround for a stream-routing bug.
- **Version:** 2.8.0 → **2.9.1**. 2.8.1 is claimed by open #487 and 2.9.0 by open #488, so this takes the next free number to avoid the duplicate-version collision that stranded #482/#483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)