### PR TITLE
strategies: XYZ perps trade 24/7 — drop the "23/5" label on bobcat + hornet

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-07-23",
+  "_updated": "2026-06-17",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -957,8 +957,8 @@
       "name": "Hornet — Semiconductor Supply-Chain Momentum",
       "emoji": "🐝",
       "tagline": "A semiconductor / AI-capex supply-chain momentum basket on Hyperliquid XYZ (equipment ASML/AMAT/MRVL, logic NVDA/AMD/AVGO/TSM/QCOM/ARM/INTC/SMH, memory MU/SNDK/SMSN/SKHX/WDC): it only trades when the whole chain confirms as a complex — a sector-breadth gate flips it long-only when most names trend up and short-only when the chain rolls over — then rides the strongest 1-2 names, with an extra edge when the equipment makers lead the move. Flat 18% margin / 4x, wide DSL ratchet capped at 48h so it never camps through the weekend pricing gap.",
-      "belief_plain": "Trades the semiconductor supply chain — the chip designers, the memory makers, and the equipment companies that build the factories — as perps on Hyperliquid XYZ, 23/5. AI spending bids the whole chain together, so Hornet refuses to trade single names in isolation: it first checks whether the sector as a whole is trending up or down, and only then takes the strongest 1-2 names in that direction. It pays special attention when the equipment makers move first, since that tends to lead the cycle. It trails a wide stop so a real move can run, but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
-      "version": "1.0.1",
+      "belief_plain": "Trades the semiconductor supply chain — the chip designers, the memory makers, and the equipment companies that build the factories — as perps on Hyperliquid XYZ, 24/7. AI spending bids the whole chain together, so Hornet refuses to trade single names in isolation: it first checks whether the sector as a whole is trending up or down, and only then takes the strongest 1-2 names in that direction. It pays special attention when the equipment makers move first, since that tends to lead the cycle. It trails a wide stop so a real move can run, but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
+      "version": "1.0.2",
       "thesis": "AI capex doesn't bid one chip name — it bids the entire semiconductor supply chain: equipment makers (ASML, AMAT, MRVL), logic/compute (NVDA, AMD, AVGO, TSM, QCOM, ARM, INTC, SMH), and memory (MU, SNDK, SMSN, SKHX, WDC). A per-name momentum agent can get chopped up taking a single semi that's moving on idiosyncratic news against a flat sector. Hornet's edge is that it requires the chain to confirm as a complex first — a sector-breadth gate (the fraction of the universe whose 4h trend is bullish) flips the agent long-only above 0.55 and short-only below 0.35, and emits nothing in the chop band between. Within an open gate it rides the strongest 1-2 names and adds conviction when the equipment sub-group leads (capex tools bid first, then logic and memory — the classic early-cycle gradient). The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap where drift accumulates without external price discovery.",
       "tags": [
         "semiconductors",
@@ -975,7 +975,7 @@
         "basket",
         "long-short",
         "advanced",
-        "23-5"
+        "24-7"
       ],
       "group": "momentum",
       "archetype": "breakout_momentum",
@@ -3448,9 +3448,9 @@
       "name": "Bobcat — Big Tech Trend Follower",
       "emoji": "🐈",
       "tagline": "A big-tech equity-perp trend follower on Hyperliquid XYZ (NVDA/TSLA/AAPL/META/MSFT/GOOGL/AMZN/AMD/MU/INTC/TSM/ORCL): enters the single strongest name when its 4h trend is non-neutral AND smart-money leans the same way (tilt >= 55%), sizes a flat 20% margin at 5x, and lets a wide DSL ratchet ride the move — with a 48h cap so positions don't camp through the weekend pricing gap.",
-      "belief_plain": "Trades the big tech stocks you already know — NVDA, TSLA, AAPL and nine more — as perps on Hyperliquid XYZ, 23/5. It only enters when a stock's 4-hour trend and the best traders are pointing the same way, holds the single strongest setup, and trails a stop so a real move can run — but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
-      "version": "1.0.1",
-      "thesis": "Big tech is the most-traded equity sector, and Hyperliquid XYZ surfaces these names as leveraged perps with 23/5 hours. A clean trend + smart-money confluence on the highest-liquidity XYZ equities catches directional moves without the small-cap noise of a broad scanner. The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap, where drift accumulates without external price discovery — so winners are let to run on the 4h timescale but never held through the full Fri-Sun window.",
+      "belief_plain": "Trades the big tech stocks you already know — NVDA, TSLA, AAPL and nine more — as perps on Hyperliquid XYZ, 24/7. It only enters when a stock's 4-hour trend and the best traders are pointing the same way, holds the single strongest setup, and trails a stop so a real move can run — but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
+      "version": "1.0.2",
+      "thesis": "Big tech is the most-traded equity sector, and Hyperliquid XYZ surfaces these names as leveraged perps that trade 24/7 — including the weekend, when the underlying market is shut and pricing runs on an internal oracle. A clean trend + smart-money confluence on the highest-liquidity XYZ equities catches directional moves without the small-cap noise of a broad scanner. The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap, where drift accumulates without external price discovery — so winners are let to run on the 4h timescale but never held through the full Fri-Sun window.",
       "tags": [
         "big-tech",
         "equities",
@@ -3462,7 +3462,7 @@
         "smart-money",
         "basket",
         "onboarding",
-        "23-5"
+        "24-7"
       ],
       "group": "single-asset",
       "archetype": "single_market",

--- a/strategies/bobcat/main/scanners/scan.py
+++ b/strategies/bobcat/main/scanners/scan.py
@@ -16,7 +16,9 @@ daemon, no push_signal, no create_position.
 
 XYZ notes (preserved from v2 — do NOT redesign):
   - every asset is xyz:NAME, dex = "xyz" — the prefix is mandatory for the HIP-3 DEX.
-  - 23/5 trading; the 48h hard_timeout (in runtime.yaml) caps holds across the
+  - 24/7 trading — the PERP never closes; it is the UNDERLYING US market that is
+#    shut Fri 17:00 ET -> Sun 18:00 ET, when XYZ prices off a 30-min EWMA internal
+#    oracle and reconciles at Monday's open. The 48h hard_timeout (in runtime.yaml) caps holds across the
     weekend pricing gap. There is NO scan-level market-hours gate (none in v2).
 
 FIDELITY NOTES vs the v2 producer (bobcat-producer.py v1.0.1):

--- a/strategies/bobcat/strategy.yaml
+++ b/strategies/bobcat/strategy.yaml
@@ -10,13 +10,13 @@
 schema_version: 1
 
 id: bobcat
-version: "1.0.1"
+version: "1.0.2"
 catalog:
   name: "Bobcat — Big Tech Trend Follower"
   emoji: "🐈"
   tagline: "A big-tech equity-perp trend follower on Hyperliquid XYZ (NVDA/TSLA/AAPL/META/MSFT/GOOGL/AMZN/AMD/MU/INTC/TSM/ORCL): enters the single strongest name when its 4h trend is non-neutral AND smart-money leans the same way (tilt >= 55%), sizes a flat 20% margin at 5x, and lets a wide DSL ratchet ride the move — with a 48h cap so positions don't camp through the weekend pricing gap."
-  belief_plain: "Trades the big tech stocks you already know — NVDA, TSLA, AAPL and nine more — as perps on Hyperliquid XYZ, 23/5. It only enters when a stock's 4-hour trend and the best traders are pointing the same way, holds the single strongest setup, and trails a stop so a real move can run — but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price."
-  thesis: "Big tech is the most-traded equity sector, and Hyperliquid XYZ surfaces these names as leveraged perps with 23/5 hours. A clean trend + smart-money confluence on the highest-liquidity XYZ equities catches directional moves without the small-cap noise of a broad scanner. The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap, where drift accumulates without external price discovery — so winners are let to run on the 4h timescale but never held through the full Fri-Sun window."
+  belief_plain: "Trades the big tech stocks you already know — NVDA, TSLA, AAPL and nine more — as perps on Hyperliquid XYZ, 24/7. It only enters when a stock's 4-hour trend and the best traders are pointing the same way, holds the single strongest setup, and trails a stop so a real move can run — but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price."
+  thesis: "Big tech is the most-traded equity sector, and Hyperliquid XYZ surfaces these names as leveraged perps that trade 24/7 — including the weekend, when the underlying market is shut and pricing runs on an internal oracle. A clean trend + smart-money confluence on the highest-liquidity XYZ equities catches directional moves without the small-cap noise of a broad scanner. The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap, where drift accumulates without external price discovery — so winners are let to run on the 4h timescale but never held through the full Fri-Sun window."
   group: single-asset
   archetype: single_market
   sub_style: big_tech
@@ -29,7 +29,7 @@ catalog:
   max_slots: 3
   min_budget: 200
   assets: ["xyz:NVDA", "xyz:TSLA", "xyz:AAPL", "xyz:META", "xyz:MSFT", "xyz:GOOGL", "xyz:AMZN", "xyz:AMD", "xyz:MU", "xyz:INTC", "xyz:TSM", "xyz:ORCL"]
-  tags: [big-tech, equities, xyz, nvda, tsla, aapl, trend-following, smart-money, basket, onboarding, 23-5]
+  tags: [big-tech, equities, xyz, nvda, tsla, aapl, trend-following, smart-money, basket, onboarding, 24-7]
 
 requires:
   runtime: ">=3.0.0"

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-07-23",
+  "_updated": "2026-06-17",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -957,8 +957,8 @@
       "name": "Hornet — Semiconductor Supply-Chain Momentum",
       "emoji": "🐝",
       "tagline": "A semiconductor / AI-capex supply-chain momentum basket on Hyperliquid XYZ (equipment ASML/AMAT/MRVL, logic NVDA/AMD/AVGO/TSM/QCOM/ARM/INTC/SMH, memory MU/SNDK/SMSN/SKHX/WDC): it only trades when the whole chain confirms as a complex — a sector-breadth gate flips it long-only when most names trend up and short-only when the chain rolls over — then rides the strongest 1-2 names, with an extra edge when the equipment makers lead the move. Flat 18% margin / 4x, wide DSL ratchet capped at 48h so it never camps through the weekend pricing gap.",
-      "belief_plain": "Trades the semiconductor supply chain — the chip designers, the memory makers, and the equipment companies that build the factories — as perps on Hyperliquid XYZ, 23/5. AI spending bids the whole chain together, so Hornet refuses to trade single names in isolation: it first checks whether the sector as a whole is trending up or down, and only then takes the strongest 1-2 names in that direction. It pays special attention when the equipment makers move first, since that tends to lead the cycle. It trails a wide stop so a real move can run, but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
-      "version": "1.0.1",
+      "belief_plain": "Trades the semiconductor supply chain — the chip designers, the memory makers, and the equipment companies that build the factories — as perps on Hyperliquid XYZ, 24/7. AI spending bids the whole chain together, so Hornet refuses to trade single names in isolation: it first checks whether the sector as a whole is trending up or down, and only then takes the strongest 1-2 names in that direction. It pays special attention when the equipment makers move first, since that tends to lead the cycle. It trails a wide stop so a real move can run, but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
+      "version": "1.0.2",
       "thesis": "AI capex doesn't bid one chip name — it bids the entire semiconductor supply chain: equipment makers (ASML, AMAT, MRVL), logic/compute (NVDA, AMD, AVGO, TSM, QCOM, ARM, INTC, SMH), and memory (MU, SNDK, SMSN, SKHX, WDC). A per-name momentum agent can get chopped up taking a single semi that's moving on idiosyncratic news against a flat sector. Hornet's edge is that it requires the chain to confirm as a complex first — a sector-breadth gate (the fraction of the universe whose 4h trend is bullish) flips the agent long-only above 0.55 and short-only below 0.35, and emits nothing in the chop band between. Within an open gate it rides the strongest 1-2 names and adds conviction when the equipment sub-group leads (capex tools bid first, then logic and memory — the classic early-cycle gradient). The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap where drift accumulates without external price discovery.",
       "tags": [
         "semiconductors",
@@ -975,7 +975,7 @@
         "basket",
         "long-short",
         "advanced",
-        "23-5"
+        "24-7"
       ],
       "group": "momentum",
       "archetype": "breakout_momentum",
@@ -3448,9 +3448,9 @@
       "name": "Bobcat — Big Tech Trend Follower",
       "emoji": "🐈",
       "tagline": "A big-tech equity-perp trend follower on Hyperliquid XYZ (NVDA/TSLA/AAPL/META/MSFT/GOOGL/AMZN/AMD/MU/INTC/TSM/ORCL): enters the single strongest name when its 4h trend is non-neutral AND smart-money leans the same way (tilt >= 55%), sizes a flat 20% margin at 5x, and lets a wide DSL ratchet ride the move — with a 48h cap so positions don't camp through the weekend pricing gap.",
-      "belief_plain": "Trades the big tech stocks you already know — NVDA, TSLA, AAPL and nine more — as perps on Hyperliquid XYZ, 23/5. It only enters when a stock's 4-hour trend and the best traders are pointing the same way, holds the single strongest setup, and trails a stop so a real move can run — but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
-      "version": "1.0.1",
-      "thesis": "Big tech is the most-traded equity sector, and Hyperliquid XYZ surfaces these names as leveraged perps with 23/5 hours. A clean trend + smart-money confluence on the highest-liquidity XYZ equities catches directional moves without the small-cap noise of a broad scanner. The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap, where drift accumulates without external price discovery — so winners are let to run on the 4h timescale but never held through the full Fri-Sun window.",
+      "belief_plain": "Trades the big tech stocks you already know — NVDA, TSLA, AAPL and nine more — as perps on Hyperliquid XYZ, 24/7. It only enters when a stock's 4-hour trend and the best traders are pointing the same way, holds the single strongest setup, and trails a stop so a real move can run — but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price.",
+      "version": "1.0.2",
+      "thesis": "Big tech is the most-traded equity sector, and Hyperliquid XYZ surfaces these names as leveraged perps that trade 24/7 — including the weekend, when the underlying market is shut and pricing runs on an internal oracle. A clean trend + smart-money confluence on the highest-liquidity XYZ equities catches directional moves without the small-cap noise of a broad scanner. The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap, where drift accumulates without external price discovery — so winners are let to run on the 4h timescale but never held through the full Fri-Sun window.",
       "tags": [
         "big-tech",
         "equities",
@@ -3462,7 +3462,7 @@
         "smart-money",
         "basket",
         "onboarding",
-        "23-5"
+        "24-7"
       ],
       "group": "single-asset",
       "archetype": "single_market",

--- a/strategies/hornet/main/scanners/scan.py
+++ b/strategies/hornet/main/scanners/scan.py
@@ -30,7 +30,9 @@ daemon, no push_signal, no create_position.
 XYZ notes (xyz-equity DEX handling, matching bobcat):
   - every asset is xyz:NAME and EVERY market read passes dex="xyz" (the prefix is
     mandatory for the HIP-3 DEX),
-  - 23/5 trading; the 48h hard_timeout (runtime.yaml) caps holds across the weekend
+  - 24/7 trading — the PERP never closes; it is the UNDERLYING US market that is
+#    shut Fri 17:00 ET -> Sun 18:00 ET, when XYZ prices off a 30-min EWMA internal
+#    oracle and reconciles at Monday's open. The 48h hard_timeout (runtime.yaml) caps holds across the weekend
     pricing gap. No scan-level market-hours gate.
 """
 

--- a/strategies/hornet/strategy.yaml
+++ b/strategies/hornet/strategy.yaml
@@ -10,12 +10,12 @@
 schema_version: 1
 
 id: hornet
-version: "1.0.1"
+version: "1.0.2"
 catalog:
   name: "Hornet — Semiconductor Supply-Chain Momentum"
   emoji: "🐝"
   tagline: "A semiconductor / AI-capex supply-chain momentum basket on Hyperliquid XYZ (equipment ASML/AMAT/MRVL, logic NVDA/AMD/AVGO/TSM/QCOM/ARM/INTC/SMH, memory MU/SNDK/SMSN/SKHX/WDC): it only trades when the whole chain confirms as a complex — a sector-breadth gate flips it long-only when most names trend up and short-only when the chain rolls over — then rides the strongest 1-2 names, with an extra edge when the equipment makers lead the move. Flat 18% margin / 4x, wide DSL ratchet capped at 48h so it never camps through the weekend pricing gap."
-  belief_plain: "Trades the semiconductor supply chain — the chip designers, the memory makers, and the equipment companies that build the factories — as perps on Hyperliquid XYZ, 23/5. AI spending bids the whole chain together, so Hornet refuses to trade single names in isolation: it first checks whether the sector as a whole is trending up or down, and only then takes the strongest 1-2 names in that direction. It pays special attention when the equipment makers move first, since that tends to lead the cycle. It trails a wide stop so a real move can run, but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price."
+  belief_plain: "Trades the semiconductor supply chain — the chip designers, the memory makers, and the equipment companies that build the factories — as perps on Hyperliquid XYZ, 24/7. AI spending bids the whole chain together, so Hornet refuses to trade single names in isolation: it first checks whether the sector as a whole is trending up or down, and only then takes the strongest 1-2 names in that direction. It pays special attention when the equipment makers move first, since that tends to lead the cycle. It trails a wide stop so a real move can run, but caps each hold at 48 hours so it never sits through the Friday-to-Sunday gap when these names have no external price."
   thesis: "AI capex doesn't bid one chip name — it bids the entire semiconductor supply chain: equipment makers (ASML, AMAT, MRVL), logic/compute (NVDA, AMD, AVGO, TSM, QCOM, ARM, INTC, SMH), and memory (MU, SNDK, SMSN, SKHX, WDC). A per-name momentum agent can get chopped up taking a single semi that's moving on idiosyncratic news against a flat sector. Hornet's edge is that it requires the chain to confirm as a complex first — a sector-breadth gate (the fraction of the universe whose 4h trend is bullish) flips the agent long-only above 0.55 and short-only below 0.35, and emits nothing in the chop band between. Within an open gate it rides the strongest 1-2 names and adds conviction when the equipment sub-group leads (capex tools bid first, then logic and memory — the classic early-cycle gradient). The 48h hard_timeout is intentional: equity perps reconcile against an internal oracle over the weekend gap where drift accumulates without external price discovery."
   group: momentum
   archetype: breakout_momentum
@@ -30,7 +30,7 @@ catalog:
   max_slots: 3
   min_budget: 200
   assets: ["xyz:ASML", "xyz:AMAT", "xyz:MRVL", "xyz:NVDA", "xyz:AMD", "xyz:AVGO", "xyz:TSM", "xyz:QCOM", "xyz:ARM", "xyz:INTC", "xyz:SMH", "xyz:MU", "xyz:SNDK", "xyz:SMSN", "xyz:SKHX", "xyz:WDC"]
-  tags: [semiconductors, ai-capex, supply-chain, sector-breadth, equities, xyz, nvda, asml, tsm, momentum, smart-money, basket, long-short, advanced, 23-5]
+  tags: [semiconductors, ai-capex, supply-chain, sector-breadth, equities, xyz, nvda, asml, tsm, momentum, smart-money, basket, long-short, advanced, 24-7]
 
 requires:
   runtime: ">=3.0.0"


### PR DESCRIPTION
`bobcat` and `hornet` both told users their instruments trade **"23/5"**. They don't — XYZ equity perps trade **7 days a week** on Hyperliquid.

`xyz:NVDA` prints real daily candles with real volume on Saturday and Sunday:

| Date | | Close | Volume |
|---|---|---|---|
| 2026-07-17 | Fri | 202.54 | 328,888 |
| 2026-07-18 | **Sat** | 202.20 | **21,345** |
| 2026-07-19 | **Sun** | 204.16 | **35,902** |
| 2026-07-20 | Mon | 202.93 | 149,154 |

23/5 describes the **underlying US market**, not the perp. The label had leaked into `belief_plain`, `thesis`, and the `23-5` tag — copy users read directly in strategy-discover — where it reads as *"this strategy sits idle on weekends"* when the scanner is live the whole time.

### What is deliberately NOT changed

The **48h `hard_timeout` and its weekend rationale are correct** and stay.

Fri 17:00 ET → Sun 18:00 ET the underlying market is shut, `trade.xyz` has no external price feed for equities, and it prices off a **30-min EWMA internal oracle** that drifts on impact-price activity before reconciling at Monday's open. This is documented in [`raccoon`](../blob/main/strategies/raccoon/strategy.yaml) — a strategy built specifically to trade that snap-back. The thin weekend volume above is what that drift looks like in practice.

So the cap is right; only the "market is closed" framing was wrong. The `scan.py` comment now names the actual mechanism instead of implying a closed market.

### Changes

- `bobcat` / `hornet` `strategy.yaml` — `belief_plain`, `thesis`, `23-5` tag → `24-7`
- `bobcat` / `hornet` `scanners/scan.py` — header comment states the oracle window
- `catalog.json` regenerated in both locations — 96 strategies, byte-identical
- bobcat `1.0.1 → 1.0.2`, hornet `1.0.1 → 1.0.2`

`deploy.py validate` green on both; 46 test suites pass.

### How it surfaced

Fact-checking weekly-performance copy. `bobcat` claimed 23/5 while `kestrel` and `cougar` claimed 24/7-including-weekends — for **overlapping names** (AAPL, NVDA, TSLA, GOOGL, AMZN, META, MSFT). Both could not be true. Worth a look at whether any other package makes hours claims that were never checked against live candles.