### PR TITLE
Taxonomy: B3 funding-gate enforcement delegated to the platform backend

### DIFF
--- a/docs/error-code-taxonomy.md
+++ b/docs/error-code-taxonomy.md
@@ -7,8 +7,9 @@ surfaces. Rules:
    re-derives it.
 2. **Codes are stable once shipped.** Messages may improve; codes never change meaning.
 3. **Format:** the code leads the string — `[E_FUNDS_SHORT] …` — so agents (and log
-   queries) can match on a fixed prefix. Structured `code` fields arrive with the MCP
-   gates (slice B3); until then the prefix IS the contract.
+   queries) can match on a fixed prefix. Structured `code` fields arrive with the B3
+   funding gates (enforced in the platform backend, relayed through the MCP); until
+   then the prefix IS the contract.
 4. **Hints are computed, never templated.** A next-step suggestion may only be rendered
    when its precondition was checked against live state in the same call. A hint that
    can be nonsense for some state is a bug (field case: `--budget ≤ $0`).
@@ -20,7 +21,7 @@ surfaces. Rules:
 
 | Code | Owner (today) | Condition | Next-step rule |
 |---|---|---|---|
-| `E_FUNDS_SHORT` | `senpi-strategy-ops/scripts/deploy.py` (`create`) → moves to MCP in slice B3 | Accessible balance covers the per-wallet floor for the requested wallet count, but not the requested budget | Offer BOTH: add USDC, or re-run with `--budget ≤ <b*>` (a bare number — the flag is `type=float`, so never `$`/comma-grouped) where b* is the computed maximum feasible budget (Σᵢ max($100, b·shareᵢ) ≤ usable — equal to usable only for even shares). The lower-budget clause may ONLY render when `usable ≥ wallets × $100` |
+| `E_FUNDS_SHORT` | `senpi-strategy-ops/scripts/deploy.py` (`create`) — B3 hard-gate enforcement delegated to the platform backend (2026-08-03); deploy.py stays as the stricter advisory preflight in front (fee buffer, multi-wallet split) and relays backend refusals verbatim | Accessible balance covers the per-wallet floor for the requested wallet count, but not the requested budget | Offer BOTH: add USDC, or re-run with `--budget ≤ <b*>` (a bare number — the flag is `type=float`, so never `$`/comma-grouped) where b* is the computed maximum feasible budget (Σᵢ max($100, b·shareᵢ) ≤ usable — equal to usable only for even shares). The lower-budget clause may ONLY render when `usable ≥ wallets × $100`. At the backend/MCP layer (single amount per call) the lower-amount hint is `≤ accessible` and may only render when `accessible ≥ floor` |
 | `E_FUNDS_BELOW_FLOOR` | same | Accessible balance cannot fund the wallet count at the $100/wallet floor — **no valid budget exists** | Deposit path ONLY (`senpi-deposit-withdraw-transfer` skill + amount still needed). NEVER suggest a lower budget |
 | `E_STATE_NO_WALLETS` | `deploy.py` (`runtime`) | Deploy state lost AND backend has zero ACTIVE wallets for the instance | `deploy.py create <id> --budget <usd>` (nothing exists; create is safe) |
 | `E_STATE_AMBIGUOUS_WALLETS` | `deploy.py` (`runtime`) | Deploy state lost AND the backend wallet set cannot be safely resolved: >1 candidate ACTIVE wallets, a candidate whose address is unreadable, or ACTIVE wallets that exist but match no instance name — any of these may hide a funded live strategy | Read-only triage (`status.py <id>`), clear ambiguity with the user. NEVER close/recreate to "start clean" |
@@ -49,5 +50,21 @@ slice B1, truthful-status instrumentation):
 
 - `E_VALIDATE_IMPORT`, `E_VALIDATE_SMOKE` — `senpi validate` failures (slice B2).
 - `E_NOT_VALIDATED`, `E_PACKAGE_CHANGED` — runtime install-gate refusals (slice B2).
-- `E_FUNDS_*` at the MCP layer (slice B3) keeps the same code meanings as above; the
-  MCP becomes the owner and `deploy.py` relays verbatim.
+- `E_FUNDS_*` hard-gate enforcement (slice B3 — delegated 2026-08-03 to the platform
+  backend service that owns strategy/wallet creation, instead of the MCP) keeps the
+  same code meanings as above. The backend refuses **pre-mutation** with a structured
+  payload (`code`, `requested`, `accessible`, `floor`, `short_by` — `short_by` rounded
+  UP to cents so a deposit hint always clears the gap); the MCP renders the teaching
+  text (deposit path, computed hints) and `deploy.py` relays verbatim. "Accessible" =
+  the create waterfall's full fundable balance (HL perps + HL spot USDC + bridgeable
+  EVM USDC), matching `deploy.py available_usd` since ops v2.11.0 — never a single
+  bucket (the Starling false-refusal), never `total_withdrawable`.
+- `E_FUNDS_BELOW_MIN` — reserved for the same B3 backend gate: requested budget/amount
+  below the per-strategy minimum ($100 production / $10 dev). Balance-independent
+  (fires even when no balance was read), so it precedes the other two — precedence:
+  `BELOW_MIN` → `BELOW_FLOOR` → `SHORT`. `deploy.py` never emits it (it floors
+  per-wallet amounts at the minimum); direct callers can. Note: the copy-create path's
+  below-minimum refusal currently surfaces as `SERR037` through the MCP — a misuse of
+  that code (its registry meaning is backend insufficient balance); it becomes
+  `E_FUNDS_BELOW_MIN` when the gate ships. These rows move to the Active table when
+  the backend gate lands.


### PR DESCRIPTION
## What

Doc-only update to `docs/error-code-taxonomy.md` recording the B3 decision change (2026-08-03): the `E_FUNDS_*` hard gate will be enforced in the **platform backend service** that owns strategy/wallet creation, not in the MCP handlers as originally sliced.

- `E_FUNDS_SHORT` owner cell: deploy.py remains the stricter advisory preflight in front and relays backend refusals verbatim; adds the single-amount hint rule for the backend/MCP layer.
- Reserved families: replaces the "MCP becomes the owner" bullet with the backend-enforcement contract (pre-mutation refusal, structured payload `code`/`requested`/`accessible`/`floor`/`short_by`, accessible = the full create funding waterfall per ops v2.11.0 — never a single bucket, never `total_withdrawable`).
- Reserves the new `E_FUNDS_BELOW_MIN` code (requested < floor, balance-independent, precedence `BELOW_MIN` → `BELOW_FLOOR` → `SHORT`; replaces the copy-create path's misuse of `SERR037` when the gate ships).

## Why

The MCP-layer gate needed a remote portfolio read (Zapper-outage fail-open compromise) and covered only MCP callers. The backend owns the funding waterfall and the mutation transaction, so it can refuse atomically, from its own authoritative balance, for every caller. Freezing the code contract now unblocks D1 (`senpi deploy`), which consumes these codes for its preflight UX.

Doc-only under `docs/` — no SKILL.md version bumps required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change under `docs/` with no runtime or skill behavior modified.
> 
> **Overview**
> Records the **2026-08-03 B3 decision** in `docs/error-code-taxonomy.md`: **`E_FUNDS_*` hard-gate enforcement moves from MCP handlers to the platform backend** that owns strategy/wallet creation, with MCP teaching copy and `deploy.py` relaying refusals verbatim.
> 
> **Rule 3** and the **`E_FUNDS_SHORT`** owner row now describe that split—`deploy.py` stays the stricter advisory preflight—and add the **single-amount** lower hint rule for the backend/MCP layer (`≤ accessible` only when `accessible ≥ floor`).
> 
> The **reserved `E_FUNDS_*` bullet** is expanded into a backend contract: **pre-mutation** refusal with structured fields (`code`, `requested`, `accessible`, `floor`, `short_by`), and **accessible** defined as the full create funding waterfall (aligned with `deploy.py` `available_usd` since ops v2.11.0—not a single bucket or `total_withdrawable`).
> 
> **Reserves `E_FUNDS_BELOW_MIN`** for below-minimum requests (balance-independent, precedence `BELOW_MIN` → `BELOW_FLOOR` → `SHORT`), including the plan to replace copy-create **`SERR037`** misuse when the gate ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49461a897cc07f2a201f75027aeaea6e2cf3883d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->