### PR TITLE
spider: stop emitting signals the wallet can't fund (insufficient-funds spam)

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -3403,7 +3403,7 @@
       "emoji": "🕷️",
       "tagline": "An AI/Tech momentum long book plus a macro/majors mean-reversion book — two legs, two wallets, one package.",
       "belief_plain": "AI/tech equities and crypto majors trend over days, while majors and energy snap back from short-term extremes — run both books side by side.",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "thesis": null,
       "tags": [
         "ai",

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -3403,7 +3403,7 @@
       "emoji": "🕷️",
       "tagline": "An AI/Tech momentum long book plus a macro/majors mean-reversion book — two legs, two wallets, one package.",
       "belief_plain": "AI/tech equities and crypto majors trend over days, while majors and energy snap back from short-term extremes — run both books side by side.",
-      "version": "6.0.2",
+      "version": "6.0.3",
       "thesis": null,
       "tags": [
         "ai",

--- a/strategies/spider/scalp/runtime.yaml
+++ b/strategies/spider/scalp/runtime.yaml
@@ -40,7 +40,10 @@ scanners:
     inputs:
       allowedAssets: ["BTC", "ETH", "SOL", "HYPE", "xyz:BRENTOIL", "xyz:CL"]
       minScore: 4
-      marginPct: 15                        # PERCENT of withdrawable (0,100] — runtime sizes (marginPct/100)*withdrawable
+      marginPct: 15                        # PERCENT (0,100]. Observed runtime sizing is (marginPct/100)*
+                                           # ACCOUNT VALUE — flat per name — NOT *withdrawable as this used
+                                           # to say (pending runtime-team confirmation). The scanner's
+                                           # open_slots/affordable cap keeps the batch within free margin.
       maxLeverage: 5
       maxSlots: 4
       rsiOversold: 30

--- a/strategies/spider/scalp/scanners/scan.py
+++ b/strategies/spider/scalp/scanners/scan.py
@@ -86,24 +86,27 @@ def _fetch_candles(ctx, asset, intervals):
 
 
 def _get_account(ctx):
-    """(account_value, [position_dicts]) — dual-DEX equity collapse via max()."""
+    """(account_value, [position_dicts], free_margin) — dual-DEX equity collapse via
+    max(); free margin = equity - committed margin (sum of per-position marginUsed)."""
     try:
         ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
                                      {"strategy_wallet": ctx.wallet})
     except Exception:
-        return 0.0, []
+        return 0.0, [], 0.0
     if not ch:
-        return 0.0, []
+        return 0.0, [], 0.0
     data = ch.get("data", ch) if isinstance(ch, dict) else ch
     if not isinstance(data, dict):
-        return 0.0, []
-    positions, account_value = [], 0.0
+        return 0.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
     for section in ("main", "xyz"):
         s = data.get(section, {})
         if not isinstance(s, dict):
             continue
         ms = s.get("marginSummary", {})
         account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
         for ap in s.get("assetPositions", []):
             pos = ap.get("position", ap)
             szi = float(pos.get("szi", 0) or 0)
@@ -111,7 +114,15 @@ def _get_account(ctx):
                 continue
             positions.append({"coin": pos.get("coin", ""),
                               "margin": float(pos.get("marginUsed", 0) or 0)})
-    return account_value, positions
+    # Read-sanity guard (ported from camel): margin/notional IN USE but an EMPTY
+    # positions list is a corrupt read — sizing or held-dedup off that re-enters
+    # held names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        print("[spider.scalp.scan] read-sanity guard: margin in use but empty "
+              "positions — skipping tick", file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
 
 
 # ── ctx.state recent-signal dedup ──
@@ -149,10 +160,20 @@ def scan(inputs, ctx):
     venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
     min_notional_pct = float(inputs.get("minNotionalPctOfEquity", 0.01))
 
-    account_value, positions = _get_account(ctx)
+    account_value, positions, free_margin = _get_account(ctx)
     held_assets = [p["coin"] for p in positions if p.get("coin")]
     held_set = {h.upper() for h in held_assets}
     if account_value <= 0:
+        return []
+
+    # Book full → emit nothing (and skip the universe scan). The runtime also caps via
+    # strategy.slots, but emitting INTO a full book is what generated the insufficient-funds
+    # spam — camel guards the same way (open_slots return before building the universe).
+    max_slots = max(1, int(inputs.get("maxSlots", 4)))
+    open_slots = max_slots - len(held_assets)
+    if open_slots <= 0:
+        print(f"[spider.scalp.scan] WAITING — slots full ({len(held_assets)}/{max_slots})",
+              file=sys.stderr)
         return []
 
     min_notional = max(account_value * min_notional_pct, venue_min_notional)
@@ -190,6 +211,13 @@ def scan(inputs, ctx):
     # and the runtime drops the ENTIRE batch (max_items_exceeded → silently missed entries). Emit only the
     # top-scoring maxEmit (default maxSlots); the runtime picks its slots from these. Overridable via inputs.maxEmit.
     emit_cap = max(1, int(inputs.get("maxEmit") or inputs.get("maxSlots") or 4))
+    # ...and by the FREE slots and what FREE margin can actually pay for. margin_usd is already
+    # (marginPct/100)*account_value (= camel's per_name_margin); ×1.1 leaves fee/slippage headroom on
+    # a FEE_OPTIMIZED_LIMIT taker fill. Without this the batch tail asks for margin already in use →
+    # insufficient-funds spam once the book is partly filled. Ports camel's open_slots/affordable cap;
+    # PER-NAME SIZE IS UNCHANGED — only the emitted count. (scalp at 60% is quiet today; kept in sync.)
+    affordable = int(free_margin / (margin_usd * 1.1)) if margin_usd > 0 else 0
+    emit_cap = max(0, min(emit_cap, open_slots, affordable))
     out = []
     for th in candidates:
         if len(out) >= emit_cap:

--- a/strategies/spider/strategy.yaml
+++ b/strategies/spider/strategy.yaml
@@ -5,7 +5,7 @@
 schema_version: 1
 
 id: spider                  # == package dir name; == every leg's runtime.yaml `group`
-version: "6.0.2"            # single source for catalog + MCP attribution (skillName/skillVersion)
+version: "6.0.3"            # single source for catalog + MCP attribution (skillName/skillVersion)
 
 catalog:                    # discovery surface. `group` here is the discovery TAXONOMY bucket —
                             # distinct from each runtime.yaml's `group: spider` linkage key.

--- a/strategies/spider/swing/runtime.yaml
+++ b/strategies/spider/swing/runtime.yaml
@@ -48,7 +48,10 @@ scanners:
       allowedAssets: ["xyz:NVDA", "xyz:AMD", "xyz:INTC", "xyz:MRVL", "xyz:MU", "xyz:TSM", "SUI", "ONDO", "HYPE", "NIL", "GRASS", "ZEC"]
       # ── scoring knobs ──
       minScore: 5
-      marginPct: 28                   # PERCENT of withdrawable (0,100] — runtime sizes (marginPct/100)*withdrawable
+      marginPct: 28                   # PERCENT (0,100]. Observed runtime sizing is (marginPct/100)*ACCOUNT
+                                      # VALUE — flat per name — NOT *withdrawable as this comment used to
+                                      # say (pending runtime-team confirmation). The scanner's open_slots/
+                                      # affordable cap keeps the batch within free margin; size unchanged.
       maxLeverage: 10
       maxSlots: 3
       rsiMaxLong: 78

--- a/strategies/spider/swing/scanners/scan.py
+++ b/strategies/spider/swing/scanners/scan.py
@@ -135,30 +135,33 @@ def _fetch_candles(ctx, asset, intervals):
 
 
 def _get_account(ctx):
-    """(account_value, [position_dicts]) from strategy_get_clearinghouse_state.
+    """(account_value, [position_dicts], free_margin) from strategy_get_clearinghouse_state.
 
     Dual-DEX equity collapse: account_value is taken via max() across the
     main/xyz sections — they are TWO VIEWS of ONE cross-margined wallet, never
     summed (summing would double every position size). assetPositions ARE
-    per-sub-DEX, so those are enumerated across both sections.
+    per-sub-DEX, so those are enumerated across both sections. Free margin =
+    equity - committed margin (sum of per-position marginUsed).
     """
     try:
         ch = ctx.senpi_mcp.call_tool("strategy_get_clearinghouse_state",
                                      {"strategy_wallet": ctx.wallet})
     except Exception:
-        return 0.0, []
+        return 0.0, [], 0.0
     if not ch:
-        return 0.0, []
+        return 0.0, [], 0.0
     data = ch.get("data", ch) if isinstance(ch, dict) else ch
     if not isinstance(data, dict):
-        return 0.0, []
-    positions, account_value = [], 0.0
+        return 0.0, [], 0.0
+    positions, account_value, used = [], 0.0, 0.0
     for section in ("main", "xyz"):
         s = data.get(section, {})
         if not isinstance(s, dict):
             continue
         ms = s.get("marginSummary", {})
         account_value = max(account_value, float(ms.get("accountValue", 0) or 0))
+        used = max(used, float(ms.get("totalMarginUsed", 0) or 0),
+                   abs(float(ms.get("totalNtlPos", 0) or 0)))
         for ap in s.get("assetPositions", []):
             pos = ap.get("position", ap)
             szi = float(pos.get("szi", 0) or 0)
@@ -166,7 +169,15 @@ def _get_account(ctx):
                 continue
             positions.append({"coin": pos.get("coin", ""),
                               "margin": float(pos.get("marginUsed", 0) or 0)})
-    return account_value, positions
+    # Read-sanity guard (ported from camel): margin/notional IN USE but an EMPTY
+    # positions list is a corrupt read — sizing or held-dedup off that re-enters
+    # held names (pyramiding) and mis-sizes. Skip the tick.
+    if used > 1.0 and not positions:
+        print("[spider.swing.scan] read-sanity guard: margin in use but empty "
+              "positions — skipping tick", file=sys.stderr)
+        return 0.0, [], 0.0
+    free_margin = max(0.0, account_value - sum(p["margin"] for p in positions))
+    return account_value, positions, free_margin
 
 
 # ── ctx.state: recent-signal dedup + xyz first-seen ledger ──
@@ -261,10 +272,20 @@ def scan(inputs, ctx):
     venue_min_notional = float(inputs.get("venueMinNotionalUsd", 10))
     min_notional_pct = float(inputs.get("minNotionalPctOfEquity", 0.01))
 
-    account_value, positions = _get_account(ctx)
+    account_value, positions, free_margin = _get_account(ctx)
     held_assets = [p["coin"] for p in positions if p.get("coin")]
     held_set = {h.upper() for h in held_assets}
     if account_value <= 0:
+        return []
+
+    # Book full → emit nothing (and skip the universe scan). The runtime also caps via
+    # strategy.slots, but emitting INTO a full book is what generated the insufficient-funds
+    # spam — camel guards the same way (open_slots return before building the universe).
+    max_slots = max(1, int(inputs.get("maxSlots", 3)))
+    open_slots = max_slots - len(held_assets)
+    if open_slots <= 0:
+        print(f"[spider.swing.scan] WAITING — slots full ({len(held_assets)}/{max_slots})",
+              file=sys.stderr)
         return []
 
     min_notional = max(account_value * min_notional_pct, venue_min_notional)
@@ -306,6 +327,13 @@ def scan(inputs, ctx):
     # and the runtime drops the ENTIRE batch (max_items_exceeded → silently missed entries). Emit only the
     # top-scoring maxEmit (default maxSlots); the runtime picks its slots from these. Overridable via inputs.maxEmit.
     emit_cap = max(1, int(inputs.get("maxEmit") or inputs.get("maxSlots") or 3))
+    # ...and by the FREE slots and what FREE margin can actually pay for. margin_usd is already
+    # (marginPct/100)*account_value (= camel's per_name_margin); ×1.1 leaves fee/slippage headroom on
+    # a FEE_OPTIMIZED_LIMIT taker fill. Without this the batch tail asks for margin already in use →
+    # CREATE_INSUFFICIENT_FUNDS spam once the book is partly filled (3 slots × 28% = 84% of equity).
+    # Ports camel's open_slots/affordable cap; PER-NAME SIZE IS UNCHANGED — only the emitted count.
+    affordable = int(free_margin / (margin_usd * 1.1)) if margin_usd > 0 else 0
+    emit_cap = max(0, min(emit_cap, open_slots, affordable))
     out = []
     for th in candidates:
         if len(out) >= emit_cap:


### PR DESCRIPTION
**Severity: low** — waste + metric corruption, not a stuck user. The strategy fills, exits, and goes flat correctly; the rejected orders are the *surplus* asks.

## Root cause (verified in code)
`spider/swing` and `/scalp` emit up to `maxSlots` signals **every tick regardless of how many slots are held**, and size each at `(marginPct/100)*account_value` — a **flat per-name margin that doesn't shrink as the book fills**. At `3 slots × 28% = 84%` of equity, the tail of every batch asks for margin already in use → Hyperliquid rejects it (`CREATE_INSUFFICIENT_FUNDS`).

The source producer (v5.1.1) computed an `affordable` slot count from free margin and emitted `min(open_slots, affordable)`. The Runtime 3.0 port **deliberately dropped it** (see the scanner docstring), betting the runtime owned affordability. It doesn't — and `camel/harvest/scan.py` already ships exactly this guard, its comment naming the same failure: *"an open slot with no free margin re-emits an un-fillable order every tick (insufficient-funds spam)."*

## Fix — port camel's gate to both legs (same shape, not a new design)
- `_get_account` returns `free_margin` (`= equity − Σ marginUsed`) + the **read-sanity guard** (margin in use but empty positions = corrupt read → skip tick).
- **Full-book early return** (`open_slots <= 0`) *before* the universe scan.
- `emit_cap = min(emit_cap, open_slots, affordable)`, `affordable = free_margin / (margin_usd × 1.1)`.

**Per-name size is unchanged** (`marginPct` stays 28/15) — only the emitted *count* drops, so no user's position sizing changes and v5.1.1 fidelity holds.

## Verification
Actual `_get_account` returns the right free margin, the read-sanity guard fires, and the gate math at `$240 / 28% → $67.20/pos`:

| book state | free margin | emitted (after) | before |
|---|---|---|---|
| 0 held | $240.00 | **3** (fits: 3×67.20=201.60) | 3 |
| 2 held | $105.60 | **1** | 3 → **2 rejected** |
| 3 held (full) | $38.40 | **0** (slot gate) | 3 → **3 rejected** |

## Scope note
The bug manifests only where **multi-signal-per-tick meets high commitment** — i.e. spider. I checked the other multi-slot packages that size off `account_value` without this gate (`hedgehog`, `tortoise`): they emit **one** signal/tick at ~24–30% commitment, so margin never binds. Not the same issue; left unchanged.

## ⚠️ Open question for the runtime team (see below)
The rejections happen *because* the runtime sizes off **account value**, not **withdrawable** — a fixed per-name margin that never shrinks as slots fill. The runtime.yaml comments (fleet-wide, including camel's) claim `*withdrawable`. This PR corrects spider's comment to match observed behavior and gates emissions to be robust either way, but **which the runtime actually uses should be confirmed** — it determines whether high-commitment configs are inherently fragile. Question routed to the runtime team separately.

## Deploy
Catalog-only; **live spider deployments need a redeploy** of the swing/scalp sleeves to pick up the scanner change. Suggested canary (from the analysis): deploy to one wallet, confirm zero `CREATE_INSUFFICIENT_FUNDS` over ~2h while fills continue at unchanged size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)