### PR TITLE
senpi-portfolio: fix ghost (closed) strategies from a stale cross-run state cache

### DIFF
--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.10.0"
+  version: "1.11.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -317,11 +317,17 @@ directly.)
 - **Don't infer "wiped out" from a low balance.** Check `total_funded` / `total_withdrawn` — a
   strategy can show a small balance because profits were withdrawn (`netFunded` can be negative). That
   is not a loss.
-- **"Current / my strategies" = ACTIVE only — never CLOSED.** The engine already filters
-  `strategy_list(status=["ACTIVE"])`, so closed strategies are excluded by construction. If you ever
-  reach for `strategy_list` directly, pass `status: ["ACTIVE"]` — a bare call returns CLOSED/PAUSED too
-  and they must not be presented as current. Mention PAUSED strategies only if relevant, clearly
+- **"Current / my strategies" = ACTIVE only — never CLOSED.** The engine filters
+  `strategy_list(status=["ACTIVE"])` AND re-validates any cached strategy set against a fresh live
+  `strategy_list` before reusing it, so a strategy CLOSED since the last read can't linger as a ghost. If
+  you ever reach for `strategy_list` directly, pass `status: ["ACTIVE"]` — a bare call returns CLOSED/PAUSED
+  too and they must not be presented as current. Mention PAUSED strategies only if relevant, clearly
   labeled "paused," never as active.
+- **If the engine's own signals disagree, STOP and re-run — do NOT narrate through it.** A `reconciles:
+  false` in `totals`, or the `money` and `strategies` steps reporting a different strategy count/set, means
+  the numbers didn't tie out. Re-run the step fresh and reconcile BEFORE you say a word — above all before
+  any close / rebalance recommendation. Recommending action on a strategy that turns out to be already
+  closed is exactly the failure this guards against.
 - **The live clearinghouse is the source of truth for whether a strategy holds capital — over the `status`
   field AND over what anyone asserts about the wallet.** The engine reconciles this: a strategy whose live
   wallet holds **$0 account value, no positions, no idle** is flagged **`empty: true`** (`empty_reason`:

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -318,8 +318,8 @@ directly.)
   strategy can show a small balance because profits were withdrawn (`netFunded` can be negative). That
   is not a loss.
 - **"Current / my strategies" = ACTIVE only — never CLOSED.** The engine filters
-  `strategy_list(status=["ACTIVE"])` AND re-validates any cached strategy set against a fresh live
-  `strategy_list` before reusing it, so a strategy CLOSED since the last read can't linger as a ghost. If
+  `strategy_list(status=["ACTIVE"])`, starts each analysis turn from a clean state, and expires the shared
+  cache after a short window — so a strategy CLOSED since a prior run can't linger as a ghost. If
   you ever reach for `strategy_list` directly, pass `status: ["ACTIVE"]` — a bare call returns CLOSED/PAUSED
   too and they must not be presented as current. Mention PAUSED strategies only if relevant, clearly
   labeled "paused," never as active.

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -32,6 +32,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 MARKET_ENRICH_CAP = 24      # cap the per-asset market pull
@@ -1170,16 +1171,25 @@ def _default_state_path():
     return os.path.join(tempfile.gettempdir(), STATE_SUBDIR, "state.json")
 
 
+STATE_TTL_S = 90   # a shared state file older than this is cross-run STALE (well beyond one narrated
+                   # money→strategies→positions turn) → recomputed, so nothing lingers across runs.
+
+
 def _load_state(path):
     """Read the shared state JSON. Never raises — a missing/corrupt/unreadable file → {} (fail-open: the
-    step then recomputes its prerequisites and self-heals)."""
+    step then recomputes its prerequisites and self-heals). Also drops a state file older than STATE_TTL_S
+    (see above): it persists across separate runs, so past that window any snapshot is treated as cross-run
+    STALE — the same fail-open self-heal as a corrupt file. This is what stops a strategy CLOSED since a
+    prior run from lingering as a ghost on a standalone `strategies`/`positions` call."""
     if not path or not os.path.isfile(path):
         return {}
     try:
+        if time.time() - os.path.getmtime(path) > STATE_TTL_S:
+            return {}
         with open(path) as fh:
             data = json.load(fh)
         return data if isinstance(data, dict) else {}
-    except Exception:  # noqa — corrupt/unreadable state is fail-open → recompute
+    except Exception:  # noqa — corrupt/unreadable/undatable state is fail-open → recompute
         return {}
 
 
@@ -1295,48 +1305,24 @@ def _money_totals(embedded, strategies, portfolio_totals):
 
 
 # ─────────────────────────────────────────────── self-heal: full strategies[] in state (for step 2 / 3)
-def _live_active_wallet_set(client, meta):
-    """Wallet set of the CURRENT ACTIVE strategy_list — a cheap freshness anchor (no per-wallet hydration).
-    Returns None on a read error, so a caller validating a cache treats it as unusable and re-fetches
-    rather than trusting possibly-stale state."""
-    try:
-        sl = _ok(client.mcp_call("strategy_list", status=["ACTIVE"], timeout=20))
-    except Exception as e:  # noqa
-        meta.setdefault("warnings", []).append(f"active-set freshness check failed, re-fetching live: {e}")
-        return None
-    rows = sl if isinstance(sl, list) else _field(sl, "strategies", "data", default=[])
-    out = {(_field(s, "strategyWalletAddress", "strategy_wallet_address", "walletAddress") or "").lower()
-           for s in (rows or [])}
-    out.discard("")
-    return out
-
-
 def _ensure_full_strategies_in_state(client, state, want_market, meta):
-    """Return the FULLY-hydrated strategies[] (positions + DSL + closed + profile/mandate) — reusing the
-    state file when a prior step already built it, else recompute the full fetch here (so `strategies` and
-    `positions` each work STANDALONE). Also rehydrates the embedded wallet + portfolio totals from state
-    (or re-fetches). Merges its work back into state for the next step. Returns (embedded, strategies,
-    portfolio_totals).
+    """Return the FULLY-hydrated strategies[] (positions + DSL + closed + profile/mandate) — from the state
+    file when a prior step already built it, else recompute the full fetch right here (so the `strategies`
+    and `positions` steps each work STANDALONE). Also rehydrates the embedded wallet + portfolio totals
+    from state (or re-fetches). Merges its work back into state for the next step. Returns (embedded,
+    strategies, portfolio_totals).
 
-    FRESHNESS GATE (the ghost-strategy fix): `strategies_full` is a WHOLE snapshot in a shared state file
-    that PERSISTS ACROSS RUNS (tempdir, no TTL). Reusing it blindly serves a strategy CLOSED since it was
-    written as a live ghost — with its stale account value + positions — and omits one DEPLOYED since. So
-    the cached snapshot is reused ONLY when its wallet set still matches a fresh strategy_list(ACTIVE); any
-    change — or an unreadable check — forces a full re-fetch. "Which strategies are live" drives
-    close/rebalance advice and is too consequential to answer from unvalidated cache."""
+    Freshness is enforced UPSTREAM, not here: `step_money` (step 1) starts each turn from a clean state,
+    and `_load_state` discards a state file older than STATE_TTL_S. So any snapshot this reuses is from
+    the CURRENT turn — the cross-run ghost (a strategy CLOSED since a prior run, or one DEPLOYED since) is
+    killed at the source, with no per-step strategy_list round-trip."""
     embedded = state.get("embedded_wallet")
     portfolio_totals = state.get("portfolio_totals")
     strategies = state.get("strategies_full")
     if isinstance(embedded, dict) and isinstance(strategies, list) and isinstance(portfolio_totals, dict):
-        live = _live_active_wallet_set(client, meta)
-        cached = {(s.get("wallet") or "").lower() for s in strategies}
-        cached.discard("")
-        if live is not None and live == cached:
-            return embedded, strategies, portfolio_totals
-        meta.setdefault("warnings", []).append(
-            "portfolio state was stale — the active-strategy set changed since it was cached; re-fetched live")
-    # state absent / partial / STALE → recompute the full pull (embedded + fully-hydrated strategies). The
-    # market enrichment is the `positions` step's job — skip it here (want_market only gates step 3's fold).
+        return embedded, strategies, portfolio_totals
+    # state absent/partial → recompute the full pull (embedded + fully-hydrated strategies). The market
+    # enrichment is the `positions` step's job — skip it here (want_market only gates step 3's fold).
     embedded, portfolio_totals = fetch_embedded(client, meta)
     strategies = fetch_strategies(client, meta)
     state["embedded_wallet"] = embedded
@@ -1359,7 +1345,10 @@ def step_money(client, want_market=True, state_path=None):
     history, no market. `want_market` is accepted for a uniform step signature but unused here."""
     if state_path is None:
         state_path = _default_state_path()
-    state = _load_state(state_path)
+    # step 1 is by definition the START of a turn — derived snapshots from a PRIOR run (e.g. a
+    # `strategies_full` cached while a since-closed strategy was ACTIVE) must not survive it. Start clean;
+    # money re-fetches everything it needs. (_load_state's TTL covers a standalone `strategies`/`positions`.)
+    state = {}
     meta = _fresh_meta()
     embedded, portfolio_totals = fetch_embedded(client, meta)
     strategies = fetch_strategy_money(client, meta)

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -1295,19 +1295,48 @@ def _money_totals(embedded, strategies, portfolio_totals):
 
 
 # ─────────────────────────────────────────────── self-heal: full strategies[] in state (for step 2 / 3)
+def _live_active_wallet_set(client, meta):
+    """Wallet set of the CURRENT ACTIVE strategy_list — a cheap freshness anchor (no per-wallet hydration).
+    Returns None on a read error, so a caller validating a cache treats it as unusable and re-fetches
+    rather than trusting possibly-stale state."""
+    try:
+        sl = _ok(client.mcp_call("strategy_list", status=["ACTIVE"], timeout=20))
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"active-set freshness check failed, re-fetching live: {e}")
+        return None
+    rows = sl if isinstance(sl, list) else _field(sl, "strategies", "data", default=[])
+    out = {(_field(s, "strategyWalletAddress", "strategy_wallet_address", "walletAddress") or "").lower()
+           for s in (rows or [])}
+    out.discard("")
+    return out
+
+
 def _ensure_full_strategies_in_state(client, state, want_market, meta):
-    """Return the FULLY-hydrated strategies[] (positions + DSL + closed + profile/mandate) — from the state
-    file when the `strategies` step already ran, else recompute the full fetch right here (so the
-    `strategies` and `positions` steps each work STANDALONE). Also rehydrates the embedded wallet +
-    portfolio totals from state (or re-fetches). Merges its work back into state for the next step.
-    Returns (embedded, strategies, portfolio_totals)."""
+    """Return the FULLY-hydrated strategies[] (positions + DSL + closed + profile/mandate) — reusing the
+    state file when a prior step already built it, else recompute the full fetch here (so `strategies` and
+    `positions` each work STANDALONE). Also rehydrates the embedded wallet + portfolio totals from state
+    (or re-fetches). Merges its work back into state for the next step. Returns (embedded, strategies,
+    portfolio_totals).
+
+    FRESHNESS GATE (the ghost-strategy fix): `strategies_full` is a WHOLE snapshot in a shared state file
+    that PERSISTS ACROSS RUNS (tempdir, no TTL). Reusing it blindly serves a strategy CLOSED since it was
+    written as a live ghost — with its stale account value + positions — and omits one DEPLOYED since. So
+    the cached snapshot is reused ONLY when its wallet set still matches a fresh strategy_list(ACTIVE); any
+    change — or an unreadable check — forces a full re-fetch. "Which strategies are live" drives
+    close/rebalance advice and is too consequential to answer from unvalidated cache."""
     embedded = state.get("embedded_wallet")
     portfolio_totals = state.get("portfolio_totals")
     strategies = state.get("strategies_full")
     if isinstance(embedded, dict) and isinstance(strategies, list) and isinstance(portfolio_totals, dict):
-        return embedded, strategies, portfolio_totals
-    # state absent/partial → recompute the full pull (embedded + fully-hydrated strategies). The market
-    # enrichment is the `positions` step's job — skip it here (want_market only gates step 3's fold).
+        live = _live_active_wallet_set(client, meta)
+        cached = {(s.get("wallet") or "").lower() for s in strategies}
+        cached.discard("")
+        if live is not None and live == cached:
+            return embedded, strategies, portfolio_totals
+        meta.setdefault("warnings", []).append(
+            "portfolio state was stale — the active-strategy set changed since it was cached; re-fetched live")
+    # state absent / partial / STALE → recompute the full pull (embedded + fully-hydrated strategies). The
+    # market enrichment is the `positions` step's job — skip it here (want_market only gates step 3's fold).
     embedded, portfolio_totals = fetch_embedded(client, meta)
     strategies = fetch_strategies(client, meta)
     state["embedded_wallet"] = embedded

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -840,6 +840,92 @@ def test_unfunded_empty_strategy_reason():
     assert res["totals"]["idle_in_strategies"] == 0
 
 
+def test_stale_cached_strategy_set_is_refetched_not_served_as_ghost():
+    """The shared state file persists across runs (tempdir, no TTL). A `strategies_full` cached while a
+    strategy was ACTIVE must NOT be served after that strategy has CLOSED — the freshness gate re-fetches
+    against a live strategy_list(ACTIVE). Regression for the 'recommend closing a strategy that was already
+    closed' bug: `money` re-fetched fresh while `strategies` served the stale snapshot incl. a ghost."""
+    LIVE = "0xLIVE0000000000000000000000000000000live"
+    GHOST = "0xORANG000000000000000000000000000000rng"   # closed since the cache was written
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"total_balance_usd": 1000, "total_withdrawable": 1000,
+                                  "total_usdc_in_hyperliquid": 0, "token_balances": []},
+        # LIVE strategy_list — the ghost is GONE (it closed); only the live wallet is ACTIVE now.
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "cub", "skillName": "cub", "status": "ACTIVE",
+             "id": "cub-1", "totalFunded": 1000, "strategyWalletAddress": LIVE}]},
+        f"strategy_get_clearinghouse_state::{LIVE.lower()}": {
+            "main": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "1000", "assetPositions": []},
+            "xyz": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "1000", "assetPositions": []}},
+    }
+    # STALE state: strategies_full still carries the now-closed GHOST with its old $1,950 + a SOL position.
+    stale_state = {
+        "embedded_wallet": {"address": "0xembed00000000000000000000000000000000ed", "idle_total": 0.0},
+        "portfolio_totals": {"total_balance_usd": 1000, "total_withdrawable": 1000},
+        "strategies_full": [
+            {"name": "orangutan", "wallet": GHOST, "strategy_id": "orang-1", "status": "ACTIVE",
+             "account_value": 1950.0, "idle_withdrawable": 1870.0, "deployed": 80.0,
+             "positions": [{"coin": "SOL", "margin": 80.0}], "empty": False},
+        ],
+    }
+    old = os.environ.get("SENPI_STATE_DIR")
+    os.environ["SENPI_STATE_DIR"] = os.path.join(HERE, "fixtures", "does_not_exist")   # no registry visible
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            state_path = os.path.join(td, "state.json")
+            with open(state_path, "w") as fh:
+                json.dump(stale_state, fh)
+            res = portfolio.step_strategies(portfolio._FixtureClient(fixture), want_market=False,
+                                            state_path=state_path)
+    finally:
+        if old is None:
+            os.environ.pop("SENPI_STATE_DIR", None)
+        else:
+            os.environ["SENPI_STATE_DIR"] = old
+    names = {s["name"] for s in res["strategies"]}
+    assert "orangutan" not in names, "closed strategy served from stale cache (ghost)"
+    assert "cub" in names, "live strategy missing after the freshness re-fetch"
+    assert any("stale" in w.lower() for w in res["meta"].get("warnings", [])), "no staleness warning emitted"
+
+
+def test_matching_cached_set_is_reused_not_refetched():
+    """When the cached active set STILL matches strategy_list(ACTIVE), the expensive hydration is reused
+    (the fast path is preserved) — the freshness gate re-fetches only on a SET CHANGE, not every step. The
+    cache carries account_value=9999, impossible from the fixture's $1000 clearinghouse; seeing 9999 proves
+    reuse."""
+    W = "0xSAME0000000000000000000000000000000same"
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"total_balance_usd": 1000, "total_withdrawable": 1000,
+                                  "total_usdc_in_hyperliquid": 0, "token_balances": []},
+        "strategy_list": {"strategies": [
+            {"tradingStrategyName": "cub", "status": "ACTIVE", "id": "cub-1",
+             "totalFunded": 1000, "strategyWalletAddress": W}]},
+        f"strategy_get_clearinghouse_state::{W.lower()}": {
+            "main": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "1000", "assetPositions": []},
+            "xyz": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "1000", "assetPositions": []}},
+    }
+    cached_state = {
+        "embedded_wallet": {"address": "0xembed00000000000000000000000000000000ed", "idle_total": 0.0},
+        "portfolio_totals": {"total_balance_usd": 1000, "total_withdrawable": 1000},
+        "strategies_full": [
+            {"name": "cub", "wallet": W, "strategy_id": "cub-1", "status": "ACTIVE",
+             "account_value": 9999.0, "idle_withdrawable": 0.0, "deployed": 9999.0, "positions": []},
+        ],
+    }
+    with tempfile.TemporaryDirectory() as td:
+        state_path = os.path.join(td, "state.json")
+        with open(state_path, "w") as fh:
+            json.dump(cached_state, fh)
+        res = portfolio.step_strategies(portfolio._FixtureClient(fixture), want_market=False,
+                                        state_path=state_path)
+    s = {x["name"]: x for x in res["strategies"]}["cub"]
+    assert s["account_value"] == 9999.0, "cache was re-fetched despite an unchanged active set (fast path lost)"
+
+
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     for fn in fns:

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import tempfile
+import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(HERE, "..", "scripts"))
@@ -840,90 +841,99 @@ def test_unfunded_empty_strategy_reason():
     assert res["totals"]["idle_in_strategies"] == 0
 
 
-def test_stale_cached_strategy_set_is_refetched_not_served_as_ghost():
-    """The shared state file persists across runs (tempdir, no TTL). A `strategies_full` cached while a
-    strategy was ACTIVE must NOT be served after that strategy has CLOSED — the freshness gate re-fetches
-    against a live strategy_list(ACTIVE). Regression for the 'recommend closing a strategy that was already
-    closed' bug: `money` re-fetched fresh while `strategies` served the stale snapshot incl. a ghost."""
-    LIVE = "0xLIVE0000000000000000000000000000000live"
-    GHOST = "0xORANG000000000000000000000000000000rng"   # closed since the cache was written
-    fixture = {
+def _one_live_fixture(wallet, name="cub"):
+    """Fixture: embedded wallet + ONE ACTIVE strategy at `wallet` (empty positions, $1000)."""
+    return {
         "user_get_me": {"wallets": [
             {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
         "account_get_portfolio": {"total_balance_usd": 1000, "total_withdrawable": 1000,
                                   "total_usdc_in_hyperliquid": 0, "token_balances": []},
-        # LIVE strategy_list — the ghost is GONE (it closed); only the live wallet is ACTIVE now.
         "strategy_list": {"strategies": [
-            {"tradingStrategyName": "cub", "skillName": "cub", "status": "ACTIVE",
-             "id": "cub-1", "totalFunded": 1000, "strategyWalletAddress": LIVE}]},
-        f"strategy_get_clearinghouse_state::{LIVE.lower()}": {
+            {"tradingStrategyName": name, "skillName": name, "status": "ACTIVE",
+             "id": f"{name}-1", "totalFunded": 1000, "strategyWalletAddress": wallet}]},
+        f"strategy_get_clearinghouse_state::{wallet.lower()}": {
             "main": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "1000", "assetPositions": []},
             "xyz": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "1000", "assetPositions": []}},
     }
-    # STALE state: strategies_full still carries the now-closed GHOST with its old $1,950 + a SOL position.
-    stale_state = {
+
+
+def _ghost_state(ghost_wallet, acct=1950.0):
+    """A prior run's persisted state whose strategies_full carries a strategy that has since CLOSED."""
+    return {
         "embedded_wallet": {"address": "0xembed00000000000000000000000000000000ed", "idle_total": 0.0},
         "portfolio_totals": {"total_balance_usd": 1000, "total_withdrawable": 1000},
         "strategies_full": [
-            {"name": "orangutan", "wallet": GHOST, "strategy_id": "orang-1", "status": "ACTIVE",
-             "account_value": 1950.0, "idle_withdrawable": 1870.0, "deployed": 80.0,
-             "positions": [{"coin": "SOL", "margin": 80.0}], "empty": False},
-        ],
+            {"name": "orangutan", "wallet": ghost_wallet, "strategy_id": "orang-1", "status": "ACTIVE",
+             "account_value": acct, "idle_withdrawable": acct - 80, "deployed": 80.0,
+             "positions": [{"coin": "SOL", "margin": 80.0}], "empty": False}],
     }
+
+
+def test_stale_cross_run_state_is_dropped_not_served_as_ghost():
+    """The shared state file persists across runs (tempdir). A `strategies_full` cached in a PRIOR run —
+    older than STATE_TTL_S — must be discarded, not served: `_load_state` drops it and `strategies`
+    self-heals with a fresh fetch. Regression for 'recommend closing an already-closed strategy' (a closed
+    strategy served from a stale snapshot as a live ghost)."""
+    LIVE = "0xLIVE0000000000000000000000000000000live"
+    GHOST = "0xORANG000000000000000000000000000000rng"
     old = os.environ.get("SENPI_STATE_DIR")
     os.environ["SENPI_STATE_DIR"] = os.path.join(HERE, "fixtures", "does_not_exist")   # no registry visible
     try:
         with tempfile.TemporaryDirectory() as td:
             state_path = os.path.join(td, "state.json")
             with open(state_path, "w") as fh:
-                json.dump(stale_state, fh)
-            res = portfolio.step_strategies(portfolio._FixtureClient(fixture), want_market=False,
-                                            state_path=state_path)
+                json.dump(_ghost_state(GHOST), fh)
+            old_mtime = time.time() - (portfolio.STATE_TTL_S + 10)   # a cross-run file, past the TTL
+            os.utime(state_path, (old_mtime, old_mtime))
+            res = portfolio.step_strategies(portfolio._FixtureClient(_one_live_fixture(LIVE)),
+                                            want_market=False, state_path=state_path)
     finally:
         if old is None:
             os.environ.pop("SENPI_STATE_DIR", None)
         else:
             os.environ["SENPI_STATE_DIR"] = old
     names = {s["name"] for s in res["strategies"]}
-    assert "orangutan" not in names, "closed strategy served from stale cache (ghost)"
+    assert "orangutan" not in names, "closed strategy served from stale cross-run cache (ghost)"
     assert "cub" in names, "live strategy missing after the freshness re-fetch"
-    assert any("stale" in w.lower() for w in res["meta"].get("warnings", [])), "no staleness warning emitted"
 
 
-def test_matching_cached_set_is_reused_not_refetched():
-    """When the cached active set STILL matches strategy_list(ACTIVE), the expensive hydration is reused
-    (the fast path is preserved) — the freshness gate re-fetches only on a SET CHANGE, not every step. The
-    cache carries account_value=9999, impossible from the fixture's $1000 clearinghouse; seeing 9999 proves
-    reuse."""
+def test_step_money_starts_clean_and_wipes_prior_strategies_full():
+    """step_money (step 1) starts each turn from a CLEAN state, so a `strategies_full` cached in a prior
+    run cannot survive into this turn's `strategies` step — even within the TTL window. This is what makes
+    `money` and `strategies` agree by construction (the 9-vs-10 mismatch that started the bug)."""
+    LIVE = "0xLIVE0000000000000000000000000000000live"
+    GHOST = "0xORANG000000000000000000000000000000rng"
+    with tempfile.TemporaryDirectory() as td:
+        state_path = os.path.join(td, "state.json")
+        with open(state_path, "w") as fh:
+            json.dump(_ghost_state(GHOST), fh)          # fresh mtime → within TTL; only step_money's reset drops it
+        portfolio.step_money(portfolio._FixtureClient(_one_live_fixture(LIVE)),
+                             want_market=False, state_path=state_path)
+        with open(state_path) as fh:
+            after = json.load(fh)
+    assert "strategies_full" not in after, "step_money preserved a prior run's strategies_full into the turn"
+
+
+def test_within_ttl_cached_state_is_reused():
+    """A fresh (within-TTL) state file IS reused — the intra-turn fast path is preserved. The cache carries
+    account_value=9999, impossible from the fixture's $1000 clearinghouse; seeing 9999 proves reuse (no
+    re-fetch)."""
     W = "0xSAME0000000000000000000000000000000same"
-    fixture = {
-        "user_get_me": {"wallets": [
-            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
-        "account_get_portfolio": {"total_balance_usd": 1000, "total_withdrawable": 1000,
-                                  "total_usdc_in_hyperliquid": 0, "token_balances": []},
-        "strategy_list": {"strategies": [
-            {"tradingStrategyName": "cub", "status": "ACTIVE", "id": "cub-1",
-             "totalFunded": 1000, "strategyWalletAddress": W}]},
-        f"strategy_get_clearinghouse_state::{W.lower()}": {
-            "main": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "1000", "assetPositions": []},
-            "xyz": {"marginSummary": {"accountValue": "1000"}, "withdrawable": "1000", "assetPositions": []}},
-    }
     cached_state = {
         "embedded_wallet": {"address": "0xembed00000000000000000000000000000000ed", "idle_total": 0.0},
         "portfolio_totals": {"total_balance_usd": 1000, "total_withdrawable": 1000},
         "strategies_full": [
             {"name": "cub", "wallet": W, "strategy_id": "cub-1", "status": "ACTIVE",
-             "account_value": 9999.0, "idle_withdrawable": 0.0, "deployed": 9999.0, "positions": []},
-        ],
+             "account_value": 9999.0, "idle_withdrawable": 0.0, "deployed": 9999.0, "positions": []}],
     }
     with tempfile.TemporaryDirectory() as td:
         state_path = os.path.join(td, "state.json")
         with open(state_path, "w") as fh:
-            json.dump(cached_state, fh)
-        res = portfolio.step_strategies(portfolio._FixtureClient(fixture), want_market=False,
-                                        state_path=state_path)
+            json.dump(cached_state, fh)                 # fresh mtime → within TTL → reused
+        res = portfolio.step_strategies(portfolio._FixtureClient(_one_live_fixture(W)),
+                                        want_market=False, state_path=state_path)
     s = {x["name"]: x for x in res["strategies"]}["cub"]
-    assert s["account_value"] == 9999.0, "cache was re-fetched despite an unchanged active set (fast path lost)"
+    assert s["account_value"] == 9999.0, "within-TTL cache was re-fetched (fast path lost)"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Bug:** `strategies`/`positions` reuse `strategies_full` from the shared state file (`<tempdir>/senpi-portfolio/state.json`) on presence alone, and that state persists across runs with no TTL. So a snapshot cached while a strategy was ACTIVE is served after it closes (a ghost), and misses strategies deployed since. `money` re-fetches fresh → the `9 vs 10` count mismatch + `reconciles:false` that led an agent to recommend closing an already-closed strategy. Both steps already filter `status=["ACTIVE"]` — this is caching, not filtering.

**Fix** (root cause, per @shnoodles' review): `step_money` (step 1) starts each turn from a clean state, and `_load_state` drops a state file older than `STATE_TTL_S` (90s). `money` and `strategies` can't disagree by construction; the standalone `strategies`/`positions` path self-heals past the TTL; no new MCP call. Intra-turn reuse preserved.

**Tests:** ghost dropped via the TTL (RED without it), `step_money` wipes a prior `strategies_full`, within-TTL cache still reused. 41/41.

**Also:** SKILL.md — stop + re-run on `reconciles:false` / a money-vs-strategies count mismatch before any close/rebalance rec. Bump 1.10.0 → 1.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)