### PR TITLE
fix(strategies): spider marginPct is a PERCENT, not a fraction

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -3122,7 +3122,7 @@
       "emoji": "🕷️",
       "tagline": "An AI/Tech momentum long book plus a macro/majors mean-reversion book — two legs, two wallets, one package.",
       "belief_plain": "AI/tech equities and crypto majors trend over days, while majors and energy snap back from short-term extremes — run both books side by side.",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "thesis": null,
       "tags": [
         "ai",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -3122,7 +3122,7 @@
       "emoji": "🕷️",
       "tagline": "An AI/Tech momentum long book plus a macro/majors mean-reversion book — two legs, two wallets, one package.",
       "belief_plain": "AI/tech equities and crypto majors trend over days, while majors and energy snap back from short-term extremes — run both books side by side.",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "thesis": null,
       "tags": [
         "ai",

--- a/strategies/spider/scalp/runtime.yaml
+++ b/strategies/spider/scalp/runtime.yaml
@@ -19,7 +19,7 @@ description: >
 strategy:
   wallet: "${SPIDER_SCALP_WALLET}"
   slots: 4                          # source maxSlots 4
-  margin_pct: 15                    # fallback %; scan emits per-signal marginPct=15 (source marginPct 0.15 * 100)
+  margin_pct: 15                    # fallback %; scan emits the same per-signal marginPct (source fraction 0.15 -> 15 PERCENT)
   default_leverage: 5               # source scalpMaxLeverage cap (clamped per-asset to HL venue max in scan.py)
   trading_risk: moderate
   enabled: true
@@ -40,7 +40,7 @@ scanners:
     inputs:
       allowedAssets: ["BTC", "ETH", "SOL", "HYPE", "xyz:BRENTOIL", "xyz:CL"]
       minScore: 4
-      marginPct: 0.15
+      marginPct: 15                        # PERCENT of withdrawable (0,100] — runtime sizes (marginPct/100)*withdrawable
       maxLeverage: 5
       maxSlots: 4
       rsiOversold: 30

--- a/strategies/spider/scalp/scanners/scan.py
+++ b/strategies/spider/scalp/scanners/scan.py
@@ -28,6 +28,9 @@ import scoring
 
 _DEFAULT_RECENT_TTL = 180
 
+# Per-signal margin as a PERCENT of equity in (0,100] (source marginPct 0.15 fraction).
+_DEFAULT_MARGIN_PCT = 15.0
+
 
 def _dex_for(asset):
     return "xyz" if asset.lower().startswith("xyz:") else ""
@@ -136,7 +139,11 @@ def _prune_signaled(signaled, ttl, now):
 def scan(inputs, ctx):
     now = time.time()
     min_score = inputs.get("minScore", 4)
-    margin_pct = float(inputs.get("marginPct", 0.15))
+    # margin PERCENT of equity in (0,100] (source fraction 0.15 -> 15). Defensive
+    # guard: a value <=1.0 is a pasted FRACTION -> x100.
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        margin_pct *= 100
     leg_max_lev = inputs.get("maxLeverage", 5)
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
     venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
@@ -149,7 +156,7 @@ def scan(inputs, ctx):
         return []
 
     min_notional = max(account_value * min_notional_pct, venue_min_notional)
-    margin_usd = round(account_value * margin_pct, 2)
+    margin_usd = round(account_value * margin_pct / 100.0, 2)
 
     signaled = _prune_signaled(_load_signaled(ctx), ttl, now)
 
@@ -192,10 +199,9 @@ def scan(inputs, ctx):
         if leverage <= 0 or notional < min_notional:
             continue
         # Runtime 3.0 sizes off a top-level marginPct (PERCENT of equity in (0,100]),
-        # NOT a top-level marginUsd (silently dropped). margin_usd was computed as
-        # account_value * marginPct, so marginPct-of-equity = margin_usd/account_value*100
-        # reproduces the intended fraction exactly. account_value > 0 here (guarded above).
-        margin_pct_emit = round(min(max(margin_usd / account_value * 100.0, 0.01), 100.0), 4)
+        # NOT a top-level marginUsd (silently dropped). Emit the configured PERCENT
+        # verbatim, clamped into the runtime's accepted range.
+        margin_pct_emit = round(min(max(margin_pct, 0.01), 100.0), 4)
         out.append({
             "asset": th["coin"],
             "direction": th["direction"],

--- a/strategies/spider/strategy.yaml
+++ b/strategies/spider/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: spider                  # == package dir name; == every leg's runtime.yaml `group`
-version: "6.0.1"            # single source for catalog + MCP attribution (skillName/skillVersion)
+version: "6.0.2"            # single source for catalog + MCP attribution (skillName/skillVersion)
 
 catalog:                    # discovery surface. `group` here is the discovery TAXONOMY bucket —
                             # distinct from each runtime.yaml's `group: spider` linkage key.

--- a/strategies/spider/swing/runtime.yaml
+++ b/strategies/spider/swing/runtime.yaml
@@ -19,7 +19,7 @@ description: >
 strategy:
   wallet: "${SPIDER_SWING_WALLET}"
   slots: 3                          # source maxSlots 3
-  margin_pct: 28                    # fallback %; scan emits per-signal marginPct=28 (source marginPct 0.28 * 100)
+  margin_pct: 28                    # fallback %; scan emits the same per-signal marginPct (source fraction 0.28 -> 28 PERCENT)
   default_leverage: 10              # source swingMaxLeverage cap (clamped per-asset to HL venue max in scan.py)
   trading_risk: moderate
   enabled: true
@@ -48,7 +48,7 @@ scanners:
       allowedAssets: ["xyz:NVDA", "xyz:AMD", "xyz:INTC", "xyz:MRVL", "xyz:MU", "xyz:TSM", "SUI", "ONDO", "HYPE", "NIL", "GRASS", "ZEC"]
       # ── scoring knobs ──
       minScore: 5
-      marginPct: 0.28
+      marginPct: 28                   # PERCENT of withdrawable (0,100] — runtime sizes (marginPct/100)*withdrawable
       maxLeverage: 10
       maxSlots: 3
       rsiMaxLong: 78

--- a/strategies/spider/swing/scanners/scan.py
+++ b/strategies/spider/swing/scanners/scan.py
@@ -24,10 +24,10 @@ What was simplified vs the source (FLAGGED):
     qualifying candidates above minScore (held + recently-signaled filtered).
     The signal-GATING thresholds (minScore, held-set, recent-dedup, venue min
     notional) are preserved exactly; only the per-tick emission CAP moves to the
-    runtime. margin_usd is still computed (account_value * marginPct) for the
-    venue-min-notional check, then emitted as a top-level `marginPct` (PERCENT of
-    equity, = marginPct*100) so Runtime 3.0 sizes the dollars identically to the
-    source.
+    runtime. inputs.marginPct is a PERCENT of equity in (0,100] (source fraction
+    0.28 -> 28); margin_usd is still computed (account_value * marginPct/100) for
+    the venue-min-notional check, and the same PERCENT is emitted as a top-level
+    `marginPct` so Runtime 3.0 sizes the dollars identically to the source.
 """
 
 import sys
@@ -39,6 +39,9 @@ import scoring
 # How long after emitting a signal we treat the asset as "in-flight" and refuse
 # to re-emit (source RECENT_SIGNAL_TTL_SEC = 180). Overridable via inputs.
 _DEFAULT_RECENT_TTL = 180
+
+# Per-signal margin as a PERCENT of equity in (0,100] (source marginPct 0.28 fraction).
+_DEFAULT_MARGIN_PCT = 28.0
 
 
 # ── MCP data fetchers (route the producer's calls through ctx.senpi_mcp) ──
@@ -248,7 +251,11 @@ def _build_universe(inputs, meta_map, first_seen, now):
 def scan(inputs, ctx):
     now = time.time()
     min_score = inputs.get("minScore", 5)
-    margin_pct = float(inputs.get("marginPct", 0.28))
+    # margin PERCENT of equity in (0,100] (source fraction 0.28 -> 28). Defensive
+    # guard: a value <=1.0 is a pasted FRACTION -> x100.
+    margin_pct = float(inputs.get("marginPct", _DEFAULT_MARGIN_PCT))
+    if margin_pct <= 1.0:
+        margin_pct *= 100
     leg_max_lev = inputs.get("maxLeverage", 10)
     ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_RECENT_TTL))
     venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
@@ -261,7 +268,7 @@ def scan(inputs, ctx):
         return []
 
     min_notional = max(account_value * min_notional_pct, venue_min_notional)
-    margin_usd = round(account_value * margin_pct, 2)
+    margin_usd = round(account_value * margin_pct / 100.0, 2)
 
     signaled, first_seen = _load_state_maps(ctx)
     signaled = _prune_signaled(signaled, ttl, now)
@@ -308,10 +315,9 @@ def scan(inputs, ctx):
         if leverage <= 0 or notional < min_notional:
             continue
         # Runtime 3.0 sizes off a top-level marginPct (PERCENT of equity in (0,100]),
-        # NOT a top-level marginUsd (silently dropped). margin_usd was computed as
-        # account_value * marginPct, so marginPct-of-equity = margin_usd/account_value*100
-        # reproduces the intended fraction exactly. account_value > 0 here (guarded above).
-        margin_pct_emit = round(min(max(margin_usd / account_value * 100.0, 0.01), 100.0), 4)
+        # NOT a top-level marginUsd (silently dropped). Emit the configured PERCENT
+        # verbatim, clamped into the runtime's accepted range.
+        margin_pct_emit = round(min(max(margin_pct, 0.01), 100.0), 4)
         out.append({
             "asset": th["coin"],
             "direction": th["direction"],


### PR DESCRIPTION
## The bug

The `spider` package on `main` is deploy-blocked. Both legs carry the fraction form of `marginPct` in their scanner inputs, and the percent guard refuses the package before funding:

```
$ python3 senpi-strategy-ops/scripts/deploy.py validate strategies/spider
instance swing: scanners[1].inputs.marginPct must be a PERCENT in (0,100] — set 28 (not 0.28)
instance scalp: scanners[1].inputs.marginPct must be a PERCENT in (0,100] — set 15 (not 0.15)
```

Confirmed live on a dev box today. Nobody can deploy spider from the catalog.

`marginPct` is a PERCENT of withdrawable margin in (0,100] everywhere in the runtime. The fraction form (`0.28` meaning 28%) is the recurring slip that sizes positions **100× too small** — a $5,000 wallet meant to open at $1,400 of margin opens at $14 instead, which then falls under the venue minimum notional and no-trades, or trades a position too small to matter. That's exactly what `margin_fraction_offenders` in `_pkg.py` and `validate_strategy.py` exist to catch pre-funding, and spider's own template tripped it.

## The fix

- `strategies/spider/swing/runtime.yaml`: `marginPct: 0.28` → `28`
- `strategies/spider/scalp/runtime.yaml`: `marginPct: 0.15` → `15`
- Both `scanners/scan.py`: read the input as a PERCENT. `margin_usd` (used only for the venue-min-notional check) is now `account_value * marginPct/100`, and the emitted top-level `marginPct` is the configured percent verbatim rather than being round-tripped back out of `margin_usd`. Added the standard `<=1.0 is a pasted fraction -> x100` defensive guard that marlin / bald-eagle / the other converted packages carry.
- Docstrings and the `strategy.margin_pct` fallback comments no longer teach the fraction form.
- `strategy.yaml` version `6.0.1` → `6.0.2`; `catalog.json` regenerated via `gen_catalog.py` into both locations (`strategies/` and `senpi-strategy-discover/`). Not hand-edited.

**Sizing is unchanged: 28% (swing) / 15% (scalp) of equity, same as the v5.1.1 producer.** Worth flagging honestly: spider's scanners divided the fraction *back out* (`margin_usd / account_value * 100`) before emitting, so the value that actually reached the runtime was already `28` / `15`. The 100× undersizing was therefore **latent, not live** — the package was internally consistent under a private unit convention that disagreed with the rest of the catalog. That convention is what tripped the validator, and it is the trap that fires the moment anyone edits the knob trusting the unit in the YAML. Both the declared inputs and the scanner math now agree with the runtime contract.

## Validation

```
$ python3 senpi-strategy-author/scripts/validate_strategy.py strategies/spider
✓ spider v6.0.2 (2 instance(s))

$ python3 senpi-strategy-ops/scripts/validate_universe.py strategies/spider
✓ strategies/spider: 17 hardcoded ticker(s), all live

$ python3 senpi-strategy-ops/scripts/deploy.py validate strategies/spider
✓ spider: deploy-ready (2 instance(s))

$ python3 -m pytest senpi-strategy-ops/tests/ -q
98 passed in 0.17s
```

Scope: spider package + the two regenerated catalogs only. No `senpi-strategy-ops` script or SKILL.md changes, to stay clear of #506. No other pre-existing spider issues surfaced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes position-sizing inputs and scanner math for a live strategy package; impact is bounded to Spider and keeps the same target margin percentages, but any mismatch with runtime expectations would affect trade size.
> 
> **Overview**
> **Spider** was **undeployable** because scalp and swing scanner inputs used **fraction** `marginPct` (`0.15` / `0.28`), which `validate_strategy` / deploy reject in favor of **percent** values in `(0,100]`.
> 
> The fix sets **`marginPct: 15`** and **`28`** in both `runtime.yaml` files, bumps the package to **`6.0.2`** in `strategy.yaml` and regenerated **`catalog.json`**, and updates **scalp/swing `scan.py`** to treat inputs as percent (`margin_usd = account_value * marginPct/100`), emit that percent on signals, and apply the usual **`<= 1.0` → ×100** guard for pasted fractions. Comments/docstrings now describe percent units consistently.
> 
> Intended sizing stays **15% / 28% of equity**; emitted runtime values were already effectively correct via the old round-trip, so this mainly **unblocks deploy** and removes a **100× undersize trap** if someone trusted the YAML fraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2116759545187a0e30bb3e98e0aa96abe691dc66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->