### PR TITLE
senpi-strategy-ops v2.11.0: funding preflight counts HL spot + EVM USDC, not perps alone

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.10.1"
+  version: "2.11.0"
   platform: senpi
   exchange: hyperliquid
   requires:

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -42,11 +42,6 @@ VERIFY_BUFFER = 120
 POLL_EVERY = 10
 FEE_BUFFER = 1.5        # USDC reserved per wallet for the creation fee (observed ~$1)
 MIN_WALLET = 100.0      # platform minimum per strategy wallet
-# Chains `strategy_create_custom_strategy` auto-bridges EVM USDC in from, per its tool contract:
-# "Hyperliquid balance FIRST (perps, then spot; no bridging), then EVM USDC bridged in only if still
-# short (Base, Optimism, Arbitrum, BNB, Polygon, Ethereum)". USDC on any OTHER chain is not fundable.
-BRIDGEABLE_CHAIN_IDS = frozenset({1, 10, 56, 137, 8453, 42161})
-FUNDABLE_SYMBOLS = frozenset({"USDC", "USDC.E"})  # what the funding waterfall pulls; USDT is not bridged
 ORDER = ("pending", "creating", "active", "registered", "live")
 
 
@@ -142,23 +137,11 @@ def inst_state(st, name):
     return st["instances"].setdefault(name, {"status": "pending"})
 
 
-def _num(v):
-    """A money field as a float — the payload mixes numbers and numeric strings (`spot_balances`
-    rows carry `"5.46"`). Unparseable → 0.0, so one odd row never poisons the whole sum."""
-    try:
-        return float(v)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def _num_of(obj, *keys):
-    """First of `keys` holding a PARSEABLE number. Not `dig` + `_num`: `dig` returns the first key
-    PRESENT, so a present-but-null `balanceInUSD` would zero the row instead of falling through to
-    `formattedBalance` — an under-count, which on this path means a false `underfunded` halt."""
-    for k in keys:
-        v = _cli.dig(obj, k)
-        if v is None:
-            continue
+def _num(*vals):
+    """First of `vals` that parses as a number, else 0.0. The payload mixes numbers, numeric strings
+    (`spot_balances` rows carry `"5.46"`) and nulls — a null must fall through to the next candidate
+    rather than zero the row, because on this path an under-count is a false `underfunded` halt."""
+    for v in vals:
         try:
             return float(v)
         except (TypeError, ValueError):
@@ -166,60 +149,52 @@ def _num_of(obj, *keys):
     return 0.0
 
 
-def _is_usdc(sym):
-    return str(sym or "").strip().upper() in FUNDABLE_SYMBOLS
+def _usdc_usd(rows, *keys):
+    """USD held as USDC in a balance list (`spot_balances` / `token_balances`). Filtered by symbol
+    because the funding waterfall pulls USDC, while the `total_*` scalars lump in every other token —
+    a spot HYPE bag or EVM WETH is not fundable balance. Chain-agnostic: create bridges from Base,
+    Optimism, Arbitrum, BNB, Polygon and Ethereum today, and hardcoding that list here is how this
+    gate would silently start refusing fundable deploys again the day a chain is added."""
+    return sum(_num(*(_cli.dig(r, k) for k in keys)) for r in (rows or [])
+               if isinstance(r, dict) and str(_cli.dig(r, "tokenSymbol") or "").strip().upper() == "USDC")
 
 
 def available_usd(mcp):
-    """Total USDC the create call can FUND FROM, summed across every tier the platform actually
-    pulls, in its order: Hyperliquid perps → Hyperliquid spot USDC → EVM USDC bridged in from
-    BRIDGEABLE_CHAIN_IDS. None if unreadable → caller falls back to the requested budget.
+    """Total USDC `strategy_create_custom_strategy` can fund from — its whole waterfall, in order:
+    HL perps → HL spot USDC → EVM USDC (auto-bridged). None if unreadable → caller proceeds.
 
-    All three tiers MUST be summed. `total_in_hyperliquid`, `total_spot_usd_in_hyperliquid` and
-    `token_balances` are DISJOINT components of `total_balance_usd` (they add up to it exactly), so
-    reading any one of them reads a FRACTION of the fundable balance. Because `plan_funding`'s
-    shortfall is a HARD halt that returns before any wallet is created, a missing tier doesn't
-    under-report — it REFUSES a deploy the create call would have funded by itself. That is the
-    Starling incident: a $440 deploy rejected as `[E_FUNDS_SHORT] only $198.42 is accessible` while
-    ~$248 USDC sat idle on Base, which create auto-bridges. Both other readers of this payload agree
-    (`senpi-portfolio` sums the same three; `senpi-deposit-withdraw-transfer` documents the
-    waterfall) — this preflight was the one place that didn't.
+    These are DISJOINT buckets of `total_balance_usd` (they sum to it exactly), so reading one reads
+    a FRACTION of the fundable balance — and because `plan_funding`'s shortfall is a HARD halt that
+    returns before any wallet exists, a missing bucket doesn't under-report, it REFUSES a deploy
+    create would have funded itself. That is the Starling incident: $440 rejected as
+    `[E_FUNDS_SHORT] only $198.42 is accessible` with ~$248 USDC idle on Base.
 
-    Deliberately does NOT read `total_withdrawable`: it is a fourth disjoint field, and the repo
-    convention (and the `account_get_portfolio` contract) treat `total_in_hyperliquid` as the idle-HL
-    number. The old `dig(port, "total_in_hyperliquid", "total_withdrawable")` never reached the
-    second key anyway — `dig` returns the first key PRESENT, and both always are.
+    Excludes the 4th bucket, `total_withdrawable` — that is free margin sitting inside OTHER strategy
+    wallets, not spendable here (senpi-portfolio calls this the balance-bucket trap). The old
+    `dig(port, "total_in_hyperliquid", "total_withdrawable")` never reached that key anyway: `dig`
+    returns the first key PRESENT and both always are.
 
-    Counts conservatively, only USDC and only on chains create can bridge from: an over-count clears
-    this gate and then burns the $1 creation fee on a SERR037, whereas an under-count is the bug
-    above. The create call remains the real authority on sufficiency — this is a cheap pre-check
-    whose only job is to avoid half-funding a multi-wallet package."""
+    Over-counting is the SAFE direction — create auto-funds and surfaces a genuine shortfall as
+    SERR037, which is exactly what the `account_get_portfolio` contract asks for ("do not declare a
+    strategy unfundable from token_balances alone"). Under-counting is the bug above. So this stays a
+    cheap pre-check whose only job is avoiding a half-funded multi-wallet package; create remains the
+    authority on sufficiency."""
     try:
-        res = mcp.mcp_call("account_get_portfolio", timeout=POLL_HTTP_TIMEOUT)
+        # forceFetch: account_get_portfolio caches HL data for ~12h otherwise, so a deposit or a just
+        # closed strategy would read stale and halt a deploy the user has already funded.
+        res = mcp.mcp_call("account_get_portfolio", forceFetch=True, timeout=POLL_HTTP_TIMEOUT)
     except MCPError:
         return None
     port = _cli.dig(_cli.dig(res, "data", default={}) or {}, "portfolio", default={}) or {}
-    # Unknown shape (none of the tier fields present) → None, never a false halt on a payload change.
+    # Unknown shape (no bucket field at all) → None, never a false halt on a payload change.
     if not any(_cli.dig(port, k) is not None for k in
                ("total_in_hyperliquid", "total_spot_usd_in_hyperliquid", "spot_balances", "token_balances")):
         return None
-
-    perps = _num(_cli.dig(port, "total_in_hyperliquid"))
-
-    # Spot: prefer the per-token rows so non-USDC spot (a spot HYPE bag) isn't counted as fundable;
-    # the `total_spot_usd_in_hyperliquid` scalar is every spot token's USD value, not just USDC.
     rows = _cli.dig(port, "spot_balances")
-    if isinstance(rows, list) and rows:
-        spot = sum(_num_of(r, "usdValue", "total") for r in rows
-                   if isinstance(r, dict) and _is_usdc(_cli.dig(r, "tokenSymbol")))
-    else:
-        spot = _num(_cli.dig(port, "total_spot_usd_in_hyperliquid"))
-
-    evm = sum(_num_of(t, "balanceInUSD", "formattedBalance")
-              for t in (_cli.dig(port, "token_balances", default=[]) or [])
-              if isinstance(t, dict) and _is_usdc(_cli.dig(t, "tokenSymbol"))
-              and _num_of(t, "chainId") in BRIDGEABLE_CHAIN_IDS)
-
+    perps = _num(_cli.dig(port, "total_in_hyperliquid"))
+    spot = (_usdc_usd(rows, "usdValue", "total") if isinstance(rows, list) and rows
+            else _num(_cli.dig(port, "total_spot_usd_in_hyperliquid")))
+    evm = _usdc_usd(_cli.dig(port, "token_balances"), "balanceInUSD", "formattedBalance")
     return round(perps + spot + evm, 2)
 
 

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -42,6 +42,11 @@ VERIFY_BUFFER = 120
 POLL_EVERY = 10
 FEE_BUFFER = 1.5        # USDC reserved per wallet for the creation fee (observed ~$1)
 MIN_WALLET = 100.0      # platform minimum per strategy wallet
+# Chains `strategy_create_custom_strategy` auto-bridges EVM USDC in from, per its tool contract:
+# "Hyperliquid balance FIRST (perps, then spot; no bridging), then EVM USDC bridged in only if still
+# short (Base, Optimism, Arbitrum, BNB, Polygon, Ethereum)". USDC on any OTHER chain is not fundable.
+BRIDGEABLE_CHAIN_IDS = frozenset({1, 10, 56, 137, 8453, 42161})
+FUNDABLE_SYMBOLS = frozenset({"USDC", "USDC.E"})  # what the funding waterfall pulls; USDT is not bridged
 ORDER = ("pending", "creating", "active", "registered", "live")
 
 
@@ -137,16 +142,85 @@ def inst_state(st, name):
     return st["instances"].setdefault(name, {"status": "pending"})
 
 
+def _num(v):
+    """A money field as a float — the payload mixes numbers and numeric strings (`spot_balances`
+    rows carry `"5.46"`). Unparseable → 0.0, so one odd row never poisons the whole sum."""
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _num_of(obj, *keys):
+    """First of `keys` holding a PARSEABLE number. Not `dig` + `_num`: `dig` returns the first key
+    PRESENT, so a present-but-null `balanceInUSD` would zero the row instead of falling through to
+    `formattedBalance` — an under-count, which on this path means a false `underfunded` halt."""
+    for k in keys:
+        v = _cli.dig(obj, k)
+        if v is None:
+            continue
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            continue
+    return 0.0
+
+
+def _is_usdc(sym):
+    return str(sym or "").strip().upper() in FUNDABLE_SYMBOLS
+
+
 def available_usd(mcp):
-    """Free USDC the create call funds from (Hyperliquid perps). None if unreadable → caller falls
-    back to the requested budget."""
+    """Total USDC the create call can FUND FROM, summed across every tier the platform actually
+    pulls, in its order: Hyperliquid perps → Hyperliquid spot USDC → EVM USDC bridged in from
+    BRIDGEABLE_CHAIN_IDS. None if unreadable → caller falls back to the requested budget.
+
+    All three tiers MUST be summed. `total_in_hyperliquid`, `total_spot_usd_in_hyperliquid` and
+    `token_balances` are DISJOINT components of `total_balance_usd` (they add up to it exactly), so
+    reading any one of them reads a FRACTION of the fundable balance. Because `plan_funding`'s
+    shortfall is a HARD halt that returns before any wallet is created, a missing tier doesn't
+    under-report — it REFUSES a deploy the create call would have funded by itself. That is the
+    Starling incident: a $440 deploy rejected as `[E_FUNDS_SHORT] only $198.42 is accessible` while
+    ~$248 USDC sat idle on Base, which create auto-bridges. Both other readers of this payload agree
+    (`senpi-portfolio` sums the same three; `senpi-deposit-withdraw-transfer` documents the
+    waterfall) — this preflight was the one place that didn't.
+
+    Deliberately does NOT read `total_withdrawable`: it is a fourth disjoint field, and the repo
+    convention (and the `account_get_portfolio` contract) treat `total_in_hyperliquid` as the idle-HL
+    number. The old `dig(port, "total_in_hyperliquid", "total_withdrawable")` never reached the
+    second key anyway — `dig` returns the first key PRESENT, and both always are.
+
+    Counts conservatively, only USDC and only on chains create can bridge from: an over-count clears
+    this gate and then burns the $1 creation fee on a SERR037, whereas an under-count is the bug
+    above. The create call remains the real authority on sufficiency — this is a cheap pre-check
+    whose only job is to avoid half-funding a multi-wallet package."""
     try:
         res = mcp.mcp_call("account_get_portfolio", timeout=POLL_HTTP_TIMEOUT)
     except MCPError:
         return None
     port = _cli.dig(_cli.dig(res, "data", default={}) or {}, "portfolio", default={}) or {}
-    avail = _cli.dig(port, "total_in_hyperliquid", "total_withdrawable")
-    return float(avail) if isinstance(avail, (int, float)) else None
+    # Unknown shape (none of the tier fields present) → None, never a false halt on a payload change.
+    if not any(_cli.dig(port, k) is not None for k in
+               ("total_in_hyperliquid", "total_spot_usd_in_hyperliquid", "spot_balances", "token_balances")):
+        return None
+
+    perps = _num(_cli.dig(port, "total_in_hyperliquid"))
+
+    # Spot: prefer the per-token rows so non-USDC spot (a spot HYPE bag) isn't counted as fundable;
+    # the `total_spot_usd_in_hyperliquid` scalar is every spot token's USD value, not just USDC.
+    rows = _cli.dig(port, "spot_balances")
+    if isinstance(rows, list) and rows:
+        spot = sum(_num_of(r, "usdValue", "total") for r in rows
+                   if isinstance(r, dict) and _is_usdc(_cli.dig(r, "tokenSymbol")))
+    else:
+        spot = _num(_cli.dig(port, "total_spot_usd_in_hyperliquid"))
+
+    evm = sum(_num_of(t, "balanceInUSD", "formattedBalance")
+              for t in (_cli.dig(port, "token_balances", default=[]) or [])
+              if isinstance(t, dict) and _is_usdc(_cli.dig(t, "tokenSymbol"))
+              and _num_of(t, "chainId") in BRIDGEABLE_CHAIN_IDS)
+
+    return round(perps + spot + evm, 2)
 
 
 def plan_funding(need, budget, available):

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -466,5 +466,119 @@ class RecoverWalletKinds(unittest.TestCase):
         self.assertEqual(kind, "none")
 
 
+# USDC contracts per chain, only used to make the fixtures below look like the real payload.
+_USDC_ETH = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+_USDC_BASE = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+
+
+def _portfolio(**over):
+    """An `account_get_portfolio` response with the REAL field set (see the live payload in
+    references/funding-sources.md). `total_in_hyperliquid`, `total_spot_usd_in_hyperliquid` and
+    `token_balances` are DISJOINT components of `total_balance_usd`, so a funding preflight has to
+    add them up — reading one of them is reading a fraction of the fundable balance."""
+    port = {"total_balance_usd": 0.0, "total_allocated_in_strategy": 0.0, "total_withdrawable": 0.0,
+            "total_in_hyperliquid": 0.0, "total_token_balance_usd": 0.0,
+            "total_spot_usd_in_hyperliquid": 0.0, "token_balances": [], "spot_balances": [],
+            "positions": []}
+    port.update(over)
+    return {"success": True, "data": {"portfolio": port}}
+
+
+def _evm(sym, amount, chain_id, addr=_USDC_BASE):
+    return {"tokenSymbol": sym, "formattedBalance": amount, "balanceInUSD": amount,
+            "chainId": chain_id, "tokenAddress": addr, "decimals": 6}
+
+
+def _spot(sym, usd_value):
+    return {"tokenSymbol": sym, "tokenId": 0, "total": str(usd_value), "hold": "0.0",
+            "usdValue": str(usd_value)}
+
+
+class _StubMCP:
+    """Returns a canned `account_get_portfolio`; raises if `raise_with` is set."""
+
+    def __init__(self, payload=None, raise_with=None):
+        self.payload, self.raise_with = payload, raise_with
+
+    def mcp_call(self, tool, timeout=None, **kw):
+        if self.raise_with:
+            raise self.raise_with
+        assert tool == "account_get_portfolio", tool
+        return self.payload
+
+
+class AvailableUsd(unittest.TestCase):
+    """`available_usd` must report what `strategy_create_custom_strategy` can actually FUND FROM:
+    Hyperliquid perps → Hyperliquid spot USDC → EVM USDC bridged in (Base, Arbitrum, Optimism,
+    Ethereum, BNB, Polygon). Reading perps alone makes the hard `underfunded` halt fire on money
+    the create call would have pulled in by itself."""
+
+    def test_incident_starling_base_usdc_is_counted(self):
+        # THE incident: $440 Starling deploy refused with [E_FUNDS_SHORT] "only $198.42 is accessible"
+        # while ~$248 USDC sat on Base — which create auto-bridges. Nothing was actually short.
+        mcp = _StubMCP(_portfolio(total_in_hyperliquid=198.42, total_token_balance_usd=248.0,
+                                  token_balances=[_evm("USDC", 248.0, 8453)]))
+        avail = deploy.available_usd(mcp)
+        self.assertAlmostEqual(avail, 446.42, places=2)
+        # and the gate it feeds must not halt a $440 ask
+        _amounts, short = deploy.plan_funding([_inst("main", 1.0)], 440, avail)
+        self.assertIsNone(short)
+
+    def test_counts_hl_spot_usdc(self):
+        # create pulls perps FIRST, then spot USDC — both are fundable without touching a bridge
+        mcp = _StubMCP(_portfolio(total_in_hyperliquid=60.0, total_spot_usd_in_hyperliquid=45.0,
+                                  spot_balances=[_spot("USDC", 45.0)]))
+        self.assertAlmostEqual(deploy.available_usd(mcp), 105.0, places=2)
+
+    def test_counts_every_supported_chain(self):
+        mcp = _StubMCP(_portfolio(token_balances=[
+            _evm("USDC", 10.0, 1), _evm("USDC", 10.0, 10), _evm("USDC", 10.0, 56),
+            _evm("USDC", 10.0, 137), _evm("USDC", 10.0, 8453), _evm("USDC", 10.0, 42161)]))
+        self.assertAlmostEqual(deploy.available_usd(mcp), 60.0, places=2)
+
+    def test_ignores_usdc_on_unsupported_chain(self):
+        # a chain create can't bridge from is NOT fundable — counting it would pass the preflight
+        # and then fail on SERR037 after burning the $1 creation fee
+        mcp = _StubMCP(_portfolio(total_in_hyperliquid=100.0,
+                                  token_balances=[_evm("USDC", 5000.0, 999999)]))
+        self.assertAlmostEqual(deploy.available_usd(mcp), 100.0, places=2)
+
+    def test_ignores_non_usdc_holdings(self):
+        # only USDC is bridged/pulled; spot HYPE and EVM WETH are not fundable balance
+        mcp = _StubMCP(_portfolio(total_in_hyperliquid=100.0,
+                                  total_spot_usd_in_hyperliquid=900.0,
+                                  spot_balances=[_spot("HYPE", 900.0)],
+                                  token_balances=[_evm("WETH", 5000.0, 8453)]))
+        self.assertAlmostEqual(deploy.available_usd(mcp), 100.0, places=2)
+
+    def test_spot_scalar_used_when_rows_absent(self):
+        # no per-token spot rows to filter → fall back to the scalar rather than dropping spot to 0
+        mcp = _StubMCP(_portfolio(total_in_hyperliquid=10.0, total_spot_usd_in_hyperliquid=25.0))
+        self.assertAlmostEqual(deploy.available_usd(mcp), 35.0, places=2)
+
+    def test_null_usd_field_falls_through_to_balance(self):
+        # `balanceInUSD` present but null must fall through to `formattedBalance`, not zero the row —
+        # `dig` alone stops at the first key PRESENT, which would under-count into a false halt
+        row = _evm("USDC", 250.0, 8453)
+        row["balanceInUSD"] = None
+        mcp = _StubMCP(_portfolio(total_in_hyperliquid=100.0, token_balances=[row]))
+        self.assertAlmostEqual(deploy.available_usd(mcp), 350.0, places=2)
+
+    def test_garbage_row_does_not_poison_the_sum(self):
+        mcp = _StubMCP(_portfolio(total_in_hyperliquid=100.0, token_balances=[
+            {"tokenSymbol": "USDC", "balanceInUSD": "not-a-number", "chainId": 8453},
+            _evm("USDC", 40.0, 8453)]))
+        self.assertAlmostEqual(deploy.available_usd(mcp), 140.0, places=2)
+
+    def test_unreadable_returns_none_so_gate_never_halts(self):
+        mcp = _StubMCP(raise_with=deploy.MCPError("boom"))
+        self.assertIsNone(deploy.available_usd(mcp))
+        self.assertIsNone(deploy.plan_funding([_inst("a", 1.0)], 1000, None)[1])
+
+    def test_empty_portfolio_is_zero_not_none(self):
+        # a genuinely empty account must still HALT (0.0), not read as unknown and sail through
+        self.assertEqual(deploy.available_usd(_StubMCP(_portfolio())), 0.0)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -530,18 +530,20 @@ class AvailableUsd(unittest.TestCase):
                                   spot_balances=[_spot("USDC", 45.0)]))
         self.assertAlmostEqual(deploy.available_usd(mcp), 105.0, places=2)
 
-    def test_counts_every_supported_chain(self):
+    def test_counts_usdc_on_every_chain(self):
+        # Base, Optimism, BNB, Polygon, Ethereum, Arbitrum — and deliberately NO chain allowlist, so
+        # a chain added to the bridge later can't silently start failing this gate closed again
         mcp = _StubMCP(_portfolio(token_balances=[
             _evm("USDC", 10.0, 1), _evm("USDC", 10.0, 10), _evm("USDC", 10.0, 56),
             _evm("USDC", 10.0, 137), _evm("USDC", 10.0, 8453), _evm("USDC", 10.0, 42161)]))
         self.assertAlmostEqual(deploy.available_usd(mcp), 60.0, places=2)
 
-    def test_ignores_usdc_on_unsupported_chain(self):
-        # a chain create can't bridge from is NOT fundable — counting it would pass the preflight
-        # and then fail on SERR037 after burning the $1 creation fee
+    def test_counts_usdc_on_unrecognised_chain(self):
+        # an unknown chainId is counted, not dropped: over-counting is the safe direction (create
+        # auto-funds and reports a real shortfall as SERR037), under-counting is a false halt
         mcp = _StubMCP(_portfolio(total_in_hyperliquid=100.0,
-                                  token_balances=[_evm("USDC", 5000.0, 999999)]))
-        self.assertAlmostEqual(deploy.available_usd(mcp), 100.0, places=2)
+                                  token_balances=[_evm("USDC", 250.0, 999999)]))
+        self.assertAlmostEqual(deploy.available_usd(mcp), 350.0, places=2)
 
     def test_ignores_non_usdc_holdings(self):
         # only USDC is bridged/pulled; spot HYPE and EVM WETH are not fundable balance


### PR DESCRIPTION
## The bug

A `$440` Starling deploy was refused with:

```
[E_FUNDS_SHORT] Requested $440, only $198.42 is accessible ($196.92 after fees) — short by $243.08
```

…while **~$248 USDC sat idle on Base**, which `strategy_create_custom_strategy` auto-bridges. Summed correctly the user had **$446.42** available. The deploy was fundable and was refused anyway.

Because no wallet is created on this path, the user's only signal was the agent telling them to go bridge money by hand — for a shortfall that did not exist.

## Root cause

`available_usd()` read a single field and fed it to `plan_funding()`, whose shortfall is a **hard halt that returns before any wallet is created**:

```python
avail = _cli.dig(port, "total_in_hyperliquid", "total_withdrawable")
```

But `strategy_create_custom_strategy` funds from a **three-tier waterfall**, per its own tool contract: HL perps → HL spot USDC → EVM USDC bridged in.

So a missing tier doesn't under-*report* the balance — it **refuses a deploy the create call would have funded by itself**.

Verified against the live `account_get_portfolio` payload that the money fields are **disjoint** buckets of `total_balance_usd` (they sum to it to 15 decimal places), so reading one field read a *fraction* of the fundable balance:

| field | live value | |
|---|---|---|
| `total_in_hyperliquid` | 3.485765 | tier 1 — the only one read |
| `total_spot_usd_in_hyperliquid` | 5.460000 | tier 2 — ignored |
| `token_balances` (EVM USDC) | 1.245539 | tier 3 — ignored |
| `total_withdrawable` | 0.573792 | 4th bucket, not spendable here |
| **`total_balance_usd`** | **10.765096** | = exact sum |

`available_usd()` returned **$3.49** where **$10.19** was fundable.

### This was a doc/code divergence, not a missing spec

- `SKILL.md:150` already said *"Funding is automatic (Hyperliquid perps → HL spot → EVM bridge)"*
- the `account_get_portfolio` contract explicitly warns *"do not declare a strategy unfundable from `token_balances` alone; let creation/top-up auto-fund and surface a real shortfall (SERR037)"*
- `senpi-portfolio/scripts/portfolio.py:519` already sums the same buckets
- `senpi-deposit-withdraw-transfer/SKILL.md:64` documents the same waterfall

This preflight was the only reader that didn't — and the only one gating money. No doc change was needed; the code now matches the doc.

## Three defects, one function

**1. Only 1 of 3 funding tiers counted** — the refusal above.

**2. `dig()` returns the first key _present_, not the first non-null.** Both keys always are, so the documented `total_withdrawable` fallback was **unreachable dead code** — and it named a bucket that isn't spendable on a new strategy anyway, so it would have been wrong in a different direction if it ever fired.

**3. `forceFetch` was never passed.** `account_get_portfolio` caches HL data ~12h, so a user who had just deposited or just closed a strategy could be halted on a balance up to half a day stale — same false-refusal symptom, different cause. `senpi-portfolio` always passes it, for exactly this reason.

## Direction of error is deliberate

**Over-counting is the safe direction**: create auto-funds and surfaces a genuine shortfall as SERR037 — which is what the `account_get_portfolio` contract asks for. **Under-counting is a false refusal**, the bug above.

So there is **no chain allowlist**. An earlier revision hardcoded the six bridgeable chain IDs; that was dropped in review because it reproduces this very failure mode — the day a chain is added to the bridge, the gate silently starts refusing fundable deploys again. `senpi-portfolio` reads the same payload with no chain filter either.

What is kept, and why:

- **A USDC symbol filter.** `total_token_balance_usd` and `total_spot_usd_in_hyperliquid` are all-token scalars, so dropping it counts a spot HYPE bag or EVM WETH as fundable. `portfolio.py:522` filters by symbol here too.
- **The `total_withdrawable` exclusion.** It is free margin inside *other* strategy wallets — `portfolio.py:14-15` documents this as the balance-bucket trap.
- **Unknown payload shape → `None`.** A future field rename degrades to "no halt" rather than blocking every deploy.

The create call remains the authority on sufficiency; this preflight's only job is avoiding a half-funded multi-wallet package.

## Verification

- Incident replayed through the real gate: `available $446.42` → **PROCEEDS, funds $440** (was: HALT)
- Same fix against the live payload: `$3.49` → `$10.19`
- **70 tests pass** (60 pre-existing + 10 new), hermetic — no MCP, no network
- 25 executable lines, two helpers, no new constants

New coverage: the incident itself; USDC on all six bridgeable chains *and* on an unrecognised chain; HL spot USDC; non-USDC exclusion (spot HYPE / EVM WETH); spot-scalar fallback; null-field fallthrough; garbage-row isolation; unreadable → `None`; empty account → `0.0` (still halts).

## Open question, deliberately not bundled

Tier 1 stays `total_in_hyperliquid`, matching the repo's convention in two places. But the MCP contract warns it *"can include open-position margin, so it is NOT the bridgeable amount"* — yet on the account inspected it is non-zero with **zero** open positions and is disjoint from `total_withdrawable`, so its exact semantics don't match that description.

If it does include locked margin for users holding positions, this gate can over-count and fail at create instead — the recoverable direction, but worth a definitive answer from whoever owns the portfolio endpoint. Same for whether `USDC.e` on Arbitrum/Optimism is bridged: it is excluded here (the contract says "EVM USDC"), and if it *is* bridged, excluding it is an under-count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)