### PR TITLE
Document the numeric market-data boundary; keep the defensive cast in templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,16 @@ Hard-won invariants (each failed silently in production once):
 
 ---
 
+## ▶ Editing skill text? Rules + snippets, not narration
+
+Skill hot paths (SKILL.md, build guides like `creating-a-strategy.md`) carry **rules and runnable
+snippets**; rationale lives in reference files and PR/commit history. Keep only the one
+justification clause that stops a future editor from "correcting" the rule (e.g. "`float` of a
+number is a no-op" is what keeps `_f()` from being stripped as redundant). A paragraph explaining
+*why* at length: move the why out, leave the rule.
+
+---
+
 ## Skill Attribution
 
 Strategies are attributed via the MCP wallet-creation call's **`skillName`/`skillVersion`**,

--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.9.0"
+  version: "2.9.1"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-author/references/creating-a-strategy.md
+++ b/senpi-strategy-author/references/creating-a-strategy.md
@@ -82,13 +82,12 @@ grep `strategies/catalog.json` by its `archetype` field (a closed set; every pac
 ### `scoring.py` — pure math (the edge)
 No I/O, no MCP, no clock, no state — just functions over candles/numbers, so it unit-tests without mocks.
 
-> **Candle schema (`market_get_asset_data`):** each candle is keyed `t,o,h,l,c,v` (+ `T,s,i,n`) — short OHLCV. Close is `c` — read `candle["c"]`, not `candle["close"]` (no such key). Hyperliquid serves `o/h/l/c/v` as **strings**. Runtimes newer than 3.0.32 numeric-cast candles and `market_get_prices` values at the `ctx.senpi_mcp` boundary (originals kept under a single `_raw` key on the response container, at the same level as `candles`/`prices` — see `senpi-trading-runtime/references/scan-contract.md` → "Market data types"); older runtimes hand you the raw strings, and **every other tool's fields keep their API types either way** (balances, budgets, leaderboard rows — often strings). So always read numerics through the fleet-standard helper below — `float` of a number is a no-op, so it is correct on every runtime version and every data path:
+> **Candle schema (`market_get_asset_data`):** keys `t,o,h,l,c,v` (+ `T,s,i,n`). Close is `candle["c"]` — there is no `candle["close"]`. Values may arrive as **strings** — always read numerics through `_f()` below (`float` of a number is a no-op, so it's correct on every runtime version and every tool). Type contract: `senpi-trading-runtime/references/scan-contract.md` → "Market data types".
 
 ```python
 def _f(v, d=0.0):
-    """Defensive numeric read (fleet standard): no-op on numbers, casts strings,
-    falls back to d on None/garbage. Shape tolerance — not a data-quality gate:
-    a fallback 0.0 in ratio math reads as a real price, so gate on presence first."""
+    """Defensive numeric read: no-op on numbers, casts strings, d on None/garbage.
+    Gate on presence first — a fallback 0.0 reads as a real price."""
     try:
         return float(v)
     except (TypeError, ValueError):

--- a/senpi-strategy-author/references/creating-a-strategy.md
+++ b/senpi-strategy-author/references/creating-a-strategy.md
@@ -82,19 +82,22 @@ grep `strategies/catalog.json` by its `archetype` field (a closed set; every pac
 ### `scoring.py` — pure math (the edge)
 No I/O, no MCP, no clock, no state — just functions over candles/numbers, so it unit-tests without mocks.
 
-> **Candle schema (`market_get_asset_data`):** each candle is keyed `t,o,h,l,c,v` (+ `T,s,i,n`) — short OHLCV. Close is `c` — read `candle["c"]`, not `candle["close"]` (no such key). The runtime **numeric-casts** candle `o/h/l/c/v` and `market_get_prices` values at the `ctx.senpi_mcp` boundary (see `senpi-trading-runtime/references/scan-contract.md` → "Market data arrives numeric"), so arithmetic on them is safe as-is; originals live under a sibling `_raw` key. ⚠️ **Only those two market tools are cast** — every other tool's fields (balances, budgets, leaderboard rows) keep their API types, often strings, and Hyperliquid serves the raw strings on older runtimes. Keep the fleet-standard defensive read below — `float()` of a number is a no-op, so it costs nothing and works everywhere:
+> **Candle schema (`market_get_asset_data`):** each candle is keyed `t,o,h,l,c,v` (+ `T,s,i,n`) — short OHLCV. Close is `c` — read `candle["c"]`, not `candle["close"]` (no such key). Hyperliquid serves `o/h/l/c/v` as **strings**. Runtimes newer than 3.0.32 numeric-cast candles and `market_get_prices` values at the `ctx.senpi_mcp` boundary (originals kept under a single `_raw` key on the response container, at the same level as `candles`/`prices` — see `senpi-trading-runtime/references/scan-contract.md` → "Market data types"); older runtimes hand you the raw strings, and **every other tool's fields keep their API types either way** (balances, budgets, leaderboard rows — often strings). So always read numerics through the fleet-standard helper below — `float` of a number is a no-op, so it is correct on every runtime version and every data path:
 
 ```python
-def _f(x):
-    """Defensive numeric read — no-op on numbers, saves you on any string/None path."""
+def _f(v, d=0.0):
+    """Defensive numeric read (fleet standard): no-op on numbers, casts strings,
+    falls back to d on None/garbage. Shape tolerance — not a data-quality gate:
+    a fallback 0.0 in ratio math reads as a real price, so gate on presence first."""
     try:
-        return float(x or 0)
+        return float(v)
     except (TypeError, ValueError):
-        return 0.0
+        return d
 
 def score(asset, candles, extra, inputs):    # candles/numbers in, thesis dict out
-    close = _f(candles[-1]["c"]) if candles else 0.0
-    if not _qualifies(...): return None
+    if not candles: return None
+    close = _f(candles[-1]["c"])
+    if not _qualifies(close, ...): return None
     return {"score": s, "direction": "LONG"|"SHORT", "reasons": [...]}
 ```
 

--- a/senpi-strategy-author/references/creating-a-strategy.md
+++ b/senpi-strategy-author/references/creating-a-strategy.md
@@ -82,10 +82,18 @@ grep `strategies/catalog.json` by its `archetype` field (a closed set; every pac
 ### `scoring.py` — pure math (the edge)
 No I/O, no MCP, no clock, no state — just functions over candles/numbers, so it unit-tests without mocks.
 
-> **Candle schema (`market_get_asset_data`):** each candle is keyed `t,o,h,l,c,v` (+ `T,s,i,n`) — short OHLCV, **string** values. Close is `c`; read fields as `float(candle["c"])`, not `candle["close"]` (no such key).
+> **Candle schema (`market_get_asset_data`):** each candle is keyed `t,o,h,l,c,v` (+ `T,s,i,n`) — short OHLCV. Close is `c` — read `candle["c"]`, not `candle["close"]` (no such key). The runtime **numeric-casts** candle `o/h/l/c/v` and `market_get_prices` values at the `ctx.senpi_mcp` boundary (see `senpi-trading-runtime/references/scan-contract.md` → "Market data arrives numeric"), so arithmetic on them is safe as-is; originals live under a sibling `_raw` key. ⚠️ **Only those two market tools are cast** — every other tool's fields (balances, budgets, leaderboard rows) keep their API types, often strings, and Hyperliquid serves the raw strings on older runtimes. Keep the fleet-standard defensive read below — `float()` of a number is a no-op, so it costs nothing and works everywhere:
 
 ```python
+def _f(x):
+    """Defensive numeric read — no-op on numbers, saves you on any string/None path."""
+    try:
+        return float(x or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
 def score(asset, candles, extra, inputs):    # candles/numbers in, thesis dict out
+    close = _f(candles[-1]["c"]) if candles else 0.0
     if not _qualifies(...): return None
     return {"score": s, "direction": "LONG"|"SHORT", "reasons": [...]}
 ```

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.0.2"
+  version: "3.0.3"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-trading-runtime/references/scan-contract.md
+++ b/senpi-trading-runtime/references/scan-contract.md
@@ -77,7 +77,7 @@ min_score = int(inputs.get("minScore", 4))
 
 | Member | What it is |
 |---|---|
-| `ctx.senpi_mcp.call_tool(name, args)` | Senpi MCP client, **read-only** (see boundary below). The only way to fetch data. Market-tool candle/price fields arrive **numeric** (see the market-data section below); all other tools' values keep their API types (often strings). |
+| `ctx.senpi_mcp.call_tool(name, args)` | Senpi MCP client, **read-only** (see boundary below). The only way to fetch data. Value types: see the market-data-types section below — cast defensively; runtimes newer than 3.0.32 numeric-cast market-tool candles/prices for you. |
 | `ctx.state` | Transactional history store (or `None` when history is disabled). API below. |
 | `ctx.wallet` | The runtime's wallet address (pass to `strategy_get_clearinghouse_state`, etc.) |
 | `ctx.scanner_name` | This scanner's name (from the recipe) |
@@ -133,30 +133,38 @@ knob. As an author: **assume you cannot mutate anything.** Produce signals; the 
 
 ---
 
-## Market data arrives numeric (everything else is strings)
+## Market data types — cast defensively; newer runtimes cast for you
 
 Hyperliquid's API returns candle `o/h/l/c/v` and price-map values as **strings**
-(`"HYPE": "58.3275"`). The runtime casts them to numbers at the `ctx.senpi_mcp` boundary before
-your `scan()` sees them, for exactly these two tools:
+(`"HYPE": "58.3275"`), and every other tool's fields keep their API types too — a strategy's
+`budget`, clearinghouse balances, leaderboard rows are often strings. **Always read numerics
+through the fleet-standard `_f()` float helper in `scoring.py`** (see the author guide's scoring
+template): `float` of a number is a no-op, so it is correct on every runtime version and every
+data path.
 
-- **`market_get_asset_data`** — candle `o/h/l/c/v` (+ `t`; `T`/`n` when valid), `asset_context`
+Runtimes **newer than 3.0.32** — those whose CHANGELOG includes *"Scanner market data is now
+numeric at the MCP boundary"* — additionally cast market data to numbers at the `ctx.senpi_mcp`
+boundary before `scan()` sees it (on such a runtime `candles[-1]["c"] / 2` runs clean), for
+exactly these two tools:
+
+- **`market_get_asset_data`** — candle `o/h/l/c/v` (+ `t`; `T`/`n` when valid) are **strict**: a
+  row whose required fields don't cast is **dropped** and logged (`senpi_mcp_cast_dropped`
+  scaffold event), never passed through as a string. The enrichment sections — `asset_context`
   numeric fields (`markPx`, `midPx`, `funding`, `openInterest`, …), `order_book` level `px`/`sz`,
-  `funding_history` `fundingRate`/`premium`.
-- **`market_get_prices`** — every value in the `prices` map.
+  `funding_history` `fundingRate`/`premium` — are **best-effort**: valid values are cast in
+  place, uncastable ones (including `None`) are left exactly as received and not logged. Don't
+  assume `asset_context` values are numeric — read them through `_f()`.
+- **`market_get_prices`** — every value in the `prices` map (**strict**: uncastable entries are
+  dropped and logged).
 
-So `candles[-1]["c"] / 2` is safe as-is. Details:
+Details:
 
-- Originals are preserved under a sibling **`_raw`** key at the same level as the cast sections
-  (exact API strings, if you ever need full precision).
-- A candle row whose `t/o/h/l/c/v` don't cast, or a price entry that doesn't cast, is **dropped**
-  and logged (`senpi_mcp_cast_dropped` scaffold event) — never passed through as a string.
-- **Every other tool's response is untouched.** A strategy's `budget`, clearinghouse balances,
-  leaderboard fields, etc. may still be strings — cast those yourself before arithmetic.
-- This guarantee ships with the runtime's boundary cast (runtime CHANGELOG: *"Scanner market data
-  is now numeric at the MCP boundary"*). On older runtimes these fields are still strings — a
-  defensive `float(...)` is harmless either way (`float` of a number is a no-op), so keeping the
-  fleet-standard cast helper in `scoring.py` costs nothing and makes your package
-  version-independent.
+- Originals are preserved under a single sibling **`_raw`** key at the same level as the cast
+  sections (exact API strings, if you ever need full precision).
+- Because uncastable candle rows are dropped, a returned series can be **shorter and
+  non-contiguous** than requested — guard on `len(candles)` before indicator math and don't
+  assume fixed `t` spacing.
+- **Every other tool's response is untouched** on every runtime version.
 
 ---
 
@@ -190,8 +198,8 @@ default_signal_validity_seconds)`), the wire envelope, delivery, and dedup. **Do
 ## `scoring.py` — keep the logic pure
 
 Every example splits a sibling `scoring.py` with **no I/O, no MCP, no daemon** — just functions over
-candles/numbers. `scan.py` fetches via `ctx.senpi_mcp` (candle/price fields already numeric — see
-the market-data section above) and hands the candle lists to `scoring`. This ports
+candles/numbers. `scan.py` fetches via `ctx.senpi_mcp` (see the market-data-types section above
+for what arrives numeric vs string) and hands the candle lists to `scoring`. This ports
 cleanly from older producers (the pure trend/scoring helpers were already unit-tested) and lets a
 reader follow the thesis without mocking MCP.
 
@@ -215,8 +223,9 @@ Both are valid — it's your thesis:
 - ✅ Pure scoring in `scoring.py`; MCP + state in `scan.py`.
 - ✅ Keep dedup / rotation / first-seen ledgers in `ctx.state` (`last()` → mutate → `append()`).
 - ✅ Declare every `data{}` key in `signal_data_schema`; set `default_signal_validity_seconds`.
-- ✅ Market-tool candles/prices arrive numeric; **any other tool's fields may be strings — cast
-  before arithmetic** (a defensive `float()` on market data is harmless too).
+- ✅ Read every numeric field through the defensive `_f()` helper — required for non-market
+  tools and for market data on runtimes ≤ 3.0.32; a harmless no-op where the boundary cast
+  already applied.
 - ✅ Put `marginPct` (fleet standard) or `marginUsd`, plus `leverage`, at the **top level**, not inside `data{}`.
 - ✅ On any failure, **return `[]`** (or a partial list) — don't crash.
 - ❌ Don't set `valid_until`/`produced_at` — the scaffold owns the envelope (`signal_id` optional).

--- a/senpi-trading-runtime/references/scan-contract.md
+++ b/senpi-trading-runtime/references/scan-contract.md
@@ -77,7 +77,7 @@ min_score = int(inputs.get("minScore", 4))
 
 | Member | What it is |
 |---|---|
-| `ctx.senpi_mcp.call_tool(name, args)` | Senpi MCP client, **read-only** (see boundary below). The only way to fetch data. Value types: see the market-data-types section below — cast defensively; runtimes newer than 3.0.32 numeric-cast market-tool candles/prices for you. |
+| `ctx.senpi_mcp.call_tool(name, args)` | Senpi MCP client, **read-only** (see boundary below). The only way to fetch data. Value types: see "Market data types" below. |
 | `ctx.state` | Transactional history store (or `None` when history is disabled). API below. |
 | `ctx.wallet` | The runtime's wallet address (pass to `strategy_get_clearinghouse_state`, etc.) |
 | `ctx.scanner_name` | This scanner's name (from the recipe) |
@@ -133,38 +133,26 @@ knob. As an author: **assume you cannot mutate anything.** Produce signals; the 
 
 ---
 
-## Market data types — cast defensively; newer runtimes cast for you
+## Market data types
 
-Hyperliquid's API returns candle `o/h/l/c/v` and price-map values as **strings**
-(`"HYPE": "58.3275"`), and every other tool's fields keep their API types too — a strategy's
-`budget`, clearinghouse balances, leaderboard rows are often strings. **Always read numerics
-through the fleet-standard `_f()` float helper in `scoring.py`** (see the author guide's scoring
-template): `float` of a number is a no-op, so it is correct on every runtime version and every
-data path.
+**Read every numeric field through the fleet-standard `_f()` helper** (author guide's scoring
+template) — `float` of a number is a no-op, so it is correct on every runtime version and every
+data path. Hyperliquid serves candle `o/h/l/c/v` and price-map values as strings; most other
+tools' numeric fields (budgets, balances, leaderboard rows) are strings too.
 
-Runtimes **newer than 3.0.32** — those whose CHANGELOG includes *"Scanner market data is now
-numeric at the MCP boundary"* — additionally cast market data to numbers at the `ctx.senpi_mcp`
-boundary before `scan()` sees it (on such a runtime `candles[-1]["c"] / 2` runs clean), for
-exactly these two tools:
+Runtimes **newer than 3.0.32** numeric-cast the two market tools at the `ctx.senpi_mcp` boundary:
 
-- **`market_get_asset_data`** — candle `o/h/l/c/v` (+ `t`; `T`/`n` when valid) are **strict**: a
-  row whose required fields don't cast is **dropped** and logged (`senpi_mcp_cast_dropped`
-  scaffold event), never passed through as a string. The enrichment sections — `asset_context`
-  numeric fields (`markPx`, `midPx`, `funding`, `openInterest`, …), `order_book` level `px`/`sz`,
-  `funding_history` `fundingRate`/`premium` — are **best-effort**: valid values are cast in
-  place, uncastable ones (including `None`) are left exactly as received and not logged. Don't
-  assume `asset_context` values are numeric — read them through `_f()`.
-- **`market_get_prices`** — every value in the `prices` map (**strict**: uncastable entries are
-  dropped and logged).
+| Section | Cast | Uncastable value |
+|---|---|---|
+| `market_get_asset_data` candles — `o/h/l/c/v` + `t` (`T`/`n` when valid) | strict | row **dropped** |
+| `market_get_prices` — every `prices` value (`count` kept in sync) | strict | entry **dropped** |
+| `asset_context`, `order_book` `px`/`sz`, `funding_history` rates | best-effort | left as-is |
 
-Details:
-
-- Originals are preserved under a single sibling **`_raw`** key at the same level as the cast
-  sections (exact API strings, if you ever need full precision).
-- Because uncastable candle rows are dropped, a returned series can be **shorter and
-  non-contiguous** than requested — guard on `len(candles)` before indicator math and don't
+- Drops are never silent: a `senpi_mcp_cast_dropped` scaffold event + a `_cast_dropped` marker on
+  the payload. A series can come back **shorter / non-contiguous** — guard `len(candles)`, don't
   assume fixed `t` spacing.
-- **Every other tool's response is untouched** on every runtime version.
+- Originals: a single `_raw` key beside the cast sections.
+- Every other tool's response is untouched, on every runtime version.
 
 ---
 
@@ -198,8 +186,8 @@ default_signal_validity_seconds)`), the wire envelope, delivery, and dedup. **Do
 ## `scoring.py` — keep the logic pure
 
 Every example splits a sibling `scoring.py` with **no I/O, no MCP, no daemon** — just functions over
-candles/numbers. `scan.py` fetches via `ctx.senpi_mcp` (see the market-data-types section above
-for what arrives numeric vs string) and hands the candle lists to `scoring`. This ports
+candles/numbers. `scan.py` fetches via `ctx.senpi_mcp` (value types: "Market data types" above)
+and hands the candle lists to `scoring`. This ports
 cleanly from older producers (the pure trend/scoring helpers were already unit-tested) and lets a
 reader follow the thesis without mocking MCP.
 
@@ -223,9 +211,7 @@ Both are valid — it's your thesis:
 - ✅ Pure scoring in `scoring.py`; MCP + state in `scan.py`.
 - ✅ Keep dedup / rotation / first-seen ledgers in `ctx.state` (`last()` → mutate → `append()`).
 - ✅ Declare every `data{}` key in `signal_data_schema`; set `default_signal_validity_seconds`.
-- ✅ Read every numeric field through the defensive `_f()` helper — required for non-market
-  tools and for market data on runtimes ≤ 3.0.32; a harmless no-op where the boundary cast
-  already applied.
+- ✅ Read every numeric field through `_f()` — no-op on numbers, required on strings.
 - ✅ Put `marginPct` (fleet standard) or `marginUsd`, plus `leverage`, at the **top level**, not inside `data{}`.
 - ✅ On any failure, **return `[]`** (or a partial list) — don't crash.
 - ❌ Don't set `valid_until`/`produced_at` — the scaffold owns the envelope (`signal_id` optional).

--- a/senpi-trading-runtime/references/scan-contract.md
+++ b/senpi-trading-runtime/references/scan-contract.md
@@ -77,7 +77,7 @@ min_score = int(inputs.get("minScore", 4))
 
 | Member | What it is |
 |---|---|
-| `ctx.senpi_mcp.call_tool(name, args)` | Senpi MCP client, **read-only** (see boundary below). The only way to fetch data. |
+| `ctx.senpi_mcp.call_tool(name, args)` | Senpi MCP client, **read-only** (see boundary below). The only way to fetch data. Market-tool candle/price fields arrive **numeric** (see the market-data section below); all other tools' values keep their API types (often strings). |
 | `ctx.state` | Transactional history store (or `None` when history is disabled). API below. |
 | `ctx.wallet` | The runtime's wallet address (pass to `strategy_get_clearinghouse_state`, etc.) |
 | `ctx.scanner_name` | This scanner's name (from the recipe) |
@@ -133,6 +133,33 @@ knob. As an author: **assume you cannot mutate anything.** Produce signals; the 
 
 ---
 
+## Market data arrives numeric (everything else is strings)
+
+Hyperliquid's API returns candle `o/h/l/c/v` and price-map values as **strings**
+(`"HYPE": "58.3275"`). The runtime casts them to numbers at the `ctx.senpi_mcp` boundary before
+your `scan()` sees them, for exactly these two tools:
+
+- **`market_get_asset_data`** — candle `o/h/l/c/v` (+ `t`; `T`/`n` when valid), `asset_context`
+  numeric fields (`markPx`, `midPx`, `funding`, `openInterest`, …), `order_book` level `px`/`sz`,
+  `funding_history` `fundingRate`/`premium`.
+- **`market_get_prices`** — every value in the `prices` map.
+
+So `candles[-1]["c"] / 2` is safe as-is. Details:
+
+- Originals are preserved under a sibling **`_raw`** key at the same level as the cast sections
+  (exact API strings, if you ever need full precision).
+- A candle row whose `t/o/h/l/c/v` don't cast, or a price entry that doesn't cast, is **dropped**
+  and logged (`senpi_mcp_cast_dropped` scaffold event) — never passed through as a string.
+- **Every other tool's response is untouched.** A strategy's `budget`, clearinghouse balances,
+  leaderboard fields, etc. may still be strings — cast those yourself before arithmetic.
+- This guarantee ships with the runtime's boundary cast (runtime CHANGELOG: *"Scanner market data
+  is now numeric at the MCP boundary"*). On older runtimes these fields are still strings — a
+  defensive `float(...)` is harmless either way (`float` of a number is a no-op), so keeping the
+  fleet-standard cast helper in `scoring.py` costs nothing and makes your package
+  version-independent.
+
+---
+
 ## The signal dict (return value)
 
 Return a `list[dict]`, one per candidate. Keys:
@@ -163,7 +190,8 @@ default_signal_validity_seconds)`), the wire envelope, delivery, and dedup. **Do
 ## `scoring.py` — keep the logic pure
 
 Every example splits a sibling `scoring.py` with **no I/O, no MCP, no daemon** — just functions over
-candles/numbers. `scan.py` fetches via `ctx.senpi_mcp` and hands plain lists to `scoring`. This ports
+candles/numbers. `scan.py` fetches via `ctx.senpi_mcp` (candle/price fields already numeric — see
+the market-data section above) and hands the candle lists to `scoring`. This ports
 cleanly from older producers (the pure trend/scoring helpers were already unit-tested) and lets a
 reader follow the thesis without mocking MCP.
 
@@ -187,6 +215,8 @@ Both are valid — it's your thesis:
 - ✅ Pure scoring in `scoring.py`; MCP + state in `scan.py`.
 - ✅ Keep dedup / rotation / first-seen ledgers in `ctx.state` (`last()` → mutate → `append()`).
 - ✅ Declare every `data{}` key in `signal_data_schema`; set `default_signal_validity_seconds`.
+- ✅ Market-tool candles/prices arrive numeric; **any other tool's fields may be strings — cast
+  before arithmetic** (a defensive `float()` on market data is harmless too).
 - ✅ Put `marginPct` (fleet standard) or `marginUsd`, plus `leverage`, at the **top level**, not inside `data{}`.
 - ✅ On any failure, **return `[]`** (or a partial list) — don't crash.
 - ❌ Don't set `valid_until`/`produced_at` — the scaffold owns the envelope (`signal_id` optional).


### PR DESCRIPTION
Companion to Senpi-ai/senpi-trading-runtime#270 (runtime numeric-casts `market_get_asset_data` / `market_get_prices` fields at the `ctx.senpi_mcp` boundary before authored `scan()` code sees them).

⚠️ **Merge gate: land only after #270 merges AND ships in a published `@senpi-ai/runtime` release.** senpi-skills `main` is cloned into agent boxes immediately, while runtimes self-update on their own cadence — the docs therefore state the boundary cast with an explicit version predicate ("runtimes newer than 3.0.32") and lead with the defensive read, so they are safe on a pre-cast fleet either way.

## What

- **`senpi-trading-runtime/references/scan-contract.md`**: new *"Market data types — cast defensively; newer runtimes cast for you"* section — the exact cast surface with **strict vs best-effort** semantics split out (candles/prices: uncastable rows/entries dropped + logged as `senpi_mcp_cast_dropped`; `asset_context`/`order_book`/`funding_history`: cast-if-valid, left as-is otherwise, not logged), `_raw` originals, a warning that dropped rows make series shorter/non-contiguous (guard `len(candles)`, don't assume fixed `t` spacing), and a loud "every other tool's fields may still be strings" note. Fixes the previously misleading "hands plain lists to scoring" line, updates the `ctx` table row, adds a checklist item.
- **`senpi-strategy-author/references/creating-a-strategy.md`**: candle-schema note rewritten around the version-gated guarantee, and the scoring template ships the **fleet-dominant** `_f()` shape (`def _f(v, d=0.0)` / `float(v)` / `except (TypeError, ValueError): return d` — the form 66 of the 98 packages already use), with a caution that it is shape tolerance, not a data-quality gate.
- Skill version bumps (`senpi-trading-runtime` 3.0.2→3.0.3, `senpi-strategy-author` 2.9.0→2.9.1) so installed boxes actually receive the update.

## Why

Four authored scanners shipped arithmetic-DOA on string OHLCV in one 48h window; `scan-contract.md` said nothing about types and its "plain lists" phrasing implied ready-to-use data. With the runtime fix landing the class at the boundary, the docs' job is to state the guarantee precisely — including its edges (only two tools; strict vs best-effort sections; version skew; other paths still strings).

Deliberately **not** added: a `validate_strategy.py` "must cast" lint — the docs now (correctly) tell authors to keep the defensive read, so a lint would add nothing, and post-rollout it would flag correct code.

## Tests

`test_scaffold_margin.py` doc pins still pass (`candle["c"]` retained); full local suite for author/ops/discover/runtime skills: 88 passed. No `strategy.yaml` touched → no catalog regen needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill version metadata only; no runtime code or strategy packages change in this repo.
> 
> **Overview**
> Documents how **string vs numeric** market data should be handled in authored scanners, aligned with runtime PR #270 (boundary casting on runtimes **> 3.0.32**).
> 
> **`scan-contract.md`** adds a **Market data types** section: fleet-standard `_f()` reads, strict vs best-effort casting for `market_get_asset_data` / `market_get_prices`, drop logging, `_raw` originals, and shorter/non-contiguous candle series. Updates the `ctx` table, fixes the “plain lists” wording, and adds a checklist item for `_f()`.
> 
> **`creating-a-strategy.md`** expands the candle schema note and ships an updated **`scoring.py` template** with `_f()` and `candle["c"]` (not `"close"`).
> 
> **`CLAUDE.md`** adds guidance that skill hot paths should be **rules + snippets**, not long rationale (so `_f()` isn’t stripped as “redundant”).
> 
> Bumps **`senpi-trading-runtime`** 3.0.2→3.0.3 and **`senpi-strategy-author`** 2.9.0→2.9.1 so installed boxes pick up the docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c73fca760e6a58873c186f3dc968085dc7880b5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->