### PR TITLE
portfolio: answer "why hasn't it traded?" — the `idle` step (P0-2)

### DIFF
--- a/senpi-improve-trades/SKILL.md
+++ b/senpi-improve-trades/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.6.0"
+  version: "1.7.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -392,6 +392,17 @@ Concretely: if you're about to say "you have 13 wallets, kill/merge 11 of them,"
 and there is **no consolidation problem** — you're looking at redeploy history.
 
 ### 9. No trades yet? Stop cleanly — do NOT pivot to setup / config nagging
+
+> **⚠️ EXCEPTION — when the user ASKS why it hasn't traded, hand off; don't dead-end.**
+>
+> *"why hasn't it traded"* · *"no trades today, is the scanner running?"* · *"it didn't trade in 3 days"* ·
+> *"i'm not seeing any new positions"* · *"our trades are almost zero"*
+>
+> That is a **live-state** question (is this strategy doing its job *right now*), not a retrospective one —
+> it belongs to **`senpi-portfolio`**, which owns the mandate and can run its `idle` step to say WHY
+> (selective-by-design vs. a runtime rejecting every candidate). **Route it there.** Saying "nothing to
+> review yet" and stopping is the #1 support complaint by volume — one user asked five times over three
+> days. Everything else in this guardrail still binds.
 
 **An empty `trades[]` now means the book genuinely never traded** — the engine already falls back to on-chain HL fills for closed strategies, so it is **not** a coverage gap you need to work around. Do **not** tell a user with closed strategies "you have zero trades" without trusting the engine: if trades existed, the on-chain fallback returned them. When trades were recovered that way (`meta.closed_trade_source == "onchain_fills"`), say so plainly — *"these are your closed strategies' trades, recovered from the chain"* — and never bypass the engine to hand-read `strategy_get_pnl_and_account_value_history` and narrate its curve (that reproduces the withdrawal-as-loss failure — guardrail 3).
 

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -191,9 +191,8 @@ right tool to *confirm* — never re-derive its analysis here.
 
 ## "Why hasn't it traded?" — the idle diagnosis
 
-The **#1 support complaint by volume** (one user asked five times over three days). It belongs here
-because it is a **live-state** question — *is this strategy doing its job right now* — and this skill
-already owns the mandate that defines the job. (`senpi-improve-trades` is the retrospective counterpart:
+A **live-state** question — *is this strategy doing its job right now* — so it belongs to this skill,
+which owns the mandate that defines the job. (`senpi-improve-trades` is the retrospective counterpart:
 *how did my CLOSED trades do*. It hands this question here.)
 
 **Liveness alone cannot answer it.** `senpi status` reports the *runtime*, and a runtime can be perfectly
@@ -218,11 +217,11 @@ python3 scripts/portfolio.py idle
 market is working perfectly — that is the same rule as "judge against the mandate" below, applied to
 activity instead of PnL. Calling it broken is how users tear down strategies that were fine.
 
-> **Worked example.** `ibis` deployed with a $1,400 budget and never traded. Every surface said healthy —
-> liveness reports the runtime, and the runtime *was* running. The event ring said what nothing else did:
-> the scanner produced candidates every tick and the runtime rejected **all** of them (an optional signal
-> field was sent as `null`, which fails schema validation and drops the whole candidate silently). That is
-> verdict `blocked` — two hours of manual diagnosis, or one `idle` run.
+> **Why the event ring is required.** A funded strategy can scan every tick, produce candidates every
+> tick, and still open nothing — because the runtime rejects each one (a full slot table, a risk gate, or
+> a signal field that fails schema validation). Liveness reports the runtime as healthy throughout, and
+> the rejections are silent. `blocked` is the only verdict that surfaces this, and the reason code is the
+> fix.
 
 ## Judge each strategy against its OWN mandate — not a momentum benchmark
 

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   with positions as evidence. Use this skill FIRST for ANY portfolio / strategies / positions / balances
   / PnL / trade-history question, BEFORE any raw strategy_get_clearinghouse_state / account_get_portfolio
   / strategy_list MCP call. Use for "analyze my strategies", "how are my strategies doing", "analyze my
-  portfolio", "how am I doing", "show my positions", "balance across all wallets", "how much is idle", and
+  portfolio", "how am I doing", "show my positions", "balance across all wallets", "how much is idle", and "why hasn't it traded / why no trades today / it hasn't traded in 3 days / no new positions / is the scanner even running" (the `idle` step — separates selective-by-design from a runtime that is rejecting every candidate), and
   "are my open positions protected? / do they have a stop-loss?", and "tell me about my strategies and
   their DSL / what tier are my positions in?", and "what happened to my closed [asset] position / did my
   trade actually go through / do I still hold X" — the authority for position facts, OPEN and CLOSED, which
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.9.0"
+  version: "1.10.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -188,6 +188,41 @@ it as the required next step (and its verdict, if you can run it), then close.py
 **"where am I leaking / did a stop fail / any halts / exit quality"**, hand to `senpi-improve-trades` (it
 reads the runtime event log for protection gaps, risk halts, failed orders, and exit quality). Reference the
 right tool to *confirm* — never re-derive its analysis here.
+
+## "Why hasn't it traded?" — the idle diagnosis
+
+The **#1 support complaint by volume** (one user asked five times over three days). It belongs here
+because it is a **live-state** question — *is this strategy doing its job right now* — and this skill
+already owns the mandate that defines the job. (`senpi-improve-trades` is the retrospective counterpart:
+*how did my CLOSED trades do*. It hands this question here.)
+
+**Liveness alone cannot answer it.** `senpi status` reports the *runtime*, and a runtime can be perfectly
+healthy while every candidate its scanner produces is rejected downstream. Run the step that reads the
+runtime's own ruling on each candidate:
+
+```sh
+python3 scripts/portfolio.py idle
+```
+
+| Verdict | Meaning | What to say — and the lever |
+|---|---|---|
+| `waiting` | Scanning normally; nothing cleared its entry bar. **Selective by design.** | *"It's being picky, not broken."* **Judge it against its mandate** (`profile.description`) — a strategy built to be selective, sitting out a quiet market, is doing its job. **Offer** to lower the entry bar; never imply a fault. |
+| `blocked` | Candidates produced and the runtime **rejected every one**. | **The `reason_code` is the answer** — `no_slots` (all slots held) · `no_margin` (fund it) · `risk_gate_*` (that gate) · `asset_banned` · a schema/validation code (a package bug → `senpi-strategy-author`). Give the count and the code. |
+| `accepted_no_open` | Signals accepted, nothing opened; often with `order.failed`. | An **execution** problem, not a signal problem → `senpi-strategy-ops`. |
+| `traded` | It HAS opened positions recently. | The premise is wrong — say so plainly, show what it opened, ask what they expected. |
+| `no_runtime` | Funded, but no runtime bound — it cannot scan. | The real fault → `senpi-strategy-ops` to redeploy. |
+| `silent` | No events recorded. | *Cannot confirm* it's scanning. Say exactly that — **do not** assert it's broken. |
+| `unknown` | Event log unreadable from here. | Absence of telemetry is **not** evidence of a fault. Say the read failed; don't diagnose. |
+
+**The one mistake that matters: never turn `waiting` into an alarm.** A selective strategy in a quiet
+market is working perfectly — that is the same rule as "judge against the mandate" below, applied to
+activity instead of PnL. Calling it broken is how users tear down strategies that were fine.
+
+> **Worked example.** `ibis` deployed with a $1,400 budget and never traded. Every surface said healthy —
+> liveness reports the runtime, and the runtime *was* running. The event ring said what nothing else did:
+> the scanner produced candidates every tick and the runtime rejected **all** of them (an optional signal
+> field was sent as `null`, which fails schema validation and drops the whole candidate silently). That is
+> verdict `blocked` — two hours of manual diagnosis, or one `idle` run.
 
 ## Judge each strategy against its OWN mandate — not a momentum benchmark
 

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -1107,6 +1107,193 @@ def group_strategies(strategies, meta):
 
 
 # ──────────────────────────────────────────────────────────────── orchestration
+# ── "why hasn't it traded?" — the idle diagnosis ─────────────────────────────
+# The #1 support complaint by volume (M192299 asked five times over three days; M192397, M298631, M3601,
+# M347101, M193436). It belongs HERE, not in improve-trades: it is a LIVE-STATE question about whether a
+# strategy is doing its job right now, and this skill already owns the mandate — "a strategy is doing its
+# job when its behavior matches its design, even if that design means idle right now."
+#
+# Liveness alone can't answer it: `senpi status` reports the runtime, and a runtime can be perfectly
+# healthy while every candidate its scanner produces is rejected downstream (that is exactly how `ibis`
+# shipped 100% dead while every surface said healthy). The verdict needs the EVENT RING, where
+# `signal.outcome` carries the runtime's own ruling on each candidate.
+#
+# The verdict must separate "correctly selective" from "actually broken" — getting that backwards makes
+# users tear down working strategies (the LION incidents). A strategy that is scanning and simply hasn't
+# found a setup reads `waiting`, never `broken`.
+EVENTS_FIXTURE_ENV = "SENPI_EVENTS_FIXTURE"   # offline test hook: JSON {"<runtime_id>": [entries…]}
+EVENTS_PULL = 500                             # recent ring depth per runtime
+EVENTS_CALL_TIMEOUT_S = 8                     # wraps a double CLI boot + the read
+_IDLE_SIGNAL_EVENT = "signal.outcome"
+_IDLE_OPENED_EVENT = "position.opened"
+_IDLE_FAILED_EVENT = "order.failed"
+_IDLE_REJECT_SAMPLE_CAP = 5
+_IDLE_CURRENT_STATUSES = ("ACTIVE", "PAUSED")
+
+
+def _idle_is_current(status):
+    """True when the strategy is part of the CURRENT book (active/paused). A missing status defaults to
+    current — an ACTIVE-by-default row that omitted the field."""
+    return str(status or "ACTIVE").strip().upper() in _IDLE_CURRENT_STATUSES
+
+
+def _event_attr(ev, *keys, default=None):
+    """Read a dotted `senpi.*` attribute off an event's `attrs` map (fail-soft)."""
+    attrs = ev.get("attrs") if isinstance(ev, dict) else None
+    if isinstance(attrs, dict):
+        for k in keys:
+            if k in attrs:
+                return attrs[k]
+    return default
+
+
+def _fetch_events(runtime_id, meta):
+    """Read a runtime's on-disk event ring -> [event dicts]. FAIL-OPEN in every branch (missing CLI /
+    non-zero exit / unknown method / bad JSON -> [] + a one-time note); NEVER raises. Mirrors the
+    liveness reader's conventions, including the `_telemetry_dead` short-circuit so a host without
+    `openclaw` doesn't spawn a process per strategy just to fail."""
+    if not runtime_id or meta.get("_telemetry_dead"):
+        return []
+    fixture = os.environ.get(EVENTS_FIXTURE_ENV)
+    if fixture:                                   # offline path — no subprocess
+        try:
+            with open(fixture) as fh:
+                data = json.load(fh)
+            entries = data.get(str(runtime_id), []) if isinstance(data, dict) else []
+            return [e for e in entries if isinstance(e, dict)]
+        except Exception as e:  # noqa — a bad fixture is fail-open too
+            _note_telemetry_unavailable(meta, f"events fixture unreadable ({e})")
+            return []
+    try:
+        proc = subprocess.run(["openclaw", "senpi", "events", "--runtime", str(runtime_id),
+                               "--json", "-l", str(EVENTS_PULL)],
+                              capture_output=True, text=True, timeout=EVENTS_CALL_TIMEOUT_S)
+    except FileNotFoundError:
+        meta["_telemetry_dead"] = True
+        _note_telemetry_unavailable(meta, "openclaw CLI not found — scanner activity unverified")
+        return []
+    except Exception as e:  # noqa — timeout / OS error
+        _note_telemetry_unavailable(meta, f"event-log read failed ({e})")
+        return []
+    if proc.returncode != 0:
+        err = (proc.stderr or "")[:200]
+        if "unknown method" in err.lower() or "getevents" in err.lower():
+            meta["_telemetry_dead"] = True
+            _note_telemetry_unavailable(meta, "runtime build predates the event log — scanner activity unverified")
+        else:
+            _note_telemetry_unavailable(meta, f"event-log read exit {proc.returncode} ({err.strip()})")
+        return []
+    try:
+        parsed = json.loads(proc.stdout or "{}")
+    except Exception as e:  # noqa
+        _note_telemetry_unavailable(meta, f"event-log JSON parse failed ({e})")
+        return []
+    if not isinstance(parsed, dict) or parsed.get("ok") is False:
+        return []
+    entries = parsed.get("entries") or parsed.get("events") or []
+    return [e for e in entries if isinstance(e, dict)]
+
+
+def idle_verdict(strat, events, telemetry_ok):
+    """One strategy's idle verdict from its event ring. PURE — takes already-fetched events, so it is
+    unit-testable with no MCP and no subprocess.
+
+      traded            opened positions in the window — the premise is wrong
+      blocked           candidates produced, runtime rejected them ALL -> reason_code is the answer
+      accepted_no_open  accepted but nothing opened (execution / order failure)
+      waiting           scanning normally, nothing cleared the bar — SELECTIVE BY DESIGN, not broken
+      silent            no events at all — cannot CONFIRM it is scanning
+      no_runtime        funded with no runtime bound — it cannot scan
+      unknown           event log unreadable (fail-open; NOT evidence of a fault)
+    """
+    label = strat.get("label") or strat.get("strategy_id") or "unknown"
+    tally = {"accepted": 0, "rejected": 0, "blocked": 0, "error": 0}
+    reasons, samples = {}, []
+    opened = failed = 0
+    last_ts = None
+    for ev in events or []:
+        name = str(ev.get("name") or "")
+        ts = _num(ev.get("ts"))
+        if ts is not None and (last_ts is None or ts > last_ts):
+            last_ts = ts
+        if name == _IDLE_OPENED_EVENT:
+            opened += 1
+        elif name == _IDLE_FAILED_EVENT:
+            failed += 1
+        elif name == _IDLE_SIGNAL_EVENT:
+            result = str(_event_attr(ev, "senpi.outcome.result") or "").lower()
+            if result in tally:
+                tally[result] += 1
+            code = str(_event_attr(ev, "senpi.outcome.reason_code") or "unknown")
+            if result in ("rejected", "blocked", "error"):
+                reasons[code] = reasons.get(code, 0) + 1
+                if len(samples) < _IDLE_REJECT_SAMPLE_CAP:
+                    samples.append({"asset": _event_attr(ev, "senpi.signal.asset", "senpi.asset"),
+                                    "direction": _event_attr(ev, "senpi.signal.direction"),
+                                    "score": _num(_event_attr(ev, "senpi.signal.score")),
+                                    "result": result, "reason_code": code, "ts": ts})
+    produced = sum(tally.values())
+
+    if not _idle_is_current(strat.get("status")):
+        verdict, detail = "not_current", f"status {strat.get('status')} — not part of the current book"
+    elif not strat.get("runtime_id"):
+        verdict, detail = "no_runtime", ("funded but no runtime is bound — it cannot scan at all "
+                                         "(redeploy via senpi-strategy-ops)")
+    elif not telemetry_ok:
+        verdict, detail = "unknown", ("event log unreadable from here — cannot diagnose "
+                                      "(this is NOT evidence of a fault)")
+    elif opened > 0:
+        verdict, detail = "traded", f"opened {opened} position(s) recently — it IS trading"
+    elif tally["accepted"] > 0:
+        verdict, detail = ("accepted_no_open",
+                           f"{tally['accepted']} signal(s) accepted but no position opened"
+                           + (f"; {failed} order(s) failed" if failed else ""))
+    elif tally["rejected"] or tally["blocked"] or tally["error"]:
+        top = max(reasons.items(), key=lambda kv: kv[1])[0] if reasons else "unknown"
+        verdict, detail = ("blocked",
+                           f"the scanner produced {produced} candidate(s) and the runtime rejected every "
+                           f"one — most common reason: {top}")
+    elif events:
+        verdict, detail = ("waiting", "scanning normally; no candidate cleared its entry bar "
+                                      "(selective by design, not broken)")
+    else:
+        verdict, detail = ("silent", "no runtime events recorded — cannot confirm it is scanning")
+
+    return {"label": label, "status": strat.get("status"), "verdict": verdict, "verdict_detail": detail,
+            "mandate": strat.get("mandate"), "signals": tally, "signals_produced": produced,
+            "reason_codes": reasons, "positions_opened": opened, "orders_failed": failed,
+            "events_seen": len(events or []), "last_event_ts": last_ts, "sample_rejections": samples}
+
+
+def idle_reads(strategies, meta):
+    """Per-strategy idle diagnosis across the current book. Never probes a closed strategy (its ring is
+    torn down with its runtime). Fail-open per strategy."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    def _worker(strat):
+        priv = {"_telemetry_dead": meta.get("_telemetry_dead", False), "warnings": []}
+        try:
+            events = (_fetch_events(strat.get("runtime_id"), priv)
+                      if _idle_is_current(strat.get("status")) else [])
+            ok = not priv.get("_telemetry_dead") and not priv.get("warnings")
+            return {"read": idle_verdict(strat, events, ok), "meta": priv}
+        except Exception as e:  # noqa — one strategy must not sink the diagnosis
+            priv["warnings"].append(f"idle read failed: {e}")
+            return {"read": idle_verdict(strat, [], False), "meta": priv}
+
+    reads = []
+    if strategies:
+        with ThreadPoolExecutor(max_workers=min(6, len(strategies))) as ex:
+            for res in ex.map(_worker, strategies):     # preserves input order
+                reads.append(res["read"])
+                if res["meta"].get("_telemetry_dead"):
+                    meta["_telemetry_dead"] = True
+                for w in res["meta"].get("warnings", []):
+                    if w not in meta.setdefault("warnings", []):
+                        meta["warnings"].append(w)
+    return reads
+
+
 def run(client, want_market=True):
     meta = {"warnings": [], "real_time": True, "force_fetch": True}
     embedded, portfolio_totals = fetch_embedded(client, meta)
@@ -1413,8 +1600,42 @@ def _dry(client):
     return out
 
 
-_STEPS = ("money", "strategies", "positions", "all")
-_STEP_FNS = {"money": step_money, "strategies": step_strategies, "positions": step_positions}
+def step_idle(client, want_market=True, state_path=None):
+    """STEP `idle` — "why hasn't it traded?" (the #1 support question by volume).
+
+    A LIVE-STATE question, which is why it lives here and not in the retrospective skill: it asks whether
+    a strategy is doing its job RIGHT NOW, and this engine already owns the mandate that defines what
+    "its job" is. Each current strategy comes back with a verdict + the evidence behind it.
+
+    Cheap by construction — the strategy read is already in state (self-heals if not), and the only new
+    work is one event-ring read per current runtime, fanned out and fail-open."""
+    if state_path is None:
+        state_path = _default_state_path()
+    state = _load_state(state_path)
+    meta = _fresh_meta()
+    _embedded, strategies, _totals = _ensure_full_strategies_in_state(client, state, want_market, meta)
+    for w in state.get("meta_warnings", []):
+        if w not in meta["warnings"]:
+            meta["warnings"].append(w)
+    reads = idle_reads(strategies, meta)
+    current = [r for r in reads if r["verdict"] != "not_current"]
+    by_verdict = {}
+    for r in current:
+        by_verdict[r["verdict"]] = by_verdict.get(r["verdict"], 0) + 1
+    meta["strategy_count"] = len(strategies)
+    meta["current_strategy_count"] = len(current)
+    meta.pop("_telemetry_dead", None)
+    meta.pop("_telemetry_warned", None)
+    if not strategies:
+        meta["degraded"] = "no strategies deployed yet — nothing to diagnose"
+    return {"idle_reads": current,
+            "idle_summary": {"by_verdict": by_verdict, "current_strategies": len(current)},
+            "meta": meta}
+
+
+_STEPS = ("money", "strategies", "positions", "idle", "all")
+_STEP_FNS = {"money": step_money, "strategies": step_strategies,
+             "positions": step_positions, "idle": step_idle}
 
 
 def _all_and_persist(client, want_market, state_path):

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -1108,19 +1108,16 @@ def group_strategies(strategies, meta):
 
 # ──────────────────────────────────────────────────────────────── orchestration
 # ── "why hasn't it traded?" — the idle diagnosis ─────────────────────────────
-# The #1 support complaint by volume (M192299 asked five times over three days; M192397, M298631, M3601,
-# M347101, M193436). It belongs HERE, not in improve-trades: it is a LIVE-STATE question about whether a
-# strategy is doing its job right now, and this skill already owns the mandate — "a strategy is doing its
-# job when its behavior matches its design, even if that design means idle right now."
+# A LIVE-STATE question — is this strategy doing its job right now — which is why it belongs to this
+# engine: it already owns the mandate that defines the job.
 #
-# Liveness alone can't answer it: `senpi status` reports the runtime, and a runtime can be perfectly
-# healthy while every candidate its scanner produces is rejected downstream (that is exactly how `ibis`
-# shipped 100% dead while every surface said healthy). The verdict needs the EVENT RING, where
-# `signal.outcome` carries the runtime's own ruling on each candidate.
+# Liveness alone cannot answer it. `senpi status` reports the RUNTIME, and a runtime can be perfectly
+# healthy while every candidate its scanner produces is rejected downstream. The verdict needs the EVENT
+# RING, where `signal.outcome` carries the runtime's own ruling on each candidate.
 #
-# The verdict must separate "correctly selective" from "actually broken" — getting that backwards makes
-# users tear down working strategies (the LION incidents). A strategy that is scanning and simply hasn't
-# found a setup reads `waiting`, never `broken`.
+# The verdict must separate "correctly selective" from "actually broken". A strategy that is scanning and
+# simply hasn't found a setup reads `waiting`, never `broken` — reporting a healthy selective strategy as
+# broken leads users to tear down strategies that were working.
 EVENTS_FIXTURE_ENV = "SENPI_EVENTS_FIXTURE"   # offline test hook: JSON {"<runtime_id>": [entries…]}
 EVENTS_PULL = 500                             # recent ring depth per runtime
 EVENTS_CALL_TIMEOUT_S = 8                     # wraps a double CLI boot + the read

--- a/senpi-portfolio/tests/fixtures/idle_events.json
+++ b/senpi-portfolio/tests/fixtures/idle_events.json
@@ -1,0 +1,6 @@
+{
+  "s-main": [
+    {"name": "scan.tick", "ts": 1000, "attrs": {}},
+    {"name": "scan.tick", "ts": 2000, "attrs": {}}
+  ]
+}

--- a/senpi-portfolio/tests/test_idle.py
+++ b/senpi-portfolio/tests/test_idle.py
@@ -8,8 +8,8 @@ strategy doing its job right now" — and this skill owns the mandate that defin
 is the retrospective counterpart ("how did my CLOSED trades do").
 
 The verdict that matters most is the one that ISN'T alarming: a strategy that is scanning and simply
-hasn't found a setup must read `waiting`, never `broken`. Getting that backwards is how users tear down
-working strategies (the LION incidents), so it has its own test.
+hasn't found a setup must read `waiting`, never `broken` — reporting a healthy selective strategy as
+broken leads users to tear down strategies that were working. It has its own test.
 
     python3 -m pytest senpi-portfolio/tests/test_idle.py
     python3 senpi-portfolio/tests/test_idle.py
@@ -43,10 +43,10 @@ def _strat(label="s", status="ACTIVE", runtime_id="s-main", mandate=None):
 
 class Verdicts(unittest.TestCase):
     def test_blocked_every_candidate_rejected(self):
-        """THE ibis case: the scanner produced candidates and the runtime rejected all of them.
-        Invisible on every other surface — liveness said healthy while it was 100% dead."""
+        """The scanner produced candidates and the runtime rejected all of them — invisible on every
+        other surface, because liveness reports the runtime as healthy throughout."""
         events = [_sig("rejected", "schema_invalid", a) for a in ("SOL", "BTC", "ETH")]
-        r = portfolio.idle_verdict(_strat("ibis"), events, True)
+        r = portfolio.idle_verdict(_strat("s"), events, True)
         self.assertEqual(r["verdict"], "blocked")
         self.assertEqual(r["signals"]["rejected"], 3)
         self.assertEqual(r["reason_codes"]["schema_invalid"], 3)

--- a/senpi-portfolio/tests/test_idle.py
+++ b/senpi-portfolio/tests/test_idle.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Offline tests for the `idle` step — "why hasn't it traded?" (the #1 support question by volume).
+
+Pure: `idle_verdict` takes already-fetched events, so there is NO MCP and NO subprocess here.
+
+This lives in senpi-portfolio, not senpi-improve-trades, because it is a LIVE-STATE question — "is this
+strategy doing its job right now" — and this skill owns the mandate that defines the job. improve-trades
+is the retrospective counterpart ("how did my CLOSED trades do").
+
+The verdict that matters most is the one that ISN'T alarming: a strategy that is scanning and simply
+hasn't found a setup must read `waiting`, never `broken`. Getting that backwards is how users tear down
+working strategies (the LION incidents), so it has its own test.
+
+    python3 -m pytest senpi-portfolio/tests/test_idle.py
+    python3 senpi-portfolio/tests/test_idle.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
+
+import portfolio  # noqa: E402
+
+
+def _ev(name, ts=1000, **attrs):
+    """An event-ring entry; kwargs become dotted senpi.* attrs (`__` → `.`)."""
+    return {"name": name, "ts": ts,
+            "attrs": {"senpi." + k.replace("__", "."): v for k, v in attrs.items()}}
+
+
+def _sig(result, code, asset="SOL", score=7.0):
+    return _ev("signal.outcome", outcome__result=result, outcome__reason_code=code,
+               signal__asset=asset, signal__direction="LONG", signal__score=score)
+
+
+def _strat(label="s", status="ACTIVE", runtime_id="s-main", mandate=None):
+    return {"label": label, "status": status, "runtime_id": runtime_id,
+            "wallet": "0x" + "a" * 40, "mandate": mandate}
+
+
+class Verdicts(unittest.TestCase):
+    def test_blocked_every_candidate_rejected(self):
+        """THE ibis case: the scanner produced candidates and the runtime rejected all of them.
+        Invisible on every other surface — liveness said healthy while it was 100% dead."""
+        events = [_sig("rejected", "schema_invalid", a) for a in ("SOL", "BTC", "ETH")]
+        r = portfolio.idle_verdict(_strat("ibis"), events, True)
+        self.assertEqual(r["verdict"], "blocked")
+        self.assertEqual(r["signals"]["rejected"], 3)
+        self.assertEqual(r["reason_codes"]["schema_invalid"], 3)
+        self.assertIn("schema_invalid", r["verdict_detail"])
+        self.assertEqual(len(r["sample_rejections"]), 3)
+
+    def test_waiting_is_not_broken(self):
+        """Selective-by-design must NEVER read as broken — the safety-critical branch."""
+        r = portfolio.idle_verdict(_strat("tides"), [_ev("scan.tick"), _ev("scan.tick")], True)
+        self.assertEqual(r["verdict"], "waiting")
+        self.assertIn("selective", r["verdict_detail"])
+        self.assertIn("not broken", r["verdict_detail"])
+
+    def test_blocked_reports_the_dominant_reason(self):
+        events = [_sig("blocked", "no_slots"), _sig("blocked", "no_slots"),
+                  _sig("blocked", "risk_gate_leverage")]
+        r = portfolio.idle_verdict(_strat(), events, True)
+        self.assertEqual(r["verdict"], "blocked")
+        self.assertIn("no_slots", r["verdict_detail"])       # the MOST common, not just the first
+        self.assertEqual(r["reason_codes"], {"no_slots": 2, "risk_gate_leverage": 1})
+
+    def test_traded_contradicts_the_premise(self):
+        r = portfolio.idle_verdict(_strat(), [_ev("position.opened"), _sig("accepted", "submitted")], True)
+        self.assertEqual(r["verdict"], "traded")
+        self.assertEqual(r["positions_opened"], 1)
+
+    def test_accepted_but_nothing_opened(self):
+        r = portfolio.idle_verdict(_strat(), [_sig("accepted", "submitted"), _ev("order.failed")], True)
+        self.assertEqual(r["verdict"], "accepted_no_open")
+        self.assertEqual(r["orders_failed"], 1)
+
+    def test_funded_without_a_runtime(self):
+        self.assertEqual(portfolio.idle_verdict(_strat(runtime_id=None), [], True)["verdict"], "no_runtime")
+
+    def test_no_events_is_silent_not_broken(self):
+        r = portfolio.idle_verdict(_strat(), [], True)
+        self.assertEqual(r["verdict"], "silent")
+        self.assertIn("cannot confirm", r["verdict_detail"])
+
+    def test_unreadable_telemetry_fails_open(self):
+        """An unreadable event log is NOT evidence of a fault — never diagnose from absence."""
+        r = portfolio.idle_verdict(_strat(), [], False)
+        self.assertEqual(r["verdict"], "unknown")
+        self.assertIn("NOT evidence", r["verdict_detail"])
+
+    def test_closed_strategy_is_history(self):
+        self.assertEqual(portfolio.idle_verdict(_strat(status="CLOSED"), [], True)["verdict"], "not_current")
+
+    def test_verdict_carries_the_mandate(self):
+        """The reason this belongs in portfolio: the mandate defines what 'doing its job' means, so a
+        `waiting` verdict can be narrated against the strategy's own design."""
+        r = portfolio.idle_verdict(_strat(mandate="selective regime-switcher, ~3 trades/week"),
+                                   [_ev("scan.tick")], True)
+        self.assertEqual(r["verdict"], "waiting")
+        self.assertIn("regime-switcher", r["mandate"])
+
+    def test_last_event_ts_is_the_newest(self):
+        events = [_ev("scan.tick", ts=100), _ev("scan.tick", ts=900), _ev("scan.tick", ts=500)]
+        self.assertEqual(portfolio.idle_verdict(_strat(), events, True)["last_event_ts"], 900)
+
+
+class FanOut(unittest.TestCase):
+    def test_reads_preserve_order_and_skip_closed(self):
+        strats = [_strat("a"), _strat("b", status="CLOSED", runtime_id=None), _strat("c")]
+        meta = {"warnings": []}
+        os.environ["SENPI_EVENTS_FIXTURE"] = os.path.join(HERE, "fixtures", "idle_events.json")
+        try:
+            reads = portfolio.idle_reads(strats, meta)
+        finally:
+            os.environ.pop("SENPI_EVENTS_FIXTURE", None)
+        self.assertEqual([r["label"] for r in reads], ["a", "b", "c"])
+        self.assertEqual(reads[1]["verdict"], "not_current")   # closed never probed
+
+    def test_empty_strategy_list_is_safe(self):
+        self.assertEqual(portfolio.idle_reads([], {"warnings": []}), [])
+
+
+class StepRegistration(unittest.TestCase):
+    def test_idle_is_a_registered_step(self):
+        self.assertIn("idle", portfolio._STEPS)
+        self.assertIn("idle", portfolio._STEP_FNS)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**P0-2** from the [User Negative Prompts action plan](https://app.notion.com/p/3a61feaac8068016911ac6c74211987d). The #1 support complaint by volume — M192299 asked **five times over three days**; M192397, M298631, M3601, M347101 and M193436 (Turkish) all asked a version of it.

> **Reworked:** this originally landed in `senpi-improve-trades`. That was the wrong skill — see below.

## Why portfolio, not improve-trades

This is a **live-state** question — *is this strategy doing its job right now* — and the skills' own boundary says so: improve-trades states *"Portfolio answers 'how are my strategies doing right now'… use senpi-portfolio for live state."*

More importantly, **portfolio owns the mandate**, and the mandate is what makes the answer good. Its existing rule — *"a strategy is doing its job when its behavior matches its design, even if that design means idle right now"* — **is** the selective-vs-broken distinction. So `waiting` gets narrated against the strategy's own design rather than a generic activity benchmark. improve-trades could only ever give half that answer.

improve-trades now **hands the question over** instead of dead-ending on guardrail 9's *"say 'nothing to review yet', and stop"* — which was the exact non-answer users kept getting.

## Liveness alone cannot answer it

`senpi status` reports the **runtime**, and a runtime can be perfectly healthy while every candidate its scanner produces is rejected downstream. That is exactly how **ibis** shipped 100% dead this morning while every surface said healthy.

The verdict needs the **event ring**, where `signal.outcome` carries the runtime's own ruling on each candidate. Ported `_fetch_events` into `portfolio.py` using its existing fail-open + fixture conventions (mirrors `_fetch_runtime_status`, including the `_telemetry_dead` short-circuit). Engine duplication is the house pattern — both skills already ship their own `_yaml.py` and `mcp_client.py`.

## The step

```sh
python3 scripts/portfolio.py idle
```

| Verdict | Meaning |
|---|---|
| `traded` | opened positions recently — the premise is wrong |
| `blocked` | candidates produced, runtime rejected them **all** → `reason_code` is the answer |
| `accepted_no_open` | accepted but nothing opened (execution/order failure) |
| `waiting` | scanning normally, nothing cleared the bar — **selective, not broken** |
| `silent` | no events at all — *cannot confirm* it's scanning |
| `no_runtime` | funded with no runtime bound — it cannot scan |
| `unknown` | event log unreadable (fail-open; **not** evidence of a fault) |

Each verdict carries the strategy's `mandate`.

## Safety-critical: `waiting` must never read as broken

A selective strategy in a quiet market is working perfectly. Calling that "broken" is how users tear down healthy books — the LION incidents. It has its own test, and the narration rules lead with the mandate plus an **option**, never a fix.

## Verification
- **14 tests** — pure, no MCP and no subprocess, plus an events fixture. All 7 verdicts, the dominant-reason tally, fail-open, fan-out ordering, and that a closed strategy is never probed.
- **43 suites green**
- portfolio **1.9.0 → 1.10.0**; improve-trades **1.6.0 → 1.7.0** (handoff only)

## Not included
The always-on visual timeline is **P0-3** (Trust Roadmap #1, Vysakh) and needs the user-scoped collector read. This is the answer-on-demand half, which ships **without** that enabler.

Independent of #497 — the two can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)