### PR TITLE
Path-form args resolve the durable package; never fetch over deploy state

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.10.0"
+  version: "2.10.1"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/scripts/_pkg.py
+++ b/senpi-strategy-ops/scripts/_pkg.py
@@ -200,8 +200,14 @@ def resolve_pkg_dir(arg):
     p = Path(arg)
     if (p / "strategy.yaml").is_file():
         return p
-    durable = strategies_root() / arg
-    nested = Path("strategies") / arg
+    # Bare-id tiers key on the BASENAME — the strategy id, and exactly what ensure_pkg would fetch.
+    # Keying on the raw arg doubled the prefix for the documented path form (strategies/<id> →
+    # <root>/strategies/<id>), so the deployed package looked missing from a foreign CWD and the
+    # fallback fetch overwrote its tuned files IN PLACE (deploy state intact, files pristine).
+    # Resolution must always try the exact location the fetch would write to.
+    sid = p.name
+    durable = strategies_root() / sid
+    nested = Path("strategies") / sid
     dur_ok = (durable / "strategy.yaml").is_file()
     nest_ok = (nested / "strategy.yaml").is_file()
     if dur_ok and nest_ok and durable.resolve() != nested.resolve():
@@ -210,7 +216,7 @@ def resolve_pkg_dir(arg):
         if nest_state and not dur_state:
             return nested
         if nest_state and dur_state:
-            print(f"⚠ two copies of {arg!r} BOTH carry deploy state ({durable} and {nested.resolve()}) "
+            print(f"⚠ two copies of {sid!r} BOTH carry deploy state ({durable} and {nested.resolve()}) "
                   f"— using the durable one. If that's wrong, pass the package path explicitly.",
                   file=sys.stderr)
         return durable
@@ -252,8 +258,9 @@ def load(pkg_dir) -> Package:
     pkg = resolve_pkg_dir(pkg_dir).resolve()
     man_path = pkg / "strategy.yaml"
     if not man_path.is_file():
+        sid = Path(str(pkg_dir)).name
         raise BadPackage(f"{pkg_dir!r}: no strategy.yaml found (looked at {pkg_dir}, "
-                         f"{strategies_root() / str(pkg_dir)}, and strategies/{pkg_dir}) — "
+                         f"{strategies_root() / sid}, and strategies/{sid}) — "
                          f"pass a strategy id or package directory")
     try:
         man = yaml.safe_load(man_path.read_text())

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -58,6 +58,14 @@ def ensure_pkg(arg, ref, log):
     # Fetch to the DURABLE root (absolute, CWD-independent), never a CWD-relative path: a relative
     # dest resolved inside a managed skill dir gets wiped on the next SKILL.md version bump.
     dest_root = _pkg.strategies_root()
+    # A dest dir carrying deploy state but no loadable strategy.yaml is a partially-wiped DEPLOYED
+    # package — fetching would graft pristine catalog files onto live deploy state, and `runtime`
+    # would then render catalog defaults onto the live wallet. Refuse; this needs eyes, not a fetch.
+    if (dest_root / sid / ".deploy-state.json").is_file():
+        raise SystemExit(
+            f"error: {dest_root / sid} carries deploy state (.deploy-state.json) but no loadable "
+            f"strategy.yaml — refusing to fetch the catalog copy over a deployed package's remains.\n"
+            f"  Inspect the directory and restore its files (or move the state aside) first.")
     log(f"package {sid!r} not on disk — fetching from remote into {dest_root}…")
     try:
         _fetch.fetch_package(sid, dest_root, ref=ref)
@@ -66,7 +74,7 @@ def ensure_pkg(arg, ref, log):
         raise SystemExit(
             f"error: {e}\n"
             f"  {arg!r} is not a package on disk (tried {arg!r}, {dest_root / sid}, and "
-            f"'strategies/{arg}' relative to the current directory) and could not be fetched as a "
+            f"'strategies/{sid}' relative to the current directory) and could not be fetched as a "
             f"catalog id.\n"
             f"  Deploying a locally-authored package? Pass its DIRECTORY path instead of a bare id, "
             f"e.g.: deploy.py validate /data/workspace/strategies/{sid}")

--- a/senpi-strategy-ops/tests/test_pkg.py
+++ b/senpi-strategy-ops/tests/test_pkg.py
@@ -255,6 +255,37 @@ def test_resolve_pkg_dir_durable_wins_over_cwd(monkeypatch, tmp_path):
     assert _pkg.resolve_pkg_dir("spider") == tmp_path / "durable" / "spider"
 
 
+def test_resolve_pkg_dir_path_form_finds_durable_package(monkeypatch, tmp_path):
+    """The documented PATH form (strategies/<id>) must hit the durable copy too: the bare-id tiers
+    key on Path(arg).name, exactly the id ensure_pkg would fetch. Building them as <tier>/<arg>
+    doubled the prefix (<root>/strategies/<id>), so from a foreign CWD the deployed package looked
+    missing and the fallback fetch OVERWROTE its tuned files in place — deploy state intact, files
+    pristine — the worst variant of the catalog-defaults-onto-live-wallet failure."""
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    make_flat(tmp_path / "durable", pkg_id="spider")
+    monkeypatch.chdir(tmp_path)  # no strategies/spider here — tier 1 misses
+    assert _pkg.resolve_pkg_dir("strategies/spider") == tmp_path / "durable" / "spider"
+
+
+def test_ensure_pkg_never_fetches_over_deploy_state(monkeypatch, tmp_path):
+    """A dest dir carrying .deploy-state.json but no loadable strategy.yaml (partially wiped
+    deployed package) must REFUSE the catalog fetch, not overwrite in place: the fetch would
+    graft pristine files onto live deploy state."""
+    deploy = _import_deploy()
+    monkeypatch.setenv("SENPI_STRATEGIES_DIR", str(tmp_path / "durable"))
+    broken = tmp_path / "durable" / "spider"
+    broken.mkdir(parents=True)
+    (broken / ".deploy-state.json").write_text("{}")
+    called = []
+    monkeypatch.setattr(deploy._fetch, "fetch_package",
+                        lambda *a, **k: called.append(a))
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(SystemExit) as e:
+        deploy.ensure_pkg("spider", None, lambda m: None)
+    assert "deploy state" in str(e.value)
+    assert not called  # the fetch must never have run
+
+
 def test_resolve_pkg_dir_deploy_state_beats_pristine_durable(monkeypatch, tmp_path):
     """A legacy CWD-relative copy CARRYING deploy state must not be shadowed by a pristine durable
     copy (e.g. one a bare-id command fetched from the catalog): .deploy-state.json is what


### PR DESCRIPTION
## Problem

Follow-up to #506 — this fix landed on the branch two minutes after the squash-merge, addressing the last Bugbot finding there (https://github.com/Senpi-ai/senpi-skills/pull/506#discussion_r3692169245).

`resolve_pkg_dir` built its bare-id tiers from the raw arg, so the documented **path form** (`strategies/<id>`) doubled the prefix (`<root>/strategies/<id>`) and missed the deployed durable copy — while `ensure_pkg`'s fallback fetch keys on the **basename** and writes to exactly the directory resolution failed to find. Path-form arg + foreign CWD = pristine catalog files grafted onto the deployed package **in place**, `.deploy-state.json` intact: a later `runtime` renders catalog defaults onto the live wallet. Worse than the shadowing case #506 fixed — there is only one copy, so no resolution preference can recover it. This variant was introduced by #506 itself (pre-durable-root, fetches were CWD-relative and couldn't land on a deployed copy).

## Fix

- Both bare-id tiers key on `Path(arg).name` — restoring the invariant that **resolution always tries the exact location a fetch would write to**. `spider`, `strategies/spider`, and any path spelling of the id resolve identically; explicit real paths still win via the as-is tier.
- Error messages (`load()`, `ensure_pkg`) name the locations actually tried instead of the double-prefixed ones.
- Defense-in-depth on the remaining edge: a fetch destination carrying `.deploy-state.json` but no loadable `strategy.yaml` (a partially wiped deployed package) now **refuses** the fetch instead of overwriting.
- Ops bumped to **2.10.1** so the fix propagates to boxes that already refreshed at 2.10.0.

Tests: `test_resolve_pkg_dir_path_form_finds_durable_package`, `test_ensure_pkg_never_fetches_over_deploy_state` (suite 111 → 113, all passing).

## Merge note

The 2.10.1 bump triggers the same fleet skill-reinstall operation as #506's 2.10.0 — it rides the same runtime-#273 preserve-list gate that cleared #506's merge. No new constraint, but if any straggler boxes were being handled per-box after #506, this bump reaches them under the same policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes deploy-time package resolution and fetch guards on money-adjacent paths; mistakes could still mis-resolve packages or block recovery, but the fix closes a live-wallet catalog-default overwrite hole.
> 
> **Overview**
> Fixes package resolution so **`strategies/<id>`** and bare **`id`** hit the same durable directory as catalog fetch (`<root>/<id>`), instead of wrongly probing `<root>/strategies/<id>` and triggering an in-place catalog overwrite that left **`.deploy-state.json`** on tuned live packages.
> 
> **`resolve_pkg_dir`** now keys durable and CWD fallback tiers on **`Path(arg).name`**; **`load`** / **`ensure_pkg`** error text lists the paths actually tried. **`ensure_pkg`** **refuses** remote fetch when the durable dest has **`.deploy-state.json`** but no loadable **`strategy.yaml`**. Skill version **2.10.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d206b1f15372cd3d7dad14f5d0f7ffb7cc46bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->