### PR TITLE
Fetch strategy packages into a durable absolute root, never CWD-relative

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.10.0"
+  version: "2.11.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -199,8 +199,12 @@ the catalog entry, then unit-test → validate → hand to smoke-test."* Then ti
 1. **Confirm the spec.** Replay name + thesis + all 7 + opening constraints → get a "yes." *("You said
    rotate the cohort every 3 days — that's in.")* Nothing is written before this yes.
 2. **Scaffold.** Match the idea to an archetype row in `references/creating-a-strategy.md`, create the
-   package dirs, and state the archetype + file plan. → *"Matched the cohort-rotation archetype; scaffolding
-   `strategies/<id>/…`."* This lets the user catch a wrong archetype/universe **before** you write code.
+   package dirs **under the durable strategies root** — `/data/workspace/strategies/<id>/`
+   (`SENPI_STRATEGIES_DIR` overrides), **NEVER inside a managed skill directory** (skill updates
+   replace those dirs; a package authored there is destroyed on the next version bump) — and state the
+   archetype + file plan. → *"Matched the cohort-rotation archetype; scaffolding
+   `/data/workspace/strategies/<id>/…`."* This lets the user catch a wrong archetype/universe
+   **before** you write code.
    **Layout: single-instance = FLAT** — `strategy.yaml` + `runtime.yaml` + `scanners/` at the package
    root, **no `instances:` list, no `main/` dir** (the deployer synthesizes the `main` instance).
    Multi-instance (e.g. a long book + a short book) = one `<instance>/` dir each + an explicit
@@ -217,12 +221,13 @@ the catalog entry, then unit-test → validate → hand to smoke-test."* Then ti
    `references/strategy-yaml-schema.md`; what each facet does for matching:
    `references/discovery-catalog-fields.md`). Write it → *"catalog entry in."*
 7. **Unit-test `scoring.py`** on sample candles (pure — no mocks). Run it → report pass/fail as its own beat.
-8. **Validate — three gates, all before any wallet exists:**
-   (a) **code-level** → `python3 senpi-strategy-author/scripts/validate_strategy.py strategies/<id>`
+8. **Validate — three gates, all before any wallet exists** (pass the package's absolute path,
+   `/data/workspace/strategies/<id>`, so the gates hit the authored copy from any CWD):
+   (a) **code-level** → `python3 senpi-strategy-author/scripts/validate_strategy.py /data/workspace/strategies/<id>`
    (0 errors — scan/scoring shape, DSL exit present, mandate description, retention/cooldown bounds);
-   (b) **universe gate** → `python3 senpi-strategy-ops/scripts/validate_universe.py strategies/<id>`
+   (b) **universe gate** → `python3 senpi-strategy-ops/scripts/validate_universe.py /data/workspace/strategies/<id>`
    — every hardcoded ticker must be a live HL instrument (derived-universe strategies pass trivially);
-   (c) **deploy contract** → `python3 senpi-strategy-ops/scripts/deploy.py validate strategies/<id>`
+   (c) **deploy contract** → `python3 senpi-strategy-ops/scripts/deploy.py validate /data/workspace/strategies/<id>`
    — the deployer's own one-pass preflight (structure, linkage, render; **no side effects**). Green
    here means `create` will not reject the package. (`deploy.py create` re-runs (b)+(c) itself and
    refuses to fund on failure.) Run each, report the result. **If validation fails, narrate the fix

--- a/senpi-strategy-author/references/creating-a-strategy.md
+++ b/senpi-strategy-author/references/creating-a-strategy.md
@@ -13,7 +13,7 @@ Your code is **one read-only, pure function**: it reads data and returns candida
 ## 2. The package
 
 ```
-strategies/<id>/
+/data/workspace/strategies/<id>/    # the DURABLE root — never author inside a managed skill dir
   strategy.yaml                 # identity, catalog facets, instances + funding
   <instance>/
     runtime.yaml                # the deterministic spec: inputs, entry action, DSL exit, risk
@@ -21,13 +21,17 @@ strategies/<id>/
       scan.py                   # scan(inputs, ctx) -> list[dict]   (reads + emits)
       scoring.py                # pure thesis math — no I/O, unit-testable
 ```
+
+**Location is load-bearing:** build under `/data/workspace/strategies/` (`SENPI_STRATEGIES_DIR`
+overrides). A package created inside a managed skill directory (`/data/.openclaw/skills/…`) is
+destroyed on that skill's next version bump — the skills-manager replaces the whole dir.
 One instance binds to one wallet. A long book + a short book, or a swing + a scalp leg, = **multiple instances**.
 
 **Single-instance? Build it FLAT** — `strategy.yaml` + `runtime.yaml` + `scanners/` at the package root,
 no `instances:` list and no `<instance>/` dir: the deployer (strategy-ops v2.4.0+) synthesizes the
 canonical `main` instance for you. The nested `<instance>/` layout above is only *required* for
-multi-instance strategies. Either way, `deploy.py validate strategies/<id>` tells you in one pass
-whether the package is deploy-ready.
+multi-instance strategies. Either way, `deploy.py validate /data/workspace/strategies/<id>` tells you
+in one pass whether the package is deploy-ready.
 
 ## 3. Division of labor — memorize this
 
@@ -228,7 +232,7 @@ Discovery matches your strategy to users by the `catalog:` block. **Validation o
 ## 9. Validate, smoke-test, deploy, confirm it *operates*
 
 ```
-python3 senpi-strategy-author/scripts/validate_strategy.py strategies/<id>      # 0 errors
+python3 senpi-strategy-author/scripts/validate_strategy.py /data/workspace/strategies/<id>   # 0 errors
 python3 senpi-strategy-ops/scripts/deploy.py create  <id> --budget N            # wallet(s); $100/instance floor
 python3 senpi-strategy-ops/scripts/deploy.py runtime <id>
 python3 senpi-strategy-ops/scripts/deploy.py verify  <id>                        # re-run after interval_seconds
@@ -251,7 +255,7 @@ If anything mismatches, fix the **contract** (the field name, the `signal_data_s
 
 - `scan()` single-pass + sync; read-only MCP only; `return []` on any error.
 - Pure scoring in `scoring.py`; MCP + state in `scan.py`.
-- **Never hardcode a ticker you didn't verify against the live list.** Every static `universe`/`asset`/`catalog.assets` entry must be a live HL instrument — a fake ticker silently no-trades (`market_get_asset_data` rejects it as an unknown coin — do not retry — and the scan skips it). Gate it: `validate_universe.py strategies/<id>` (and `deploy.py create` runs it as a preflight). Real index = `xyz:XYZ100`, *not* `xyz:NASDAQ`.
+- **Never hardcode a ticker you didn't verify against the live list.** Every static `universe`/`asset`/`catalog.assets` entry must be a live HL instrument — a fake ticker silently no-trades (`market_get_asset_data` rejects it as an unknown coin — do not retry — and the scan skips it). Gate it: `validate_universe.py /data/workspace/strategies/<id>` (and `deploy.py create` runs it as a preflight). Real index = `xyz:XYZ100`, *not* `xyz:NASDAQ`.
 - Emit a **`marginPct` intent**, not dollars; `marginPct`/`leverage` top-level, not in `data{}`.
 - Declare every `data{}` key in `signal_data_schema`.
 - **Anchor on the references:** MCP fields → I/O guide; exit → a named preset; catalog facets → the glossary.

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.9.0"
+  version: "2.10.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -47,10 +47,12 @@ python3 senpi-strategy-ops/scripts/close.py          --all                 # tea
 strategy. A raw `strategy_close` MCP call closes the strategy but **leaves the runtime registered**, which
 collides on the next deploy. "close all strategies / return funds to main" → `close.py --all`.
 Pass the **strategy `id`** for a CATALOG strategy (what `senpi-strategy-discover` hands over, e.g.
-`spider`) — it's fetched from the remote if not on disk. For a **locally-authored package, pass its
-DIRECTORY path** (absolute is safest, e.g. `/data/workspace/strategies/<id>`): a bare id only resolves
-locally relative to your CWD, so from anywhere else it becomes a remote catalog fetch — never what you
-want for a package you just wrote. An on-disk package is authoritative; an invalid one surfaces its
+`spider`) — it's fetched from the remote if not on disk, always into the **durable strategies root**
+(`SENPI_STRATEGIES_DIR` if set, else `/data/workspace/strategies`), never a CWD-relative path — a
+package written inside a managed skill dir is destroyed on the next skill update. A bare id resolves
+against your CWD first, then the durable root, so re-running a step works from any directory. For a
+**locally-authored package, pass its DIRECTORY path** (absolute is safest, e.g.
+`/data/workspace/strategies/<id>`): author into the durable root too, never into a skill directory. An on-disk package is authoritative; an invalid one surfaces its
 real errors and is never silently replaced by a remote fetch. The scripts call MCP directly
 (`scripts/mcp_client.py`, reads
 `SENPI_AUTH_TOKEN`) + drive `openclaw senpi runtime …`. Mechanics + state machine:

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -48,11 +48,13 @@ strategy. A raw `strategy_close` MCP call closes the strategy but **leaves the r
 collides on the next deploy. "close all strategies / return funds to main" → `close.py --all`.
 Pass the **strategy `id`** for a CATALOG strategy (what `senpi-strategy-discover` hands over, e.g.
 `spider`) — it's fetched from the remote if not on disk, always into the **durable strategies root**
-(`SENPI_STRATEGIES_DIR` if set, else `/data/workspace/strategies`), never a CWD-relative path — a
-package written inside a managed skill dir is destroyed on the next skill update. A bare id resolves
-against your CWD first, then the durable root, so re-running a step works from any directory. For a
-**locally-authored package, pass its DIRECTORY path** (absolute is safest, e.g.
-`/data/workspace/strategies/<id>`): author into the durable root too, never into a skill directory. An on-disk package is authoritative; an invalid one surfaces its
+(`SENPI_STRATEGIES_DIR` if set, else the agent workspace `strategies/` dir — normally
+`/data/workspace/strategies`), never a CWD-relative path — a package written inside a managed skill
+dir is destroyed on the next skill update. A bare id resolves from the durable root first (that copy
+holds the deploy state and is authoritative), then CWD-relative `strategies/<id>` as a legacy
+fallback, so re-running a step works from any directory. For a **locally-authored package, pass its
+DIRECTORY path** (absolute is safest, e.g. `/data/workspace/strategies/<id>`): author into the
+durable root too, never into a skill directory. An on-disk package is authoritative; an invalid one surfaces its
 real errors and is never silently replaced by a remote fetch. The scripts call MCP directly
 (`scripts/mcp_client.py`, reads
 `SENPI_AUTH_TOKEN`) + drive `openclaw senpi runtime …`. Mechanics + state machine:

--- a/senpi-strategy-ops/references/lifecycle.md
+++ b/senpi-strategy-ops/references/lifecycle.md
@@ -22,8 +22,11 @@ default 150s) and the agent **re-runs a step until it reports done**.
 **Package fetch.** Any step fetches `strategies/<id>/` from the remote if it isn't on disk (`_fetch.py`:
 GitHub tree + raw from `SENPI_SKILLS_REPO`@`SENPI_SKILLS_REF`, default `Senpi-ai/senpi-skills`@`main`;
 `--ref` overrides). Fetches land in the **durable strategies root** — `SENPI_STRATEGIES_DIR` if set,
-else `/data/workspace/strategies` on agent hosts — never a CWD-relative path: a package written inside
-a managed skill dir is destroyed on the next skill update.
+else `<OPENCLAW_WORKSPACE_DIR>/strategies`, else `/data/workspace/strategies` on agent hosts (with a
+loud stderr warning on the last-resort CWD-relative dev fallback) — never inside a managed skill dir:
+a package written there is destroyed on the next skill update. Bare-id resolution prefers the durable
+root over CWD-relative `strategies/<id>` so a pristine checkout or stale skill-dir copy can't shadow
+the deployed package and its `.deploy-state.json`.
 
 **State file** `<pkg>/.deploy-state.json` — `{instances: {name: {strategyId, wallet, status}}}`, status
 flowing `pending → creating → active → registered → live`. Every sub-action persists, so a kill mid-step

--- a/senpi-strategy-ops/references/lifecycle.md
+++ b/senpi-strategy-ops/references/lifecycle.md
@@ -21,7 +21,9 @@ default 150s) and the agent **re-runs a step until it reports done**.
 
 **Package fetch.** Any step fetches `strategies/<id>/` from the remote if it isn't on disk (`_fetch.py`:
 GitHub tree + raw from `SENPI_SKILLS_REPO`@`SENPI_SKILLS_REF`, default `Senpi-ai/senpi-skills`@`main`;
-`--ref` overrides).
+`--ref` overrides). Fetches land in the **durable strategies root** — `SENPI_STRATEGIES_DIR` if set,
+else `/data/workspace/strategies` on agent hosts — never a CWD-relative path: a package written inside
+a managed skill dir is destroyed on the next skill update.
 
 **State file** `<pkg>/.deploy-state.json` — `{instances: {name: {strategyId, wallet, status}}}`, status
 flowing `pending → creating → active → registered → live`. Every sub-action persists, so a kill mid-step

--- a/senpi-strategy-ops/scripts/_fetch.py
+++ b/senpi-strategy-ops/scripts/_fetch.py
@@ -8,7 +8,10 @@ list the repo tree, then download every strategies/<id>/* file via raw.githubuse
 senpi-skills is public, so this works unauthenticated. Override repo/ref via env or pass ref=.
 GITHUB_TOKEN is used if present (private repos / higher rate limit).
 
-  fetch_package("spider", "strategies")   # -> writes strategies/spider/... , returns the dir
+  fetch_package("spider", _pkg.strategies_root())   # -> writes <root>/spider/... , returns the dir
+
+Callers pass the ABSOLUTE durable root (_pkg.strategies_root()), never a CWD-relative path — a
+package fetched into a managed skill dir is destroyed on the next skill update.
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import http.client

--- a/senpi-strategy-ops/scripts/_fetch.py
+++ b/senpi-strategy-ops/scripts/_fetch.py
@@ -45,6 +45,16 @@ def _get(host, path, accept, timeout):
             pass
 
 
+def _out_path(dest_root, tree_path):
+    """Local dest for a remote tree entry (strategies/<id>/...), refusing any path that escapes
+    dest_root. Defense-in-depth: git won't emit `..` in tree paths, but the repo/ref this fetches
+    from are env-overridable (SENPI_SKILLS_REPO/_REF)."""
+    out = Path(dest_root) / tree_path[len("strategies/"):]
+    if not out.resolve().is_relative_to(Path(dest_root).resolve()):
+        raise FetchError(f"remote tree entry {tree_path!r} escapes the dest root — refusing")
+    return out
+
+
 def fetch_package(strategy_id, dest_root, ref=None, repo=None, timeout=30):
     """Download strategies/<strategy_id>/ from the remote repo into <dest_root>/<strategy_id>.
 
@@ -72,7 +82,7 @@ def fetch_package(strategy_id, dest_root, ref=None, repo=None, timeout=30):
         status, content = _get("raw.githubusercontent.com", f"/{repo}/{ref}/{path}", "*/*", timeout)
         if status != 200:
             raise FetchError(f"raw fetch HTTP {status} for {path}")
-        out = Path(dest_root) / path[len("strategies/"):]
+        out = _out_path(dest_root, path)
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_bytes(content)
     return dest

--- a/senpi-strategy-ops/scripts/_fetch.py
+++ b/senpi-strategy-ops/scripts/_fetch.py
@@ -50,7 +50,9 @@ def _out_path(dest_root, tree_path):
     dest_root. Defense-in-depth: git won't emit `..` in tree paths, but the repo/ref this fetches
     from are env-overridable (SENPI_SKILLS_REPO/_REF)."""
     out = Path(dest_root) / tree_path[len("strategies/"):]
-    if not out.resolve().is_relative_to(Path(dest_root).resolve()):
+    try:  # relative_to+ValueError, not is_relative_to: hosts are documented Python 3.8+
+        out.resolve().relative_to(Path(dest_root).resolve())
+    except ValueError:
         raise FetchError(f"remote tree entry {tree_path!r} escapes the dest root — refusing")
     return out
 

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -15,6 +15,7 @@ Render substitutes ONLY `${wallet_env}` (+ the decision-model env iff a runtime 
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import os
 import re
+import sys
 from pathlib import Path
 
 try:
@@ -156,30 +157,45 @@ def strategies_root():
     dirs on every SKILL.md version bump, destroying anything inside (the 2026-07-30 incident —
     a CWD-relative dest meant deploys run from a skill dir were wiped on the next bump).
 
-    Precedence: SENPI_STRATEGIES_DIR env > /data/workspace/strategies (agent hosts) >
-    CWD-relative strategies/ (dev hosts without /data/workspace — unchanged legacy behavior)."""
+    Precedence: SENPI_STRATEGIES_DIR env > <OPENCLAW_WORKSPACE_DIR>/strategies (the agent
+    workspace, relocatable) > /data/workspace/strategies (agent-host default) > CWD-relative
+    strategies/ (dev hosts with no workspace — legacy behavior, WARNED loudly because it
+    reintroduces the exact CWD-dependence this function exists to remove)."""
     env = os.environ.get("SENPI_STRATEGIES_DIR", "").strip()
     if env:
-        return Path(env)
+        root = Path(env)
+        if not root.is_absolute():
+            print(f"⚠ SENPI_STRATEGIES_DIR={env!r} is a RELATIVE path — packages there may not "
+                  f"survive skill updates; use an absolute path.", file=sys.stderr)
+        return root
+    workspace_env = os.environ.get("OPENCLAW_WORKSPACE_DIR", "").strip()
+    if workspace_env and Path(workspace_env).is_dir():
+        return Path(workspace_env) / "strategies"
     workspace = Path("/data/workspace")
     if workspace.is_dir():
         return workspace / "strategies"
+    print("⚠ no durable strategies root found (no SENPI_STRATEGIES_DIR, no workspace dir) — "
+          "falling back to CWD-relative strategies/. Packages here may not survive skill updates.",
+          file=sys.stderr)
     return Path("strategies")
 
 
 def resolve_pkg_dir(arg):
     """Accept a package PATH (strategies/spider) OR a bare strategy id (spider, as discover emits)
-    and return the directory that holds strategy.yaml. Tries the arg as-is, then strategies/<arg>
-    (CWD-relative, legacy), then <strategies_root()>/<arg> (where remote fetches land)."""
+    and return the directory that holds strategy.yaml. Tries the arg as-is, then
+    <strategies_root()>/<arg> (the durable root where remote fetches land — authoritative for bare
+    ids, since it holds the deploy state), then strategies/<arg> (CWD-relative, legacy fallback for
+    pre-durable-root deploys). Durable-before-CWD matters: a pristine repo checkout or a stale
+    skill-dir copy must not shadow the deployed package and its .deploy-state.json."""
     p = Path(arg)
     if (p / "strategy.yaml").is_file():
         return p
-    nested = Path("strategies") / arg
-    if (nested / "strategy.yaml").is_file():
-        return nested
     durable = strategies_root() / arg
     if (durable / "strategy.yaml").is_file():
         return durable
+    nested = Path("strategies") / arg
+    if (nested / "strategy.yaml").is_file():
+        return nested
     return p  # let load() raise the BadPackage with the original arg
 
 
@@ -214,8 +230,9 @@ def load(pkg_dir) -> Package:
     pkg = resolve_pkg_dir(pkg_dir).resolve()
     man_path = pkg / "strategy.yaml"
     if not man_path.is_file():
-        raise BadPackage(f"{pkg_dir!r}: no strategy.yaml found (looked at {pkg_dir} and "
-                         f"strategies/{pkg_dir}) — pass a strategy id or package directory")
+        raise BadPackage(f"{pkg_dir!r}: no strategy.yaml found (looked at {pkg_dir}, "
+                         f"{strategies_root() / str(pkg_dir)}, and strategies/{pkg_dir}) — "
+                         f"pass a strategy id or package directory")
     try:
         man = yaml.safe_load(man_path.read_text())
     except yaml.YAMLError as e:

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -174,6 +174,9 @@ def strategies_root():
     # is only legitimate on the hardcoded tier below, where it's host detection.
     workspace_env = os.environ.get("OPENCLAW_WORKSPACE_DIR", "").strip()
     if workspace_env:
+        if not Path(workspace_env).is_absolute():
+            print(f"⚠ OPENCLAW_WORKSPACE_DIR={workspace_env!r} is a RELATIVE path — packages there "
+                  f"may not survive skill updates; use an absolute path.", file=sys.stderr)
         return Path(workspace_env) / "strategies"
     workspace = Path("/data/workspace")
     if workspace.is_dir():

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -168,8 +168,12 @@ def strategies_root():
             print(f"⚠ SENPI_STRATEGIES_DIR={env!r} is a RELATIVE path — packages there may not "
                   f"survive skill updates; use an absolute path.", file=sys.stderr)
         return root
+    # A SET workspace env is honored even before the dir exists (fresh volume, gateway not yet
+    # booted — the gateway mkdir -p's it at boot, and fetch mkdir -p's on write): gating on
+    # is_dir() would fall through to CWD-relative, the exact incident behavior. Existence-gating
+    # is only legitimate on the hardcoded tier below, where it's host detection.
     workspace_env = os.environ.get("OPENCLAW_WORKSPACE_DIR", "").strip()
-    if workspace_env and Path(workspace_env).is_dir():
+    if workspace_env:
         return Path(workspace_env) / "strategies"
     workspace = Path("/data/workspace")
     if workspace.is_dir():

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -13,6 +13,7 @@ Render substitutes ONLY `${wallet_env}` (+ the decision-model env iff a runtime 
 `decision_mode: llm` action), then asserts zero `${...}` placeholders remain before deploy.
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import os
 import re
 from pathlib import Path
 
@@ -148,15 +149,37 @@ class Package:
         return any(i.needs_model for i in self.instances)
 
 
+def strategies_root():
+    """Absolute, CWD-independent root where fetched strategy packages live.
+
+    MUST stay outside any managed skill dir: the runtime's skills-manager swap-replaces those
+    dirs on every SKILL.md version bump, destroying anything inside (the 2026-07-30 incident —
+    a CWD-relative dest meant deploys run from a skill dir were wiped on the next bump).
+
+    Precedence: SENPI_STRATEGIES_DIR env > /data/workspace/strategies (agent hosts) >
+    CWD-relative strategies/ (dev hosts without /data/workspace — unchanged legacy behavior)."""
+    env = os.environ.get("SENPI_STRATEGIES_DIR", "").strip()
+    if env:
+        return Path(env)
+    workspace = Path("/data/workspace")
+    if workspace.is_dir():
+        return workspace / "strategies"
+    return Path("strategies")
+
+
 def resolve_pkg_dir(arg):
     """Accept a package PATH (strategies/spider) OR a bare strategy id (spider, as discover emits)
-    and return the directory that holds strategy.yaml. Tries the arg as-is, then strategies/<arg>."""
+    and return the directory that holds strategy.yaml. Tries the arg as-is, then strategies/<arg>
+    (CWD-relative, legacy), then <strategies_root()>/<arg> (where remote fetches land)."""
     p = Path(arg)
     if (p / "strategy.yaml").is_file():
         return p
     nested = Path("strategies") / arg
     if (nested / "strategy.yaml").is_file():
         return nested
+    durable = strategies_root() / arg
+    if (durable / "strategy.yaml").is_file():
+        return durable
     return p  # let load() raise the BadPackage with the original arg
 
 

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -186,19 +186,34 @@ def strategies_root():
 
 def resolve_pkg_dir(arg):
     """Accept a package PATH (strategies/spider) OR a bare strategy id (spider, as discover emits)
-    and return the directory that holds strategy.yaml. Tries the arg as-is, then
-    <strategies_root()>/<arg> (the durable root where remote fetches land — authoritative for bare
-    ids, since it holds the deploy state), then strategies/<arg> (CWD-relative, legacy fallback for
-    pre-durable-root deploys). Durable-before-CWD matters: a pristine repo checkout or a stale
-    skill-dir copy must not shadow the deployed package and its .deploy-state.json."""
+    and return the directory that holds strategy.yaml. Tries the arg as-is (an explicit path is
+    explicit intent — never second-guessed), then <strategies_root()>/<arg> (the durable root where
+    remote fetches land), then strategies/<arg> (CWD-relative, legacy fallback for pre-durable-root
+    deploys). When BOTH the durable and CWD copies exist, the one carrying .deploy-state.json wins —
+    that file is what distinguishes THE DEPLOYED PACKAGE from a checkout of the same id. Either
+    direction of shadowing is money-adjacent: a pristine copy over the deployed one makes `runtime`
+    render catalog-default parameters onto a live recovered wallet; ties go durable (and two copies
+    BOTH carrying state is a real ambiguity — warned loudly, the backend reconcile owns wallet truth)."""
     p = Path(arg)
     if (p / "strategy.yaml").is_file():
         return p
     durable = strategies_root() / arg
-    if (durable / "strategy.yaml").is_file():
-        return durable
     nested = Path("strategies") / arg
-    if (nested / "strategy.yaml").is_file():
+    dur_ok = (durable / "strategy.yaml").is_file()
+    nest_ok = (nested / "strategy.yaml").is_file()
+    if dur_ok and nest_ok and durable.resolve() != nested.resolve():
+        dur_state = (durable / ".deploy-state.json").is_file()
+        nest_state = (nested / ".deploy-state.json").is_file()
+        if nest_state and not dur_state:
+            return nested
+        if nest_state and dur_state:
+            print(f"⚠ two copies of {arg!r} BOTH carry deploy state ({durable} and {nested.resolve()}) "
+                  f"— using the durable one. If that's wrong, pass the package path explicitly.",
+                  file=sys.stderr)
+        return durable
+    if dur_ok:
+        return durable
+    if nest_ok:
         return nested
     return p  # let load() raise the BadPackage with the original arg
 

--- a/senpi-strategy-ops/scripts/close.py
+++ b/senpi-strategy-ops/scripts/close.py
@@ -145,8 +145,10 @@ def main(argv):
         except _pkg.BadPackage as e:
             sid = Path(a.package).name
             try:
-                _fetch.fetch_package(sid, "strategies", ref=a.ref)
-                pkg = _pkg.load(sid)
+                # Same durable, CWD-independent fetch root as deploy.py (see _pkg.strategies_root).
+                dest_root = _pkg.strategies_root()
+                _fetch.fetch_package(sid, dest_root, ref=a.ref)
+                pkg = _pkg.load(dest_root / sid)
             except (_fetch.FetchError, _pkg.BadPackage):
                 raise SystemExit(f"error: {e}")
         if a.instance and a.instance not in {i.name for i in pkg.instances}:

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -55,15 +55,19 @@ def ensure_pkg(arg, ref, log):
     if (_pkg.resolve_pkg_dir(arg) / "strategy.yaml").is_file():
         return _pkg.load(arg)
     sid = Path(arg).name
-    log(f"package {sid!r} not on disk — fetching from remote…")
+    # Fetch to the DURABLE root (absolute, CWD-independent), never a CWD-relative path: a relative
+    # dest resolved inside a managed skill dir gets wiped on the next SKILL.md version bump.
+    dest_root = _pkg.strategies_root()
+    log(f"package {sid!r} not on disk — fetching from remote into {dest_root}…")
     try:
-        _fetch.fetch_package(sid, "strategies", ref=ref)
-        return _pkg.load(sid)
+        _fetch.fetch_package(sid, dest_root, ref=ref)
+        return _pkg.load(dest_root / sid)
     except (_fetch.FetchError, _pkg.BadPackage) as e:
         raise SystemExit(
             f"error: {e}\n"
-            f"  {arg!r} is not a package on disk (tried {arg!r} and 'strategies/{arg}' relative to the "
-            f"current directory) and could not be fetched as a catalog id.\n"
+            f"  {arg!r} is not a package on disk (tried {arg!r} and 'strategies/{arg}' relative to "
+            f"the current directory, and {dest_root / str(arg)}) and could not be fetched as a "
+            f"catalog id.\n"
             f"  Deploying a locally-authored package? Pass its DIRECTORY path instead of a bare id, "
             f"e.g.: deploy.py validate /data/workspace/strategies/{sid}")
 

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -65,8 +65,8 @@ def ensure_pkg(arg, ref, log):
     except (_fetch.FetchError, _pkg.BadPackage) as e:
         raise SystemExit(
             f"error: {e}\n"
-            f"  {arg!r} is not a package on disk (tried {arg!r} and 'strategies/{arg}' relative to "
-            f"the current directory, and {dest_root / str(arg)}) and could not be fetched as a "
+            f"  {arg!r} is not a package on disk (tried {arg!r}, {dest_root / sid}, and "
+            f"'strategies/{arg}' relative to the current directory) and could not be fetched as a "
             f"catalog id.\n"
             f"  Deploying a locally-authored package? Pass its DIRECTORY path instead of a bare id, "
             f"e.g.: deploy.py validate /data/workspace/strategies/{sid}")

--- a/senpi-strategy-ops/scripts/validate_universe.py
+++ b/senpi-strategy-ops/scripts/validate_universe.py
@@ -6,7 +6,7 @@ name, and the strategy silently trades nothing (the `xyz:NASDAQ` incident — th
 `xyz:XYZ100`). This gate makes that failure loud, before money moves.
 
   python3 validate_universe.py strategies/<id> [strategies/<id2> …]   # exit 1 on any unknown ticker
-  python3 validate_universe.py --all                                  # every package under strategies/
+  python3 validate_universe.py --all                                  # every package under the durable root
   python3 validate_universe.py strategies/<id> --json                 # machine-readable report
 
 What counts as "hardcoded": ticker-shaped strings (BTC, xyz:AAPL) in `strategy.yaml` `catalog.assets`
@@ -30,6 +30,7 @@ try:
 except ImportError:  # agent hosts may lack PyYAML / pip
     import _yaml as yaml  # vendored stdlib-only fallback
 from mcp_client import MCPClient, MCPError  # noqa: E402
+import _pkg  # noqa: E402 — strategies_root(), the durable CWD-independent root
 
 
 def load_yaml(path):
@@ -92,16 +93,25 @@ def live_instruments():
     return names
 
 
+def all_packages():
+    """Every package dir under the durable strategies root (`--all`). CWD-relative globbing here was
+    the fetch-dest bug class again: run from a skill dir it scans the wrong root. On a dev host with
+    no durable root, strategies_root() itself falls back to CWD-relative strategies/."""
+    root = _pkg.strategies_root()
+    return sorted(str(d) for d in root.glob("*") if (d / "strategy.yaml").is_file())
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(description="verify hardcoded tickers against live HL instruments")
     ap.add_argument("packages", nargs="*", help="strategy package dirs (e.g. strategies/spider)")
-    ap.add_argument("--all", action="store_true", help="validate every package under strategies/")
+    ap.add_argument("--all", action="store_true",
+                    help="validate every package under the durable strategies root")
     ap.add_argument("--json", action="store_true")
     a = ap.parse_args(argv)
 
     pkgs = a.packages
     if a.all:
-        pkgs = sorted(d for d in glob.glob("strategies/*") if os.path.isfile(os.path.join(d, "strategy.yaml")))
+        pkgs = all_packages()
     if not pkgs:
         ap.error("give package dir(s) or --all")
 

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -245,6 +245,34 @@ def test_resolve_pkg_dir_durable_wins_over_cwd(monkeypatch, tmp_path):
     assert _pkg.resolve_pkg_dir("spider") == tmp_path / "durable" / "spider"
 
 
+def test_resolve_pkg_dir_deploy_state_beats_pristine_durable(monkeypatch, tmp_path):
+    """A legacy CWD-relative copy CARRYING deploy state must not be shadowed by a pristine durable
+    copy (e.g. one a bare-id command fetched from the catalog): .deploy-state.json is what
+    distinguishes 'the deployed package' from 'a checkout of the same id'. Without this, `runtime`
+    self-heals the live wallet from the backend and renders the pristine copy's catalog-default
+    runtime.yaml onto it — silently replacing the user's tuned parameters on live money."""
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="spider")  # pristine fetch, no deploy state
+    legacy = make_flat(tmp_path / "cwd" / "strategies", pkg_id="spider")
+    (legacy / ".deploy-state.json").write_text("{}")
+    monkeypatch.chdir(tmp_path / "cwd")
+    assert _pkg.resolve_pkg_dir("spider") == Path("strategies") / "spider"
+
+
+def test_resolve_pkg_dir_both_have_state_durable_wins_loudly(monkeypatch, tmp_path, capsys):
+    """TWO copies with deploy state = two deploys of the same id — genuinely ambiguous. Durable wins
+    (unchanged precedence), but LOUDLY: the backend reconcile owns wallet truth, the warning makes
+    the ambiguity visible instead of silently picking."""
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    dur = make_flat(tmp_path / "durable", pkg_id="spider")
+    (dur / ".deploy-state.json").write_text("{}")
+    legacy = make_flat(tmp_path / "cwd" / "strategies", pkg_id="spider")
+    (legacy / ".deploy-state.json").write_text("{}")
+    monkeypatch.chdir(tmp_path / "cwd")
+    assert _pkg.resolve_pkg_dir("spider") == tmp_path / "durable" / "spider"
+    assert "deploy state" in capsys.readouterr().err
+
+
 def test_resolve_pkg_dir_cwd_fallback_for_legacy_deploys(monkeypatch, tmp_path):
     """A pre-durable-root deploy that only exists CWD-relative is still found (legacy fallback)."""
     monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))  # exists, but empty

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -203,11 +203,22 @@ def test_strategies_root_workspace_env_tier(monkeypatch, tmp_path):
     assert _pkg.strategies_root() == ws / "strategies"
 
 
+def test_strategies_root_workspace_env_honored_before_dir_exists(monkeypatch, tmp_path):
+    """A SET OPENCLAW_WORKSPACE_DIR is honored even when the dir hasn't materialized yet (fresh
+    volume, gateway not yet booted): the env var declares intent, and the fetch mkdir -p's on
+    write. Gating this tier on is_dir() would silently fall through to CWD-relative — the exact
+    incident behavior — on the boxes least likely to be watched."""
+    monkeypatch.delenv("SENPI_STRATEGIES_DIR", raising=False)
+    ws = tmp_path / "not-created-yet"
+    monkeypatch.setenv("OPENCLAW_WORKSPACE_DIR", str(ws))
+    assert _pkg.strategies_root() == ws / "strategies"
+
+
 def test_strategies_root_cwd_fallback_warns(monkeypatch, tmp_path, capsys):
     """The last-resort CWD-relative fallback (dev host, no workspace) must be LOUD — it silently
     reintroduces the exact CWD-dependence the durable root exists to remove."""
     monkeypatch.delenv("SENPI_STRATEGIES_DIR", raising=False)
-    monkeypatch.setenv("OPENCLAW_WORKSPACE_DIR", str(tmp_path / "nonexistent"))
+    monkeypatch.delenv("OPENCLAW_WORKSPACE_DIR", raising=False)
     if Path("/data/workspace").is_dir():
         pytest.skip("host has /data/workspace — fallback tier unreachable")
     assert _pkg.strategies_root() == Path("strategies")

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -275,6 +275,24 @@ def test_ensure_pkg_fetches_into_durable_root_regardless_of_cwd(monkeypatch, tmp
     assert not (skill_dir / "strategies").exists()  # nothing landed in the skill dir
 
 
+def test_validate_universe_all_lists_durable_root(monkeypatch, tmp_path):
+    """`validate_universe.py --all` must enumerate the durable root, not CWD-relative strategies/ —
+    the same bug class as the fetch dest (a CWD glob inside a skill dir sees nothing / the wrong
+    packages). On a dev host with no durable root, strategies_root() itself falls back to
+    CWD-relative, so legacy behavior is preserved there."""
+    import validate_universe
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="spider")
+    make_flat(tmp_path / "durable", pkg_id="tech-breakout")
+    (tmp_path / "durable" / "not-a-pkg").mkdir()  # no strategy.yaml — must be skipped
+    make_flat(tmp_path / "cwd" / "strategies", pkg_id="cwd-only")
+    monkeypatch.chdir(tmp_path / "cwd")
+    assert validate_universe.all_packages() == [
+        str(tmp_path / "durable" / "spider"),
+        str(tmp_path / "durable" / "tech-breakout"),
+    ]
+
+
 # ─────────────────────── marginPct fraction-vs-percent guard ───────────────────────
 # marginPct is a PERCENT in (0,100]; the v2 FRACTION form (0.10 meant 10) sizes 100× too small and
 # every order is rejected below the ~$10 min notional. The scaffold doc used to teach the fraction —

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -214,6 +214,16 @@ def test_strategies_root_workspace_env_honored_before_dir_exists(monkeypatch, tm
     assert _pkg.strategies_root() == ws / "strategies"
 
 
+def test_strategies_root_relative_workspace_env_warns(monkeypatch, capsys):
+    """A RELATIVE OPENCLAW_WORKSPACE_DIR is honored (platform sets it; overriding a set env would
+    surprise) but warned about, exactly like a relative SENPI_STRATEGIES_DIR: a relative root is
+    CWD-dependent, the wipe hole this module exists to close."""
+    monkeypatch.delenv("SENPI_STRATEGIES_DIR", raising=False)
+    monkeypatch.setenv("OPENCLAW_WORKSPACE_DIR", "relative-ws")
+    assert _pkg.strategies_root() == Path("relative-ws") / "strategies"
+    assert "RELATIVE" in capsys.readouterr().err
+
+
 def test_strategies_root_cwd_fallback_warns(monkeypatch, tmp_path, capsys):
     """The last-resort CWD-relative fallback (dev host, no workspace) must be LOUD — it silently
     reintroduces the exact CWD-dependence the durable root exists to remove."""

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -8,6 +8,7 @@ bake-off (Samurai/Qwen, Gemini, GLM), where every model tripped on the same auth
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -179,6 +180,57 @@ def test_full_validate_catches_unresolved_placeholder(tmp_path):
     pkg = _pkg.load(str(d))
     errs = deploy.full_validate(pkg)
     assert any("UNBOUND_THING" in e for e in errs)
+
+
+# ─────────────────────── durable strategies root (the 2026-07-30 wipe fix) ───────────────────────
+# Remote fetches must land at an ABSOLUTE, CWD-independent root: a CWD-relative dest resolved inside
+# a managed skill dir gets destroyed on the next SKILL.md version bump (the skills-manager
+# swap-replace). These lock the env override, the resolution fallback, and the fetch destination.
+
+
+def test_strategies_root_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    assert _pkg.strategies_root() == tmp_path / "durable"
+
+
+def test_resolve_pkg_dir_falls_back_to_durable_root(monkeypatch, tmp_path):
+    """A bare id resolves from the durable root when the CWD has no such package — so `deploy.py
+    runtime <id>` finds a previously fetched package from ANY working directory."""
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="spider")
+    monkeypatch.chdir(tmp_path)  # CWD has no strategies/spider
+    assert _pkg.resolve_pkg_dir("spider") == tmp_path / "durable" / "spider"
+
+
+def test_resolve_pkg_dir_cwd_still_wins(monkeypatch, tmp_path):
+    """CWD-relative resolution is unchanged (and wins over the durable root) — an on-disk package
+    next to the caller stays authoritative."""
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="spider")
+    make_flat(tmp_path / "cwd" / "strategies", pkg_id="spider")
+    monkeypatch.chdir(tmp_path / "cwd")
+    assert _pkg.resolve_pkg_dir("spider") == Path("strategies") / "spider"
+
+
+def test_ensure_pkg_fetches_into_durable_root_regardless_of_cwd(monkeypatch, tmp_path):
+    """The incident fix itself: a remote fetch writes to the durable root even when the CWD is a
+    (managed, wipeable) skill dir — and the fetched package loads without CWD help."""
+    deploy = _import_deploy()
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    fetched = {}
+
+    def fake_fetch(sid, dest_root, ref=None, **kw):
+        fetched["dest_root"] = dest_root
+        make_flat(Path(dest_root), pkg_id=sid)
+
+    monkeypatch.setattr(deploy._fetch, "fetch_package", fake_fetch)
+    skill_dir = tmp_path / "skills" / "senpi-strategy-ops"
+    skill_dir.mkdir(parents=True)
+    monkeypatch.chdir(skill_dir)  # the CWD-lottery losing position
+    pkg = deploy.ensure_pkg("tech-breakout", None, lambda m: None)
+    assert fetched["dest_root"] == tmp_path / "durable"
+    assert pkg.dir == (tmp_path / "durable" / "tech-breakout").resolve()
+    assert not (skill_dir / "strategies").exists()  # nothing landed in the skill dir
 
 
 # ─────────────────────── marginPct fraction-vs-percent guard ───────────────────────

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -303,6 +303,16 @@ def test_ensure_pkg_fetches_into_durable_root_regardless_of_cwd(monkeypatch, tmp
     assert not (skill_dir / "strategies").exists()  # nothing landed in the skill dir
 
 
+def test_fetch_out_path_refuses_traversal(tmp_path):
+    """Defense-in-depth: a remote tree entry with a `..` segment must never write outside the
+    dest root. git won't emit `..` in tree paths, but the repo/ref are env-overridable."""
+    import _fetch
+    assert _fetch._out_path(tmp_path, "strategies/spider/runtime.yaml") \
+        == tmp_path / "spider" / "runtime.yaml"
+    with pytest.raises(_fetch.FetchError):
+        _fetch._out_path(tmp_path, "strategies/../../evil.py")
+
+
 def test_validate_universe_all_lists_durable_root(monkeypatch, tmp_path):
     """`validate_universe.py --all` must enumerate the durable root, not CWD-relative strategies/ —
     the same bug class as the fetch dest (a CWD glob inside a skill dir sees nothing / the wrong

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -193,7 +193,28 @@ def test_strategies_root_env_override(monkeypatch, tmp_path):
     assert _pkg.strategies_root() == tmp_path / "durable"
 
 
-def test_resolve_pkg_dir_falls_back_to_durable_root(monkeypatch, tmp_path):
+def test_strategies_root_workspace_env_tier(monkeypatch, tmp_path):
+    """Without SENPI_STRATEGIES_DIR, the agent workspace (OPENCLAW_WORKSPACE_DIR) is the root —
+    the workspace is relocatable and /data/workspace must not be assumed."""
+    monkeypatch.delenv("SENPI_STRATEGIES_DIR", raising=False)
+    ws = tmp_path / "relocated-ws"
+    ws.mkdir()
+    monkeypatch.setenv("OPENCLAW_WORKSPACE_DIR", str(ws))
+    assert _pkg.strategies_root() == ws / "strategies"
+
+
+def test_strategies_root_cwd_fallback_warns(monkeypatch, tmp_path, capsys):
+    """The last-resort CWD-relative fallback (dev host, no workspace) must be LOUD — it silently
+    reintroduces the exact CWD-dependence the durable root exists to remove."""
+    monkeypatch.delenv("SENPI_STRATEGIES_DIR", raising=False)
+    monkeypatch.setenv("OPENCLAW_WORKSPACE_DIR", str(tmp_path / "nonexistent"))
+    if Path("/data/workspace").is_dir():
+        pytest.skip("host has /data/workspace — fallback tier unreachable")
+    assert _pkg.strategies_root() == Path("strategies")
+    assert "may not survive skill updates" in capsys.readouterr().err
+
+
+def test_resolve_pkg_dir_durable_root_from_any_cwd(monkeypatch, tmp_path):
     """A bare id resolves from the durable root when the CWD has no such package — so `deploy.py
     runtime <id>` finds a previously fetched package from ANY working directory."""
     monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
@@ -202,11 +223,21 @@ def test_resolve_pkg_dir_falls_back_to_durable_root(monkeypatch, tmp_path):
     assert _pkg.resolve_pkg_dir("spider") == tmp_path / "durable" / "spider"
 
 
-def test_resolve_pkg_dir_cwd_still_wins(monkeypatch, tmp_path):
-    """CWD-relative resolution is unchanged (and wins over the durable root) — an on-disk package
-    next to the caller stays authoritative."""
+def test_resolve_pkg_dir_durable_wins_over_cwd(monkeypatch, tmp_path):
+    """When BOTH exist, the durable copy wins: it holds the deploy state (.deploy-state.json), so a
+    pristine repo checkout or stale skill-dir copy in the CWD must not shadow it — resolving the
+    wrong copy can fund a wallet twice or register a runtime against a dead wallet."""
     monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
     make_flat(tmp_path / "durable", pkg_id="spider")
+    make_flat(tmp_path / "cwd" / "strategies", pkg_id="spider")
+    monkeypatch.chdir(tmp_path / "cwd")
+    assert _pkg.resolve_pkg_dir("spider") == tmp_path / "durable" / "spider"
+
+
+def test_resolve_pkg_dir_cwd_fallback_for_legacy_deploys(monkeypatch, tmp_path):
+    """A pre-durable-root deploy that only exists CWD-relative is still found (legacy fallback)."""
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))  # exists, but empty
+    (tmp_path / "durable").mkdir()
     make_flat(tmp_path / "cwd" / "strategies", pkg_id="spider")
     monkeypatch.chdir(tmp_path / "cwd")
     assert _pkg.resolve_pkg_dir("spider") == Path("strategies") / "spider"


### PR DESCRIPTION
## Problem

`deploy.py`/`close.py` fetched remote strategy packages into a **CWD-relative** `strategies/` dir. When the agent shell's CWD was inside a managed skill dir (a common place to run the scripts from), the package — and its `.deploy-state.json` — landed inside a directory the runtime's skills-manager swap-replaces on every SKILL.md version bump. Those deployments were silently destroyed and their scanners died at the next gateway restart (`scanner mount failed — entrypoint not found`, the 2026-07-30 fleet incident). Whether a user's deploy survived was a pure CWD lottery — and the authoring flow had the same lottery, since the author skill scaffolded at CWD-relative `strategies/<id>` too.

Ticket: https://app.notion.com/p/3ae1feaac80681478ddde5d6a307648a

## Fix

- New `_pkg.strategies_root()` — the single durable, CWD-independent root: `SENPI_STRATEGIES_DIR` env override → `<OPENCLAW_WORKSPACE_DIR>/strategies` (the workspace is relocatable) → `/data/workspace/strategies` (agent-host default) → legacy CWD-relative `strategies/` for dev hosts, now with a **loud stderr warning** (it reintroduces the exact CWD-dependence this exists to remove; a relative `SENPI_STRATEGIES_DIR` warns too).
- `deploy.py ensure_pkg` and `close.py` fetch into that root and load by explicit absolute path — no CWD dependence.
- **Bare-id resolution prefers the durable root over CWD** (arg-as-is → durable → CWD-relative legacy fallback): the durable copy holds the deploy state, and letting a pristine checkout or stale skill-dir copy shadow it can double-fund a wallet or register a runtime against a dead one. Pre-durable-root deploys that only exist CWD-relative are still found via the fallback.
- **Author flow fixed** (the remaining wipe vector): `senpi-strategy-author/SKILL.md` + `references/creating-a-strategy.md` now scaffold and validate at `/data/workspace/strategies/<id>` with an explicit never-inside-a-skill-dir rule. Author bumped to **2.11.0**.
- Ops `SKILL.md` + `references/lifecycle.md` document the root and the resolution order; resolver error messages name every location actually tried. Ops bumped to **2.10.0**.
- Tests (111 passing): env/workspace tiers, loud fallback, durable-from-any-CWD, durable-beats-CWD shadowing, legacy CWD fallback, and the incident case itself (fetch with CWD = skill dir writes to the durable root, nothing lands in the skill dir).

## Review

Adversarially reviewed by two independent passes; addressed in `b2fbb22a` (workspace tier, loud fallbacks, durable-first precedence, author-skill guidance, error messages). Known residuals, deliberate: an on-disk package remains authoritative (`--ref` never overwrites a resolvable local copy — pre-existing design); `close.py`'s invalid-local → remote-fetch fallback is pre-existing; already-deployed packages inside skill dirs are not migrated by this PR (the restore initiative owns relocation — until then they're protected by the runtime preserve-list).

## ⚠️ Merge ordering

**Do not merge until Senpi-ai/senpi-trading-runtime#273 is released and fleet-converged** (verify via ClickStack `service.version` distribution). Merging this bumps ops to 2.10.0 and author to 2.11.0, triggering fleet-wide reinstalls of both skill dirs — the exact operation that wipes user data on boxes still running a runtime without the preserve-list fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes where packages resolve and which copy wins when duplicates exist — wrong resolution can double-fund or render the wrong runtime onto live wallets; fleet skill bumps can still wipe pre-migration packages until runtime #273 is deployed.
> 
> **Overview**
> **Strategy packages and deploy state must live outside managed skill dirs** — CWD-relative `strategies/` caused fetches and authored packages to land inside wipeable skill trees on the next version bump.
> 
> Ops adds **`_pkg.strategies_root()`** (`SENPI_STRATEGIES_DIR` → `OPENCLAW_WORKSPACE_DIR/strategies` → `/data/workspace/strategies` → legacy CWD with stderr warnings). **`deploy.py`**, **`close.py`**, and **`validate_universe.py --all`** fetch and enumerate from that root. **`resolve_pkg_dir`** prefers the durable copy, uses **`.deploy-state.json`** when durable and CWD copies conflict, and keeps a CWD legacy fallback. **`_fetch._out_path`** blocks path traversal on remote tree entries.
> 
> **Author skill 2.11.0** scaffolds and validates at `/data/workspace/strategies/<id>` with an explicit never-inside-skill-dir rule; **ops 2.10.0** docs mirror the resolution order. Tests lock root tiers, shadowing, fetch-from-skill-CWD, and traversal refusal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec7e88ad17562d3a82978eb0b11ff630d004354. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

