### PR TITLE
Drop the deprecated BARREN token from portfolio diagnostics wording

### DIFF
--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -182,7 +182,7 @@ strategy and per group. Narrate it honestly — a registered runtime is not auto
 This health check owns **liveness triage** (registered + running + healthy) via telemetry, and **references
 `diagnose.py` as the confirmation step** — it does not re-derive the deep checks. A thorough health check
 does not stop at the verdict: for **any** strategy that isn't cleanly `live` (`not_running` / `degraded` /
-`unknown`), running **`senpi-strategy-ops` `diagnose.py <id>`** (registered? ticked? BARREN? erroring?
+`unknown`), running **`senpi-strategy-ops` `diagnose.py <id>`** (registered? ticked? no signals yet? erroring?
 `--run-scan` for the literal scan output) is how you **confirm what's actually wrong and fix it** — surface
 it as the required next step (and its verdict, if you can run it), then close.py → redeploy as needed. For
 **"where am I leaking / did a stop fail / any halts / exit quality"**, hand to `senpi-improve-trades` (it

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -725,7 +725,7 @@ def fetch_strategies(client, meta):
         meta.setdefault("warnings", []).append(
             f"{len(degraded)} strategy(ies) have a runtime that telemetry reports DEGRADED/unhealthy — "
             f"registered but not working cleanly. Confirm the cause with senpi-strategy-ops "
-            f"`diagnose.py <id>` (scanner registered? ticked? BARREN? erroring?): "
+            f"`diagnose.py <id>` (scanner registered? ticked? no signals yet? erroring?): "
             f"{', '.join(str(d) for d in degraded)}")
     return strategies
 


### PR DESCRIPTION
The runtime renamed the `senpi scanner` CLI output flag `BARREN` to `(no signals yet)` (senpi-trading-runtime PR #272). The `senpi-trading-runtime` skill was synced in #505; `senpi-portfolio` still cited the old literal token in its diagnostics checklist, so it was telling the agent to look for a string the CLI no longer prints.

Wording only, in two places:

- `senpi-portfolio/SKILL.md` — the `diagnose.py <id>` checklist
- `senpi-portfolio/scripts/portfolio.py` — the same checklist in the degraded-runtime warning string

No behavior change; no strategy.yaml touched, so `catalog.json` is unchanged.

Conceptual lower-case "barren scanner" prose in `senpi-strategy-ops/references/liveness-verification.md`, `deploy.py`, and `tests/test_deploy_gates.py` is left alone — it describes the concept (a scanner that runs and finds nothing), not the CLI token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only changes in skill documentation and warning strings; no runtime or portfolio logic modified.
> 
> **Overview**
> **Documentation-only** alignment after `senpi-trading-runtime` renamed the scanner CLI label from **`BARREN`** to **`(no signals yet)`**.
> 
> The **`diagnose.py <id>`** checklist text is updated in two places so agents are not told to look for a string the CLI no longer prints:
> 
> - **`senpi-portfolio/SKILL.md`** — degraded / non-`live` runtime triage guidance
> - **`senpi-portfolio/scripts/portfolio.py`** — the same checklist inside **`meta.warnings`** for degraded runtimes
> 
> No engine behavior, tests, or catalog changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce2a0df20b11bab69bf08596cc133ee6cf8400b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->