### PR TITLE
albatross: block from catalog — The Arena is paused

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.9.0"
+  version: "2.10.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -304,48 +304,6 @@
       "sort_order": 4
     },
     {
-      "id": "albatross",
-      "name": "Albatross — Multi-week Arena Conviction Mirror",
-      "emoji": "🐦‍⬛",
-      "tagline": "Mirrors trades from Senpi Arena participants whose ROE has been consistently strong across the last 4 weekly periods AND the current month — a composite conviction score (0.3 monthly + 0.7 weekly_mean - 0.5 weekly_stdev) picks the persistent winners over the one-week wonders, and the producer mirrors each new position they open.",
-      "belief_plain": "The Arena resets every Thursday, so a trader can top the board with one lucky +98% week and three flat ones. Albatross looks back over four weeks plus the month and copies the traders who have been steadily winning the whole time, not the ones who got lucky once — then it opens what they open and rides it on its own wide stop.",
-      "version": "1.0.0",
-      "thesis": "Single-week Arena mirroring is a survivor-bias trap: it copies whoever spiked, who is then most likely to mean-revert. Selecting on a multi-week composite that rewards persistence and penalizes weekly variance corrects for that — a steady +22%/week-for-4-weeks trader scores far above an identical-mean trader who got there on one +98% week. You copy the proven hand, cap their leverage, size fixed, and exit on your own DSL because you can't see when they will.",
-      "tags": [
-        "arena",
-        "copy-trading",
-        "multi-week",
-        "conviction",
-        "mirror",
-        "long-short",
-        "persistence"
-      ],
-      "group": "copy-trading",
-      "archetype": "copy_trading",
-      "archetype_label": "Copy-Trader",
-      "sub_style": "arena_winners",
-      "sub_style_label": "Copies multi-week arena winners, not one-week wonders.",
-      "asset_classes": [
-        "universe_crypto"
-      ],
-      "asset_scope": "follows_traders",
-      "assets": [],
-      "direction": "long_short",
-      "risk_level": "moderate",
-      "tier": "advanced",
-      "leverage_max": 5,
-      "time_horizon": "swing",
-      "cadence_seconds": 300,
-      "min_budget": 200,
-      "instance_count": 1,
-      "funding_split": [
-        1.0
-      ],
-      "max_slots": 3,
-      "branch": "main",
-      "sort_order": 1
-    },
-    {
       "id": "jackal",
       "name": "Jackal — The Smart Stalker",
       "emoji": "🐺",
@@ -386,7 +344,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 2
+      "sort_order": 1
     },
     {
       "id": "tortoise",

--- a/strategies/albatross/strategy.yaml
+++ b/strategies/albatross/strategy.yaml
@@ -29,7 +29,12 @@ catalog:
   max_slots: 3
   min_budget: 200
   assets: []
-  tags: [arena, copy-trading, multi-week, conviction, mirror, long-short, persistence]
+  # ⚠️ PAUSED 2026-07-23: The Arena is paused, so the arena_* feed Albatross mirrors is
+  # unavailable — the strategy would fund but never find a trader to copy. Blocked from the
+  # catalog (non-discoverable, non-installable) until the Arena resumes; re-enable by deleting
+  # the `status: blocked` line below. Package kept on disk + tested meanwhile.
+  status: blocked
+  tags: [arena, copy-trading, multi-week, conviction, mirror, long-short, persistence, blocked, arena-paused]
 
 requires:
   runtime: ">=3.0.0"

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -304,48 +304,6 @@
       "sort_order": 4
     },
     {
-      "id": "albatross",
-      "name": "Albatross — Multi-week Arena Conviction Mirror",
-      "emoji": "🐦‍⬛",
-      "tagline": "Mirrors trades from Senpi Arena participants whose ROE has been consistently strong across the last 4 weekly periods AND the current month — a composite conviction score (0.3 monthly + 0.7 weekly_mean - 0.5 weekly_stdev) picks the persistent winners over the one-week wonders, and the producer mirrors each new position they open.",
-      "belief_plain": "The Arena resets every Thursday, so a trader can top the board with one lucky +98% week and three flat ones. Albatross looks back over four weeks plus the month and copies the traders who have been steadily winning the whole time, not the ones who got lucky once — then it opens what they open and rides it on its own wide stop.",
-      "version": "1.0.0",
-      "thesis": "Single-week Arena mirroring is a survivor-bias trap: it copies whoever spiked, who is then most likely to mean-revert. Selecting on a multi-week composite that rewards persistence and penalizes weekly variance corrects for that — a steady +22%/week-for-4-weeks trader scores far above an identical-mean trader who got there on one +98% week. You copy the proven hand, cap their leverage, size fixed, and exit on your own DSL because you can't see when they will.",
-      "tags": [
-        "arena",
-        "copy-trading",
-        "multi-week",
-        "conviction",
-        "mirror",
-        "long-short",
-        "persistence"
-      ],
-      "group": "copy-trading",
-      "archetype": "copy_trading",
-      "archetype_label": "Copy-Trader",
-      "sub_style": "arena_winners",
-      "sub_style_label": "Copies multi-week arena winners, not one-week wonders.",
-      "asset_classes": [
-        "universe_crypto"
-      ],
-      "asset_scope": "follows_traders",
-      "assets": [],
-      "direction": "long_short",
-      "risk_level": "moderate",
-      "tier": "advanced",
-      "leverage_max": 5,
-      "time_horizon": "swing",
-      "cadence_seconds": 300,
-      "min_budget": 200,
-      "instance_count": 1,
-      "funding_split": [
-        1.0
-      ],
-      "max_slots": 3,
-      "branch": "main",
-      "sort_order": 1
-    },
-    {
       "id": "jackal",
       "name": "Jackal — The Smart Stalker",
       "emoji": "🐺",
@@ -386,7 +344,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 2
+      "sort_order": 1
     },
     {
       "id": "tortoise",


### PR DESCRIPTION
The Arena is paused, so **Albatross** (multi-week Arena conviction mirror) has no data source — the `arena_*` feed it mirrors is unavailable, so it would fund but never find a trader to copy.

**Mechanism** — the same `catalog.status: blocked` flag `crane` already uses: `gen_catalog.py` skips it (loudly), so it drops out of **both** `catalog.json` files and is no longer discoverable or installable. The package and its tests stay on disk.

**Fully reversible** — delete the one `status: blocked` line when the Arena resumes and rerun `gen_catalog.py --branch main`. The manifest carries a dated note explaining why.

**Scope checked** — verified Albatross is the *only* Arena-dependent strategy in the fleet (nothing else references `arena_*` MCP tools or the `arena_winners` facet), so nothing else is affected.

- Catalog 97 → 96; no longer surfaces for copy-trading/arena queries in discover
- Package still validates structurally (`deploy.py validate albatross` ✓) — blocking is catalog-level, files untouched
- discover skill 2.9.0 → 2.10.0; 42 suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)