### PR TITLE
strategies: Terrapin — Turtle-Style Breakout Pyramid with a DSL twist

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.7.0"
+  version: "2.9.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -3891,6 +3891,57 @@
       "sort_order": 13
     },
     {
+      "id": "terrapin",
+      "name": "Terrapin — Turtle-Style Breakout Pyramid",
+      "emoji": "🐢",
+      "tagline": "The Turtle breakout, rebuilt with our DSL. It enters when price breaks its 20-day high (long) or low (short) and MACD agrees, then ADDS units as the move extends — a second at +½N, a third at +1N, a fourth at +1½N (N = 20-day ATR). Each unit is its own wallet with its own trailing stop, calibrated to its rung: the base breathes widest and carries the trend, the tip locks tightest and peels off first, so the pyramid unwinds top-down instead of all at once. One asset (BTC by default), long or short, four units.",
+      "belief_plain": "This is the classic Turtle trading system with a modern exit. It waits for a real breakout — price pushing past its highest level in 20 days — and only takes it if momentum (MACD) agrees, which filters out the false breaks that trap breakout buyers. Then, the Turtle move: as the trend keeps running in your favor, it adds more size in steps, building a bigger position into a winner. The twist is how it gets out. The original Turtles dumped the whole stack at one stop; Terrapin gives each added chunk its own trailing stop — the first, safest chunk rides the longest, while the chunks added late (which have the least cushion) protect their profit fastest and exit first if it turns. You fund it once and it splits across four sub-wallets, one per chunk.",
+      "version": "1.0.0",
+      "thesis": "The Turtle breakout is one of the most documented trend-following systems in existence, and the catalog had no expression of it — because a faithful pyramid needs to ADD to a winning position, and Hyperliquid nets positions per coin per wallet, so a single-wallet build can only ever hold the first unit. Terrapin solves that structurally: four units, four wallets, each arming off the same statelessly-computed frozen breakout anchor so the ½N ladder is consistent without any cross-wallet coordination. The deliberate modernization is the exit. Turtle's unified 2N / 10-day-low stop becomes four independent DSL ladders, progressively tighter up the pyramid — which is not just faithful-enough but arguably better: the position unwinds from the top on a reversal, banking the exposed upper units while the base rides, instead of giving the whole stack back at one level. The MACD filter is the user's requested addition ('turtle con MACD') and does real work — it vetoes the momentum-less breakout that is the system's classic whipsaw.",
+      "tags": [
+        "turtle",
+        "breakout",
+        "donchian",
+        "pyramid",
+        "add-to-winner",
+        "atr",
+        "macd",
+        "trend-following",
+        "multi-wallet",
+        "position-trading",
+        "long-short"
+      ],
+      "group": "single-asset",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "pyramid_breakout",
+      "sub_style_label": "Turtle-style: enters a Donchian breakout and ADDS units as it runs, each unit on its own wallet with its own trailing stop.",
+      "asset_classes": [
+        "btc_eth"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "BTC"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 1800,
+      "min_budget": 400,
+      "instance_count": 4,
+      "funding_split": [
+        0.25,
+        0.25,
+        0.25,
+        0.25
+      ],
+      "max_slots": 4,
+      "branch": "main",
+      "sort_order": 14
+    },
+    {
       "id": "wolverine",
       "name": "Wolverine — HYPE Alpha Hunter",
       "emoji": "🦡",
@@ -3933,7 +3984,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "hydra",

--- a/senpi-strategy-discover/references/glossary.yaml
+++ b/senpi-strategy-discover/references/glossary.yaml
@@ -101,6 +101,7 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   breakout:      { gloss: "Enters on a clean breakout of structure." }
   confluence_sniper: { gloss: "Fires only when multiple timeframes/factors line up." }
   parabolic_runner: { gloss: "Rides parabolic runs with a very wide let-winners-run exit." }
+  pyramid_breakout: { gloss: "Turtle-style: enters a Donchian breakout and ADDS units as it runs, each unit on its own wallet with its own trailing stop." }
   sector_momentum: { gloss: "Rides a whole sector / supply chain only when its breadth confirms; won't chase a lone name." }
   # structural_neutral
   cross_asset_lag: { gloss: "Trades an alt that lags a BTC move." }

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -3891,6 +3891,57 @@
       "sort_order": 13
     },
     {
+      "id": "terrapin",
+      "name": "Terrapin — Turtle-Style Breakout Pyramid",
+      "emoji": "🐢",
+      "tagline": "The Turtle breakout, rebuilt with our DSL. It enters when price breaks its 20-day high (long) or low (short) and MACD agrees, then ADDS units as the move extends — a second at +½N, a third at +1N, a fourth at +1½N (N = 20-day ATR). Each unit is its own wallet with its own trailing stop, calibrated to its rung: the base breathes widest and carries the trend, the tip locks tightest and peels off first, so the pyramid unwinds top-down instead of all at once. One asset (BTC by default), long or short, four units.",
+      "belief_plain": "This is the classic Turtle trading system with a modern exit. It waits for a real breakout — price pushing past its highest level in 20 days — and only takes it if momentum (MACD) agrees, which filters out the false breaks that trap breakout buyers. Then, the Turtle move: as the trend keeps running in your favor, it adds more size in steps, building a bigger position into a winner. The twist is how it gets out. The original Turtles dumped the whole stack at one stop; Terrapin gives each added chunk its own trailing stop — the first, safest chunk rides the longest, while the chunks added late (which have the least cushion) protect their profit fastest and exit first if it turns. You fund it once and it splits across four sub-wallets, one per chunk.",
+      "version": "1.0.0",
+      "thesis": "The Turtle breakout is one of the most documented trend-following systems in existence, and the catalog had no expression of it — because a faithful pyramid needs to ADD to a winning position, and Hyperliquid nets positions per coin per wallet, so a single-wallet build can only ever hold the first unit. Terrapin solves that structurally: four units, four wallets, each arming off the same statelessly-computed frozen breakout anchor so the ½N ladder is consistent without any cross-wallet coordination. The deliberate modernization is the exit. Turtle's unified 2N / 10-day-low stop becomes four independent DSL ladders, progressively tighter up the pyramid — which is not just faithful-enough but arguably better: the position unwinds from the top on a reversal, banking the exposed upper units while the base rides, instead of giving the whole stack back at one level. The MACD filter is the user's requested addition ('turtle con MACD') and does real work — it vetoes the momentum-less breakout that is the system's classic whipsaw.",
+      "tags": [
+        "turtle",
+        "breakout",
+        "donchian",
+        "pyramid",
+        "add-to-winner",
+        "atr",
+        "macd",
+        "trend-following",
+        "multi-wallet",
+        "position-trading",
+        "long-short"
+      ],
+      "group": "single-asset",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "pyramid_breakout",
+      "sub_style_label": "Turtle-style: enters a Donchian breakout and ADDS units as it runs, each unit on its own wallet with its own trailing stop.",
+      "asset_classes": [
+        "btc_eth"
+      ],
+      "asset_scope": "single",
+      "assets": [
+        "BTC"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 1800,
+      "min_budget": 400,
+      "instance_count": 4,
+      "funding_split": [
+        0.25,
+        0.25,
+        0.25,
+        0.25
+      ],
+      "max_slots": 4,
+      "branch": "main",
+      "sort_order": 14
+    },
+    {
       "id": "wolverine",
       "name": "Wolverine — HYPE Alpha Hunter",
       "emoji": "🦡",
@@ -3933,7 +3984,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "hydra",

--- a/strategies/terrapin/strategy.yaml
+++ b/strategies/terrapin/strategy.yaml
@@ -1,0 +1,56 @@
+# Terrapin — Turtle-Style Breakout Pyramid (DSL twist). A FOUR-instance PACKAGE: this manifest
+# + one runtime.yaml per unit + per-unit scanners/. The four units are the four rungs of a Turtle
+# pyramid, each on its own wallet (Hyperliquid nets positions per coin per wallet, so stacking
+# units into one directional position REQUIRES one wallet per unit). Install/teardown via
+# senpi-strategy-ops — funding one budget splits equally across the four unit wallets.
+schema_version: 1
+
+id: terrapin
+version: "1.0.0"
+
+catalog:
+  name: "Terrapin — Turtle-Style Breakout Pyramid"
+  emoji: "🐢"
+  tagline: "The Turtle breakout, rebuilt with our DSL. It enters when price breaks its 20-day high (long) or low (short) and MACD agrees, then ADDS units as the move extends — a second at +½N, a third at +1N, a fourth at +1½N (N = 20-day ATR). Each unit is its own wallet with its own trailing stop, calibrated to its rung: the base breathes widest and carries the trend, the tip locks tightest and peels off first, so the pyramid unwinds top-down instead of all at once. One asset (BTC by default), long or short, four units."
+  belief_plain: "This is the classic Turtle trading system with a modern exit. It waits for a real breakout — price pushing past its highest level in 20 days — and only takes it if momentum (MACD) agrees, which filters out the false breaks that trap breakout buyers. Then, the Turtle move: as the trend keeps running in your favor, it adds more size in steps, building a bigger position into a winner. The twist is how it gets out. The original Turtles dumped the whole stack at one stop; Terrapin gives each added chunk its own trailing stop — the first, safest chunk rides the longest, while the chunks added late (which have the least cushion) protect their profit fastest and exit first if it turns. You fund it once and it splits across four sub-wallets, one per chunk."
+  thesis: "The Turtle breakout is one of the most documented trend-following systems in existence, and the catalog had no expression of it — because a faithful pyramid needs to ADD to a winning position, and Hyperliquid nets positions per coin per wallet, so a single-wallet build can only ever hold the first unit. Terrapin solves that structurally: four units, four wallets, each arming off the same statelessly-computed frozen breakout anchor so the ½N ladder is consistent without any cross-wallet coordination. The deliberate modernization is the exit. Turtle's unified 2N / 10-day-low stop becomes four independent DSL ladders, progressively tighter up the pyramid — which is not just faithful-enough but arguably better: the position unwinds from the top on a reversal, banking the exposed upper units while the base rides, instead of giving the whole stack back at one level. The MACD filter is the user's requested addition ('turtle con MACD') and does real work — it vetoes the momentum-less breakout that is the system's classic whipsaw."
+  group: single-asset
+  archetype: breakout_momentum
+  sub_style: pyramid_breakout
+  asset_classes: [btc_eth]
+  asset_scope: single
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  time_horizon: position
+  leverage_max: 5
+  max_slots: 4
+  min_budget: 400
+  assets: ["BTC"]
+  tags: [turtle, breakout, donchian, pyramid, add-to-winner, atr, macd, trend-following, multi-wallet, position-trading, long-short]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+# Four equal units — a faithful Turtle pyramid sizes every unit the same. Each wallet funds one
+# rung; the upper rungs sit as dry powder until a strong trend extends far enough to arm them.
+instances:
+  - name: u1
+    runtime: u1/runtime.yaml
+    wallet_env: TERRAPIN_U1_WALLET
+    funding_share: 0.25
+  - name: u2
+    runtime: u2/runtime.yaml
+    wallet_env: TERRAPIN_U2_WALLET
+    funding_share: 0.25
+  - name: u3
+    runtime: u3/runtime.yaml
+    wallet_env: TERRAPIN_U3_WALLET
+    funding_share: 0.25
+  - name: u4
+    runtime: u4/runtime.yaml
+    wallet_env: TERRAPIN_U4_WALLET
+    funding_share: 0.25

--- a/strategies/terrapin/tests/test_engine.py
+++ b/strategies/terrapin/tests/test_engine.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Terrapin engine tests — Donchian/ATR/MACD, the frozen-anchor pyramid ladder, the MACD filter.
+
+The load-bearing property is the LADDER: unit k must arm only once price has extended k·½N
+beyond the FROZEN breakout anchor, so the four wallets build a real pyramid rather than four
+copies of the same entry. Also guards the same silent-no-trade family we've been chasing:
+a live (sliding) channel would leave u3/u4 perpetually un-armed in a normal trend.
+
+Run: python3 strategies/terrapin/tests/test_engine.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load():
+    d = ROOT / "strategies" / "terrapin" / "u1" / "scanners"
+    sys.path.insert(0, str(d))
+    try:
+        sys.modules.pop("scoring", None)
+        spec = importlib.util.spec_from_file_location("terrapin_scoring", d / "scoring.py")
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return m
+    finally:
+        sys.path.pop(0)
+
+
+def _c(px, hi=None, lo=None):
+    return {"o": str(px), "h": str(hi if hi else px * 1.004), "l": str(lo if lo else px * 0.996),
+            "c": str(px), "v": "1000"}
+
+
+class Indicators(unittest.TestCase):
+    def setUp(self):
+        self.S = _load()
+
+    def test_donchian_excludes_current_bar(self):
+        cs = [_c(100 + i) for i in range(21)] + [_c(200)]   # last bar is a spike
+        hi, lo = self.S.donchian(cs, 20)
+        self.assertLess(hi, 200)                             # the 200 spike is the current bar → excluded
+
+    def test_atr_positive_on_moving_series(self):
+        cs = [_c(100 + i * 0.5) for i in range(25)]
+        self.assertGreater(self.S.atr(cs, 20), 0)
+
+    def test_macd_sign_tracks_trend(self):
+        # a flat base then a fresh accelerating move — the sign the filter actually keys on
+        up = [_c(100)] * 30 + [_c(100 + i * 0.8) for i in range(12)]
+        dn = [_c(100)] * 30 + [_c(100 - i * 0.8) for i in range(12)]
+        self.assertGreater(self.S.macd_hist(up, 12, 26, 9), 0)
+        self.assertLess(self.S.macd_hist(dn, 12, 26, 9), 0)
+
+
+class FrozenAnchorLadder(unittest.TestCase):
+    """The pyramid ladder on REALISTIC breakout data — a range with a sticky prior high/low that
+    the Donchian channel locks onto, then a clean break that runs. (A monotonic ramp is
+    pathological: every bar prints a new high, so the channel never sticks and no real breakout
+    exists to anchor to — which is not how markets or the strategy behave.)"""
+
+    def setUp(self):
+        self.S = _load()
+
+    def _range_then_break(self, run, cap=101.0, floor=None):
+        """40 bars ranging under a sticky resistance `cap` (or over support `floor`), then `run`."""
+        base = []
+        for i in range(40):
+            p = 99.0 + (2.0 if i % 6 == 0 else 0.0) - (1.5 if i % 4 == 0 else 0.0) + (0.3 if i % 2 else -0.3)
+            if floor is None:
+                p = min(p, cap)
+                base.append(_c(round(p, 3), hi=round(min(p * 1.004, cap + 0.2), 3)))
+            else:
+                p = max(200 - p, floor)
+                base.append(_c(round(p, 3), lo=round(max(p * 0.996, floor - 0.2), 3)))
+        return base + [_c(round(x, 3)) for x in run]
+
+    def test_units_arm_progressively(self):
+        series = self._range_then_break([101.5, 102.4, 103.3, 104.2])
+        armed = [u for u in range(4)
+                 if self.S.build_thesis("BTC", series, u, {"requireMacd": False})]
+        self.assertEqual(armed, [0, 1, 2, 3], "a full-extension breakout must arm all four rungs")
+
+    def test_lower_rung_arms_before_upper(self):
+        just_broke = self._range_then_break([101.4])         # only just past resistance
+        armed = [u for u in range(4)
+                 if self.S.build_thesis("BTC", just_broke, u, {"requireMacd": False})]
+        self.assertIn(0, armed)                              # base arms
+        self.assertNotIn(3, armed)                           # tip does not — price hasn't extended 1½N
+
+    def test_anchor_is_frozen_not_sliding(self):
+        """A slow, steady breakout must still arm the upper units — the live-channel bug would not."""
+        slow = self._range_then_break([101.5, 102.4, 103.3, 104.2, 105.0])
+        self.assertIsNotNone(self.S.build_thesis("BTC", slow, 3, {"requireMacd": False}),
+                             "u4 must arm in a sustained trend (frozen anchor), not only a spike")
+        # the anchor stays put across the whole run
+        a1 = self.S.breakout_anchor(self._range_then_break([101.5]), 20, "LONG")
+        a2 = self.S.breakout_anchor(slow, 20, "LONG")
+        self.assertAlmostEqual(a1, a2, delta=0.5)
+
+    def test_no_breakout_no_arm(self):
+        flat = [_c(100 + (0.3 if i % 2 else -0.3)) for i in range(45)]
+        for u in range(4):
+            self.assertIsNone(self.S.build_thesis("BTC", flat, u, {"requireMacd": False}))
+
+    def test_short_pyramid_is_symmetric(self):
+        down = self._range_then_break([98.5, 97.6, 96.7, 95.8], floor=99.0)
+        armed = [self.S.build_thesis("BTC", down, u, {"requireMacd": False})
+                 for u in range(4)]
+        armed = [t for t in armed if t]
+        self.assertTrue(armed and all(t["direction"] == "SHORT" for t in armed))
+        self.assertGreaterEqual(len(armed), 3)
+
+
+class MacdFilter(unittest.TestCase):
+    """A Donchian-20 breakout means price is at a 20-bar extreme, which almost always drags MACD
+    the same way — so the filter rarely vetoes a FRESH breakout (a good property: it doesn't
+    neuter the strategy). Its job is the marginal re-test. That makes an organic opposing-momentum
+    breakout near-impossible to construct, so the veto CONTRACT is tested by forcing the sign."""
+
+    def setUp(self):
+        self.S = _load()
+
+    def _long_breakout(self):
+        base = []
+        for i in range(38):
+            p = min(99.0 + (0.3 if i % 2 else -0.3) + (1.5 if i % 6 == 0 else 0), 100.5)
+            base.append(_c(round(p, 3), hi=round(min(p * 1.003, 100.6), 3)))
+        return base + [_c(101.5), _c(102.5)]                 # clean break above ~100.5
+
+    def test_valid_breakout_fires_with_macd_on(self):
+        """The filter must NOT block a legitimate breakout where momentum agrees."""
+        th = self.S.build_thesis("BTC", self._long_breakout(), 0, {})
+        self.assertIsNotNone(th)
+        self.assertEqual(th["direction"], "LONG")
+
+    def test_opposing_macd_is_vetoed(self):
+        """Force MACD to disagree with a valid long-breakout geometry -> must veto."""
+        series = self._long_breakout()
+        orig = self.S.macd_hist
+        self.S.macd_hist = lambda *a, **k: -5.0            # momentum opposes the long breakout
+        try:
+            self.assertIsNone(self.S.build_thesis("BTC", series, 0, {}),
+                              "opposing MACD must veto")
+            self.assertIsNotNone(self.S.build_thesis("BTC", series, 0, {"requireMacd": False}),
+                                 "with the filter off, geometry alone still arms")
+        finally:
+            self.S.macd_hist = orig
+
+
+class MarginTier(unittest.TestCase):
+    def setUp(self):
+        self.S = _load()
+
+    def test_margin_is_percent_scaled(self):
+        # base 40% of the unit's wallet; a strong score nudges up but stays a sane percent
+        self.assertEqual(self.S.margin_tier_pct(5, 40), 40)
+        self.assertAlmostEqual(self.S.margin_tier_pct(6, 40), 44.0)
+        self.assertAlmostEqual(self.S.margin_tier_pct(8, 40), 50.0)
+        self.assertLessEqual(self.S.margin_tier_pct(9, 40), 100)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/strategies/terrapin/u1/runtime.yaml
+++ b/strategies/terrapin/u1/runtime.yaml
@@ -1,0 +1,138 @@
+# ── TERRAPIN · unit 1 of 4 — the BASE of the breakout pyramid ─────────────────
+# Enters on the Donchian breakout itself (unitIndex 0), so it has the most cushion and
+# is the core trend position. Its DSL is the WIDEST of the four — it breathes through
+# noise and rides the whole move. The upper units lock tighter; the base holds.
+name: terrapin-u1
+group: terrapin
+version: 1.0.0
+description: >
+  TERRAPIN unit 1/4 — the base unit of a Turtle-style breakout pyramid on a single asset
+  (BTC by default). Enters when price breaks the prior 20-day Donchian channel and MACD
+  agrees (long above the high, short below the low). This is the base rung (arms at the
+  breakout, offset 0), given the widest let-winners-run DSL so it carries the core trend
+  position while the upper units protect profit. One position at a time; the DSL owns the exit.
+
+strategy:
+  wallet: "${TERRAPIN_U1_WALLET}"
+  slots: 1
+  margin_pct: 40                          # % of THIS unit's wallet (each unit funds 1/4 of the book)
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: terrapin_u1_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 1800                 # 30m — a daily breakout doesn't need faster; this catches
+                                           # the intraday breach of the daily level promptly enough
+    timeout_seconds: 120
+    default_signal_validity_seconds: 3600  # 2x tick
+    state_history_max_count: 100
+    inputs:
+      asset: "BTC"                         # the ONE market the whole pyramid stacks into
+      unitIndex: 0                         # BASE rung — arms at the breakout (offset 0 x N)
+      candleInterval: "1d"                 # Turtle is a daily-breakout system
+      breakoutLookback: 20                 # Turtle System 1: the 20-day channel
+      atrPeriod: 20                        # N = 20-day ATR
+      addStepN: 0.5                        # units ladder every ½N (u1=0, u2=½N, u3=1N, u4=1½N)
+      macdFast: 12
+      macdSlow: 26
+      macdSignal: 9
+      requireMacd: true                    # "turtle con MACD": a breakout MACD disagrees with is vetoed
+      macdStrongHistPct: 0.05
+      beyondRungN: 0.15
+      minScore: 6                          # breakout(4) + MACD agree(2)
+      marginPctBase: 40                    # PERCENT of this unit's wallet in (0,100]
+      leverageDefault: 3
+      leverageMin: 2
+      leverageMax: 5
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      unit: { type: number, required: false }
+      atr: { type: number, required: false }
+      rung: { type: number, required: false }
+      beyondN: { type: number, required: false }
+      channelHigh: { type: number, required: false }
+      channelLow: { type: number, required: false }
+      macdHist: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: terrapin_u1_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied the breakout + ladder + MACD gate
+    scanners: [terrapin_u1_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # a breakout is a fast move; a resting maker order misses it
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: terrapin_u1_signals
+
+# ── EXIT (DSL — the TWIST: base rung = widest ladder) ────────────────────────
+# Classic Turtle exits the whole pyramid on one 2N / 10-day-low stop. Our twist hands each
+# unit its own DSL, calibrated to its rung. This is u1, the base: entered lowest, most cushion,
+# so it gets the WIDEST let-winners-run ladder — late first lock, wide phase-1 floor — to carry
+# the core trend. Time-cuts off; the trailing ratchet IS the modern 10-day-low exit.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 240             # a daily breakout that does nothing for 4h was a fakeout
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 25.0                   # WIDEST — the base rides through the noise
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                               # lock LATE, let the core trend run
+        - { trigger_pct: 15, lock_hw_pct: 0 }
+        - { trigger_pct: 25, lock_hw_pct: 25 }
+        - { trigger_pct: 45, lock_hw_pct: 45 }
+        - { trigger_pct: 70, lock_hw_pct: 62 }
+        - { trigger_pct: 100, lock_hw_pct: 78 }
+
+# ── RISK guard rails (moderate) ──
+risk:
+  data_retention_seconds: 604800           # 7d
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400       # 4h — don't instantly re-arm the same rung after a shakeout
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/terrapin/u1/scanners/scan.py
+++ b/strategies/terrapin/u1/scanners/scan.py
@@ -1,0 +1,151 @@
+"""TERRAPIN — supervised scanner: one pyramid UNIT of a Turtle-style breakout.
+
+The SAME file runs on all four unit wallets; the only thing that differs is the `unitIndex`
+input (0..3) in each unit's runtime.yaml, which sets how far beyond the breakout this unit
+arms. Each unit is a single-asset, single-position wallet:
+
+Per tick:
+  - reads account + held positions (dual-DEX equity via max(), never sum; corrupt-read guard),
+  - if this wallet already holds the asset, does nothing — the DSL owns the exit,
+  - fetches daily candles for the configured asset,
+  - runs pure `scoring.build_thesis(coin, candles, unitIndex, inputs)`: Donchian breakout,
+    frozen-anchor ATR ladder, MACD filter,
+  - emits at most one signal (this unit either arms this tick or it doesn't).
+
+Read-only + single-pass. Emits a `marginPct` INTENT (PERCENT in (0,100]) + `leverage`.
+Candle values are strings keyed o/h/l/c/v — scoring._close/_f coerce.
+
+Coherence note: the four wallets never talk. Each derives the SAME frozen breakout anchor
+from the SAME candles, so the ladder is consistent without coordination. On a reversal the
+pyramid unwinds top-down through the per-unit DSLs (the tighter upper units lock/stop first);
+a genuine channel flip has closed the upper units before the opposite breakout arms. A wallet
+never flips direction while holding — it must exit (via DSL) and go flat first.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_ASSET = "BTC"
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, held_bare_tickers) — dual-DEX equity via max() (never sum: two views of
+    ONE cross-margined wallet), positions enumerated across BOTH sub-DEX sections. Read-guarded."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the tick
+        print(f"[terrapin.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, set()
+    if not ch:
+        return 0.0, set()
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, set()
+    held, account_value, used = set(), 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)), abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            coin = str(pos.get("coin", "")).strip()
+            if coin:
+                held.add(coin.split(":", 1)[-1].upper())
+    if used > 1.0 and not held:   # corrupt read: margin in use but empty positions — skip tick
+        print("[terrapin.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, set()
+    return account_value, held
+
+
+def _candles(ctx, coin, interval):
+    """Daily (or configured) candle list for `coin`, or None. Read-guarded."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin, "candle_intervals": [interval],
+            "include_funding": False, "include_order_book": False, "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[terrapin.scan] market_get_asset_data({coin}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md or (isinstance(md, dict) and md.get("success") is False):
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    c = d.get("candles", {}) if isinstance(d, dict) else {}
+    return c.get(interval, []) if isinstance(c, dict) else None
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    coin = str(inputs.get("asset", _DEFAULT_ASSET))
+    unit_index = int(inputs.get("unitIndex", 0))
+    interval = str(inputs.get("candleInterval", "1d"))
+    min_score = float(inputs.get("minScore", 6))
+    base_margin_pct = float(inputs.get("marginPctBase", 40))   # PERCENT of THIS unit's wallet
+    lev_default = int(inputs.get("leverageDefault", 3))
+    lev_min = int(inputs.get("leverageMin", 2))
+    lev_max = int(inputs.get("leverageMax", 5))
+
+    unit = unit_index + 1
+    account_value, held = _get_account(ctx)
+    if account_value <= 0:
+        print(f"[terrapin.scan] u{unit} WAITING — no account value / corrupt read", file=sys.stderr)
+        return []
+
+    bare = coin.split(":", 1)[-1].upper()
+    if bare in held:
+        print(f"[terrapin.scan] u{unit} holding {bare} — DSL owns the exit", file=sys.stderr)
+        if ctx.state is not None:
+            try:
+                ctx.state.append({"result": {"ts": now, "unit": unit, "state": "holding", "emitted": 0}})
+            except Exception as exc:  # noqa: BLE001
+                print(f"[terrapin.scan] u{unit} WARNING: state append failed: {exc!r}", file=sys.stderr)
+        return []
+
+    candles = _candles(ctx, coin, interval)
+    if not candles:
+        print(f"[terrapin.scan] u{unit} WAITING — no candles for {coin}", file=sys.stderr)
+        return []
+
+    th = scoring.build_thesis(coin, candles, unit_index, inputs)
+    armed = bool(th and th["score"] >= min_score)
+
+    out = []
+    if armed:
+        leverage = max(lev_min, min(lev_default, lev_max))
+        margin_pct = round(scoring.margin_tier_pct(th["score"], base_margin_pct), 4)
+        out.append({
+            "asset": coin,
+            "direction": th["direction"],
+            "marginPct": margin_pct,      # PERCENT of this unit's wallet — runtime sizes the dollars
+            "leverage": leverage,
+            "data": {
+                "score": th["score"], "leverage": leverage, "direction": th["direction"],
+                "unit": unit, "atr": th["atr"], "rung": th["rung"], "beyondN": th["beyond_n"],
+                "channelHigh": th["channel_high"], "channelLow": th["channel_low"],
+                "macdHist": th["macd_hist"], "reasons": th["reasons"][:8],
+            },
+        })
+
+    print(f"[terrapin.scan] u{unit} {'ARM ' + th['direction'] if armed else 'WAITING'} "
+          f"{coin} price={scoring._close(candles[-1]):.6g} "
+          f"{'rung=%.6g beyond=%.2fN score=%d' % (th['rung'], th['beyond_n'], th['score']) if th else 'no breakout'}",
+          file=sys.stderr)
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"result": {"ts": now, "unit": unit, "emitted": len(out),
+                                         "armed": armed, "score": (th or {}).get("score")}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[terrapin.scan] u{unit} WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/terrapin/u1/scanners/scoring.py
+++ b/strategies/terrapin/u1/scanners/scoring.py
@@ -1,0 +1,237 @@
+"""TERRAPIN — pure thesis math: Turtle-style breakout pyramid + MACD filter (no I/O, no clock).
+
+A faithful port of the Turtle breakout, decomposed so each of the four pyramid UNITS lives on
+its own wallet and is driven by the SAME code with a different `unitIndex` (0..3). One asset,
+one direction at a time; the units stack into a single directional position as the trend runs.
+
+The three ideas:
+
+  DONCHIAN BREAKOUT   entry is a break of the prior-N-day channel — long above the N-day high,
+                      short below the N-day low. The channel EXCLUDES the current bar, so a
+                      break is price exceeding settled history, not itself.
+  ATR LADDER (N)      unit k arms `k * addStep * N` beyond the breakout (½N steps by default),
+                      the Turtle "add as it runs" rule expressed as a price level each wallet
+                      can evaluate independently — no cross-wallet coordination.
+  MACD FILTER         the user's "turtle con MACD": a long needs a positive MACD histogram, a
+                      short a negative one. A breakout the momentum oscillator disagrees with is
+                      the classic Turtle whipsaw, and this is what filters it.
+
+The EXIT is not here. Classic Turtle exits the whole pyramid on one 2N / 10-day-low stop; our
+twist hands each unit to the runtime DSL instead, calibrated per unit (base breathes, tip
+ratchets). See the per-unit runtime.yaml. This module only decides ENTRY.
+
+Pure + single-pass + unit-testable on plain candle lists. Candles are keyed o/h/l/c/v with
+STRING values — `_f`/`_close` coerce both shapes.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+# ── indicators ───────────────────────────────────────────────────────────────
+
+def donchian(candles, lookback):
+    """(channel_high, channel_low) over the prior `lookback` bars, EXCLUDING the current
+    (forming) bar — the standard breakout channel. None if too short."""
+    if len(candles) < lookback + 1 or lookback < 2:
+        return None
+    window = candles[-(lookback + 1):-1]
+    return max(_high(c) for c in window), min(_low(c) for c in window)
+
+
+def atr(candles, period):
+    """Wilder-style ATR (N) over `period` bars. 0.0 if too short.
+
+    True range uses the prior close, so it captures gaps — which on 24/7 crypto are rare but on
+    the XYZ weekend session are not."""
+    if len(candles) < period + 1 or period < 1:
+        return 0.0
+    trs = []
+    for i in range(len(candles) - period, len(candles)):
+        hi, lo, pc = _high(candles[i]), _low(candles[i]), _close(candles[i - 1])
+        trs.append(max(hi - lo, abs(hi - pc), abs(lo - pc)))
+    return sum(trs) / len(trs) if trs else 0.0
+
+
+def _ema(vals, period):
+    if len(vals) < period:
+        return []
+    k = 2.0 / (period + 1)
+    ema = [sum(vals[:period]) / period]
+    for v in vals[period:]:
+        ema.append(v * k + ema[-1] * (1.0 - k))
+    return ema
+
+
+def macd_hist(candles, fast, slow, signal):
+    """MACD histogram (macd_line - signal_line) on closes. None if too short.
+
+    Sign is all the filter needs: > 0 confirms a long breakout, < 0 a short."""
+    closes = [_close(c) for c in candles]
+    if len(closes) < slow + signal:
+        return None
+    ef, es = _ema(closes, fast), _ema(closes, slow)
+    if not ef or not es:
+        return None
+    n = min(len(ef), len(es))
+    macd_line = [ef[-n + i] - es[-n + i] for i in range(n)]
+    sig = _ema(macd_line, signal)
+    if not sig:
+        return None
+    return macd_line[-1] - sig[-1]
+
+
+def breakout_anchor(candles, lookback, direction):
+    """The FROZEN channel level that started the current breakout run — computed statelessly by
+    walking back to the bar that first broke out, so every unit's wallet derives the SAME anchor
+    from the same candles with no shared state.
+
+    Turtle adds units off the breakout price, not off a channel that keeps sliding up as price
+    runs (which would leave the upper units perpetually un-armed in a normal trend). Anchoring to
+    the frozen breakout level is what lets u3/u4 actually fire — the reason the four wallets exist.
+
+    Returns the anchor price, or None if the current bar is not part of a breakout run.
+    """
+    if len(candles) < lookback + 2:
+        return None
+    i = len(candles) - 1
+    anchor = None
+    while i >= lookback:
+        ch = donchian(candles[:i + 1], lookback)      # channel as of bar i (excludes bar i)
+        if ch is None:
+            break
+        hi, lo = ch
+        px = _close(candles[i])
+        broken = (direction == "LONG" and px > hi) or (direction == "SHORT" and px < lo)
+        if not broken:
+            break                                      # walked back past the start of the run
+        anchor = hi if direction == "LONG" else lo     # keep the earliest still-broken channel
+        i -= 1
+    return anchor
+
+
+# ── the pyramid trigger ────────────────────────────────────────────────────────
+
+def build_thesis(coin, candles, unit_index, inputs):
+    """Decide whether THIS unit should be armed on `coin`. Returns a thesis dict or None.
+
+    unit_index 0..3 is the unit's rung. Unit k arms only once price has extended
+    `k * addStep * N` beyond the Donchian breakout in the trend direction — so u1 fires on the
+    break, u4 only in a move that has already run ~1.5N. The MACD sign must agree.
+
+    Scoring (max 9; `minScore` gates the MACD quality, the geometry is a hard gate):
+      +4  price has cleared this unit's ladder level (the hard entry gate)
+      +2  MACD histogram agrees with the breakout direction
+      +2  MACD agreement is strong (|hist| vs price)
+      +1  price is meaningfully beyond the rung (momentum, not a graze)
+    """
+    lookback = int(inputs.get("breakoutLookback", 20))
+    atr_period = int(inputs.get("atrPeriod", 20))
+    add_step = float(inputs.get("addStepN", 0.5))
+    fast = int(inputs.get("macdFast", 12))
+    slow = int(inputs.get("macdSlow", 26))
+    signal = int(inputs.get("macdSignal", 9))
+    require_macd = bool(inputs.get("requireMacd", True))
+    strong_hist_pct = float(inputs.get("macdStrongHistPct", 0.05))
+
+    need = max(lookback + 1, atr_period + 1, slow + signal)
+    if len(candles) < need:
+        return None
+
+    ch = donchian(candles, lookback)
+    n = atr(candles, atr_period)
+    if ch is None or n <= 0:
+        return None
+    ch_high, ch_low = ch
+    price = _close(candles[-1])
+    if price <= 0:
+        return None
+
+    # direction is set by which channel edge price has broken (current bar excluded from the channel)
+    if price > ch_high:
+        direction = "LONG"
+    elif price < ch_low:
+        direction = "SHORT"
+    else:
+        return None                              # inside the channel — no breakout, no unit
+
+    # arm off the FROZEN breakout anchor, not the live (sliding) channel — so u3/u4 fire in a
+    # normal sustained trend instead of only in a fast spike.
+    anchor = breakout_anchor(candles, lookback, direction)
+    if anchor is None:
+        anchor = ch_high if direction == "LONG" else ch_low   # fallback: current channel edge
+    if direction == "LONG":
+        rung = anchor + unit_index * add_step * n
+        cleared = price >= rung
+        beyond = (price - rung) / n if cleared else 0.0
+    else:
+        rung = anchor - unit_index * add_step * n
+        cleared = price <= rung
+        beyond = (rung - price) / n if cleared else 0.0
+
+    if not cleared:
+        return None                              # price hasn't reached THIS unit's rung yet
+
+    hist = macd_hist(candles, fast, slow, signal)
+    macd_ok = hist is not None and ((direction == "LONG" and hist > 0) or
+                                    (direction == "SHORT" and hist < 0))
+    if require_macd and not macd_ok:
+        return None                              # the MACD filter vetoes the breakout
+
+    score, reasons = 4, [
+        f"unit {unit_index + 1} armed: {direction} breakout of the {lookback}-bar channel",
+        f"rung {rung:.6g} = channel {anchor:.6g} {'+' if direction == 'LONG' else '-'} "
+        f"{unit_index}x{add_step:g}N (N={n:.6g})",
+    ]
+    hist_pct = abs(hist) / price * 100.0 if hist is not None else 0.0
+    if macd_ok:
+        score += 2
+        reasons.append(f"MACD hist {hist:+.6g} agrees")
+        if hist_pct >= strong_hist_pct:
+            score += 2
+            reasons.append(f"MACD strong ({hist_pct:.3f}% of price)")
+    if beyond >= float(inputs.get("beyondRungN", 0.15)):
+        score += 1
+        reasons.append(f"price {beyond:.2f}N beyond the rung")
+
+    return {"coin": coin, "direction": direction, "score": score, "unit_index": unit_index,
+            "atr": round(n, 8), "channel_high": round(ch_high, 8), "channel_low": round(ch_low, 8),
+            "rung": round(rung, 8), "beyond_n": round(beyond, 4),
+            "macd_hist": None if hist is None else round(hist, 10), "reasons": reasons}
+
+
+def margin_tier_pct(score, base_pct):
+    """Conviction sizing on the PERCENT scale (base_pct is a PERCENT in (0,100])."""
+    if score >= 8:
+        return base_pct * 1.25
+    if score >= 6:
+        return base_pct * 1.1
+    return base_pct

--- a/strategies/terrapin/u2/runtime.yaml
+++ b/strategies/terrapin/u2/runtime.yaml
@@ -1,0 +1,134 @@
+# ── TERRAPIN · unit 2 of 4 — the +½N rung ────────────────────────────────────
+# Arms a half-N above the breakout (unitIndex 1). Slightly less cushion than the base,
+# so a slightly tighter DSL — it still rides, but starts protecting a touch sooner.
+name: terrapin-u2
+group: terrapin
+version: 1.0.0
+description: >
+  TERRAPIN unit 2/4 — the +½N rung of the breakout pyramid. Adds once price has extended
+  half an ATR beyond the breakout with MACD still agreeing. Tighter DSL than the base unit,
+  wider than the units above it. One position at a time; the DSL owns the exit.
+
+strategy:
+  wallet: "${TERRAPIN_U2_WALLET}"
+  slots: 1
+  margin_pct: 40                          # % of THIS unit's wallet (each unit funds 1/4 of the book)
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: terrapin_u2_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 1800                 # 30m — a daily breakout doesn't need faster; this catches
+                                           # the intraday breach of the daily level promptly enough
+    timeout_seconds: 120
+    default_signal_validity_seconds: 3600  # 2x tick
+    state_history_max_count: 100
+    inputs:
+      asset: "BTC"                         # the ONE market the whole pyramid stacks into
+      unitIndex: 1                         # BASE rung — arms at the breakout (offset 0 x N)
+      candleInterval: "1d"                 # Turtle is a daily-breakout system
+      breakoutLookback: 20                 # Turtle System 1: the 20-day channel
+      atrPeriod: 20                        # N = 20-day ATR
+      addStepN: 0.5                        # units ladder every ½N (u1=0, u2=½N, u3=1N, u4=1½N)
+      macdFast: 12
+      macdSlow: 26
+      macdSignal: 9
+      requireMacd: true                    # "turtle con MACD": a breakout MACD disagrees with is vetoed
+      macdStrongHistPct: 0.05
+      beyondRungN: 0.15
+      minScore: 6                          # breakout(4) + MACD agree(2)
+      marginPctBase: 40                    # PERCENT of this unit's wallet in (0,100]
+      leverageDefault: 3
+      leverageMin: 2
+      leverageMax: 5
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      unit: { type: number, required: false }
+      atr: { type: number, required: false }
+      rung: { type: number, required: false }
+      beyondN: { type: number, required: false }
+      channelHigh: { type: number, required: false }
+      channelLow: { type: number, required: false }
+      macdHist: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: terrapin_u2_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied the breakout + ladder + MACD gate
+    scanners: [terrapin_u2_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # a breakout is a fast move; a resting maker order misses it
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: terrapin_u2_signals
+
+# ── EXIT (DSL — the TWIST: second rung (+½N) = tighter ladder than the units below) ──
+# Each unit's DSL is calibrated to its rung; this is the second rung (+½N), so it locks sooner and
+# rides less than the base. On a reversal the higher units peel off first — the pyramid
+# unwinds top-down through these independent DSLs, our replacement for Turtle's unified stop.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 240
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 22.0
+      retrace_threshold: 10
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 12, lock_hw_pct: 0 }
+        - { trigger_pct: 22, lock_hw_pct: 28 }
+        - { trigger_pct: 38, lock_hw_pct: 48 }
+        - { trigger_pct: 60, lock_hw_pct: 65 }
+        - { trigger_pct: 88, lock_hw_pct: 78 }
+
+# ── RISK guard rails (moderate) ──
+risk:
+  data_retention_seconds: 604800           # 7d
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400       # 4h — don't instantly re-arm the same rung after a shakeout
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/terrapin/u2/scanners/scan.py
+++ b/strategies/terrapin/u2/scanners/scan.py
@@ -1,0 +1,151 @@
+"""TERRAPIN — supervised scanner: one pyramid UNIT of a Turtle-style breakout.
+
+The SAME file runs on all four unit wallets; the only thing that differs is the `unitIndex`
+input (0..3) in each unit's runtime.yaml, which sets how far beyond the breakout this unit
+arms. Each unit is a single-asset, single-position wallet:
+
+Per tick:
+  - reads account + held positions (dual-DEX equity via max(), never sum; corrupt-read guard),
+  - if this wallet already holds the asset, does nothing — the DSL owns the exit,
+  - fetches daily candles for the configured asset,
+  - runs pure `scoring.build_thesis(coin, candles, unitIndex, inputs)`: Donchian breakout,
+    frozen-anchor ATR ladder, MACD filter,
+  - emits at most one signal (this unit either arms this tick or it doesn't).
+
+Read-only + single-pass. Emits a `marginPct` INTENT (PERCENT in (0,100]) + `leverage`.
+Candle values are strings keyed o/h/l/c/v — scoring._close/_f coerce.
+
+Coherence note: the four wallets never talk. Each derives the SAME frozen breakout anchor
+from the SAME candles, so the ladder is consistent without coordination. On a reversal the
+pyramid unwinds top-down through the per-unit DSLs (the tighter upper units lock/stop first);
+a genuine channel flip has closed the upper units before the opposite breakout arms. A wallet
+never flips direction while holding — it must exit (via DSL) and go flat first.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_ASSET = "BTC"
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, held_bare_tickers) — dual-DEX equity via max() (never sum: two views of
+    ONE cross-margined wallet), positions enumerated across BOTH sub-DEX sections. Read-guarded."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the tick
+        print(f"[terrapin.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, set()
+    if not ch:
+        return 0.0, set()
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, set()
+    held, account_value, used = set(), 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)), abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            coin = str(pos.get("coin", "")).strip()
+            if coin:
+                held.add(coin.split(":", 1)[-1].upper())
+    if used > 1.0 and not held:   # corrupt read: margin in use but empty positions — skip tick
+        print("[terrapin.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, set()
+    return account_value, held
+
+
+def _candles(ctx, coin, interval):
+    """Daily (or configured) candle list for `coin`, or None. Read-guarded."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin, "candle_intervals": [interval],
+            "include_funding": False, "include_order_book": False, "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[terrapin.scan] market_get_asset_data({coin}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md or (isinstance(md, dict) and md.get("success") is False):
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    c = d.get("candles", {}) if isinstance(d, dict) else {}
+    return c.get(interval, []) if isinstance(c, dict) else None
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    coin = str(inputs.get("asset", _DEFAULT_ASSET))
+    unit_index = int(inputs.get("unitIndex", 0))
+    interval = str(inputs.get("candleInterval", "1d"))
+    min_score = float(inputs.get("minScore", 6))
+    base_margin_pct = float(inputs.get("marginPctBase", 40))   # PERCENT of THIS unit's wallet
+    lev_default = int(inputs.get("leverageDefault", 3))
+    lev_min = int(inputs.get("leverageMin", 2))
+    lev_max = int(inputs.get("leverageMax", 5))
+
+    unit = unit_index + 1
+    account_value, held = _get_account(ctx)
+    if account_value <= 0:
+        print(f"[terrapin.scan] u{unit} WAITING — no account value / corrupt read", file=sys.stderr)
+        return []
+
+    bare = coin.split(":", 1)[-1].upper()
+    if bare in held:
+        print(f"[terrapin.scan] u{unit} holding {bare} — DSL owns the exit", file=sys.stderr)
+        if ctx.state is not None:
+            try:
+                ctx.state.append({"result": {"ts": now, "unit": unit, "state": "holding", "emitted": 0}})
+            except Exception as exc:  # noqa: BLE001
+                print(f"[terrapin.scan] u{unit} WARNING: state append failed: {exc!r}", file=sys.stderr)
+        return []
+
+    candles = _candles(ctx, coin, interval)
+    if not candles:
+        print(f"[terrapin.scan] u{unit} WAITING — no candles for {coin}", file=sys.stderr)
+        return []
+
+    th = scoring.build_thesis(coin, candles, unit_index, inputs)
+    armed = bool(th and th["score"] >= min_score)
+
+    out = []
+    if armed:
+        leverage = max(lev_min, min(lev_default, lev_max))
+        margin_pct = round(scoring.margin_tier_pct(th["score"], base_margin_pct), 4)
+        out.append({
+            "asset": coin,
+            "direction": th["direction"],
+            "marginPct": margin_pct,      # PERCENT of this unit's wallet — runtime sizes the dollars
+            "leverage": leverage,
+            "data": {
+                "score": th["score"], "leverage": leverage, "direction": th["direction"],
+                "unit": unit, "atr": th["atr"], "rung": th["rung"], "beyondN": th["beyond_n"],
+                "channelHigh": th["channel_high"], "channelLow": th["channel_low"],
+                "macdHist": th["macd_hist"], "reasons": th["reasons"][:8],
+            },
+        })
+
+    print(f"[terrapin.scan] u{unit} {'ARM ' + th['direction'] if armed else 'WAITING'} "
+          f"{coin} price={scoring._close(candles[-1]):.6g} "
+          f"{'rung=%.6g beyond=%.2fN score=%d' % (th['rung'], th['beyond_n'], th['score']) if th else 'no breakout'}",
+          file=sys.stderr)
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"result": {"ts": now, "unit": unit, "emitted": len(out),
+                                         "armed": armed, "score": (th or {}).get("score")}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[terrapin.scan] u{unit} WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/terrapin/u2/scanners/scoring.py
+++ b/strategies/terrapin/u2/scanners/scoring.py
@@ -1,0 +1,237 @@
+"""TERRAPIN — pure thesis math: Turtle-style breakout pyramid + MACD filter (no I/O, no clock).
+
+A faithful port of the Turtle breakout, decomposed so each of the four pyramid UNITS lives on
+its own wallet and is driven by the SAME code with a different `unitIndex` (0..3). One asset,
+one direction at a time; the units stack into a single directional position as the trend runs.
+
+The three ideas:
+
+  DONCHIAN BREAKOUT   entry is a break of the prior-N-day channel — long above the N-day high,
+                      short below the N-day low. The channel EXCLUDES the current bar, so a
+                      break is price exceeding settled history, not itself.
+  ATR LADDER (N)      unit k arms `k * addStep * N` beyond the breakout (½N steps by default),
+                      the Turtle "add as it runs" rule expressed as a price level each wallet
+                      can evaluate independently — no cross-wallet coordination.
+  MACD FILTER         the user's "turtle con MACD": a long needs a positive MACD histogram, a
+                      short a negative one. A breakout the momentum oscillator disagrees with is
+                      the classic Turtle whipsaw, and this is what filters it.
+
+The EXIT is not here. Classic Turtle exits the whole pyramid on one 2N / 10-day-low stop; our
+twist hands each unit to the runtime DSL instead, calibrated per unit (base breathes, tip
+ratchets). See the per-unit runtime.yaml. This module only decides ENTRY.
+
+Pure + single-pass + unit-testable on plain candle lists. Candles are keyed o/h/l/c/v with
+STRING values — `_f`/`_close` coerce both shapes.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+# ── indicators ───────────────────────────────────────────────────────────────
+
+def donchian(candles, lookback):
+    """(channel_high, channel_low) over the prior `lookback` bars, EXCLUDING the current
+    (forming) bar — the standard breakout channel. None if too short."""
+    if len(candles) < lookback + 1 or lookback < 2:
+        return None
+    window = candles[-(lookback + 1):-1]
+    return max(_high(c) for c in window), min(_low(c) for c in window)
+
+
+def atr(candles, period):
+    """Wilder-style ATR (N) over `period` bars. 0.0 if too short.
+
+    True range uses the prior close, so it captures gaps — which on 24/7 crypto are rare but on
+    the XYZ weekend session are not."""
+    if len(candles) < period + 1 or period < 1:
+        return 0.0
+    trs = []
+    for i in range(len(candles) - period, len(candles)):
+        hi, lo, pc = _high(candles[i]), _low(candles[i]), _close(candles[i - 1])
+        trs.append(max(hi - lo, abs(hi - pc), abs(lo - pc)))
+    return sum(trs) / len(trs) if trs else 0.0
+
+
+def _ema(vals, period):
+    if len(vals) < period:
+        return []
+    k = 2.0 / (period + 1)
+    ema = [sum(vals[:period]) / period]
+    for v in vals[period:]:
+        ema.append(v * k + ema[-1] * (1.0 - k))
+    return ema
+
+
+def macd_hist(candles, fast, slow, signal):
+    """MACD histogram (macd_line - signal_line) on closes. None if too short.
+
+    Sign is all the filter needs: > 0 confirms a long breakout, < 0 a short."""
+    closes = [_close(c) for c in candles]
+    if len(closes) < slow + signal:
+        return None
+    ef, es = _ema(closes, fast), _ema(closes, slow)
+    if not ef or not es:
+        return None
+    n = min(len(ef), len(es))
+    macd_line = [ef[-n + i] - es[-n + i] for i in range(n)]
+    sig = _ema(macd_line, signal)
+    if not sig:
+        return None
+    return macd_line[-1] - sig[-1]
+
+
+def breakout_anchor(candles, lookback, direction):
+    """The FROZEN channel level that started the current breakout run — computed statelessly by
+    walking back to the bar that first broke out, so every unit's wallet derives the SAME anchor
+    from the same candles with no shared state.
+
+    Turtle adds units off the breakout price, not off a channel that keeps sliding up as price
+    runs (which would leave the upper units perpetually un-armed in a normal trend). Anchoring to
+    the frozen breakout level is what lets u3/u4 actually fire — the reason the four wallets exist.
+
+    Returns the anchor price, or None if the current bar is not part of a breakout run.
+    """
+    if len(candles) < lookback + 2:
+        return None
+    i = len(candles) - 1
+    anchor = None
+    while i >= lookback:
+        ch = donchian(candles[:i + 1], lookback)      # channel as of bar i (excludes bar i)
+        if ch is None:
+            break
+        hi, lo = ch
+        px = _close(candles[i])
+        broken = (direction == "LONG" and px > hi) or (direction == "SHORT" and px < lo)
+        if not broken:
+            break                                      # walked back past the start of the run
+        anchor = hi if direction == "LONG" else lo     # keep the earliest still-broken channel
+        i -= 1
+    return anchor
+
+
+# ── the pyramid trigger ────────────────────────────────────────────────────────
+
+def build_thesis(coin, candles, unit_index, inputs):
+    """Decide whether THIS unit should be armed on `coin`. Returns a thesis dict or None.
+
+    unit_index 0..3 is the unit's rung. Unit k arms only once price has extended
+    `k * addStep * N` beyond the Donchian breakout in the trend direction — so u1 fires on the
+    break, u4 only in a move that has already run ~1.5N. The MACD sign must agree.
+
+    Scoring (max 9; `minScore` gates the MACD quality, the geometry is a hard gate):
+      +4  price has cleared this unit's ladder level (the hard entry gate)
+      +2  MACD histogram agrees with the breakout direction
+      +2  MACD agreement is strong (|hist| vs price)
+      +1  price is meaningfully beyond the rung (momentum, not a graze)
+    """
+    lookback = int(inputs.get("breakoutLookback", 20))
+    atr_period = int(inputs.get("atrPeriod", 20))
+    add_step = float(inputs.get("addStepN", 0.5))
+    fast = int(inputs.get("macdFast", 12))
+    slow = int(inputs.get("macdSlow", 26))
+    signal = int(inputs.get("macdSignal", 9))
+    require_macd = bool(inputs.get("requireMacd", True))
+    strong_hist_pct = float(inputs.get("macdStrongHistPct", 0.05))
+
+    need = max(lookback + 1, atr_period + 1, slow + signal)
+    if len(candles) < need:
+        return None
+
+    ch = donchian(candles, lookback)
+    n = atr(candles, atr_period)
+    if ch is None or n <= 0:
+        return None
+    ch_high, ch_low = ch
+    price = _close(candles[-1])
+    if price <= 0:
+        return None
+
+    # direction is set by which channel edge price has broken (current bar excluded from the channel)
+    if price > ch_high:
+        direction = "LONG"
+    elif price < ch_low:
+        direction = "SHORT"
+    else:
+        return None                              # inside the channel — no breakout, no unit
+
+    # arm off the FROZEN breakout anchor, not the live (sliding) channel — so u3/u4 fire in a
+    # normal sustained trend instead of only in a fast spike.
+    anchor = breakout_anchor(candles, lookback, direction)
+    if anchor is None:
+        anchor = ch_high if direction == "LONG" else ch_low   # fallback: current channel edge
+    if direction == "LONG":
+        rung = anchor + unit_index * add_step * n
+        cleared = price >= rung
+        beyond = (price - rung) / n if cleared else 0.0
+    else:
+        rung = anchor - unit_index * add_step * n
+        cleared = price <= rung
+        beyond = (rung - price) / n if cleared else 0.0
+
+    if not cleared:
+        return None                              # price hasn't reached THIS unit's rung yet
+
+    hist = macd_hist(candles, fast, slow, signal)
+    macd_ok = hist is not None and ((direction == "LONG" and hist > 0) or
+                                    (direction == "SHORT" and hist < 0))
+    if require_macd and not macd_ok:
+        return None                              # the MACD filter vetoes the breakout
+
+    score, reasons = 4, [
+        f"unit {unit_index + 1} armed: {direction} breakout of the {lookback}-bar channel",
+        f"rung {rung:.6g} = channel {anchor:.6g} {'+' if direction == 'LONG' else '-'} "
+        f"{unit_index}x{add_step:g}N (N={n:.6g})",
+    ]
+    hist_pct = abs(hist) / price * 100.0 if hist is not None else 0.0
+    if macd_ok:
+        score += 2
+        reasons.append(f"MACD hist {hist:+.6g} agrees")
+        if hist_pct >= strong_hist_pct:
+            score += 2
+            reasons.append(f"MACD strong ({hist_pct:.3f}% of price)")
+    if beyond >= float(inputs.get("beyondRungN", 0.15)):
+        score += 1
+        reasons.append(f"price {beyond:.2f}N beyond the rung")
+
+    return {"coin": coin, "direction": direction, "score": score, "unit_index": unit_index,
+            "atr": round(n, 8), "channel_high": round(ch_high, 8), "channel_low": round(ch_low, 8),
+            "rung": round(rung, 8), "beyond_n": round(beyond, 4),
+            "macd_hist": None if hist is None else round(hist, 10), "reasons": reasons}
+
+
+def margin_tier_pct(score, base_pct):
+    """Conviction sizing on the PERCENT scale (base_pct is a PERCENT in (0,100])."""
+    if score >= 8:
+        return base_pct * 1.25
+    if score >= 6:
+        return base_pct * 1.1
+    return base_pct

--- a/strategies/terrapin/u3/runtime.yaml
+++ b/strategies/terrapin/u3/runtime.yaml
@@ -1,0 +1,134 @@
+# ── TERRAPIN · unit 3 of 4 — the +1N rung ─────────────────────────────────────
+# Arms a full N above the breakout (unitIndex 2). Entered well into the move, less cushion,
+# so a tighter ladder that locks profit sooner — the trend has to keep paying to keep it.
+name: terrapin-u3
+group: terrapin
+version: 1.0.0
+description: >
+  TERRAPIN unit 3/4 — the +1N rung of the breakout pyramid. Adds only in a move that has
+  already run a full ATR past the breakout. Tight DSL: it locks profit early because it
+  entered high and has the least room of the lower three. One position; the DSL owns the exit.
+
+strategy:
+  wallet: "${TERRAPIN_U3_WALLET}"
+  slots: 1
+  margin_pct: 40                          # % of THIS unit's wallet (each unit funds 1/4 of the book)
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: terrapin_u3_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 1800                 # 30m — a daily breakout doesn't need faster; this catches
+                                           # the intraday breach of the daily level promptly enough
+    timeout_seconds: 120
+    default_signal_validity_seconds: 3600  # 2x tick
+    state_history_max_count: 100
+    inputs:
+      asset: "BTC"                         # the ONE market the whole pyramid stacks into
+      unitIndex: 2                         # BASE rung — arms at the breakout (offset 0 x N)
+      candleInterval: "1d"                 # Turtle is a daily-breakout system
+      breakoutLookback: 20                 # Turtle System 1: the 20-day channel
+      atrPeriod: 20                        # N = 20-day ATR
+      addStepN: 0.5                        # units ladder every ½N (u1=0, u2=½N, u3=1N, u4=1½N)
+      macdFast: 12
+      macdSlow: 26
+      macdSignal: 9
+      requireMacd: true                    # "turtle con MACD": a breakout MACD disagrees with is vetoed
+      macdStrongHistPct: 0.05
+      beyondRungN: 0.15
+      minScore: 6                          # breakout(4) + MACD agree(2)
+      marginPctBase: 40                    # PERCENT of this unit's wallet in (0,100]
+      leverageDefault: 3
+      leverageMin: 2
+      leverageMax: 5
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      unit: { type: number, required: false }
+      atr: { type: number, required: false }
+      rung: { type: number, required: false }
+      beyondN: { type: number, required: false }
+      channelHigh: { type: number, required: false }
+      channelLow: { type: number, required: false }
+      macdHist: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: terrapin_u3_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied the breakout + ladder + MACD gate
+    scanners: [terrapin_u3_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # a breakout is a fast move; a resting maker order misses it
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: terrapin_u3_signals
+
+# ── EXIT (DSL — the TWIST: third rung (+1N) = tighter ladder than the units below) ──
+# Each unit's DSL is calibrated to its rung; this is the third rung (+1N), so it locks sooner and
+# rides less than the base. On a reversal the higher units peel off first — the pyramid
+# unwinds top-down through these independent DSLs, our replacement for Turtle's unified stop.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 180
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 18.0
+      retrace_threshold: 9
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }
+        - { trigger_pct: 18, lock_hw_pct: 32 }
+        - { trigger_pct: 32, lock_hw_pct: 55 }
+        - { trigger_pct: 52, lock_hw_pct: 70 }
+        - { trigger_pct: 78, lock_hw_pct: 80 }
+
+# ── RISK guard rails (moderate) ──
+risk:
+  data_retention_seconds: 604800           # 7d
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400       # 4h — don't instantly re-arm the same rung after a shakeout
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/terrapin/u3/scanners/scan.py
+++ b/strategies/terrapin/u3/scanners/scan.py
@@ -1,0 +1,151 @@
+"""TERRAPIN — supervised scanner: one pyramid UNIT of a Turtle-style breakout.
+
+The SAME file runs on all four unit wallets; the only thing that differs is the `unitIndex`
+input (0..3) in each unit's runtime.yaml, which sets how far beyond the breakout this unit
+arms. Each unit is a single-asset, single-position wallet:
+
+Per tick:
+  - reads account + held positions (dual-DEX equity via max(), never sum; corrupt-read guard),
+  - if this wallet already holds the asset, does nothing — the DSL owns the exit,
+  - fetches daily candles for the configured asset,
+  - runs pure `scoring.build_thesis(coin, candles, unitIndex, inputs)`: Donchian breakout,
+    frozen-anchor ATR ladder, MACD filter,
+  - emits at most one signal (this unit either arms this tick or it doesn't).
+
+Read-only + single-pass. Emits a `marginPct` INTENT (PERCENT in (0,100]) + `leverage`.
+Candle values are strings keyed o/h/l/c/v — scoring._close/_f coerce.
+
+Coherence note: the four wallets never talk. Each derives the SAME frozen breakout anchor
+from the SAME candles, so the ladder is consistent without coordination. On a reversal the
+pyramid unwinds top-down through the per-unit DSLs (the tighter upper units lock/stop first);
+a genuine channel flip has closed the upper units before the opposite breakout arms. A wallet
+never flips direction while holding — it must exit (via DSL) and go flat first.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_ASSET = "BTC"
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, held_bare_tickers) — dual-DEX equity via max() (never sum: two views of
+    ONE cross-margined wallet), positions enumerated across BOTH sub-DEX sections. Read-guarded."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the tick
+        print(f"[terrapin.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, set()
+    if not ch:
+        return 0.0, set()
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, set()
+    held, account_value, used = set(), 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)), abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            coin = str(pos.get("coin", "")).strip()
+            if coin:
+                held.add(coin.split(":", 1)[-1].upper())
+    if used > 1.0 and not held:   # corrupt read: margin in use but empty positions — skip tick
+        print("[terrapin.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, set()
+    return account_value, held
+
+
+def _candles(ctx, coin, interval):
+    """Daily (or configured) candle list for `coin`, or None. Read-guarded."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin, "candle_intervals": [interval],
+            "include_funding": False, "include_order_book": False, "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[terrapin.scan] market_get_asset_data({coin}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md or (isinstance(md, dict) and md.get("success") is False):
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    c = d.get("candles", {}) if isinstance(d, dict) else {}
+    return c.get(interval, []) if isinstance(c, dict) else None
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    coin = str(inputs.get("asset", _DEFAULT_ASSET))
+    unit_index = int(inputs.get("unitIndex", 0))
+    interval = str(inputs.get("candleInterval", "1d"))
+    min_score = float(inputs.get("minScore", 6))
+    base_margin_pct = float(inputs.get("marginPctBase", 40))   # PERCENT of THIS unit's wallet
+    lev_default = int(inputs.get("leverageDefault", 3))
+    lev_min = int(inputs.get("leverageMin", 2))
+    lev_max = int(inputs.get("leverageMax", 5))
+
+    unit = unit_index + 1
+    account_value, held = _get_account(ctx)
+    if account_value <= 0:
+        print(f"[terrapin.scan] u{unit} WAITING — no account value / corrupt read", file=sys.stderr)
+        return []
+
+    bare = coin.split(":", 1)[-1].upper()
+    if bare in held:
+        print(f"[terrapin.scan] u{unit} holding {bare} — DSL owns the exit", file=sys.stderr)
+        if ctx.state is not None:
+            try:
+                ctx.state.append({"result": {"ts": now, "unit": unit, "state": "holding", "emitted": 0}})
+            except Exception as exc:  # noqa: BLE001
+                print(f"[terrapin.scan] u{unit} WARNING: state append failed: {exc!r}", file=sys.stderr)
+        return []
+
+    candles = _candles(ctx, coin, interval)
+    if not candles:
+        print(f"[terrapin.scan] u{unit} WAITING — no candles for {coin}", file=sys.stderr)
+        return []
+
+    th = scoring.build_thesis(coin, candles, unit_index, inputs)
+    armed = bool(th and th["score"] >= min_score)
+
+    out = []
+    if armed:
+        leverage = max(lev_min, min(lev_default, lev_max))
+        margin_pct = round(scoring.margin_tier_pct(th["score"], base_margin_pct), 4)
+        out.append({
+            "asset": coin,
+            "direction": th["direction"],
+            "marginPct": margin_pct,      # PERCENT of this unit's wallet — runtime sizes the dollars
+            "leverage": leverage,
+            "data": {
+                "score": th["score"], "leverage": leverage, "direction": th["direction"],
+                "unit": unit, "atr": th["atr"], "rung": th["rung"], "beyondN": th["beyond_n"],
+                "channelHigh": th["channel_high"], "channelLow": th["channel_low"],
+                "macdHist": th["macd_hist"], "reasons": th["reasons"][:8],
+            },
+        })
+
+    print(f"[terrapin.scan] u{unit} {'ARM ' + th['direction'] if armed else 'WAITING'} "
+          f"{coin} price={scoring._close(candles[-1]):.6g} "
+          f"{'rung=%.6g beyond=%.2fN score=%d' % (th['rung'], th['beyond_n'], th['score']) if th else 'no breakout'}",
+          file=sys.stderr)
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"result": {"ts": now, "unit": unit, "emitted": len(out),
+                                         "armed": armed, "score": (th or {}).get("score")}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[terrapin.scan] u{unit} WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/terrapin/u3/scanners/scoring.py
+++ b/strategies/terrapin/u3/scanners/scoring.py
@@ -1,0 +1,237 @@
+"""TERRAPIN — pure thesis math: Turtle-style breakout pyramid + MACD filter (no I/O, no clock).
+
+A faithful port of the Turtle breakout, decomposed so each of the four pyramid UNITS lives on
+its own wallet and is driven by the SAME code with a different `unitIndex` (0..3). One asset,
+one direction at a time; the units stack into a single directional position as the trend runs.
+
+The three ideas:
+
+  DONCHIAN BREAKOUT   entry is a break of the prior-N-day channel — long above the N-day high,
+                      short below the N-day low. The channel EXCLUDES the current bar, so a
+                      break is price exceeding settled history, not itself.
+  ATR LADDER (N)      unit k arms `k * addStep * N` beyond the breakout (½N steps by default),
+                      the Turtle "add as it runs" rule expressed as a price level each wallet
+                      can evaluate independently — no cross-wallet coordination.
+  MACD FILTER         the user's "turtle con MACD": a long needs a positive MACD histogram, a
+                      short a negative one. A breakout the momentum oscillator disagrees with is
+                      the classic Turtle whipsaw, and this is what filters it.
+
+The EXIT is not here. Classic Turtle exits the whole pyramid on one 2N / 10-day-low stop; our
+twist hands each unit to the runtime DSL instead, calibrated per unit (base breathes, tip
+ratchets). See the per-unit runtime.yaml. This module only decides ENTRY.
+
+Pure + single-pass + unit-testable on plain candle lists. Candles are keyed o/h/l/c/v with
+STRING values — `_f`/`_close` coerce both shapes.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+# ── indicators ───────────────────────────────────────────────────────────────
+
+def donchian(candles, lookback):
+    """(channel_high, channel_low) over the prior `lookback` bars, EXCLUDING the current
+    (forming) bar — the standard breakout channel. None if too short."""
+    if len(candles) < lookback + 1 or lookback < 2:
+        return None
+    window = candles[-(lookback + 1):-1]
+    return max(_high(c) for c in window), min(_low(c) for c in window)
+
+
+def atr(candles, period):
+    """Wilder-style ATR (N) over `period` bars. 0.0 if too short.
+
+    True range uses the prior close, so it captures gaps — which on 24/7 crypto are rare but on
+    the XYZ weekend session are not."""
+    if len(candles) < period + 1 or period < 1:
+        return 0.0
+    trs = []
+    for i in range(len(candles) - period, len(candles)):
+        hi, lo, pc = _high(candles[i]), _low(candles[i]), _close(candles[i - 1])
+        trs.append(max(hi - lo, abs(hi - pc), abs(lo - pc)))
+    return sum(trs) / len(trs) if trs else 0.0
+
+
+def _ema(vals, period):
+    if len(vals) < period:
+        return []
+    k = 2.0 / (period + 1)
+    ema = [sum(vals[:period]) / period]
+    for v in vals[period:]:
+        ema.append(v * k + ema[-1] * (1.0 - k))
+    return ema
+
+
+def macd_hist(candles, fast, slow, signal):
+    """MACD histogram (macd_line - signal_line) on closes. None if too short.
+
+    Sign is all the filter needs: > 0 confirms a long breakout, < 0 a short."""
+    closes = [_close(c) for c in candles]
+    if len(closes) < slow + signal:
+        return None
+    ef, es = _ema(closes, fast), _ema(closes, slow)
+    if not ef or not es:
+        return None
+    n = min(len(ef), len(es))
+    macd_line = [ef[-n + i] - es[-n + i] for i in range(n)]
+    sig = _ema(macd_line, signal)
+    if not sig:
+        return None
+    return macd_line[-1] - sig[-1]
+
+
+def breakout_anchor(candles, lookback, direction):
+    """The FROZEN channel level that started the current breakout run — computed statelessly by
+    walking back to the bar that first broke out, so every unit's wallet derives the SAME anchor
+    from the same candles with no shared state.
+
+    Turtle adds units off the breakout price, not off a channel that keeps sliding up as price
+    runs (which would leave the upper units perpetually un-armed in a normal trend). Anchoring to
+    the frozen breakout level is what lets u3/u4 actually fire — the reason the four wallets exist.
+
+    Returns the anchor price, or None if the current bar is not part of a breakout run.
+    """
+    if len(candles) < lookback + 2:
+        return None
+    i = len(candles) - 1
+    anchor = None
+    while i >= lookback:
+        ch = donchian(candles[:i + 1], lookback)      # channel as of bar i (excludes bar i)
+        if ch is None:
+            break
+        hi, lo = ch
+        px = _close(candles[i])
+        broken = (direction == "LONG" and px > hi) or (direction == "SHORT" and px < lo)
+        if not broken:
+            break                                      # walked back past the start of the run
+        anchor = hi if direction == "LONG" else lo     # keep the earliest still-broken channel
+        i -= 1
+    return anchor
+
+
+# ── the pyramid trigger ────────────────────────────────────────────────────────
+
+def build_thesis(coin, candles, unit_index, inputs):
+    """Decide whether THIS unit should be armed on `coin`. Returns a thesis dict or None.
+
+    unit_index 0..3 is the unit's rung. Unit k arms only once price has extended
+    `k * addStep * N` beyond the Donchian breakout in the trend direction — so u1 fires on the
+    break, u4 only in a move that has already run ~1.5N. The MACD sign must agree.
+
+    Scoring (max 9; `minScore` gates the MACD quality, the geometry is a hard gate):
+      +4  price has cleared this unit's ladder level (the hard entry gate)
+      +2  MACD histogram agrees with the breakout direction
+      +2  MACD agreement is strong (|hist| vs price)
+      +1  price is meaningfully beyond the rung (momentum, not a graze)
+    """
+    lookback = int(inputs.get("breakoutLookback", 20))
+    atr_period = int(inputs.get("atrPeriod", 20))
+    add_step = float(inputs.get("addStepN", 0.5))
+    fast = int(inputs.get("macdFast", 12))
+    slow = int(inputs.get("macdSlow", 26))
+    signal = int(inputs.get("macdSignal", 9))
+    require_macd = bool(inputs.get("requireMacd", True))
+    strong_hist_pct = float(inputs.get("macdStrongHistPct", 0.05))
+
+    need = max(lookback + 1, atr_period + 1, slow + signal)
+    if len(candles) < need:
+        return None
+
+    ch = donchian(candles, lookback)
+    n = atr(candles, atr_period)
+    if ch is None or n <= 0:
+        return None
+    ch_high, ch_low = ch
+    price = _close(candles[-1])
+    if price <= 0:
+        return None
+
+    # direction is set by which channel edge price has broken (current bar excluded from the channel)
+    if price > ch_high:
+        direction = "LONG"
+    elif price < ch_low:
+        direction = "SHORT"
+    else:
+        return None                              # inside the channel — no breakout, no unit
+
+    # arm off the FROZEN breakout anchor, not the live (sliding) channel — so u3/u4 fire in a
+    # normal sustained trend instead of only in a fast spike.
+    anchor = breakout_anchor(candles, lookback, direction)
+    if anchor is None:
+        anchor = ch_high if direction == "LONG" else ch_low   # fallback: current channel edge
+    if direction == "LONG":
+        rung = anchor + unit_index * add_step * n
+        cleared = price >= rung
+        beyond = (price - rung) / n if cleared else 0.0
+    else:
+        rung = anchor - unit_index * add_step * n
+        cleared = price <= rung
+        beyond = (rung - price) / n if cleared else 0.0
+
+    if not cleared:
+        return None                              # price hasn't reached THIS unit's rung yet
+
+    hist = macd_hist(candles, fast, slow, signal)
+    macd_ok = hist is not None and ((direction == "LONG" and hist > 0) or
+                                    (direction == "SHORT" and hist < 0))
+    if require_macd and not macd_ok:
+        return None                              # the MACD filter vetoes the breakout
+
+    score, reasons = 4, [
+        f"unit {unit_index + 1} armed: {direction} breakout of the {lookback}-bar channel",
+        f"rung {rung:.6g} = channel {anchor:.6g} {'+' if direction == 'LONG' else '-'} "
+        f"{unit_index}x{add_step:g}N (N={n:.6g})",
+    ]
+    hist_pct = abs(hist) / price * 100.0 if hist is not None else 0.0
+    if macd_ok:
+        score += 2
+        reasons.append(f"MACD hist {hist:+.6g} agrees")
+        if hist_pct >= strong_hist_pct:
+            score += 2
+            reasons.append(f"MACD strong ({hist_pct:.3f}% of price)")
+    if beyond >= float(inputs.get("beyondRungN", 0.15)):
+        score += 1
+        reasons.append(f"price {beyond:.2f}N beyond the rung")
+
+    return {"coin": coin, "direction": direction, "score": score, "unit_index": unit_index,
+            "atr": round(n, 8), "channel_high": round(ch_high, 8), "channel_low": round(ch_low, 8),
+            "rung": round(rung, 8), "beyond_n": round(beyond, 4),
+            "macd_hist": None if hist is None else round(hist, 10), "reasons": reasons}
+
+
+def margin_tier_pct(score, base_pct):
+    """Conviction sizing on the PERCENT scale (base_pct is a PERCENT in (0,100])."""
+    if score >= 8:
+        return base_pct * 1.25
+    if score >= 6:
+        return base_pct * 1.1
+    return base_pct

--- a/strategies/terrapin/u4/runtime.yaml
+++ b/strategies/terrapin/u4/runtime.yaml
@@ -1,0 +1,135 @@
+# ── TERRAPIN · unit 4 of 4 — the TIP (+1½N) ───────────────────────────────────
+# Arms 1½N above the breakout (unitIndex 3) — only in a strong, extended run. Least cushion
+# of all, most exposed to a pullback, so the TIGHTEST DSL: it banks profit fastest and is
+# the first unit to peel off on a reversal, unwinding the pyramid from the top.
+name: terrapin-u4
+group: terrapin
+version: 1.0.0
+description: >
+  TERRAPIN unit 4/4 — the tip of the breakout pyramid. Adds only when a breakout has already
+  extended 1½ ATR with MACD agreeing — a strong trend. Tightest DSL of the four: it locks
+  aggressively and is first to exit on a pullback, so the pyramid unwinds top-down. One
+  position; the DSL owns the exit.
+
+strategy:
+  wallet: "${TERRAPIN_U4_WALLET}"
+  slots: 1
+  margin_pct: 40                          # % of THIS unit's wallet (each unit funds 1/4 of the book)
+  default_leverage: 3
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: terrapin_u4_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 1800                 # 30m — a daily breakout doesn't need faster; this catches
+                                           # the intraday breach of the daily level promptly enough
+    timeout_seconds: 120
+    default_signal_validity_seconds: 3600  # 2x tick
+    state_history_max_count: 100
+    inputs:
+      asset: "BTC"                         # the ONE market the whole pyramid stacks into
+      unitIndex: 3                         # BASE rung — arms at the breakout (offset 0 x N)
+      candleInterval: "1d"                 # Turtle is a daily-breakout system
+      breakoutLookback: 20                 # Turtle System 1: the 20-day channel
+      atrPeriod: 20                        # N = 20-day ATR
+      addStepN: 0.5                        # units ladder every ½N (u1=0, u2=½N, u3=1N, u4=1½N)
+      macdFast: 12
+      macdSlow: 26
+      macdSignal: 9
+      requireMacd: true                    # "turtle con MACD": a breakout MACD disagrees with is vetoed
+      macdStrongHistPct: 0.05
+      beyondRungN: 0.15
+      minScore: 6                          # breakout(4) + MACD agree(2)
+      marginPctBase: 40                    # PERCENT of this unit's wallet in (0,100]
+      leverageDefault: 3
+      leverageMin: 2
+      leverageMax: 5
+    signal_data_schema:
+      score: { type: number }
+      leverage: { type: number }
+      direction: { type: string }
+      unit: { type: number, required: false }
+      atr: { type: number, required: false }
+      rung: { type: number, required: false }
+      beyondN: { type: number, required: false }
+      channelHigh: { type: number, required: false }
+      channelLow: { type: number, required: false }
+      macdHist: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: terrapin_u4_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                    # the scan already applied the breakout + ladder + MACD gate
+    scanners: [terrapin_u4_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true    # a breakout is a fast move; a resting maker order misses it
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: terrapin_u4_signals
+
+# ── EXIT (DSL — the TWIST: tip (+1½N) = tighter ladder than the units below) ──
+# Each unit's DSL is calibrated to its rung; this is the tip (+1½N), so it locks sooner and
+# rides less than the base. On a reversal the higher units peel off first — the pyramid
+# unwinds top-down through these independent DSLs, our replacement for Turtle's unified stop.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout:
+      enabled: false
+      interval_in_minutes: 1440
+    weak_peak_cut:
+      enabled: true
+      interval_in_minutes: 120
+      min_value: 2.0
+    dead_weight_cut:
+      enabled: false
+      interval_in_minutes: 60
+    phase1:
+      enabled: true
+      max_loss_pct: 14.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8, lock_hw_pct: 0 }
+        - { trigger_pct: 14, lock_hw_pct: 40 }
+        - { trigger_pct: 24, lock_hw_pct: 62 }
+        - { trigger_pct: 40, lock_hw_pct: 80 }
+
+# ── RISK guard rails (moderate) ──
+risk:
+  data_retention_seconds: 604800           # 7d
+  guard_rails:
+    daily_loss_limit_pct: 12
+    max_entries_per_day: 3
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600
+    drawdown_halt_pct: 25
+    drawdown_reset_on_day_rollover: false
+    per_asset_cooldown_seconds: 14400       # 4h — don't instantly re-arm the same rung after a shakeout
+
+notifications:
+  dsl_lifecycle: true
+  dsl_notify_sl_updates: false
+  action_lifecycle: true

--- a/strategies/terrapin/u4/scanners/scan.py
+++ b/strategies/terrapin/u4/scanners/scan.py
@@ -1,0 +1,151 @@
+"""TERRAPIN — supervised scanner: one pyramid UNIT of a Turtle-style breakout.
+
+The SAME file runs on all four unit wallets; the only thing that differs is the `unitIndex`
+input (0..3) in each unit's runtime.yaml, which sets how far beyond the breakout this unit
+arms. Each unit is a single-asset, single-position wallet:
+
+Per tick:
+  - reads account + held positions (dual-DEX equity via max(), never sum; corrupt-read guard),
+  - if this wallet already holds the asset, does nothing — the DSL owns the exit,
+  - fetches daily candles for the configured asset,
+  - runs pure `scoring.build_thesis(coin, candles, unitIndex, inputs)`: Donchian breakout,
+    frozen-anchor ATR ladder, MACD filter,
+  - emits at most one signal (this unit either arms this tick or it doesn't).
+
+Read-only + single-pass. Emits a `marginPct` INTENT (PERCENT in (0,100]) + `leverage`.
+Candle values are strings keyed o/h/l/c/v — scoring._close/_f coerce.
+
+Coherence note: the four wallets never talk. Each derives the SAME frozen breakout anchor
+from the SAME candles, so the ladder is consistent without coordination. On a reversal the
+pyramid unwinds top-down through the per-unit DSLs (the tighter upper units lock/stop first);
+a genuine channel flip has closed the upper units before the opposite breakout arms. A wallet
+never flips direction while holding — it must exit (via DSL) and go flat first.
+"""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_ASSET = "BTC"
+
+
+def _dex_for(asset):
+    return "xyz" if asset.lower().startswith("xyz:") else ""
+
+
+def _get_account(ctx):
+    """(account_value, held_bare_tickers) — dual-DEX equity via max() (never sum: two views of
+    ONE cross-margined wallet), positions enumerated across BOTH sub-DEX sections. Read-guarded."""
+    try:
+        ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet})
+    except Exception as exc:  # noqa: BLE001 — a read error must not roll back the tick
+        print(f"[terrapin.scan] clearinghouse read failed: {exc!r}", file=sys.stderr)
+        return 0.0, set()
+    if not ch:
+        return 0.0, set()
+    data = ch.get("data", ch) if isinstance(ch, dict) else ch
+    if not isinstance(data, dict):
+        return 0.0, set()
+    held, account_value, used = set(), 0.0, 0.0
+    for section in ("main", "xyz"):
+        s = data.get(section, {})
+        if not isinstance(s, dict):
+            continue
+        ms = s.get("marginSummary", {}) if isinstance(s, dict) else {}
+        account_value = max(account_value, scoring._f(ms.get("accountValue", 0)))
+        used = max(used, scoring._f(ms.get("totalMarginUsed", 0)), abs(scoring._f(ms.get("totalNtlPos", 0))))
+        for ap in s.get("assetPositions", []) or []:
+            pos = ap.get("position", ap)
+            if scoring._f(pos.get("szi", 0)) == 0:
+                continue
+            coin = str(pos.get("coin", "")).strip()
+            if coin:
+                held.add(coin.split(":", 1)[-1].upper())
+    if used > 1.0 and not held:   # corrupt read: margin in use but empty positions — skip tick
+        print("[terrapin.scan] read-sanity guard: margin in use but empty positions — skipping tick",
+              file=sys.stderr)
+        return 0.0, set()
+    return account_value, held
+
+
+def _candles(ctx, coin, interval):
+    """Daily (or configured) candle list for `coin`, or None. Read-guarded."""
+    try:
+        md = ctx.senpi_mcp.call_tool("market_get_asset_data", {
+            "asset": coin, "candle_intervals": [interval],
+            "include_funding": False, "include_order_book": False, "dex": _dex_for(coin),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"[terrapin.scan] market_get_asset_data({coin}) failed: {exc!r}", file=sys.stderr)
+        return None
+    if not md or (isinstance(md, dict) and md.get("success") is False):
+        return None
+    d = md.get("data", md) if isinstance(md, dict) else md
+    c = d.get("candles", {}) if isinstance(d, dict) else {}
+    return c.get(interval, []) if isinstance(c, dict) else None
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    coin = str(inputs.get("asset", _DEFAULT_ASSET))
+    unit_index = int(inputs.get("unitIndex", 0))
+    interval = str(inputs.get("candleInterval", "1d"))
+    min_score = float(inputs.get("minScore", 6))
+    base_margin_pct = float(inputs.get("marginPctBase", 40))   # PERCENT of THIS unit's wallet
+    lev_default = int(inputs.get("leverageDefault", 3))
+    lev_min = int(inputs.get("leverageMin", 2))
+    lev_max = int(inputs.get("leverageMax", 5))
+
+    unit = unit_index + 1
+    account_value, held = _get_account(ctx)
+    if account_value <= 0:
+        print(f"[terrapin.scan] u{unit} WAITING — no account value / corrupt read", file=sys.stderr)
+        return []
+
+    bare = coin.split(":", 1)[-1].upper()
+    if bare in held:
+        print(f"[terrapin.scan] u{unit} holding {bare} — DSL owns the exit", file=sys.stderr)
+        if ctx.state is not None:
+            try:
+                ctx.state.append({"result": {"ts": now, "unit": unit, "state": "holding", "emitted": 0}})
+            except Exception as exc:  # noqa: BLE001
+                print(f"[terrapin.scan] u{unit} WARNING: state append failed: {exc!r}", file=sys.stderr)
+        return []
+
+    candles = _candles(ctx, coin, interval)
+    if not candles:
+        print(f"[terrapin.scan] u{unit} WAITING — no candles for {coin}", file=sys.stderr)
+        return []
+
+    th = scoring.build_thesis(coin, candles, unit_index, inputs)
+    armed = bool(th and th["score"] >= min_score)
+
+    out = []
+    if armed:
+        leverage = max(lev_min, min(lev_default, lev_max))
+        margin_pct = round(scoring.margin_tier_pct(th["score"], base_margin_pct), 4)
+        out.append({
+            "asset": coin,
+            "direction": th["direction"],
+            "marginPct": margin_pct,      # PERCENT of this unit's wallet — runtime sizes the dollars
+            "leverage": leverage,
+            "data": {
+                "score": th["score"], "leverage": leverage, "direction": th["direction"],
+                "unit": unit, "atr": th["atr"], "rung": th["rung"], "beyondN": th["beyond_n"],
+                "channelHigh": th["channel_high"], "channelLow": th["channel_low"],
+                "macdHist": th["macd_hist"], "reasons": th["reasons"][:8],
+            },
+        })
+
+    print(f"[terrapin.scan] u{unit} {'ARM ' + th['direction'] if armed else 'WAITING'} "
+          f"{coin} price={scoring._close(candles[-1]):.6g} "
+          f"{'rung=%.6g beyond=%.2fN score=%d' % (th['rung'], th['beyond_n'], th['score']) if th else 'no breakout'}",
+          file=sys.stderr)
+    if ctx.state is not None:
+        try:
+            ctx.state.append({"result": {"ts": now, "unit": unit, "emitted": len(out),
+                                         "armed": armed, "score": (th or {}).get("score")}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[terrapin.scan] u{unit} WARNING: state append failed: {exc!r}", file=sys.stderr)
+    return out

--- a/strategies/terrapin/u4/scanners/scoring.py
+++ b/strategies/terrapin/u4/scanners/scoring.py
@@ -1,0 +1,237 @@
+"""TERRAPIN — pure thesis math: Turtle-style breakout pyramid + MACD filter (no I/O, no clock).
+
+A faithful port of the Turtle breakout, decomposed so each of the four pyramid UNITS lives on
+its own wallet and is driven by the SAME code with a different `unitIndex` (0..3). One asset,
+one direction at a time; the units stack into a single directional position as the trend runs.
+
+The three ideas:
+
+  DONCHIAN BREAKOUT   entry is a break of the prior-N-day channel — long above the N-day high,
+                      short below the N-day low. The channel EXCLUDES the current bar, so a
+                      break is price exceeding settled history, not itself.
+  ATR LADDER (N)      unit k arms `k * addStep * N` beyond the breakout (½N steps by default),
+                      the Turtle "add as it runs" rule expressed as a price level each wallet
+                      can evaluate independently — no cross-wallet coordination.
+  MACD FILTER         the user's "turtle con MACD": a long needs a positive MACD histogram, a
+                      short a negative one. A breakout the momentum oscillator disagrees with is
+                      the classic Turtle whipsaw, and this is what filters it.
+
+The EXIT is not here. Classic Turtle exits the whole pyramid on one 2N / 10-day-low stop; our
+twist hands each unit to the runtime DSL instead, calibrated per unit (base breathes, tip
+ratchets). See the per-unit runtime.yaml. This module only decides ENTRY.
+
+Pure + single-pass + unit-testable on plain candle lists. Candles are keyed o/h/l/c/v with
+STRING values — `_f`/`_close` coerce both shapes.
+"""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+# ── indicators ───────────────────────────────────────────────────────────────
+
+def donchian(candles, lookback):
+    """(channel_high, channel_low) over the prior `lookback` bars, EXCLUDING the current
+    (forming) bar — the standard breakout channel. None if too short."""
+    if len(candles) < lookback + 1 or lookback < 2:
+        return None
+    window = candles[-(lookback + 1):-1]
+    return max(_high(c) for c in window), min(_low(c) for c in window)
+
+
+def atr(candles, period):
+    """Wilder-style ATR (N) over `period` bars. 0.0 if too short.
+
+    True range uses the prior close, so it captures gaps — which on 24/7 crypto are rare but on
+    the XYZ weekend session are not."""
+    if len(candles) < period + 1 or period < 1:
+        return 0.0
+    trs = []
+    for i in range(len(candles) - period, len(candles)):
+        hi, lo, pc = _high(candles[i]), _low(candles[i]), _close(candles[i - 1])
+        trs.append(max(hi - lo, abs(hi - pc), abs(lo - pc)))
+    return sum(trs) / len(trs) if trs else 0.0
+
+
+def _ema(vals, period):
+    if len(vals) < period:
+        return []
+    k = 2.0 / (period + 1)
+    ema = [sum(vals[:period]) / period]
+    for v in vals[period:]:
+        ema.append(v * k + ema[-1] * (1.0 - k))
+    return ema
+
+
+def macd_hist(candles, fast, slow, signal):
+    """MACD histogram (macd_line - signal_line) on closes. None if too short.
+
+    Sign is all the filter needs: > 0 confirms a long breakout, < 0 a short."""
+    closes = [_close(c) for c in candles]
+    if len(closes) < slow + signal:
+        return None
+    ef, es = _ema(closes, fast), _ema(closes, slow)
+    if not ef or not es:
+        return None
+    n = min(len(ef), len(es))
+    macd_line = [ef[-n + i] - es[-n + i] for i in range(n)]
+    sig = _ema(macd_line, signal)
+    if not sig:
+        return None
+    return macd_line[-1] - sig[-1]
+
+
+def breakout_anchor(candles, lookback, direction):
+    """The FROZEN channel level that started the current breakout run — computed statelessly by
+    walking back to the bar that first broke out, so every unit's wallet derives the SAME anchor
+    from the same candles with no shared state.
+
+    Turtle adds units off the breakout price, not off a channel that keeps sliding up as price
+    runs (which would leave the upper units perpetually un-armed in a normal trend). Anchoring to
+    the frozen breakout level is what lets u3/u4 actually fire — the reason the four wallets exist.
+
+    Returns the anchor price, or None if the current bar is not part of a breakout run.
+    """
+    if len(candles) < lookback + 2:
+        return None
+    i = len(candles) - 1
+    anchor = None
+    while i >= lookback:
+        ch = donchian(candles[:i + 1], lookback)      # channel as of bar i (excludes bar i)
+        if ch is None:
+            break
+        hi, lo = ch
+        px = _close(candles[i])
+        broken = (direction == "LONG" and px > hi) or (direction == "SHORT" and px < lo)
+        if not broken:
+            break                                      # walked back past the start of the run
+        anchor = hi if direction == "LONG" else lo     # keep the earliest still-broken channel
+        i -= 1
+    return anchor
+
+
+# ── the pyramid trigger ────────────────────────────────────────────────────────
+
+def build_thesis(coin, candles, unit_index, inputs):
+    """Decide whether THIS unit should be armed on `coin`. Returns a thesis dict or None.
+
+    unit_index 0..3 is the unit's rung. Unit k arms only once price has extended
+    `k * addStep * N` beyond the Donchian breakout in the trend direction — so u1 fires on the
+    break, u4 only in a move that has already run ~1.5N. The MACD sign must agree.
+
+    Scoring (max 9; `minScore` gates the MACD quality, the geometry is a hard gate):
+      +4  price has cleared this unit's ladder level (the hard entry gate)
+      +2  MACD histogram agrees with the breakout direction
+      +2  MACD agreement is strong (|hist| vs price)
+      +1  price is meaningfully beyond the rung (momentum, not a graze)
+    """
+    lookback = int(inputs.get("breakoutLookback", 20))
+    atr_period = int(inputs.get("atrPeriod", 20))
+    add_step = float(inputs.get("addStepN", 0.5))
+    fast = int(inputs.get("macdFast", 12))
+    slow = int(inputs.get("macdSlow", 26))
+    signal = int(inputs.get("macdSignal", 9))
+    require_macd = bool(inputs.get("requireMacd", True))
+    strong_hist_pct = float(inputs.get("macdStrongHistPct", 0.05))
+
+    need = max(lookback + 1, atr_period + 1, slow + signal)
+    if len(candles) < need:
+        return None
+
+    ch = donchian(candles, lookback)
+    n = atr(candles, atr_period)
+    if ch is None or n <= 0:
+        return None
+    ch_high, ch_low = ch
+    price = _close(candles[-1])
+    if price <= 0:
+        return None
+
+    # direction is set by which channel edge price has broken (current bar excluded from the channel)
+    if price > ch_high:
+        direction = "LONG"
+    elif price < ch_low:
+        direction = "SHORT"
+    else:
+        return None                              # inside the channel — no breakout, no unit
+
+    # arm off the FROZEN breakout anchor, not the live (sliding) channel — so u3/u4 fire in a
+    # normal sustained trend instead of only in a fast spike.
+    anchor = breakout_anchor(candles, lookback, direction)
+    if anchor is None:
+        anchor = ch_high if direction == "LONG" else ch_low   # fallback: current channel edge
+    if direction == "LONG":
+        rung = anchor + unit_index * add_step * n
+        cleared = price >= rung
+        beyond = (price - rung) / n if cleared else 0.0
+    else:
+        rung = anchor - unit_index * add_step * n
+        cleared = price <= rung
+        beyond = (rung - price) / n if cleared else 0.0
+
+    if not cleared:
+        return None                              # price hasn't reached THIS unit's rung yet
+
+    hist = macd_hist(candles, fast, slow, signal)
+    macd_ok = hist is not None and ((direction == "LONG" and hist > 0) or
+                                    (direction == "SHORT" and hist < 0))
+    if require_macd and not macd_ok:
+        return None                              # the MACD filter vetoes the breakout
+
+    score, reasons = 4, [
+        f"unit {unit_index + 1} armed: {direction} breakout of the {lookback}-bar channel",
+        f"rung {rung:.6g} = channel {anchor:.6g} {'+' if direction == 'LONG' else '-'} "
+        f"{unit_index}x{add_step:g}N (N={n:.6g})",
+    ]
+    hist_pct = abs(hist) / price * 100.0 if hist is not None else 0.0
+    if macd_ok:
+        score += 2
+        reasons.append(f"MACD hist {hist:+.6g} agrees")
+        if hist_pct >= strong_hist_pct:
+            score += 2
+            reasons.append(f"MACD strong ({hist_pct:.3f}% of price)")
+    if beyond >= float(inputs.get("beyondRungN", 0.15)):
+        score += 1
+        reasons.append(f"price {beyond:.2f}N beyond the rung")
+
+    return {"coin": coin, "direction": direction, "score": score, "unit_index": unit_index,
+            "atr": round(n, 8), "channel_high": round(ch_high, 8), "channel_low": round(ch_low, 8),
+            "rung": round(rung, 8), "beyond_n": round(beyond, 4),
+            "macd_hist": None if hist is None else round(hist, 10), "reasons": reasons}
+
+
+def margin_tier_pct(score, base_pct):
+    """Conviction sizing on the PERCENT scale (base_pct is a PERCENT in (0,100])."""
+    if score >= 8:
+        return base_pct * 1.25
+    if score >= 6:
+        return base_pct * 1.1
+    return base_pct


### PR DESCRIPTION
The one I said I'd only build honestly — here it is, built honestly. From M194258 ("turtle con macd").

**Why the catalog couldn't do this before:** a faithful Turtle pyramid must *add* to a winning position, and Hyperliquid nets positions per coin per wallet, so a single-wallet build can only ever hold the first unit. Terrapin solves it the way remora solved multi-tranche — **four units, four wallets** — except here they *stack* into one directional position rather than running independently.

### Entry (shared `scan.py`/`scoring.py`, byte-identical across all 4 units — only `unitIndex` differs)
- **Donchian(20) breakout** — long above the 20-day high, short below the low
- **MACD filter** (the user's "con macd") — vetoes the momentum-less breakout, the system's classic whipsaw
- **Frozen-anchor ATR ladder** — unit *k* arms only once price extends *k*·½N (N = 20-day ATR) beyond the breakout. The anchor is computed **statelessly**, so all four wallets derive the same ladder with zero cross-wallet coordination. u1 fires on the break; u4 only in a move that's already run ~1.5N.

Verified day-by-day on realistic sticky-resistance data — the pyramid builds `u1 → u1,u2 → u1,u2,u3 → all four` as price extends, and the anchor stays frozen the whole way up.

### The twist (per-unit `runtime.yaml`)
Classic Turtle exits the whole pyramid on one 2N / 10-day-low stop. **Terrapin hands each unit its own DSL, progressively tighter up the pyramid:**

| Unit | Rung | phase1 max-loss | first profit-lock |
|---|---|---|---|
| u1 (base) | breakout | 25% | 15% |
| u2 | +½N | 22% | 12% |
| u3 | +1N | 18% | 10% |
| u4 (tip) | +1½N | 14% | 8% |

The base breathes widest and carries the trend; the tip locks fastest and peels off first — so **the pyramid unwinds top-down on a reversal** instead of giving the whole stack back at one level. This is the coherence mechanism that replaces Turtle's unified stop, and it's arguably a better risk profile than the original.

### Honest naming
Named **"Turtle-Style," not "Turtle."** The description states plainly it's a four-wallet laddered pyramid with independent trailing exits and a frozen-anchor add rule — a faithful *modernization*, not a bit-exact replica. The unified stop is deliberately gone; funding splits four ways so `min_budget` is higher (400 vs 100). This was the whole condition I flagged, and it's met.

### Learnings applied
- marginPct a PERCENT (0,100]; robust `o/h/l/c/v` candle keys; dual-DEX clearinghouse via `max()` never sum, positions across both sections
- **Validators: 0 dex-blind, 0 marginPct-fraction, 0 candle-key across all 4 units**

### Verification
- 11-test engine suite: Donchian/ATR/MACD, the frozen-anchor ladder (long **and** short, realistic breakouts), the MACD-veto contract. It documents *why* a Donchian breakout almost always agrees with MACD (both key off a 20-bar extreme) and tests the marginal veto via a forced sign rather than a contrived market state.
- 41 suites green; `deploy.py validate` clean (4 instances); catalog regenerated (93 strategies, **0 warnings**); new `pyramid_breakout` glossary term
- Ranks #1 in discover for "turtle breakout" (26), "add to winners donchian" (17), "pyramid trend" (15)

**Version note:** discover skill → **2.9.0** (2.8.0 is claimed by the unmerged #492, so this stays monotonic after it). Independent of #492/#491 except the shared catalog + glossary — whichever merges second reruns `gen_catalog.py --branch main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)