### PR TITLE
CUB preipo: fresh-listing 1h starter path (enter new IPOPs ~6h after launch)

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1756,7 +1756,7 @@
       "emoji": "🐅",
       "tagline": "Longs the structural winners of a K-shaped world (the AI complex on Hyperliquid XYZ + crypto winners HYPE/SOL) and shorts the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) — both trend-confirmed on separate wallets — plus a ~10% pre-IPO ramp satellite that auto-discovers pre-IPO perpetuals (IPOPs) and rides them into their listing.",
       "belief_plain": "The world is splitting into haves and have-nots: AI companies and crypto's winners keep booming while the broad economy and the rest of crypto struggle. Cub buys the booming side and shorts the struggling side at the same time on separate wallets, so it makes money on the GAP between the two — and keeps a small slice aimed at the next SpaceX before it goes public.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their leverage signature (fresh perps launch capped low) and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open.",
       "tags": [
         "k-shaped",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1756,7 +1756,7 @@
       "emoji": "🐅",
       "tagline": "Longs the structural winners of a K-shaped world (the AI complex on Hyperliquid XYZ + crypto winners HYPE/SOL) and shorts the laggards (the broad U.S. market via SP500 + a gated basket of laggard alts) — both trend-confirmed on separate wallets — plus a ~10% pre-IPO ramp satellite that auto-discovers pre-IPO perpetuals (IPOPs) and rides them into their listing.",
       "belief_plain": "The world is splitting into haves and have-nots: AI companies and crypto's winners keep booming while the broad economy and the rest of crypto struggle. Cub buys the booming side and shorts the struggling side at the same time on separate wallets, so it makes money on the GAP between the two — and keeps a small slice aimed at the next SpaceX before it goes public.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "thesis": "The edge is K-shaped DISPERSION, not market direction. Long the AI complex + HYPE/SOL only while they're actually trending up; short SP500 + laggard alts only while they're actually rolling over; the P&L is the spread between the two speeds. A ~10% pre-IPO sleeve adds optionality — it discovers IPOPs by their leverage signature (fresh perps launch capped low) and longs the ones ramping into their listing. Tokenized equities trade 24/7 on Hyperliquid, so the book never waits for a market open.",
       "tags": [
         "k-shaped",

--- a/strategies/cub/long/scanners/scoring.py
+++ b/strategies/cub/long/scanners/scoring.py
@@ -5,7 +5,10 @@ cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights a
 (marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be redesigned), EXCEPT the
 IPOP funding gate, which is CORRECTED: the v2 `|funding| <= 1e-7` "throttled pre-listing" signature
 matched no live IPOP (pre-IPO perps fund like ordinary equities), so it is now opt-in and OFF by
-default — see is_ipop. Unit-testable on plain candle lists + instrument dicts.
+default — see is_ipop. A fresh-listing 1h starter path is ALSO added for the preipo leg (off unless
+inputs['freshListing']['enabled']) so a just-listed IPOP can be entered ~6h after launch at reduced
+size instead of waiting ~24h for 4h history — see score_thematic. Unit-testable on plain candle lists
++ instrument dicts.
 
 KEY DISTINCTION FROM COUGAR (do not "simplify" toward cougar): in Cub the hard gate is
 ABSOLUTE TREND (long a have only while it actually trends up; short a have-not only while it
@@ -115,14 +118,28 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
     `excess` = the asset's 24h return minus the leg-universe mean (cross-sectional).
     `own24h`  = the asset's own 24h return (sign is an absolute-momentum component).
 
-    None is returned ONLY when: insufficient candle history (len(c1h) < 8 or len(c4h) < 6),
-    OR the ABSOLUTE-trend hard gate fails (long: 4h BEARISH; short: 4h BULLISH).
+    None is returned ONLY when: insufficient candle history for the chosen confirmation basis,
+    OR the ABSOLUTE-trend hard gate fails (long: primary-TF BEARISH; short: 4h BULLISH).
     minScore is applied by the CALLER (scan.py), not here.
+
+    FRESH-LISTING FAST PATH (LONG only; OFF unless inputs['freshListing']['enabled']): a just-listed
+    IPOP has no 4h history for ~24h. When enabled and a name has >= minCandles1h 1h candles but not yet
+    the full 4h history, confirm the ramp on the 1h structure instead and return a REDUCED starter size
+    (size_factor = starterSizeFactor). The normal 4h engine takes over — at full size — once 24h of 4h
+    history exists. long/short never set freshListing, so their behaviour is byte-for-byte unchanged.
 
     v2-quirk: excess is a SCORE MODIFIER (bonus only), NOT a gate — never disqualifies a
     genuinely-trending name. Do NOT add cougar's `excess < 0 -> return None` here.
     """
-    if len(candles_1h) < 8 or len(candles_4h) < 6:
+    # Confirmation basis: 4h normally (full size); 1h on the fresh-listing starter path (reduced size).
+    fresh = inputs.get("freshListing") or {}
+    fresh_on = bool(fresh.get("enabled")) and direction == "LONG"
+    fresh_min_1h = int(fresh.get("minCandles1h", 6))
+    if len(candles_1h) >= 8 and len(candles_4h) >= 6:
+        basis, size_factor = "4h", 1.0
+    elif fresh_on and len(candles_1h) >= fresh_min_1h:
+        basis, size_factor = "1h", float(fresh.get("starterSizeFactor", 0.5))
+    else:
         return None
     closes1 = [_close(c) for c in candles_1h]
     price = closes1[-1]
@@ -130,6 +147,8 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
 
     trend4, s4 = trend_structure(candles_4h)
     trend1, s1 = trend_structure(candles_1h)
+    # primary structure = the confirmation-basis TF (4h normally; 1h on the fresh-listing starter path)
+    prim, s_prim = (trend4, s4) if basis == "4h" else (trend1, s1)
     rsi = calc_rsi(closes1)
     rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
 
@@ -137,21 +156,22 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
     reasons = []
 
     if direction == "LONG":     # haves (curated) + preipo (discovered IPOPs)
-        # ── HARD GATE: never long a confirmed downtrend ──
-        if trend4 == "BEARISH":
+        # ── HARD GATE: never long a confirmed downtrend (on the confirmation-basis TF) ──
+        if prim == "BEARISH":
             return None
-        if trend4 == "BULLISH":
+        if prim == "BULLISH":
             score += 3
-            reasons.append(f"4h_bullish_{s4:.0%}")
+            reasons.append(f"{basis}_bullish_{s_prim:.0%}")
         else:
             score += 1
-            reasons.append("4h_neutral")
-        if trend1 == "BULLISH":
-            score += 1
-            reasons.append(f"1h_bullish_{s1:.0%}")
-        elif trend1 == "BEARISH":
-            score -= 1
-            reasons.append("1h_bearish")
+            reasons.append(f"{basis}_neutral")
+        if basis == "4h":               # 1h is the SECONDARY confirmation only when 4h is the primary
+            if trend1 == "BULLISH":
+                score += 1
+                reasons.append(f"1h_bullish_{s1:.0%}")
+            elif trend1 == "BEARISH":
+                score -= 1
+                reasons.append("1h_bearish")
         # absolute momentum
         if own >= 0:
             score += 1
@@ -172,6 +192,11 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
         if rsi > rsi_ob:
             score -= 2
             reasons.append(f"rsi_blowoff_{rsi:.0f}")
+        # fresh-listing starter: RSI-14 needs ~15h of 1h history (inert on a day-1 name), so guard the
+        # blow-off with return-since-launch instead — never CHASE a fresh IPOP that already ran vertical.
+        if basis == "1h" and own > float(fresh.get("maxRunPct", 25.0)):
+            score -= 2
+            reasons.append(f"fresh_chase_{own:+.1f}%")
     else:  # SHORT — have-nots
         # ── HARD GATE: never short a confirmed uptrend ──
         if trend4 == "BULLISH":
@@ -218,6 +243,8 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
         "trend1h": trend1,
         "excess": excess,
         "own24h": own,
+        "size_factor": size_factor,   # 1.0 normal (4h-confirmed) ; starterSizeFactor on the 1h fresh path
+        "basis": basis,               # "4h" (full engine) or "1h" (fresh-listing starter)
     }
 
 

--- a/strategies/cub/preipo/runtime.yaml
+++ b/strategies/cub/preipo/runtime.yaml
@@ -9,7 +9,9 @@ description: >
   signature (venue max_leverage <= ipopMaxLeverageCap — fresh pre-IPO perps launch capped low) plus a
   budget-relative liquidity floor, and LONGS the ones with a confirming absolute 4h/1h uptrend, riding
   the pre-listing ramp (the SpaceX / Cerebras pattern). No static universe — discovered every tick,
-  so the next IPOP auto-joins on listing. Blow-off guard loosened (pre-IPO names run hot). LONG only.
+  so the next IPOP auto-joins on listing; a fresh listing is entered ~6h after launch on a 1h-confirmed
+  STARTER (half size), scaling to full size once 24h of 4h history exists. Blow-off guard loosened
+  (pre-IPO names run hot). LONG only.
   Episodic by design — most ticks may find 0-2 IPOPs. The IPOP liquidity floor is BUDGET-RELATIVE
   (no hardcoded $). Runs on its OWN wallet, funded with ~10% of Cub's combined pool (allocation =
   the operator's funding split across the three book wallets, NOT a runtime field). Pairs with the
@@ -52,6 +54,16 @@ scanners:
       rsThresholdPct: 3.0
       rsiOverbought: 88       # pre-IPO ramps run hot; loosen the blow-off guard
       recentSignalTtlSeconds: 180
+      # FRESH-LISTING FAST PATH — a just-listed IPOP has no 4h history for ~24h. When enabled, confirm the
+      # ramp on the 1h structure once it has >= minCandles1h 1h candles (~6h from launch, vs ~24h for 4h)
+      # and enter a de-risked STARTER (starterSizeFactor × normal margin); the full 4h engine sizes up once
+      # 24h of history exists. maxRunPct blocks chasing a name already up big since launch (RSI-14 is inert
+      # day-1). Set enabled:false to revert to 4h-only (~24h) entry.
+      freshListing:
+        enabled: true
+        minCandles1h: 6          # ~6h of 1h candles before a fresh IPOP is eligible for the starter
+        starterSizeFactor: 0.5   # starter enters at half the normal per-name margin
+        maxRunPct: 25            # skip the starter if already up >25% since launch (don't chase the spike)
     signal_data_schema:
       score: { type: number }
       leverage: { type: number }
@@ -61,6 +73,8 @@ scanners:
       excess: { type: number, required: false }
       own24h: { type: number, required: false }
       weight: { type: number, required: false }
+      basis: { type: string, required: false }      # "4h" full engine | "1h" fresh-listing starter
+      sizeFactor: { type: number, required: false }
       heldAssets: { type: array, required: false }
 
 actions:

--- a/strategies/cub/preipo/scanners/scan.py
+++ b/strategies/cub/preipo/scanners/scan.py
@@ -241,7 +241,8 @@ def scan(inputs, ctx):
         if open_slots <= 0:
             break
         weight = scoring.sizing_weight(th["coin"], weights)
-        margin_pct = round(base_margin_pct * weight, 4)
+        size_factor = float(th.get("size_factor", 1.0))     # fresh-listing starter -> reduced margin
+        margin_pct = round(base_margin_pct * weight * size_factor, 4)
         venue_max = (th.get("_meta") or {}).get("max_leverage")
         leverage = scoring.clamp_leverage(max_lev, venue_max)
         if margin_pct <= 0 or leverage <= 0:
@@ -263,6 +264,8 @@ def scan(inputs, ctx):
                 "excess": round(th.get("excess", 0), 2),
                 "own24h": round(th.get("own24h", 0), 2),
                 "weight": weight,
+                "basis": th.get("basis"),                    # "4h" full engine | "1h" fresh-listing starter
+                "sizeFactor": size_factor,
                 "heldAssets": held,
             },
         })
@@ -271,7 +274,8 @@ def scan(inputs, ctx):
         free_margin -= margin_usd * 1.1
 
     _persist()
+    starters = sum(1 for o in out if o["data"].get("basis") == "1h")
     print(f"[cub.preipo.scan] universe={len(universe)} pool={len(pool)} candidates={len(candidates)} "
-          f"emitted={len(out)} mean_rs={mean_rs:.2f} elapsed={time.time() - run_start:.2f}s",
+          f"emitted={len(out)} starters={starters} mean_rs={mean_rs:.2f} elapsed={time.time() - run_start:.2f}s",
           file=sys.stderr)
     return out

--- a/strategies/cub/preipo/scanners/scoring.py
+++ b/strategies/cub/preipo/scanners/scoring.py
@@ -5,7 +5,10 @@ cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights a
 (marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be redesigned), EXCEPT the
 IPOP funding gate, which is CORRECTED: the v2 `|funding| <= 1e-7` "throttled pre-listing" signature
 matched no live IPOP (pre-IPO perps fund like ordinary equities), so it is now opt-in and OFF by
-default — see is_ipop. Unit-testable on plain candle lists + instrument dicts.
+default — see is_ipop. A fresh-listing 1h starter path is ALSO added for the preipo leg (off unless
+inputs['freshListing']['enabled']) so a just-listed IPOP can be entered ~6h after launch at reduced
+size instead of waiting ~24h for 4h history — see score_thematic. Unit-testable on plain candle lists
++ instrument dicts.
 
 KEY DISTINCTION FROM COUGAR (do not "simplify" toward cougar): in Cub the hard gate is
 ABSOLUTE TREND (long a have only while it actually trends up; short a have-not only while it
@@ -115,14 +118,28 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
     `excess` = the asset's 24h return minus the leg-universe mean (cross-sectional).
     `own24h`  = the asset's own 24h return (sign is an absolute-momentum component).
 
-    None is returned ONLY when: insufficient candle history (len(c1h) < 8 or len(c4h) < 6),
-    OR the ABSOLUTE-trend hard gate fails (long: 4h BEARISH; short: 4h BULLISH).
+    None is returned ONLY when: insufficient candle history for the chosen confirmation basis,
+    OR the ABSOLUTE-trend hard gate fails (long: primary-TF BEARISH; short: 4h BULLISH).
     minScore is applied by the CALLER (scan.py), not here.
+
+    FRESH-LISTING FAST PATH (LONG only; OFF unless inputs['freshListing']['enabled']): a just-listed
+    IPOP has no 4h history for ~24h. When enabled and a name has >= minCandles1h 1h candles but not yet
+    the full 4h history, confirm the ramp on the 1h structure instead and return a REDUCED starter size
+    (size_factor = starterSizeFactor). The normal 4h engine takes over — at full size — once 24h of 4h
+    history exists. long/short never set freshListing, so their behaviour is byte-for-byte unchanged.
 
     v2-quirk: excess is a SCORE MODIFIER (bonus only), NOT a gate — never disqualifies a
     genuinely-trending name. Do NOT add cougar's `excess < 0 -> return None` here.
     """
-    if len(candles_1h) < 8 or len(candles_4h) < 6:
+    # Confirmation basis: 4h normally (full size); 1h on the fresh-listing starter path (reduced size).
+    fresh = inputs.get("freshListing") or {}
+    fresh_on = bool(fresh.get("enabled")) and direction == "LONG"
+    fresh_min_1h = int(fresh.get("minCandles1h", 6))
+    if len(candles_1h) >= 8 and len(candles_4h) >= 6:
+        basis, size_factor = "4h", 1.0
+    elif fresh_on and len(candles_1h) >= fresh_min_1h:
+        basis, size_factor = "1h", float(fresh.get("starterSizeFactor", 0.5))
+    else:
         return None
     closes1 = [_close(c) for c in candles_1h]
     price = closes1[-1]
@@ -130,6 +147,8 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
 
     trend4, s4 = trend_structure(candles_4h)
     trend1, s1 = trend_structure(candles_1h)
+    # primary structure = the confirmation-basis TF (4h normally; 1h on the fresh-listing starter path)
+    prim, s_prim = (trend4, s4) if basis == "4h" else (trend1, s1)
     rsi = calc_rsi(closes1)
     rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
 
@@ -137,21 +156,22 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
     reasons = []
 
     if direction == "LONG":     # haves (curated) + preipo (discovered IPOPs)
-        # ── HARD GATE: never long a confirmed downtrend ──
-        if trend4 == "BEARISH":
+        # ── HARD GATE: never long a confirmed downtrend (on the confirmation-basis TF) ──
+        if prim == "BEARISH":
             return None
-        if trend4 == "BULLISH":
+        if prim == "BULLISH":
             score += 3
-            reasons.append(f"4h_bullish_{s4:.0%}")
+            reasons.append(f"{basis}_bullish_{s_prim:.0%}")
         else:
             score += 1
-            reasons.append("4h_neutral")
-        if trend1 == "BULLISH":
-            score += 1
-            reasons.append(f"1h_bullish_{s1:.0%}")
-        elif trend1 == "BEARISH":
-            score -= 1
-            reasons.append("1h_bearish")
+            reasons.append(f"{basis}_neutral")
+        if basis == "4h":               # 1h is the SECONDARY confirmation only when 4h is the primary
+            if trend1 == "BULLISH":
+                score += 1
+                reasons.append(f"1h_bullish_{s1:.0%}")
+            elif trend1 == "BEARISH":
+                score -= 1
+                reasons.append("1h_bearish")
         # absolute momentum
         if own >= 0:
             score += 1
@@ -172,6 +192,11 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
         if rsi > rsi_ob:
             score -= 2
             reasons.append(f"rsi_blowoff_{rsi:.0f}")
+        # fresh-listing starter: RSI-14 needs ~15h of 1h history (inert on a day-1 name), so guard the
+        # blow-off with return-since-launch instead — never CHASE a fresh IPOP that already ran vertical.
+        if basis == "1h" and own > float(fresh.get("maxRunPct", 25.0)):
+            score -= 2
+            reasons.append(f"fresh_chase_{own:+.1f}%")
     else:  # SHORT — have-nots
         # ── HARD GATE: never short a confirmed uptrend ──
         if trend4 == "BULLISH":
@@ -218,6 +243,8 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
         "trend1h": trend1,
         "excess": excess,
         "own24h": own,
+        "size_factor": size_factor,   # 1.0 normal (4h-confirmed) ; starterSizeFactor on the 1h fresh path
+        "basis": basis,               # "4h" (full engine) or "1h" (fresh-listing starter)
     }
 
 

--- a/strategies/cub/short/scanners/scoring.py
+++ b/strategies/cub/short/scanners/scoring.py
@@ -5,7 +5,10 @@ cub-producer.py scoring (cub-producer.py v1.0.0) — the gates + point weights a
 (marked `# v2-quirk` where the v2 behaviour is load-bearing and must not be redesigned), EXCEPT the
 IPOP funding gate, which is CORRECTED: the v2 `|funding| <= 1e-7` "throttled pre-listing" signature
 matched no live IPOP (pre-IPO perps fund like ordinary equities), so it is now opt-in and OFF by
-default — see is_ipop. Unit-testable on plain candle lists + instrument dicts.
+default — see is_ipop. A fresh-listing 1h starter path is ALSO added for the preipo leg (off unless
+inputs['freshListing']['enabled']) so a just-listed IPOP can be entered ~6h after launch at reduced
+size instead of waiting ~24h for 4h history — see score_thematic. Unit-testable on plain candle lists
++ instrument dicts.
 
 KEY DISTINCTION FROM COUGAR (do not "simplify" toward cougar): in Cub the hard gate is
 ABSOLUTE TREND (long a have only while it actually trends up; short a have-not only while it
@@ -115,14 +118,28 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
     `excess` = the asset's 24h return minus the leg-universe mean (cross-sectional).
     `own24h`  = the asset's own 24h return (sign is an absolute-momentum component).
 
-    None is returned ONLY when: insufficient candle history (len(c1h) < 8 or len(c4h) < 6),
-    OR the ABSOLUTE-trend hard gate fails (long: 4h BEARISH; short: 4h BULLISH).
+    None is returned ONLY when: insufficient candle history for the chosen confirmation basis,
+    OR the ABSOLUTE-trend hard gate fails (long: primary-TF BEARISH; short: 4h BULLISH).
     minScore is applied by the CALLER (scan.py), not here.
+
+    FRESH-LISTING FAST PATH (LONG only; OFF unless inputs['freshListing']['enabled']): a just-listed
+    IPOP has no 4h history for ~24h. When enabled and a name has >= minCandles1h 1h candles but not yet
+    the full 4h history, confirm the ramp on the 1h structure instead and return a REDUCED starter size
+    (size_factor = starterSizeFactor). The normal 4h engine takes over — at full size — once 24h of 4h
+    history exists. long/short never set freshListing, so their behaviour is byte-for-byte unchanged.
 
     v2-quirk: excess is a SCORE MODIFIER (bonus only), NOT a gate — never disqualifies a
     genuinely-trending name. Do NOT add cougar's `excess < 0 -> return None` here.
     """
-    if len(candles_1h) < 8 or len(candles_4h) < 6:
+    # Confirmation basis: 4h normally (full size); 1h on the fresh-listing starter path (reduced size).
+    fresh = inputs.get("freshListing") or {}
+    fresh_on = bool(fresh.get("enabled")) and direction == "LONG"
+    fresh_min_1h = int(fresh.get("minCandles1h", 6))
+    if len(candles_1h) >= 8 and len(candles_4h) >= 6:
+        basis, size_factor = "4h", 1.0
+    elif fresh_on and len(candles_1h) >= fresh_min_1h:
+        basis, size_factor = "1h", float(fresh.get("starterSizeFactor", 0.5))
+    else:
         return None
     closes1 = [_close(c) for c in candles_1h]
     price = closes1[-1]
@@ -130,6 +147,8 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
 
     trend4, s4 = trend_structure(candles_4h)
     trend1, s1 = trend_structure(candles_1h)
+    # primary structure = the confirmation-basis TF (4h normally; 1h on the fresh-listing starter path)
+    prim, s_prim = (trend4, s4) if basis == "4h" else (trend1, s1)
     rsi = calc_rsi(closes1)
     rs_thresh = float(inputs.get("rsThresholdPct", 3.0))
 
@@ -137,21 +156,22 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
     reasons = []
 
     if direction == "LONG":     # haves (curated) + preipo (discovered IPOPs)
-        # ── HARD GATE: never long a confirmed downtrend ──
-        if trend4 == "BEARISH":
+        # ── HARD GATE: never long a confirmed downtrend (on the confirmation-basis TF) ──
+        if prim == "BEARISH":
             return None
-        if trend4 == "BULLISH":
+        if prim == "BULLISH":
             score += 3
-            reasons.append(f"4h_bullish_{s4:.0%}")
+            reasons.append(f"{basis}_bullish_{s_prim:.0%}")
         else:
             score += 1
-            reasons.append("4h_neutral")
-        if trend1 == "BULLISH":
-            score += 1
-            reasons.append(f"1h_bullish_{s1:.0%}")
-        elif trend1 == "BEARISH":
-            score -= 1
-            reasons.append("1h_bearish")
+            reasons.append(f"{basis}_neutral")
+        if basis == "4h":               # 1h is the SECONDARY confirmation only when 4h is the primary
+            if trend1 == "BULLISH":
+                score += 1
+                reasons.append(f"1h_bullish_{s1:.0%}")
+            elif trend1 == "BEARISH":
+                score -= 1
+                reasons.append("1h_bearish")
         # absolute momentum
         if own >= 0:
             score += 1
@@ -172,6 +192,11 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
         if rsi > rsi_ob:
             score -= 2
             reasons.append(f"rsi_blowoff_{rsi:.0f}")
+        # fresh-listing starter: RSI-14 needs ~15h of 1h history (inert on a day-1 name), so guard the
+        # blow-off with return-since-launch instead — never CHASE a fresh IPOP that already ran vertical.
+        if basis == "1h" and own > float(fresh.get("maxRunPct", 25.0)):
+            score -= 2
+            reasons.append(f"fresh_chase_{own:+.1f}%")
     else:  # SHORT — have-nots
         # ── HARD GATE: never short a confirmed uptrend ──
         if trend4 == "BULLISH":
@@ -218,6 +243,8 @@ def score_thematic(asset, candles_1h, candles_4h, excess, own24h, direction, inp
         "trend1h": trend1,
         "excess": excess,
         "own24h": own,
+        "size_factor": size_factor,   # 1.0 normal (4h-confirmed) ; starterSizeFactor on the 1h fresh path
+        "basis": basis,               # "4h" (full engine) or "1h" (fresh-listing starter)
     }
 
 

--- a/strategies/cub/strategy.yaml
+++ b/strategies/cub/strategy.yaml
@@ -12,7 +12,7 @@
 schema_version: 1
 
 id: cub
-version: "1.0.1"
+version: "1.1.0"
 
 catalog:
   name: "Cub — Two-Speed-Market Long/Short + Pre-IPO"

--- a/strategies/cub/test_preipo_fresh_listing.py
+++ b/strategies/cub/test_preipo_fresh_listing.py
@@ -1,0 +1,79 @@
+"""CUB preipo — fresh-listing fast-path regression tests (pure, no I/O).
+
+Proves (1) the normal 4h-confirmed path is UNCHANGED by the fast-path refactor, and (2) the
+fresh-listing 1h starter path fires only when it should, at reduced size, and stays OFF by default.
+Run: python3 strategies/cub/test_preipo_fresh_listing.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "preipo", "scanners"))
+import scoring  # noqa: E402
+
+
+def C(o, h, l, c):
+    return {"o": o, "h": h, "l": l, "c": c, "v": 1000}
+
+
+def bull(n, base=100):
+    # strictly higher lows + higher highs -> trend_structure BULLISH
+    return [C(base + i, base + 2 + i, base + i, base + 1 + i) for i in range(n)]
+
+
+def bear(n, base=100):
+    # strictly lower highs + lower lows -> trend_structure BEARISH
+    return [C(base - i, base + 2 - i, base - 2 - i, base - 1 - i) for i in range(n)]
+
+
+FRESH = {"freshListing": {"enabled": True, "minCandles1h": 6, "starterSizeFactor": 0.5, "maxRunPct": 25}}
+OFF = {}  # no freshListing -> fast path disabled
+
+
+def _assert(name, cond):
+    print(("PASS" if cond else "FAIL"), name)
+    if not cond:
+        raise SystemExit(f"FAILED: {name}")
+
+
+# 1) NORMAL 4h path unchanged: mature bullish name (8x1h + 6x4h), up since launch.
+#    4h_bull(+3) + 1h_bull secondary(+1) + abs_up(+1) = 5 ; full size ; basis 4h.
+t = scoring.score_thematic("xyz:NVDA", bull(8), bull(6), 0.0, 5.0, "LONG", OFF)
+_assert("normal-4h score==5", t and t["score"] == 5)
+_assert("normal-4h size_factor==1.0", t["size_factor"] == 1.0)
+_assert("normal-4h basis==4h", t["basis"] == "4h")
+# same inputs WITH freshListing enabled must be byte-identical (name has 4h history -> never fresh)
+t2 = scoring.score_thematic("xyz:NVDA", bull(8), bull(6), 0.0, 5.0, "LONG", FRESH)
+_assert("freshListing does not change a name that has 4h history", t2 == t)
+
+# 2) FRESH path fires: just-listed name, 6x1h bullish, only 1x4h, up +5% since launch.
+#    1h_bull(+3) + abs_up(+1) = 4 ; half size ; basis 1h ; clears minScore 4.
+f = scoring.score_thematic("xyz:UNITREE", bull(6), bull(1), 0.0, 5.0, "LONG", FRESH)
+_assert("fresh fires with score==4", f and f["score"] == 4)
+_assert("fresh size_factor==0.5", f["size_factor"] == 0.5)
+_assert("fresh basis==1h", f["basis"] == "1h")
+
+# 3) OFF by default: same fresh name with no freshListing input -> None (waits for 4h history).
+_assert("fresh OFF by default -> None",
+        scoring.score_thematic("xyz:UNITREE", bull(6), bull(1), 0.0, 5.0, "LONG", OFF) is None)
+
+# 4) Chase guard: fresh + already up big (+40% > maxRunPct 25) -> -2 -> score 2 (below minScore).
+c = scoring.score_thematic("xyz:UNITREE", bull(6), bull(1), 0.0, 40.0, "LONG", FRESH)
+_assert("chase guard drops a vertical fresh name below minScore", c and c["score"] == 2)
+
+# 5) Fresh DUMP rejected: 1h bearish -> hard gate -> None (never buy a fresh downtrend).
+_assert("fresh 1h-bearish -> None",
+        scoring.score_thematic("xyz:UNITREE", bear(6), bull(1), 0.0, 5.0, "LONG", FRESH) is None)
+
+# 6) LONG-only: a fresh SHORT never takes the fast path (fresh_on requires LONG) -> None.
+_assert("fresh path is LONG-only (short returns None)",
+        scoring.score_thematic("xyz:MU", bear(6), bear(1), 0.0, -5.0, "SHORT", FRESH) is None)
+# and a mature SHORT is unaffected by freshListing.
+s1 = scoring.score_thematic("xyz:MU", bear(8), bear(6), 0.0, -5.0, "SHORT", FRESH)
+s2 = scoring.score_thematic("xyz:MU", bear(8), bear(6), 0.0, -5.0, "SHORT", OFF)
+_assert("mature short unaffected by freshListing", s1 == s2 and s1 and s1["basis"] == "4h")
+
+# 7) Too-fresh: fewer than minCandles1h 1h candles -> None even with fast path on.
+_assert("below minCandles1h -> None",
+        scoring.score_thematic("xyz:UNITREE", bull(4), bull(1), 0.0, 5.0, "LONG", FRESH) is None)
+
+print("\nall fresh-listing tests passed")


### PR DESCRIPTION
Follow-up to #521. That fix let CUB's preipo sleeve *discover* live IPOPs; this makes it enter a **freshly-listed** one without waiting a full day.

## Problem
The engine confirms ramps on **4h structure** (6× 4h candles ⇒ ~24h of history), so a just-listed IPOP couldn't be entered for ~24h after launch — too slow for an announcement-driven name ("catch the next SpaceX").

But entering at t=0 is a coinflip, not alpha: the first hours of a thin new perp are pure noise. `xyz:UNITREE`, ~1h after launch, is **down 1.4%** with **±5% 15-minute wicks** and a thin book. There's no ramp to ride yet.

## Fix — a fresh-listing fast path (LONG only, off unless `freshListing.enabled`)
When a name has `>= minCandles1h` 1h candles but not yet 24h of 4h history:
- confirm the ramp on the **1h structure** (hard-gate on 1h BEARISH, same as the 4h gate)
- enter a **de-risked STARTER** at `starterSizeFactor × normal margin` (default 0.5)
- the normal **4h engine takes over at full size** once 24h of history exists
- a **return-since-launch guard** (`maxRunPct`, default 25%) replaces the RSI blow-off check — RSI-14 is inert on a day-1 name — so we never chase one that already ran vertical

Net: entry lag **~24h → ~6h at half size**, without buying launch chaos blind.

## Config (`preipo/runtime.yaml`)
```yaml
freshListing:
  enabled: true
  minCandles1h: 6          # ~6h from launch before a fresh IPOP is eligible
  starterSizeFactor: 0.5   # starter enters at half normal per-name margin
  maxRunPct: 25            # skip if already up >25% since launch
```
Set `enabled: false` to revert to 4h-only (~24h) entry.

## Verification
`test_preipo_fresh_listing.py` (13 cases, all pass), plus a **live UNITREE replay**:
```
UNITREE now (~1h old, 1 candle, down 1.4%):  None   → correctly too-fresh
UNITREE at ~6h IF ramping (1h uptrend, +3%):  score 4, basis 1h, size 0.5  → starter fires
```
The **4h-confirmed path is byte-identical** to before for any name with 4h history (asserted directly), so long/short and mature IPOPs are untouched. The three sleeves' `scoring.py` stay byte-identical; all scanners compile; YAMLs parse.

## Notes
- `strategy.yaml` `1.0.1 → 1.1.0` (new feature); catalog regenerated (both locations).
- **Deploy:** already-running CUB instances need a **redeploy of the preipo sleeve** to pick this up.
- This is the *ramp-rider* refined, not a launch sniper — a blind-buy-every-IPO-at-t=0 primitive would be a separate strategy; the UNITREE tape says the first hours are a coinflip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)