### PR TITLE
deploy: fund multi-wallet packages one at a time; treat SERR083 as a name conflict

### DIFF
--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -9,7 +9,8 @@ in order and re-runs a step until it reports done.
   python3 deploy.py status   <id> [--json]
 
 Step 1 `create`  — creating wallets & funding them: per instance strategy_create_custom_strategy (records
-                   strategyId IMMEDIATELY), then poll strategy_list until ACTIVE, BOUNDED by --max-wait.
+                   strategyId IMMEDIATELY), then poll strategy_list until ACTIVE before submitting the
+                   NEXT instance — one wallet funds at a time — all BOUNDED by one --max-wait budget.
                    Not all ACTIVE yet → exits `creating`; re-run `create` to RESUME (never re-creates).
                    Refuses if it finds skillName==<id> strategies not in the state file (close first).
 Step 2 `runtime` — setting up the autonomous trading strategy: render each runtime.yaml with its wallet →
@@ -299,6 +300,47 @@ def underfunded_note(shortfall):
             f"across these {shortfall['wallets']} wallet(s) at the {usd(MIN_WALLET)}/wallet floor).")
 
 
+def is_name_rejection(err):
+    """True when the backend is refusing the wallet NAME, not the deploy — so retrying unnamed works.
+
+    SERR083 belongs here despite its generic text ("Custom strategy creation failed unexpectedly.
+    Retry with the same payload."): a strategy stuck in PENDING_FUNDING keeps holding its
+    strategyName, and every create reusing that name 500s until the record expires ~15 min later.
+    Retrying the SAME payload — what the error itself advises — can never clear it; dropping the
+    name clears it instantly. Observed on a real deploy, two calls 3.6s apart, same $693 budget:
+        {initialBudget: 693, strategyName: "vanguard-long"}  → SERR083
+        {initialBudget: 693}                                 → success
+    It also failed at $100 with the name, ruling out any funding cause.
+    """
+    s = str(err)
+    return any(c in s for c in ("SERR055", "SERR056", "SERR058", "SERR083")) or "name" in s.lower()
+
+
+def await_funded(mcp, pkg, st, insts, deadline, log=lambda m: None):
+    """Poll `insts` until each is ACTIVE with a wallet, or `deadline` passes.
+
+    Returns the still-pending ["name=STATUS", …] list — empty means every leg settled.
+    """
+    while True:
+        pending = []
+        for inst in insts:
+            s = inst_state(st, inst.name)
+            if s.get("status") in ("active", "registered", "live"):
+                continue
+            m = _cli.strategies_for(mcp, strategy_id=s["strategyId"], timeout=POLL_HTTP_TIMEOUT)
+            status = str(_cli.strategy_status(m[0]) if m else "").upper()
+            addr = _cli.strategy_wallet(m[0]) if m else None
+            if status == "ACTIVE" and addr:
+                s.update(wallet=addr, status="active")
+                save_state(pkg, st)
+            else:
+                pending.append(f"{inst.name}={status or '…'}")
+        if not pending or time.time() >= deadline:
+            return pending
+        log(f"  waiting on {', '.join(pending)}…")
+        time.sleep(POLL_EVERY)
+
+
 def report(pkg, st, overall, note=None, as_json=False):
     insts = [{"instance": i, **st["instances"].get(i, {"status": "pending"})}
              for i in [x for x in st["instances"]]]
@@ -466,6 +508,10 @@ def cmd_create(pkg, a, log):
     if shortfall:
         return report(pkg, st, "underfunded", note=underfunded_note(shortfall), as_json=a.json)
 
+    # ONE SHARED poll budget across every leg — a per-leg budget would let an N-wallet package
+    # run for N × max_wait and blow past the tool timeout.
+    deadline = time.time() + a.max_wait
+
     # create any instance that has no strategyId yet — record the id IMMEDIATELY (before polling),
     # so an interrupted run resumes instead of re-creating.
     for inst in pkg.instances:
@@ -491,7 +537,7 @@ def cmd_create(pkg, a, log):
             res = _create(sname)
         except MCPError as e:
             # Naming is best-effort — a name conflict/format rejection must never block the deploy.
-            if any(c in str(e) for c in ("SERR055", "SERR056", "SERR058")) or "name" in str(e).lower():
+            if is_name_rejection(e):
                 log(f"  [{inst.name}] name {sname!r} rejected ({e}); creating without a custom name")
                 try:
                     res = _create()
@@ -513,30 +559,24 @@ def cmd_create(pkg, a, log):
         s.update(strategyId=sid, status="creating", error=None)
         save_state(pkg, st)  # ← persist before any polling
 
-    # poll to ACTIVE, bounded by --max-wait (resume on re-run)
-    deadline = time.time() + a.max_wait
-    while True:
-        pending = []
-        for inst in pkg.instances:
-            s = inst_state(st, inst.name)
-            if s.get("status") in ("active", "registered", "live"):
-                continue
-            m = _cli.strategies_for(mcp, strategy_id=s["strategyId"], timeout=POLL_HTTP_TIMEOUT)
-            status = str(_cli.strategy_status(m[0]) if m else "").upper()
-            addr = _cli.strategy_wallet(m[0]) if m else None
-            if status == "ACTIVE" and addr:
-                s.update(wallet=addr, status="active")
-                save_state(pkg, st)
-            else:
-                pending.append(f"{inst.name}={status or '…'}")
-        if not pending:
-            return report(pkg, st, "wallets-ready", note="Next: deploy.py runtime " + pkg.id, as_json=a.json)
-        if time.time() >= deadline:
+        # Fund ONE WALLET AT A TIME. `create` returns at CREATE_WALLET and funding settles
+        # asynchronously afterwards, so submitting the next leg straight away puts two funding
+        # jobs on the SAME embedded wallet concurrently — one reads a balance the other has
+        # already claimed, funds $0, and sticks in PENDING_FUNDING. Waiting here is what makes
+        # the balance check in plan_funding actually mean something.
+        if await_funded(mcp, pkg, st, [inst], deadline, log):
+            # Not settled inside the budget — do NOT submit the next leg, that is the race.
+            # State is saved, so a re-run picks up exactly here.
             return report(pkg, st, "creating",
-                          note="Wallets still funding. Re-run `deploy.py create " + pkg.id + "` to resume.",
-                          as_json=a.json)
-        log(f"  waiting on {', '.join(pending)}…")
-        time.sleep(POLL_EVERY)
+                          note=("Wallet still funding. Re-run `deploy.py create " + pkg.id +
+                                "` to resume — wallets are funded one at a time."), as_json=a.json)
+
+    # everything submitted; wait out any leg that was already in flight from a previous run
+    if await_funded(mcp, pkg, st, pkg.instances, deadline, log):
+        return report(pkg, st, "creating",
+                      note="Wallets still funding. Re-run `deploy.py create " + pkg.id + "` to resume.",
+                      as_json=a.json)
+    return report(pkg, st, "wallets-ready", note="Next: deploy.py runtime " + pkg.id, as_json=a.json)
 
 
 # ---------- step 2: deploy runtimes ----------

--- a/senpi-strategy-ops/tests/test_sequential_funding.py
+++ b/senpi-strategy-ops/tests/test_sequential_funding.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Hermetic tests for one-wallet-at-a-time funding + the SERR083 name-collision fallback.
+
+No MCP, no openclaw, no network, no sleeping. Run:
+    python3 senpi-strategy-ops/tests/test_sequential_funding.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+import types
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import deploy  # noqa: E402
+
+
+class IsNameRejection(unittest.TestCase):
+    """SERR083 must route to the unnamed retry — that is the whole unblock."""
+
+    def test_serr083_is_a_name_rejection(self):
+        # Real payload: "tool failed: SERR083: Custom strategy creation failed unexpectedly.
+        # Retry with the same payload." — generic text, no "name" anywhere in it.
+        err = deploy.MCPError("tool failed: SERR083: Custom strategy creation failed "
+                              "unexpectedly. Retry with the same payload.")
+        self.assertTrue(deploy.is_name_rejection(err))
+
+    def test_existing_name_codes_still_route(self):
+        for code in ("SERR055", "SERR056", "SERR058"):
+            self.assertTrue(deploy.is_name_rejection(deploy.MCPError(f"tool failed: {code}: nope")))
+
+    def test_word_name_still_routes(self):
+        self.assertTrue(deploy.is_name_rejection(deploy.MCPError("strategyName is invalid")))
+
+    def test_unrelated_errors_do_not_route(self):
+        # These must stay hard failures — retrying them unnamed would mask a real problem.
+        for msg in ("tool failed: SERR037: Insufficient USDC balance",
+                    "tool failed: SERR045: not in a state to be topped up",
+                    "HTTP 503"):
+            self.assertFalse(deploy.is_name_rejection(deploy.MCPError(msg)), msg)
+
+
+class _Inst:
+    def __init__(self, name):
+        self.name = name
+
+
+class _StubCli:
+    """Stands in for _cli: each strategy reports NOT-ACTIVE once, then ACTIVE."""
+
+    def __init__(self):
+        self.polls = {}
+
+    def strategies_for(self, mcp, strategy_id=None, timeout=None):
+        n = self.polls.get(strategy_id, 0) + 1
+        self.polls[strategy_id] = n
+        return [{"id": strategy_id, "status": "ACTIVE" if n >= 2 else "FUND_WALLET",
+                 "strategyWalletAddress": "0xabc" if n >= 2 else ""}]
+
+    @staticmethod
+    def strategy_status(row):
+        return row["status"]
+
+    @staticmethod
+    def strategy_wallet(row):
+        return row["strategyWalletAddress"] or None
+
+
+class AwaitFunded(unittest.TestCase):
+    def setUp(self):
+        self.pkg = types.SimpleNamespace(id="vanguard", version="2.1.0",
+                                         instances=[_Inst("long"), _Inst("short")])
+        self.st = {"instances": {"long": {"strategyId": "S-long", "status": "creating"},
+                                 "short": {"strategyId": "S-short", "status": "creating"}}}
+        self._orig = (deploy._cli, deploy.save_state, deploy.POLL_EVERY)
+        self.cli = _StubCli()
+        deploy._cli = self.cli
+        deploy.save_state = lambda pkg, st: None
+        deploy.POLL_EVERY = 0  # no real sleeping
+
+    def tearDown(self):
+        (deploy._cli, deploy.save_state, deploy.POLL_EVERY) = self._orig
+
+    def test_polls_until_active_and_records_wallet(self):
+        pending = deploy.await_funded(None, self.pkg, self.st, [self.pkg.instances[0]],
+                                      deadline=time.time() + 60)
+        self.assertEqual(pending, [])
+        self.assertEqual(self.st["instances"]["long"]["status"], "active")
+        self.assertEqual(self.st["instances"]["long"]["wallet"], "0xabc")
+
+    def test_scoped_to_the_given_leg_only(self):
+        # Waiting on `long` must not poll — or settle — `short`.
+        deploy.await_funded(None, self.pkg, self.st, [self.pkg.instances[0]],
+                            deadline=time.time() + 60)
+        self.assertNotIn("S-short", self.cli.polls)
+        self.assertEqual(self.st["instances"]["short"]["status"], "creating")
+
+    def test_expired_deadline_returns_pending_instead_of_looping(self):
+        pending = deploy.await_funded(None, self.pkg, self.st, self.pkg.instances,
+                                      deadline=time.time() - 1)
+        self.assertEqual(sorted(pending), ["long=FUND_WALLET", "short=FUND_WALLET"])
+
+    def test_already_active_leg_is_not_repolled(self):
+        self.st["instances"]["long"]["status"] = "active"
+        deploy.await_funded(None, self.pkg, self.st, [self.pkg.instances[0]],
+                            deadline=time.time() + 60)
+        self.assertEqual(self.cli.polls, {})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
A user holding **$999.54** could not deploy a 2-leg package. Two bugs stack; both are small.

## 1. The funding race

`strategy_create_custom_strategy` returns at `CREATE_WALLET` — funding settles **asynchronously afterwards**. We submitted every leg back-to-back, so two funding jobs ran on the **same embedded wallet ~1s apart**. One reads a balance the other has already claimed, funds **$0**, and sticks in `PENDING_FUNDING`.

Real deploy, `--budget 996` split 70/30:

| wallet | budget | funded | status |
|---|---|---|---|
| `0x3d7f6393` (long) | $697.20 | **$0.00** | **PENDING_FUNDING** |
| `0x6b2138c5` (short) | $298.80 | $298.80 | funded ✓ |

The user-facing error is actively misleading — ~$700 was sitting right there:

```
SERR121: Funding failed and recovery not possible.
Funded: $0.00, Still needed: $697.20, Available from remaining chains: $0.00
```

**Fix:** poll each leg to ACTIVE before submitting the next, under **one shared** `--max-wait` budget. If a leg doesn't settle in time we stop rather than submit into the race; saved state resumes on re-run.

## 2. SERR083 is a name conflict

The dead `PENDING_FUNDING` record keeps holding its `strategyName`, so every retry of that name 500s until it expires ~15 min later. `deploy.py` **already** retries unnamed on SERR055/056/058 — SERR083 just wasn't in the list, and its text carries no `"name"` to match on.

Same user: 7 failed retries over 3 minutes, **including at $100** (so: not a funding problem), then —

```
00:03:34  {initialBudget: 693, strategyName: "vanguard-long"}  → SERR083
00:03:38  {initialBudget: 693}                                 → success
```

3.6 seconds apart, same budget, only the name dropped. SERR083's own advice — *"Retry with the same payload"* — can never clear it.

**Fix:** add SERR083 to the existing fallback, via a named `is_name_rejection()` predicate so the reasoning is documented and testable.

Fixing (1) largely prevents (2) — no orphaned record, no held name — but both stay: the unnamed fallback also covers a name held by an unrelated stale record.

## Cost

A 2-leg deploy now takes sum-of-legs (~10–20s each) instead of max — well inside the 150s default budget.

## Tests

`tests/test_sequential_funding.py` (new, hermetic — no MCP, no network, no sleeping):
- SERR083 routes to the unnamed retry; SERR037 / SERR045 / HTTP 503 still hard-fail
- `await_funded` polls **only** the legs it was given, records the wallet, skips already-active legs, and returns pending instead of looping past its deadline

Full `senpi-strategy-ops` suite green (`test_pkg.py` needs `python3.11 -m pytest`; 28 passed).

## Not addressed

Depositing exactly $1,000 can't deploy $1,000 — `E_FUNDS_SHORT` at `$999.75 accessible ($996.75 after fees), short by $3.25`. The arithmetic is right and the hard-target halt is deliberate, so I left it; it costs one extra round-trip and the error already hints the correct budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
