### PR TITLE
strategies: 4 new templates from live user prompts (rooster, ibis, bloodhound, manta)

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.7.0"
+  version: "2.8.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -758,6 +758,56 @@
       "sort_order": 3
     },
     {
+      "id": "bloodhound",
+      "name": "Bloodhound — Chart-Pattern Scanner",
+      "emoji": "🐕",
+      "tagline": "Scans the whole liquid market for the patterns traders actually draw and trades whichever way the pattern points. A double bottom goes long once price reclaims the peak between the two lows; a double top goes short on a break of the trough; intact higher-high or lower-low structure is traded as continuation. Every pattern must clear a depth and magnitude floor so noise can't manufacture one, and each coin+pattern fires at most once per 6 hours.",
+      "belief_plain": "Instead of watching one coin, this hunts the entire liquid market for recognisable chart setups — the double bottom (a W), the double top (an M), and clean staircase trends. It doesn't take the pattern on faith: the two lows have to be at genuinely the same level, the shape has to be deep enough to matter, and price has to actually break the confirmation line before it commits. It has no opinion on direction — if the chart says down, it shorts. And it won't keep re-entering the same setup, because a pattern that's on the chart today is still there tomorrow.",
+      "version": "1.0.0",
+      "thesis": "Pattern recognition is the most common way retail traders actually read a chart, and the catalog had no equivalent — the closest template reads market structure on a single name rather than hunting setups across a universe. The engineering that matters is not finding patterns but refusing bad ones: swing pivots come from a symmetric fractal window (so a pivot needs bars of hindsight on both sides and cannot be invented at the live edge), the two lows of a W must sit within a tolerance of each other and be separated by real time, the shape must clear a depth floor, and continuation structure must STEP by a minimum percent — without that last gate random data produces a clean 'lower low' about half the time. Direction is an output of the pattern, never an input.",
+      "tags": [
+        "pattern",
+        "chart-pattern",
+        "double-bottom",
+        "double-top",
+        "price-action",
+        "technical-analysis",
+        "structure",
+        "higher-high",
+        "scanner",
+        "dynamic-universe",
+        "dedup",
+        "multi-asset",
+        "long-short"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "chart_pattern",
+      "sub_style_label": "Scans for classic chart patterns (double bottom/top, higher-high structure) and trades the direction the pattern points.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 1800,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "main",
+      "sort_order": 4
+    },
+    {
       "id": "caracal",
       "name": "Caracal — Volatility Hedge Fund",
       "emoji": "🐱",
@@ -808,7 +858,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "condor",
@@ -850,7 +900,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "falcon",
@@ -893,7 +943,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 6
+      "sort_order": 7
     },
     {
       "id": "hedgehog",
@@ -942,7 +992,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 7
+      "sort_order": 8
     },
     {
       "id": "hornet",
@@ -1009,7 +1059,56 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
+    },
+    {
+      "id": "ibis",
+      "name": "Ibis — Trend/Range Regime-Switcher",
+      "emoji": "🦤",
+      "tagline": "Two strategies behind one gate. It first decides whether a market is TRENDING or RANGING on the 4-hour chart (Kaufman efficiency ratio + structure), then applies the entry rule that belongs to that regime: a continuation entry when trending — confirmed by RISING open interest, so it only joins moves new money is committing to — or a fade of the range edge when ranging, skipped outright when funding is extreme. In between the two is a deliberate no-trade band. Long & short, 2-5x.",
+      "belief_plain": "Most strategies only work in one kind of market: trend-followers get chopped to pieces in a sideways market, and mean-reverters get run over when a real trend starts. Ibis checks which kind of market it's in before deciding what to do. If price is genuinely travelling in one direction it joins the move — but only if open interest is rising, meaning new money is actually backing it. If price is just bouncing in a range it buys the bottom and sells the top instead — unless funding has gotten extreme, which usually means the range is about to break, in which case it stays out. When it can't tell which regime it's in, it does nothing.",
+      "version": "1.0.0",
+      "thesis": "The regime question comes before the entry question, and most retail strategies never ask it — which is why the same rule that prints in a trend bleeds in chop. The Kaufman efficiency ratio (net move divided by the path actually travelled) separates the two cleanly and cheaply: a directional market covers nearly all of its path, a choppy one retraces itself. Each regime then gets the confirmation that specifically protects it — OI velocity for trend entries, because a breakout on flat OI is short-covering rather than commitment; funding extremes for range fades, because crowded funding precedes the break that kills a fader. The gap between the thresholds is a no-trade band by design: an ambiguous regime gets no rule at all, rather than the closest one.",
+      "tags": [
+        "regime",
+        "regime-switching",
+        "adaptive",
+        "trend",
+        "range",
+        "mean-reversion",
+        "efficiency-ratio",
+        "open-interest",
+        "oi-velocity",
+        "funding",
+        "4h",
+        "multi-asset",
+        "long-short"
+      ],
+      "group": "momentum",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "adaptive",
+      "sub_style_label": "Self-tunes its thresholds from its own track record.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 1800,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "main",
+      "sort_order": 10
     },
     {
       "id": "kingfisher",
@@ -1067,7 +1166,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 11
     },
     {
       "id": "lemur",
@@ -1113,7 +1212,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 12
     },
     {
       "id": "lynx",
@@ -1164,7 +1263,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 13
     },
     {
       "id": "meerkat",
@@ -1208,7 +1307,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 14
     },
     {
       "id": "orca",
@@ -1251,7 +1350,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 15
     },
     {
       "id": "otter",
@@ -1295,7 +1394,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 16
     },
     {
       "id": "piranha",
@@ -1347,7 +1446,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 15
+      "sort_order": 17
     },
     {
       "id": "python",
@@ -1391,7 +1490,55 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 16
+      "sort_order": 18
+    },
+    {
+      "id": "rooster",
+      "name": "Rooster — The Opener",
+      "emoji": "🐓",
+      "tagline": "Trades the clock, not the chart. In the window before a session opens (default 45 minutes, configurable — the knob that matters) it reads how price and volume are setting up: the drift across the window sets direction, expanding volume confirms real positioning, and a break of the prior session's range adds conviction. Carries the position INTO the open, one signal per session, BTC by default at 2-5x with a session-aware DSL ladder.",
+      "belief_plain": "Most of the day is noise. The move that matters often starts setting up in the 30-60 minutes BEFORE a session opens, and by the time the bell rings the direction is already showing. Rooster wakes up in that window, checks whether price is actually drifting one way on real volume (not just wandering on thin trade), and takes the position into the open. It fires at most once per session, banks profit early, and lets go if the open comes and goes with nothing happening.",
+      "version": "1.0.0",
+      "thesis": "Every other template in the catalog reads price; none reads the clock. Session opens are the most reliable recurring liquidity event in any market, and pre-open drift on expanding volume is a genuine directional tell — but only when it clears a noise floor and only when volume confirms it, which is what separates positioning from wandering. Rooster makes the window itself the strategy: outside it the scanner emits nothing and reads nothing (a cheap idle tick), inside it it scores once and commits. The pre-open window, the session times, and the noise floor are all inputs, because the right window is exactly what a user wants to tune.",
+      "tags": [
+        "session",
+        "market-open",
+        "time-of-day",
+        "opener",
+        "pre-open",
+        "clock",
+        "intraday",
+        "btc",
+        "single-asset",
+        "long-short",
+        "beginner"
+      ],
+      "group": "momentum",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "session_open",
+      "sub_style_label": "Positions into a session open on the clock — reads pre-open drift/volume and carries into the open, rather than reacting after.",
+      "asset_classes": [
+        "btc_eth"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "BTC"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "main",
+      "sort_order": 19
     },
     {
       "id": "sailfish",
@@ -1441,7 +1588,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 17
+      "sort_order": 20
     },
     {
       "id": "salamander",
@@ -1491,7 +1638,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 18
+      "sort_order": 21
     },
     {
       "id": "sheep",
@@ -1544,7 +1691,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 19
+      "sort_order": 22
     },
     {
       "id": "jaguar",
@@ -3755,6 +3902,59 @@
       "sort_order": 10
     },
     {
+      "id": "manta",
+      "name": "Manta — Multi-Timeframe Structure (FX)",
+      "emoji": "🐟",
+      "tagline": "Top-down structure trading on FX pairs (EUR / GBP / JPY), the way it's taught: the Daily, 4-hour and 1-hour charts must all agree on trend direction, the 4-hour marks the area price is expected to retest, and the 15-minute times the entry off a break of structure inside that zone. If the timeframes disagree, or price isn't at the level, or there's no 15-minute trigger, it does nothing. Long & short, low leverage scaled to how small FX moves are.",
+      "belief_plain": "This is how structure traders actually read a chart: start wide, then zoom in. First it checks that the Daily, 4-hour and 1-hour charts are all pointing the same way — if they disagree, there's no trade. Then on the 4-hour it marks the zone price is likely to pull back to. Then it waits, on the 15-minute chart, for price to actually reach that zone AND break in the trend direction before entering. Three things have to line up: direction, location, and timing. Miss any one and it stands aside. It trades the major currency pairs, which move in small percentages, so it uses the leverage that matches.",
+      "version": "1.0.0",
+      "thesis": "Multi-timeframe / ICT-style structure trading is one of the largest retail methodologies and the catalog had no expression of it — nor any FX template at all, despite Hyperliquid listing EUR, GBP and JPY. Manta encodes the top-down cascade faithfully: each timeframe answers exactly one question (higher frames = bias, 4h = location, 15m = timing) and is not allowed to answer another, which is the discipline the method is really about. The confluence is mandatory, not additive — a signal requires all three, because a 15m break outside the zone is noise and a zone touch with no break is a falling knife. Thresholds are FX-scaled throughout: a 0.5% daily move is a big FX day, so a crypto-sized structure filter would call every currency chart neutral forever.",
+      "tags": [
+        "fx",
+        "forex",
+        "multi-timeframe",
+        "mtf",
+        "market-structure",
+        "ict",
+        "smc",
+        "top-down",
+        "break-of-structure",
+        "area-of-interest",
+        "eur",
+        "gbp",
+        "jpy",
+        "long-short"
+      ],
+      "group": "single-asset",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "market_structure",
+      "sub_style_label": "Trades SMC/ICT/Wyckoff structure: break-of-structure, liquidity sweeps, fair-value gaps.",
+      "asset_classes": [
+        "fx"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:EUR",
+        "xyz:GBP",
+        "xyz:JPY"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 8,
+      "time_horizon": "swing",
+      "cadence_seconds": 900,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "main",
+      "sort_order": 11
+    },
+    {
       "id": "polar",
       "name": "Polar — ETH Alpha Hunter",
       "emoji": "🧊",
@@ -3796,7 +3996,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "ram",
@@ -3840,7 +4040,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "stag",
@@ -3888,7 +4088,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "wolverine",
@@ -3933,7 +4133,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "hydra",

--- a/senpi-strategy-discover/references/glossary.yaml
+++ b/senpi-strategy-discover/references/glossary.yaml
@@ -94,6 +94,8 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   pullback:      { gloss: "Buys the dip within an uptrend." }
   mean_reversion: { gloss: "Buys oversold / sells overbought, betting price reverts to its mean (works in chop, not just trends)." }
   market_structure: { gloss: "Trades SMC/ICT/Wyckoff structure: break-of-structure, liquidity sweeps, fair-value gaps." }
+  chart_pattern: { gloss: "Scans for classic chart patterns (double bottom/top, higher-high structure) and trades the direction the pattern points." }
+  session_open: { gloss: "Positions into a session open on the clock — reads pre-open drift/volume and carries into the open, rather than reacting after." }
   rank_jump:     { gloss: "Catches leaderboard rank-jumps early." }
   momentum_event: { gloss: "Snipes fresh momentum events the instant they fire." }
   liquidation_cascade: { gloss: "Rides liquidation cascades / forced flow." }

--- a/strategies/bloodhound/main/runtime.yaml
+++ b/strategies/bloodhound/main/runtime.yaml
@@ -1,0 +1,152 @@
+# ── BLOODHOUND · single instance — Chart-Pattern Scanner ─────────────────────
+# Scans a dynamic universe for the patterns retail traders actually draw — double
+# bottoms, double tops, and intact higher-high / lower-low structure — and trades
+# whichever direction the pattern points. Direction is never a preference here.
+name: bloodhound-main
+group: bloodhound
+version: 1.0.0
+description: >
+  BLOODHOUND — Chart-Pattern Scanner. Derives a liquid universe from live instruments,
+  then hunts each name's 1h chart for a recognisable setup. Swing pivots are found with a
+  symmetric fractal window, and from those: a DOUBLE BOTTOM (two lows at the same level
+  with a peak between) goes LONG once price closes back above that peak; a DOUBLE TOP
+  goes SHORT on a close below the intervening trough; intact HIGHER-HIGH / HIGHER-LOW
+  structure is a long continuation and LOWER-LOW / LOWER-HIGH a short one. Every pattern
+  must clear a depth floor and a magnitude floor so noise cannot manufacture one, volume
+  expansion and 4h trend agreement add conviction, and each coin+pattern fires at most
+  once per TTL. Long & short, 2-5x, DSL-only exits.
+
+strategy:
+  wallet: "${BLOODHOUND_WALLET}"
+  slots: 3
+  margin_pct: 10                          # baseline %; scan emits the conviction-tier marginPct per signal
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: bloodhound_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 1800                 # 30m on a 1h primary. A pattern that is real at 12:00
+                                           # is still real at 12:30 — scanning faster buys nothing
+                                           # but fees.
+    timeout_seconds: 240                   # instruments + candles per universe name
+    default_signal_validity_seconds: 3600  # 2x tick
+    state_history_max_count: 150           # dedup ledger + per-tick scan-results history
+    inputs:
+      universeVolFloorUsd: 20000000        # $20M+ 24h notional
+      maxUniverseNames: 25
+      includeXyz: false                    # true also hunts patterns on xyz: equities/commodities
+      excludeAssets: ["USDC", "USDT"]
+      primaryInterval: "1h"                # the chart the patterns are drawn on
+      minScore: 6
+      marginPctBase: 10                    # PERCENT of withdrawable (0,100]; tiered x1.25 / x1.5
+      maxSlots: 3
+      leverageDefault: 3
+      leverageMin: 2
+      leverageMax: 5
+      signalTtlSeconds: 21600              # 6h — a pattern stays on the chart; fire it ONCE
+      # ── pattern geometry ──
+      pivotWindow: 2                       # k-bar fractal: a pivot needs k bars either side
+      minCandles: 40
+      levelTolerancePct: 1.8               # how close two lows must be to count as "the same level"
+      minPivotSeparation: 4                # bars between the two tests — closer is one event, not two
+      maxPatternAgeBars: 14                # older than this and the setup has moved on
+      minPatternDepthPct: 2.0              # shallower than this is noise, not a pattern
+      goodDepthPct: 4.0
+      minStructureMovePct: 1.5             # continuation structure must STEP by this much. Without
+                                           # it, random data produces "lower lows" about half the
+                                           # time (measured: 0/200 false positives with it on).
+      requireConfirmed: true               # only trade the neckline break, never the anticipation
+      minVolumeRatio: 1.15
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      pattern: { type: string }
+      confirmed: { type: boolean, required: false }
+      depthPct: { type: number, required: false }
+      neckline: { type: number, required: false }
+      volRatio: { type: number, required: false }
+      trend4h: { type: string, required: false }
+      reasons: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: bloodhound_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already found, confirmed and deduped the pattern
+    scanners: [bloodhound_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # a neckline break is a fast move; a resting maker order
+                                           # misses exactly the fill the pattern predicted
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: bloodhound_main_signals
+
+# ── EXIT (DSL — pattern-target ladder) ───────────────────────────────────────
+# A completed pattern has a measured move, and most of it arrives early — so this locks
+# sooner than a trend-rider, then widens for the ones that keep going. Time-cuts off;
+# weak_peak_cut releases a "confirmed" break that immediately did nothing, which is the
+# most common way a pattern trade fails.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 480
+    weak_peak_cut:
+      enabled: true                        # the break failed to follow through -> release it
+      interval_in_minutes: 90
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 16.0                   # a failed pattern invalidates fast — the neckline is right there
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 7, lock_hw_pct: 0 }
+        - { trigger_pct: 13, lock_hw_pct: 30 }
+        - { trigger_pct: 22, lock_hw_pct: 50 }
+        - { trigger_pct: 36, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+
+# ── RISK guard rails (moderate) ──
+risk:
+  data_retention_seconds: 259200           # 72h
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 4                  # a scanner over 25 names must not open all day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 3600
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 21600       # 6h — matches the pattern dedup TTL
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/bloodhound/main/scanners/scan.py
+++ b/strategies/bloodhound/main/scanners/scan.py
@@ -1,0 +1,222 @@
+"""BLOODHOUND — supervised scanner: chart-pattern recognition across a dynamic universe.
+
+Per tick:
+  - reads account + held positions (dual-DEX equity via max(), never sum; corrupt-read guard),
+  - derives the universe from LIVE `market_list_instruments` (notional-volume floor + top-N),
+    routing by name prefix because dex="" returns BOTH sub-DEXes,
+  - fetches 1h + 4h candles per candidate and runs pure `scoring.build_thesis` — double
+    bottom / double top / higher-high / lower-low, scored on confirmation, volume and depth,
+  - DEDUPES: one signal per coin per pattern per TTL, so a pattern that stays on the chart for
+    a day does not re-fire every tick. (Explicitly requested; also what stops a pattern scanner
+    from turning into a fee pump.)
+
+Read-only + single-pass. Emits a `marginPct` INTENT (PERCENT in (0,100]) + `leverage`.
+Candle values are strings keyed o/h/l/c/v — scoring._close/_f coerce.
+
+Direction comes from the pattern, never from a preference — a double top shorts, a double
+bottom longs, and the scanner has no view of its own.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_EXCLUDE = ["USDC", "USDT"]
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position dicts]) — dual-DEX equity via max() (never sum: two views of ONE
+    cross-margined wallet), positions enumerated across BOTH sub-DEX sections. Read-guarded."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the tick
+        print(f"[bloodhound.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)), abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""), "margin": scoring._f(pos.get("marginUsed", 0))})
+    if used > 1.0 and not positions:
+        print("[bloodhound.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _instruments(ctx, dex):
+    try:
+        raw = ctx.senpi_mcp.call_tool("market_list_instruments", {"dex": dex})
+    except Exception as exc:  # noqa: BLE001
+        print(f"[bloodhound.scan] market_list_instruments(dex={dex!r}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    d = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(d, dict):
+        d = d.get("instruments", d.get("universe", d.get("markets", [])))
+    return d if isinstance(d, list) else None
+
+
+def _derive_universe(ctx, inputs):
+    """[name] over the notional-volume floor, top-N by volume.
+
+    `market_list_instruments` with dex="" returns BOTH sub-DEXes and carries NO dex field — the
+    `xyz:` name prefix is the only discriminator — so names are routed by prefix and deduped on
+    the bare ticker across both pools.
+    """
+    vol_floor = float(inputs.get("universeVolFloorUsd", 20_000_000))
+    max_names = int(inputs.get("maxUniverseNames", 25))
+    include_xyz = bool(inputs.get("includeXyz", False))
+    exclude = {str(x).upper() for x in (inputs.get("excludeAssets") or _DEFAULT_EXCLUDE)}
+
+    rows = _instruments(ctx, "")
+    if rows is None:
+        return None
+    seen, out = set(), []
+    for r in rows:
+        if not isinstance(r, dict) or r.get("is_delisted"):
+            continue
+        name = str(r.get("name") or r.get("coin") or "").strip()
+        if not name:
+            continue
+        if name.lower().startswith("xyz:") and not include_xyz:
+            continue
+        bare = name.split(":", 1)[-1].upper()
+        if bare in seen or bare in exclude:
+            continue
+        seen.add(bare)
+        c = r.get("context", {}) if isinstance(r.get("context"), dict) else {}
+        vol = scoring._f(c.get("dayNtlVlm"))
+        if vol < vol_floor:
+            continue
+        out.append((name, vol))
+    out.sort(key=lambda t: t[1], reverse=True)
+    return [n for n, _ in out[:max_names]]
+
+
+def _candles(ctx, coin, primary):
+    """{primary:[...], '4h':[...]} for `coin` or None. Read-guarded."""
+    intervals = [primary] if primary == "4h" else [primary, "4h"]
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin, "candle_intervals": intervals,
+            "include_funding": False, "include_order_book": False, "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[bloodhound.scan] market_get_asset_data({coin}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md or (isinstance(md, dict) and md.get("success") is False):
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    return d.get("candles", {}) if isinstance(d, dict) else None
+
+
+def _load_signaled(ctx):
+    """{'COIN:pattern': ts} — the dedup ledger."""
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    sig = (ctx.state.last() or {}).get("signaled", {})
+    return dict(sig) if isinstance(sig, dict) else {}
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    primary = str(inputs.get("primaryInterval", "1h"))
+    min_score = float(inputs.get("minScore", 6))
+    base_margin_pct = float(inputs.get("marginPctBase", 10))   # PERCENT in (0,100]
+    max_slots = int(inputs.get("maxSlots", 3))
+    lev_default = int(inputs.get("leverageDefault", 3))
+    lev_min = int(inputs.get("leverageMin", 2))
+    lev_max = int(inputs.get("leverageMax", 5))
+    ttl = float(inputs.get("signalTtlSeconds", 21600))         # 6h: a pattern persists on the chart
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[bloodhound.scan] WAITING — no account value / corrupt read", file=sys.stderr)
+        return []
+    held = {p["coin"].split(":", 1)[-1].upper() for p in positions if p.get("coin")}
+    open_slots = max_slots - len(held)
+
+    signaled = {k: v for k, v in _load_signaled(ctx).items() if (now - v) < ttl * 4}
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"signaled": signaled, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[bloodhound.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    if open_slots <= 0:
+        print(f"[bloodhound.scan] slots full ({len(held)}/{max_slots}) — DSL manages exits",
+              file=sys.stderr)
+        _persist({"ts": now, "scanned": 0, "emitted": 0, "note": "slots full"})
+        return []
+
+    universe = _derive_universe(ctx, inputs)
+    if universe is None:
+        print("[bloodhound.scan] instruments unreadable — skipping tick", file=sys.stderr)
+        return []
+
+    candidates, scanned, patterns = [], 0, {}
+    for coin in universe:
+        bare = coin.split(":", 1)[-1].upper()
+        if bare in held:
+            continue
+        scanned += 1
+        candles = _candles(ctx, coin, primary)
+        if not candles:
+            continue
+        th = scoring.build_thesis(coin, candles.get(primary, []), candles.get("4h", []), inputs)
+        if not th or th["score"] < min_score:
+            continue
+        patterns[th["pattern"]] = patterns.get(th["pattern"], 0) + 1
+        if (now - signaled.get(f"{bare}:{th['pattern']}", 0)) < ttl:
+            continue                                  # same pattern, same coin, still inside TTL
+        candidates.append(th)
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    leverage = max(lev_min, min(lev_default, lev_max))
+    out = []
+    for th in candidates[:open_slots]:
+        margin_pct = round(scoring.margin_tier_pct(th["score"], base_margin_pct), 4)
+        signaled[f"{th['coin'].split(':', 1)[-1].upper()}:{th['pattern']}"] = now
+        out.append({
+            "asset": th["coin"],
+            "direction": th["direction"],
+            "marginPct": margin_pct,      # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,
+            "data": {
+                "score": th["score"], "leverage": leverage, "direction": th["direction"],
+                "pattern": th["pattern"], "confirmed": th["confirmed"],
+                "depthPct": th["depth_pct"], "neckline": th["neckline"],
+                "volRatio": th["vol_ratio"], "trend4h": th["trend_4h"],
+                "reasons": th["reasons"][:8], "heldAssets": sorted(held),
+            },
+        })
+
+    print(f"[bloodhound.scan] {'EMIT' if out else 'WAITING'} universe={len(universe)} "
+          f"scanned={scanned} patterns={patterns or '{}'} emitted={len(out)} "
+          f"min_score={min_score:.0f} held={sorted(held)}", file=sys.stderr)
+    _persist({"ts": now, "scanned": scanned, "emitted": len(out), "patterns": patterns,
+              "universe": len(universe)})
+    return out

--- a/strategies/bloodhound/main/scanners/scoring.py
+++ b/strategies/bloodhound/main/scanners/scoring.py
@@ -1,0 +1,302 @@
+"""BLOODHOUND — pure thesis math: chart-pattern recognition (no I/O, no MCP, no clock).
+
+Finds the patterns retail traders actually draw, on whatever the market is currently showing:
+
+  DOUBLE BOTTOM (W)  two swing lows at a similar level with a peak between them. LONG once
+                     price closes back above that peak (the neckline). The second low holding
+                     where the first one did is the evidence that sellers are done.
+  DOUBLE TOP (M)     the mirror. SHORT on a close below the intervening trough.
+  HIGHER HIGH / LOW  an intact uptrend structure — each swing high above the last AND each
+                     swing low above the last. LONG continuation.
+  LOWER LOW / HIGH   the mirror. SHORT continuation.
+
+Everything is built on SWING PIVOTS found with a symmetric fractal window: a bar is a swing
+high if its high is the maximum of the `k` bars either side of it. A pivot therefore needs `k`
+bars of hindsight to exist, which is exactly why patterns are only ever confirmed late — the
+alternative is inventing pivots out of noise.
+
+Pure + single-pass + unit-testable on plain candle lists. Candles are keyed o/h/l/c/v with
+STRING values — `_f`/`_close` coerce both shapes.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── swing pivots ─────────────────────────────────────────────────────────────
+
+def _push(pivots, idx, price, k, keep_max):
+    """Append a pivot, COLLAPSING a plateau into one point.
+
+    A flat top (two or more bars at the same extreme) satisfies the `>=` fractal test on EVERY
+    bar of the run, so a naive append records the same pivot twice. The last two entries are
+    then duplicates of each other, every higher-high / double-bottom comparison sees a 0% step,
+    and the strategy silently never trades. Collapse anything within `k` bars of the previous
+    pivot into the more extreme of the two.
+    """
+    if pivots and idx - pivots[-1][0] <= k:
+        if (keep_max and price >= pivots[-1][1]) or (not keep_max and price <= pivots[-1][1]):
+            pivots[-1] = (idx, price)
+        return
+    pivots.append((idx, price))
+
+
+def swing_points(candles, k=2):
+    """([(idx, price)] highs, [(idx, price)] lows) using a symmetric k-bar fractal window.
+
+    A pivot is only recognised once `k` bars have printed after it — patterns are confirmed
+    late by construction, which is the honest behaviour. Bars within `k` of either end can
+    never qualify.
+    """
+    highs, lows = [], []
+    n = len(candles)
+    if n < 2 * k + 1 or k < 1:
+        return highs, lows
+    for i in range(k, n - k):
+        h = _high(candles[i])
+        lo = _low(candles[i])
+        window = range(i - k, i + k + 1)
+        if all(h >= _high(candles[j]) for j in window) and \
+                any(h > _high(candles[j]) for j in window if j != i):
+            _push(highs, i, h, k, keep_max=True)
+        if all(lo <= _low(candles[j]) for j in window) and \
+                any(lo < _low(candles[j]) for j in window if j != i):
+            _push(lows, i, lo, k, keep_max=False)
+    return highs, lows
+
+
+def _pct_apart(a, b):
+    """|a-b| as a percent of the mean. Used to decide whether two pivots are 'the same level'."""
+    m = (abs(a) + abs(b)) / 2.0
+    return 0.0 if m <= 0 else abs(a - b) / m * 100.0
+
+
+# ── the patterns ─────────────────────────────────────────────────────────────
+
+def double_bottom(candles, highs, lows, inputs):
+    """W. Returns dict or None. `confirmed` = price has closed back above the neckline."""
+    tol = float(inputs.get("levelTolerancePct", 1.8))
+    min_sep = int(inputs.get("minPivotSeparation", 4))
+    max_age = int(inputs.get("maxPatternAgeBars", 14))
+
+    if len(lows) < 2 or not highs:
+        return None
+    (i1, l1), (i2, l2) = lows[-2], lows[-1]
+    if i2 - i1 < min_sep:
+        return None                                   # too close together to be two distinct tests
+    if _pct_apart(l1, l2) > tol:
+        return None                                   # not the same level
+    necks = [(i, h) for i, h in highs if i1 < i < i2]
+    if not necks:
+        return None                                   # no peak between the two lows -> not a W
+    ni, neck = max(necks, key=lambda t: t[1])
+    if len(candles) - 1 - i2 > max_age:
+        return None                                   # stale — the setup has moved on
+    last = _close(candles[-1])
+    depth_pct = (neck - min(l1, l2)) / neck * 100.0 if neck > 0 else 0.0
+    if depth_pct < float(inputs.get("minPatternDepthPct", 2.0)):
+        return None                                   # too shallow to be a pattern rather than noise
+    return {"pattern": "double_bottom", "direction": "LONG", "neckline": neck,
+            "confirmed": last > neck, "depth_pct": depth_pct,
+            "levels": [l1, l2], "neck_idx": ni, "second_idx": i2}
+
+
+def double_top(candles, highs, lows, inputs):
+    """M — the mirror of double_bottom."""
+    tol = float(inputs.get("levelTolerancePct", 1.8))
+    min_sep = int(inputs.get("minPivotSeparation", 4))
+    max_age = int(inputs.get("maxPatternAgeBars", 14))
+
+    if len(highs) < 2 or not lows:
+        return None
+    (i1, h1), (i2, h2) = highs[-2], highs[-1]
+    if i2 - i1 < min_sep:
+        return None
+    if _pct_apart(h1, h2) > tol:
+        return None
+    troughs = [(i, l) for i, l in lows if i1 < i < i2]
+    if not troughs:
+        return None
+    ni, neck = min(troughs, key=lambda t: t[1])
+    if len(candles) - 1 - i2 > max_age:
+        return None
+    last = _close(candles[-1])
+    depth_pct = (max(h1, h2) - neck) / neck * 100.0 if neck > 0 else 0.0
+    if depth_pct < float(inputs.get("minPatternDepthPct", 2.0)):
+        return None
+    return {"pattern": "double_top", "direction": "SHORT", "neckline": neck,
+            "confirmed": last < neck, "depth_pct": depth_pct,
+            "levels": [h1, h2], "neck_idx": ni, "second_idx": i2}
+
+
+def structure_trend(highs, lows, min_move_pct=1.5):
+    """Higher-high/higher-low or lower-low/lower-high structure. Returns dict or None.
+
+    Two requirements, both of which exist to keep noise out:
+      1. BOTH series must agree. Rising highs on falling lows is a broadening pattern, not an
+         uptrend, and treating it as one is how a scanner buys into a widening mess.
+      2. The step must CLEAR `min_move_pct`. On random data consecutive pivots are descending
+         about half the time by chance, so without a magnitude floor this fires on anything —
+         measured on synthetic noise, which produced a clean `lower_low` before this gate.
+    """
+    if len(highs) < 2 or len(lows) < 2:
+        return None
+    h_step = _pct_apart(highs[-1][1], highs[-2][1])
+    l_step = _pct_apart(lows[-1][1], lows[-2][1])
+    if h_step < min_move_pct or l_step < min_move_pct:
+        return None
+    hh = highs[-1][1] > highs[-2][1]
+    hl = lows[-1][1] > lows[-2][1]
+    ll = lows[-1][1] < lows[-2][1]
+    lh = highs[-1][1] < highs[-2][1]
+    depth = min(h_step, l_step)
+    if hh and hl:
+        return {"pattern": "higher_high", "direction": "LONG", "confirmed": True,
+                "neckline": highs[-2][1], "depth_pct": depth, "levels": [],
+                "second_idx": highs[-1][0]}
+    if ll and lh:
+        return {"pattern": "lower_low", "direction": "SHORT", "confirmed": True,
+                "neckline": lows[-2][1], "depth_pct": depth, "levels": [],
+                "second_idx": lows[-1][0]}
+    return None
+
+
+def volume_confirms(candles, pattern_idx, bars=3, baseline=12):
+    """Did volume expand on the bars that formed/broke the pattern? Ratio vs baseline (0.0 = unknown)."""
+    if pattern_idx is None or len(candles) < baseline + bars:
+        return 0.0
+    recent = [_vol(c) for c in candles[-bars:]]
+    base = [_vol(c) for c in candles[-(baseline + bars):-bars]]
+    bm = sum(base) / len(base) if base else 0.0
+    if bm <= 0:
+        return 0.0
+    return (sum(recent) / len(recent)) / bm
+
+
+def trend_structure_4h(candles, bars=6):
+    """('UP'|'DOWN'|'NEUTRAL') on the higher timeframe — context only."""
+    if len(candles) < bars:
+        return "NEUTRAL"
+    highs = [_high(c) for c in candles[-bars:]]
+    lows = [_low(c) for c in candles[-bars:]]
+    up = sum(1 for i in range(1, len(highs)) if highs[i] > highs[i - 1])
+    down = sum(1 for i in range(1, len(lows)) if lows[i] < lows[i - 1])
+    n = len(highs) - 1
+    if up >= n * 0.6:
+        return "UP"
+    if down >= n * 0.6:
+        return "DOWN"
+    return "NEUTRAL"
+
+
+# ── the thesis ───────────────────────────────────────────────────────────────
+
+def build_thesis(coin, candles, candles_4h, inputs):
+    """Best pattern on `candles`, scored. Returns a thesis dict or None.
+
+    Scoring (max 9):
+      +5  confirmed reversal pattern (double bottom/top, neckline broken)
+      +3  unconfirmed reversal still forming, or a continuation structure
+      +2  volume expansion on the pattern
+      +2  pattern depth is meaningful
+      +1  higher-timeframe trend agrees   (-1 if it opposes)
+    """
+    k = int(inputs.get("pivotWindow", 2))
+    min_vol_ratio = float(inputs.get("minVolumeRatio", 1.15))
+    require_confirmed = bool(inputs.get("requireConfirmed", True))
+    good_depth = float(inputs.get("goodDepthPct", 4.0))
+
+    if len(candles) < int(inputs.get("minCandles", 40)):
+        return None
+    highs, lows = swing_points(candles, k)
+
+    found = [p for p in (double_bottom(candles, highs, lows, inputs),
+                         double_top(candles, highs, lows, inputs)) if p]
+    if not found:
+        st = structure_trend(highs, lows, float(inputs.get("minStructureMovePct", 1.5)))
+        if st:
+            found = [st]
+    if not found:
+        return None
+
+    # A confirmed reversal outranks a continuation structure.
+    found.sort(key=lambda p: (p["confirmed"], p["depth_pct"]), reverse=True)
+    pat = found[0]
+    if require_confirmed and not pat["confirmed"]:
+        return None
+
+    is_reversal = pat["pattern"] in ("double_bottom", "double_top")
+    score = 5 if (is_reversal and pat["confirmed"]) else 3
+    reasons = [f"{pat['pattern'].replace('_', ' ')} "
+               f"{'confirmed (neckline broken)' if pat['confirmed'] else 'forming'}"]
+
+    vr = volume_confirms(candles, pat.get("second_idx"))
+    if vr >= min_vol_ratio:
+        score += 2
+        reasons.append(f"volume {vr:.2f}x baseline on the pattern")
+    else:
+        reasons.append(f"volume only {vr:.2f}x baseline")
+
+    if pat["depth_pct"] >= good_depth:
+        score += 2
+        reasons.append(f"pattern depth {pat['depth_pct']:.1f}%")
+    elif is_reversal:
+        reasons.append(f"shallow pattern ({pat['depth_pct']:.1f}%)")
+
+    t4 = trend_structure_4h(candles_4h)
+    if (t4 == "UP" and pat["direction"] == "LONG") or (t4 == "DOWN" and pat["direction"] == "SHORT"):
+        score += 1
+        reasons.append(f"4h trend {t4} agrees")
+    elif t4 != "NEUTRAL":
+        score -= 1
+        reasons.append(f"4h trend {t4} opposes")
+
+    return {"coin": coin, "direction": pat["direction"], "score": max(0, score),
+            "pattern": pat["pattern"], "confirmed": pat["confirmed"],
+            "depth_pct": round(pat["depth_pct"], 3), "neckline": round(pat["neckline"], 8),
+            "vol_ratio": round(vr, 3), "trend_4h": t4, "reasons": reasons}
+
+
+def margin_tier_pct(score, base_pct):
+    """Conviction sizing on the PERCENT scale (base_pct is a PERCENT in (0,100])."""
+    if score >= 8:
+        return base_pct * 1.5
+    if score >= 6:
+        return base_pct * 1.25
+    return base_pct

--- a/strategies/bloodhound/strategy.yaml
+++ b/strategies/bloodhound/strategy.yaml
@@ -1,0 +1,40 @@
+# Bloodhound — Chart-Pattern Scanner. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. Hunts a dynamic universe for double bottoms,
+# double tops and trend structure. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: bloodhound
+
+version: "1.0.0"
+
+catalog:
+  name: "Bloodhound — Chart-Pattern Scanner"
+  emoji: "🐕"
+  tagline: "Scans the whole liquid market for the patterns traders actually draw and trades whichever way the pattern points. A double bottom goes long once price reclaims the peak between the two lows; a double top goes short on a break of the trough; intact higher-high or lower-low structure is traded as continuation. Every pattern must clear a depth and magnitude floor so noise can't manufacture one, and each coin+pattern fires at most once per 6 hours."
+  belief_plain: "Instead of watching one coin, this hunts the entire liquid market for recognisable chart setups — the double bottom (a W), the double top (an M), and clean staircase trends. It doesn't take the pattern on faith: the two lows have to be at genuinely the same level, the shape has to be deep enough to matter, and price has to actually break the confirmation line before it commits. It has no opinion on direction — if the chart says down, it shorts. And it won't keep re-entering the same setup, because a pattern that's on the chart today is still there tomorrow."
+  thesis: "Pattern recognition is the most common way retail traders actually read a chart, and the catalog had no equivalent — the closest template reads market structure on a single name rather than hunting setups across a universe. The engineering that matters is not finding patterns but refusing bad ones: swing pivots come from a symmetric fractal window (so a pivot needs bars of hindsight on both sides and cannot be invented at the live edge), the two lows of a W must sit within a tolerance of each other and be separated by real time, the shape must clear a depth floor, and continuation structure must STEP by a minimum percent — without that last gate random data produces a clean 'lower low' about half the time. Direction is an output of the pattern, never an input."
+  group: momentum
+  archetype: breakout_momentum
+  sub_style: chart_pattern
+  asset_classes: [btc_eth, major_alts, universe_crypto]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: starter
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 3
+  min_budget: 200
+  tags: [pattern, chart-pattern, double-bottom, double-top, price-action, technical-analysis, structure, higher-high, scanner, dynamic-universe, dedup, multi-asset, long-short]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: BLOODHOUND_WALLET
+    funding_share: 1.0

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -758,6 +758,56 @@
       "sort_order": 3
     },
     {
+      "id": "bloodhound",
+      "name": "Bloodhound — Chart-Pattern Scanner",
+      "emoji": "🐕",
+      "tagline": "Scans the whole liquid market for the patterns traders actually draw and trades whichever way the pattern points. A double bottom goes long once price reclaims the peak between the two lows; a double top goes short on a break of the trough; intact higher-high or lower-low structure is traded as continuation. Every pattern must clear a depth and magnitude floor so noise can't manufacture one, and each coin+pattern fires at most once per 6 hours.",
+      "belief_plain": "Instead of watching one coin, this hunts the entire liquid market for recognisable chart setups — the double bottom (a W), the double top (an M), and clean staircase trends. It doesn't take the pattern on faith: the two lows have to be at genuinely the same level, the shape has to be deep enough to matter, and price has to actually break the confirmation line before it commits. It has no opinion on direction — if the chart says down, it shorts. And it won't keep re-entering the same setup, because a pattern that's on the chart today is still there tomorrow.",
+      "version": "1.0.0",
+      "thesis": "Pattern recognition is the most common way retail traders actually read a chart, and the catalog had no equivalent — the closest template reads market structure on a single name rather than hunting setups across a universe. The engineering that matters is not finding patterns but refusing bad ones: swing pivots come from a symmetric fractal window (so a pivot needs bars of hindsight on both sides and cannot be invented at the live edge), the two lows of a W must sit within a tolerance of each other and be separated by real time, the shape must clear a depth floor, and continuation structure must STEP by a minimum percent — without that last gate random data produces a clean 'lower low' about half the time. Direction is an output of the pattern, never an input.",
+      "tags": [
+        "pattern",
+        "chart-pattern",
+        "double-bottom",
+        "double-top",
+        "price-action",
+        "technical-analysis",
+        "structure",
+        "higher-high",
+        "scanner",
+        "dynamic-universe",
+        "dedup",
+        "multi-asset",
+        "long-short"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "chart_pattern",
+      "sub_style_label": "Scans for classic chart patterns (double bottom/top, higher-high structure) and trades the direction the pattern points.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 1800,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "main",
+      "sort_order": 4
+    },
+    {
       "id": "caracal",
       "name": "Caracal — Volatility Hedge Fund",
       "emoji": "🐱",
@@ -808,7 +858,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 4
+      "sort_order": 5
     },
     {
       "id": "condor",
@@ -850,7 +900,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 5
+      "sort_order": 6
     },
     {
       "id": "falcon",
@@ -893,7 +943,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 6
+      "sort_order": 7
     },
     {
       "id": "hedgehog",
@@ -942,7 +992,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 7
+      "sort_order": 8
     },
     {
       "id": "hornet",
@@ -1009,7 +1059,56 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
+    },
+    {
+      "id": "ibis",
+      "name": "Ibis — Trend/Range Regime-Switcher",
+      "emoji": "🦤",
+      "tagline": "Two strategies behind one gate. It first decides whether a market is TRENDING or RANGING on the 4-hour chart (Kaufman efficiency ratio + structure), then applies the entry rule that belongs to that regime: a continuation entry when trending — confirmed by RISING open interest, so it only joins moves new money is committing to — or a fade of the range edge when ranging, skipped outright when funding is extreme. In between the two is a deliberate no-trade band. Long & short, 2-5x.",
+      "belief_plain": "Most strategies only work in one kind of market: trend-followers get chopped to pieces in a sideways market, and mean-reverters get run over when a real trend starts. Ibis checks which kind of market it's in before deciding what to do. If price is genuinely travelling in one direction it joins the move — but only if open interest is rising, meaning new money is actually backing it. If price is just bouncing in a range it buys the bottom and sells the top instead — unless funding has gotten extreme, which usually means the range is about to break, in which case it stays out. When it can't tell which regime it's in, it does nothing.",
+      "version": "1.0.0",
+      "thesis": "The regime question comes before the entry question, and most retail strategies never ask it — which is why the same rule that prints in a trend bleeds in chop. The Kaufman efficiency ratio (net move divided by the path actually travelled) separates the two cleanly and cheaply: a directional market covers nearly all of its path, a choppy one retraces itself. Each regime then gets the confirmation that specifically protects it — OI velocity for trend entries, because a breakout on flat OI is short-covering rather than commitment; funding extremes for range fades, because crowded funding precedes the break that kills a fader. The gap between the thresholds is a no-trade band by design: an ambiguous regime gets no rule at all, rather than the closest one.",
+      "tags": [
+        "regime",
+        "regime-switching",
+        "adaptive",
+        "trend",
+        "range",
+        "mean-reversion",
+        "efficiency-ratio",
+        "open-interest",
+        "oi-velocity",
+        "funding",
+        "4h",
+        "multi-asset",
+        "long-short"
+      ],
+      "group": "momentum",
+      "archetype": "trend_following",
+      "archetype_label": "Trend-Follower",
+      "sub_style": "adaptive",
+      "sub_style_label": "Self-tunes its thresholds from its own track record.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 1800,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 3,
+      "branch": "main",
+      "sort_order": 10
     },
     {
       "id": "kingfisher",
@@ -1067,7 +1166,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 11
     },
     {
       "id": "lemur",
@@ -1113,7 +1212,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 12
     },
     {
       "id": "lynx",
@@ -1164,7 +1263,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 13
     },
     {
       "id": "meerkat",
@@ -1208,7 +1307,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 14
     },
     {
       "id": "orca",
@@ -1251,7 +1350,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 15
     },
     {
       "id": "otter",
@@ -1295,7 +1394,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 16
     },
     {
       "id": "piranha",
@@ -1347,7 +1446,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 15
+      "sort_order": 17
     },
     {
       "id": "python",
@@ -1391,7 +1490,55 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 16
+      "sort_order": 18
+    },
+    {
+      "id": "rooster",
+      "name": "Rooster — The Opener",
+      "emoji": "🐓",
+      "tagline": "Trades the clock, not the chart. In the window before a session opens (default 45 minutes, configurable — the knob that matters) it reads how price and volume are setting up: the drift across the window sets direction, expanding volume confirms real positioning, and a break of the prior session's range adds conviction. Carries the position INTO the open, one signal per session, BTC by default at 2-5x with a session-aware DSL ladder.",
+      "belief_plain": "Most of the day is noise. The move that matters often starts setting up in the 30-60 minutes BEFORE a session opens, and by the time the bell rings the direction is already showing. Rooster wakes up in that window, checks whether price is actually drifting one way on real volume (not just wandering on thin trade), and takes the position into the open. It fires at most once per session, banks profit early, and lets go if the open comes and goes with nothing happening.",
+      "version": "1.0.0",
+      "thesis": "Every other template in the catalog reads price; none reads the clock. Session opens are the most reliable recurring liquidity event in any market, and pre-open drift on expanding volume is a genuine directional tell — but only when it clears a noise floor and only when volume confirms it, which is what separates positioning from wandering. Rooster makes the window itself the strategy: outside it the scanner emits nothing and reads nothing (a cheap idle tick), inside it it scores once and commits. The pre-open window, the session times, and the noise floor are all inputs, because the right window is exactly what a user wants to tune.",
+      "tags": [
+        "session",
+        "market-open",
+        "time-of-day",
+        "opener",
+        "pre-open",
+        "clock",
+        "intraday",
+        "btc",
+        "single-asset",
+        "long-short",
+        "beginner"
+      ],
+      "group": "momentum",
+      "archetype": "single_market",
+      "archetype_label": "Single-Market Specialist",
+      "sub_style": "session_open",
+      "sub_style_label": "Positions into a session open on the clock — reads pre-open drift/volume and carries into the open, rather than reacting after.",
+      "asset_classes": [
+        "btc_eth"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "BTC"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "starter",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 100,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 1,
+      "branch": "main",
+      "sort_order": 19
     },
     {
       "id": "sailfish",
@@ -1441,7 +1588,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 17
+      "sort_order": 20
     },
     {
       "id": "salamander",
@@ -1491,7 +1638,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 18
+      "sort_order": 21
     },
     {
       "id": "sheep",
@@ -1544,7 +1691,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 19
+      "sort_order": 22
     },
     {
       "id": "jaguar",
@@ -3755,6 +3902,59 @@
       "sort_order": 10
     },
     {
+      "id": "manta",
+      "name": "Manta — Multi-Timeframe Structure (FX)",
+      "emoji": "🐟",
+      "tagline": "Top-down structure trading on FX pairs (EUR / GBP / JPY), the way it's taught: the Daily, 4-hour and 1-hour charts must all agree on trend direction, the 4-hour marks the area price is expected to retest, and the 15-minute times the entry off a break of structure inside that zone. If the timeframes disagree, or price isn't at the level, or there's no 15-minute trigger, it does nothing. Long & short, low leverage scaled to how small FX moves are.",
+      "belief_plain": "This is how structure traders actually read a chart: start wide, then zoom in. First it checks that the Daily, 4-hour and 1-hour charts are all pointing the same way — if they disagree, there's no trade. Then on the 4-hour it marks the zone price is likely to pull back to. Then it waits, on the 15-minute chart, for price to actually reach that zone AND break in the trend direction before entering. Three things have to line up: direction, location, and timing. Miss any one and it stands aside. It trades the major currency pairs, which move in small percentages, so it uses the leverage that matches.",
+      "version": "1.0.0",
+      "thesis": "Multi-timeframe / ICT-style structure trading is one of the largest retail methodologies and the catalog had no expression of it — nor any FX template at all, despite Hyperliquid listing EUR, GBP and JPY. Manta encodes the top-down cascade faithfully: each timeframe answers exactly one question (higher frames = bias, 4h = location, 15m = timing) and is not allowed to answer another, which is the discipline the method is really about. The confluence is mandatory, not additive — a signal requires all three, because a 15m break outside the zone is noise and a zone touch with no break is a falling knife. Thresholds are FX-scaled throughout: a 0.5% daily move is a big FX day, so a crypto-sized structure filter would call every currency chart neutral forever.",
+      "tags": [
+        "fx",
+        "forex",
+        "multi-timeframe",
+        "mtf",
+        "market-structure",
+        "ict",
+        "smc",
+        "top-down",
+        "break-of-structure",
+        "area-of-interest",
+        "eur",
+        "gbp",
+        "jpy",
+        "long-short"
+      ],
+      "group": "single-asset",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "market_structure",
+      "sub_style_label": "Trades SMC/ICT/Wyckoff structure: break-of-structure, liquidity sweeps, fair-value gaps.",
+      "asset_classes": [
+        "fx"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "xyz:EUR",
+        "xyz:GBP",
+        "xyz:JPY"
+      ],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 8,
+      "time_horizon": "swing",
+      "cadence_seconds": 900,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "main",
+      "sort_order": 11
+    },
+    {
       "id": "polar",
       "name": "Polar — ETH Alpha Hunter",
       "emoji": "🧊",
@@ -3796,7 +3996,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "ram",
@@ -3840,7 +4040,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "stag",
@@ -3888,7 +4088,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "wolverine",
@@ -3933,7 +4133,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "hydra",

--- a/strategies/ibis/main/runtime.yaml
+++ b/strategies/ibis/main/runtime.yaml
@@ -1,0 +1,159 @@
+# ── IBIS · single instance — Trend/Range Regime-Switcher ──────────────────────
+# Two strategies behind one gate. Classify the 4h regime first (Kaufman efficiency
+# ratio + structure), then apply the entry rule that belongs to THAT regime:
+# continuation when trending (confirmed by rising open interest), band-edge fade when
+# ranging (skipped outright when funding is extreme). Neither rule ever runs in the
+# other's regime — which is the whole point.
+name: ibis-main
+group: ibis
+version: 1.0.0
+description: >
+  IBIS — Trend/Range Regime-Switcher. Primary timeframe 4h. Each tick it derives a
+  liquid universe from live instruments, then for each name computes the Kaufman
+  EFFICIENCY RATIO (net move / path travelled): a high ratio means the market is
+  travelling, a low one means it is retracing itself. Above the trend threshold with
+  confirming higher-high/lower-low structure it takes a CONTINUATION entry — hard-gated
+  on OI VELOCITY so it only joins moves that new money is committing to, and preferring
+  a shallow pullback over the extreme. Below the range threshold it FADES the band edge
+  — hard-gated on funding, skipping the trade entirely when funding is extreme, because
+  crowded funding is the tell that a range is about to break. Between the two thresholds
+  is a deliberate NO-TRADE band. Long & short, 2-5x, DSL-only exits.
+
+strategy:
+  wallet: "${IBIS_WALLET}"
+  slots: 3
+  margin_pct: 10                          # baseline %; scan emits the conviction-tier marginPct per signal
+  default_leverage: 4                     # fallback; scan emits per-regime leverage (trend 4x / range 3x)
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: ibis_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 1800                 # 30m on a 4h primary timeframe. Deliberately slow: the
+                                           # regime is a slow variable, and a fast clock on a
+                                           # rotating universe is how a strategy pays its edge to fees.
+    timeout_seconds: 240                   # instruments + one 4h candle read per universe name
+    default_signal_validity_seconds: 3600  # 2x tick
+    state_history_max_count: 120           # OI snapshot (velocity baseline) + per-tick results
+    inputs:
+      universeVolFloorUsd: 25000000        # $25M+ 24h notional — deep enough to size into
+      maxUniverseNames: 18
+      includeXyz: false                    # crypto majors by default; true also scans xyz: names
+      excludeAssets: ["USDC", "USDT"]
+      minScore: 6
+      marginPctBase: 10                    # PERCENT of withdrawable (0,100]; tiered x1.25 / x1.5
+      maxSlots: 3
+      leverageTrend: 4                     # a confirmed trend earns more size than a fade
+      leverageRange: 3
+      leverageMin: 2
+      leverageMax: 5
+      # ── regime classification ──
+      erLookback: 20                       # 20 x 4h = ~3.3 days of path
+      trendErThreshold: 0.36               # >= this AND confirming structure -> TREND
+      rangeErThreshold: 0.20               # <= this -> RANGE. Between the two -> NO TRADE.
+      strongErThreshold: 0.55
+      # ── trend rule (OI-confirmed continuation) ──
+      minOiVelocityPct: 0.35               # OI must be RISING tick-over-tick: new money, not covering
+      strongOiVelocityPct: 1.5
+      idealPullbackPct: 1.2                # prefer a shallow retrace over buying the extreme
+      maxPullbackPct: 4.0                  # deeper than this is a reversal, not a continuation
+      # ── range rule (funding-gated fade) ──
+      rangeBars: 24                        # 24 x 4h = 4 days of range
+      rangeBuyBelowPct: 0.22               # long in the bottom 22% of the range
+      rangeSellAbovePct: 0.78              # short in the top 22%
+      minRangeWidthPct: 3.0                # a narrower range cannot clear fees on the round trip
+      extremeFundingApr: 35.0              # |APR| >= this -> SKIP the fade entirely
+      calmFundingApr: 12.0
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      regime: { type: string }
+      er: { type: number, required: false }
+      reasons: { type: array, required: false }
+      structure: { type: string, required: false }
+      oiVelocityPct: { type: number, required: false }
+      pullbackPct: { type: number, required: false }
+      rangePos: { type: number, required: false }
+      fundingApr: { type: number, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: ibis_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already classified the regime and gated the entry
+    scanners: [ibis_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # maker-only rests and misses the fill on the move that
+                                           # triggered the signal (CREATE_ORDER_RESTING)
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: ibis_main_signals
+
+# ── EXIT (DSL — balanced, must serve BOTH regimes) ───────────────────────────
+# One ladder covers a continuation trade and a fade, so it is deliberately middle-of-the-road:
+# it locks earlier than a pure trend-rider (a fade's profit target is the middle of the range,
+# not a new high) while still letting a confirmed trend breathe past the first tiers.
+# Time-cuts off — exits are price action. weak_peak_cut stays as the thesis-validity check.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 480
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 120             # 2h on a 4h timeframe — release a setup that never worked
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 7, lock_hw_pct: 0 }
+        - { trigger_pct: 14, lock_hw_pct: 28 }
+        - { trigger_pct: 24, lock_hw_pct: 48 }
+        - { trigger_pct: 38, lock_hw_pct: 62 }
+        - { trigger_pct: 58, lock_hw_pct: 76 }
+
+# ── RISK guard rails (moderate) ──
+risk:
+  data_retention_seconds: 259200           # 72h
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 4                  # a 4h timeframe should not be opening all day
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 3600
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400       # 4h — one entry per name per primary-timeframe bar
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/ibis/main/scanners/scan.py
+++ b/strategies/ibis/main/scanners/scan.py
@@ -1,0 +1,230 @@
+"""IBIS — supervised scanner: trend/range regime switch with regime-specific entry logic.
+
+Per tick:
+  - reads account + held positions (dual-DEX equity via max(), never sum; corrupt-read guard),
+  - derives the universe from LIVE `market_list_instruments` (notional-volume floor + top-N),
+    routing by name prefix because dex="" returns BOTH sub-DEXes,
+  - snapshots per-coin open interest in USD into ctx.state so the NEXT tick can measure OI
+    VELOCITY (the trend-entry confirmation the user asked for),
+  - fetches 4h candles per candidate and scores via pure `scoring.build_thesis`, which
+    classifies the regime and then applies that regime's entry rule,
+  - emits every candidate at/above `minScore`, best-first, up to the open slots.
+
+Read-only + single-pass. Emits a `marginPct` INTENT (PERCENT in (0,100]) + `leverage`.
+Candle values are strings keyed o/h/l/c/v — scoring._close/_f coerce.
+
+OI velocity needs a PRIOR snapshot, so the first tick after a (re)start takes no TREND entry
+by design — `oi_velocity_pct` returns None and `trend_thesis` refuses to guess. Range entries
+are unaffected. This is the correct trade-off: a missed entry costs nothing, a fabricated
+confirmation costs money.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_EXCLUDE = ["USDC", "USDT"]
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position dicts]) — dual-DEX equity via max() (never sum: two views of ONE
+    cross-margined wallet), positions enumerated across BOTH sub-DEX sections. Read-guarded."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the tick
+        print(f"[ibis.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)), abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""), "margin": scoring._f(pos.get("marginUsed", 0))})
+    if used > 1.0 and not positions:
+        print("[ibis.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _instruments(ctx, dex):
+    """Raw instrument rows for one sub-DEX, or None on a read failure."""
+    try:
+        raw = ctx.senpi_mcp.call_tool("market_list_instruments", {"dex": dex})
+    except Exception as exc:  # noqa: BLE001
+        print(f"[ibis.scan] market_list_instruments(dex={dex!r}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    d = raw.get("data", raw) if isinstance(raw, dict) else raw
+    if isinstance(d, dict):
+        d = d.get("instruments", d.get("universe", d.get("markets", [])))
+    return d if isinstance(d, list) else None
+
+
+def _derive_universe(ctx, inputs):
+    """[{name, oi_usd, funding_apr}] over the notional-volume floor, top-N by volume.
+
+    `market_list_instruments` with dex="" returns BOTH sub-DEXes and carries NO dex field — the
+    `xyz:` name prefix is the only discriminator — so names are routed by prefix and deduped on
+    the bare ticker across both pools.
+    """
+    vol_floor = float(inputs.get("universeVolFloorUsd", 25_000_000))
+    max_names = int(inputs.get("maxUniverseNames", 18))
+    include_xyz = bool(inputs.get("includeXyz", False))
+    exclude = {str(x).upper() for x in (inputs.get("excludeAssets") or _DEFAULT_EXCLUDE)}
+
+    rows = _instruments(ctx, "")
+    if rows is None:
+        return None
+    seen, out = set(), []
+    for r in rows:
+        if not isinstance(r, dict) or r.get("is_delisted"):
+            continue
+        name = str(r.get("name") or r.get("coin") or "").strip()
+        if not name:
+            continue
+        is_xyz = name.lower().startswith("xyz:")
+        if is_xyz and not include_xyz:
+            continue
+        bare = name.split(":", 1)[-1].upper()
+        if bare in seen or bare in exclude:
+            continue
+        seen.add(bare)
+        c = r.get("context", {}) if isinstance(r.get("context"), dict) else {}
+        vol = scoring._f(c.get("dayNtlVlm"))
+        if vol < vol_floor:
+            continue
+        out.append({"name": name, "vol": vol, "oi_usd": scoring.oi_usd(c),
+                    "funding_apr": scoring.annualized_funding_pct(c.get("funding"))})
+    out.sort(key=lambda x: x["vol"], reverse=True)
+    return out[:max_names]
+
+
+def _candles_4h(ctx, coin):
+    """4h candle list for `coin`, or None. Read-guarded."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin, "candle_intervals": ["4h"],
+            "include_funding": False, "include_order_book": False, "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[ibis.scan] market_get_asset_data({coin}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md or (isinstance(md, dict) and md.get("success") is False):
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    c = d.get("candles", {}) if isinstance(d, dict) else {}
+    return c.get("4h", []) if isinstance(c, dict) else None
+
+
+def _load_oi(ctx):
+    """{BARE_TICKER: oi_usd} from the previous tick — the OI-velocity baseline."""
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    prev = (ctx.state.last() or {}).get("oi", {})
+    return dict(prev) if isinstance(prev, dict) else {}
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    min_score = float(inputs.get("minScore", 6))
+    base_margin_pct = float(inputs.get("marginPctBase", 10))   # PERCENT in (0,100]
+    max_slots = int(inputs.get("maxSlots", 3))
+    lev_trend = int(inputs.get("leverageTrend", 4))
+    lev_range = int(inputs.get("leverageRange", 3))
+    lev_min = int(inputs.get("leverageMin", 2))
+    lev_max = int(inputs.get("leverageMax", 5))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[ibis.scan] WAITING — no account value / corrupt read", file=sys.stderr)
+        return []
+    held = {p["coin"].split(":", 1)[-1].upper() for p in positions if p.get("coin")}
+    open_slots = max_slots - len(held)
+
+    universe = _derive_universe(ctx, inputs)
+    if universe is None:
+        print("[ibis.scan] instruments unreadable — skipping tick (keeping prior OI baseline)",
+              file=sys.stderr)
+        return []
+
+    # OI snapshot: written EVERY tick (even when slots are full) so the velocity baseline
+    # never goes stale just because the book happened to be busy.
+    prev_oi = _load_oi(ctx)
+    oi_now = {u["name"].split(":", 1)[-1].upper(): u["oi_usd"] for u in universe if u["oi_usd"] > 0}
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"oi": oi_now, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[ibis.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    if open_slots <= 0:
+        print(f"[ibis.scan] slots full ({len(held)}/{max_slots}) — DSL manages exits", file=sys.stderr)
+        _persist({"ts": now, "scanned": 0, "emitted": 0, "note": "slots full"})
+        return []
+
+    candidates, scanned, regimes = [], 0, {"TREND": 0, "RANGE": 0, "UNCLEAR": 0}
+    for u in universe:
+        coin = u["name"]
+        bare = coin.split(":", 1)[-1].upper()
+        if bare in held:
+            continue
+        scanned += 1
+        candles = _candles_4h(ctx, coin)
+        if not candles:
+            continue
+        regime, _er, _s, _st = scoring.classify_regime(candles, inputs)
+        regimes[regime] = regimes.get(regime, 0) + 1
+        oi_vel = scoring.oi_velocity_pct(u["oi_usd"], prev_oi.get(bare))
+        th = scoring.build_thesis(coin, candles, oi_vel, u["funding_apr"], inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    out = []
+    for th in candidates[:open_slots]:
+        lev = lev_trend if th["regime"] == "TREND" else lev_range
+        leverage = max(lev_min, min(lev, lev_max))
+        margin_pct = round(scoring.margin_tier_pct(th["score"], base_margin_pct), 4)
+        out.append({
+            "asset": th["coin"],
+            "direction": th["direction"],
+            "marginPct": margin_pct,      # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,
+            "data": {
+                "score": th["score"], "leverage": leverage, "direction": th["direction"],
+                "regime": th["regime"], "er": th["er"], "reasons": th["reasons"][:8],
+                "structure": th["structure"], "oiVelocityPct": th["oi_velocity_pct"],
+                "pullbackPct": th["pullback_pct"], "rangePos": th["range_pos"],
+                "fundingApr": th["funding_apr"], "heldAssets": sorted(held),
+            },
+        })
+
+    baseline = "yes" if prev_oi else "NO (first tick — trend entries wait for it)"
+    print(f"[ibis.scan] {'EMIT' if out else 'WAITING'} universe={len(universe)} scanned={scanned} "
+          f"regimes={regimes} emitted={len(out)} oi_baseline={baseline} held={sorted(held)}",
+          file=sys.stderr)
+    _persist({"ts": now, "scanned": scanned, "emitted": len(out), "regimes": regimes,
+              "universe": len(universe)})
+    return out

--- a/strategies/ibis/main/scanners/scoring.py
+++ b/strategies/ibis/main/scanners/scoring.py
@@ -1,0 +1,272 @@
+"""IBIS — pure thesis math: trend/range regime detection, then regime-specific entry logic.
+
+The strategy is two strategies behind one gate. First classify the 4h regime, then apply the
+entry rule that belongs to THAT regime — a continuation rule in a trend, a fade rule in a range.
+Applying either rule in the wrong regime is how a trend-follower gets chopped up and how a
+mean-reverter gets run over.
+
+REGIME — Kaufman efficiency ratio on 4h closes:
+    ER = |net move| / sum(|bar-to-bar moves|)   over the lookback
+  A clean directional move travels nearly all of its path distance (ER -> 1); chop retraces
+  itself and travels almost none of it (ER -> 0). Confirmed against higher-high/lower-low
+  structure so a one-bar spike can't fake a trend.
+
+TREND entry  — continuation in the structural direction, gated on OI VELOCITY: open interest
+  must be RISING, i.e. new money is committing to the move rather than shorts covering into it.
+  Prefers a shallow pullback over buying the extreme.
+
+RANGE entry  — fade the band edge (long the low, short the high), and SKIPPED OUTRIGHT when
+  funding is extreme: crowded funding is the tell that a range is about to break, which is
+  exactly when a fade is the wrong trade.
+
+Pure + single-pass. Candles are keyed o/h/l/c/v with STRING values — `_f`/`_close` coerce.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+# ── funding / OI helpers ─────────────────────────────────────────────────────
+
+def annualized_funding_pct(hourly_rate):
+    """market_list_instruments `context.funding` is an HOURLY rate (string fraction,
+    e.g. '0.0000125'). Annualize to a percent: rate * 24 * 365 * 100."""
+    return _f(hourly_rate) * 24.0 * 365.0 * 100.0
+
+
+def oi_usd(context):
+    """`context.openInterest` is in BASE units (coins), not USD — multiply by mark price."""
+    if not isinstance(context, dict):
+        return 0.0
+    return _f(context.get("openInterest")) * _f(context.get("markPx", context.get("midPx", 0)))
+
+
+def oi_velocity_pct(oi_now, oi_prev):
+    """% change in open interest since the previous snapshot. None when there is no baseline
+    (first tick after a restart) — the caller must treat None as 'unknown', never as zero."""
+    if oi_prev is None or _f(oi_prev) <= 0 or _f(oi_now) <= 0:
+        return None
+    return (_f(oi_now) - _f(oi_prev)) / _f(oi_prev) * 100.0
+
+
+# ── regime classification ────────────────────────────────────────────────────
+
+def efficiency_ratio(candles, lookback):
+    """Kaufman efficiency ratio over the last `lookback` closes. 0.0 when too short."""
+    if len(candles) < lookback + 1 or lookback < 2:
+        return 0.0
+    closes = [_close(c) for c in candles[-(lookback + 1):]]
+    net = abs(closes[-1] - closes[0])
+    path = sum(abs(closes[i] - closes[i - 1]) for i in range(1, len(closes)))
+    if path <= 0:
+        return 0.0
+    return net / path
+
+
+def trend_structure(candles, bars=6):
+    """('UP'|'DOWN'|'NEUTRAL', strength 0-1) from higher-highs / lower-lows."""
+    if len(candles) < bars:
+        return "NEUTRAL", 0.0
+    highs = [_high(c) for c in candles[-bars:]]
+    lows = [_low(c) for c in candles[-bars:]]
+    up = sum(1 for i in range(1, len(highs)) if highs[i] > highs[i - 1])
+    down = sum(1 for i in range(1, len(lows)) if lows[i] < lows[i - 1])
+    n = len(highs) - 1
+    if up >= n * 0.6:
+        return "UP", up / n
+    if down >= n * 0.6:
+        return "DOWN", down / n
+    return "NEUTRAL", 0.0
+
+
+def classify_regime(candles_4h, inputs):
+    """('TREND'|'RANGE'|'UNCLEAR', er, structure, strength).
+
+    The deliberate gap between the two thresholds is a NO-TRADE band: a market that is neither
+    cleanly trending nor cleanly ranging gets no entry rule at all, rather than the closest one.
+    """
+    er_lookback = int(inputs.get("erLookback", 20))
+    trend_er = float(inputs.get("trendErThreshold", 0.36))
+    range_er = float(inputs.get("rangeErThreshold", 0.20))
+
+    er = efficiency_ratio(candles_4h, er_lookback)
+    struct, strength = trend_structure(candles_4h)
+    if er >= trend_er and struct != "NEUTRAL":
+        return "TREND", er, struct, strength
+    if er <= range_er:
+        return "RANGE", er, struct, strength
+    return "UNCLEAR", er, struct, strength
+
+
+def range_bounds(candles_4h, bars):
+    """(low, high, position_0_to_1) of the latest close inside the recent range. None if flat."""
+    if len(candles_4h) < bars or bars < 4:
+        return None
+    window = candles_4h[-bars:]
+    hi = max(_high(c) for c in window)
+    lo = min(_low(c) for c in window)
+    if hi <= lo:
+        return None
+    last = _close(candles_4h[-1])
+    return lo, hi, max(0.0, min(1.0, (last - lo) / (hi - lo)))
+
+
+def pullback_pct(candles_4h, direction, bars=6):
+    """How far price has retraced from the recent extreme in the trend direction, as a percent.
+    A shallow pullback is a better continuation entry than the extreme itself."""
+    if len(candles_4h) < bars:
+        return 0.0
+    window = candles_4h[-bars:]
+    last = _close(candles_4h[-1])
+    if direction == "LONG":
+        hi = max(_high(c) for c in window)
+        return 0.0 if hi <= 0 else (hi - last) / hi * 100.0
+    lo = min(_low(c) for c in window)
+    return 0.0 if lo <= 0 else (last - lo) / lo * 100.0
+
+
+# ── the two entry rules ──────────────────────────────────────────────────────
+
+def trend_thesis(coin, candles_4h, er, struct, strength, oi_vel, inputs):
+    """Continuation entry. HARD GATE: open interest must be rising (new money), which is the
+    user's stated OI-velocity confirmation. Returns a thesis dict or None.
+
+    Scoring (max 9): structure 3 · ER quality 2 · OI velocity 2 · pullback quality 2
+    """
+    min_oi_vel = float(inputs.get("minOiVelocityPct", 0.35))
+    strong_oi_vel = float(inputs.get("strongOiVelocityPct", 1.5))
+    max_pullback = float(inputs.get("maxPullbackPct", 4.0))
+    ideal_pullback = float(inputs.get("idealPullbackPct", 1.2))
+
+    if oi_vel is None:
+        return None                      # no OI baseline yet — never guess the confirmation away
+    if oi_vel < min_oi_vel:
+        return None                      # flat/falling OI: short-covering, not new commitment
+
+    direction = "LONG" if struct == "UP" else "SHORT"
+    score, reasons = 3, [f"4h {struct} structure (strength {strength:.2f})", f"ER {er:.2f} = trending"]
+    score += 2 if er >= float(inputs.get("strongErThreshold", 0.55)) else 1
+
+    if oi_vel >= strong_oi_vel:
+        score += 2
+        reasons.append(f"OI +{oi_vel:.2f}% — strong new commitment")
+    else:
+        score += 1
+        reasons.append(f"OI +{oi_vel:.2f}% — rising")
+
+    pb = pullback_pct(candles_4h, direction)
+    if pb > max_pullback:
+        return None                      # too deep to still be a continuation — that's a reversal
+    if pb >= ideal_pullback:
+        score += 2
+        reasons.append(f"entering on a {pb:.2f}% pullback, not the extreme")
+    else:
+        reasons.append(f"shallow {pb:.2f}% pullback (near the extreme)")
+
+    return {"coin": coin, "direction": direction, "score": score, "regime": "TREND",
+            "er": round(er, 4), "structure": struct, "oi_velocity_pct": round(oi_vel, 4),
+            "pullback_pct": round(pb, 4), "range_pos": None,
+            "funding_apr": None, "reasons": reasons}
+
+
+def range_thesis(coin, candles_4h, er, funding_apr, inputs):
+    """Band-edge fade. HARD GATE: skipped when |annualized funding| is extreme — crowded funding
+    is the tell that a range is about to break, and a fade into a break is the losing side.
+
+    Scoring (max 9): at the band edge 4 · range quality 2 · funding calm 2 · deep edge 1
+    """
+    bars = int(inputs.get("rangeBars", 24))
+    buy_below = float(inputs.get("rangeBuyBelowPct", 0.22))
+    sell_above = float(inputs.get("rangeSellAbovePct", 0.78))
+    extreme_apr = float(inputs.get("extremeFundingApr", 35.0))
+    calm_apr = float(inputs.get("calmFundingApr", 12.0))
+
+    if funding_apr is None:
+        return None                      # the gate is mandatory — no funding read, no range trade
+    if abs(funding_apr) >= extreme_apr:
+        return None                      # crowded: the range is about to break, don't fade it
+
+    rb = range_bounds(candles_4h, bars)
+    if rb is None:
+        return None
+    lo, hi, pos = rb
+
+    if pos <= buy_below:
+        direction = "LONG"
+    elif pos >= sell_above:
+        direction = "SHORT"
+    else:
+        return None                      # mid-range: no edge, and the fee is certain
+
+    score = 4
+    reasons = [f"at the range {'low' if direction == 'LONG' else 'high'} (pos {pos:.2f})",
+               f"ER {er:.2f} = ranging"]
+    width_pct = (hi - lo) / lo * 100.0 if lo > 0 else 0.0
+    if width_pct >= float(inputs.get("minRangeWidthPct", 3.0)):
+        score += 2
+        reasons.append(f"range is {width_pct:.1f}% wide — worth fading")
+    else:
+        return None                      # too tight to clear fees on the round trip
+
+    if abs(funding_apr) <= calm_apr:
+        score += 2
+        reasons.append(f"funding calm ({funding_apr:+.1f}% APR)")
+    else:
+        score += 1
+        reasons.append(f"funding elevated but not extreme ({funding_apr:+.1f}% APR)")
+
+    if pos <= buy_below / 2 or pos >= 1 - (1 - sell_above) / 2:
+        score += 1
+        reasons.append("deep at the edge")
+
+    return {"coin": coin, "direction": direction, "score": score, "regime": "RANGE",
+            "er": round(er, 4), "structure": None, "oi_velocity_pct": None,
+            "pullback_pct": None, "range_pos": round(pos, 4),
+            "funding_apr": round(funding_apr, 3), "reasons": reasons}
+
+
+def build_thesis(coin, candles_4h, oi_vel, funding_apr, inputs):
+    """Classify the regime, then apply THAT regime's entry rule. None in the no-trade band."""
+    regime, er, struct, strength = classify_regime(candles_4h, inputs)
+    if regime == "TREND":
+        return trend_thesis(coin, candles_4h, er, struct, strength, oi_vel, inputs)
+    if regime == "RANGE":
+        return range_thesis(coin, candles_4h, er, funding_apr, inputs)
+    return None
+
+
+def margin_tier_pct(score, base_pct):
+    """Conviction sizing on the PERCENT scale (base_pct is a PERCENT in (0,100])."""
+    if score >= 8:
+        return base_pct * 1.5
+    if score >= 6:
+        return base_pct * 1.25
+    return base_pct

--- a/strategies/ibis/strategy.yaml
+++ b/strategies/ibis/strategy.yaml
@@ -1,0 +1,39 @@
+# Ibis — Trend/Range Regime-Switcher. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. Classifies the 4h regime first, then applies the
+# entry rule belonging to that regime. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: ibis
+version: "1.0.0"
+
+catalog:
+  name: "Ibis — Trend/Range Regime-Switcher"
+  emoji: "🦤"
+  tagline: "Two strategies behind one gate. It first decides whether a market is TRENDING or RANGING on the 4-hour chart (Kaufman efficiency ratio + structure), then applies the entry rule that belongs to that regime: a continuation entry when trending — confirmed by RISING open interest, so it only joins moves new money is committing to — or a fade of the range edge when ranging, skipped outright when funding is extreme. In between the two is a deliberate no-trade band. Long & short, 2-5x."
+  belief_plain: "Most strategies only work in one kind of market: trend-followers get chopped to pieces in a sideways market, and mean-reverters get run over when a real trend starts. Ibis checks which kind of market it's in before deciding what to do. If price is genuinely travelling in one direction it joins the move — but only if open interest is rising, meaning new money is actually backing it. If price is just bouncing in a range it buys the bottom and sells the top instead — unless funding has gotten extreme, which usually means the range is about to break, in which case it stays out. When it can't tell which regime it's in, it does nothing."
+  thesis: "The regime question comes before the entry question, and most retail strategies never ask it — which is why the same rule that prints in a trend bleeds in chop. The Kaufman efficiency ratio (net move divided by the path actually travelled) separates the two cleanly and cheaply: a directional market covers nearly all of its path, a choppy one retraces itself. Each regime then gets the confirmation that specifically protects it — OI velocity for trend entries, because a breakout on flat OI is short-covering rather than commitment; funding extremes for range fades, because crowded funding precedes the break that kills a fader. The gap between the thresholds is a no-trade band by design: an ambiguous regime gets no rule at all, rather than the closest one."
+  group: momentum
+  archetype: trend_following
+  sub_style: adaptive
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: universe
+  direction: long_short
+  risk_level: moderate
+  tier: starter
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 3
+  min_budget: 200
+  tags: [regime, regime-switching, adaptive, trend, range, mean-reversion, efficiency-ratio, open-interest, oi-velocity, funding, 4h, multi-asset, long-short]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: IBIS_WALLET
+    funding_share: 1.0

--- a/strategies/manta/main/runtime.yaml
+++ b/strategies/manta/main/runtime.yaml
@@ -1,0 +1,146 @@
+# ── MANTA · single instance — Multi-Timeframe Structure (FX) ─────────────────
+# Textbook top-down structure trading on Hyperliquid's FX pairs. Daily/4h/1h set the
+# bias, the 4h marks the Area Of Interest, the 15m times the entry off a break of
+# structure inside that zone. Nothing fires without all three aligning.
+name: manta-main
+group: manta
+version: 1.0.0
+description: >
+  MANTA — Multi-Timeframe Structure on FX (xyz:EUR / xyz:GBP / xyz:JPY). The classic
+  top-down method, each timeframe answering one question: DAILY + 4h + 1h must all agree
+  on trend direction (one dissenter is a no-trade); the 4h marks the AREA OF INTEREST —
+  the most recent swing price broke away from and is expected to retest; the 15m provides
+  the trigger — price must tag that zone and then BREAK 15m structure in the bias direction.
+  Missing any layer means no trade: a 15m break outside the zone is noise, a zone touch with
+  no break is a falling knife, aligned timeframes with neither are just an opinion. The
+  confluence is the strategy. Long & short, low leverage (FX moves are small), DSL-only exits.
+
+strategy:
+  wallet: "${MANTA_WALLET}"
+  slots: 2
+  margin_pct: 12                          # baseline %; scan emits the conviction-tier marginPct per signal
+  default_leverage: 5                     # FX: small % moves, so leverage carries the size (still capped)
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: manta_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 900                  # 15m — the execution timeframe; fine enough to catch the
+                                           # trigger bar, and the higher frames move far slower
+    timeout_seconds: 180                   # 4 timeframes x a few pairs + account
+    default_signal_validity_seconds: 1800  # 2x tick — a 15m trigger goes stale fast
+    state_history_max_count: 120           # trigger dedup + per-tick scan-results history
+    inputs:
+      pairs: ["xyz:EUR", "xyz:GBP", "xyz:JPY"]   # Hyperliquid FX (validated present in instruments)
+      minScore: 9                          # bias(4) + AOI(3) + break(2) — the confluence is mandatory
+      marginPctBase: 12                    # PERCENT of withdrawable (0,100]; tiered x1.25 / x1.5
+      maxSlots: 2
+      leverageDefault: 5
+      leverageMin: 3
+      leverageMax: 8                       # FX-appropriate; a 0.4% move at 8x is a 3.2% position move
+      # ── bias (Daily / 4h / 1h) ──
+      pivotWindow: 2
+      minStructureStepPct: 0.15            # FX-scaled: a 0.5% daily move is a big FX day. A crypto
+                                           # threshold (1-2%) would call every FX chart NEUTRAL forever.
+      requireAllThree: true                # all three timeframes must agree; false demotes 1h to tiebreaker
+      minCandles: 20
+      # ── AOI (4h) ──
+      aoiPaddingPct: 0.12                  # widen the pivot into a zone — price respects areas, not lines
+      maxAoiAgeBars: 30                    # a 4h level older than ~5 days has stopped mattering
+      aoiTouchWindowBars: 8                # price must have tagged the zone within the last 8 x 15m (2h)
+      # ── trigger (15m) ──
+      pivotWindow15m: 1                    # tighter fractal on the execution frame
+      triggerLookbackBars: 12
+      minDisplacementPct: 0.08             # the break bar must actually move, not just tick through
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      bias: { type: string, required: false }
+      biases: { type: array, required: false }
+      aoiLow: { type: number, required: false }
+      aoiHigh: { type: number, required: false }
+      triggerLevel: { type: number, required: false }
+      displacementPct: { type: number, required: false }
+      reasons: { type: array, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: manta_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already ran the full top-down cascade
+    scanners: [manta_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # the trigger IS a break of structure — a resting maker
+                                           # order misses the very move it was waiting for
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: manta_main_signals
+
+# ── EXIT (DSL — structure ladder, FX-scaled) ─────────────────────────────────
+# FX moves in fractions of a percent, so the ROE tiers are TIGHTER than a crypto swing: a
+# 0.5% pair move at 5x is a 2.5% position move, and the profit-lock ladder is scaled to that
+# reality rather than a crypto template's. Time-cuts off; weak_peak_cut releases a break that
+# failed to follow through inside the zone — the classic MTF failure.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 480
+    weak_peak_cut:
+      enabled: true                        # the break didn't follow through -> release it
+      interval_in_minutes: 90
+      min_value: 1.5
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                   # tighter: the invalidation (other side of the AOI) is close
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # FX-scaled position-ROE ladder (leverage already applied)
+        - { trigger_pct: 5, lock_hw_pct: 0 }
+        - { trigger_pct: 10, lock_hw_pct: 30 }
+        - { trigger_pct: 18, lock_hw_pct: 50 }
+        - { trigger_pct: 30, lock_hw_pct: 65 }
+        - { trigger_pct: 45, lock_hw_pct: 78 }
+
+# ── RISK guard rails (moderate) ──
+risk:
+  data_retention_seconds: 259200           # 72h
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 4
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 1800
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 7200        # 2h — one setup per pair per few hours
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/manta/main/scanners/scan.py
+++ b/strategies/manta/main/scanners/scan.py
@@ -1,0 +1,168 @@
+"""MANTA — supervised scanner: top-down multi-timeframe structure on FX pairs.
+
+Per tick (the tick IS the 15m execution frame):
+  - reads account + held positions (dual-DEX equity via max(), never sum; corrupt-read guard),
+  - for each configured FX pair fetches Daily / 4h / 1h / 15m candles in one call,
+  - runs the pure `scoring.build_thesis` cascade: bias alignment -> 4h AOI -> 15m trigger,
+  - emits at most one signal per pair per trigger (dedup keyed on the trigger level in ctx.state)
+    so the same break does not re-fire every 15 minutes while price sits above it.
+
+Read-only + single-pass. Emits a `marginPct` INTENT (PERCENT in (0,100]) + `leverage`.
+Candle values are strings keyed o/h/l/c/v — scoring._close/_f coerce.
+
+FX on Hyperliquid lives on the XYZ sub-DEX: pairs carry the `xyz:` prefix, the asset read
+passes dex="xyz", and positions come back coined `xyz:EUR` — all handled below. FX trades
+24/7 on Hyperliquid (no market-hours gate needed).
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_PAIRS = ["xyz:EUR", "xyz:GBP", "xyz:JPY"]
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position dicts]) — dual-DEX equity via max() (never sum: two views of ONE
+    cross-margined wallet), positions enumerated across BOTH sub-DEX sections. Read-guarded.
+
+    FX positions live in the `xyz` section coined `xyz:EUR`; the main section is enumerated too
+    so a crypto position from another strategy on the same wallet is still seen as held."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the tick
+        print(f"[manta.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)), abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""), "margin": scoring._f(pos.get("marginUsed", 0))})
+    if used > 1.0 and not positions:
+        print("[manta.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _candles(ctx, coin):
+    """{'1d':[], '4h':[], '1h':[], '15m':[]} for `coin` or None. Read-guarded."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin, "candle_intervals": ["1d", "4h", "1h", "15m"],
+            "include_funding": False, "include_order_book": False, "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[manta.scan] market_get_asset_data({coin}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md or (isinstance(md, dict) and md.get("success") is False):
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    return d.get("candles", {}) if isinstance(d, dict) else None
+
+
+def _load_fired(ctx):
+    """{'xyz:EUR': trigger_level} — last trigger we acted on per pair (level-based dedup)."""
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    f = (ctx.state.last() or {}).get("fired", {})
+    return dict(f) if isinstance(f, dict) else {}
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    pairs = inputs.get("pairs", _DEFAULT_PAIRS)
+    min_score = float(inputs.get("minScore", 9))
+    base_margin_pct = float(inputs.get("marginPctBase", 12))   # PERCENT in (0,100]
+    max_slots = int(inputs.get("maxSlots", 2))
+    lev_default = int(inputs.get("leverageDefault", 5))
+    lev_min = int(inputs.get("leverageMin", 3))
+    lev_max = int(inputs.get("leverageMax", 8))
+    dedup_tol = float(inputs.get("triggerDedupTolerancePct", 0.15))
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[manta.scan] WAITING — no account value / corrupt read", file=sys.stderr)
+        return []
+    held = {p["coin"].split(":", 1)[-1].upper() for p in positions if p.get("coin")}
+    open_slots = max_slots - len(held)
+
+    fired = _load_fired(ctx)
+
+    def _persist(result):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"fired": fired, "result": result})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[manta.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    if open_slots <= 0:
+        print(f"[manta.scan] slots full ({len(held)}/{max_slots}) — DSL manages exits", file=sys.stderr)
+        _persist({"ts": now, "scanned": 0, "emitted": 0, "note": "slots full"})
+        return []
+
+    candidates, scanned = [], 0
+    for coin in pairs:
+        if not coin:
+            continue
+        bare = coin.split(":", 1)[-1].upper()
+        if bare in held:
+            continue
+        scanned += 1
+        cd = _candles(ctx, coin)
+        if not cd:
+            continue
+        th = scoring.build_thesis(coin, cd.get("1d", []), cd.get("4h", []),
+                                  cd.get("1h", []), cd.get("15m", []), inputs)
+        if not th or th["score"] < min_score:
+            continue
+        # level-based dedup: the same trigger level (within tolerance) fires once, not every tick
+        prev = fired.get(coin)
+        if prev and scoring._f(prev) > 0 and \
+                abs(th["trigger_level"] - prev) / prev * 100.0 < dedup_tol:
+            continue
+        candidates.append(th)
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    leverage = max(lev_min, min(lev_default, lev_max))
+    out = []
+    for th in candidates[:open_slots]:
+        margin_pct = round(scoring.margin_tier_pct(th["score"], base_margin_pct), 4)
+        fired[th["coin"]] = th["trigger_level"]
+        out.append({
+            "asset": th["coin"],
+            "direction": th["direction"],
+            "marginPct": margin_pct,      # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,
+            "data": {
+                "score": th["score"], "leverage": leverage, "direction": th["direction"],
+                "bias": th["bias"], "biases": th["biases"], "reasons": th["reasons"][:8],
+                "aoiLow": round(th["aoi_low"], 8), "aoiHigh": round(th["aoi_high"], 8),
+                "triggerLevel": round(th["trigger_level"], 8),
+                "displacementPct": th["displacement_pct"], "heldAssets": sorted(held),
+            },
+        })
+
+    print(f"[manta.scan] {'EMIT' if out else 'WAITING'} pairs={len(pairs)} scanned={scanned} "
+          f"emitted={len(out)} min_score={min_score:.0f} held={sorted(held)}", file=sys.stderr)
+    _persist({"ts": now, "scanned": scanned, "emitted": len(out)})
+    return out

--- a/strategies/manta/main/scanners/scoring.py
+++ b/strategies/manta/main/scanners/scoring.py
@@ -1,0 +1,301 @@
+"""MANTA — pure thesis math: top-down multi-timeframe structure (no I/O, no MCP, no clock).
+
+The classic top-down method, in the order a structure trader actually applies it. Each
+timeframe answers exactly one question and is not allowed to answer any of the others:
+
+  DAILY / 4h / 1h  →  WHICH WAY?   Trend bias. All three must agree; one dissenter is a
+                      no-trade, because the whole premise is alignment.
+  4h               →  WHERE?       The Area Of Interest: the most recent swing that price
+                      broke away from, i.e. the level it is expected to retest.
+  15m              →  WHEN?        Execution. Price must be INSIDE the AOI and then print a
+                      break of 15m structure in the bias direction — the trigger.
+
+Nothing here is allowed to fire on its own. A 15m break outside the AOI is noise; an AOI
+touch with no trigger is a falling knife; three aligned timeframes with neither is just an
+opinion. The confluence IS the strategy.
+
+Pure + single-pass + unit-testable on plain candle lists. Candles are keyed o/h/l/c/v with
+STRING values — `_f`/`_close` coerce both shapes.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _open(c):
+    if isinstance(c, dict):
+        return _f(c.get("open", c.get("o", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[1])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+# ── swing pivots (shared by bias, AOI and trigger) ───────────────────────────
+
+def _push(pivots, idx, price, k, keep_max):
+    """Append a pivot, COLLAPSING a plateau into one point.
+
+    A flat top (two or more bars at the same extreme) satisfies the `>=` fractal test on EVERY
+    bar of the run, so a naive append records the same pivot twice. The last two entries are
+    then duplicates of each other, every higher-high / double-bottom comparison sees a 0% step,
+    and the strategy silently never trades. Collapse anything within `k` bars of the previous
+    pivot into the more extreme of the two.
+    """
+    if pivots and idx - pivots[-1][0] <= k:
+        if (keep_max and price >= pivots[-1][1]) or (not keep_max and price <= pivots[-1][1]):
+            pivots[-1] = (idx, price)
+        return
+    pivots.append((idx, price))
+
+
+def swing_points(candles, k=2):
+    """([(idx, price)] highs, [(idx, price)] lows) via a symmetric k-bar fractal window."""
+    highs, lows = [], []
+    n = len(candles)
+    if n < 2 * k + 1 or k < 1:
+        return highs, lows
+    for i in range(k, n - k):
+        h, lo = _high(candles[i]), _low(candles[i])
+        w = range(i - k, i + k + 1)
+        if all(h >= _high(candles[j]) for j in w) and any(h > _high(candles[j]) for j in w if j != i):
+            _push(highs, i, h, k, keep_max=True)
+        if all(lo <= _low(candles[j]) for j in w) and any(lo < _low(candles[j]) for j in w if j != i):
+            _push(lows, i, lo, k, keep_max=False)
+    return highs, lows
+
+
+# ── 1. WHICH WAY — trend bias per timeframe ──────────────────────────────────
+
+def timeframe_bias(candles, k=2, min_step_pct=0.15):
+    """'UP' | 'DOWN' | 'NEUTRAL' from swing structure on one timeframe.
+
+    `min_step_pct` is deliberately small for FX, where a 0.5% daily move is a big day —
+    a crypto-scale threshold would call every FX chart neutral forever.
+    """
+    highs, lows = swing_points(candles, k)
+    if len(highs) < 2 or len(lows) < 2:
+        return "NEUTRAL"
+    hh = highs[-1][1] > highs[-2][1]
+    hl = lows[-1][1] > lows[-2][1]
+    ll = lows[-1][1] < lows[-2][1]
+    lh = highs[-1][1] < highs[-2][1]
+    ref = abs(highs[-2][1]) or 1.0
+    h_step = abs(highs[-1][1] - highs[-2][1]) / ref * 100.0
+    l_step = abs(lows[-1][1] - lows[-2][1]) / (abs(lows[-2][1]) or 1.0) * 100.0
+    if max(h_step, l_step) < min_step_pct:
+        return "NEUTRAL"                    # the structure moved, but not enough to mean anything
+    if hh and hl:
+        return "UP"
+    if ll and lh:
+        return "DOWN"
+    return "NEUTRAL"
+
+
+def aligned_bias(daily, h4, h1, inputs):
+    """The shared bias across Daily/4h/1h, or None when they disagree.
+
+    `requireAllThree` off demotes the 1h to a tiebreaker: Daily+4h must still agree, and the
+    1h may be NEUTRAL but never opposed.
+    """
+    k = int(inputs.get("pivotWindow", 2))
+    step = float(inputs.get("minStructureStepPct", 0.15))
+    require_all = bool(inputs.get("requireAllThree", True))
+
+    bd = timeframe_bias(daily, k, step)
+    b4 = timeframe_bias(h4, k, step)
+    b1 = timeframe_bias(h1, k, step)
+    if bd == "NEUTRAL" or bd != b4:
+        return None, (bd, b4, b1)
+    if require_all:
+        if b1 != bd:
+            return None, (bd, b4, b1)
+    elif b1 not in (bd, "NEUTRAL"):
+        return None, (bd, b4, b1)
+    return bd, (bd, b4, b1)
+
+
+# ── 2. WHERE — the 4h Area Of Interest ───────────────────────────────────────
+
+def find_aoi(candles_4h, bias, inputs):
+    """(lo, hi) of the 4h Area Of Interest, or None.
+
+    In an uptrend the AOI is the most recent swing LOW that price rallied away from — the
+    level it is expected to retest and hold. In a downtrend, the most recent swing HIGH.
+    The zone is that pivot widened by `aoiPaddingPct`, because price respects areas, not lines.
+    """
+    k = int(inputs.get("pivotWindow", 2))
+    pad = float(inputs.get("aoiPaddingPct", 0.12)) / 100.0
+    max_age = int(inputs.get("maxAoiAgeBars", 30))
+
+    highs, lows = swing_points(candles_4h, k)
+    n = len(candles_4h)
+    if bias == "UP":
+        if not lows:
+            return None
+        idx, level = lows[-1]
+    else:
+        if not highs:
+            return None
+        idx, level = highs[-1]
+    if n - 1 - idx > max_age or level <= 0:
+        return None                          # the level is stale; price has moved on from it
+    return level * (1 - pad), level * (1 + pad)
+
+
+def in_aoi(price, aoi):
+    return aoi is not None and aoi[0] <= price <= aoi[1]
+
+
+def touched_aoi(candles_15m, aoi, bars):
+    """Did price TRADE INTO the zone within the last `bars` candles? (touched, bars_ago)
+
+    Deliberately not `in_aoi(latest_close)`. The entry trigger is a break of structure, and a
+    real break carries price OUT of the zone on the very bar that triggers it — so testing the
+    current close rejects precisely the setups the method is built to take. What matters is
+    that price came back and TAGGED the level (wick counts, hence high/low rather than close)
+    and then broke. Measured on synthetic data: the close-based test rejected a textbook
+    entry whose break closed 0.04% above the zone.
+    """
+    if aoi is None or not candles_15m:
+        return False, None
+    lo, hi = aoi
+    window = candles_15m[-int(max(1, bars)):]
+    for offset, cd in enumerate(reversed(window)):
+        if _low(cd) <= hi and _high(cd) >= lo:      # the bar's range overlaps the zone
+            return True, offset
+    return False, None
+
+
+def distance_to_aoi_pct(price, aoi):
+    """How far price sits outside the zone, as a percent (0.0 when inside)."""
+    if aoi is None or price <= 0:
+        return None
+    lo, hi = aoi
+    if price < lo:
+        return (lo - price) / price * 100.0
+    if price > hi:
+        return (price - hi) / price * 100.0
+    return 0.0
+
+
+# ── 3. WHEN — the 15m structure trigger ──────────────────────────────────────
+
+def structure_break(candles_15m, bias, inputs):
+    """Did 15m structure just break in the bias direction? (broke, level, kind).
+
+    'continuation' — price took out the most recent 15m swing high (up) / low (down).
+    A break AGAINST the bias is never a trigger; it is the reason to stand aside.
+    """
+    k = int(inputs.get("pivotWindow15m", 1))
+    lookback = int(inputs.get("triggerLookbackBars", 12))
+    if len(candles_15m) < lookback + 2 * k + 1:
+        return False, None, None
+    recent = candles_15m[-(lookback + 2 * k + 1):]
+    highs, lows = swing_points(recent, k)
+    last = _close(recent[-1])
+    if bias == "UP":
+        if not highs:
+            return False, None, None
+        level = highs[-1][1]
+        return (last > level), level, "continuation"
+    if not lows:
+        return False, None, None
+    level = lows[-1][1]
+    return (last < level), level, "continuation"
+
+
+def displacement_pct(candles_15m, bars=3):
+    """Size of the most recent 15m push, as a percent — the 'is this a real break' check."""
+    if len(candles_15m) < bars + 1:
+        return 0.0
+    start = _close(candles_15m[-(bars + 1)])
+    end = _close(candles_15m[-1])
+    return 0.0 if start <= 0 else abs(end - start) / start * 100.0
+
+
+# ── the thesis ───────────────────────────────────────────────────────────────
+
+def build_thesis(coin, daily, h4, h1, m15, inputs):
+    """The full top-down cascade. Returns a thesis dict or None at the first failed step.
+
+    Scoring (max 9):
+      +4  Daily/4h/1h bias aligned
+      +3  price inside the 4h AOI
+      +2  15m structure break in the bias direction
+      +1  displacement confirms the break is real   (never awarded without the break)
+    """
+    min_disp = float(inputs.get("minDisplacementPct", 0.08))
+
+    if min(len(daily), len(h4), len(h1), len(m15)) < int(inputs.get("minCandles", 20)):
+        return None
+
+    bias, seen = aligned_bias(daily, h4, h1, inputs)
+    if bias is None:
+        return None                          # step 1 failed: no agreed direction
+    direction = "LONG" if bias == "UP" else "SHORT"
+    reasons = [f"D/4h/1h all {bias} ({'/'.join(seen)})"]
+
+    aoi = find_aoi(h4, bias, inputs)
+    if aoi is None:
+        return None                          # step 2 failed: no valid area of interest
+    price = _close(m15[-1])
+    touched, bars_ago = touched_aoi(m15, aoi, int(inputs.get("aoiTouchWindowBars", 8)))
+    if not touched:
+        return None                          # never came back to the level — the common stand-aside
+    reasons.append(f"price tagged the 4h AOI [{aoi[0]:.6g}, {aoi[1]:.6g}] "
+                   f"{'this bar' if bars_ago == 0 else f'{bars_ago} bars ago'}")
+
+    broke, level, kind = structure_break(m15, bias, inputs)
+    if not broke:
+        return None                          # step 3 failed: at the level but no trigger yet
+    reasons.append(f"15m {kind} break of {level:.6g}")
+
+    score = 4 + 3 + 2
+    disp = displacement_pct(m15)
+    if disp >= min_disp:
+        score += 1
+        reasons.append(f"displacement {disp:.3f}% confirms the break")
+    else:
+        reasons.append(f"weak displacement {disp:.3f}%")
+
+    return {"coin": coin, "direction": direction, "score": score,
+            "bias": bias, "biases": list(seen), "aoi_low": aoi[0], "aoi_high": aoi[1],
+            "trigger_level": level, "displacement_pct": round(disp, 4),
+            "reasons": reasons}
+
+
+def margin_tier_pct(score, base_pct):
+    """Conviction sizing on the PERCENT scale (base_pct is a PERCENT in (0,100])."""
+    if score >= 9:
+        return base_pct * 1.5
+    if score >= 8:
+        return base_pct * 1.25
+    return base_pct

--- a/strategies/manta/strategy.yaml
+++ b/strategies/manta/strategy.yaml
@@ -1,0 +1,40 @@
+# Manta — Multi-Timeframe Structure (FX). A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. The catalog's first FX template: top-down
+# structure trading on Hyperliquid's xyz: currency pairs. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: manta
+version: "1.0.0"
+
+catalog:
+  name: "Manta — Multi-Timeframe Structure (FX)"
+  emoji: "🐟"
+  tagline: "Top-down structure trading on FX pairs (EUR / GBP / JPY), the way it's taught: the Daily, 4-hour and 1-hour charts must all agree on trend direction, the 4-hour marks the area price is expected to retest, and the 15-minute times the entry off a break of structure inside that zone. If the timeframes disagree, or price isn't at the level, or there's no 15-minute trigger, it does nothing. Long & short, low leverage scaled to how small FX moves are."
+  belief_plain: "This is how structure traders actually read a chart: start wide, then zoom in. First it checks that the Daily, 4-hour and 1-hour charts are all pointing the same way — if they disagree, there's no trade. Then on the 4-hour it marks the zone price is likely to pull back to. Then it waits, on the 15-minute chart, for price to actually reach that zone AND break in the trend direction before entering. Three things have to line up: direction, location, and timing. Miss any one and it stands aside. It trades the major currency pairs, which move in small percentages, so it uses the leverage that matches."
+  thesis: "Multi-timeframe / ICT-style structure trading is one of the largest retail methodologies and the catalog had no expression of it — nor any FX template at all, despite Hyperliquid listing EUR, GBP and JPY. Manta encodes the top-down cascade faithfully: each timeframe answers exactly one question (higher frames = bias, 4h = location, 15m = timing) and is not allowed to answer another, which is the discipline the method is really about. The confluence is mandatory, not additive — a signal requires all three, because a 15m break outside the zone is noise and a zone touch with no break is a falling knife. Thresholds are FX-scaled throughout: a 0.5% daily move is a big FX day, so a crypto-sized structure filter would call every currency chart neutral forever."
+  group: single-asset
+  archetype: breakout_momentum
+  sub_style: market_structure
+  asset_classes: [fx]
+  asset_scope: basket
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  time_horizon: swing
+  leverage_max: 8
+  max_slots: 2
+  min_budget: 200
+  assets: ["xyz:EUR", "xyz:GBP", "xyz:JPY"]
+  tags: [fx, forex, multi-timeframe, mtf, market-structure, ict, smc, top-down, break-of-structure, area-of-interest, eur, gbp, jpy, long-short]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: MANTA_WALLET
+    funding_share: 1.0

--- a/strategies/rooster/main/runtime.yaml
+++ b/strategies/rooster/main/runtime.yaml
@@ -1,0 +1,144 @@
+# ── ROOSTER · single instance — The Opener (pre-session-open positioning) ─────
+# The only fleet strategy whose signal is the CLOCK. It wakes in the window before a
+# configured session open, reads how price and volume are setting up, and carries a
+# position INTO the open. Outside that window it emits nothing and reads nothing.
+name: rooster-main
+group: rooster
+version: 1.0.0
+description: >
+  ROOSTER — The Opener. Positions into a session open instead of reacting after it.
+  In the configured pre-open window (default 45m before 13:30 and 08:00 UTC) it scores
+  the setup on 15m candles: the signed DRIFT across the window is the directional read,
+  expanding VOLUME vs the trailing baseline confirms real positioning (a drift on thin
+  volume scores nothing), a break of the PRIOR session's range adds conviction, and 4h
+  trend structure is context only. Emits at most ONE signal per session open per asset.
+  Single asset by default (BTC) at 2-5x. Exits are DSL-led price action, with a session
+  hard_timeout as the thesis clock — the edge is the open, so a trade still running long
+  after it is no longer the trade that was entered.
+
+strategy:
+  wallet: "${ROOSTER_WALLET}"
+  slots: 1
+  margin_pct: 12                          # baseline %; scan emits the conviction-tier marginPct per signal
+  default_leverage: 3                     # fallback; scan emits 2-5x per signal
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: rooster_main_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                  # 5m: fine enough to catch the window, cheap when idle
+                                           # (outside the pre-open window the tick makes ZERO market reads)
+    timeout_seconds: 120
+    default_signal_validity_seconds: 900   # 3x tick — a pre-open read goes stale fast
+    state_history_max_count: 120           # per-session fired map + per-tick scan-results history
+    inputs:
+      assets: ["BTC"]                      # M192397: "on the opener — yes, only BTC". Add names to widen.
+      sessionOpensUtc: ["13:30", "08:00"]  # UTC ALWAYS. US equity open is 13:30 UTC in EDT / 14:30 in EST
+                                           # — set for the half-year you are in, or list both.
+      preOpenMinutes: 45                   # "start scanning 30-60 minutes earlier" — the core knob
+      minScore: 5                          # drift (3) + one of volume/breakout (2)
+      marginPctBase: 12                    # PERCENT of withdrawable (0,100]; tiered x1.25 (>=6) / x1.5 (>=8)
+      maxSlots: 1
+      leverageDefault: 3
+      leverageMin: 2
+      leverageMax: 5
+      windowBars: 3                        # 3 x 15m = the 45m pre-open drift window
+      baselineBars: 16                     # 4h of 15m bars as the volume baseline
+      priorRangeBars: 24                   # 6h of settled price for the breakout reference
+      minDriftPct: 0.35                    # noise floor — below this there is no directional read
+      strongDriftPct: 0.9
+      minVolumeRatio: 1.15                 # window volume must beat baseline by 15% to count
+      breakoutHighPct: 0.8                 # >=80% of the prior range = breaking the high
+      breakoutLowPct: 0.2
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      reasons: { type: array, required: false }
+      driftPct: { type: number, required: false }
+      volRatio: { type: number, required: false }
+      rangePos: { type: number, required: false }
+      trend4h: { type: string, required: false }
+      minutesToOpen: { type: number, required: false }
+      sessionOpenUtc: { type: string, required: false }
+      heldAssets: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: rooster_main_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied the clock gate + every filter
+    scanners: [rooster_main_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # a pre-open entry that rests and misses the fill has
+                                           # missed the whole thesis — the open does not wait.
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: rooster_main_signals
+
+# ── EXIT (DSL — session ladder) ──────────────────────────────────────────────
+# Price action leads, as everywhere. The one deliberate difference from the fleet default:
+# hard_timeout is ENABLED here. Elsewhere a clock-based cut is an arbitrary guess, but this
+# strategy's whole thesis IS a time window — a position still open 8h after the bell is no
+# longer the trade that was entered, so the timeout is signal-invalidation, not a blind cut.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: true                        # the session thesis expires — see note above
+      interval_in_minutes: 480             # 8h: covers the open plus the session that follows it
+    weak_peak_cut:
+      enabled: true                        # the open came and went and nothing happened -> release it
+      interval_in_minutes: 90
+      min_value: 1.5
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0                   # tighter than a swing: an open that goes wrong goes fast
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # bank the open move early, then let a real trend breathe
+        - { trigger_pct: 6, lock_hw_pct: 0 }
+        - { trigger_pct: 12, lock_hw_pct: 30 }
+        - { trigger_pct: 20, lock_hw_pct: 50 }
+        - { trigger_pct: 35, lock_hw_pct: 65 }
+        - { trigger_pct: 55, lock_hw_pct: 78 }
+
+# ── RISK guard rails (moderate) ──
+risk:
+  data_retention_seconds: 259200           # 72h
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 3                  # at most one per configured session open
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3
+    cooldown_seconds: 1800
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400       # 4h — never two entries into the same session
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/rooster/main/scanners/scan.py
+++ b/strategies/rooster/main/scanners/scan.py
@@ -1,0 +1,175 @@
+"""ROOSTER — supervised scanner: pre-session-open positioning.
+
+The only strategy in the fleet whose signal is the CLOCK. Every tick it asks "are we inside the
+pre-open window of a configured session?" — and outside that window it emits nothing at all,
+cheaply, without a single market read.
+
+Per tick, inside the window:
+  - reads account + held positions (dual-DEX equity via max(), never sum; corrupt-read guard),
+  - fetches 15m + 4h candles for the configured asset(s),
+  - scores the pre-open setup via pure `scoring.build_thesis` (drift + volume expansion +
+    prior-range breakout + 4h context),
+  - emits at most one signal PER SESSION per asset (session-keyed dedup in ctx.state), so a
+    45-minute window scanned every 5 minutes cannot fire nine times.
+
+Read-only + single-pass. Emits a `marginPct` INTENT (PERCENT in (0,100]) + `leverage`.
+Candle values are strings keyed o/h/l/c/v — scoring._close/_f coerce.
+
+TIMEZONE: `sessionOpensUtc` is UTC, always. A US equity open is 13:30 UTC during EDT and
+14:30 UTC during EST — set it for the half of the year you are in, or list both.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_ASSETS = ["BTC"]
+_DEFAULT_OPENS = ["13:30", "08:00"]        # US equity open (EDT) + London open, UTC
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, [position dicts]) from strategy_get_clearinghouse_state — dual-DEX equity via
+    max() (never sum: two views of ONE cross-margined wallet), positions enumerated across BOTH
+    sub-DEX sections. Read-guarded (a read error skips the tick)."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the tick
+        print(f"[rooster.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, []
+    if not ch:
+        return 0.0, []
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, []
+    positions, account_value, used = [], 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)), abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            positions.append({"coin": pos.get("coin", ""), "margin": scoring._f(pos.get("marginUsed", 0))})
+    if used > 1.0 and not positions:   # corrupt read: margin in use but empty positions — skip tick
+        print("[rooster.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, []
+    return account_value, positions
+
+
+def _candles(ctx, coin):
+    """{'15m':[...], '4h':[...]} for `coin` or None. Read-guarded."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin, "candle_intervals": ["15m", "4h"],
+            "include_funding": False, "include_order_book": False, "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[rooster.scan] market_get_asset_data({coin}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md or (isinstance(md, dict) and md.get("success") is False):
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    return d.get("candles", {}) if isinstance(d, dict) else None
+
+
+def _load_fired(ctx):
+    """{session_key: ts} — which session opens we have already positioned into."""
+    if ctx.state is None or len(ctx.state) == 0:
+        return {}
+    f = (ctx.state.last() or {}).get("fired", {})
+    return dict(f) if isinstance(f, dict) else {}
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    assets = inputs.get("assets", _DEFAULT_ASSETS)
+    opens = inputs.get("sessionOpensUtc", _DEFAULT_OPENS)
+    pre_open_minutes = int(inputs.get("preOpenMinutes", 45))
+    min_score = float(inputs.get("minScore", 5))
+    base_margin_pct = float(inputs.get("marginPctBase", 12))   # PERCENT in (0,100]
+    max_slots = int(inputs.get("maxSlots", 1))
+    lev_default = int(inputs.get("leverageDefault", 3))
+    lev_min = int(inputs.get("leverageMin", 2))
+    lev_max = int(inputs.get("leverageMax", 5))
+
+    # ── THE CLOCK GATE — outside the pre-open window we do nothing, and read nothing ──
+    minute_of_day = int((now // 60) % 1440)             # UTC (time.time() is epoch/UTC)
+    phase, open_minute, mins_to_open = scoring.session_phase(minute_of_day, opens, pre_open_minutes)
+    if phase != "pre_open":
+        print(f"[rooster.scan] IDLE — {minute_of_day // 60:02d}:{minute_of_day % 60:02d} UTC is outside "
+              f"every pre-open window (opens={opens}, window={pre_open_minutes}m)", file=sys.stderr)
+        return []
+
+    session_key = f"{int(now // 86400)}:{open_minute}"  # one key per calendar-day per session open
+    fired = {k: v for k, v in _load_fired(ctx).items() if (now - v) < 86400 * 2}
+
+    account_value, positions = _get_account(ctx)
+    if account_value <= 0:
+        print("[rooster.scan] WAITING — no account value / corrupt read", file=sys.stderr)
+        return []
+    held = {p["coin"].upper() for p in positions if p.get("coin")}
+    open_slots = max_slots - len(held)
+    if open_slots <= 0:
+        print(f"[rooster.scan] slots full ({len(held)}/{max_slots}) — DSL manages exits", file=sys.stderr)
+        return []
+
+    candidates, scanned = [], 0
+    for coin in assets:
+        if not coin:
+            continue
+        cu = coin.upper()
+        if cu in held:
+            continue
+        if f"{session_key}:{cu}" in fired:              # already positioned into THIS open
+            continue
+        scanned += 1
+        candles = _candles(ctx, coin)
+        if not candles:
+            continue
+        th = scoring.build_thesis(coin, candles.get("15m", []), candles.get("4h", []),
+                                  mins_to_open, inputs)
+        if th and th["score"] >= min_score:
+            candidates.append(th)
+
+    candidates.sort(key=lambda x: x["score"], reverse=True)
+    leverage = max(lev_min, min(lev_default, lev_max))
+    out = []
+    for th in candidates[:open_slots]:
+        margin_pct = round(scoring.margin_tier_pct(th["score"], base_margin_pct), 4)
+        fired[f"{session_key}:{th['coin'].upper()}"] = now
+        out.append({
+            "asset": th["coin"],
+            "direction": th["direction"],
+            "marginPct": margin_pct,      # PERCENT in (0,100] — runtime sizes the dollars
+            "leverage": leverage,
+            "data": {
+                "score": th["score"], "leverage": leverage, "direction": th["direction"],
+                "reasons": th["reasons"][:8], "driftPct": th["drift_pct"],
+                "volRatio": th["vol_ratio"], "rangePos": th["range_pos"],
+                "trend4h": th["trend_4h"], "minutesToOpen": th["minutes_to_open"],
+                "sessionOpenUtc": f"{open_minute // 60:02d}:{open_minute % 60:02d}",
+                "heldAssets": sorted(held),
+            },
+        })
+
+    print(f"[rooster.scan] {'EMIT' if out else 'WAITING'} — {mins_to_open}m to the "
+          f"{open_minute // 60:02d}:{open_minute % 60:02d} UTC open; scanned={scanned} "
+          f"emitted={len(out)} min_score={min_score:.0f} held={sorted(held)}", file=sys.stderr)
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"fired": fired,
+                              "result": {"ts": now, "session": session_key, "scanned": scanned,
+                                         "emitted": len(out), "minutesToOpen": mins_to_open}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[rooster.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/rooster/main/scanners/scoring.py
+++ b/strategies/rooster/main/scanners/scoring.py
@@ -1,0 +1,237 @@
+"""ROOSTER — pure thesis math: pre-session-open positioning (no I/O, no MCP, no clock).
+
+The edge is the CLOCK, not the chart: liquidity and directional intent build in the window
+BEFORE a session opens, and the open itself is when that intent gets expressed. So the read is
+taken during the pre-open window and the position is carried INTO the open.
+
+What the scorer measures over the pre-open window (15m candles):
+  - DRIFT      — signed % move across the window. This is the directional read.
+  - VOLUME     — window volume vs the trailing baseline. Real pre-positioning shows up as
+                 expanding volume; a drift on thin volume is noise and scores nothing.
+  - RANGE POS  — where price sits inside the prior session's range. A drift that is also
+                 breaking out of the prior range is a stronger setup than one mid-range.
+  - 4h TREND   — context only. Aligned adds, opposed subtracts; it never sets direction.
+
+`session_phase` is the one clock-aware function and it is PURE — it takes `minute_of_day` from
+the caller (scan.py owns the clock) and returns where we are relative to the configured opens.
+
+Candles are keyed o/h/l/c/v with STRING values — `_f`/`_close` coerce both shapes.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── the clock (pure — minute_of_day is supplied by scan.py) ───────────────────
+
+def parse_hhmm(s):
+    """'13:30' -> 810 minutes past UTC midnight. None if unparseable."""
+    try:
+        h, m = str(s).strip().split(":")
+        h, m = int(h), int(m)
+    except (ValueError, AttributeError):
+        return None
+    if not (0 <= h < 24 and 0 <= m < 60):
+        return None
+    return h * 60 + m
+
+
+def session_phase(minute_of_day, opens_hhmm, pre_open_minutes):
+    """Where the clock sits relative to the configured session opens.
+
+    Returns (phase, open_minute, minutes_to_open):
+      'pre_open' — inside [open - pre_open_minutes, open): the ONLY window that emits.
+      'idle'     — anywhere else.
+
+    Wraps midnight correctly (an 00:30 open has a pre-open window in the prior day's 23:xx).
+    """
+    if not opens_hhmm:
+        return "idle", None, None
+    span = max(1, int(pre_open_minutes))
+    best = None
+    for raw in opens_hhmm:
+        om = parse_hhmm(raw)
+        if om is None:
+            continue
+        delta = (om - minute_of_day) % 1440          # minutes until this open, forward-looking
+        if 0 < delta <= span and (best is None or delta < best[1]):
+            best = (om, delta)
+    if best is None:
+        return "idle", None, None
+    return "pre_open", best[0], best[1]
+
+
+# ── measurements ─────────────────────────────────────────────────────────────
+
+def window_drift_pct(candles_15m, bars):
+    """Signed % move across the last `bars` 15m candles. 0.0 if too short."""
+    if len(candles_15m) < bars + 1 or bars < 1:
+        return 0.0
+    start = _close(candles_15m[-(bars + 1)])
+    end = _close(candles_15m[-1])
+    if start <= 0:
+        return 0.0
+    return (end - start) / start * 100.0
+
+
+def volume_expansion(candles_15m, bars, baseline_bars):
+    """Mean volume over the last `bars` vs the mean over the `baseline_bars` before them.
+    Returns a ratio (1.0 = in line with baseline). 0.0 when there is not enough history."""
+    need = bars + baseline_bars
+    if len(candles_15m) < need or bars < 1 or baseline_bars < 1:
+        return 0.0
+    recent = [_vol(c) for c in candles_15m[-bars:]]
+    base = [_vol(c) for c in candles_15m[-need:-bars]]
+    base_mean = sum(base) / len(base)
+    if base_mean <= 0:
+        return 0.0
+    return (sum(recent) / len(recent)) / base_mean
+
+
+def prior_range_position(candles_15m, window_bars, prior_bars):
+    """Where the latest close sits within the prior session's range, as a 0-1 fraction
+    (0 = at/below the prior low, 1 = at/above the prior high). None if unavailable.
+
+    The prior range EXCLUDES the pre-open window itself, so a breakout is measured against
+    settled price, not against the drift we are trying to score.
+    """
+    need = window_bars + prior_bars
+    if len(candles_15m) < need or prior_bars < 2:
+        return None
+    prior = candles_15m[-need:-window_bars] if window_bars > 0 else candles_15m[-prior_bars:]
+    hi = max(_high(c) for c in prior)
+    lo = min(_low(c) for c in prior)
+    if hi <= lo:
+        return None
+    last = _close(candles_15m[-1])
+    return max(0.0, min(1.0, (last - lo) / (hi - lo)))
+
+
+def trend_structure(candles):
+    """('UP'|'DOWN'|'NEUTRAL', strength 0-1) from higher-highs / lower-lows over the series.
+    Context only — never sets direction."""
+    if len(candles) < 6:
+        return "NEUTRAL", 0.0
+    highs = [_high(c) for c in candles[-6:]]
+    lows = [_low(c) for c in candles[-6:]]
+    up = sum(1 for i in range(1, len(highs)) if highs[i] > highs[i - 1])
+    down = sum(1 for i in range(1, len(lows)) if lows[i] < lows[i - 1])
+    n = len(highs) - 1
+    if up >= n * 0.6:
+        return "UP", up / n
+    if down >= n * 0.6:
+        return "DOWN", down / n
+    return "NEUTRAL", 0.0
+
+
+# ── the thesis ───────────────────────────────────────────────────────────────
+
+def build_thesis(coin, candles_15m, candles_4h, minutes_to_open, inputs):
+    """Score the pre-open setup. Returns a thesis dict or None (no setup).
+
+    Scoring (max 8; `minScore` gates):
+      +3  drift clears the noise floor          — the directional read
+      +2  volume expanding vs baseline          — real positioning, not drift on air
+      +2  breaking out of the prior range in the drift direction
+      +1  4h trend agrees   (-1 if it opposes)
+    """
+    min_drift = float(inputs.get("minDriftPct", 0.35))
+    strong_drift = float(inputs.get("strongDriftPct", 0.9))
+    min_vol_ratio = float(inputs.get("minVolumeRatio", 1.15))
+    window_bars = int(inputs.get("windowBars", 3))
+    baseline_bars = int(inputs.get("baselineBars", 16))
+    prior_bars = int(inputs.get("priorRangeBars", 24))
+    breakout_hi = float(inputs.get("breakoutHighPct", 0.8))
+    breakout_lo = float(inputs.get("breakoutLowPct", 0.2))
+
+    if len(candles_15m) < window_bars + baseline_bars:
+        return None
+
+    drift = window_drift_pct(candles_15m, window_bars)
+    if abs(drift) < min_drift:
+        return None                                   # no directional read — the common case
+
+    direction = "LONG" if drift > 0 else "SHORT"
+    score, reasons = 3, [f"pre-open drift {drift:+.2f}% over {window_bars * 15}m"]
+
+    vol_ratio = volume_expansion(candles_15m, window_bars, baseline_bars)
+    if vol_ratio >= min_vol_ratio:
+        score += 2
+        reasons.append(f"volume {vol_ratio:.2f}x baseline")
+    else:
+        reasons.append(f"volume only {vol_ratio:.2f}x baseline (thin)")
+
+    pos = prior_range_position(candles_15m, window_bars, prior_bars)
+    if pos is not None:
+        if direction == "LONG" and pos >= breakout_hi:
+            score += 2
+            reasons.append(f"breaking prior range high (pos {pos:.2f})")
+        elif direction == "SHORT" and pos <= breakout_lo:
+            score += 2
+            reasons.append(f"breaking prior range low (pos {pos:.2f})")
+        else:
+            reasons.append(f"mid prior range (pos {pos:.2f})")
+
+    t4, _ = trend_structure(candles_4h)
+    if (t4 == "UP" and direction == "LONG") or (t4 == "DOWN" and direction == "SHORT"):
+        score += 1
+        reasons.append(f"4h trend {t4} agrees")
+    elif t4 != "NEUTRAL":
+        score -= 1
+        reasons.append(f"4h trend {t4} opposes")
+
+    if abs(drift) >= strong_drift:
+        reasons.append("drift is strong")
+
+    return {
+        "coin": coin, "direction": direction, "score": max(0, score),
+        "drift_pct": round(drift, 4), "vol_ratio": round(vol_ratio, 3),
+        "range_pos": None if pos is None else round(pos, 3),
+        "trend_4h": t4, "minutes_to_open": minutes_to_open,
+        "reasons": reasons,
+    }
+
+
+def margin_tier_pct(score, base_pct):
+    """Conviction sizing on the PERCENT scale (base_pct is a PERCENT in (0,100])."""
+    if score >= 8:
+        return base_pct * 1.5
+    if score >= 6:
+        return base_pct * 1.25
+    return base_pct

--- a/strategies/rooster/strategy.yaml
+++ b/strategies/rooster/strategy.yaml
@@ -1,0 +1,40 @@
+# Rooster — The Opener. A single-instance PACKAGE: this manifest + one self-contained
+# runtime.yaml + scanners/. The only fleet strategy whose signal is the CLOCK: it positions
+# into a session open rather than reacting after it. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: rooster
+version: "1.0.0"
+
+catalog:
+  name: "Rooster — The Opener"
+  emoji: "🐓"
+  tagline: "Trades the clock, not the chart. In the window before a session opens (default 45 minutes, configurable — the knob that matters) it reads how price and volume are setting up: the drift across the window sets direction, expanding volume confirms real positioning, and a break of the prior session's range adds conviction. Carries the position INTO the open, one signal per session, BTC by default at 2-5x with a session-aware DSL ladder."
+  belief_plain: "Most of the day is noise. The move that matters often starts setting up in the 30-60 minutes BEFORE a session opens, and by the time the bell rings the direction is already showing. Rooster wakes up in that window, checks whether price is actually drifting one way on real volume (not just wandering on thin trade), and takes the position into the open. It fires at most once per session, banks profit early, and lets go if the open comes and goes with nothing happening."
+  thesis: "Every other template in the catalog reads price; none reads the clock. Session opens are the most reliable recurring liquidity event in any market, and pre-open drift on expanding volume is a genuine directional tell — but only when it clears a noise floor and only when volume confirms it, which is what separates positioning from wandering. Rooster makes the window itself the strategy: outside it the scanner emits nothing and reads nothing (a cheap idle tick), inside it it scores once and commits. The pre-open window, the session times, and the noise floor are all inputs, because the right window is exactly what a user wants to tune."
+  group: momentum
+  archetype: single_market
+  sub_style: session_open
+  asset_classes: [btc_eth]
+  asset_scope: single
+  direction: long_short
+  risk_level: moderate
+  tier: starter
+  time_horizon: swing
+  leverage_max: 5
+  max_slots: 1
+  min_budget: 100
+  assets: ["BTC"]
+  tags: [session, market-open, time-of-day, opener, pre-open, clock, intraday, btc, single-asset, long-short, beginner]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: ROOSTER_WALLET
+    funding_share: 1.0

--- a/strategies/rooster/tests/test_engine.py
+++ b/strategies/rooster/tests/test_engine.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Rooster + shared-engine unit tests — the clock gate, the pivot-plateau fix, the cascades.
+
+These cover the two bugs found building this wave, both silent no-trades of the same family
+we've been chasing all week:
+  - pivot PLATEAU: a flat top registered the same pivot twice, so every higher-high / double-
+    bottom comparison saw a 0% step and the strategy never fired (manta + bloodhound).
+  - AOI on the trigger bar: requiring the current close INSIDE the zone rejected exactly the
+    break that triggers entry, because a real break leaves the zone on that bar (manta).
+
+Run: python3 strategies/rooster/tests/test_engine.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load(strategy, module):
+    d = ROOT / "strategies" / strategy / "main" / "scanners"
+    sys.path.insert(0, str(d))
+    try:
+        sys.modules.pop("scoring", None)
+        spec = importlib.util.spec_from_file_location(f"{strategy}_{module}", d / f"{module}.py")
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return m
+    finally:
+        sys.path.pop(0)
+
+
+def _c(px, v=1000):
+    return {"o": str(px), "h": str(px * 1.0008), "l": str(px * 0.9992), "c": str(px), "v": str(v)}
+
+
+class RoosterClock(unittest.TestCase):
+    def setUp(self):
+        self.S = _load("rooster", "scoring")
+
+    def test_inside_pre_open_window(self):
+        # 12:50 UTC, 45m window before 13:30 -> pre_open, 40m to go
+        ph, om, mt = self.S.session_phase(12 * 60 + 50, ["13:30"], 45)
+        self.assertEqual(ph, "pre_open")
+        self.assertEqual(mt, 40)
+
+    def test_at_and_after_open_is_idle(self):
+        self.assertEqual(self.S.session_phase(13 * 60 + 30, ["13:30"], 45)[0], "idle")
+        self.assertEqual(self.S.session_phase(13 * 60 + 45, ["13:30"], 45)[0], "idle")
+
+    def test_outside_window_is_idle(self):
+        self.assertEqual(self.S.session_phase(3 * 60, ["13:30"], 45)[0], "idle")
+
+    def test_midnight_wrap(self):
+        # a 00:30 open has its pre-open window in the PRIOR day's 23:xx
+        self.assertEqual(self.S.session_phase(23 * 60 + 50, ["00:30"], 45)[0], "pre_open")
+        self.assertEqual(self.S.session_phase(0 * 60 + 31, ["00:30"], 45)[0], "idle")
+
+    def test_nearest_of_multiple_opens(self):
+        ph, om, mt = self.S.session_phase(7 * 60 + 30, ["13:30", "08:00"], 45)
+        self.assertEqual((ph, om, mt), ("pre_open", 8 * 60, 30))
+
+    def test_drift_on_volume_is_a_setup(self):
+        base = [_c(100 + i * 0.001, 1000) for i in range(40)]
+        setup = base + [_c(100.2, 2500), _c(100.45, 2800), _c(100.7, 3100)]
+        th = self.S.build_thesis("BTC", setup, [], 20, {})
+        self.assertIsNotNone(th)
+        self.assertEqual(th["direction"], "LONG")
+
+    def test_flat_thin_is_no_setup(self):
+        base = [_c(100 + i * 0.001, 1000) for i in range(40)]
+        flat = base + [_c(100.03, 900), _c(100.02, 850), _c(100.04, 880)]
+        self.assertIsNone(self.S.build_thesis("BTC", flat, [], 20, {}))
+
+
+class PivotPlateau(unittest.TestCase):
+    """The flat-top duplicate-pivot bug, on BOTH engines that share the fractal finder."""
+
+    def _zig(self, S, base, legs, up=True, amp=0.010, ret=0.004):
+        out, p = [], base
+        for _ in range(legs):
+            for x in range(5):
+                out.append(p * (1 + (amp * x if up else -amp * x)))
+            p = p * (1 + amp * 4) if up else p * (1 - amp * 4)
+            for x in range(3):
+                out.append(p * (1 - (ret * x if up else -ret * x)))
+            p = p * (1 - ret * 2) if up else p * (1 + ret * 2)
+        return [_c(round(v, 6)) for v in out]
+
+    def test_manta_bias_reads_a_clean_uptrend(self):
+        S = _load("manta", "scoring")
+        up = self._zig(S, 1.10, 5)
+        # before the plateau fix this returned NEUTRAL (duplicate pivots -> 0% step)
+        self.assertEqual(S.timeframe_bias(up), "UP")
+
+    def test_no_duplicate_pivots(self):
+        S = _load("manta", "scoring")
+        highs, lows = S.swing_points(self._zig(S, 1.10, 5), 2)
+        idxs = [i for i, _ in highs]
+        self.assertEqual(len(idxs), len(set(idxs)))
+        # adjacent pivots must differ by more than k bars (no plateau twins)
+        self.assertTrue(all(idxs[i] - idxs[i - 1] > 2 for i in range(1, len(idxs))))
+
+    def test_bloodhound_still_finds_a_W(self):
+        S = _load("bloodhound", "scoring")
+        w = [_c(110)] * 25 + [_c(x) for x in
+                              [110, 106, 102, 98, 94, 90, 92, 95, 98, 100, 97, 94, 91, 90.5, 93, 96, 99, 101.5]]
+        th = S.build_thesis("T", w, [], {})
+        self.assertIsNotNone(th)
+        self.assertEqual((th["pattern"], th["direction"]), ("double_bottom", "LONG"))
+
+    def test_bloodhound_no_false_positive_on_noise(self):
+        S = _load("bloodhound", "scoring")
+        # deterministic pseudo-noise (no Math.random in engine; fixed LCG here)
+        seed, out = 12345, []
+        for _ in range(60):
+            seed = (1103515245 * seed + 12345) % (2 ** 31)
+            out.append(_c(round(100 + (seed / 2 ** 31 - 0.5) * 0.8, 4)))
+        self.assertIsNone(S.build_thesis("T", out, [], {}))
+
+
+class MantaCascade(unittest.TestCase):
+    def setUp(self):
+        self.S = _load("manta", "scoring")
+
+    def _zig(self, base, legs, up=True, amp=0.010, ret=0.004):
+        out, p = [], base
+        for _ in range(legs):
+            for x in range(5):
+                out.append(p * (1 + (amp * x if up else -amp * x)))
+            p = p * (1 + amp * 4) if up else p * (1 - amp * 4)
+            for x in range(3):
+                out.append(p * (1 - (ret * x if up else -ret * x)))
+            p = p * (1 - ret * 2) if up else p * (1 + ret * 2)
+        return [_c(round(v, 6)) for v in out]
+
+    def _entry_15m(self, aoi):
+        mid = (aoi[0] + aoi[1]) / 2
+        m = [_c(round(mid * (1 + 0.0004 * (1 if i % 2 else -1)), 6)) for i in range(20)]
+        return m + [_c(round(mid * 0.9996, 6)), _c(round(mid * 1.0003, 6)), _c(round(mid * 1.0018, 6))]
+
+    def test_full_cascade_fires(self):
+        D = self._zig(1.10, 5)
+        aoi = self.S.find_aoi(self._zig(1.10, 6), "UP", {})
+        th = self.S.build_thesis("xyz:EUR", D, self._zig(1.10, 6), self._zig(1.10, 6),
+                                 self._entry_15m(aoi), {})
+        self.assertIsNotNone(th, "textbook aligned setup must fire")
+        self.assertEqual(th["direction"], "LONG")
+
+    def test_break_bar_leaving_zone_still_counts(self):
+        # the AOI regression: the trigger bar closes ABOVE the zone, and that must be OK
+        aoi = self.S.find_aoi(self._zig(1.10, 6), "UP", {})
+        m15 = self._entry_15m(aoi)
+        self.assertGreater(self.S._close(m15[-1]), aoi[1])   # closed outside the zone
+        touched, _ = self.S.touched_aoi(m15, aoi, 8)
+        self.assertTrue(touched)                              # ...but tagged it earlier -> valid
+
+    def test_one_dissenting_timeframe_blocks(self):
+        D, H4 = self._zig(1.10, 5), self._zig(1.10, 6)
+        aoi = self.S.find_aoi(H4, "UP", {})
+        down_1h = self._zig(1.10, 5, up=False)
+        self.assertIsNone(self.S.build_thesis("xyz:EUR", D, H4, down_1h, self._entry_15m(aoi), {}))
+
+
+class IbisRegime(unittest.TestCase):
+    def setUp(self):
+        self.S = _load("ibis", "scoring")
+
+    def test_clean_trend_is_TREND(self):
+        up = [_c(round(100 * (1.012 ** i), 4)) for i in range(26)]
+        self.assertEqual(self.S.classify_regime(up, {})[0], "TREND")
+
+    def test_oscillation_is_RANGE(self):
+        chop = [_c(100 + (2 if i % 2 else -2)) for i in range(26)]
+        self.assertEqual(self.S.classify_regime(chop, {})[0], "RANGE")
+
+    def test_trend_entry_requires_oi_baseline(self):
+        up = [_c(round(100 * (1.012 ** i), 4)) for i in range(26)]
+        _r, er, st, stg = self.S.classify_regime(up, {})
+        self.assertIsNone(self.S.trend_thesis("BTC", up, er, st, stg, None, {}))   # no baseline
+        self.assertIsNone(self.S.trend_thesis("BTC", up, er, st, stg, 0.1, {}))    # OI flat
+        self.assertIsNotNone(self.S.trend_thesis("BTC", up, er, st, stg, 2.0, {}))  # OI rising
+
+    def test_range_fade_skipped_on_extreme_funding(self):
+        rng = [_c(100 + (3 if i % 4 in (1, 2) else -3)) for i in range(30)] + [_c(97.2)]
+        _r, er, _s, _st = self.S.classify_regime(rng, {})
+        self.assertIsNone(self.S.range_thesis("BTC", rng, er, 60.0, {}))    # extreme -> skip
+        self.assertIsNotNone(self.S.range_thesis("BTC", rng, er, 5.0, {}))  # calm -> fade
+
+    def test_funding_annualization(self):
+        # '0.0000125' hourly -> ~10.95% APR
+        self.assertAlmostEqual(self.S.annualized_funding_pct("0.0000125"), 10.95, places=1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Built from the highest-signal organic build requests in telemetry. You asked for these after the 100%-template vs 40%-scratch success-rate finding — every one is a mental model users tried to build from scratch and a gap the catalog didn't cover.

Each **ranks #1 for its motivating query** in discover (theme score in parens):

| Template | Style | Fills | Prompt | discover |
|---|---|---|---|---|
| 🐓 **Rooster** | `session_open` | the clock — nothing in the fleet traded time-of-day | M192397 "The Opener" | market open → **22** |
| 🦤 **Ibis** | `adaptive` | regime-switching (coyote/wolf don't switch *entry logic*) | M298631, deployed live | trend or range → **36** |
| 🐕 **Bloodhound** | `chart_pattern` | pattern recognition over a dynamic universe | M325784 | double bottom → **21** |
| 🐟 **Manta** | `market_structure` | **the catalog's first FX template** | M361867 MTF/ICT | mtf forex → **17** |

### What each does
- **Rooster** — the only fleet strategy whose signal is the **clock**. In the pre-open window it scores drift + volume expansion + prior-range breakout and carries the position *into* the open; outside the window it emits nothing and reads nothing. Exposes the pre-open window as the core knob (M192397 was tuning exactly that).
- **Ibis** — classifies the 4h regime (Kaufman efficiency ratio + structure) **then** applies that regime's rule: OI-velocity-confirmed continuation when trending, funding-gated band-edge fade when ranging, a deliberate **no-trade band** between. Implements the user's stated "skip range entries when funding is extreme, OI-velocity to confirm trend entries" verbatim.
- **Bloodhound** — hunts a dynamic universe for double bottoms/tops and higher-high structure, trades whichever way the pattern points. Fractal pivots + depth/magnitude floors + dedup.
- **Manta** — top-down cascade on Hyperliquid FX: D/4h/1h bias → 4h Area of Interest → 15m break-of-structure trigger. Confluence mandatory, thresholds FX-scaled (a 0.5% daily move is a big FX day). `xyz:EUR/GBP/JPY` verified present in the live instrument list.

### Two silent-no-trade bugs found and fixed while building
Same family we've been chasing all week — caught here by testing against synthetic data **before** shipping:
- **Pivot plateau** (manta + bloodhound): a flat top satisfied the `>=` fractal test on every bar of the run, recording the same pivot twice → the last two pivots were duplicates → every higher-high/double-bottom comparison saw a 0% step → silent never-fires. `_push` collapses a plateau to one point.
- **AOI on the trigger bar** (manta): requiring the current close *inside* the zone rejected exactly the break that triggers entry (a real break leaves the zone on that bar). `touched_aoi` checks price *tagged* the zone within a window instead.

### Strategy-author learnings applied
Every one, verbatim — this wave is also a test of whether the guardrails hold on net-new code:
- `marginPct` a PERCENT in (0,100]; candles via the robust `o/h/l/c/v` short-key idiom
- dual-DEX clearinghouse via `max()` never sum, positions across **both** main+xyz sections
- leaderboard/instrument reads dex-aware (name-prefix routing)
- **Validators confirm: 0 dex-blind, 0 marginPct-fraction, 0 candle-key findings across all 4.**

### Verification
- 19-test engine suite (`rooster/tests/test_engine.py`) — clock gate, both plateau engines, manta cascade + AOI regression, ibis regime gates. Each new bug has a test that fails against pre-fix code.
- 41 suites green; `deploy.py validate` clean on all 4
- catalog regenerated (96 strategies, **0 warnings**); 2 new glossary sub_styles; discover skill 2.7.0 → 2.8.0

All four are `starter`/`advanced` tier — aimed squarely at the template on-ramp where the success-rate gap pays off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)