### PR TITLE
Add 5 demand-driven templates: Shadow, Rotator, Mandate, Hare, Kite

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,19 +122,19 @@ The scanner proposes; the runtime's risk engine disposes.
 
 ### The strategy templates, by archetype
 
-The 80+ templates span the full cross-asset spectrum (majors, alts, universe crypto, XYZ equities, commodities, indices, pre-IPO) at 3–10× leverage, 69 advanced / 13 starter, mostly long/short. The range is deliberate — directional and market-neutral, single-asset and whole-universe, momentum and mean-reversion, copy-trading and macro, everyday starters and crisis insurance:
+The 80+ templates span the full cross-asset spectrum (majors, alts, universe crypto, XYZ equities, commodities, indices, pre-IPO) at 1–10× leverage, 74 advanced / 13 starter, mostly long/short. The range is deliberate — directional and market-neutral, single-asset and whole-universe, momentum and mean-reversion, copy-trading and macro, everyday starters and crisis insurance:
 
 | Archetype | # | What it does | Examples |
 |---|---|---|---|
 | Trend-following | 22 | Ride durable multi-timeframe trends | Spider, Elephant, Python, Lynx |
 | Single-market specialist | 15 | Master one asset deeply | Kodiak (SOL), Coyote (BTC/ETH), Falcon (pre-IPO) |
-| Breakout / momentum | 14 | Buy the break, gated on trend + smart money | Hawk, Badger, Condor, Orca |
+| Breakout / momentum | 16 | Buy the break, gated on trend + smart money | Hawk, Badger, Hare (crypto session scalp), Kite (SMC/ICT) |
 | Structural / neutral | 9 | Non-directional (DCA, market-neutral, thematic) | Tortoise (DCA), Cougar |
 | Contrarian / fade | 8 | Fade crowding once it exhausts | Camel (funding), Owl, Pangolin |
-| Copy-trading | 8 | Mirror proven traders | Albatross, Jackal, Whalehunter |
-| Macro thesis | 3 | Read the regime, set a posture, rotate by attrition | Chimp (daily), Gorilla (weekly) |
+| Copy-trading | 9 | Mirror proven traders | Jackal, Whalehunter, Shadow (multi-trader fresh-entry mirror) |
+| Macro thesis | 4 | Read the regime, set a posture, rotate by attrition | Chimp (daily), Gorilla (weekly), Rotator (3h conviction rebalance) |
 | Event-driven | 1 | IPO / new-listing convexity | Magpie |
-| Risk parity | 1 | Equal-risk across uncorrelated classes | Ox |
+| Risk parity | 2 | Equal-risk / diversified capital preservation across uncorrelated classes | Ox, Mandate (no-leverage crypto + RWA) |
 | Tail-risk | 1 | Standing insurance + crisis convexity | Rhino |
 
 Browse the live set with `senpi-strategy-discover` rather than any hand-maintained list — the catalog is the source of truth.

--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -849,6 +849,56 @@
       "sort_order": 7
     },
     {
+      "id": "hare",
+      "name": "Hare — Crypto Majors Session Scalper",
+      "emoji": "🐇",
+      "tagline": "A fast BTC/ETH scalper that only trades inside the Asia, London, and US high-volume windows — scoring a 30-minute momentum burst backed by real volume, targeting roughly 1:3 risk-reward at 5-10x. Maker-only entries and a hard per-name cooldown keep it from churning into fees.",
+      "belief_plain": "This trades only the two most liquid coins, Bitcoin and Ethereum, and only during the hours when the market is actually busy — the Asia, London, and US sessions. It waits for a quick burst of momentum backed by a real jump in volume, takes a leveraged position aiming to make about three times what it risks, and gets out fast if it's wrong. Crucially, it posts its orders to earn the maker rebate instead of paying to chase, and it refuses to re-enter the same coin for 45 minutes — because at this speed, fees are what kill a scalper.",
+      "version": "1.0.0",
+      "thesis": "A sub-hourly scalper lives or dies on cost. The edge — a volume-backed momentum burst at a session open — is real but small, so the whole design is built to protect it: session gating means it only trades when moves are large enough to matter, a volume floor rejects fee-bait bursts on thin tape, maker-only entries turn the fee from a cost into a rebate, and a hard per-name cooldown plus a daily entry cap make churning structurally impossible. The DSL is tuned for asymmetry — a tight stop, a profit-lock that arms at ~3x the risk — so the winners pay for the losers.",
+      "tags": [
+        "scalp",
+        "session",
+        "btc",
+        "eth",
+        "crypto-majors",
+        "maker-only",
+        "fee-guarded",
+        "sub-hourly",
+        "momentum",
+        "asia-london-us",
+        "long-short",
+        "cobra-guard"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "session_open",
+      "sub_style_label": "Positions into a session open on the clock — reads pre-open drift/volume and carries into the open, rather than reacting after.",
+      "asset_classes": [
+        "btc_eth"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 120,
+      "min_budget": 300,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "main",
+      "sort_order": 8
+    },
+    {
       "id": "hedgehog",
       "name": "Hedgehog — Major Crypto Basket",
       "emoji": "🦔",
@@ -895,7 +945,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
     },
     {
       "id": "hen",
@@ -958,7 +1008,7 @@
       ],
       "max_slots": 4,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "hornet",
@@ -1025,7 +1075,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "ibis",
@@ -1074,7 +1124,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "kingfisher",
@@ -1132,7 +1182,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "lemur",
@@ -1178,7 +1228,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "lynx",
@@ -1229,7 +1279,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "meerkat",
@@ -1273,7 +1323,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 15
+      "sort_order": 16
     },
     {
       "id": "orca",
@@ -1316,7 +1366,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 16
+      "sort_order": 17
     },
     {
       "id": "otter",
@@ -1360,7 +1410,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 17
+      "sort_order": 18
     },
     {
       "id": "piranha",
@@ -1412,7 +1462,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 18
+      "sort_order": 19
     },
     {
       "id": "python",
@@ -1456,7 +1506,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 19
+      "sort_order": 20
     },
     {
       "id": "rooster",
@@ -1504,7 +1554,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 20
+      "sort_order": 21
     },
     {
       "id": "sailfish",
@@ -1554,7 +1604,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 21
+      "sort_order": 22
     },
     {
       "id": "salamander",
@@ -1604,7 +1654,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 22
+      "sort_order": 23
     },
     {
       "id": "sheep",
@@ -1657,7 +1707,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 23
+      "sort_order": 24
     },
     {
       "id": "jaguar",
@@ -2201,6 +2251,51 @@
       "sort_order": 9
     },
     {
+      "id": "rotator",
+      "name": "Rotator — Scheduled Conviction Rebalance",
+      "emoji": "🔁",
+      "tagline": "On a fixed clock (default every 3 hours) it re-reads the market and rebalances a deliberately concentrated book — never more than two positions, long OR short — ranking candidates on a blended score of cross-asset flows, the funding regime, and live leaderboard momentum events.",
+      "belief_plain": "Every few hours this strategy re-underwrites its whole book from scratch. It looks at which alts are lagging a big Bitcoin move and should catch up, whether the crowd is dangerously one-sided on funding (a contrarian warning), and which coins the best traders are piling into right now — then blends those into a single conviction score and holds only the one or two best long-or-short ideas. Weak positions retire on their stop and the next rebalance fills the freed slot.",
+      "version": "1.0.0",
+      "thesis": "Concentration plus a fixed re-underwrite clock beats a sprawling always-on book: a small number of high-conviction positions, re-scored every few hours against the freshest short-horizon data, keeps the book aligned with current conditions instead of yesterday's. The three inputs are deliberately short-horizon (4h flows, live funding, 4h momentum events) — not a long-lookback cohort — so the reads match the timescale of the trades. It rotates by attrition rather than force-closing, so it never fights its own DSL.",
+      "tags": [
+        "rebalance",
+        "conviction",
+        "concentrated",
+        "cross-asset-flows",
+        "funding-regime",
+        "momentum-events",
+        "blended-score",
+        "long-short",
+        "rotate-by-attrition",
+        "three-hourly"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "macro_thesis",
+      "archetype_label": "Macro Thesis",
+      "sub_style": "conviction_rebalance",
+      "sub_style_label": "Re-underwrites a concentrated book on a fixed clock (e.g. every 3h) from a blended short-horizon score — cross-asset flows + funding regime + momentum events — holding only the 1-2 highest-conviction long/short ideas.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 10800,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "main",
+      "sort_order": 10
+    },
+    {
       "id": "salmon",
       "name": "Salmon — RSI Mean-Reversion",
       "emoji": "🐟",
@@ -2241,7 +2336,7 @@
       ],
       "max_slots": 5,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "starling",
@@ -2289,7 +2384,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "viper",
@@ -2335,7 +2430,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "asia-ai",
@@ -2729,6 +2824,59 @@
       "sort_order": 7
     },
     {
+      "id": "kite",
+      "name": "Kite — Market Structure & Divergence (SMC)",
+      "emoji": "🪁",
+      "tagline": "Trades the ICT/SMC playbook on BTC, ETH, SOL and FARTCOIN: it maps 3-bar fractal swings, waits for a break of structure, then enters on the 0.618 fibonacci retracement of that move with invalidation behind 0.786 — only when an RSI divergence confirms. Every entry carries its stop and 1R/2R/3R targets.",
+      "belief_plain": "This speaks the language of smart-money-concept traders. It watches for the market to break its own structure — taking out a prior swing high or low — which signals a real shift. Then, instead of chasing, it waits for price to pull back to the 0.618 fibonacci level of that move, checks that momentum (RSI) is diverging in its favour, and enters there with a clear invalidation just beyond the 0.786 level. It works out its 1x, 2x and 3x reward targets up front and manages the trade with a ladder that locks in gains in thirds as each target is reached.",
+      "version": "1.0.0",
+      "thesis": "A break of structure marks where order flow shifted; the 0.618 retracement is where that move offers the best risk-reward to rejoin, and the 0.786 is where the idea is simply wrong. Requiring an RSI divergence at the retracement filters the continuations that have already exhausted. The result is a defined-risk, defined-target structure trade — the exact methodology a whole trader subculture uses by hand — automated across a few liquid names. The step-up profit ladder approximates a 33/33/33 scale-out; true partial take-profit lands with the native DSL scale-out capability.",
+      "tags": [
+        "smc",
+        "ict",
+        "market-structure",
+        "break-of-structure",
+        "fractal",
+        "fibonacci",
+        "retracement",
+        "divergence",
+        "rsi",
+        "defined-risk",
+        "long-short",
+        "structure"
+      ],
+      "group": "multi-asset-whitelist",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "market_structure",
+      "sub_style_label": "Trades SMC/ICT/Wyckoff structure: break-of-structure, liquidity sweeps, fair-value gaps.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "FARTCOIN"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 300,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 4,
+      "branch": "main",
+      "sort_order": 8
+    },
+    {
       "id": "lion",
       "name": "Lion — Two-Speed-Market Cross-Asset L/S",
       "emoji": "🦁",
@@ -2814,7 +2962,69 @@
       ],
       "max_slots": 9,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
+    },
+    {
+      "id": "mandate",
+      "name": "Mandate — Capital-Preservation Portfolio (Crypto + RWA)",
+      "emoji": "🏛️",
+      "tagline": "A diversified, long-only, NO-LEVERAGE basket across crypto blue chips, equity indices and blue-chip names, metals, and energy — sized to a hard per-position cap, gated by a fee hurdle so it only trades when the expected move beats the cost, and diversified with a per-class limit. Capital preservation first.",
+      "belief_plain": "This is a conservative, institution-style portfolio, not a punt. It holds a diversified spread of blue-chip crypto and real-world assets (stock indices, big-cap names, gold, silver, oil), never uses leverage, and never puts more than a small capped slice into any one position. It only opens a position when the trend is genuinely there on both the 4-hour and daily view AND the expected move is large enough to be worth the trading cost — otherwise it does nothing. Doing nothing is a valid decision.",
+      "version": "1.0.0",
+      "thesis": "For capital preservation, what you DON'T do matters more than what you do. No leverage means a bad position can't wipe the book; hard per-position and per-class caps mean no single name or theme can sink it; a fee hurdle means small, cost-eroding edges are declined rather than churned. The result is a low-volatility diversified compounder across crypto and RWA that trades rarely and holds patiently, cutting a real breakdown early and locking gains before giving them back.",
+      "tags": [
+        "capital-preservation",
+        "no-leverage",
+        "diversified",
+        "rwa",
+        "blue-chip",
+        "fee-aware",
+        "position-caps",
+        "long-only",
+        "institutional",
+        "portfolio",
+        "low-risk",
+        "conservative"
+      ],
+      "group": "multi-asset-whitelist",
+      "archetype": "risk_parity",
+      "archetype_label": "Risk-Parity / All-Weather",
+      "sub_style": "capital_preservation",
+      "sub_style_label": "Diversified, NO-leverage, capped portfolio that preserves capital first — enters only high-quality multi-timeframe trends that clear a fee hurdle, with hard per-position and per-class limits; 'no trade is better than a poor trade'.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "indices",
+        "commodities"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE",
+        "xyz:SP500",
+        "xyz:XYZ100",
+        "xyz:NVDA",
+        "xyz:AAPL",
+        "xyz:GOLD",
+        "xyz:SILVER",
+        "xyz:BRENTOIL"
+      ],
+      "direction": "long_only",
+      "risk_level": "conservative",
+      "tier": "advanced",
+      "leverage_max": 1,
+      "time_horizon": "position",
+      "cadence_seconds": 1800,
+      "min_budget": 500,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 8,
+      "branch": "main",
+      "sort_order": 10
     },
     {
       "id": "mongoose",
@@ -2871,7 +3081,7 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 11
     },
     {
       "id": "ox",
@@ -2930,7 +3140,7 @@
       ],
       "max_slots": 14,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 12
     },
     {
       "id": "rhino",
@@ -2992,7 +3202,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 13
     },
     {
       "id": "scorpion",
@@ -3059,7 +3269,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 14
     },
     {
       "id": "spider",
@@ -3122,7 +3332,7 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 15
     },
     {
       "id": "thesis-fund",
@@ -3179,7 +3389,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 16
     },
     {
       "id": "vulture",
@@ -3250,7 +3460,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 15
+      "sort_order": 17
     },
     {
       "id": "wolf",
@@ -3310,7 +3520,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 16
+      "sort_order": 18
     },
     {
       "id": "coyote",
@@ -4687,6 +4897,48 @@
       "sort_order": 10
     },
     {
+      "id": "shadow",
+      "name": "Shadow — Multi-Trader Fresh-Entry Mirror",
+      "emoji": "🕶️",
+      "tagline": "Watches a handful of vetted Hyperliquid traders and mirrors only the positions they NEWLY open — never inheriting a stale book mid-move — with a hard entry-slippage guard so you never chase a fill that already ran, plus budget-relative sizing with a min-notional floor.",
+      "belief_plain": "Instead of copying one trader's whole account — and inheriting trades already deep in profit or loss at a worse price than they got — Shadow watches two or three proven traders and only acts when one of them OPENS a brand-new position. It checks how far price has already moved from their entry and skips the trade if it is too late to get a comparable fill. It sizes each mirror to your budget with a floor so a position is never too small to matter, and it manages its own exit.",
+      "version": "1.0.0",
+      "thesis": "The failure mode of naive mirroring is entry drift: you inherit a book at a 1-5% worse price than the trader got, so the same trade is a loss for you. Shadow fires ONLY on fresh opens (a snapshot-diff against a seeded book, so nothing pre-existing is ever inherited), rejects any entry whose price has already run past a slippage cap, and can require multi-trader confirmation before committing size. You follow proven money at their price, not yesterday's book at yours. Leverage is capped, so a trader's 40x book becomes something survivable.",
+      "tags": [
+        "copy-trading",
+        "multi-trader",
+        "fresh-entry",
+        "mirror",
+        "entry-slippage-guard",
+        "smart-money",
+        "budget-relative"
+      ],
+      "group": "smart-money",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "fresh_entry_mirror",
+      "sub_style_label": "Mirrors only the FRESHLY-opened positions of a small vetted cohort — never inherits an existing book — with an entry-slippage guard so you don't chase a fill that already ran.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 120,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 11
+    },
+    {
       "id": "stingray",
       "name": "Stingray — Cross-Asset Smart-Money Rotation",
       "emoji": "🐠",
@@ -4731,7 +4983,7 @@
       ],
       "max_slots": 4,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "whalehunter",
@@ -4774,7 +5026,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "osprey",

--- a/senpi-strategy-discover/references/glossary.yaml
+++ b/senpi-strategy-discover/references/glossary.yaml
@@ -80,6 +80,7 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   cohort_divergence: { gloss: "Acts when a smart-money cohort diverges from price." }
   sm_rotation: { gloss: "Follows where smart money is rotating across asset classes — long the crowded-into, short the fled." }
   elite_conviction: { gloss: "Mirrors only top-tier (elite/reliable) traders' concentrated, high-conviction positions." }
+  fresh_entry_mirror: { gloss: "Mirrors only the FRESHLY-opened positions of a small vetted cohort — never inherits an existing book — with an entry-slippage guard so you don't chase a fill that already ran." }
   # single_market
   pre_ipo:       { gloss: "Trades pre-IPO perpetuals (IPOPs) before the company lists." }
   ipo_moment:    { gloss: "Trades the IPO conversion moment." }
@@ -111,6 +112,9 @@ sub_style:        # archetype-scoped refinement; EXTENSIBLE (add new values with
   market_making: { gloss: "Volume / market-making, not directional." }
   pairs_rv:      { gloss: "Trades a pair's ratio back to its mean (relative value)." }
   dca:           { gloss: "Dollar-cost-averages on a schedule; predicts nothing." }
+  capital_preservation: { gloss: "Diversified, NO-leverage, capped portfolio that preserves capital first — enters only high-quality multi-timeframe trends that clear a fee hurdle, with hard per-position and per-class limits; 'no trade is better than a poor trade'." }
+  # macro_thesis
+  conviction_rebalance: { gloss: "Re-underwrites a concentrated book on a fixed clock (e.g. every 3h) from a blended short-horizon score — cross-asset flows + funding regime + momentum events — holding only the 1-2 highest-conviction long/short ideas." }
   # tail_risk
   crisis_alpha:  { gloss: "Convex crisis hedge that pays off in tail / vol events." }
   # event_driven

--- a/senpi-strategy-discover/tests/test_new_strategy_discoverability.py
+++ b/senpi-strategy-discover/tests/test_new_strategy_discoverability.py
@@ -30,14 +30,20 @@ def _rank(target, itn, theme):
 
 # (target, intent, theme) mirroring the real user prompts
 _CASES = [
-    ("viper",     _intent(), "smc ict market structure"),                      # M174126
-    ("salmon",    _intent(), "mean reversion rsi oversold buy the dip"),       # M210373 / M272040
-    ("armadillo", _intent(), "low risk capital preservation conservative"),    # M264525 / M287260
-    ("starling",  _intent(), "follow smart money rotation"),                   # M279357 / M196406
-    ("ant",       _intent(), "funding carry cash and carry harvest"),          # M242529
+    ("viper",     _intent(), "smc ict market structure"),
+    ("salmon",    _intent(), "mean reversion rsi oversold buy the dip"),
+    ("armadillo", _intent(), "low risk capital preservation conservative"),
+    ("starling",  _intent(), "follow smart money rotation"),
+    ("ant",       _intent(), "funding carry cash and carry harvest"),
     ("raven",     _intent(), "adaptive self tuning momentum learns"),
-    ("ram",       _intent(assets=[("class", "commodities")]), "gold xauusd metals"),  # M207348 / M197292
-    ("gecko",     _intent(assets=[("named", "VVV")]), "any coin"),             # M279357 (VVV) / M199951 ($LIT)
+    ("ram",       _intent(assets=[("class", "commodities")]), "gold xauusd metals"),
+    ("gecko",     _intent(assets=[("named", "VVV")]), "any coin"),
+    # ── demand-driven builds from the 2026-08-04 verbatim-prompts doc ──
+    ("shadow",   _intent(), "mirror multiple traders fresh entry copy the top traders"),
+    ("rotator",  _intent(), "rebalance conviction every few hours concentrated smart money"),
+    ("mandate",  _intent(), "capital preservation no leverage diversified portfolio rwa"),
+    ("hare",     _intent(), "scalp btc eth session quick in and out leverage"),
+    ("kite",     _intent(), "smc ict break of structure fibonacci divergence"),
 ]
 
 

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -849,6 +849,56 @@
       "sort_order": 7
     },
     {
+      "id": "hare",
+      "name": "Hare — Crypto Majors Session Scalper",
+      "emoji": "🐇",
+      "tagline": "A fast BTC/ETH scalper that only trades inside the Asia, London, and US high-volume windows — scoring a 30-minute momentum burst backed by real volume, targeting roughly 1:3 risk-reward at 5-10x. Maker-only entries and a hard per-name cooldown keep it from churning into fees.",
+      "belief_plain": "This trades only the two most liquid coins, Bitcoin and Ethereum, and only during the hours when the market is actually busy — the Asia, London, and US sessions. It waits for a quick burst of momentum backed by a real jump in volume, takes a leveraged position aiming to make about three times what it risks, and gets out fast if it's wrong. Crucially, it posts its orders to earn the maker rebate instead of paying to chase, and it refuses to re-enter the same coin for 45 minutes — because at this speed, fees are what kill a scalper.",
+      "version": "1.0.0",
+      "thesis": "A sub-hourly scalper lives or dies on cost. The edge — a volume-backed momentum burst at a session open — is real but small, so the whole design is built to protect it: session gating means it only trades when moves are large enough to matter, a volume floor rejects fee-bait bursts on thin tape, maker-only entries turn the fee from a cost into a rebate, and a hard per-name cooldown plus a daily entry cap make churning structurally impossible. The DSL is tuned for asymmetry — a tight stop, a profit-lock that arms at ~3x the risk — so the winners pay for the losers.",
+      "tags": [
+        "scalp",
+        "session",
+        "btc",
+        "eth",
+        "crypto-majors",
+        "maker-only",
+        "fee-guarded",
+        "sub-hourly",
+        "momentum",
+        "asia-london-us",
+        "long-short",
+        "cobra-guard"
+      ],
+      "group": "momentum",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "session_open",
+      "sub_style_label": "Positions into a session open on the clock — reads pre-open drift/volume and carries into the open, rather than reacting after.",
+      "asset_classes": [
+        "btc_eth"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 120,
+      "min_budget": 300,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "main",
+      "sort_order": 8
+    },
+    {
       "id": "hedgehog",
       "name": "Hedgehog — Major Crypto Basket",
       "emoji": "🦔",
@@ -895,7 +945,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
     },
     {
       "id": "hen",
@@ -958,7 +1008,7 @@
       ],
       "max_slots": 4,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 10
     },
     {
       "id": "hornet",
@@ -1025,7 +1075,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "ibis",
@@ -1074,7 +1124,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "kingfisher",
@@ -1132,7 +1182,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "lemur",
@@ -1178,7 +1228,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 14
     },
     {
       "id": "lynx",
@@ -1229,7 +1279,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 15
     },
     {
       "id": "meerkat",
@@ -1273,7 +1323,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 15
+      "sort_order": 16
     },
     {
       "id": "orca",
@@ -1316,7 +1366,7 @@
       ],
       "max_slots": 3,
       "branch": "main",
-      "sort_order": 16
+      "sort_order": 17
     },
     {
       "id": "otter",
@@ -1360,7 +1410,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 17
+      "sort_order": 18
     },
     {
       "id": "piranha",
@@ -1412,7 +1462,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 18
+      "sort_order": 19
     },
     {
       "id": "python",
@@ -1456,7 +1506,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 19
+      "sort_order": 20
     },
     {
       "id": "rooster",
@@ -1504,7 +1554,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 20
+      "sort_order": 21
     },
     {
       "id": "sailfish",
@@ -1554,7 +1604,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 21
+      "sort_order": 22
     },
     {
       "id": "salamander",
@@ -1604,7 +1654,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 22
+      "sort_order": 23
     },
     {
       "id": "sheep",
@@ -1657,7 +1707,7 @@
       ],
       "max_slots": 1,
       "branch": "main",
-      "sort_order": 23
+      "sort_order": 24
     },
     {
       "id": "jaguar",
@@ -2201,6 +2251,51 @@
       "sort_order": 9
     },
     {
+      "id": "rotator",
+      "name": "Rotator — Scheduled Conviction Rebalance",
+      "emoji": "🔁",
+      "tagline": "On a fixed clock (default every 3 hours) it re-reads the market and rebalances a deliberately concentrated book — never more than two positions, long OR short — ranking candidates on a blended score of cross-asset flows, the funding regime, and live leaderboard momentum events.",
+      "belief_plain": "Every few hours this strategy re-underwrites its whole book from scratch. It looks at which alts are lagging a big Bitcoin move and should catch up, whether the crowd is dangerously one-sided on funding (a contrarian warning), and which coins the best traders are piling into right now — then blends those into a single conviction score and holds only the one or two best long-or-short ideas. Weak positions retire on their stop and the next rebalance fills the freed slot.",
+      "version": "1.0.0",
+      "thesis": "Concentration plus a fixed re-underwrite clock beats a sprawling always-on book: a small number of high-conviction positions, re-scored every few hours against the freshest short-horizon data, keeps the book aligned with current conditions instead of yesterday's. The three inputs are deliberately short-horizon (4h flows, live funding, 4h momentum events) — not a long-lookback cohort — so the reads match the timescale of the trades. It rotates by attrition rather than force-closing, so it never fights its own DSL.",
+      "tags": [
+        "rebalance",
+        "conviction",
+        "concentrated",
+        "cross-asset-flows",
+        "funding-regime",
+        "momentum-events",
+        "blended-score",
+        "long-short",
+        "rotate-by-attrition",
+        "three-hourly"
+      ],
+      "group": "multi-asset-universe",
+      "archetype": "macro_thesis",
+      "archetype_label": "Macro Thesis",
+      "sub_style": "conviction_rebalance",
+      "sub_style_label": "Re-underwrites a concentrated book on a fixed clock (e.g. every 3h) from a blended short-horizon score — cross-asset flows + funding regime + momentum events — holding only the 1-2 highest-conviction long/short ideas.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "universe",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "position",
+      "cadence_seconds": 10800,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 2,
+      "branch": "main",
+      "sort_order": 10
+    },
+    {
       "id": "salmon",
       "name": "Salmon — RSI Mean-Reversion",
       "emoji": "🐟",
@@ -2241,7 +2336,7 @@
       ],
       "max_slots": 5,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 11
     },
     {
       "id": "starling",
@@ -2289,7 +2384,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "viper",
@@ -2335,7 +2430,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "asia-ai",
@@ -2729,6 +2824,59 @@
       "sort_order": 7
     },
     {
+      "id": "kite",
+      "name": "Kite — Market Structure & Divergence (SMC)",
+      "emoji": "🪁",
+      "tagline": "Trades the ICT/SMC playbook on BTC, ETH, SOL and FARTCOIN: it maps 3-bar fractal swings, waits for a break of structure, then enters on the 0.618 fibonacci retracement of that move with invalidation behind 0.786 — only when an RSI divergence confirms. Every entry carries its stop and 1R/2R/3R targets.",
+      "belief_plain": "This speaks the language of smart-money-concept traders. It watches for the market to break its own structure — taking out a prior swing high or low — which signals a real shift. Then, instead of chasing, it waits for price to pull back to the 0.618 fibonacci level of that move, checks that momentum (RSI) is diverging in its favour, and enters there with a clear invalidation just beyond the 0.786 level. It works out its 1x, 2x and 3x reward targets up front and manages the trade with a ladder that locks in gains in thirds as each target is reached.",
+      "version": "1.0.0",
+      "thesis": "A break of structure marks where order flow shifted; the 0.618 retracement is where that move offers the best risk-reward to rejoin, and the 0.786 is where the idea is simply wrong. Requiring an RSI divergence at the retracement filters the continuations that have already exhausted. The result is a defined-risk, defined-target structure trade — the exact methodology a whole trader subculture uses by hand — automated across a few liquid names. The step-up profit ladder approximates a 33/33/33 scale-out; true partial take-profit lands with the native DSL scale-out capability.",
+      "tags": [
+        "smc",
+        "ict",
+        "market-structure",
+        "break-of-structure",
+        "fractal",
+        "fibonacci",
+        "retracement",
+        "divergence",
+        "rsi",
+        "defined-risk",
+        "long-short",
+        "structure"
+      ],
+      "group": "multi-asset-whitelist",
+      "archetype": "breakout_momentum",
+      "archetype_label": "Breakout / Momentum",
+      "sub_style": "market_structure",
+      "sub_style_label": "Trades SMC/ICT/Wyckoff structure: break-of-structure, liquidity sweeps, fair-value gaps.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "FARTCOIN"
+      ],
+      "direction": "long_short",
+      "risk_level": "aggressive",
+      "tier": "advanced",
+      "leverage_max": 5,
+      "time_horizon": "swing",
+      "cadence_seconds": 300,
+      "min_budget": 300,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 4,
+      "branch": "main",
+      "sort_order": 8
+    },
+    {
       "id": "lion",
       "name": "Lion — Two-Speed-Market Cross-Asset L/S",
       "emoji": "🦁",
@@ -2814,7 +2962,69 @@
       ],
       "max_slots": 9,
       "branch": "main",
-      "sort_order": 8
+      "sort_order": 9
+    },
+    {
+      "id": "mandate",
+      "name": "Mandate — Capital-Preservation Portfolio (Crypto + RWA)",
+      "emoji": "🏛️",
+      "tagline": "A diversified, long-only, NO-LEVERAGE basket across crypto blue chips, equity indices and blue-chip names, metals, and energy — sized to a hard per-position cap, gated by a fee hurdle so it only trades when the expected move beats the cost, and diversified with a per-class limit. Capital preservation first.",
+      "belief_plain": "This is a conservative, institution-style portfolio, not a punt. It holds a diversified spread of blue-chip crypto and real-world assets (stock indices, big-cap names, gold, silver, oil), never uses leverage, and never puts more than a small capped slice into any one position. It only opens a position when the trend is genuinely there on both the 4-hour and daily view AND the expected move is large enough to be worth the trading cost — otherwise it does nothing. Doing nothing is a valid decision.",
+      "version": "1.0.0",
+      "thesis": "For capital preservation, what you DON'T do matters more than what you do. No leverage means a bad position can't wipe the book; hard per-position and per-class caps mean no single name or theme can sink it; a fee hurdle means small, cost-eroding edges are declined rather than churned. The result is a low-volatility diversified compounder across crypto and RWA that trades rarely and holds patiently, cutting a real breakdown early and locking gains before giving them back.",
+      "tags": [
+        "capital-preservation",
+        "no-leverage",
+        "diversified",
+        "rwa",
+        "blue-chip",
+        "fee-aware",
+        "position-caps",
+        "long-only",
+        "institutional",
+        "portfolio",
+        "low-risk",
+        "conservative"
+      ],
+      "group": "multi-asset-whitelist",
+      "archetype": "risk_parity",
+      "archetype_label": "Risk-Parity / All-Weather",
+      "sub_style": "capital_preservation",
+      "sub_style_label": "Diversified, NO-leverage, capped portfolio that preserves capital first — enters only high-quality multi-timeframe trends that clear a fee hurdle, with hard per-position and per-class limits; 'no trade is better than a poor trade'.",
+      "asset_classes": [
+        "btc_eth",
+        "major_alts",
+        "indices",
+        "commodities"
+      ],
+      "asset_scope": "basket",
+      "assets": [
+        "BTC",
+        "ETH",
+        "SOL",
+        "HYPE",
+        "xyz:SP500",
+        "xyz:XYZ100",
+        "xyz:NVDA",
+        "xyz:AAPL",
+        "xyz:GOLD",
+        "xyz:SILVER",
+        "xyz:BRENTOIL"
+      ],
+      "direction": "long_only",
+      "risk_level": "conservative",
+      "tier": "advanced",
+      "leverage_max": 1,
+      "time_horizon": "position",
+      "cadence_seconds": 1800,
+      "min_budget": 500,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 8,
+      "branch": "main",
+      "sort_order": 10
     },
     {
       "id": "mongoose",
@@ -2871,7 +3081,7 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 9
+      "sort_order": 11
     },
     {
       "id": "ox",
@@ -2930,7 +3140,7 @@
       ],
       "max_slots": 14,
       "branch": "main",
-      "sort_order": 10
+      "sort_order": 12
     },
     {
       "id": "rhino",
@@ -2992,7 +3202,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 13
     },
     {
       "id": "scorpion",
@@ -3059,7 +3269,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 14
     },
     {
       "id": "spider",
@@ -3122,7 +3332,7 @@
       ],
       "max_slots": 7,
       "branch": "main",
-      "sort_order": 13
+      "sort_order": 15
     },
     {
       "id": "thesis-fund",
@@ -3179,7 +3389,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 14
+      "sort_order": 16
     },
     {
       "id": "vulture",
@@ -3250,7 +3460,7 @@
       ],
       "max_slots": 2,
       "branch": "main",
-      "sort_order": 15
+      "sort_order": 17
     },
     {
       "id": "wolf",
@@ -3310,7 +3520,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 16
+      "sort_order": 18
     },
     {
       "id": "coyote",
@@ -4687,6 +4897,48 @@
       "sort_order": 10
     },
     {
+      "id": "shadow",
+      "name": "Shadow — Multi-Trader Fresh-Entry Mirror",
+      "emoji": "🕶️",
+      "tagline": "Watches a handful of vetted Hyperliquid traders and mirrors only the positions they NEWLY open — never inheriting a stale book mid-move — with a hard entry-slippage guard so you never chase a fill that already ran, plus budget-relative sizing with a min-notional floor.",
+      "belief_plain": "Instead of copying one trader's whole account — and inheriting trades already deep in profit or loss at a worse price than they got — Shadow watches two or three proven traders and only acts when one of them OPENS a brand-new position. It checks how far price has already moved from their entry and skips the trade if it is too late to get a comparable fill. It sizes each mirror to your budget with a floor so a position is never too small to matter, and it manages its own exit.",
+      "version": "1.0.0",
+      "thesis": "The failure mode of naive mirroring is entry drift: you inherit a book at a 1-5% worse price than the trader got, so the same trade is a loss for you. Shadow fires ONLY on fresh opens (a snapshot-diff against a seeded book, so nothing pre-existing is ever inherited), rejects any entry whose price has already run past a slippage cap, and can require multi-trader confirmation before committing size. You follow proven money at their price, not yesterday's book at yours. Leverage is capped, so a trader's 40x book becomes something survivable.",
+      "tags": [
+        "copy-trading",
+        "multi-trader",
+        "fresh-entry",
+        "mirror",
+        "entry-slippage-guard",
+        "smart-money",
+        "budget-relative"
+      ],
+      "group": "smart-money",
+      "archetype": "copy_trading",
+      "archetype_label": "Copy-Trader",
+      "sub_style": "fresh_entry_mirror",
+      "sub_style_label": "Mirrors only the FRESHLY-opened positions of a small vetted cohort — never inherits an existing book — with an entry-slippage guard so you don't chase a fill that already ran.",
+      "asset_classes": [
+        "universe_crypto"
+      ],
+      "asset_scope": "follows_traders",
+      "assets": [],
+      "direction": "long_short",
+      "risk_level": "moderate",
+      "tier": "advanced",
+      "leverage_max": 10,
+      "time_horizon": "swing",
+      "cadence_seconds": 120,
+      "min_budget": 200,
+      "instance_count": 1,
+      "funding_split": [
+        1.0
+      ],
+      "max_slots": 5,
+      "branch": "main",
+      "sort_order": 11
+    },
+    {
       "id": "stingray",
       "name": "Stingray — Cross-Asset Smart-Money Rotation",
       "emoji": "🐠",
@@ -4731,7 +4983,7 @@
       ],
       "max_slots": 4,
       "branch": "main",
-      "sort_order": 11
+      "sort_order": 12
     },
     {
       "id": "whalehunter",
@@ -4774,7 +5026,7 @@
       ],
       "max_slots": 6,
       "branch": "main",
-      "sort_order": 12
+      "sort_order": 13
     },
     {
       "id": "osprey",

--- a/strategies/hare/main/runtime.yaml
+++ b/strategies/hare/main/runtime.yaml
@@ -1,0 +1,114 @@
+# ── HARE · crypto-majors session scalper (BTC/ETH, maker-only, fee-guarded) ──
+name: hare-main
+group: hare
+version: 3.0.0
+description: >
+  HARE — a BTC/ETH sub-hourly scalper that only trades DURING the Asia / London / US
+  high-volume windows. It scores a 30m momentum burst backed by real volume expansion and
+  emits a 5-10x intent, targeting a ~1:3 risk-reward via a tight DSL stop and a profit-lock
+  ladder that arms at ~3x the risk. The fee guard is structural and non-negotiable: entries
+  are MAKER-ONLY (post for the rebate, never chase), and a hard frequency cap (per-asset
+  cooldown + max entries/day + session gating) stops it churning into fees.
+
+strategy:
+  wallet: "${HARE_WALLET}"
+  slots: 2                                 # BTC + ETH — a two-name scalp book
+  margin_pct: 12
+  default_leverage: 6
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: hare_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 120                   # 2m: fine enough to catch a session burst; ZERO reads when idle
+    timeout_seconds: 60
+    default_signal_validity_seconds: 300    # a scalp read goes stale fast
+    state_history_max_count: 120
+    inputs:
+      assets: ["BTC", "ETH"]
+      sessionWindows:                       # UTC high-volume windows — only trades inside these
+        - { name: "asia",   start: "00:00", end: "04:00" }
+        - { name: "london", start: "07:00", end: "11:00" }
+        - { name: "us",     start: "13:30", end: "17:00" }
+      maxSlots: 2
+      burstBars: 2                          # 2 x 15m = the 30m momentum window
+      baselineBars: 12                      # 3h of 15m bars as the volume baseline
+      minBurstPct: 0.4                      # noise floor — below this there is no burst
+      strongBurstPct: 0.9
+      minVolumeRatio: 1.3                   # burst MUST beat baseline volume by 30% (fee-bait guard)
+      minScore: 4
+      marginPct: 12                         # PERCENT of withdrawable (0,100]; tiered x1.2 / x1.4
+      maxMarginPct: 22
+      stdLeverage: 6
+      maxLeverage: 10
+      cooldownMinutes: 45                   # HARD frequency cap — no re-entry on a name for 45m
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      session: { type: string, required: false }
+      driftPct: { type: number, required: false }
+      volRatio: { type: number, required: false }
+      trend1h: { type: string, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: hare_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule
+    scanners: [hare_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false    # MAKER-ONLY — post for the rebate, never chase (the fee guard)
+        execution_timeout_seconds: 60
+    context:
+      - type: signal
+        scanner: hare_signals
+
+# EXIT — scalp DSL tuned to ~1:3 R:R: a tight Phase-1 stop is the "1"; the first Phase-2 lock
+# arms at ~3x the risk (the "3") and trails from there. Short time cuts — a session scalp that
+# is not working is out within the hour, and never held past ~3h.
+exit:
+  engine: dsl
+  interval_seconds: 30
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: false        # maker on the way out too, where it can
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout: { enabled: true, interval_in_minutes: 180 }               # scalp: flat within ~3h
+    weak_peak_cut: { enabled: true, interval_in_minutes: 45, min_value: 1.5 }  # not working in 45m -> release
+    phase1:
+      enabled: true
+      max_loss_pct: 8.0                      # tight stop — the "1" in 1:3
+      retrace_threshold: 5
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 10, lock_hw_pct: 0 }    # arm
+        - { trigger_pct: 24, lock_hw_pct: 50 }   # ~3x the risk — lock half (the "3" in 1:3)
+        - { trigger_pct: 40, lock_hw_pct: 70 }
+        - { trigger_pct: 65, lock_hw_pct: 82 }
+
+risk:
+  data_retention_seconds: 172800
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 6                   # 2 names x 3 sessions ceiling — the hard frequency cap
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 3                # scalping into losses halts fast
+    cooldown_seconds: 2700                   # 45m global cooldown after a close
+    drawdown_halt_pct: 15
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 2700         # 45m — never churn the same name (matches cooldownMinutes)

--- a/strategies/hare/main/scanners/scan.py
+++ b/strategies/hare/main/scanners/scan.py
@@ -1,0 +1,125 @@
+"""HARE — supervised scanner: crypto-majors (BTC/ETH) session scalper.
+
+Per tick: check the UTC clock — OUTSIDE the configured Asia/London/US high-volume windows it
+reads NOTHING and emits nothing (cheap + no fee exposure). Inside a window, for each of BTC/ETH
+that is not already held and not inside its per-asset cooldown (the hard frequency cap), read
+15m + 1h candles, score a sub-hourly momentum burst that clears the volume/fee bar, and emit a
+conviction-sized 5-10x intent. Maker-only entry + short DSL exit live in runtime.yaml. Read-only,
+single-pass. The fee guard is the whole point: session-gated, cooldown-capped, maker-only."""
+
+import sys
+import time
+
+import scoring
+
+_ASSETS = ["BTC", "ETH"]
+_DEFAULT_WINDOWS = [
+    {"name": "asia",   "start": "00:00", "end": "04:00"},
+    {"name": "london", "start": "07:00", "end": "11:00"},
+    {"name": "us",     "start": "13:30", "end": "17:00"},
+]
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[hare.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _held(ctx):
+    """Bare-uppercase coins with an open position (dual-DEX main+xyz), or None on failure."""
+    d = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet}, "clearinghouse")
+    if not isinstance(d, dict):
+        return None
+    rows = []
+    for sec in ("main", "xyz"):
+        s = d.get(sec)
+        if isinstance(s, dict):
+            rows.extend(s.get("assetPositions", s.get("asset_positions", [])) or [])
+    if not rows:
+        rows = d.get("assetPositions", d.get("asset_positions", [])) or []
+    out = set()
+    for e in rows:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["15m", "1h"],
+        "include_funding": False, "include_order_book": False,
+    }, f"market_get_asset_data({name})")
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    gm = time.gmtime(now)
+    minute_of_day = gm.tm_hour * 60 + gm.tm_min
+    windows = inputs.get("sessionWindows") or _DEFAULT_WINDOWS
+    assets = inputs.get("assets") or _ASSETS
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 2))
+    min_score = scoring._f(inputs.get("minScore"), 4)
+    cooldown = scoring._f(inputs.get("cooldownMinutes"), 45) * 60.0
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (st.get("recent") or {}).items() if (now - v) < cooldown}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent, "result": {"ts": now}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[hare.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    in_sess, sess = scoring.in_session(minute_of_day, windows)
+    if not in_sess:                                   # OUTSIDE a session: read nothing, emit nothing
+        _persist()
+        return []
+
+    held = _held(ctx)
+    if held is None:
+        return []
+    free = max_slots - len(held)
+    if free <= 0:
+        _persist()
+        return []
+
+    out = []
+    for coin in assets:
+        if free <= 0:
+            break
+        bare = str(coin).split(":", 1)[-1].upper()
+        if bare in held:
+            continue
+        if recent.get(bare) is not None and (now - recent[bare]) < cooldown:   # hard frequency cap
+            continue
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        candles = md.get("candles", {}) or {}
+        th = scoring.scalp_thesis(coin, candles.get("15m", []), candles.get("1h", []), sess, inputs)
+        if not th or th["score"] < min_score:
+            continue
+        mgn, lev = scoring.sizing(th["score"], inputs)
+        out.append({
+            "asset": coin, "direction": th["direction"], "marginPct": mgn, "leverage": lev,
+            "data": {"score": th["score"], "direction": th["direction"], "session": sess,
+                     "driftPct": th["drift"], "volRatio": th["vol_ratio"],
+                     "trend1h": th["trend_1h"], "reasons": th["reasons"]},
+        })
+        recent[bare] = now
+        free -= 1
+        print(f"[hare.scan] SCALP {th['direction']} {coin} [{sess}] score={th['score']} "
+              f"{lev}x {mgn}%", file=sys.stderr)
+
+    _persist()
+    return out

--- a/strategies/hare/main/scanners/scoring.py
+++ b/strategies/hare/main/scanners/scoring.py
@@ -1,0 +1,163 @@
+"""HARE — pure crypto-majors session-scalp math (no I/O, no MCP; the clock is supplied).
+
+BTC/ETH only. Sub-hourly momentum bursts during the Asia / London / US high-volume windows.
+The fee guard is structural (runtime.yaml: maker-only entries + a hard frequency cap); this
+module refuses to score a burst that is not backed by real volume, so a scalp only fires when
+the move is large enough to clear costs. Candles keyed o/h/l/c/v (string-safe)."""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    if isinstance(c, dict):
+        return _f(c.get("close", c.get("c", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[4])
+    return 0.0
+
+
+def _high(c):
+    if isinstance(c, dict):
+        return _f(c.get("high", c.get("h", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[2])
+    return 0.0
+
+
+def _low(c):
+    if isinstance(c, dict):
+        return _f(c.get("low", c.get("l", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 5:
+        return _f(c[3])
+    return 0.0
+
+
+def _vol(c):
+    if isinstance(c, dict):
+        return _f(c.get("volume", c.get("v", 0)))
+    if isinstance(c, (list, tuple)) and len(c) >= 6:
+        return _f(c[5])
+    return 0.0
+
+
+# ── the clock (pure — minute_of_day is supplied by scan.py) ──
+
+def parse_hhmm(s):
+    """'13:30' -> 810 minutes past UTC midnight. None if unparseable."""
+    try:
+        h, m = str(s).strip().split(":")
+        h, m = int(h), int(m)
+    except (ValueError, AttributeError):
+        return None
+    if not (0 <= h < 24 and 0 <= m < 60):
+        return None
+    return h * 60 + m
+
+
+def in_session(minute_of_day, windows):
+    """Inside any configured [start, end) UTC high-volume window? Returns (bool, name).
+    Handles a window that wraps midnight (start > end)."""
+    for w in windows or []:
+        s, e = parse_hhmm(w.get("start")), parse_hhmm(w.get("end"))
+        if s is None or e is None:
+            continue
+        inside = (s <= minute_of_day < e) if s < e else (minute_of_day >= s or minute_of_day < e)
+        if inside:
+            return True, str(w.get("name", "session"))
+    return False, None
+
+
+# ── measurements ──
+
+def window_drift_pct(candles, bars):
+    """Signed % move across the last `bars` candles. 0.0 if too short."""
+    if len(candles) < bars + 1 or bars < 1:
+        return 0.0
+    start, end = _close(candles[-(bars + 1)]), _close(candles[-1])
+    return (end - start) / start * 100.0 if start > 0 else 0.0
+
+
+def volume_expansion(candles, bars, baseline_bars):
+    """Mean volume over the last `bars` vs the mean over the `baseline_bars` before them
+    (1.0 = in line). 0.0 when there is not enough history."""
+    need = bars + baseline_bars
+    if len(candles) < need or bars < 1 or baseline_bars < 1:
+        return 0.0
+    recent = [_vol(c) for c in candles[-bars:]]
+    base = [_vol(c) for c in candles[-need:-bars]]
+    base_mean = sum(base) / len(base)
+    return (sum(recent) / len(recent)) / base_mean if base_mean > 0 else 0.0
+
+
+def trend_structure(candles):
+    """('UP'|'DOWN'|'NEUTRAL', strength) from higher-highs / lower-lows over the series.
+    Context only — never sets direction."""
+    if len(candles) < 6:
+        return "NEUTRAL", 0.0
+    highs = [_high(c) for c in candles[-6:]]
+    lows = [_low(c) for c in candles[-6:]]
+    up = sum(1 for i in range(1, len(highs)) if highs[i] > highs[i - 1])
+    down = sum(1 for i in range(1, len(lows)) if lows[i] < lows[i - 1])
+    n = len(highs) - 1
+    if up >= n * 0.6:
+        return "UP", up / n
+    if down >= n * 0.6:
+        return "DOWN", down / n
+    return "NEUTRAL", 0.0
+
+
+# ── the scalp thesis ──
+
+def scalp_thesis(coin, c15, c1h, session, inputs):
+    """A sub-hourly momentum burst that clears the fee bar. REQUIRES real volume expansion
+    (a burst on thin volume is fee-bait -> rejected). Returns a thesis dict or None.
+
+      base 4  drift over the burst window AND volume expanding (both required)
+      +1      drift is strong
+      +1/-1   1h trend agrees / opposes
+    """
+    burst_bars = int(inputs.get("burstBars", 2))            # 2 x 15m = 30m
+    base_bars = int(inputs.get("baselineBars", 12))
+    min_burst = float(inputs.get("minBurstPct", 0.4))
+    strong_burst = float(inputs.get("strongBurstPct", 0.9))
+    min_vol = float(inputs.get("minVolumeRatio", 1.3))
+    if len(c15) < burst_bars + base_bars:
+        return None
+    drift = window_drift_pct(c15, burst_bars)
+    if abs(drift) < min_burst:
+        return None
+    vr = volume_expansion(c15, burst_bars, base_bars)
+    if vr < min_vol:                                         # fee-bait guard — no volume, no scalp
+        return None
+    direction = "LONG" if drift > 0 else "SHORT"
+    score, reasons = 4, [f"{session} {burst_bars * 15}m burst {drift:+.2f}%", f"vol {vr:.2f}x baseline"]
+    if abs(drift) >= strong_burst:
+        score += 1
+        reasons.append("burst is strong")
+    t1, _ = trend_structure(c1h)
+    if (t1 == "UP" and direction == "LONG") or (t1 == "DOWN" and direction == "SHORT"):
+        score += 1
+        reasons.append(f"1h trend {t1} agrees")
+    elif t1 != "NEUTRAL":
+        score -= 1
+        reasons.append(f"1h trend {t1} opposes")
+    return {"coin": coin, "direction": direction, "score": max(0, score), "drift": round(drift, 4),
+            "vol_ratio": round(vr, 3), "trend_1h": t1, "session": session, "reasons": reasons}
+
+
+def sizing(score, inputs):
+    """Conviction-tiered (marginPct PERCENT of withdrawable, leverage). Returns (marginPct, leverage)."""
+    base_m = float(inputs.get("marginPct", 12))
+    cap = float(inputs.get("maxMarginPct", 22))
+    std_l = int(inputs.get("stdLeverage", 6))
+    max_l = int(inputs.get("maxLeverage", 10))
+    if score >= 6:
+        return round(min(base_m * 1.4, cap), 4), max_l
+    if score >= 5:
+        return round(min(base_m * 1.2, cap), 4), min(std_l + 2, max_l)
+    return round(base_m, 4), std_l

--- a/strategies/hare/strategy.yaml
+++ b/strategies/hare/strategy.yaml
@@ -1,0 +1,41 @@
+# Hare — crypto-majors session scalper. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. BTC/ETH only, sub-hourly momentum bursts traded
+# ONLY inside the Asia/London/US high-volume windows, ~1:3 R:R. The fee guard is structural
+# and non-negotiable: maker-only entries + a hard frequency cap. Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: hare
+version: "1.0.0"
+
+catalog:
+  name: "Hare — Crypto Majors Session Scalper"
+  emoji: "🐇"
+  tagline: "A fast BTC/ETH scalper that only trades inside the Asia, London, and US high-volume windows — scoring a 30-minute momentum burst backed by real volume, targeting roughly 1:3 risk-reward at 5-10x. Maker-only entries and a hard per-name cooldown keep it from churning into fees."
+  belief_plain: "This trades only the two most liquid coins, Bitcoin and Ethereum, and only during the hours when the market is actually busy — the Asia, London, and US sessions. It waits for a quick burst of momentum backed by a real jump in volume, takes a leveraged position aiming to make about three times what it risks, and gets out fast if it's wrong. Crucially, it posts its orders to earn the maker rebate instead of paying to chase, and it refuses to re-enter the same coin for 45 minutes — because at this speed, fees are what kill a scalper."
+  thesis: "A sub-hourly scalper lives or dies on cost. The edge — a volume-backed momentum burst at a session open — is real but small, so the whole design is built to protect it: session gating means it only trades when moves are large enough to matter, a volume floor rejects fee-bait bursts on thin tape, maker-only entries turn the fee from a cost into a rebate, and a hard per-name cooldown plus a daily entry cap make churning structurally impossible. The DSL is tuned for asymmetry — a tight stop, a profit-lock that arms at ~3x the risk — so the winners pay for the losers."
+  group: momentum
+  archetype: breakout_momentum
+  sub_style: session_open
+  asset_classes: [btc_eth]
+  asset_scope: basket
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  leverage_max: 10
+  max_slots: 2
+  min_budget: 300
+  assets: ["BTC", "ETH"]
+  tags: [scalp, session, btc, eth, crypto-majors, maker-only, fee-guarded, sub-hourly, momentum, asia-london-us, long-short, cobra-guard]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: HARE_WALLET
+    funding_share: 1.0

--- a/strategies/kite/main/runtime.yaml
+++ b/strategies/kite/main/runtime.yaml
@@ -1,0 +1,115 @@
+# ── KITE · market structure & divergence (ICT/SMC) — BTC/ETH/SOL/FARTCOIN ──
+name: kite-main
+group: kite
+version: 3.0.0
+description: >
+  KITE — an ICT/SMC market-structure engine. For each name it reads the 4h for a break of
+  structure (3-bar fractal swings) and the 15m for the retracement, enters at the 0.618 fib of
+  the impulse leg with invalidation behind 0.786, and requires an RSI divergence to confirm.
+  The 0.786 stop and 1R/2R/3R targets are computed and carried on the signal. The DSL exit is a
+  step-up profit-lock ladder that APPROXIMATES the requested 33/33/33 scale-out — true partial
+  take-profit awaits the native DSL scale-out capability.
+
+strategy:
+  wallet: "${KITE_WALLET}"
+  slots: 4                                 # one structure setup per name
+  margin_pct: 12
+  default_leverage: 3
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: kite_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 300                   # 5m: fine enough to catch a retracement into the 0.618 zone
+    timeout_seconds: 150
+    default_signal_validity_seconds: 900
+    state_history_max_count: 60
+    inputs:
+      assets: ["BTC", "ETH", "SOL", "FARTCOIN"]   # the desk's tickers — must match live HL casing
+      maxSlots: 4
+      fractalWing: 1                        # 3-bar fractal ("look at three candles, not five")
+      entryFib: 0.618                       # enter at the 0.618 retracement of the BOS impulse leg
+      stopFib: 0.786                        # invalidation behind 0.786
+      entryBandPct: 0.3                     # tolerance around the 0.618 level to count as "in the zone"
+      rsiPeriod: 14
+      divLookback: 20
+      requireDivergence: true               # confirm with a regular RSI divergence before entry
+      strongRiskPct: 1.0
+      minScore: 4
+      marginPct: 12                         # PERCENT of withdrawable (0,100]; tiered x1.2 / x1.4
+      maxMarginPct: 22
+      stdLeverage: 3
+      maxLeverage: 5
+      recentSignalTtlSeconds: 14400         # 4h anti-re-fire per name
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      entry: { type: number, required: false }
+      stop786: { type: number, required: false }
+      targets: { type: array, required: false }
+      riskPct: { type: number, required: false }
+      divergence: { type: boolean, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: kite_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the SMC engine already applied every filter
+    scanners: [kite_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false    # entry is a level (0.618) — post it, take the rebate
+        execution_timeout_seconds: 120
+    context:
+      - type: signal
+        scanner: kite_signals
+
+# EXIT — DSL. Phase-1 is the structural invalidation (a break beyond 0.786 area, expressed as a
+# generous ROE stop); the Phase-2 ladder is a STEP-UP profit lock that banks progressively at ~1R
+# / ~2R / ~3R — the closest the current DSL gets to the requested 33/33/33 scale-out. A structure
+# trade is given room (weak-peak retires dead setups at 2d; a 5d hard cap backstops).
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 60
+  dsl_preset:
+    hard_timeout: { enabled: true, interval_in_minutes: 7200 }               # 5d backstop
+    weak_peak_cut: { enabled: true, interval_in_minutes: 2880, min_value: 2.0 }  # retire a dead setup ~2d
+    phase1:
+      enabled: true
+      max_loss_pct: 12.0                     # structural invalidation (0.786 area) as an ROE stop
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:                                 # step-up ladder ~ the 33/33/33 intent (locks, not partials)
+        - { trigger_pct: 9,  lock_hw_pct: 33 }   # ~1R — lock the first third
+        - { trigger_pct: 18, lock_hw_pct: 60 }   # ~2R — lock through two thirds
+        - { trigger_pct: 30, lock_hw_pct: 78 }   # ~3R — trail the runner
+        - { trigger_pct: 55, lock_hw_pct: 88 }
+
+risk:
+  data_retention_seconds: 345600
+  guard_rails:
+    daily_loss_limit_pct: 10
+    max_entries_per_day: 4                   # one setup per name; structure is not high-frequency
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600
+    drawdown_halt_pct: 18
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 14400        # 4h — matches the anti-re-fire TTL

--- a/strategies/kite/main/scanners/scan.py
+++ b/strategies/kite/main/scanners/scan.py
@@ -1,0 +1,117 @@
+"""KITE — supervised scanner: ICT/SMC market-structure + divergence entries.
+
+Per tick: for each name in the whitelist (BTC/ETH/SOL/FARTCOIN by default), read a higher
+timeframe (4h) for the break-of-structure + impulse leg and a lower timeframe (15m) for the
+retracement + divergence, run the pure SMC engine (fractal -> BOS -> 0.618 entry / 0.786 stop
+-> RSI-divergence confirm), and emit an intent with the entry/stop/1R-2R-3R targets on it. The
+runtime sizes, owns slots/dedup, and trails the DSL exit (a step-up ladder approximating the
+33/33/33 scale-out until native partial take-profit ships). Read-only, single-pass, long/short."""
+
+import sys
+import time
+
+import scoring
+
+_ASSETS = ["BTC", "ETH", "SOL", "FARTCOIN"]
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[kite.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _dex_of(name):
+    return "xyz" if str(name).lower().startswith("xyz:") else ""
+
+
+def _held(ctx):
+    """Bare-uppercase coins with an open position (dual-DEX main+xyz), or None on failure."""
+    d = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet}, "clearinghouse")
+    if not isinstance(d, dict):
+        return None
+    rows = []
+    for sec in ("main", "xyz"):
+        s = d.get(sec)
+        if isinstance(s, dict):
+            rows.extend(s.get("assetPositions", s.get("asset_positions", [])) or [])
+    if not rows:
+        rows = d.get("assetPositions", d.get("asset_positions", [])) or []
+    out = set()
+    for e in rows:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["4h", "15m"],
+        "include_funding": False, "include_order_book": False, "dex": _dex_of(name),
+    }, f"market_get_asset_data({name})")
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    assets = inputs.get("assets") or _ASSETS
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 4))
+    min_score = scoring._f(inputs.get("minScore"), 4)
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 14400)
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (st.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent, "result": {"ts": now}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[kite.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    held = _held(ctx)
+    if held is None:
+        return []
+    free = max_slots - len(held)
+    if free <= 0:
+        _persist()
+        return []
+
+    out = []
+    for coin in assets:
+        if free <= 0:
+            break
+        bare = str(coin).split(":", 1)[-1].upper()
+        if bare in held:
+            continue
+        if recent.get(bare) is not None and (now - recent[bare]) < ttl:
+            continue
+        md = _asset_data(ctx, coin)
+        if not md:
+            continue
+        candles = md.get("candles", {}) or {}
+        th = scoring.smc_thesis(coin, candles.get("4h", []), candles.get("15m", []), inputs)
+        if not th or th["score"] < min_score:
+            continue
+        mgn, lev = scoring.sizing(th["score"], inputs)
+        out.append({
+            "asset": coin, "direction": th["direction"], "marginPct": mgn, "leverage": lev,
+            "data": {"score": th["score"], "direction": th["direction"],
+                     "entry": round(th["entry"], 8), "stop786": round(th["stop"], 8),
+                     "targets": th["targets"], "riskPct": th["risk_pct"],
+                     "divergence": th["divergence"], "reasons": th["reasons"]},
+        })
+        recent[bare] = now
+        free -= 1
+        print(f"[kite.scan] SMC {th['direction']} {coin} score={th['score']} "
+              f"entry={th['entry']:.6g} stop={th['stop']:.6g} {lev}x {mgn}%", file=sys.stderr)
+
+    _persist()
+    return out

--- a/strategies/kite/main/scanners/scoring.py
+++ b/strategies/kite/main/scanners/scoring.py
@@ -1,0 +1,196 @@
+"""KITE — pure market-structure + divergence math (no I/O, no MCP, no clock).
+
+Implements the ICT/SMC entry the desk asks for: find 3-bar fractal swings, detect a BREAK OF
+STRUCTURE (BOS), then on a retracement into the 0.618 fib of the BOS impulse leg (invalidation
+behind 0.786) enter in the BOS direction, confirmed by an RSI divergence. The 0.786 stop and
+1R/2R/3R targets are computed and surfaced on the signal; the DSL approximates the step-up exit
+until native partial-take-profit ships. scan.py owns the reads/state; this is the numbers.
+
+Candles keyed o/h/l/c/v (string-safe)."""
+
+
+def _f(v, d=0.0):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return d
+
+
+def _close(c):
+    return _f(c.get("close", c.get("c", 0))) if isinstance(c, dict) else 0.0
+
+
+def _high(c):
+    return _f(c.get("high", c.get("h", 0))) if isinstance(c, dict) else 0.0
+
+
+def _low(c):
+    return _f(c.get("low", c.get("l", 0))) if isinstance(c, dict) else 0.0
+
+
+# ── momentum ──
+
+def rsi(closes, n=14):
+    """Wilder-simplified RSI over the last n deltas. None if too short."""
+    if len(closes) < n + 1:
+        return None
+    deltas = [closes[i] - closes[i - 1] for i in range(1, len(closes))]
+    win = deltas[-n:]
+    g = sum(d for d in win if d > 0) / n
+    l = sum(-d for d in win if d < 0) / n
+    if l == 0:
+        return 100.0
+    return 100.0 - 100.0 / (1.0 + g / l)
+
+
+def rsi_series(closes, n=14):
+    """RSI at each bar (None for the first n). Aligned to `closes`."""
+    return [rsi(closes[:k + 1], n) if k >= n else None for k in range(len(closes))]
+
+
+# ── structure ──
+
+def fractal_swings(candles, wing=1):
+    """3-bar fractal swings (wing=1): swing HIGH at i if high[i] strictly exceeds its `wing`
+    neighbours on each side; swing LOW symmetrically. Returns (highs, lows) as [(index, price)]
+    oldest first."""
+    highs, lows = [], []
+    for i in range(wing, len(candles) - wing):
+        h, l = _high(candles[i]), _low(candles[i])
+        if (all(h > _high(candles[i - k]) for k in range(1, wing + 1))
+                and all(h > _high(candles[i + k]) for k in range(1, wing + 1))):
+            highs.append((i, h))
+        if (all(l < _low(candles[i - k]) for k in range(1, wing + 1))
+                and all(l < _low(candles[i + k]) for k in range(1, wing + 1))):
+            lows.append((i, l))
+    return highs, lows
+
+
+def detect_bos(candles, wing=1):
+    """Most recent break of structure. Bullish BOS = the last close breaks the most recent
+    prior swing HIGH; bearish = breaks the most recent swing LOW. The impulse leg runs from the
+    origin swing (the swing low before a bullish break / swing high before a bearish break) to
+    the break. Returns {dir, leg_low, leg_high, break_i} or None."""
+    if len(candles) < 2 * wing + 3:
+        return None
+    highs, lows = fractal_swings(candles, wing)
+    last = _close(candles[-1])
+    bull = bear = None
+    if highs:
+        sh_i, sh = highs[-1]
+        prior_lows = [x for x in lows if x[0] < sh_i]
+        if last > sh and prior_lows:
+            leg_low = min(prior_lows, key=lambda x: x[1])[1]
+            bull = {"dir": "LONG", "leg_low": leg_low, "leg_high": max(sh, last), "break_i": sh_i}
+    if lows:
+        sl_i, sl = lows[-1]
+        prior_highs = [x for x in highs if x[0] < sl_i]
+        if last < sl and prior_highs:
+            leg_high = max(prior_highs, key=lambda x: x[1])[1]
+            bear = {"dir": "SHORT", "leg_low": min(sl, last), "leg_high": leg_high, "break_i": sl_i}
+    if bull and bear:
+        return bull if bull["break_i"] >= bear["break_i"] else bear     # the more recent break
+    return bull or bear
+
+
+def fib_zone(bos, entry_ratio=0.618, stop_ratio=0.786):
+    """Fib retracement levels of the BOS impulse leg. LONG: entry below the high (a pullback),
+    stop deeper at 0.786; targets 1R/2R/3R above. SHORT mirrors. Returns None on a degenerate leg."""
+    lo, hi = bos["leg_low"], bos["leg_high"]
+    rng = hi - lo
+    if rng <= 0:
+        return None
+    if bos["dir"] == "LONG":
+        entry = hi - entry_ratio * rng
+        stop = hi - stop_ratio * rng
+        risk = entry - stop
+        targets = [round(entry + i * risk, 8) for i in (1, 2, 3)]
+    else:
+        entry = lo + entry_ratio * rng
+        stop = lo + stop_ratio * rng
+        risk = stop - entry
+        targets = [round(entry - i * risk, 8) for i in (1, 2, 3)]
+    if risk <= 0:
+        return None
+    return {"entry": entry, "stop": stop, "risk": risk, "targets": targets,
+            "risk_pct": round(risk / entry * 100.0, 4) if entry > 0 else 0.0}
+
+
+def in_entry_zone(price, zone, direction, band_pct):
+    """Is price currently inside the 0.618 entry zone and not past the 0.786 invalidation?
+    LONG: stop < price <= entry*(1+band). SHORT: entry*(1-band) <= price < stop."""
+    if price <= 0 or zone is None:
+        return False
+    band = band_pct / 100.0
+    if direction == "LONG":
+        return zone["stop"] < price <= zone["entry"] * (1.0 + band)
+    return zone["entry"] * (1.0 - band) <= price < zone["stop"]
+
+
+def divergence(candles, direction, inputs):
+    """Regular RSI divergence over the last `divLookback` bars, split into two halves. Bullish
+    (LONG): a lower price low with a HIGHER RSI low. Bearish (SHORT): a higher price high with a
+    LOWER RSI high. Returns True/False."""
+    n = int(inputs.get("rsiPeriod", 14))
+    look = int(inputs.get("divLookback", 20))
+    closes = [_close(c) for c in candles]
+    if len(candles) < look + n or look < 4:
+        return False
+    seg = candles[-look:]
+    rseg = rsi_series(closes, n)[-look:]
+    half = look // 2
+    a, b = range(0, half), range(half, look)
+
+    def pick(idxs, key, want_min):
+        vals = [(i, key(seg[i]), rseg[i]) for i in idxs if rseg[i] is not None]
+        if not vals:
+            return None
+        return (min if want_min else max)(vals, key=lambda x: x[1])
+
+    if direction == "LONG":
+        p1, p2 = pick(a, _low, True), pick(b, _low, True)
+        return bool(p1 and p2 and p2[1] < p1[1] and p2[2] > p1[2])
+    p1, p2 = pick(a, _high, False), pick(b, _high, False)
+    return bool(p1 and p2 and p2[1] > p1[1] and p2[2] < p1[2])
+
+
+# ── the thesis ──
+
+def smc_thesis(coin, htf, ltf, inputs):
+    """BOS on the higher timeframe + retracement into the 0.618 zone on the lower timeframe +
+    an RSI divergence confirm. Returns a full setup dict (entry/stop/targets/score) or None."""
+    wing = int(inputs.get("fractalWing", 1))
+    bos = detect_bos(htf, wing)
+    if not bos:
+        return None
+    zone = fib_zone(bos, float(inputs.get("entryFib", 0.618)), float(inputs.get("stopFib", 0.786)))
+    if not zone:
+        return None
+    ltf = ltf or htf
+    price = _close(ltf[-1])
+    if not in_entry_zone(price, zone, bos["dir"], float(inputs.get("entryBandPct", 0.3))):
+        return None
+    div = divergence(ltf, bos["dir"], inputs)
+    if bool(inputs.get("requireDivergence", True)) and not div:
+        return None
+    score = 4 + (1 if div else 0) + (1 if zone["risk_pct"] >= float(inputs.get("strongRiskPct", 1.0)) else 0)
+    reasons = [f"{bos['dir']} BOS — impulse leg {bos['leg_low']:.6g}->{bos['leg_high']:.6g}",
+               f"retraced into 0.618 entry {zone['entry']:.6g} (stop 0.786 {zone['stop']:.6g})",
+               f"risk {zone['risk_pct']:.2f}% · targets 1R/2R/3R {['%.6g' % t for t in zone['targets']]}",
+               f"RSI divergence {'CONFIRMED' if div else 'absent'}"]
+    return {"coin": coin, "direction": bos["dir"], "score": max(0, score), "entry": zone["entry"],
+            "stop": zone["stop"], "targets": zone["targets"], "risk_pct": zone["risk_pct"],
+            "divergence": div, "reasons": reasons}
+
+
+def sizing(score, inputs):
+    """Conviction-tiered (marginPct PERCENT of withdrawable, leverage) for a structure swing."""
+    base_m = float(inputs.get("marginPct", 12))
+    cap = float(inputs.get("maxMarginPct", 22))
+    std_l = int(inputs.get("stdLeverage", 3))
+    max_l = int(inputs.get("maxLeverage", 5))
+    if score >= 6:
+        return round(min(base_m * 1.4, cap), 4), max_l
+    if score >= 5:
+        return round(min(base_m * 1.2, cap), 4), min(std_l + 1, max_l)
+    return round(base_m, 4), std_l

--- a/strategies/kite/strategy.yaml
+++ b/strategies/kite/strategy.yaml
@@ -1,0 +1,40 @@
+# Kite — market structure & divergence (ICT/SMC). A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. Trades a small crypto whitelist on the ICT/SMC
+# playbook: 3-bar fractal swings -> break of structure -> 0.618 fib entry -> 0.786 invalidation
+# -> RSI-divergence confirm, with a step-up profit ladder. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: kite
+version: "1.0.0"
+
+catalog:
+  name: "Kite — Market Structure & Divergence (SMC)"
+  emoji: "🪁"
+  tagline: "Trades the ICT/SMC playbook on BTC, ETH, SOL and FARTCOIN: it maps 3-bar fractal swings, waits for a break of structure, then enters on the 0.618 fibonacci retracement of that move with invalidation behind 0.786 — only when an RSI divergence confirms. Every entry carries its stop and 1R/2R/3R targets."
+  belief_plain: "This speaks the language of smart-money-concept traders. It watches for the market to break its own structure — taking out a prior swing high or low — which signals a real shift. Then, instead of chasing, it waits for price to pull back to the 0.618 fibonacci level of that move, checks that momentum (RSI) is diverging in its favour, and enters there with a clear invalidation just beyond the 0.786 level. It works out its 1x, 2x and 3x reward targets up front and manages the trade with a ladder that locks in gains in thirds as each target is reached."
+  thesis: "A break of structure marks where order flow shifted; the 0.618 retracement is where that move offers the best risk-reward to rejoin, and the 0.786 is where the idea is simply wrong. Requiring an RSI divergence at the retracement filters the continuations that have already exhausted. The result is a defined-risk, defined-target structure trade — the exact methodology a whole trader subculture uses by hand — automated across a few liquid names. The step-up profit ladder approximates a 33/33/33 scale-out; true partial take-profit lands with the native DSL scale-out capability."
+  group: multi-asset-whitelist
+  archetype: breakout_momentum
+  sub_style: market_structure
+  asset_classes: [btc_eth, major_alts]
+  asset_scope: basket
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  leverage_max: 5
+  max_slots: 4
+  min_budget: 300
+  assets: ["BTC", "ETH", "SOL", "FARTCOIN"]
+  tags: [smc, ict, market-structure, break-of-structure, fractal, fibonacci, retracement, divergence, rsi, defined-risk, long-short, structure]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: KITE_WALLET
+    funding_share: 1.0

--- a/strategies/mandate/main/runtime.yaml
+++ b/strategies/mandate/main/runtime.yaml
@@ -1,0 +1,114 @@
+# ── MANDATE · capital-preservation portfolio (single wallet, NO leverage) ──
+name: mandate-main
+group: mandate
+version: 3.0.0
+description: >
+  MANDATE — a diversified, LONG-ONLY, NO-LEVERAGE basket across curated classes (crypto
+  blue chips + equity indices/blue-chip names + metals + energy). Capital preservation
+  first: enters only high-quality multi-timeframe trends that clear a fee hurdle (expected
+  move must beat round-trip cost), caps every position at the mandate ceiling (default 10%
+  of equity), and diversifies with a per-class cap. Held and rebalanced, never force-closed
+  (DSL is the only exit). Being inactive is a valid outcome.
+
+strategy:
+  wallet: "${MANDATE_WALLET}"
+  slots: 8
+  margin_pct: 5                          # fallback; scan emits per-signal capped allocation
+  default_leverage: 1                    # NO leverage — the mandate's defining constraint
+  trading_risk: conservative
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: mandate_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 1800                # low turnover — a preservation book rebalances slowly
+    timeout_seconds: 240
+    default_signal_validity_seconds: 3600
+    state_history_max_count: 60
+    inputs:
+      maxSlots: 8
+      maxPerClass: 2                      # diversification: no class dominates the book
+      classes:
+        crypto:  ["BTC", "ETH", "SOL", "HYPE"]
+        equity:  ["xyz:SP500", "xyz:XYZ100", "xyz:NVDA", "xyz:AAPL"]
+        metals:  ["xyz:GOLD", "xyz:SILVER"]
+        energy:  ["xyz:BRENTOIL"]
+      trendLookback: 6
+      dailyLookback: 6
+      minTrendStrength: 0.6              # only high-quality 4h uptrends
+      atrBars: 14
+      roundTripCostPct: 0.2             # ~2x taker fee + slippage estimate
+      costBufferMult: 6.0               # expected move must be >= 6x the round-trip cost (fee-aware)
+      minAllocationPct: 3.0
+      baseAllocationPct: 5.0            # the mandate's default 5% position size
+      maxAllocationPct: 10.0            # the mandate's hard 10% ceiling — never exceeded
+      goodScore: 7.0
+      recentSignalTtlSeconds: 43200     # 12h anti-re-add per name
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      assetClass: { type: string, required: false }
+      edgePct: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: mandate_add
+    action_type: OPEN_POSITION
+    decision_mode: rule                  # the quality + fee gate already filtered
+    scanners: [mandate_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: false # patient: prefer the maker rebate, don't chase (cost-aware)
+        execution_timeout_seconds: 120
+    context:
+      - type: signal
+        scanner: mandate_signals
+  # NO CLOSE_POSITION — a preservation book is held & rebalanced; DSL is the only exit.
+
+# EXIT — capital preservation: cut a real breakdown before it compounds (10% Phase 1, no
+# leverage so that is a 10% notional loss ~= <1% of a diversified book), lock gains early,
+# retire dead weight at 4 days, 14d staleness backstop.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: false
+    execution_timeout_seconds: 120
+  dsl_preset:
+    hard_timeout: { enabled: true, interval_in_minutes: 20160 }        # 14d staleness cap
+    weak_peak_cut: { enabled: true, interval_in_minutes: 5760, min_value: 2.0 }  # retire dead weight ~4d
+    phase1:
+      enabled: true
+      max_loss_pct: 10.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 2
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 5,  lock_hw_pct: 30 }   # lock gains early — preserve, don't give it back
+        - { trigger_pct: 12, lock_hw_pct: 55 }
+        - { trigger_pct: 25, lock_hw_pct: 70 }
+        - { trigger_pct: 50, lock_hw_pct: 82 }
+
+risk:
+  data_retention_seconds: 604800
+  guard_rails:
+    daily_loss_limit_pct: 5
+    max_entries_per_day: 8               # builds the basket on deploy, then rebalances slowly
+    bypass_max_entries_per_day_on_profit: false
+    max_consecutive_losses: 4
+    cooldown_seconds: 3600
+    drawdown_halt_pct: 12                # preservation: halt well before a deep hole
+    drawdown_reset_on_day_rollover: true
+    per_asset_cooldown_seconds: 43200

--- a/strategies/mandate/main/scanners/scan.py
+++ b/strategies/mandate/main/scanners/scan.py
@@ -1,0 +1,146 @@
+"""MANDATE — supervised scanner: build & hold a diversified, no-leverage, capital-
+preservation basket.
+
+Per tick (slow cadence): read this wallet's open positions (dual-DEX), count them per
+asset class, and if a slot is free AND its class is under the per-class cap, walk the
+curated whitelist (crypto blue chips, equity indices + blue-chip names, metals, energy),
+apply a multi-timeframe LONG quality gate and a fee hurdle (expected move must clear
+round-trip cost), and emit a capped, NO-LEVERAGE allocation. Long-only, rotate-by-attrition
+(DSL is the only exit — a preservation book is held and rebalanced, never force-closed).
+Read-only, single-pass. Being inactive is a valid outcome."""
+
+import sys
+import time
+
+import scoring
+
+_DEFAULT_CLASSES = {
+    "crypto":  ["BTC", "ETH", "SOL", "HYPE"],
+    "equity":  ["xyz:SP500", "xyz:XYZ100", "xyz:NVDA", "xyz:AAPL"],
+    "metals":  ["xyz:GOLD", "xyz:SILVER"],
+    "energy":  ["xyz:BRENTOIL"],
+}
+
+
+def _read(ctx, tool, args, label):
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[mandate.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _dex_of(name):
+    return "xyz" if str(name).lower().startswith("xyz:") else ""
+
+
+def _held(ctx):
+    """Bare-uppercase coins with an open position (dual-DEX main+xyz), or None on failure."""
+    d = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet}, "clearinghouse")
+    if not isinstance(d, dict):
+        return None
+    rows = []
+    for sec in ("main", "xyz"):
+        s = d.get(sec)
+        if isinstance(s, dict):
+            rows.extend(s.get("assetPositions", s.get("asset_positions", [])) or [])
+    if not rows:
+        rows = d.get("assetPositions", d.get("asset_positions", [])) or []
+    out = set()
+    for e in rows:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def _asset_data(ctx, name):
+    return _read(ctx, "market_get_asset_data", {
+        "asset": name, "candle_intervals": ["4h", "1d"],
+        "include_funding": False, "include_order_book": False, "dex": _dex_of(name),
+    }, f"market_get_asset_data({name})")
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    classes = inputs.get("classes") or _DEFAULT_CLASSES
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 8))
+    max_per_class = int(scoring._f(inputs.get("maxPerClass"), 2))
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 43200)
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (st.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent, "result": {"ts": now}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[mandate.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    held = _held(ctx)
+    if held is None:
+        return []
+    class_count = {}
+    for h in held:
+        cls = scoring.class_of(h, classes)
+        class_count[cls] = class_count.get(cls, 0) + 1
+    free = max_slots - len(held)
+    if free <= 0:
+        _persist()
+        return []
+
+    scored = []
+    for cls, coins in classes.items():
+        if class_count.get(cls, 0) >= max_per_class:
+            continue
+        for coin in coins:
+            bare = str(coin).split(":", 1)[-1].upper()
+            if bare in held:
+                continue
+            if recent.get(bare) is not None and (now - recent[bare]) < ttl:
+                continue
+            md = _asset_data(ctx, coin)
+            if not md:
+                continue
+            candles = md.get("candles", {}) or {}
+            ok, score, strength, reasons = scoring.quality(
+                candles.get("4h", []), candles.get("1d", []), inputs)
+            if not ok:
+                continue
+            edge = scoring.atr_pct(candles.get("4h", []), int(scoring._f(inputs.get("atrBars"), 14)))
+            if not scoring.passes_fee_hurdle(edge, inputs):
+                continue
+            scored.append({"coin": coin, "cls": cls, "score": score, "edge": edge,
+                           "reasons": reasons + [f"edge {edge:.2f}% clears fee hurdle"]})
+
+    scored.sort(key=lambda s: s["score"], reverse=True)
+    out = []
+    for s in scored:
+        if free <= 0:
+            break
+        if class_count.get(s["cls"], 0) >= max_per_class:      # re-check as we fill (diversification)
+            continue
+        bare = str(s["coin"]).split(":", 1)[-1].upper()
+        out.append({
+            "asset": s["coin"], "direction": "LONG",
+            "marginPct": scoring.alloc_pct(s["score"], inputs), "leverage": 1,   # NO leverage
+            "data": {"score": s["score"], "direction": "LONG", "assetClass": s["cls"],
+                     "edgePct": round(s["edge"], 3), "reasons": s["reasons"]},
+        })
+        recent[bare] = now
+        class_count[s["cls"]] = class_count.get(s["cls"], 0) + 1
+        free -= 1
+        print(f"[mandate.scan] ADD {s['coin']} ({s['cls']}) score={s['score']} "
+              f"alloc={out[-1]['marginPct']}% 1x", file=sys.stderr)
+
+    if not out:
+        print(f"[mandate.scan] no add: held={len(held)}/{max_slots} — being inactive is valid",
+              file=sys.stderr)
+    _persist()
+    return out

--- a/strategies/mandate/main/scanners/scoring.py
+++ b/strategies/mandate/main/scanners/scoring.py
@@ -1,0 +1,110 @@
+"""MANDATE — pure capital-preservation portfolio math (no I/O, no MCP, no clock).
+
+A diversified, LONG-ONLY, NO-LEVERAGE basket across curated classes (crypto blue chips,
+equity indices + blue-chip names, metals, energy). The mandate: preserve capital first,
+enter only high-quality multi-timeframe trends, and only when the expected move clears the
+round-trip cost (fee-aware) — 'no trade is better than a poor trade'. Hard per-position
+caps, no leverage. scan.py owns the reads/state; this module is the numbers."""
+
+
+def _f(x, *keys, default=0.0):
+    if keys:
+        if not isinstance(x, dict):
+            return default
+        for k in keys:
+            if x.get(k) is not None:
+                try:
+                    return float(x[k])
+                except (TypeError, ValueError):
+                    continue
+        return default
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return default
+
+
+def _close(c):
+    return _f(c, "close", "c")
+
+
+def _high(c):
+    return _f(c, "high", "h")
+
+
+def _low(c):
+    return _f(c, "low", "l")
+
+
+def trend_structure(candles, lookback=6):
+    """Higher-lows => BULLISH, lower-highs => BEARISH, 60% confirm threshold (strength =
+    fraction of confirming bars). Same structure read Ox uses."""
+    if len(candles) < lookback:
+        return "NEUTRAL", 0.0
+    lows = [_low(c) for c in candles[-lookback:]]
+    highs = [_high(c) for c in candles[-lookback:]]
+    higher_lows = sum(1 for i in range(1, len(lows)) if lows[i] > lows[i - 1])
+    lower_highs = sum(1 for i in range(1, len(highs)) if highs[i] < highs[i - 1])
+    total = lookback - 1
+    if total <= 0:
+        return "NEUTRAL", 0.0
+    if higher_lows >= total * 0.6:
+        return "BULLISH", higher_lows / total
+    if lower_highs >= total * 0.6:
+        return "BEARISH", lower_highs / total
+    return "NEUTRAL", 0.0
+
+
+def atr_pct(candles, n=14):
+    """Average true range over n bars as a PERCENT of the last close — the expected-move
+    proxy the fee hurdle is measured against."""
+    if len(candles) < 2:
+        return 0.0
+    trs = []
+    for i in range(1, len(candles)):
+        h, l, pc = _high(candles[i]), _low(candles[i]), _close(candles[i - 1])
+        trs.append(max(h - l, abs(h - pc), abs(l - pc)))
+    win = trs[-n:] if len(trs) >= n else trs
+    atr = sum(win) / len(win) if win else 0.0
+    last = _close(candles[-1])
+    return (atr / last * 100.0) if last > 0 else 0.0
+
+
+def quality(c4, c1d, inputs):
+    """LONG-only quality gate: 4h structure BULLISH with strength above the floor, and the
+    daily NOT breaking down (BULLISH or NEUTRAL) — multi-timeframe evidence. Returns
+    (ok, score, strength, reasons). 'No trade is better than a poor trade.'"""
+    t4, s4 = trend_structure(c4, int(inputs.get("trendLookback", 6)))
+    t1d, s1d = trend_structure(c1d, int(inputs.get("dailyLookback", 6)))
+    min_strength = float(inputs.get("minTrendStrength", 0.6))
+    ok = (t4 == "BULLISH" and s4 >= min_strength and t1d in ("BULLISH", "NEUTRAL"))
+    score = 5 + (1 if t4 == "BULLISH" else 0) + (1 if t1d == "BULLISH" else 0) + (1 if s4 >= 0.8 else 0)
+    return ok, score, s4, [f"4h {t4} ({s4:.0%})", f"1d {t1d} ({s1d:.0%})"]
+
+
+def passes_fee_hurdle(edge_pct, inputs):
+    """The mandate's cost-awareness: the expected move (4h ATR%) must clear the round-trip
+    cost (taker fees + slippage) times a buffer, so we never churn a tiny edge into fees."""
+    rt_cost = float(inputs.get("roundTripCostPct", 0.2))    # ~2x taker (~5bps) + slippage
+    buffer = float(inputs.get("costBufferMult", 6.0))       # require the move to be >= 6x the cost
+    return edge_pct >= rt_cost * buffer
+
+
+def alloc_pct(score, inputs):
+    """Position size as PERCENT of equity, conviction-scaled within [minAlloc, maxAlloc] and
+    HARD-CAPPED at the mandate ceiling (default 10%). No leverage — this is notional."""
+    lo = float(inputs.get("minAllocationPct", 3.0))
+    base = float(inputs.get("baseAllocationPct", 5.0))
+    cap = float(inputs.get("maxAllocationPct", 10.0))
+    good = float(inputs.get("goodScore", 7.0))
+    scaled = base + (cap - base) * max(0.0, min(1.0, (score - good) / 2.0))
+    return round(min(max(scaled, lo), cap), 4)
+
+
+def class_of(bare, classes):
+    """Map a bare-uppercase coin to its declared asset class (for diversification caps)."""
+    for cls, coins in (classes or {}).items():
+        for c in coins:
+            if str(c).split(":", 1)[-1].upper() == bare:
+                return cls
+    return "?"

--- a/strategies/mandate/strategy.yaml
+++ b/strategies/mandate/strategy.yaml
@@ -1,0 +1,41 @@
+# Mandate — capital-preservation portfolio (crypto + RWA). A single-instance PACKAGE: this
+# manifest + one self-contained runtime.yaml + scanners/. A diversified, LONG-ONLY, NO-LEVERAGE
+# basket across curated classes with a fee hurdle and hard per-position caps. Capital
+# preservation first — 'no trade is better than a poor trade'. Install/teardown via
+# senpi-strategy-ops.
+schema_version: 1
+
+id: mandate
+version: "1.0.0"
+
+catalog:
+  name: "Mandate — Capital-Preservation Portfolio (Crypto + RWA)"
+  emoji: "🏛️"
+  tagline: "A diversified, long-only, NO-LEVERAGE basket across crypto blue chips, equity indices and blue-chip names, metals, and energy — sized to a hard per-position cap, gated by a fee hurdle so it only trades when the expected move beats the cost, and diversified with a per-class limit. Capital preservation first."
+  belief_plain: "This is a conservative, institution-style portfolio, not a punt. It holds a diversified spread of blue-chip crypto and real-world assets (stock indices, big-cap names, gold, silver, oil), never uses leverage, and never puts more than a small capped slice into any one position. It only opens a position when the trend is genuinely there on both the 4-hour and daily view AND the expected move is large enough to be worth the trading cost — otherwise it does nothing. Doing nothing is a valid decision."
+  thesis: "For capital preservation, what you DON'T do matters more than what you do. No leverage means a bad position can't wipe the book; hard per-position and per-class caps mean no single name or theme can sink it; a fee hurdle means small, cost-eroding edges are declined rather than churned. The result is a low-volatility diversified compounder across crypto and RWA that trades rarely and holds patiently, cutting a real breakdown early and locking gains before giving them back."
+  group: multi-asset-whitelist
+  archetype: risk_parity
+  sub_style: capital_preservation
+  asset_classes: [btc_eth, major_alts, indices, commodities]
+  asset_scope: basket
+  direction: long_only
+  risk_level: conservative
+  tier: advanced
+  leverage_max: 1
+  max_slots: 8
+  min_budget: 500
+  assets: ["BTC", "ETH", "SOL", "HYPE", "xyz:SP500", "xyz:XYZ100", "xyz:NVDA", "xyz:AAPL", "xyz:GOLD", "xyz:SILVER", "xyz:BRENTOIL"]
+  tags: [capital-preservation, no-leverage, diversified, rwa, blue-chip, fee-aware, position-caps, long-only, institutional, portfolio, low-risk, conservative]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: MANDATE_WALLET
+    funding_share: 1.0

--- a/strategies/rotator/main/runtime.yaml
+++ b/strategies/rotator/main/runtime.yaml
@@ -1,0 +1,116 @@
+# ── ROTATOR · scheduled conviction rebalance (single wallet, concentrated <=2 book) ──
+name: rotator-main
+group: rotator
+version: 3.0.0
+description: >
+  ROTATOR — every ~3h re-underwrites a concentrated (max 2) long/short book from a blend
+  of three short-horizon reads: cross-asset flows (alts lagging BTC's move), the market
+  funding regime (crowding = contrarian), and leaderboard momentum events (winners
+  entering strong phases). Fills only FREE slots and rotates by attrition — the DSL is the
+  only exit; the next rebalance refills a freed slot with the current best. Aggressive size
+  on a deliberately small book.
+
+strategy:
+  wallet: "${ROTATOR_WALLET}"
+  slots: 2
+  default_leverage: 4
+  trading_risk: aggressive
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: rotator_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 10800                 # 3h rebalance cadence (the originating brief)
+    timeout_seconds: 120
+    default_signal_validity_seconds: 5400
+    state_history_max_count: 48             # dedup + rebalance results
+    inputs:
+      maxSlots: 2
+      leaderAsset: "BTC"
+      leaderMinMovePct: 1.0
+      minFollowRate: 0.7                     # laggard must historically follow the leader
+      minConfidence: 0.5
+      minGapPct: 0.5
+      gapFullPct: 3.0                        # gap that saturates the flow component
+      minEventTier: 2                        # tier>=2 momentum events only (winners entering)
+      eventWindowMin: 240                    # 4h freshness on events
+      eventCoinWeight: 1.5
+      eventMarketWeight: 0.5
+      flowWeight: 4.0
+      fundingWeight: 1.5
+      minScore: 4.0
+      goodScore: 5.5
+      apexScore: 7.0
+      marginPctTiers: { apex: 42, good: 32, base: 22 }   # PERCENT of withdrawable — aggressive, concentrated
+      leverageTiers: { apex: 5, good: 5, base: 4 }
+      recentSignalTtlSeconds: 10800
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      band: { type: string, required: false }
+      regime: { type: string, required: false }
+      gapPct: { type: number, required: false }
+      followRate: { type: number, required: false }
+      confidence: { type: number, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: rotator_open
+    action_type: OPEN_POSITION
+    decision_mode: rule                      # the blended score already filtered
+    scanners: [rotator_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true
+        execution_timeout_seconds: 45
+    context:
+      - type: signal
+        scanner: rotator_signals
+  # NO CLOSE_POSITION action — DSL is the only exit (rotate-by-attrition).
+
+# EXIT — DSL owns every exit. A concentrated rebalancer needs its slots to free up so the
+# next 3h read can refill: weak_peak_cut retires a stalled position in ~1 day, a 48h hard
+# cap guarantees full turnover, winners ride the ladder.
+exit:
+  engine: dsl
+  interval_seconds: 45
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout: { enabled: true, interval_in_minutes: 2880 }              # 48h — full turnover
+    weak_peak_cut: { enabled: true, interval_in_minutes: 1440, min_value: 2.5 }  # free a stalled slot in ~1d
+    phase1:
+      enabled: true
+      max_loss_pct: 15.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 1
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 6,  lock_hw_pct: 0 }
+        - { trigger_pct: 15, lock_hw_pct: 40 }
+        - { trigger_pct: 35, lock_hw_pct: 62 }
+        - { trigger_pct: 70, lock_hw_pct: 80 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 12
+    drawdown_halt_pct: 22
+    drawdown_reset_on_day_rollover: true
+    max_consecutive_losses: 4
+    cooldown_seconds: 1800
+    per_asset_cooldown_seconds: 10800
+    max_entries_per_day: 6
+    bypass_max_entries_per_day_on_profit: false

--- a/strategies/rotator/main/scanners/scan.py
+++ b/strategies/rotator/main/scanners/scan.py
@@ -1,0 +1,132 @@
+"""ROTATOR — supervised scanner: rebalance a concentrated (<=2) conviction book on a
+fixed clock (default 3h) from a blend of three SHORT-HORIZON reads.
+
+Per tick (every ~3h): read this wallet's open positions (dual-DEX), and if a slot is
+free, pull cross-asset flows (alts lagging BTC's move), the market funding regime
+(crowding => contrarian), and leaderboard momentum events (winners entering strong
+phases), blend them into ONE conviction score per candidate, and emit the top 1-2
+LONG/SHORT intents to fill the free slots. Rotate-by-attrition: NEVER closes — the DSL
+exits, and the next rebalance fills the freed slot with the current best. Read-only,
+single-pass, aggressive size on a deliberately small book."""
+
+import sys
+import time
+
+import scoring
+
+
+def _read(ctx, tool, args, label):
+    """Guarded MCP read: degrade to None, never crash the whole tick."""
+    try:
+        raw = ctx.senpi_mcp.call_tool(tool, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[rotator.scan] {label} read failed: {exc!r}", file=sys.stderr)
+        return None
+    if not raw:
+        return None
+    return raw.get("data", raw) if isinstance(raw, dict) else raw
+
+
+def _held(ctx):
+    """Bare-uppercase coins with an open position (dual-DEX main+xyz), or None on failure.
+    Reading assetPositions off the TOP level silently yields NOTHING held -> re-opens a
+    name already held; both sub-DEX views must be walked (Hyperliquid wallet structure)."""
+    d = _read(ctx, "strategy_get_clearinghouse_state", {"strategy_wallet": ctx.wallet}, "clearinghouse")
+    if not isinstance(d, dict):
+        return None
+    rows = []
+    for sec in ("main", "xyz"):
+        s = d.get(sec)
+        if isinstance(s, dict):
+            rows.extend(s.get("assetPositions", s.get("asset_positions", [])) or [])
+    if not rows:
+        rows = d.get("assetPositions", d.get("asset_positions", [])) or []
+    out = set()
+    for e in rows:
+        pos = e.get("position", e) if isinstance(e, dict) else {}
+        coin = str(pos.get("coin", "")).strip()
+        if coin and scoring._f(pos.get("szi")) != 0:
+            out.add(coin.split(":", 1)[-1].upper())
+    return out
+
+
+def _events(ctx, inputs):
+    raw = _read(ctx, "leaderboard_get_momentum_events",
+                {"tier": int(scoring._f(inputs.get("minEventTier"), 2))}, "momentum_events")
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict):
+        ev = raw.get("events", raw.get("momentum_events", raw.get("results", [])))
+        return ev if isinstance(ev, list) else []
+    return []
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    max_slots = int(scoring._f(inputs.get("maxSlots"), 2))
+    min_score = scoring._f(inputs.get("minScore"), 4.0)
+    ttl = scoring._f(inputs.get("recentSignalTtlSeconds"), 10800)
+    leader = str(inputs.get("leaderAsset", "BTC"))
+
+    st = (ctx.state.last() or {}) if ctx.state else {}
+    recent = {k: v for k, v in (st.get("recent") or {}).items() if (now - v) < ttl}
+
+    def _persist():
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"recent": recent, "result": {"ts": now}})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[rotator.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    held = _held(ctx)
+    if held is None:
+        return []                                     # clearinghouse unreadable — act next tick
+    free = max_slots - len(held)
+    if free <= 0:
+        print(f"[rotator.scan] book full ({len(held)}/{max_slots}) — rotate-by-attrition", file=sys.stderr)
+        _persist()
+        return []
+
+    flow = scoring.unwrap_flow(_read(ctx, "market_get_cross_asset_flows",
+                                     {"leader_asset": leader,
+                                      "min_move_pct": scoring._f(inputs.get("leaderMinMovePct"), 1.0)},
+                                     "cross_asset_flows"))
+    cands0 = scoring.laggards(flow, inputs)
+    if not cands0:
+        print(f"[rotator.scan] no qualifying laggards (leader {leader} quiet)", file=sys.stderr)
+        _persist()
+        return []
+
+    reg = _read(ctx, "market_get_funding_regime", {}, "funding_regime")
+    regime = reg.get("regime") if isinstance(reg, dict) else None
+    ev_per, ev_total = scoring.events_by_coin(_events(ctx, inputs), now, inputs)
+
+    scored = [scoring.blended_score(lg, regime, ev_per, ev_total, inputs) for lg in cands0]
+    scored = [s for s in scored if s["score"] >= min_score]
+    scored.sort(key=lambda s: s["score"], reverse=True)
+
+    out = []
+    for s in scored:
+        if free <= 0:
+            break
+        bare = str(s["coin"]).split(":", 1)[-1].upper()
+        if bare in held:                              # already hold this name
+            continue
+        if recent.get(bare) is not None and (now - recent[bare]) < ttl:
+            continue
+        band = scoring.band_for(s["score"], inputs)
+        lev, mgn = scoring.sizing_for(band, inputs)
+        out.append({
+            "asset": s["coin"], "direction": s["direction"], "marginPct": mgn, "leverage": lev,
+            "data": {"score": s["score"], "direction": s["direction"], "band": band,
+                     "regime": regime or "NEUTRAL", "gapPct": s["gap"], "followRate": s["follow"],
+                     "confidence": s["conf"], "reasons": s["reasons"]},
+        })
+        recent[bare] = now
+        free -= 1
+        print(f"[rotator.scan] OPEN {s['direction']} {s['coin']} score={s['score']} "
+              f"band={band} {lev}x {mgn}%", file=sys.stderr)
+
+    _persist()
+    return out

--- a/strategies/rotator/main/scanners/scoring.py
+++ b/strategies/rotator/main/scanners/scoring.py
@@ -1,0 +1,149 @@
+"""ROTATOR — pure blended-conviction math (no I/O, no MCP, no clock).
+
+Every rebalance the scan hands this module three SHORT-HORIZON reads — cross-asset flows
+(alts lagging the leader's move), the market funding regime (crowding = contrarian), and
+leaderboard momentum events (winners entering strong phases) — and it blends them into ONE
+conviction score per candidate, in the direction the leader moved. scan.py owns the
+reads/state; this module is the numbers, unit-testable in isolation."""
+
+
+def _f(x, *keys, default=0.0):
+    """Float from x. If keys given, x is a dict and we try each key in order."""
+    if keys:
+        if not isinstance(x, dict):
+            return default
+        for k in keys:
+            if x.get(k) is not None:
+                try:
+                    return float(x[k])
+                except (TypeError, ValueError):
+                    continue
+        return default
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return default
+
+
+def unwrap_flow(raw):
+    """market_get_cross_asset_flows -> the flow dict ({leader/leader_move_pct, laggards})."""
+    if not isinstance(raw, dict):
+        return {}
+    d = raw.get("data", raw)
+    if isinstance(d, dict) and isinstance(d.get("flows"), dict):
+        d = d["flows"]
+    return d if isinstance(d, dict) else {}
+
+
+def laggards(flow, inputs):
+    """Filtered catch-up candidates, each tagged with the direction the LEADER moved
+    (leader up => laggards should catch up => LONG; leader down => SHORT). Gates on the
+    tool's pre-computed follow_rate, confidence, |gap_pct|."""
+    lead = _f(flow.get("leader_move_pct"))
+    if lead == 0:
+        return []
+    direction = "LONG" if lead > 0 else "SHORT"
+    min_follow = float(inputs.get("minFollowRate", 0.7))
+    min_conf = float(inputs.get("minConfidence", 0.5))
+    min_gap = float(inputs.get("minGapPct", 0.5))
+    out = []
+    for lg in (flow.get("laggards") or []):
+        if not isinstance(lg, dict):
+            continue
+        coin = lg.get("asset") or lg.get("coin") or lg.get("symbol")
+        if not coin:
+            continue
+        follow, conf, gap = _f(lg, "follow_rate"), _f(lg, "confidence"), _f(lg, "gap_pct")
+        if follow < min_follow or conf < min_conf or abs(gap) < min_gap:
+            continue
+        out.append({"coin": coin, "direction": direction, "leader_move": lead,
+                    "follow": follow, "conf": conf, "gap": gap})
+    return out
+
+
+def funding_tilt(regime, direction, weight):
+    """Crowding = contrarian. LONG_CROWDED (longs pay, crowded) dampens LONGs / boosts
+    SHORTs; SHORT_CROWDED the reverse; NEUTRAL is 0. Returns an additive tilt."""
+    r = (regime or "").upper()
+    if r == "LONG_CROWDED":
+        return -weight if direction == "LONG" else +weight
+    if r == "SHORT_CROWDED":
+        return +weight if direction == "LONG" else -weight
+    return 0.0
+
+
+def events_by_coin(events, now, inputs):
+    """Aggregate fresh (within eventWindowMin) tier>=minTier momentum events per coin,
+    with the net side lean. Returns ({COIN: {count, longs, shorts}}, market_wide_count)."""
+    win = float(inputs.get("eventWindowMin", 240)) * 60.0
+    min_tier = int(inputs.get("minEventTier", 2))
+    per, total = {}, 0
+    for e in events or []:
+        if not isinstance(e, dict):
+            continue
+        if int(_f(e, "tier", default=1)) < min_tier:
+            continue
+        ts = _f(e, "ts", "timestamp", "time", "created_at", default=0.0)
+        ts = ts / 1000.0 if ts > 1e12 else ts            # ms -> s if needed
+        if ts and now and (now - ts) > win:
+            continue
+        total += 1
+        coin = str(e.get("token") or e.get("coin") or e.get("asset") or e.get("symbol") or "").upper()
+        if not coin:
+            continue
+        side = str(e.get("direction") or e.get("side") or "").upper()
+        d = per.setdefault(coin, {"count": 0, "longs": 0, "shorts": 0})
+        d["count"] += 1
+        if side == "LONG":
+            d["longs"] += 1
+        elif side == "SHORT":
+            d["shorts"] += 1
+    return per, total
+
+
+def event_boost(coin, direction, ev_per, ev_total, inputs):
+    """Per-coin boost if winners are entering this coin in OUR direction, plus a small
+    market-wide activity floor (winners active => a touch more conviction)."""
+    w_coin = float(inputs.get("eventCoinWeight", 1.5))
+    w_mkt = float(inputs.get("eventMarketWeight", 0.5))
+    rec = ev_per.get(str(coin).split(":", 1)[-1].upper(), {})
+    aligned = rec.get("longs", 0) if direction == "LONG" else rec.get("shorts", 0)
+    return min(1.0, aligned / 2.0) * w_coin + min(1.0, ev_total / 8.0) * w_mkt
+
+
+def blended_score(lg, regime, ev_per, ev_total, inputs):
+    """Blend the three short-horizon reads into ONE conviction score:
+      flow  = normalized |gap| * follow_rate * confidence (the catch-up expectation)
+      fund  = contrarian funding tilt
+      event = winners entering this name + market activity."""
+    w_flow = float(inputs.get("flowWeight", 4.0))
+    w_fund = float(inputs.get("fundingWeight", 1.5))
+    gap_norm = min(1.0, abs(lg["gap"]) / float(inputs.get("gapFullPct", 3.0)))
+    flow = gap_norm * lg["follow"] * lg["conf"] * w_flow
+    fund = funding_tilt(regime, lg["direction"], w_fund)
+    ev = event_boost(lg["coin"], lg["direction"], ev_per, ev_total, inputs)
+    score = round(flow + fund + ev, 3)
+    reasons = [
+        f"{lg['coin']} lags leader {lg['leader_move']:+.2f}% (gap {lg['gap']:+.2f}%, "
+        f"follow {lg['follow']:.0%}, conf {lg['conf']:.2f})",
+        f"funding {regime or 'NEUTRAL'} tilt {fund:+.2f}",
+        f"momentum-event boost {ev:+.2f} ({ev_total} tier2+ events)",
+    ]
+    return {"coin": lg["coin"], "direction": lg["direction"], "score": score,
+            "gap": lg["gap"], "follow": lg["follow"], "conf": lg["conf"], "reasons": reasons}
+
+
+def band_for(score, inputs):
+    if score >= float(inputs.get("apexScore", 7.0)):
+        return "apex"
+    if score >= float(inputs.get("goodScore", 5.5)):
+        return "good"
+    return "base"
+
+
+def sizing_for(band, inputs):
+    """Aggressive, conviction-banded sizing for a concentrated (<=2 slot) book.
+    Returns (leverage:int, marginPct:float) — marginPct a PERCENT of withdrawable."""
+    mtiers = inputs.get("marginPctTiers") or {"apex": 42, "good": 32, "base": 22}
+    ltiers = inputs.get("leverageTiers") or {"apex": 5, "good": 5, "base": 4}
+    return int(_f(ltiers, band, default=4)), round(_f(mtiers, band, default=22), 4)

--- a/strategies/rotator/strategy.yaml
+++ b/strategies/rotator/strategy.yaml
@@ -1,0 +1,41 @@
+# Rotator — scheduled conviction rebalance. A single-instance PACKAGE: this manifest + one
+# self-contained runtime.yaml + scanners/. On a fixed clock (default 3h) it re-underwrites a
+# concentrated max-2 long/short book from a blend of three short-horizon reads (cross-asset
+# flows + funding regime + leaderboard momentum events). Rotates by attrition — the DSL is the
+# only exit. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: rotator
+version: "1.0.0"
+
+catalog:
+  name: "Rotator — Scheduled Conviction Rebalance"
+  emoji: "🔁"
+  tagline: "On a fixed clock (default every 3 hours) it re-reads the market and rebalances a deliberately concentrated book — never more than two positions, long OR short — ranking candidates on a blended score of cross-asset flows, the funding regime, and live leaderboard momentum events."
+  belief_plain: "Every few hours this strategy re-underwrites its whole book from scratch. It looks at which alts are lagging a big Bitcoin move and should catch up, whether the crowd is dangerously one-sided on funding (a contrarian warning), and which coins the best traders are piling into right now — then blends those into a single conviction score and holds only the one or two best long-or-short ideas. Weak positions retire on their stop and the next rebalance fills the freed slot."
+  thesis: "Concentration plus a fixed re-underwrite clock beats a sprawling always-on book: a small number of high-conviction positions, re-scored every few hours against the freshest short-horizon data, keeps the book aligned with current conditions instead of yesterday's. The three inputs are deliberately short-horizon (4h flows, live funding, 4h momentum events) — not a long-lookback cohort — so the reads match the timescale of the trades. It rotates by attrition rather than force-closing, so it never fights its own DSL."
+  group: multi-asset-universe
+  archetype: macro_thesis
+  sub_style: conviction_rebalance
+  asset_classes: [universe_crypto]
+  asset_scope: universe
+  direction: long_short
+  risk_level: aggressive
+  tier: advanced
+  leverage_max: 5
+  max_slots: 2
+  min_budget: 200
+  assets: []
+  tags: [rebalance, conviction, concentrated, cross-asset-flows, funding-regime, momentum-events, blended-score, long-short, rotate-by-attrition, three-hourly]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: ROTATOR_WALLET
+    funding_share: 1.0

--- a/strategies/shadow/main/runtime.yaml
+++ b/strategies/shadow/main/runtime.yaml
@@ -1,0 +1,110 @@
+# ── SHADOW · multi-trader fresh-entry mirror (single wallet) ──
+name: shadow-main
+group: shadow
+version: 3.0.0
+description: >
+  SHADOW — mirrors ONLY the freshly-opened positions of a small cohort of vetted
+  Hyperliquid traders (explicit traderAddresses, else auto-selected top-N by all-time
+  realized PnL). Diffs each trader's live book against a seeded snapshot so an existing
+  book is NEVER inherited; rejects any entry whose price has already run past the slippage
+  cap; sizes budget-relative with a min-notional floor. Manages its own DSL exit — it
+  follows opens, not the trader's close. ~1 tick warmup per trader (first sight seeds the book).
+
+strategy:
+  wallet: "${SHADOW_WALLET}"
+  slots: 5
+  default_leverage: 5
+  trading_risk: moderate
+  enabled: true
+
+scanners:
+  - name: position_tracker
+    type: position_tracker
+    interval_seconds: 10
+  - name: shadow_signals
+    type: external_scanner
+    path: ./scanners
+    entrypoint: scan.py
+    interval_seconds: 120                   # tight enough to catch fresh opens near the trader's fill
+    timeout_seconds: 90
+    default_signal_validity_seconds: 600
+    state_history_max_count: 12             # seeded per-trader book + cohort cache + dedup
+    inputs:
+      traderAddresses: []                   # name your traders here; empty -> auto-select vetted top-N
+      autoSelectMinRealizedUsd: 1000000
+      autoSelectPool: 50
+      cohortRefreshHours: 24
+      maxWatched: 3
+      minConfirm: 1                         # 1 = mirror any watched trader's fresh open; 2 = require confirmation
+      maxEntrySlippagePct: 1.5             # skip if price already ran >1.5% past their entry
+      marginPct: 15                         # PERCENT of withdrawable (0,100]
+      minMarginPct: 8                       # min-notional floor — never 'too small to enter'
+      maxMarginPct: 30
+      convictionStepPct: 0.5                # +50% of base per extra confirming trader
+      stdLeverage: 5
+      maxLeverage: 10                       # caps a trader's 40x book to something survivable
+      recentSignalTtlSeconds: 3600
+    signal_data_schema:
+      score: { type: number }
+      direction: { type: string }
+      signalKind: { type: string, required: false }
+      confirmCount: { type: number, required: false }
+      entrySlippagePct: { type: number, required: false }
+      traderEntry: { type: number, required: false }
+      traders: { type: array, required: false }
+      reasons: { type: array, required: false }
+
+actions:
+  - name: position_tracker_action
+    action_type: POSITION_TRACKER
+    decision_mode: rule
+    scanners: [position_tracker]
+  - name: shadow_entry
+    action_type: OPEN_POSITION
+    decision_mode: rule                     # the scan already applied every filter
+    scanners: [shadow_signals]
+    params:
+      order_type: FEE_OPTIMIZED_LIMIT
+      fee_optimized_limit_options:
+        ensure_execution_as_taker: true     # a fresh mirror must fill near the trader's price
+        execution_timeout_seconds: 30
+    context:
+      - type: signal
+        scanner: shadow_signals
+
+# EXIT — Shadow follows opens, not the trader's close, so it runs its OWN exit: a moderate
+# disaster stop, a ratchet that locks gains as they build, and a hard cap so a mirrored
+# position never bag-holds after the trader has likely moved on.
+exit:
+  engine: dsl
+  interval_seconds: 60
+  order_type: FEE_OPTIMIZED_LIMIT
+  fee_optimized_limit_options:
+    ensure_execution_as_taker: true
+    execution_timeout_seconds: 45
+  dsl_preset:
+    hard_timeout: { enabled: true, interval_in_minutes: 2880 }      # 48h cap
+    weak_peak_cut: { enabled: true, interval_in_minutes: 720, min_value: 2.0 }
+    phase1:
+      enabled: true
+      max_loss_pct: 20.0
+      retrace_threshold: 8
+      consecutive_breaches_required: 2
+    phase2:
+      enabled: true
+      tiers:
+        - { trigger_pct: 8,  lock_hw_pct: 30 }
+        - { trigger_pct: 18, lock_hw_pct: 50 }
+        - { trigger_pct: 40, lock_hw_pct: 68 }
+        - { trigger_pct: 90, lock_hw_pct: 82 }
+
+risk:
+  guard_rails:
+    daily_loss_limit_pct: 12
+    drawdown_halt_pct: 20
+    drawdown_reset_on_day_rollover: true
+    max_consecutive_losses: 4
+    cooldown_seconds: 1800
+    per_asset_cooldown_seconds: 10800
+    max_entries_per_day: 8
+    bypass_max_entries_per_day_on_profit: false

--- a/strategies/shadow/main/scanners/scan.py
+++ b/strategies/shadow/main/scanners/scan.py
@@ -1,0 +1,155 @@
+"""SHADOW — supervised scanner: mirror vetted traders' FRESH opens only.
+
+Per tick: resolve the watched cohort (explicit `traderAddresses`, else auto-select the
+top-N vetted traders by ALL-TIME realized PnL, cached daily in ctx.state), fetch each
+trader's current open positions, diff against the seeded per-trader book to find only
+NEWLY opened (coin, side) pairs, require optional multi-trader confirmation, reject any
+whose price has already run past the entry-slippage cap, and emit a budget-relative,
+min-notional-floored INTENT. The runtime sizes, owns slots/dedup, and trails the DSL exit.
+Read-only, single-pass. Never inherits an existing book — first sight of a trader seeds it."""
+
+import sys
+import time
+
+import scoring
+
+CACHE_VERSION = 1
+_DEFAULT_TTL = 3600
+
+
+def _read(ctx, name, args):
+    """Guarded MCP read: a transient/permission error must NOT roll back the whole tick."""
+    try:
+        return ctx.senpi_mcp.call_tool(name, args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[shadow.scan] {name} read failed: {exc!r}", file=sys.stderr)
+        return None
+
+
+def _unwrap(resp, *keys):
+    """discovery/market responses wrap payloads under data/<key>; return the first list/dict."""
+    if resp is None:
+        return None
+    data = resp.get("data", resp) if isinstance(resp, dict) else resp
+    if isinstance(data, dict):
+        for k in keys:
+            if isinstance(data.get(k), (list, dict)):
+                return data[k]
+    return data
+
+
+def _resolve_cohort(ctx, cached, inputs, now):
+    """Explicit traderAddresses win. Else auto-select the top-N vetted traders by ALL-TIME
+    realized PnL (>= autoSelectMinRealizedUsd), cached daily so we don't re-rank every tick."""
+    explicit = [a.lower() for a in (inputs.get("traderAddresses") or []) if isinstance(a, str) and a]
+    max_watch = int(inputs.get("maxWatched", 3))
+    if explicit:
+        return explicit[:max_watch], cached
+    refresh_h = float(inputs.get("cohortRefreshHours", 24))
+    if (cached.get("addrs") and cached.get("cache_version") == CACHE_VERSION
+            and (now - cached.get("refreshed_at", 0)) / 3600 < refresh_h):
+        return cached["addrs"], cached
+    smin = float(inputs.get("autoSelectMinRealizedUsd", 1_000_000))
+    resp = _read(ctx, "discovery_get_top_traders", {
+        "time_frame": "ALL_TIME", "sort_by": "PROFIT_AND_LOSS_REALIZED",
+        "open_position_filter": False, "limit": int(inputs.get("autoSelectPool", 50)), "offset": 0})
+    raw = _unwrap(resp, "traders", "data") or []
+    picked = []
+    for t in raw if isinstance(raw, list) else []:
+        if not isinstance(t, dict):
+            continue
+        addr = (t.get("address") or t.get("trader_address") or "").lower()
+        rp = scoring._f(t, "realizedProfitAndLoss", "profit_and_loss_realized",
+                        "realized_profit_and_loss", "realizedPnl", default=0.0)
+        if addr and rp >= smin and addr not in picked:
+            picked.append(addr)
+        if len(picked) >= max_watch:
+            break
+    if not picked:
+        return cached.get("addrs", []), cached                 # failed refresh -> keep old cache
+    return picked, {"refreshed_at": now, "cache_version": CACHE_VERSION, "addrs": picked}
+
+
+def _fetch_states(ctx, addrs):
+    """discovery_get_trader_state in batches of 50 -> {addr: trader-state dict}."""
+    out = {}
+    for i in range(0, len(addrs), 50):
+        resp = _read(ctx, "discovery_get_trader_state",
+                     {"trader_addresses": addrs[i:i + 50], "include_position_age": True})
+        data = _unwrap(resp, "traders")
+        for t in (data or []) if isinstance(data, list) else []:
+            if isinstance(t, dict):
+                addr = (t.get("address") or t.get("trader_address") or "").lower()
+                if addr:
+                    out[addr] = t
+    return out
+
+
+def scan(inputs, ctx):
+    now = time.time()
+    ttl = float(inputs.get("recentSignalTtlSeconds", _DEFAULT_TTL))
+    min_confirm = int(inputs.get("minConfirm", 1))
+    max_slip = float(inputs.get("maxEntrySlippagePct", 1.5))
+
+    last = (ctx.state.last() or {}) if ctx.state else {}
+    seen_map = dict(last.get("seen") or {})
+    recent = {k: v for k, v in (last.get("recent") or {}).items() if (now - v) < ttl}
+
+    addrs, cohort = _resolve_cohort(ctx, last.get("cohort", {}), inputs, now)
+
+    def _persist(new_seen):
+        if ctx.state is None:
+            return
+        try:
+            ctx.state.append({"cohort": cohort, "seen": new_seen, "recent": recent})
+        except Exception as exc:  # noqa: BLE001
+            print(f"[shadow.scan] WARNING: state append failed: {exc!r}", file=sys.stderr)
+
+    if not addrs:
+        _persist(seen_map)
+        return []
+
+    states = _fetch_states(ctx, addrs)
+
+    fresh_by_trader = {}
+    new_seen = {}
+    for addr in addrs:                              # only re-seed CURRENTLY-watched traders
+        positions = scoring.extract_positions(states.get(addr))
+        fresh, keys = scoring.diff_fresh(addr, positions, seen_map)
+        new_seen[addr] = keys
+        if fresh:
+            fresh_by_trader[addr] = fresh
+
+    agg = scoring.aggregate_fresh(fresh_by_trader)
+    cands = [a for a in agg.values() if a["confirm"] >= min_confirm]     # confirmation gate
+
+    out = []
+    for a in sorted(cands, key=lambda c: c["confirm"], reverse=True):
+        k = scoring.pos_key(a["coin"], a["side"])
+        if recent.get(k) is not None and (now - recent[k]) < ttl:        # dedup: one fire per book event
+            continue
+        slip = scoring.chase_pct(a["entry_avg"], a.get("mark", 0.0), a["side"])
+        if a.get("mark", 0.0) > 0 and slip > max_slip:                   # already ran past a fair fill
+            print(f"[shadow.scan] skip {k}: chase {slip:.2f}% > cap {max_slip}%", file=sys.stderr)
+            continue
+        out.append({
+            "asset": a["coin"],
+            "direction": a["side"],
+            "marginPct": scoring.margin_pct_for(a["confirm"], inputs),
+            "leverage": scoring.leverage_for(a["lev_avg"], inputs),
+            "data": {
+                "score": scoring.score_candidate(a, slip),
+                "direction": a["side"],
+                "signalKind": "FRESH_ENTRY_MIRROR",
+                "confirmCount": a["confirm"],
+                "entrySlippagePct": slip,
+                "traderEntry": round(a["entry_avg"], 6),
+                "traders": a["traders"],
+                "reasons": [f"{a['confirm']} watched trader(s) opened {a['side']} {a['coin']} fresh",
+                            f"chase {slip:+.2f}% vs their entry (cap {max_slip}%)"],
+            },
+        })
+        recent[k] = now
+
+    _persist(new_seen)
+    return out

--- a/strategies/shadow/main/scanners/scoring.py
+++ b/strategies/shadow/main/scanners/scoring.py
@@ -1,0 +1,135 @@
+"""SHADOW — pure fresh-entry mirror math (no I/O, no MCP, no clock).
+
+Given trader-state dicts already fetched by scan.py, decide which positions are FRESHLY
+opened (never seen before for that trader), aggregate multi-trader confirmation per
+(coin, side), gate on entry slippage vs the trader's fill, and size budget-relative with
+a min-notional floor. scan.py owns the MCP reads + state; this module is the numbers,
+unit-testable in isolation."""
+
+
+def _f(x, *keys, default=0.0):
+    """Float from x. If keys given, x is a dict and we try each key in order."""
+    if keys:
+        if not isinstance(x, dict):
+            return default
+        for k in keys:
+            if x.get(k) is not None:
+                try:
+                    return float(x[k])
+                except (TypeError, ValueError):
+                    continue
+        return default
+    try:
+        return float(x)
+    except (TypeError, ValueError):
+        return default
+
+
+def _side(szi):
+    return "LONG" if szi > 0 else ("SHORT" if szi < 0 else None)
+
+
+def pos_key(coin, side):
+    return f"{coin}|{side}"
+
+
+def extract_positions(state):
+    """Flatten one discovery_get_trader_state dict -> [{coin, side, szi, entry, mark,
+    notional, leverage}]. Reads the openPositions list (coin keeps its dex prefix; szi
+    sign = side; entryPx = the trader's fill; markPx = current mark for slippage)."""
+    if not isinstance(state, dict):
+        return []
+    out = []
+    for p in (state.get("openPositions") or state.get("open_positions") or []):
+        if not isinstance(p, dict):
+            continue
+        coin = p.get("coin") or p.get("asset")
+        szi = _f(p, "szi", "size")
+        side = _side(szi)
+        if not coin or side is None:
+            continue
+        entry = _f(p, "entryPx", "entry_price", "entryPrice")
+        mark = _f(p, "markPx", "mark_price", "oraclePx")
+        notional = _f(p, "positionValue", "notional", "position_value")
+        if notional <= 0:
+            notional = abs(szi) * (mark or entry)
+        lev = _f(p.get("leverage"), "value") or _f(p, "leverage", default=0.0)
+        out.append({"coin": coin, "side": side, "szi": szi, "entry": entry,
+                    "mark": mark, "notional": notional, "leverage": lev})
+    return out
+
+
+def diff_fresh(addr, positions, seen_map):
+    """FRESH = a (coin, side) this trader holds now but that was NOT in their prior
+    seen-set. First sight of a trader (addr absent from seen_map) SEEDS their whole book
+    as already-seen and returns NO fresh entries — Shadow never inherits an existing book.
+    Returns (fresh_positions, sorted_current_keys)."""
+    now_keys = {pos_key(p["coin"], p["side"]) for p in positions}
+    if addr not in seen_map:                       # first sight -> seed, emit nothing
+        return [], sorted(now_keys)
+    prior = set(seen_map.get(addr) or [])
+    fresh = [p for p in positions if pos_key(p["coin"], p["side"]) not in prior]
+    return fresh, sorted(now_keys)
+
+
+def chase_pct(entry, mark, side):
+    """How far price has ALREADY moved in the trade's direction since the trader's entry
+    (adverse for a late mirror). LONG: (mark-entry)/entry; SHORT: (entry-mark)/entry.
+    Positive => we'd chase a worse fill than the trader got; negative => we'd get in
+    better. Guarded against a zero/absent entry or mark."""
+    if entry <= 0 or mark <= 0:
+        return 0.0
+    raw = (mark - entry) / entry if side == "LONG" else (entry - mark) / entry
+    return round(raw * 100.0, 4)
+
+
+def aggregate_fresh(fresh_by_trader):
+    """Collapse fresh entries across traders into per-(coin,side) candidates with a
+    confirmation count. fresh_by_trader: {addr: [pos, ...]}. entry_avg = mean of confirming
+    traders' entries (the reference fill to slippage-check); mark is the shared coin mark."""
+    agg = {}
+    for addr, positions in fresh_by_trader.items():
+        for p in positions:
+            k = pos_key(p["coin"], p["side"])
+            a = agg.setdefault(k, {"coin": p["coin"], "side": p["side"], "confirm": 0,
+                                   "traders": [], "entry_sum": 0.0, "lev_sum": 0.0, "mark": 0.0})
+            a["confirm"] += 1
+            a["traders"].append(addr[:10])
+            a["entry_sum"] += p["entry"]
+            a["lev_sum"] += p["leverage"]
+            if p["mark"] > 0:
+                a["mark"] = p["mark"]              # same coin across confirmers -> same mark
+    for a in agg.values():
+        n = max(1, a["confirm"])
+        a["entry_avg"] = a["entry_sum"] / n
+        a["lev_avg"] = a["lev_sum"] / n
+    return agg
+
+
+def margin_pct_for(confirm, inputs):
+    """Budget-relative sizing as a PERCENT of withdrawable in (0,100]. Base marginPct,
+    scaled per extra confirming trader, capped, and FLOORED at minMarginPct so a mirror is
+    never 'too small to enter'."""
+    base = float(inputs.get("marginPct", 15))
+    floor = float(inputs.get("minMarginPct", 8))
+    cap = float(inputs.get("maxMarginPct", 30))
+    step = float(inputs.get("convictionStepPct", 0.5))    # +50% of base per extra confirmer
+    scaled = base * (1.0 + step * max(0, confirm - 1))
+    return round(min(max(scaled, floor), cap), 4)
+
+
+def leverage_for(lev_avg, inputs):
+    """Follow the traders' leaning leverage, clamped to [1, maxLeverage]; fall back to
+    stdLeverage when unknown. Shadow never blindly mirrors a 40x book — the cap is the
+    guardrail."""
+    std = float(inputs.get("stdLeverage", 5))
+    mx = float(inputs.get("maxLeverage", 10))
+    lev = lev_avg if lev_avg and lev_avg > 0 else std
+    return int(round(min(max(lev, 1.0), mx)))
+
+
+def score_candidate(cand, slip):
+    """Conviction score for observability: base 3, +1 per extra confirmer (capped 2),
+    +1 for a favorable (negative) chase. Not a gate — the gates are confirm count and
+    slippage in scan.py."""
+    return int(3 + min(2, max(0, cand["confirm"] - 1)) + (1 if slip < 0 else 0))

--- a/strategies/shadow/strategy.yaml
+++ b/strategies/shadow/strategy.yaml
@@ -1,0 +1,41 @@
+# Shadow — multi-trader fresh-entry mirror. A single-instance PACKAGE: this manifest +
+# one self-contained runtime.yaml + scanners/. Watches a small cohort of vetted Hyperliquid
+# traders and mirrors ONLY the positions they NEWLY open — it never inherits an existing
+# book mid-move — with a hard entry-slippage guard and budget-relative sizing that has a
+# min-notional floor. Install/teardown via senpi-strategy-ops.
+schema_version: 1
+
+id: shadow
+version: "1.0.0"
+
+catalog:
+  name: "Shadow — Multi-Trader Fresh-Entry Mirror"
+  emoji: "🕶️"
+  tagline: "Watches a handful of vetted Hyperliquid traders and mirrors only the positions they NEWLY open — never inheriting a stale book mid-move — with a hard entry-slippage guard so you never chase a fill that already ran, plus budget-relative sizing with a min-notional floor."
+  belief_plain: "Instead of copying one trader's whole account — and inheriting trades already deep in profit or loss at a worse price than they got — Shadow watches two or three proven traders and only acts when one of them OPENS a brand-new position. It checks how far price has already moved from their entry and skips the trade if it is too late to get a comparable fill. It sizes each mirror to your budget with a floor so a position is never too small to matter, and it manages its own exit."
+  thesis: "The failure mode of naive mirroring is entry drift: you inherit a book at a 1-5% worse price than the trader got, so the same trade is a loss for you. Shadow fires ONLY on fresh opens (a snapshot-diff against a seeded book, so nothing pre-existing is ever inherited), rejects any entry whose price has already run past a slippage cap, and can require multi-trader confirmation before committing size. You follow proven money at their price, not yesterday's book at yours. Leverage is capped, so a trader's 40x book becomes something survivable."
+  group: smart-money
+  archetype: copy_trading
+  sub_style: fresh_entry_mirror
+  asset_classes: [universe_crypto]
+  asset_scope: follows_traders
+  direction: long_short
+  risk_level: moderate
+  tier: advanced
+  leverage_max: 10
+  max_slots: 5
+  min_budget: 200
+  assets: []
+  tags: [copy-trading, multi-trader, fresh-entry, mirror, entry-slippage-guard, smart-money, budget-relative]
+
+requires:
+  runtime: ">=3.0.0"
+
+defaults:
+  auth_token_env: SENPI_AUTH_TOKEN
+
+instances:
+  - name: main
+    runtime: main/runtime.yaml
+    wallet_env: SHADOW_WALLET
+    funding_share: 1.0


### PR DESCRIPTION
## What

Five new Runtime 3.0 strategy templates, built from the recent verbatim-user-prompts analysis — the templates users described in their own words but the catalog didn't have. Each closes a specific, quantified catalog gap.

| Template | Gap it fills | Engine (analog) |
|---|---|---|
| **Shadow** 🕶️ | `multi-trader`=0 — all 8 copy templates are single-trader | whalehunter |
| **Rotator** 🔁 | `rebalance`=0 — nothing clock-driven + concentrated | chimp |
| **Mandate** 🏛️ | `RWA`=0 — no capital-preservation, no-leverage, capped option | ox |
| **Hare** 🐇 | no crypto-majors session scalper | hen |
| **Kite** 🪁 | SMC/divergence only present as components, never the headline | manta |

## The templates

- **Shadow** — watches a vetted cohort (explicit or auto-selected), fires **only on newly-opened** positions (snapshot-diff against a seeded book, so it **never inherits** an existing book mid-move), rejects any entry that has already run past a slippage cap, budget-relative sizing with a **min-notional floor**. Fixes the naive-mirror failure mode: inheriting a book at a worse entry than the trader got.
- **Rotator** — every 3h re-underwrites a **max-2** long/short book on a blended score of **cross-asset flows + funding regime + leaderboard momentum events** (all short-horizon on purpose). Rotate-by-attrition, DSL-only exit.
- **Mandate** — diversified, **NO-leverage**, per-position (5%/10%) and per-class capped, **fee-aware** (expected move must clear round-trip cost) basket across crypto blue chips + RWA equities/indices/metals/energy. "No trade is better than a poor trade."
- **Hare** — BTC/ETH sub-hourly scalp, **session-gated** (Asia/London/US), ~1:3 R:R. Fee guard is structural and non-negotiable: **maker-only entries + hard per-name cooldown + daily cap + volume floor**.
- **Kite** — ICT/SMC: 3-bar fractal → **break of structure** → **0.618 fib entry / 0.786 stop** → **RSI-divergence confirm**, with entry/stop/1R-2R-3R on every signal. The step-up DSL ladder approximates the 33/33/33 scale-out until native partial-take-profit ships.

## Verification (offline)

- **All scanners compile**; each scoring engine has an inline smoke test (fresh-entry seed/detection, blended score, quality/fee gate, session gate + fee-bait rejection, BOS→fib→divergence).
- **gen_catalog: 96 → 101 strategies, ZERO warnings** (3 new glossary sub_styles added).
- **runtime.yaml load-time invariants** validated for all 5 (scanners/actions present, DSL phase2 tiers ascending, margin_pct ≤100, position_tracker + POSITION_TRACKER for the DSL, etc.).
- **Discoverability regression: each of the 5 ranks #1** for its target prompt; existing cases still top-3. Full discover suite **7/7 green**.

## Notes

- Every scanner is read-only + single-pass, dual-DEX position reads, per-signal `marginPct` (PERCENT), DSL-managed exits — the fleet-standard shape.
- **Kite's 33/33/33 partial-take-profit** is the DSL scale-out capability gap (being scoped separately) — Kite approximates it with the phase2 lock ladder and surfaces the exact targets for future native consumption.
- No live wallets touched; these are catalog templates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
