### PR TITLE
Fix CUB pre-IPO sleeve: funding gate excluded every live IPOP

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-08-04",
+  "_updated": "2026-08-05",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -1756,8 +1756,8 @@
       "emoji": "🐅",
       "tagline": "Longs the structural winners of a K-shaped world (the AI complex on Hyperliquid XYZ + crypto winners HYPE/SOL) and shorts the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) — both trend-confirmed on separate wallets — plus a ~10% pre-IPO ramp satellite that auto-discovers pre-IPO perpetuals (IPOPs) and rides them into their listing.",
       "belief_plain": "The world is splitting into haves and have-nots: AI companies and crypto's winners keep booming while the broad economy and the rest of crypto struggle. Cub buys the booming side and shorts the struggling side at the same time on separate wallets, so it makes money on the GAP between the two — and keeps a small slice aimed at the next SpaceX before it goes public.",
-      "version": "1.0.0",
-      "thesis": "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their funding signature and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open.",
+      "version": "1.0.1",
+      "thesis": "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their leverage signature (fresh perps launch capped low) and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open.",
       "tags": [
         "k-shaped",
         "two-speed",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-08-04",
+  "_updated": "2026-08-05",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the effective floor (max(declared, 100 x instance_count)); positions scale with budget — NOT a hard gate. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -1756,8 +1756,8 @@
       "emoji": "🐅",
       "tagline": "Longs the structural winners of a K-shaped world (the AI complex on Hyperliquid XYZ + crypto winners HYPE/SOL) and shorts the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) — both trend-confirmed on separate wallets — plus a ~10% pre-IPO ramp satellite that auto-discovers pre-IPO perpetuals (IPOPs) and rides them into their listing.",
       "belief_plain": "The world is splitting into haves and have-nots: AI companies and crypto's winners keep booming while the broad economy and the rest of crypto struggle. Cub buys the booming side and shorts the struggling side at the same time on separate wallets, so it makes money on the GAP between the two — and keeps a small slice aimed at the next SpaceX before it goes public.",
-      "version": "1.0.0",
-      "thesis": "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their funding signature and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open.",
+      "version": "1.0.1",
+      "thesis": "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their leverage signature (fresh perps launch capped low) and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open.",
       "tags": [
         "k-shaped",
         "two-speed",

--- a/strategies/cub/long/scanners/scoring.py
+++ b/strategies/cub/long/scanners/scoring.py
@@ -1,9 +1,11 @@
 """CUB — pure thesis math (no I/O, no MCP, no clock). Shared verbatim by all three books
 (long "haves", short "have-nots", preipo pre-IPO ramp); the direction and the universe builder
 differ per book but the scoring is one function. A faithful Runtime 3.0 port of the v2
-cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights + the IPOP
-discovery filter are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing
-and must not be redesigned). Unit-testable on plain candle lists + instrument dicts.
+cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights are copied EXACTLY
+(marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be redesigned), EXCEPT the
+IPOP funding gate, which is CORRECTED: the v2 `|funding| <= 1e-7` "throttled pre-listing" signature
+matched no live IPOP (pre-IPO perps fund like ordinary equities), so it is now opt-in and OFF by
+default — see is_ipop. Unit-testable on plain candle lists + instrument dicts.
 
 KEY DISTINCTION FROM COUGAR (do not "simplify" toward cougar): in Cub the hard gate is
 ABSOLUTE TREND (long a have only while it actually trends up; short a have-not only while it
@@ -18,8 +20,14 @@ its peers ran harder. Cougar instead gates on excess (long requires excess>=0); 
 NORM_DIV = 9.0
 
 # v2 preipo defaults (cub-producer.py _DEFAULTS["preipo"] / cub-preipo-config.json)
-DEFAULT_IPOP_FUNDING_MAX = 1e-7    # IPOP funding signature (throttled pre-listing)
-DEFAULT_IPOP_LEV_CAP = 5           # IPOP leverage signature
+DEFAULT_IPOP_FUNDING_MAX = 0.0     # 0 = OFF. Funding does NOT identify an IPOP: live pre-IPO perps
+                                   # fund at the same ~1e-5..1e-4 magnitude as ordinary xyz equities
+                                   # (e.g. UNITREE -3.16e-5 sits inside the NVDA/MU/TSM pack). The only
+                                   # names with |funding| <= 1e-7 are DEAD zero-volume markets, which
+                                   # fail the liquidity floor anyway — so the v2 1e-7 gate was empty-set
+                                   # on EVERY tick and no live IPOP ever passed it. Leverage cap +
+                                   # liquidity floor + absolute-trend discriminate; funding is opt-in.
+DEFAULT_IPOP_LEV_CAP = 5           # IPOP leverage signature (fresh pre-IPO perps launch capped low)
 
 
 def _f(v, d=0.0):
@@ -240,15 +248,19 @@ def clamp_leverage(desired, venue_max):
     return max(1, min(int(desired), venue))
 
 
-# ── IPOP discovery filter (preipo leg only; ported verbatim from v2 ipop_universe) ──
+# ── IPOP discovery filter (preipo leg only) — funding gate CORRECTED vs v2 (see is_ipop + the
+#    DEFAULT_IPOP_FUNDING_MAX note): the v2 `|funding| <= 1e-7` "throttled pre-listing" signature
+#    matched NO live IPOP, so it is now opt-in/off; the leverage cap + liquidity floor identify a
+#    fresh IPOP, and the absolute-trend gate (score_thematic) confirms the ramp. ──
 
 def is_ipop(name, meta, max_funding=DEFAULT_IPOP_FUNDING_MAX, lev_cap=DEFAULT_IPOP_LEV_CAP,
             min_day_vol=0.0):
-    """True iff a live xyz: instrument matches the structural IPOP signature (verbatim v2):
+    """True iff a live xyz: instrument matches the structural IPOP signature:
         name.startswith("xyz:")
-        AND 0 < venue max_leverage <= lev_cap (the throttled pre-listing leverage cap)
-        AND abs(funding) <= max_funding (the throttled pre-listing funding signature)
-        AND 24h notional volume >= min_day_vol (budget-relative liquidity floor)."""
+        AND 0 < venue max_leverage <= lev_cap (fresh pre-IPO perps launch leverage-capped low)
+        AND 24h notional volume >= min_day_vol (budget-relative liquidity floor)
+        AND (opt-in) abs(funding) <= max_funding — OFF by default (max_funding <= 0); funding does
+            NOT discriminate IPOPs from ordinary equities, see the DEFAULT_IPOP_FUNDING_MAX note."""
     if not isinstance(name, str) or not name.lower().startswith("xyz:"):
         return False
     if not isinstance(meta, dict):
@@ -257,17 +269,18 @@ def is_ipop(name, meta, max_funding=DEFAULT_IPOP_FUNDING_MAX, lev_cap=DEFAULT_IP
         lev = int(meta.get("max_leverage"))
     except (TypeError, ValueError):
         return False
-    if lev <= 0 or lev > lev_cap:               # IPOP leverage signature
+    if lev <= 0 or lev > lev_cap:               # IPOP leverage signature (the real discriminator)
         return False
-    ctx = meta.get("ctx", {}) if isinstance(meta.get("ctx"), dict) else {}
-    try:
-        funding_abs = abs(_f(ctx.get("funding", 0)))
-    except (TypeError, ValueError):
+    if day_vol(meta) < min_day_vol:             # budget-relative liquidity floor
         return False
-    if funding_abs > max_funding:               # IPOP funding signature
-        return False
-    if day_vol(meta) < min_day_vol:             # budget-relative liquidity
-        return False
+    if max_funding and max_funding > 0:         # OPT-IN funding band — OFF by default (see note above)
+        ctx = meta.get("ctx", {}) if isinstance(meta.get("ctx"), dict) else {}
+        try:
+            funding_abs = abs(_f(ctx.get("funding", 0)))
+        except (TypeError, ValueError):
+            return False
+        if funding_abs > max_funding:
+            return False
     return True
 
 

--- a/strategies/cub/preipo/runtime.yaml
+++ b/strategies/cub/preipo/runtime.yaml
@@ -5,9 +5,9 @@ version: 3.0.0
 description: >
   CUB PREIPO (satellite) — the ~10% pre-IPO ramp sleeve of the Cub combined fund (~90% Lion
   two-speed AI long/short + ~10% pre-IPO). Runtime 3.0 port of v2 Cub v1.0.0, CUB_LEG=preipo. This
-  book auto-DISCOVERS pre-IPO perpetuals (IPOPs) on Hyperliquid XYZ by their structural funding
-  signature (|funding| <= ipopFundingMaxAbs AND venue max_leverage <= ipopMaxLeverageCap — the
-  throttled pre-listing state) and LONGS the ones with a confirming absolute 4h/1h uptrend, riding
+  book auto-DISCOVERS pre-IPO perpetuals (IPOPs) on Hyperliquid XYZ by their structural leverage
+  signature (venue max_leverage <= ipopMaxLeverageCap — fresh pre-IPO perps launch capped low) plus a
+  budget-relative liquidity floor, and LONGS the ones with a confirming absolute 4h/1h uptrend, riding
   the pre-listing ramp (the SpaceX / Cerebras pattern). No static universe — discovered every tick,
   so the next IPOP auto-joins on listing. Blow-off guard loosened (pre-IPO names run hot). LONG only.
   Episodic by design — most ticks may find 0-2 IPOPs. The IPOP liquidity floor is BUDGET-RELATIVE
@@ -36,7 +36,7 @@ scanners:
     default_signal_validity_seconds: 900
     state_history_max_count: 50
     inputs:
-      # NO static universe — IPOPs are DISCOVERED each tick by the funding+leverage signature below.
+      # NO static universe — IPOPs are DISCOVERED each tick by the leverage-cap + liquidity signature below.
       sizingWeights:
         _default: 1.0
       minScore: 4             # pre-IPO data is sparse — slightly lower bar
@@ -44,8 +44,10 @@ scanners:
       maxLeverage: 5          # IPOPs are venue-capped at 5x anyway; clamp then each name's HL venue max
       maxSlots: 3
       rankPoolSize: 16
-      ipopFundingMaxAbs: 1.0e-7   # IPOP funding signature (throttled pre-listing)
-      ipopMaxLeverageCap: 5       # IPOP leverage signature
+      ipopFundingMaxAbs: 0        # OFF (0) — funding does NOT identify an IPOP: live pre-IPO perps fund
+                                  # like ordinary equities, so the old 1.0e-7 gate matched NO live IPOP
+                                  # and left this wallet empty. Leverage cap + liquidity floor discriminate.
+      ipopMaxLeverageCap: 5       # IPOP leverage signature — the real discriminator (fresh perps launch capped low)
       ipopLiqVolMultiple: 30      # budget-relative IPOP liquidity floor (× position notional)
       rsThresholdPct: 3.0
       rsiOverbought: 88       # pre-IPO ramps run hot; loosen the blow-off guard

--- a/strategies/cub/preipo/scanners/scan.py
+++ b/strategies/cub/preipo/scanners/scan.py
@@ -1,9 +1,9 @@
 """CUB · PREIPO satellite — supervised scanner (Runtime 3.0 port of cub-producer.py CUB_LEG=preipo).
 
 The ~10% pre-IPO ramp sleeve (Lemur IPOP-discovery method). Each tick it auto-DISCOVERS pre-IPO
-perpetuals (IPOPs) from the live Hyperliquid XYZ board by their structural funding signature
-(|funding| <= ipopFundingMaxAbs AND venue max_leverage <= ipopMaxLeverageCap — the throttled
-pre-listing state), then LONGS the ones with a confirming absolute 4h/1h uptrend (rides the
+perpetuals (IPOPs) from the live Hyperliquid XYZ board by their structural leverage signature
+(venue max_leverage <= ipopMaxLeverageCap — fresh pre-IPO perps launch capped low) plus a
+budget-relative liquidity floor, then LONGS the ones with a confirming absolute 4h/1h uptrend (rides the
 pre-listing ramp; blow-off guard loosened since pre-IPO names run hot). There is NO static universe
 — it is discovered every tick, so a new IPOP (the next SpaceX/Cerebras) auto-joins the moment it
 lists. LONG-only. Episodic by design — most ticks may find 0-2 IPOPs. Read-only, single-pass.

--- a/strategies/cub/preipo/scanners/scoring.py
+++ b/strategies/cub/preipo/scanners/scoring.py
@@ -1,9 +1,11 @@
 """CUB — pure thesis math (no I/O, no MCP, no clock). Shared verbatim by all three books
 (long "haves", short "have-nots", preipo pre-IPO ramp); the direction and the universe builder
 differ per book but the scoring is one function. A faithful Runtime 3.0 port of the v2
-cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights + the IPOP
-discovery filter are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing
-and must not be redesigned). Unit-testable on plain candle lists + instrument dicts.
+cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights are copied EXACTLY
+(marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be redesigned), EXCEPT the
+IPOP funding gate, which is CORRECTED: the v2 `|funding| <= 1e-7` "throttled pre-listing" signature
+matched no live IPOP (pre-IPO perps fund like ordinary equities), so it is now opt-in and OFF by
+default — see is_ipop. Unit-testable on plain candle lists + instrument dicts.
 
 KEY DISTINCTION FROM COUGAR (do not "simplify" toward cougar): in Cub the hard gate is
 ABSOLUTE TREND (long a have only while it actually trends up; short a have-not only while it
@@ -18,8 +20,14 @@ its peers ran harder. Cougar instead gates on excess (long requires excess>=0); 
 NORM_DIV = 9.0
 
 # v2 preipo defaults (cub-producer.py _DEFAULTS["preipo"] / cub-preipo-config.json)
-DEFAULT_IPOP_FUNDING_MAX = 1e-7    # IPOP funding signature (throttled pre-listing)
-DEFAULT_IPOP_LEV_CAP = 5           # IPOP leverage signature
+DEFAULT_IPOP_FUNDING_MAX = 0.0     # 0 = OFF. Funding does NOT identify an IPOP: live pre-IPO perps
+                                   # fund at the same ~1e-5..1e-4 magnitude as ordinary xyz equities
+                                   # (e.g. UNITREE -3.16e-5 sits inside the NVDA/MU/TSM pack). The only
+                                   # names with |funding| <= 1e-7 are DEAD zero-volume markets, which
+                                   # fail the liquidity floor anyway — so the v2 1e-7 gate was empty-set
+                                   # on EVERY tick and no live IPOP ever passed it. Leverage cap +
+                                   # liquidity floor + absolute-trend discriminate; funding is opt-in.
+DEFAULT_IPOP_LEV_CAP = 5           # IPOP leverage signature (fresh pre-IPO perps launch capped low)
 
 
 def _f(v, d=0.0):
@@ -240,15 +248,19 @@ def clamp_leverage(desired, venue_max):
     return max(1, min(int(desired), venue))
 
 
-# ── IPOP discovery filter (preipo leg only; ported verbatim from v2 ipop_universe) ──
+# ── IPOP discovery filter (preipo leg only) — funding gate CORRECTED vs v2 (see is_ipop + the
+#    DEFAULT_IPOP_FUNDING_MAX note): the v2 `|funding| <= 1e-7` "throttled pre-listing" signature
+#    matched NO live IPOP, so it is now opt-in/off; the leverage cap + liquidity floor identify a
+#    fresh IPOP, and the absolute-trend gate (score_thematic) confirms the ramp. ──
 
 def is_ipop(name, meta, max_funding=DEFAULT_IPOP_FUNDING_MAX, lev_cap=DEFAULT_IPOP_LEV_CAP,
             min_day_vol=0.0):
-    """True iff a live xyz: instrument matches the structural IPOP signature (verbatim v2):
+    """True iff a live xyz: instrument matches the structural IPOP signature:
         name.startswith("xyz:")
-        AND 0 < venue max_leverage <= lev_cap (the throttled pre-listing leverage cap)
-        AND abs(funding) <= max_funding (the throttled pre-listing funding signature)
-        AND 24h notional volume >= min_day_vol (budget-relative liquidity floor)."""
+        AND 0 < venue max_leverage <= lev_cap (fresh pre-IPO perps launch leverage-capped low)
+        AND 24h notional volume >= min_day_vol (budget-relative liquidity floor)
+        AND (opt-in) abs(funding) <= max_funding — OFF by default (max_funding <= 0); funding does
+            NOT discriminate IPOPs from ordinary equities, see the DEFAULT_IPOP_FUNDING_MAX note."""
     if not isinstance(name, str) or not name.lower().startswith("xyz:"):
         return False
     if not isinstance(meta, dict):
@@ -257,17 +269,18 @@ def is_ipop(name, meta, max_funding=DEFAULT_IPOP_FUNDING_MAX, lev_cap=DEFAULT_IP
         lev = int(meta.get("max_leverage"))
     except (TypeError, ValueError):
         return False
-    if lev <= 0 or lev > lev_cap:               # IPOP leverage signature
+    if lev <= 0 or lev > lev_cap:               # IPOP leverage signature (the real discriminator)
         return False
-    ctx = meta.get("ctx", {}) if isinstance(meta.get("ctx"), dict) else {}
-    try:
-        funding_abs = abs(_f(ctx.get("funding", 0)))
-    except (TypeError, ValueError):
+    if day_vol(meta) < min_day_vol:             # budget-relative liquidity floor
         return False
-    if funding_abs > max_funding:               # IPOP funding signature
-        return False
-    if day_vol(meta) < min_day_vol:             # budget-relative liquidity
-        return False
+    if max_funding and max_funding > 0:         # OPT-IN funding band — OFF by default (see note above)
+        ctx = meta.get("ctx", {}) if isinstance(meta.get("ctx"), dict) else {}
+        try:
+            funding_abs = abs(_f(ctx.get("funding", 0)))
+        except (TypeError, ValueError):
+            return False
+        if funding_abs > max_funding:
+            return False
     return True
 
 

--- a/strategies/cub/short/scanners/scoring.py
+++ b/strategies/cub/short/scanners/scoring.py
@@ -1,9 +1,11 @@
 """CUB — pure thesis math (no I/O, no MCP, no clock). Shared verbatim by all three books
 (long "haves", short "have-nots", preipo pre-IPO ramp); the direction and the universe builder
 differ per book but the scoring is one function. A faithful Runtime 3.0 port of the v2
-cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights + the IPOP
-discovery filter are copied EXACTLY (marked `# v2-quirk` where the v2 behaviour is load-bearing
-and must not be redesigned). Unit-testable on plain candle lists + instrument dicts.
+cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights are copied EXACTLY
+(marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be redesigned), EXCEPT the
+IPOP funding gate, which is CORRECTED: the v2 `|funding| <= 1e-7` "throttled pre-listing" signature
+matched no live IPOP (pre-IPO perps fund like ordinary equities), so it is now opt-in and OFF by
+default — see is_ipop. Unit-testable on plain candle lists + instrument dicts.
 
 KEY DISTINCTION FROM COUGAR (do not "simplify" toward cougar): in Cub the hard gate is
 ABSOLUTE TREND (long a have only while it actually trends up; short a have-not only while it
@@ -18,8 +20,14 @@ its peers ran harder. Cougar instead gates on excess (long requires excess>=0); 
 NORM_DIV = 9.0
 
 # v2 preipo defaults (cub-producer.py _DEFAULTS["preipo"] / cub-preipo-config.json)
-DEFAULT_IPOP_FUNDING_MAX = 1e-7    # IPOP funding signature (throttled pre-listing)
-DEFAULT_IPOP_LEV_CAP = 5           # IPOP leverage signature
+DEFAULT_IPOP_FUNDING_MAX = 0.0     # 0 = OFF. Funding does NOT identify an IPOP: live pre-IPO perps
+                                   # fund at the same ~1e-5..1e-4 magnitude as ordinary xyz equities
+                                   # (e.g. UNITREE -3.16e-5 sits inside the NVDA/MU/TSM pack). The only
+                                   # names with |funding| <= 1e-7 are DEAD zero-volume markets, which
+                                   # fail the liquidity floor anyway — so the v2 1e-7 gate was empty-set
+                                   # on EVERY tick and no live IPOP ever passed it. Leverage cap +
+                                   # liquidity floor + absolute-trend discriminate; funding is opt-in.
+DEFAULT_IPOP_LEV_CAP = 5           # IPOP leverage signature (fresh pre-IPO perps launch capped low)
 
 
 def _f(v, d=0.0):
@@ -240,15 +248,19 @@ def clamp_leverage(desired, venue_max):
     return max(1, min(int(desired), venue))
 
 
-# ── IPOP discovery filter (preipo leg only; ported verbatim from v2 ipop_universe) ──
+# ── IPOP discovery filter (preipo leg only) — funding gate CORRECTED vs v2 (see is_ipop + the
+#    DEFAULT_IPOP_FUNDING_MAX note): the v2 `|funding| <= 1e-7` "throttled pre-listing" signature
+#    matched NO live IPOP, so it is now opt-in/off; the leverage cap + liquidity floor identify a
+#    fresh IPOP, and the absolute-trend gate (score_thematic) confirms the ramp. ──
 
 def is_ipop(name, meta, max_funding=DEFAULT_IPOP_FUNDING_MAX, lev_cap=DEFAULT_IPOP_LEV_CAP,
             min_day_vol=0.0):
-    """True iff a live xyz: instrument matches the structural IPOP signature (verbatim v2):
+    """True iff a live xyz: instrument matches the structural IPOP signature:
         name.startswith("xyz:")
-        AND 0 < venue max_leverage <= lev_cap (the throttled pre-listing leverage cap)
-        AND abs(funding) <= max_funding (the throttled pre-listing funding signature)
-        AND 24h notional volume >= min_day_vol (budget-relative liquidity floor)."""
+        AND 0 < venue max_leverage <= lev_cap (fresh pre-IPO perps launch leverage-capped low)
+        AND 24h notional volume >= min_day_vol (budget-relative liquidity floor)
+        AND (opt-in) abs(funding) <= max_funding — OFF by default (max_funding <= 0); funding does
+            NOT discriminate IPOPs from ordinary equities, see the DEFAULT_IPOP_FUNDING_MAX note."""
     if not isinstance(name, str) or not name.lower().startswith("xyz:"):
         return False
     if not isinstance(meta, dict):
@@ -257,17 +269,18 @@ def is_ipop(name, meta, max_funding=DEFAULT_IPOP_FUNDING_MAX, lev_cap=DEFAULT_IP
         lev = int(meta.get("max_leverage"))
     except (TypeError, ValueError):
         return False
-    if lev <= 0 or lev > lev_cap:               # IPOP leverage signature
+    if lev <= 0 or lev > lev_cap:               # IPOP leverage signature (the real discriminator)
         return False
-    ctx = meta.get("ctx", {}) if isinstance(meta.get("ctx"), dict) else {}
-    try:
-        funding_abs = abs(_f(ctx.get("funding", 0)))
-    except (TypeError, ValueError):
+    if day_vol(meta) < min_day_vol:             # budget-relative liquidity floor
         return False
-    if funding_abs > max_funding:               # IPOP funding signature
-        return False
-    if day_vol(meta) < min_day_vol:             # budget-relative liquidity
-        return False
+    if max_funding and max_funding > 0:         # OPT-IN funding band — OFF by default (see note above)
+        ctx = meta.get("ctx", {}) if isinstance(meta.get("ctx"), dict) else {}
+        try:
+            funding_abs = abs(_f(ctx.get("funding", 0)))
+        except (TypeError, ValueError):
+            return False
+        if funding_abs > max_funding:
+            return False
     return True
 
 

--- a/strategies/cub/strategy.yaml
+++ b/strategies/cub/strategy.yaml
@@ -12,14 +12,14 @@
 schema_version: 1
 
 id: cub
-version: "1.0.0"
+version: "1.0.1"
 
 catalog:
   name: "Cub — Two-Speed-Market Long/Short + Pre-IPO"
   emoji: "🐅"
   tagline: "Longs the structural winners of a K-shaped world (the AI complex on Hyperliquid XYZ + crypto winners HYPE/SOL) and shorts the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) — both trend-confirmed on separate wallets — plus a ~10% pre-IPO ramp satellite that auto-discovers pre-IPO perpetuals (IPOPs) and rides them into their listing."
   belief_plain: "The world is splitting into haves and have-nots: AI companies and crypto's winners keep booming while the broad economy and the rest of crypto struggle. Cub buys the booming side and shorts the struggling side at the same time on separate wallets, so it makes money on the GAP between the two — and keeps a small slice aimed at the next SpaceX before it goes public."
-  thesis: "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their funding signature and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open."
+  thesis: "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their leverage signature (fresh perps launch capped low) and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open."
   group: multi-asset-thematic
   archetype: structural_neutral   # cross-asset L/S dispersion — net beta set by operator funding split
   sub_style: pairs_rv             # cross-sectional relative-value (haves vs have-nots dispersion)


### PR DESCRIPTION
## Symptom
CUB's `preipo` sleeve (the ~10% pre-IPO ramp satellite, its own wallet) never opens a position — the wallet just sits empty.

## Root cause
The IPOP discovery gate in `is_ipop` (`strategies/cub/preipo/scanners/scoring.py`) required **`abs(funding) <= 1.0e-7`** — a "throttled pre-listing funding" signature that **no live pre-IPO perp has ever matched**.

Verified against the live Hyperliquid XYZ board (105 instruments):

| gate | `xyz:UNITREE` (IPOP launched today) |
|---|---|
| `xyz:` prefix | ✅ |
| `0 < max_leverage <= 5` | ✅ `5` — the **only** lev-5 name on the entire board |
| `abs(funding) <= 1e-7` | ❌ `3.16e-5` — ~316× over the ceiling |
| liquidity floor | ✅ $898K/day |

Live IPOPs fund at the same `~1e-5..1e-4` magnitude as ordinary xyz equities (UNITREE `-3.16e-5` sits right in the NVDA/MU/TSM pack). The *only* names with `|funding| <= 1e-7` are **dead zero-volume markets** (CORN, ALUMINIUM, VIX…) whose funding was never initialised — and they fail the liquidity floor anyway. So the funding∧leverage intersection was **empty-set on every tick**; the scanner logged `WAITING — no live IPOPs ramping` forever.

The funding gate was also **mutually exclusive** with the engine's own ~24h candle-history requirement: near-zero funding only exists before a market trades, but the trend gate needs history — nothing can satisfy both. The sleeve was structurally incapable of emitting.

## Fix
Funding does not discriminate IPOPs — **leverage does** (HL launches fresh pre-IPO perps capped low, then raises the cap as they mature; `SPCX`/SpaceX has already graduated to 20×). Make the funding band **opt-in / OFF by default**; rely on the leverage cap + budget-relative liquidity floor + absolute-trend confirmation.

- `scoring.py` (×3 sleeves, kept byte-identical): `is_ipop` funding check is now opt-in; `DEFAULT_IPOP_FUNDING_MAX 1e-7 → 0.0`
- `preipo/runtime.yaml`: `ipopFundingMaxAbs → 0`; mandate description + input comments
- `preipo/scan.py`: docstring
- `strategy.yaml`: `1.0.0 → 1.0.1` + thesis wording; catalog regenerated (both locations)

## Verification
Replaying the real board through the discovery path:
```
new gate (funding OFF):  IPOP universe = ['xyz:UNITREE']   (every wallet size $2k–$30k)
old gate (1e-7):         IPOP universe = []
```
A lev-20 equity (NVDA) is correctly **not** discovered. All scanners compile; YAMLs parse; the three `scoring.py` copies remain byte-identical.

> **Note:** even with this fix, a brand-new IPOP won't trade for its first ~day until it accrues enough candle history + a confirmed non-bearish 4h trend — by design (ramp-confirmation, not launch-day sniper).

> **Deploy:** already-running CUB instances need a **redeploy of the preipo sleeve** to pick up the corrected scanner code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)