### PR TITLE
fix(strategies): whale-mirror notional shape + case-sensitive coin symbols

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-07-23",
+  "_updated": "2026-06-17",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -223,7 +223,7 @@
       "emoji": "🦉",
       "tagline": "Scans every liquid Hyperliquid crypto perp (OI > $3M) for one-sided crowding — extreme funding + lopsided smart money + concentrated OI — then waits for that crowding to persist 1h+ AND for exhaustion to fire (volume fading, price stalling, RSI divergence) before fading the crowd. Conviction-scaled leverage (7/8/10) at 25% margin, with a macro gate that stands down when BTC's 4h move is extreme.",
       "belief_plain": "The crowd is wrong at the extremes. When everyone piles onto one side of a coin — paying punishing funding, the best traders all leaning the same way, open interest stacking up — and the price then stops following through, the unwind is violent and predictable. Owl waits for both the crowded state AND the exhaustion trigger, then takes the other side. Most days it does nothing, because most days one or both is missing.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "thesis": "Crowded trades unwind violently. Owl's edge is timing the unwind: it never fades on crowding alone (which can persist and grind), it waits for crowding to PERSIST 1h+ and for distinct exhaustion signals (declining volume under extreme funding, price stalling against the crowd, capitulation wicks, 4h RSI divergence) to confirm the move is dying. Mean reversion fails in trending macro, so a hard gate blocks all fades when |BTC 4h| > 3%. XYZ banned — the funding/smart-money scoring is calibrated on crypto data shape.",
       "tags": [
         "contrarian",
@@ -1316,7 +1316,7 @@
       "emoji": "🦦",
       "tagline": "Watches the rate of change of open interest across every liquid Hyperliquid crypto perp and fires at most a couple of positions — only when 1h OI jumps >=5% while price moves >=0.5% the same way (fresh leveraged money entering with conviction), 4h isn't unwinding, and the spread is tight. Sizes margin to conviction at 5/7/10x, then rides the flow 1-3h on a tight DSL.",
       "belief_plain": "Open interest only grows when new leveraged money enters a perp. When that money piles in fast (OI up 5%+ in an hour) AND price moves the same direction, that's real conviction — not just a wick. Otter rides that fresh flow for an hour or three, then trails a tight stop. It does nothing on the much more common days when no coin shows that burst, and it never trades unwinds.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "thesis": "OI velocity — the delta of open interest over time — is a perp-native conviction signal nobody else in the fleet trades (others read OI only as a static size filter). Fresh OI growth aligned with price (the top two quadrants of the OI/price matrix) is new leveraged positioning with direction; unwinds (the bottom two) are exhaustion and get skipped. Confluence scoring (OI tier, 4h confirmation, price magnitude, smart-money lean, spread, time-of-day) at a high floor keeps it a sniper, and a tight DSL locks profit early because the flow edge is in the first 1-3 hours.",
       "tags": [
         "open-interest",
@@ -4249,7 +4249,7 @@
       "emoji": "🐦",
       "tagline": "Auto-discovers the platform's top-performing strategies, then trades the asset + direction they agree on most — performance-weighted, so a stronger strategy gets more say (capped so one outlier can't dominate).",
       "belief_plain": "Lets the best strategies on the platform do the work. Every few minutes it finds the top performers, looks at what they're holding right now, and copies whatever the most (and best) of them are piling into together — going long what they're long and short what they're short.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "thesis": "Following one trader or one leaderboard is one layer; Cuckoo is a layer above it. The strategies it follows are themselves copy/algo/trader-following strategies, so it captures the consensus of the consensus. When the best strategies independently pile into the same asset+direction, that agreement is a strong, self-cleaning signal — underperformers fall out of the top-N automatically, so the pool refreshes toward whatever is working.",
       "tags": [
         "copy-trading",
@@ -4510,7 +4510,7 @@
       "emoji": "🐦",
       "tagline": "Maintains a daily-refreshed pool of the most consistent (ELITE/RELIABLE) Hyperliquid traders, reads each one's open book, and mirrors ONLY their single highest-conviction bet — and only when that one position dominates their whole book (e.g. ~98% of capital in one 3x position). Leans hardest when several elite traders independently pile into the same concentrated trade.",
       "belief_plain": "Looks past the leaderboard noise and keeps a shortlist of the steadiest, most-proven traders on Hyperliquid. Instead of copying everything they do, Oxpecker copies only the trade they're betting their whole book on — the one position that makes up most of their capital. When more than one of those proven traders is all-in on the same trade in the same direction, it bets harder, then trails a wide stop so the conviction can run.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "thesis": "A proven trader's signal is loudest exactly when they concentrate. Cohort copiers average a pool and whale mirrors ride a fixed name list; Oxpecker does neither — it screens for the highest consistency tier (ELITE/RELIABLE) and then, within that elite set, only acts on positions that represent real conviction: where one bet is the overwhelming majority of the trader's book. A reliable trader with ~98% of their capital in one short is telling you something an opaque cohort average buries. Quality-tier x position-concentration is the whole edge — consensus across multiple elite traders on the same concentrated trade is the strongest signal there is, and the wide let-winners-run DSL respects that conviction rather than scalping it.",
       "tags": [
         "copy-trading",
@@ -4596,7 +4596,7 @@
       "emoji": "🐟",
       "tagline": "Autonomous smart-money whale mirror — auto-builds a top-trader cohort and mirrors their highest-conviction positions; optionally mirror specific whales you name via inputs.whales. Like a remora fish riding a shark, it leans hardest when several whales pile into the same trade (consensus) or when a whale is ELITE/RELIABLE tier.",
       "belief_plain": "Out of the box, Remora finds the most proven traders on Hyperliquid, watches their open positions, and copies the strongest bets — betting bigger when several of them are in the same trade and one has an elite track record. Prefer to ride specific traders you trust? Name them and Remora mirrors exactly those instead. Either way it trails a wide stop so the trade can run.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "thesis": "Riding the highest-conviction position of proven traders keeps your exposure tracking real smart money, and the consensus multiplier means it leans hardest exactly when those traders independently agree — one whale can be wrong, three agreeing is a much stronger signal. By default Remora is autonomous: it auto-builds a top-trader cohort (all-time realized PnL, refreshed daily) so it always has whales to mirror — no config required. Name your own whales to make it ride exactly the traders you choose. Whales hold winners, so the exit lets the mirror run and only caps staleness.",
       "tags": [
         "whale",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-07-23",
+  "_updated": "2026-06-17",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -223,7 +223,7 @@
       "emoji": "🦉",
       "tagline": "Scans every liquid Hyperliquid crypto perp (OI > $3M) for one-sided crowding — extreme funding + lopsided smart money + concentrated OI — then waits for that crowding to persist 1h+ AND for exhaustion to fire (volume fading, price stalling, RSI divergence) before fading the crowd. Conviction-scaled leverage (7/8/10) at 25% margin, with a macro gate that stands down when BTC's 4h move is extreme.",
       "belief_plain": "The crowd is wrong at the extremes. When everyone piles onto one side of a coin — paying punishing funding, the best traders all leaning the same way, open interest stacking up — and the price then stops following through, the unwind is violent and predictable. Owl waits for both the crowded state AND the exhaustion trigger, then takes the other side. Most days it does nothing, because most days one or both is missing.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "thesis": "Crowded trades unwind violently. Owl's edge is timing the unwind: it never fades on crowding alone (which can persist and grind), it waits for crowding to PERSIST 1h+ and for distinct exhaustion signals (declining volume under extreme funding, price stalling against the crowd, capitulation wicks, 4h RSI divergence) to confirm the move is dying. Mean reversion fails in trending macro, so a hard gate blocks all fades when |BTC 4h| > 3%. XYZ banned — the funding/smart-money scoring is calibrated on crypto data shape.",
       "tags": [
         "contrarian",
@@ -1316,7 +1316,7 @@
       "emoji": "🦦",
       "tagline": "Watches the rate of change of open interest across every liquid Hyperliquid crypto perp and fires at most a couple of positions — only when 1h OI jumps >=5% while price moves >=0.5% the same way (fresh leveraged money entering with conviction), 4h isn't unwinding, and the spread is tight. Sizes margin to conviction at 5/7/10x, then rides the flow 1-3h on a tight DSL.",
       "belief_plain": "Open interest only grows when new leveraged money enters a perp. When that money piles in fast (OI up 5%+ in an hour) AND price moves the same direction, that's real conviction — not just a wick. Otter rides that fresh flow for an hour or three, then trails a tight stop. It does nothing on the much more common days when no coin shows that burst, and it never trades unwinds.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "thesis": "OI velocity — the delta of open interest over time — is a perp-native conviction signal nobody else in the fleet trades (others read OI only as a static size filter). Fresh OI growth aligned with price (the top two quadrants of the OI/price matrix) is new leveraged positioning with direction; unwinds (the bottom two) are exhaustion and get skipped. Confluence scoring (OI tier, 4h confirmation, price magnitude, smart-money lean, spread, time-of-day) at a high floor keeps it a sniper, and a tight DSL locks profit early because the flow edge is in the first 1-3 hours.",
       "tags": [
         "open-interest",
@@ -4249,7 +4249,7 @@
       "emoji": "🐦",
       "tagline": "Auto-discovers the platform's top-performing strategies, then trades the asset + direction they agree on most — performance-weighted, so a stronger strategy gets more say (capped so one outlier can't dominate).",
       "belief_plain": "Lets the best strategies on the platform do the work. Every few minutes it finds the top performers, looks at what they're holding right now, and copies whatever the most (and best) of them are piling into together — going long what they're long and short what they're short.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "thesis": "Following one trader or one leaderboard is one layer; Cuckoo is a layer above it. The strategies it follows are themselves copy/algo/trader-following strategies, so it captures the consensus of the consensus. When the best strategies independently pile into the same asset+direction, that agreement is a strong, self-cleaning signal — underperformers fall out of the top-N automatically, so the pool refreshes toward whatever is working.",
       "tags": [
         "copy-trading",
@@ -4510,7 +4510,7 @@
       "emoji": "🐦",
       "tagline": "Maintains a daily-refreshed pool of the most consistent (ELITE/RELIABLE) Hyperliquid traders, reads each one's open book, and mirrors ONLY their single highest-conviction bet — and only when that one position dominates their whole book (e.g. ~98% of capital in one 3x position). Leans hardest when several elite traders independently pile into the same concentrated trade.",
       "belief_plain": "Looks past the leaderboard noise and keeps a shortlist of the steadiest, most-proven traders on Hyperliquid. Instead of copying everything they do, Oxpecker copies only the trade they're betting their whole book on — the one position that makes up most of their capital. When more than one of those proven traders is all-in on the same trade in the same direction, it bets harder, then trails a wide stop so the conviction can run.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "thesis": "A proven trader's signal is loudest exactly when they concentrate. Cohort copiers average a pool and whale mirrors ride a fixed name list; Oxpecker does neither — it screens for the highest consistency tier (ELITE/RELIABLE) and then, within that elite set, only acts on positions that represent real conviction: where one bet is the overwhelming majority of the trader's book. A reliable trader with ~98% of their capital in one short is telling you something an opaque cohort average buries. Quality-tier x position-concentration is the whole edge — consensus across multiple elite traders on the same concentrated trade is the strongest signal there is, and the wide let-winners-run DSL respects that conviction rather than scalping it.",
       "tags": [
         "copy-trading",
@@ -4596,7 +4596,7 @@
       "emoji": "🐟",
       "tagline": "Autonomous smart-money whale mirror — auto-builds a top-trader cohort and mirrors their highest-conviction positions; optionally mirror specific whales you name via inputs.whales. Like a remora fish riding a shark, it leans hardest when several whales pile into the same trade (consensus) or when a whale is ELITE/RELIABLE tier.",
       "belief_plain": "Out of the box, Remora finds the most proven traders on Hyperliquid, watches their open positions, and copies the strongest bets — betting bigger when several of them are in the same trade and one has an elite track record. Prefer to ride specific traders you trust? Name them and Remora mirrors exactly those instead. Either way it trails a wide stop so the trade can run.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "thesis": "Riding the highest-conviction position of proven traders keeps your exposure tracking real smart money, and the consensus multiplier means it leans hardest exactly when those traders independently agree — one whale can be wrong, three agreeing is a much stronger signal. By default Remora is autonomous: it auto-builds a top-trader cohort (all-time realized PnL, refreshed daily) so it always has whales to mirror — no config required. Name your own whales to make it ride exactly the traders you choose. Whales hold winners, so the exit lets the mirror run and only caps staleness.",
       "tags": [
         "whale",

--- a/strategies/cuckoo/main/scanners/scoring.py
+++ b/strategies/cuckoo/main/scanners/scoring.py
@@ -59,20 +59,43 @@ def mirror_direction(pos):
 def position_asset(pos):
     """Asset symbol for a position (multi-key fallback). Verbatim from v2.
 
-    Preserves the symbol as returned by the upstream strategy's position
-    (e.g. an `xyz:` prefix survives). Case is uppercased, matching v2."""
+    Preserves the symbol EXACTLY as returned by the upstream strategy's
+    position — both the `xyz:` prefix and the original case. v2 upper-cased it,
+    which is wrong for a derived universe: the emitted symbol goes straight into
+    a Senpi tool call and Hyperliquid coin names are CASE-SENSITIVE (kPEPE /
+    kSHIB / kBONK are rejected as `KPEPE`; HIP-3 prefixes are lowercase
+    `xyz:`). Callers needing a case-insensitive COMPARISON upper-case at the
+    comparison site instead."""
     if not isinstance(pos, dict):
         return ""
-    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", ""))))).upper()
+    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", "")))))
 
 
 def position_notional(pos):
-    """USD notional for a position (size*entry, else marginUsed, else size).
-    Verbatim from v2."""
+    """USD notional for a position: notional_size, else size*entry, else
+    marginUsed, else size.
+
+    Handles BOTH position shapes: the Hyperliquid clearinghouse one
+    (szi/entryPx/marginUsed) and the leaderboard_get_trader_positions one
+    (market/size/entry_price/notional_size). Cuckoo feeds this the LEADERBOARD
+    shape (see scan._fetch_strategy_positions) — without these keys `entry`
+    resolved to 0 and the notional collapsed to the RAW TOKEN COUNT via the
+    final fallback. Because gather_entries filters on `< min_notional` (USD),
+    that silently inverted the filter: every memecoin cleared the $2k floor on
+    token count alone, while a $10M BTC position (~100 tokens) fell BELOW it and
+    was dropped — so the consensus vote structurally could not see BTC.
+
+    `notional_size` is the documented USD field (|size| x current price) per
+    senpi://guides/hyperfeed-trader-positions."""
     if not isinstance(pos, dict):
         return 0.0
+    # leaderboard shape: USD notional is returned directly — no math needed.
+    ns = abs(safe_float(pos.get("notional_size", pos.get("notionalSize", 0))))
+    if ns > 0:
+        return ns
     size = abs(safe_float(pos.get("szi", pos.get("size", 0))))
-    entry = safe_float(pos.get("entryPx", pos.get("entryPrice", pos.get("entry", 0))))
+    entry = safe_float(pos.get("entryPx", pos.get("entryPrice",
+                       pos.get("entry_price", pos.get("entry", 0)))))
     notional = size * entry
     if notional > 0:
         return notional

--- a/strategies/cuckoo/strategy.yaml
+++ b/strategies/cuckoo/strategy.yaml
@@ -9,7 +9,7 @@
 schema_version: 1
 
 id: cuckoo
-version: "1.0.0"
+version: "1.0.1"
 
 catalog:
   name: "Cuckoo — Copy-the-Copiers"

--- a/strategies/otter/main/scanners/scan.py
+++ b/strategies/otter/main/scanners/scan.py
@@ -141,7 +141,13 @@ def fetch_instruments(ctx):
     for inst in instruments:
         if not isinstance(inst, dict):
             continue
-        name = str(inst.get("name", inst.get("coin", ""))).upper()
+        # CASE-PRESERVED: market_list_instruments is the source of truth for exact
+        # coin-name casing, and HL names are CASE-SENSITIVE — the 1000x names carry
+        # a lowercase k (kPEPE/kSHIB/kBONK) and `KPEPE` is rejected as
+        # INVALID_ARGUMENT. This symbol is emitted as the signal asset and passed to
+        # fetch_spread_bps, so upper-casing it silently no-traded every
+        # k-denominated name. Comparisons upper-case at their site.
+        name = str(inst.get("name", inst.get("coin", "")))
         dex = str(inst.get("dex", "")).lower()
         if not name:
             continue
@@ -337,7 +343,10 @@ def scan(inputs, ctx):
     bootstrapping = 0
     for inst in instruments:
         samples = history.get(inst["asset"], [])
-        sig = scoring.evaluate_oi_velocity(inst, samples, sm_map.get(inst["asset"]),
+        # sm_map is keyed upper-case (see the token parse in the sm fetch); asset
+        # names are now case-preserved, so upper-case at the lookup.
+        sig = scoring.evaluate_oi_velocity(inst, samples,
+                                           sm_map.get(inst["asset"].upper()),
                                            hour, inputs)
         if sig == "BOOTSTRAP":
             bootstrapping += 1
@@ -351,7 +360,9 @@ def scan(inputs, ctx):
     eligible = [
         c for c in candidates
         if c["score"] >= min_score
-        and not _is_cooled_down(cooldowns, c["asset"], cooldown_min, now)
+        # cooldowns is keyed upper-case at the write site (`cooldowns[au]`), and
+        # asset names are case-preserved — upper-case here so the lookup matches.
+        and not _is_cooled_down(cooldowns, c["asset"].upper(), cooldown_min, now)
     ]
 
     total = len(instruments)

--- a/strategies/otter/strategy.yaml
+++ b/strategies/otter/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: otter
-version: "1.0.0"
+version: "1.0.1"
 
 catalog:
   name: "Otter — Open Interest Velocity Hunter"

--- a/strategies/owl/main/scanners/scan.py
+++ b/strategies/owl/main/scanners/scan.py
@@ -102,7 +102,13 @@ def fetch_all_assets(ctx, inputs):
         if not isinstance(inst, dict):
             continue
         coin = inst.get("coin") or inst.get("name", "")
-        coin = str(coin).upper() if coin else ""
+        # CASE-PRESERVED: market_list_instruments is the source of truth for exact
+        # coin-name casing, and HL names are CASE-SENSITIVE — the 1000x names carry
+        # a lowercase k (kPEPE/kSHIB/kBONK) and `KPEPE` is rejected as
+        # INVALID_ARGUMENT. This symbol is passed straight to market_get_asset_data
+        # and emitted as the signal asset, so upper-casing it here silently
+        # no-traded every k-denominated name. Comparisons upper-case at their site.
+        coin = str(coin) if coin else ""
         if not coin:
             continue
         if _is_xyz(coin):                          # XYZ ban (name-prefix; see module docstring)
@@ -344,7 +350,9 @@ def scan(inputs, ctx):
     crowding_results = []
     for asset in assets:
         coin = asset["coin"]
-        sm_long_pct, sm_count = sm_map.get(coin, (50, 0))
+        # sm_map is keyed upper-case (see the token parse above); `coin` is now
+        # case-preserved, so upper-case at the lookup to keep the join intact.
+        sm_long_pct, sm_count = sm_map.get(coin.upper(), (50, 0))
         crowd_score, crowd_direction, details = scoring.score_crowding(
             asset, sm_long_pct, sm_count, min_funding_ann)
 

--- a/strategies/owl/strategy.yaml
+++ b/strategies/owl/strategy.yaml
@@ -7,7 +7,7 @@
 schema_version: 1
 
 id: owl
-version: "1.0.0"
+version: "1.0.1"
 
 catalog:
   name: "Owl — Contrarian Crowding-Unwind Hunter"

--- a/strategies/oxpecker/main/scanners/scoring.py
+++ b/strategies/oxpecker/main/scanners/scoring.py
@@ -193,10 +193,15 @@ def mirror_direction(pos):
 
 
 def position_asset(pos):
-    """Asset symbol, upper-cased. Verbatim from Remora."""
+    """Asset symbol, CASE-PRESERVED. Verbatim from Remora.
+
+    Not upper-cased: the emitted symbol goes straight into a Senpi tool call and
+    Hyperliquid coin names are CASE-SENSITIVE (kPEPE/kSHIB/kBONK are rejected as
+    `KPEPE`; HIP-3 prefixes are lowercase `xyz:`). Callers needing a
+    case-insensitive COMPARISON upper-case at the comparison site."""
     if not isinstance(pos, dict):
         return ""
-    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", ""))))).upper()
+    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", "")))))
 
 
 def position_leverage(pos):

--- a/strategies/oxpecker/strategy.yaml
+++ b/strategies/oxpecker/strategy.yaml
@@ -11,7 +11,7 @@
 schema_version: 1
 
 id: oxpecker
-version: "1.0.0"
+version: "1.0.1"
 
 catalog:
   name: "Oxpecker — Elite-Conviction Concentrated Mirror"

--- a/strategies/remora/main/runtime.yaml
+++ b/strategies/remora/main/runtime.yaml
@@ -15,7 +15,7 @@
 # scanners/scoring.py + scanners/scan.py.
 name: remora-main
 group: remora
-version: 1.1.0
+version: 1.1.1
 description: >
   REMORA — autonomous smart-money whale mirror. By default it auto-builds a cohort
   of proven top traders (discovery_get_top_traders, ranked by all-time realized PnL,

--- a/strategies/remora/main/scanners/scoring.py
+++ b/strategies/remora/main/scanners/scoring.py
@@ -76,12 +76,29 @@ def trader_address(t):
 
 
 def position_notional(pos):
-    """USD notional of a position for conviction ranking: size x entry,
-    falling back to marginUsed, then to raw size. Verbatim from v2."""
+    """USD notional of a position for conviction ranking: notional_size, else
+    size x entry, falling back to marginUsed, then to raw size.
+
+    Handles BOTH position shapes: the Hyperliquid clearinghouse one
+    (szi/entryPx/marginUsed) and the leaderboard_get_trader_positions one
+    (market/size/entry_price/notional_size). The leaderboard shape is what
+    scan.py actually receives — without these keys `entry` resolved to 0 and
+    the notional collapsed to the RAW TOKEN COUNT via the final fallback, so a
+    184M-token PUMP dust position ($350K) outranked a 59K-token ETH short
+    ($112M) and Remora mirrored meme dust instead of real conviction.
+
+    `notional_size` is the documented USD field (|size| x current price) per
+    senpi://guides/hyperfeed-trader-positions, so it is preferred over the
+    size x entry product; `entry_price` backs it up if it is ever absent."""
     if not isinstance(pos, dict):
         return 0.0
+    # leaderboard shape: USD notional is returned directly — no math needed.
+    ns = abs(safe_float(pos.get("notional_size", pos.get("notionalSize", 0))))
+    if ns > 0:
+        return ns
     size = abs(safe_float(pos.get("szi", pos.get("size", 0))))
-    entry = safe_float(pos.get("entryPx", pos.get("entryPrice", pos.get("entry", 0))))
+    entry = safe_float(pos.get("entryPx", pos.get("entryPrice",
+                       pos.get("entry_price", pos.get("entry", 0)))))
     notional = size * entry
     if notional > 0:
         return notional
@@ -106,10 +123,19 @@ def mirror_direction(pos):
 
 
 def position_asset(pos):
-    """Verbatim from v2."""
+    """Asset symbol for a position, CASE-PRESERVED.
+
+    v2 upper-cased this. That is wrong for a derived universe: the emitted
+    symbol goes straight into a Senpi tool call, and Hyperliquid coin names are
+    CASE-SENSITIVE. The 1000x-denominated names carry a lowercase k (kPEPE,
+    kSHIB, kBONK) and `KPEPE` is rejected as INVALID_ARGUMENT; HIP-3 assets
+    carry a lowercase dex prefix (`xyz:GOLD`, not `XYZ:GOLD`). Remora mirrors
+    whatever the whales hold, so both forms occur live — upper-casing turned
+    those into silent no-trades. Callers that need a case-insensitive COMPARISON
+    (held-asset set, dedup map) upper-case at the comparison site instead."""
     if not isinstance(pos, dict):
         return ""
-    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", ""))))).upper()
+    return str(pos.get("coin", pos.get("market", pos.get("asset", pos.get("symbol", "")))))
 
 
 def top_position(positions, min_notional=0.0):

--- a/strategies/remora/strategy.yaml
+++ b/strategies/remora/strategy.yaml
@@ -12,7 +12,7 @@
 schema_version: 1
 
 id: remora
-version: "1.1.0"
+version: "1.1.1"
 
 catalog:
   name: "Remora — Autonomous Smart-Money Whale Mirror"


### PR DESCRIPTION
Two silent-failure bugs in the strategies that mirror other traders. Neither errors, logs, or fails a validator — they just trade the wrong thing, or nothing.

## 1. `position_notional()` didn't recognise the leaderboard position shape

`scan.py` fetches positions via `leaderboard_get_trader_positions`, which returns:

```json
{ "market": "ETH", "direction": "short", "size": -59267.5639,
  "entry_price": 1869.4, "notional_size": 112270546.30 }
```

`position_notional()` looked for `szi` / `entryPx` / `entryPrice` / `marginUsed` — **none of which exist in that shape**. So `entry` resolved to `0`, `size × entry` was `0`, the `marginUsed` fallback missed too, and it fell through to `return size`: the **raw token count**, returned as if it were USD.

The failure mode differs by how each strategy uses the value:

| | role | effect |
|---|---|---|
| **remora** | ranking (`top_position`) | A 184,160,374-token PUMP position (**$350K**) outranked a 59,268-token ETH short (**$112M**). Remora mirrored meme dust. The real signal — 4 of the top 10 whales short ETH — never cleared `minScore`. Live strategy `feca601f` made 3 trades, all PUMP SHORT. |
| **cuckoo** | filter (`< min_notional`, $2k) | Every memecoin cleared the floor on token count alone, while a $10M BTC position (~100 tokens) fell **below** it. The consensus vote structurally could not see BTC. |

**Fix:** prefer `notional_size` — the documented USD field (`|size| × current_price`) per `senpi://guides/hyperfeed-trader-positions` — and add `entry_price` to the fallback chain. All clearinghouse keys preserved, so `discovery_get_trader_state`-fed callers (oxpecker) are unaffected.

## 2. Coin symbols were upper-cased before being emitted

Hyperliquid coin names are **case-sensitive**. The 1000x-denominated names carry a lowercase `k` (`kPEPE`, `kSHIB`, `kBONK`) and `KPEPE` is rejected as `INVALID_ARGUMENT`; HIP-3 assets carry a lowercase `xyz:` prefix. These symbols are emitted as the signal asset and passed to `market_get_asset_data`, so upper-casing them was a silent no-trade on every affected name.

Not hypothetical for remora: the verified whale book holds `xyz:GOLD` and `xyz:BRENTOIL` in its top 5 positions.

Case is now preserved at the source — `position_asset()` in remora/cuckoo/oxpecker, and the `market_list_instruments` parse in owl/otter. Comparisons still upper-case **at the comparison site**, which is correct.

Three lookups were keyed upper-case against a value that had just stopped being upper-case, and needed correcting or the fix would have introduced a new bug:

- `owl` `sm_map` lookup
- `otter` `sm_map` lookup
- `otter` `_is_cooled_down` — `cooldowns[]` is written upper-case, so without this **`kPEPE` could re-emit inside its own cooldown window**

⚠️ **Side effect:** owl/otter `ctx.state` history + cooldown keys change case, so each does a one-time persistence reset on the first tick after deploy. Self-healing, but their crowding-persistence counters restart.

## Verification

Confirmed against **live** `senpi-dev` `discovery_get_trader_state` for whale `0xb83d…6e36`:

| | `szi` | `entryPx` | `positionValue` |
|---|---|---|---|
| ETH | -59,267.5639 | 1869.42 | **$112,069,036** |
| PUMP | -184,160,374 | 0.001634 | **$345,116** |

Plus the `hyperfeed-trader-positions` guide, which documents the position fields as `market` / `size` / `direction` / `notional_size` / `account_value` / `leverage` — no `szi`, no `entryPx`, no `marginUsed`. The fall-through is provable from the contract, not inferred.

- 11/11 assertions pass across the three scoring modules (leaderboard shape, casing, clearinghouse no-regression, oxpecker `positionValue` precedence intact)
- `validate_strategy.py` ✓ and `validate_universe.py` ✓ on all five packages
- `py_compile` clean

## Versions

`remora 1.1.0→1.1.1`, `cuckoo`/`oxpecker`/`owl`/`otter` `1.0.0→1.0.1`, `catalog.json` regenerated to both locations. Bumped so pre-fix and post-fix trades stay separable in attribution — otherwise the PUMP trades and the corrected trades are indistinguishable in fleet analytics.

## Audit scope — please read before assuming coverage

Checked all 98 strategies / 248 scanner files for related shape-mismatch classes. Clean: nested `leverage` `{type,value}` (all 5 real reads handle it), `coinDisplayName` misuse (zero), clearinghouse parse consistency (all 84 agree). `raptor` and `cheetah` were checked and are safe.

**The casing list is a floor, not a ceiling.** My static tracer follows only direct variable assignments and initially missed remora/cuckoo/oxpecker, whose asset reaches `.upper()` indirectly through `position_asset()`. owl and otter are what it caught plus manual review. Other strategies among the 96 that touch symbol case could have the same issue via paths the tracer can't see — a complete sweep needs per-strategy reading, which is not done here.

**No test coverage exists** for these strategies (no `tests/` dir, no pytest config, nothing referencing `position_notional`). Verification was an ad-hoc harness, not committed. Given this is the *second* shape bug in this one function, real unit tests for `position_notional` are worth adding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)