### PR TITLE
Catalog freshness: bump discover to propagate the 101-strategy catalog + real date

### DIFF
--- a/senpi-strategy-discover/SKILL.md
+++ b/senpi-strategy-discover/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.12.0"
+  version: "2.13.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-06-17",
+  "_updated": "2026-08-04",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.1.0"
+  version: "3.1.1"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-trading-runtime/scripts/gen_catalog.py
+++ b/senpi-trading-runtime/scripts/gen_catalog.py
@@ -12,6 +12,7 @@ still generates.
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
 import argparse
+import datetime
 import glob
 import json
 import os
@@ -272,7 +273,9 @@ def build(updated, branch):
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
-    ap.add_argument("--updated", default="2026-06-17")
+    ap.add_argument("--updated", default=datetime.date.today().isoformat(),
+                    help="catalog _updated date (YYYY-MM-DD); defaults to today so it is a real "
+                         "freshness signal, not a frozen string")
     ap.add_argument("--branch", default="main")
     a = ap.parse_args()
     catalog = build(a.updated, a.branch)

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-06-17",
+  "_updated": "2026-08-04",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [


### PR DESCRIPTION
## What
Fixes the stale-catalog report ("v2.12.0, 97 strategies, updated 2026-06-17"). Two things:

1. **Version bump propagates the catalog.** Agents auto-upgrade on a skill version bump, but turbine removal (#513) and the 5-template PR (#516) edited `senpi-strategy-discover/catalog.json` and left the version at **2.12.0** — so agents already on 2.12.0 never pulled the new **101-strategy** catalog (they still report 97). Bumped **2.12.0 → 2.13.0** to push it.
2. **The `_updated` date is now real.** It was a frozen `"2026-06-17"` default in `gen_catalog.py`, stamped on every regen — so the date was never a freshness signal. Now defaults to **today**. Regenerated → `_updated 2026-08-04`, 101 strategies (catalog content unchanged, only the date moved).

`senpi-trading-runtime` **3.1.0 → 3.1.1** (PATCH) for the gen_catalog change.

## Note
This is independent of the $10-minimum PR (#519) and its backend dependency — it just propagates already-merged content (turbine-out + the 5 new templates). #519 carries its own version bumps when it merges.

## Verified
Regen clean (0 warnings); catalog diff is date-only; discover suite 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
