### PR TITLE
Scrub internal user MIDs from public code comments

### DIFF
--- a/senpi-improve-trades/tests/test_review.py
+++ b/senpi-improve-trades/tests/test_review.py
@@ -334,7 +334,7 @@ def test_fails_open_when_ratchet_source_missing():
     assert all(t["exit_reason"]["terminal"] == "UNKNOWN" for t in res["trades"])
     # timing still works — SOL still beat holding
     assert {t["asset"]: t["exit_vs_hold"] for t in res["trades"]}["SOL"] == "exit_ahead"
-    # WS3: telemetry down AND zero exits attributed → the M404726 case → status UNDETERMINED, not all-clear
+    # WS3: telemetry down AND zero exits attributed → the telemetry-down case → status UNDETERMINED, not all-clear
     ta = res["telemetry_availability"]
     assert ta["status"] == "undetermined"
     assert ta["streams_computed"] is False
@@ -863,7 +863,7 @@ def test_no_trades_when_both_sources_empty():
     assert "closed_trade_source" not in meta
 
 
-# ────────────────────────────── scope + fast-fail (the "telemetry unavailable" live-run fix, M404726) ──
+# ────────────────────────────── scope + fast-fail (the "telemetry unavailable" live-run fix) ──
 # The failure: "improve my last 10 trades" fanned the event-log shell-out across a churned book of dozens of
 # CLOSED runtimes. A closed runtime's on-disk ring is torn down, so each `openclaw senpi events` hung to its
 # timeout; N hangs → the whole review reported "telemetry unavailable" (every exit_reason UNKNOWN) — even for

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -71,7 +71,7 @@ def error_tail(err, out="", limit=600):
     """Best-available error text from a failed CLI call: prefer stderr, fall back to stdout;
     drop blank + known banner lines; return the LAST `limit` chars. CLI failures print the
     real cause at the END of the stream — a head truncation (`text[:N]`) returns the banner
-    flood and destroys the cause (the M407593 register-error blackout).
+    flood and destroys the cause (a register-error banner-flood blackout).
 
     ANSI escapes are stripped FIRST (before filtering) so a color-coded `\\x1b[90m[plugins]…`
     banner still matches the noise filter, and no raw escape sequences leak into

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -270,7 +270,7 @@ def underfunded_note(shortfall):
     """Agent-facing halt text for a funding shortfall. The lower-budget escape is only rendered
     when the usable balance can still fund every wallet at the MIN_WALLET floor — below that NO
     budget is valid, and suggesting one produces nonsense the agent follows ("--budget ≤ $0",
-    the M381223 churn). Codes: docs/error-code-taxonomy.md (repo root)."""
+    a $0-accessible-budget churn). Codes: docs/error-code-taxonomy.md (repo root)."""
     floor_needed = shortfall["wallets"] * MIN_WALLET
     facts = (f"Requested {usd(shortfall['requested'])} across {shortfall['wallets']} wallet(s) "
              f"(min {usd(MIN_WALLET)}/wallet), but only {usd(shortfall['available'])} is accessible "

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -70,7 +70,7 @@ class UnderfundedNote(unittest.TestCase):
                 "shares": shares if shares is not None else [1.0 / wallets] * wallets}
 
     def test_zero_balance_never_suggests_lower_budget(self):
-        # the M381223 case: $0 accessible → the old note said "--budget ≤ $0"
+        # the $0-accessible-budget case: $0 accessible → the old note said "--budget ≤ $0"
         note = deploy.underfunded_note(self._short(500, 1, 0, 0))
         self.assertIn("[E_FUNDS_BELOW_FLOOR]", note)
         self.assertNotIn("--budget ≤", note)

--- a/senpi-strategy-ops/tests/test_error_tail.py
+++ b/senpi-strategy-ops/tests/test_error_tail.py
@@ -17,7 +17,7 @@ import _cli  # noqa: E402
 
 class ErrorTail(unittest.TestCase):
     def test_real_error_survives_banner_flood(self):
-        # the M407593 shape: dozens of banner lines, real error on the last line —
+        # the banner-flood shape: dozens of banner lines, real error on the last line —
         # a head-truncating capture returns only banners
         err = "\n".join(["[plugins] [senpi-runtime] plugin registered …"] * 60) \
               + "\nError: exit block invalid: retrace_threshold must be > 0"

--- a/strategies/rooster/main/runtime.yaml
+++ b/strategies/rooster/main/runtime.yaml
@@ -38,7 +38,7 @@ scanners:
     default_signal_validity_seconds: 900   # 3x tick — a pre-open read goes stale fast
     state_history_max_count: 120           # per-session fired map + per-tick scan-results history
     inputs:
-      assets: ["BTC"]                      # M192397: "on the opener — yes, only BTC". Add names to widen.
+      assets: ["BTC"]                      # only BTC on the opener by default. Add names to widen.
       sessionOpensUtc: ["13:30", "08:00"]  # UTC ALWAYS. US equity open is 13:30 UTC in EDT / 14:30 in EST
                                            # — set for the half-year you are in, or list both.
       preOpenMinutes: 45                   # "start scanning 30-60 minutes earlier" — the core knob


### PR DESCRIPTION
## What

`senpi-skills` is public. Seven **real user MIDs** were sitting in **code comments / docstrings** — they documented an incident's lesson but leaked the user id. This keeps every lesson and drops every id.

| File | Was | Now |
|---|---|---|
| `senpi-strategy-ops/scripts/_cli.py` | "the M##### register-error blackout" | "a register-error banner-flood blackout" |
| `senpi-strategy-ops/scripts/deploy.py` | "the M##### churn" | "a $0-accessible-budget churn" |
| `senpi-strategy-ops/tests/test_deploy_gates.py` | "the M##### case: $0 accessible" | "the $0-accessible-budget case" |
| `senpi-strategy-ops/tests/test_error_tail.py` | "the M##### shape" | "the banner-flood shape" |
| `senpi-improve-trades/tests/test_review.py` (×2) | "the M##### case" | "the telemetry-down case" |
| `strategies/rooster/main/runtime.yaml` | a user MID + verbatim quote | "only BTC on the opener by default" |

## Left as-is (intentional)

`senpi-trader-research/tests/fixtures/research_fixture.json` has `M000001` / `M000009` with userName **"Tester"** — synthetic placeholder test data, not real users.

## Verification

`git grep -oE 'M[0-9]{6}'` over the repo now returns only the two synthetic fixture ids. Touched Python compiles.

Companion to the 5-template PR (which independently strips the MID comments from its own discoverability test). No file overlap between the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
