### PR TITLE
deploy.py: fix 3 stale "$100 floor" comments to $10

### DIFF
--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -208,7 +208,7 @@ def plan_funding(need, budget, available):
     The requested budget is a HARD TARGET, not a suggestion: if the live balance can't cover it (minus a
     per-wallet fee buffer) we return a `shortfall` dict and the caller HALTS — we never silently fund
     LESS than asked. The old behaviour scaled every wallet down to fit `available`, which quietly turned
-    a "$1,000 / $2,000" request into two $100 floor wallets; that silent under-funding is the bug this
+    a "$1,000 / $2,000" request into two $10 floor wallets; that silent under-funding is the bug this
     removes. (`available` unreadable → shortfall stays None → proceed; create would fail loudly anyway.)"""
     shares = [(i.funding_share or (1.0 / len(need))) for i in need]
     raw = {i.name: max(MIN_WALLET, round((budget or 0) * s, 2)) for i, s in zip(need, shares)}
@@ -248,8 +248,8 @@ def max_feasible_budget(shares, usable):
 
     Computed with the SAME per-wallet rounding `plan_funding` uses, so re-running `create` at the
     hinted `--budget ≤ $b*` round-trips with NO shortfall — even for uneven shares, where the old
-    `usable` ceiling was wrong (2 wallets 0.6/0.4, usable $230 → the small leg floors to $100, so
-    the true max is $216.67, not the hinted $230). Bisection in integer cents; exact to the cent."""
+    `usable` ceiling was wrong (2 wallets 0.6/0.4, usable $23 → the small leg floors to $10, so
+    the true max is $21.67, not the hinted $23). Bisection in integer cents; exact to the cent."""
     def total_cents(cents):
         b = cents / 100.0
         return int(round(sum(max(MIN_WALLET, round(b * s, 2)) for s in shares) * 100))
@@ -461,7 +461,7 @@ def cmd_create(pkg, a, log):
 
     # Size the to-create instances against the LIVE available balance. The requested --budget is a HARD
     # TARGET: if the balance can't cover it, HALT with the shortfall (fund more / lower the ask) rather
-    # than silently funding the $100 floor. Nothing is created on this path.
+    # than silently funding the $10 floor. Nothing is created on this path.
     amounts, shortfall = plan_funding(need, a.budget, available_usd(mcp)) if need else ({}, None)
     if shortfall:
         return report(pkg, st, "underfunded", note=underfunded_note(shortfall), as_json=a.json)


### PR DESCRIPTION
Follow-up to the $10-minimum rollout (#519). That PR lowered `MIN_WALLET` `100 → 10` (now imported from `min_budget.WALLET_FLOOR`), but three explanatory comments/docstrings in `senpi-strategy-ops/scripts/deploy.py` still referenced the old **$100 floor**, so a reader gets the wrong number.

**Comment-only — no behavior change.** The code already floors at $10.

- `:211` — "two ~~$100~~ **$10** floor wallets" (old-behavior description)
- `:251` — `max_feasible_budget` docstring worked example, recomputed at the $10 floor so it still demonstrates the uneven-shares flooring effect: ~~usable $230 → floors to $100 → true max $216.67~~ → **usable $23 → floors to $10 → true max $21.67**
- `:464` — "silently funding the ~~$100~~ **$10** floor"

(The `usd(100.0) → $100` example on `:230` is a currency-formatting demo, not a floor — left as-is.)

`python3 -m py_compile deploy.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)