### PR TITLE
feat(strategy-ops): add `deploy.py upgrade` — apply an edit to a live strategy

### DIFF
--- a/senpi-strategy-author/SKILL.md
+++ b/senpi-strategy-author/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.12.0"
+  version: "2.13.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -291,6 +291,12 @@ re-smoke-test if you touched `scan.py`/`runtime.yaml`.
 
 Authoring produces the **package** only; going live is a **separate, gated loop**, and a strategy is live
 only once **`senpi-strategy-ops` deploys it AND `deploy.py verify` passes**. Walk the full loop every time:
+
+> **Was this an edit to a strategy that is ALREADY LIVE?** (you changed the scoring / scanner / DSL of a
+> deployed package — "make my live strategy more aggressive", re-tune, re-score) — then the apply is
+> **`senpi-strategy-ops` `deploy.py upgrade <id> [--instance <arm>] --budget <usd>`**, NOT the fresh-deploy
+> loop below. `create` will refuse a running strategy; `upgrade` closes the arm and redeploys your edited
+> package on a fresh wallet, consent-gated, per arm. The steps below are for a strategy that is not yet live.
 
 1. **Confirm with the user** — budget + "ready to deploy?" Funding a wallet is real money and one-way, so
    this is an explicit yes, not an assumption.

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -308,9 +308,16 @@ exists to prevent).
      with `--yes`.
    - Each re-run reports where it is: `closing` (async flatten in flight — re-run) → `closed` → then the
      normal `wallets-ready` → `registered` → `live`. A transient `underfunded` right after close just
-     means the old funds are still returning — wait and re-run.
-3. **Tell the user what changed:** the wallet is NEW (old → new); funds moved main → new; a custom
-   ratchet/stop ladder on the old positions does NOT carry over (they were closed) — re-apply it if wanted.
+     means the old funds are still returning — wait and re-run. **Exit codes:** `0` = done (`live`), `2` =
+     refused / action-required (`needs-consent`, `blocked`, `failed`), **`3` = resumable, re-run**
+     (`closing`/`closed`). Don't treat `closed` as done — the old arm is gone and nothing is deployed yet;
+     keep re-running until `live`.
+   - **Budget continuity:** the fresh wallet is funded with `--budget` from the main wallet. If the old arm
+     held **more** than `--budget`, the surplus does NOT follow it across — it returns to main and stays
+     there. To carry the whole balance over, set `--budget` to the old arm's size (or higher).
+3. **Tell the user what changed:** the wallet is NEW (old → new); funds moved main → new (up to `--budget`
+   — any surplus stays in main); a custom ratchet/stop ladder on the old positions does NOT carry over
+   (they were closed) — re-apply it if wanted.
 
 **NEVER, during an upgrade:**
 - hand-render a `runtime.yaml` or run raw `openclaw senpi runtime create` on a hand-built file — the

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -277,6 +277,11 @@ all). **Redeploy / upgrade a deployed strategy — see the next section, never a
 
 ## Upgrade — apply an edited scan.py / scoring.py / runtime.yaml to a LIVE strategy
 
+> **STOPGAP.** The close→redeploy-on-a-fresh-wallet mechanics below exist only until the runtime engine
+> ships in-place scanner reload (`update`/`refresh`). When it lands, this whole section and the `upgrade`
+> verb collapse to a thin call to it — the command surface stays, the wallet-swap semantics go away. Treat
+> the wallet-swap as scheduled for deletion, not durable doctrine.
+
 The most common change request: the user asks to re-score / re-scan / re-tune a strategy (e.g. "make my
 live strategy more aggressive"). **The edit itself — changing `scoring.py` / `scan.py` / `runtime.yaml`,
 leverage, sizing, DSL — is authored in `senpi-strategy-author`** (the only skill that knows the scanner /

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -9,18 +9,19 @@ description: >-
   "stop/close/uninstall polar" — and for teardown like "close all strategies",
   "return funds to main", "tear everything down" (→ close.py --all). ALWAYS tear
   down via close.py, never a raw strategy_close (that strands the runtime). Also
-  use to APPLY AN EDIT to a strategy that is already live — "re-score / re-tune /
-  change the scanner on my live strategy", "apply my new scoring", "make it buy
-  more aggressively" — via deploy.py upgrade (there is no in-place reload yet, so
-  it closes the arm and redeploys on a fresh wallet; consent-gated, per arm).
-  Authoring the edited files themselves is senpi-strategy-author; APPLYING them to
-  a running strategy is upgrade here. A strategy is a PACKAGE (strategy.yaml + one
+  the skill that APPLIES an edit to an already-live strategy: the edit itself is
+  authored in senpi-strategy-author (the only skill that knows the scanner / yaml /
+  DSL schema — "make my live strategy more aggressive", change leverage/sizing/DSL
+  starts THERE); ops then applies it with deploy.py upgrade — no in-place reload
+  yet, so it closes the arm and redeploys on a FRESH wallet (consent-gated, per
+  arm). ops deploys / closes / applies; it does NOT author or edit strategy files.
+  A strategy is a PACKAGE (strategy.yaml + one
   runtime.yaml per instance + scanners/) the runtime supervises in-process — no
   scanner daemon. deploy.py runs three resumable steps (create→runtime→verify),
   plus upgrade (edit a live strategy); close.py tears down (stop runtime +
   strategy_close → flattens positions, returns funds). The id (spider, polar,
   kodiak) is the package folder. NOT for choosing WHICH strategy
-  (senpi-strategy-discover) or building/editing one (senpi-strategy-author).
+  (senpi-strategy-discover) or authoring / editing the strategy files themselves (senpi-strategy-author).
 license: Apache-2.0
 metadata:
   author: Senpi
@@ -107,7 +108,8 @@ wallet — every deploy gets a FRESH one.** If an existing `<id>` strategy is fo
 (funded but never got a runtime — the reuse trap an agent keeps landing back on) is **closed to recover its
 funds**, then a new wallet is created (prints **`closing-existing`**; re-run `create` once it's closed and
 funds are back); a **live, running** one is left untouched — `create` **refuses** so it can't silently
-flatten a real book (`close.py <id>` first to redeploy). The **`--budget` is a hard target**: create funds
+flatten a real book (to apply an edit to it, use **`deploy.py upgrade`** — see *Upgrade*; `close.py <id>`
+only to tear it down). The **`--budget` is a hard target**: create funds
 exactly what you ask (split by `funding_share`, $10/wallet floor); if your live balance can't cover it,
 create **HALTS with `underfunded`** and the exact shortfall — it will **NEVER silently fund less** (the
 "$1,000 → $10" failure). Fund/free USDC or confirm a smaller amount, then re-run. **Never hand-edit
@@ -165,7 +167,8 @@ scheduled/supervised scanner passes, so it does **not** wait for the first scan 
 > suggest a lower budget below the floor. Do not switch tools. If
 > `create` reports **`closing-existing`**, it's closing a runtime-less `<id>` wallet to recover funds so it
 > can deploy fresh — re-run `create` once it's closed. If it **refuses** "already deployed AND running", a
-> live `<id>` strategy exists — `close.py <id>` first to redeploy on a fresh wallet. If **`runtime`** lost its
+> live `<id>` strategy exists — to apply an edit use **`deploy.py upgrade <id> [--instance <arm>] --budget
+> <usd>`** (closes + redeploys fresh, consent-gated; see *Upgrade*), not a bare `close`+`create`. If **`runtime`** lost its
 > deploy state and can't safely resolve the fresh wallet, it refuses **split by cause** — and in **both**
 > cases you **never hand-register a runtime onto an old wallet** (no manual `runtime create`/`update` with a
 > wallet from a leftover yaml). **`[E_STATE_NO_WALLETS]`**: the backend has **zero** ACTIVE `<id>` wallets, so
@@ -274,18 +277,20 @@ all). **Redeploy / upgrade a deployed strategy — see the next section, never a
 
 ## Upgrade — apply an edited scan.py / scoring.py / runtime.yaml to a LIVE strategy
 
-The most common change request: the user asks to re-score / re-scan / re-tune a strategy, or you recommend
-it after analysis. **There is no in-place scanner reload yet** (a runtime-team `refresh` is coming). Until
-then, upgrading = **close the arm, then recreate it on a FRESH wallet with the edited files** — done **per
-arm**, so a multi-instance strategy's other sleeves keep running. **`deploy.py upgrade` does the whole
-thing** — it is the ONLY correct way to apply an edit to a live strategy. Do not hand-sequence it, and
-never hand-render a runtime.yaml (that's the `./scanners` "NO ENTRY SCANNERS" trap the verb exists to
-prevent).
+The most common change request: the user asks to re-score / re-scan / re-tune a strategy (e.g. "make my
+live strategy more aggressive"). **The edit itself — changing `scoring.py` / `scan.py` / `runtime.yaml`,
+leverage, sizing, DSL — is authored in `senpi-strategy-author`** (the only skill that knows the scanner /
+yaml / DSL schema). This skill's job is to **APPLY** that edited package to the live strategy. **There is no
+in-place scanner reload yet** (a runtime-team `refresh` is coming), so applying = **close the arm, then
+recreate it on a FRESH wallet with the edited files** — done **per arm**, so a multi-instance strategy's
+other sleeves keep running. **`deploy.py upgrade` does the whole apply** — the ONLY correct way. Do not
+hand-sequence it, and never hand-render a runtime.yaml (the `./scanners` "NO ENTRY SCANNERS" trap the verb
+exists to prevent).
 
 **Do this:**
-1. **Edit the on-disk package** in the durable root (`/data/workspace/strategies/<id>/[<instance>/]…`) —
-   `scoring.py` / `scan.py` / `runtime.yaml`. (`upgrade` re-runs the full `validate` preflight itself, so a
-   bad `./scanners` path is caught BEFORE anything closes.)
+1. **Confirm the edited package is on disk** in the durable root (`/data/workspace/strategies/<id>/[<instance>/]…`)
+   — authored via `senpi-strategy-author`, not hand-guessed here. (`upgrade` re-runs the full `validate`
+   preflight itself, so a bad `./scanners` path is caught BEFORE anything closes.)
 2. **Run `upgrade` and re-run it to advance** — one guided step per call (close → fund fresh wallet →
    register runtime → verify), exactly like `create` resumes. `--instance` is required for a multi-arm
    package (upgrades one sleeve, siblings untouched); the budget funds the fresh wallet:

--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -8,17 +8,23 @@ description: >-
   "are my positions protected? / do they have a stop-loss (DSL)?",
   "stop/close/uninstall polar" — and for teardown like "close all strategies",
   "return funds to main", "tear everything down" (→ close.py --all). ALWAYS tear
-  down via close.py, never a raw strategy_close (that strands the runtime). A
-  strategy is a PACKAGE (strategy.yaml + one runtime.yaml per instance + scanners/)
-  the runtime supervises in-process — no scanner daemon. deploy.py runs three
-  resumable steps (create→runtime→verify); close.py tears down (stop runtime +
+  down via close.py, never a raw strategy_close (that strands the runtime). Also
+  use to APPLY AN EDIT to a strategy that is already live — "re-score / re-tune /
+  change the scanner on my live strategy", "apply my new scoring", "make it buy
+  more aggressively" — via deploy.py upgrade (there is no in-place reload yet, so
+  it closes the arm and redeploys on a fresh wallet; consent-gated, per arm).
+  Authoring the edited files themselves is senpi-strategy-author; APPLYING them to
+  a running strategy is upgrade here. A strategy is a PACKAGE (strategy.yaml + one
+  runtime.yaml per instance + scanners/) the runtime supervises in-process — no
+  scanner daemon. deploy.py runs three resumable steps (create→runtime→verify),
+  plus upgrade (edit a live strategy); close.py tears down (stop runtime +
   strategy_close → flattens positions, returns funds). The id (spider, polar,
   kodiak) is the package folder. NOT for choosing WHICH strategy
   (senpi-strategy-discover) or building/editing one (senpi-strategy-author).
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.13.0"
+  version: "2.14.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -39,6 +45,7 @@ python3 senpi-strategy-ops/scripts/deploy.py validate <id>                 # 0. 
 python3 senpi-strategy-ops/scripts/deploy.py create  <id> --budget <usd>   # 1. create wallets & fund them
 python3 senpi-strategy-ops/scripts/deploy.py runtime <id>                  # 2. register the runtime(s)
 python3 senpi-strategy-ops/scripts/deploy.py verify  <id>                  # 3. GATE — confirm LIVE (runtime+scanner+DSL+budget)
+python3 senpi-strategy-ops/scripts/deploy.py upgrade <id> --instance <arm> --budget <usd>  # apply an EDIT to a live strategy (close→redeploy fresh; resumable; consent-gated)
 python3 senpi-strategy-ops/scripts/status.py                               # what am I running? (+ health)
 python3 senpi-strategy-ops/scripts/close.py          <id>                  # teardown one strategy
 python3 senpi-strategy-ops/scripts/close.py          --all                 # teardown EVERY open strategy
@@ -263,7 +270,49 @@ it returns `closing` and hands polling to you: **re-run `close.py spider`** unti
 Re-runs are idempotent (runtime already gone → skip; already closing/closed → no re-submit). Strategies
 are discovered from `strategy_list` (`skillName==<id>`), so close also cleans up **orphaned** wallets
 that have no runtime. `--instance <name>` scopes an instance (needs its live runtime to map; else omit to close
-all). **Redeploy** = `close` then `create`/`runtime`/`verify`.
+all). **Redeploy / upgrade a deployed strategy — see the next section, never a bare `close`+`create`.**
+
+## Upgrade — apply an edited scan.py / scoring.py / runtime.yaml to a LIVE strategy
+
+The most common change request: the user asks to re-score / re-scan / re-tune a strategy, or you recommend
+it after analysis. **There is no in-place scanner reload yet** (a runtime-team `refresh` is coming). Until
+then, upgrading = **close the arm, then recreate it on a FRESH wallet with the edited files** — done **per
+arm**, so a multi-instance strategy's other sleeves keep running. **`deploy.py upgrade` does the whole
+thing** — it is the ONLY correct way to apply an edit to a live strategy. Do not hand-sequence it, and
+never hand-render a runtime.yaml (that's the `./scanners` "NO ENTRY SCANNERS" trap the verb exists to
+prevent).
+
+**Do this:**
+1. **Edit the on-disk package** in the durable root (`/data/workspace/strategies/<id>/[<instance>/]…`) —
+   `scoring.py` / `scan.py` / `runtime.yaml`. (`upgrade` re-runs the full `validate` preflight itself, so a
+   bad `./scanners` path is caught BEFORE anything closes.)
+2. **Run `upgrade` and re-run it to advance** — one guided step per call (close → fund fresh wallet →
+   register runtime → verify), exactly like `create` resumes. `--instance` is required for a multi-arm
+   package (upgrades one sleeve, siblings untouched); the budget funds the fresh wallet:
+   ```
+   python3 scripts/deploy.py upgrade <id> --instance <arm> --budget <usd>
+   ```
+   - **Flatten consent is built in.** If the arm holds an open position, the first call HALTS with
+     `needs-consent` — it will NOT silently market-exit a live book. Surface the flatten to the user
+     (positions close, funds return to main, redeploy on a NEW wallet), get an explicit yes, then re-run
+     with `--yes`.
+   - Each re-run reports where it is: `closing` (async flatten in flight — re-run) → `closed` → then the
+     normal `wallets-ready` → `registered` → `live`. A transient `underfunded` right after close just
+     means the old funds are still returning — wait and re-run.
+3. **Tell the user what changed:** the wallet is NEW (old → new); funds moved main → new; a custom
+   ratchet/stop ladder on the old positions does NOT carry over (they were closed) — re-apply it if wanted.
+
+**NEVER, during an upgrade:**
+- hand-render a `runtime.yaml` or run raw `openclaw senpi runtime create` on a hand-built file — the
+  `./scanners` trap. `upgrade` renders it INSIDE the instance dir for you.
+- raw `strategy_create_custom_strategy` — that's a naked wallet with no runtime.
+- `create` on top of a live strategy to "just re-fund it" — `create` refuses a running strategy; `upgrade`
+  is the path that closes-then-redeploys.
+- claim "upgraded / live" before `upgrade` reports `live`.
+
+*(Under the hood `upgrade` drives the same tested `close → create → runtime → verify` path on a fresh
+wallet. In-place `refresh` — reload the scanner with no close, no flatten, same wallet — is coming from the
+runtime team; the verb swaps to it when it lands, same command surface.)*
 
 ## Invariants
 

--- a/senpi-strategy-ops/references/lifecycle.md
+++ b/senpi-strategy-ops/references/lifecycle.md
@@ -67,7 +67,9 @@ just means re-run that step.
 it once all instances are `live`** (a partial `registered` keeps it). So a completed deploy leaves no
 state → the next deploy (e.g. after a close) starts clean and can't reuse stale wallets. `verify`/`status`
 work without it (runtime ids derive from the manifest). `create`'s reconcile is the safety net for partial
-state. There is **no `--reinstall`** and no wallet-reuse — redeploy = `close` then `create`/`runtime`/`verify`.
+state. There is **no `--reinstall`** and no wallet-reuse. To apply an edit to a live strategy, use
+**`deploy.py upgrade <id> [--instance <arm>] --budget <usd>`** (it drives close → create → runtime → verify
+on a fresh wallet, consent-gated, per arm) — never a bare `close`+`create` by hand.
 
 ## `close.py [<id>] [--all] [--instance name] [--dry-run] [--json]`
 

--- a/senpi-strategy-ops/scripts/_cli.py
+++ b/senpi-strategy-ops/scripts/_cli.py
@@ -442,17 +442,41 @@ def strategy_open(s):
     return str(strategy_status(s) or "").upper() not in DEAD_STATUSES
 
 
+def list_strategies_or_none(mcp, timeout=15, statuses=None):
+    """Like `list_strategies()` but returns None when the `strategy_list` read FAILED (transport error) —
+    so a money path can tell 'no strategies' (→ []) from 'couldn't read the list' (→ None) and REFUSE
+    rather than fund a second wallet next to an unread live one. Mirrors `list_runtimes_or_none`."""
+    args = {"status": statuses} if statuses else {}
+    try:
+        res = mcp.mcp_call("strategy_list", timeout=timeout, **args)
+    except Exception:  # noqa: BLE001 — the WHOLE point: surface the failure instead of swallowing to []
+        return None
+    return find_list(res, "strategies")
+
+
+def _match_strategy(s, skill_name, strategy_id, wallet):
+    if strategy_id is not None and strategy_id_of(s) != strategy_id:
+        return False
+    if skill_name is not None and strategy_skill(s) != skill_name:
+        return False
+    if wallet is not None and str(strategy_wallet(s) or "").lower() != str(wallet).lower():
+        return False
+    return True
+
+
 def strategies_for(mcp, skill_name=None, strategy_id=None, wallet=None, timeout=15, statuses=None):
     """Return strategies matching any provided filter (skill_name / strategyId / wallet). Pass `statuses`
     to filter server-side (faster; e.g. close only needs live ones). Leave None when you must also see
-    CLOSED/FAILED (e.g. create's reconcile checks a recorded id's terminal state)."""
-    out = []
-    for s in list_strategies(mcp, timeout, statuses=statuses):
-        if strategy_id is not None and strategy_id_of(s) != strategy_id:
-            continue
-        if skill_name is not None and strategy_skill(s) != skill_name:
-            continue
-        if wallet is not None and str(strategy_wallet(s) or "").lower() != str(wallet).lower():
-            continue
-        out.append(s)
-    return out
+    CLOSED/FAILED (e.g. create's reconcile checks a recorded id's terminal state). Fail-OPEN ([] on read
+    error) — fine for reads that only ADD work; use `strategies_for_or_none` on a money path."""
+    return [s for s in list_strategies(mcp, timeout, statuses=statuses)
+            if _match_strategy(s, skill_name, strategy_id, wallet)]
+
+
+def strategies_for_or_none(mcp, skill_name=None, strategy_id=None, wallet=None, timeout=15, statuses=None):
+    """Fail-CLOSED `strategies_for`: returns None when the `strategy_list` read failed, so a money path
+    can refuse rather than mistake 'unreadable' for 'none' (the double-fund / un-consented-flatten trap)."""
+    rows = list_strategies_or_none(mcp, timeout, statuses=statuses)
+    if rows is None:
+        return None
+    return [s for s in rows if _match_strategy(s, skill_name, strategy_id, wallet)]

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -1111,8 +1111,9 @@ def cmd_upgrade(pkg, a, log):
                                   "note": (f"Closing `{inst.runtime_name}` (flatten positions + return funds; "
                                            f"async). Re-run `{rerun}` to redeploy once it's closed.")})
 
-        # arm_kind == "none" (verified absent) — genuinely not deployed, or a runtime-less trap `create`
-        # itself clears → straight to redeploy.
+        # Nothing live to close, reached two ways: arm_kind == "none" (verified absent — genuinely not
+        # deployed), OR a wallet resolved but its strategy is already closed so `open_mine` is empty (a
+        # runtime-less trap `create`'s own live-guard then backstops). Either way → straight to redeploy.
         up["phase"] = "redeploy"; st["_upgrade"] = up
         save_state(pkg, st)
 
@@ -1142,6 +1143,20 @@ def cmd_upgrade(pkg, a, log):
 
 
 # ---------- cli ----------
+
+def _exit_code(status):
+    """Process exit code for a command result. **0** = done / informational; **2** = refused or failed
+    (action required — `failed`/`underfunded`/`not-live`/`needs-consent`/`blocked`); **3** = RESUMABLE,
+    re-run (in-flight). `closing`/`closed` exit 3 — NOT 0 — so a `$?`/`&&` caller can't misread upgrade's
+    most dangerous in-flight state (`closed`: the old arm is gone, funds are back in main, and NOTHING is
+    deployed yet) as "done" and stop, stranding the user's capital. These two statuses are emitted only by
+    `upgrade`; the standalone deploy steps keep their existing exit-0 done-for-this-step semantics."""
+    if status in ("failed", "underfunded", "not-live", "needs-consent", "blocked"):
+        return 2
+    if status in ("closing", "closed"):
+        return 3
+    return 0
+
 
 def main(argv):
     ap = argparse.ArgumentParser(description="Deploy a strategy package in resumable steps.")
@@ -1237,10 +1252,7 @@ def main(argv):
     else:  # status
         out = report(pkg, load_state(pkg), "status", as_json=a.json)
 
-    # `needs-consent` (blocked on operator confirming the flatten) and `blocked` (unreadable/ambiguous
-    # backend — refused rather than fund blind) exit non-zero: not complete, action required.
-    # `closing`/`closed`/`creating`/`wallets-ready` are in-progress (re-run) and exit 0.
-    sys.exit(2 if out.get("status") in ("failed", "underfunded", "not-live", "needs-consent", "blocked") else 0)
+    sys.exit(_exit_code(out.get("status")))
 
 
 if __name__ == "__main__":

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -351,6 +351,22 @@ def strategy_min(pkg):
     return strategy_min_budget(manifest, runtimes)
 
 
+def _scope_pkg(pkg, instance_name):
+    """Narrow a multi-instance package to ONE instance for a single-arm op (redeploy/upgrade one sleeve,
+    leaving siblings running). Mutates pkg.instances in place — each command runs in a fresh process — so
+    every per-instance loop, plus the create live-guard, acts on this arm only; the siblings' deploy-state
+    entries are left untouched. Raises on an unknown instance name."""
+    names = [i.name for i in pkg.instances]
+    if instance_name not in names:
+        raise SystemExit(f"error: no instance {instance_name!r} in {pkg.id} (have: {', '.join(names)})")
+    kept = [i for i in pkg.instances if i.name == instance_name]
+    # Fund THIS arm with the full --budget: its fractional share of the whole package is irrelevant when
+    # it's the only arm being (re)deployed, and keeping it would scale the budget down (a 0.10-share sleeve
+    # funded at 10% of what the user asked). Treat the scoped arm as the whole.
+    kept[0].funding_share = 1.0
+    pkg.instances = kept
+
+
 def cmd_create(pkg, a, log):
     st = load_state(pkg)
     st["budget"] = a.budget
@@ -429,6 +445,14 @@ def cmd_create(pkg, a, log):
     #     creates a fresh wallet. strategy_close is async, so hand off and re-run `create` once it's closed.
     runtimes = _cli.list_runtimes()
     existing_open = [s for s in _cli.strategies_for(mcp, skill_name=pkg.id) if _cli.strategy_open(s)]
+    if getattr(a, "instance", None):
+        # single-arm: the live-guard + close-existing must consider ONLY this arm's strategy (the one on
+        # this arm's runtime wallet), never its siblings — else a one-arm redeploy refuses/closes a healthy
+        # sibling. Once this arm is closed, its runtime is gone → no match → create proceeds on a fresh wallet.
+        _arm_rt = _cli.find_runtime(f"{pkg.id}-{a.instance}")
+        _arm_wallet = _cli.runtime_wallet(_arm_rt) if _arm_rt else None
+        existing_open = [s for s in existing_open
+                         if _arm_wallet and _cli.wallet_match(_cli.strategy_wallet(s), _arm_wallet)]
 
     def _has_running_runtime(s):
         rt = _cli.find_runtime_by_wallet(_cli.strategy_wallet(s))
@@ -891,6 +915,105 @@ def cmd_verify(pkg, a, log):
         time.sleep(POLL_EVERY)
 
 
+# ---------- upgrade: apply an edited package to a LIVE strategy (close → redeploy fresh) ----------
+
+def cmd_upgrade(pkg, a, log):
+    """Resumable single-arm UPGRADE — apply an edited scan.py / scoring.py / runtime.yaml to a LIVE
+    strategy by closing it and redeploying on a FRESH wallet, one step per call (the way `create` resumes).
+    The supported way to re-score / re-scan / re-tune a deployed strategy until in-place scanner reload
+    lands, at which point the close/redeploy guts swap for it. Two invariants:
+      • routes through the tested `close → create → runtime → verify` path, so the runtime yaml is rendered
+        INSIDE the instance dir (`./scanners` resolves) on a FRESH wallet — never a hand-rendered root yaml
+        or a raw `strategy_create_custom_strategy` (the naked-wallet / "NO ENTRY SCANNERS" traps);
+      • consent-gated — closing a live arm market-exits its positions, so it refuses without `--yes`.
+    Per arm (`--instance <arm>`), siblings untouched. State: the deploy-state `_upgrade` block, phase
+    `closing` (async flatten in flight) → `redeploy`."""
+    # `upgrade` acts on ONE arm. main() already narrowed pkg to a single arm when --instance was given;
+    # a still-multi-instance pkg here means the caller didn't name which sleeve to upgrade.
+    if len(pkg.instances) != 1:
+        names = ", ".join(i.name for i in pkg.instances if i.name)
+        raise SystemExit(
+            f"error: `upgrade` acts on ONE arm at a time — pass --instance <arm> (have: {names}). "
+            f"Each arm is closed and redeployed on its own fresh wallet; siblings keep running.")
+    if a.budget is None and not a.dry_run:
+        raise SystemExit("error: --budget <usd> is required for `upgrade` — it funds the FRESH wallet the "
+                         "arm is redeployed onto (the old wallet is retired on close).")
+    inst = pkg.instances[0]
+    mcp = MCPClient()
+    st = load_state(pkg)
+    up = st.get("_upgrade") or {}
+    rerun = (f"python3 {Path(__file__).name} upgrade {pkg.id} --instance {inst.name}"
+             + (f" --budget {budget_arg(a.budget)}" if a.budget is not None else ""))
+
+    # ---------- PHASE A: close the currently-live arm (once), consent-gated ----------
+    # Skipped on --dry-run: the preview must be side-effect + network free, so it routes straight to the
+    # create dry-run without probing the backend for a live arm.
+    if not a.dry_run and up.get("phase") != "redeploy":
+        arm_rt = _cli.find_runtime(inst.runtime_name)
+        arm_wallet = _cli.runtime_wallet(arm_rt) if arm_rt else None
+        open_mine = ([s for s in _cli.strategies_for(mcp, skill_name=pkg.id)
+                      if _cli.strategy_open(s)
+                      and _cli.wallet_match(_cli.strategy_wallet(s), arm_wallet)]
+                     if arm_wallet else [])
+
+        if up.get("phase") == "closing":
+            # a close was triggered on a prior call — strategy_close is async, so wait for the flatten
+            # to finish (the arm's open strategy disappears) before minting the fresh wallet.
+            if open_mine:
+                out = {"strategy": pkg.id, "instance": inst.name, "status": "closing",
+                       "note": f"old {inst.runtime_name} still flattening — re-run `{rerun}` to continue."}
+                log("  " + out["note"]); return out
+            up["phase"] = "redeploy"; st["_upgrade"] = up; save_state(pkg, st)
+            out = {"strategy": pkg.id, "instance": inst.name, "status": "closed",
+                   "note": f"old arm closed, funds returning to main. Re-run `{rerun}` to redeploy on a "
+                           f"FRESH wallet. (If create reports `underfunded`, the funds are still returning "
+                           f"— wait a moment and re-run.)"}
+            log("  " + out["note"]); return out
+
+        if open_mine:
+            # START: the arm is LIVE. Closing it MARKET-EXITS its positions — never do that silently.
+            if not a.yes:
+                out = {"strategy": pkg.id, "instance": inst.name, "status": "needs-consent",
+                       "wallet": arm_wallet,
+                       "note": (f"UPGRADE will CLOSE the live `{inst.runtime_name}` on wallet {arm_wallet}: "
+                                f"it market-exits any open position (often NONE if the strategy isn't "
+                                f"entering — that's the usual re-tune case), returns funds to your main "
+                                f"wallet, and redeploys the edited arm on a FRESH wallet. The old wallet is "
+                                f"retired, and a custom ratchet/stop ladder on the old positions does NOT "
+                                f"carry over — re-apply it after if wanted. Confirm with the user, then "
+                                f"re-run with --yes:\n      {rerun} --yes")}
+                log("\n  " + out["note"]); return out
+            # consent given → close THIS arm via the tested close primitive (same in-process call
+            # cmd_create uses for the runtime-less trap), then hand off to redeploy on a fresh wallet.
+            import close as _close  # noqa: E402 — sibling module, lazy import
+            runtimes = _cli.list_runtimes()
+            for s in open_mine:
+                _close.close_one(pkg.id, s, runtimes, False, log)
+            st["instances"][inst.name] = {"status": "pending"}  # forget the old id → create makes a FRESH wallet
+            st["_upgrade"] = {"phase": "closing"}
+            save_state(pkg, st)
+            out = {"strategy": pkg.id, "instance": inst.name, "status": "closing",
+                   "note": (f"Closing `{inst.runtime_name}` (flatten positions + return funds; async). "
+                            f"Re-run `{rerun}` to redeploy once it's closed.")}
+            log("\n  " + out["note"]); return out
+
+        # nothing live to close (arm not deployed, or a runtime-less trap that `create` itself clears) →
+        # straight to redeploy.
+        up["phase"] = "redeploy"; st["_upgrade"] = up
+        save_state(pkg, st)
+
+    # ---------- PHASE B: redeploy the arm on a fresh wallet — one resumable step per call ----------
+    s = inst_state(st, inst.name)
+    status = s.get("status")
+    if a.dry_run or not s.get("strategyId") or status in (None, "pending", "creating"):
+        return cmd_create(pkg, a, log)
+    if status == "active":
+        return cmd_runtime(pkg, a, log)
+    # registered → a fast single check (max_wait=0); verify deletes state on `live`, clearing _upgrade too.
+    av = argparse.Namespace(**{**vars(a), "max_wait": 0})
+    return cmd_verify(pkg, av, log)
+
+
 # ---------- cli ----------
 
 def main(argv):
@@ -902,22 +1025,41 @@ def main(argv):
         p.add_argument("--ref", default=None, help="Branch/ref to fetch the package from if not on disk.")
         p.add_argument("--json", action="store_true")
 
+    # --instance scopes create/runtime/verify to ONE arm of a multi-instance package (single-arm
+    # redeploy / upgrade), leaving its siblings running. Same mapping as close.py --instance.
+    def _inst(p):
+        p.add_argument("--instance", default=None,
+                       help="Scope to ONE instance of a multi-arm package (siblings untouched).")
+
     pc = sub.add_parser("create", help="Step 1: create + fund the strategy wallet(s) (resumable).")
-    common(pc)
+    common(pc); _inst(pc)
     pc.add_argument("--budget", type=float, default=None, help="Total USDC split across wallets by funding_share.")
     pc.add_argument("--max-wait", type=int, default=DEFAULT_MAX_WAIT, help="Poll budget for this call (s).")
     pc.add_argument("--dry-run", action="store_true")
 
     pr = sub.add_parser("runtime", help="Step 2: render + create the runtime(s) on the ready wallet(s).")
-    common(pr)
+    common(pr); _inst(pr)
     pr.add_argument("--decision-model", default=None, help="Bare model name (only for a decision_mode: llm action).")
     pr.add_argument("--dry-run", action="store_true")
 
     pv = sub.add_parser("verify", help="Step 3: confirm each scanner is ticking (fast single check; re-run as needed).")
-    common(pv)
+    common(pv); _inst(pv)
     pv.add_argument("--max-wait", type=int, default=0,
                     help="Default 0 = one fast check (first tick is gated by interval_seconds; re-run later). "
                          ">0 keeps polling up to S seconds (useful for fast instances).")
+
+    pu = sub.add_parser("upgrade",
+                        help="Apply an edited scan.py/scoring.py/runtime.yaml to a LIVE strategy: close the "
+                             "arm + redeploy on a FRESH wallet (resumable; consent-gated). Per arm.")
+    common(pu); _inst(pu)
+    pu.add_argument("--budget", type=float, default=None,
+                    help="USDC to fund the fresh wallet the arm is redeployed onto (required).")
+    pu.add_argument("--yes", action="store_true",
+                    help="Consent to FLATTEN: closing the live arm market-exits its open positions. Required "
+                         "to proceed while the arm holds a book.")
+    pu.add_argument("--decision-model", default=None, help="Bare model name (only for a decision_mode: llm action).")
+    pu.add_argument("--max-wait", type=int, default=DEFAULT_MAX_WAIT, help="Poll budget for the create step (s).")
+    pu.add_argument("--dry-run", action="store_true", help="Show the plan (routes to the create dry-run) with no side effects.")
 
     ps = sub.add_parser("status", help="Show the deploy state.")
     common(ps)
@@ -931,9 +1073,16 @@ def main(argv):
 
     pkg = ensure_pkg(a.package, a.ref, log)
 
-    # `validate` is the standalone, side-effect-free preflight; `create` runs the SAME full check
-    # before funding any wallet; runtime/verify/status keep the structural gate.
-    gate = full_validate(pkg) if a.cmd in ("validate", "create") else _pkg.validate(pkg)
+    # single-arm scoping — narrow a multi-instance package to ONE arm so create/runtime/verify (and the
+    # create live-guard) act on it alone, leaving siblings running. Applied BEFORE validate so we gate
+    # only the arm being touched.
+    if getattr(a, "instance", None):
+        _scope_pkg(pkg, a.instance)
+
+    # `validate` is the standalone, side-effect-free preflight; `create` AND `upgrade` run the SAME full
+    # check before touching any wallet — this is what catches a bad `./scanners` path (the wrong-directory
+    # trap) BEFORE an upgrade closes a live book; runtime/verify/status keep the structural gate.
+    gate = full_validate(pkg) if a.cmd in ("validate", "create", "upgrade") else _pkg.validate(pkg)
     if a.cmd == "validate":
         if a.json:
             print(json.dumps({"status": "valid" if not gate else "invalid", "id": pkg.id, "errors": gate}))
@@ -956,10 +1105,14 @@ def main(argv):
         out = cmd_runtime(pkg, a, log)
     elif a.cmd == "verify":
         out = cmd_verify(pkg, a, log)
+    elif a.cmd == "upgrade":
+        out = cmd_upgrade(pkg, a, log)
     else:  # status
         out = report(pkg, load_state(pkg), "status", as_json=a.json)
 
-    sys.exit(2 if out.get("status") in ("failed", "underfunded", "not-live") else 0)
+    # `needs-consent` exits non-zero: the upgrade is BLOCKED on the operator confirming the flatten, not
+    # complete. `closing`/`closed`/`creating`/`wallets-ready` are in-progress (re-run) and exit 0.
+    sys.exit(2 if out.get("status") in ("failed", "underfunded", "not-live", "needs-consent") else 0)
 
 
 if __name__ == "__main__":

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -334,7 +334,10 @@ def _wallet_name(pkg, inst):
     """The strategyName `create` assigns this instance's wallet: `<id>-<instance>` for a multi-instance
     package, else the bare `<id>` — sanitized. Recovery re-derives the SAME name to match a wallet back
     to its instance, so a lost-state redeploy binds to the right wallet instead of guessing."""
-    multi = len(pkg.instances) > 1
+    # Arity from the ORIGINAL package, not the possibly-scoped `pkg.instances` — `_scope_pkg` narrows that
+    # list to 1 for a single-arm op, and a multi-arm arm must still be named `<id>-<arm>`, not the bare
+    # `<id>`. The getattr default leaves every unscoped caller (create, _recover_wallet) on today's path.
+    multi = getattr(pkg, "full_instance_count", len(pkg.instances)) > 1
     raw = f"{pkg.id}-{inst.name}" if (multi and inst.name) else str(pkg.id)
     return _sanitize_strategy_name(raw, pkg.id)
 
@@ -364,7 +367,31 @@ def _scope_pkg(pkg, instance_name):
     # it's the only arm being (re)deployed, and keeping it would scale the budget down (a 0.10-share sleeve
     # funded at 10% of what the user asked). Treat the scoped arm as the whole.
     kept[0].funding_share = 1.0
+    # Preserve the TRUE arity before narrowing — `_wallet_name` derives `<id>-<arm>` vs bare `<id>` from
+    # it, and reading the post-narrow `len(pkg.instances)` (== 1) would collapse a multi-arm arm's wallet
+    # name to the bare `<id>`, breaking every by-name lookup (upgrade's fallback, scoped create's naming).
+    pkg.full_instance_count = len(names)
     pkg.instances = kept
+
+
+def _arm_wallet(pkg, inst, mcp):
+    """This arm's wallet address, or None. Prefers its live runtime; if the runtime is GONE (crashed, or
+    the funded-but-never-registered trap) the strategy can still be OPEN, so fall back to the unique ACTIVE
+    strategy carrying the name `create` gave this arm (`_wallet_name`) — the same key `_recover_wallet`
+    matches on, held fixed by the backend while the strategy is active. NEVER guesses: anything but a
+    unique name match stays None, so a sibling's wallet can't bind. Without the fallback a runtime-less-
+    but-open arm reads as 'not deployed', and a single-arm op would fund a fresh wallet NEXT TO the
+    orphaned open one (double funding, un-consented flatten). Shared by cmd_create's live-guard and
+    cmd_upgrade's PHASE A so the two resolve the arm identically and can't drift."""
+    rt = _cli.find_runtime(inst.runtime_name)
+    wallet = _cli.runtime_wallet(rt) if rt else None
+    if wallet:
+        return wallet
+    want = _wallet_name(pkg, inst)
+    cands = [s for s in _cli.strategies_for(mcp, skill_name=pkg.id, statuses=["ACTIVE"])
+             if _cli.strategy_name(s) == want]
+    addrs = {str(_cli.strategy_wallet(s)).lower() for s in cands if _cli.strategy_wallet(s)}
+    return _cli.strategy_wallet(cands[0]) if len(addrs) == 1 else None
 
 
 def cmd_create(pkg, a, log):
@@ -446,13 +473,12 @@ def cmd_create(pkg, a, log):
     runtimes = _cli.list_runtimes()
     existing_open = [s for s in _cli.strategies_for(mcp, skill_name=pkg.id) if _cli.strategy_open(s)]
     if getattr(a, "instance", None):
-        # single-arm: the live-guard + close-existing must consider ONLY this arm's strategy (the one on
-        # this arm's runtime wallet), never its siblings — else a one-arm redeploy refuses/closes a healthy
-        # sibling. Once this arm is closed, its runtime is gone → no match → create proceeds on a fresh wallet.
-        _arm_rt = _cli.find_runtime(f"{pkg.id}-{a.instance}")
-        _arm_wallet = _cli.runtime_wallet(_arm_rt) if _arm_rt else None
-        existing_open = [s for s in existing_open
-                         if _arm_wallet and _cli.wallet_match(_cli.strategy_wallet(s), _arm_wallet)]
+        # single-arm: the live-guard + close-existing must consider ONLY this arm's strategy, never its
+        # siblings — else a one-arm redeploy refuses/closes a healthy sibling. `_arm_wallet` also resolves
+        # a runtime-LESS open arm by name, so the funded-but-stuck trap is closed here too rather than
+        # double-funded; a genuinely absent arm resolves to None → no match → fresh wallet.
+        w = _arm_wallet(pkg, pkg.instances[0], mcp)
+        existing_open = [s for s in existing_open if _cli.wallet_match(_cli.strategy_wallet(s), w)]
 
     def _has_running_runtime(s):
         rt = _cli.find_runtime_by_wallet(_cli.strategy_wallet(s))
@@ -460,10 +486,14 @@ def cmd_create(pkg, a, log):
 
     live = [s for s in existing_open if _has_running_runtime(s)]
     if live:
+        _inst_flag = f" --instance {a.instance}" if getattr(a, "instance", None) else ""
         raise SystemExit(
             f"error: {pkg.id} is already deployed AND running ({len(live)} live wallet(s)) — `create` will not "
-            f"silently close a live strategy. To redeploy on a fresh wallet, close it first:\n"
-            f"  python3 {Path(__file__).with_name('close.py')} {pkg.id}\n"
+            f"silently close a live strategy.\n"
+            f"To APPLY AN EDIT to it (re-score / re-scan / re-tune), use `upgrade` — it closes and redeploys "
+            f"on a fresh wallet, consent-gated:\n"
+            f"  python3 {Path(__file__).name} upgrade {pkg.id}{_inst_flag} --budget <usd>\n"
+            f"To tear it down instead:  python3 {Path(__file__).with_name('close.py')} {pkg.id}\n"
             f"Or just re-check it:  python3 {Path(__file__).name} verify {pkg.id}")
 
     if existing_open:  # open but NOT running → the runtime-less trap: close (recover funds) → fresh wallet
@@ -917,6 +947,17 @@ def cmd_verify(pkg, a, log):
 
 # ---------- upgrade: apply an edited package to a LIVE strategy (close → redeploy fresh) ----------
 
+def _emit(a, log, out):
+    """Emit an upgrade PHASE-A verdict. These are hand-built dicts, not `report()` rows, so they need the
+    same --json handling report() gives: under --json `log` is a no-op, so without this the consent text —
+    the one thing an agent must relay to the user before a flatten — would reach an empty stdout."""
+    if a.json:
+        print(json.dumps(out, indent=2))
+    else:
+        log("\n  " + out["note"])
+    return out
+
+
 def cmd_upgrade(pkg, a, log):
     """Resumable single-arm UPGRADE — apply an edited scan.py / scoring.py / runtime.yaml to a LIVE
     strategy by closing it and redeploying on a FRESH wallet, one step per call (the way `create` resumes).
@@ -949,21 +990,11 @@ def cmd_upgrade(pkg, a, log):
     # Skipped on --dry-run: the preview must be side-effect + network free, so it routes straight to the
     # create dry-run without probing the backend for a live arm.
     if not a.dry_run and up.get("phase") != "redeploy":
-        # Resolve the arm's wallet. Prefer its live runtime; but if the runtime is GONE (crashed, or the
-        # funded-but-never-registered trap) the strategy can still be OPEN — so fall back to the arm's
-        # stable strategyName (== `_wallet_name(<id>-<instance>)`) among ACTIVE strategies. The backend
-        # keeps that name fixed while the strategy is active (confirmed), so this reliably re-finds the
-        # wallet — the same key `_recover_wallet` uses for lost-state recovery. Without the fallback a
-        # runtime-less-but-open arm looks "not deployed", so upgrade would skip consent + old-wallet
-        # cleanup and DOUBLE-FUND a fresh wallet next to the orphaned open one.
-        arm_rt = _cli.find_runtime(inst.runtime_name)
-        arm_wallet = _cli.runtime_wallet(arm_rt) if arm_rt else None
-        if not arm_wallet:
-            want = _wallet_name(pkg, inst)
-            cands = [s for s in _cli.strategies_for(mcp, skill_name=pkg.id, statuses=["ACTIVE"])
-                     if _cli.strategy_name(s) == want]
-            addrs = {str(_cli.strategy_wallet(s)).lower() for s in cands if _cli.strategy_wallet(s)}
-            arm_wallet = _cli.strategy_wallet(cands[0]) if len(addrs) == 1 else None  # unique match only
+        # Resolve the arm's wallet via the shared resolver — its live runtime, or (runtime gone) the
+        # unique ACTIVE strategy carrying the arm's name. Without the fallback a runtime-less-but-open arm
+        # reads as "not deployed", so upgrade would skip consent + old-wallet cleanup and DOUBLE-FUND a
+        # fresh wallet next to the orphaned open one. Same resolver cmd_create's live-guard uses.
+        arm_wallet = _arm_wallet(pkg, inst, mcp)
         open_mine = ([s for s in _cli.strategies_for(mcp, skill_name=pkg.id)
                       if _cli.strategy_open(s)
                       and _cli.wallet_match(_cli.strategy_wallet(s), arm_wallet)]
@@ -973,42 +1004,47 @@ def cmd_upgrade(pkg, a, log):
             # a close was triggered on a prior call — strategy_close is async, so wait for the flatten
             # to finish (the arm's open strategy disappears) before minting the fresh wallet.
             if open_mine:
-                out = {"strategy": pkg.id, "instance": inst.name, "status": "closing",
-                       "note": f"old {inst.runtime_name} still flattening — re-run `{rerun}` to continue."}
-                log("  " + out["note"]); return out
+                return _emit(a, log, {"strategy": pkg.id, "instance": inst.name, "status": "closing",
+                                      "note": f"old {inst.runtime_name} still flattening — re-run `{rerun}` to continue."})
             up["phase"] = "redeploy"; st["_upgrade"] = up; save_state(pkg, st)
-            out = {"strategy": pkg.id, "instance": inst.name, "status": "closed",
-                   "note": f"old arm closed, funds returning to main. Re-run `{rerun}` to redeploy on a "
-                           f"FRESH wallet. (If create reports `underfunded`, the funds are still returning "
-                           f"— wait a moment and re-run.)"}
-            log("  " + out["note"]); return out
+            return _emit(a, log, {"strategy": pkg.id, "instance": inst.name, "status": "closed",
+                                  "note": f"old arm closed, funds returning to main. Re-run `{rerun}` to redeploy on "
+                                          f"a FRESH wallet. (If create reports `underfunded`, the funds are still "
+                                          f"returning — wait a moment and re-run.)"})
 
         if open_mine:
             # START: the arm is LIVE. Closing it MARKET-EXITS its positions — never do that silently.
             if not a.yes:
-                out = {"strategy": pkg.id, "instance": inst.name, "status": "needs-consent",
-                       "wallet": arm_wallet,
-                       "note": (f"UPGRADE will CLOSE the live `{inst.runtime_name}` on wallet {arm_wallet}: "
-                                f"it market-exits any open position (often NONE if the strategy isn't "
-                                f"entering — that's the usual re-tune case), returns funds to your main "
-                                f"wallet, and redeploys the edited arm on a FRESH wallet. The old wallet is "
-                                f"retired, and a custom ratchet/stop ladder on the old positions does NOT "
-                                f"carry over — re-apply it after if wanted. Confirm with the user, then "
-                                f"re-run with --yes:\n      {rerun} --yes")}
-                log("\n  " + out["note"]); return out
-            # consent given → close THIS arm via the tested close primitive (same in-process call
-            # cmd_create uses for the runtime-less trap), then hand off to redeploy on a fresh wallet.
+                return _emit(a, log, {
+                    "strategy": pkg.id, "instance": inst.name, "status": "needs-consent", "wallet": arm_wallet,
+                    "note": (f"UPGRADE will CLOSE the live `{inst.runtime_name}` on wallet {arm_wallet}: it "
+                             f"market-exits any open position (often NONE if the strategy isn't entering — that's "
+                             f"the usual re-tune case), returns funds to your main wallet, and redeploys the edited "
+                             f"arm on a FRESH wallet. The old wallet is retired, and a custom ratchet/stop ladder on "
+                             f"the old positions does NOT carry over — re-apply it after if wanted. Confirm with the "
+                             f"user, then re-run with --yes:\n      {rerun} --yes")})
+            # consent given → close THIS arm via the tested close primitive (same in-process call cmd_create
+            # uses for the runtime-less trap), then hand off to redeploy on a fresh wallet.
             import close as _close  # noqa: E402 — sibling module, lazy import
             runtimes = _cli.list_runtimes()
-            for s in open_mine:
-                _close.close_one(pkg.id, s, runtimes, False, log)
+            recs = [_close.close_one(pkg.id, s, runtimes, False, log) for s in open_mine]
+            bad = [r for r in recs if r.get("status") == "failed"]
+            if bad:
+                # A failed close (runtime still listed after two delete attempts → it may re-enter
+                # positions) must SURFACE, not be swallowed. State stays put, so the next run re-enters this
+                # branch and re-attempts; advancing to `closing` would poll a strategy nothing is closing,
+                # forever, with the real error never shown.
+                return _emit(a, log, {
+                    "strategy": pkg.id, "instance": inst.name, "status": "failed",
+                    "note": "close FAILED, nothing redeployed: "
+                            + "; ".join(str(r.get("error") or "?") for r in bad)
+                            + f"\n      Resolve it, then re-run `{rerun} --yes`."})
             st["instances"][inst.name] = {"status": "pending"}  # forget the old id → create makes a FRESH wallet
             st["_upgrade"] = {"phase": "closing"}
             save_state(pkg, st)
-            out = {"strategy": pkg.id, "instance": inst.name, "status": "closing",
-                   "note": (f"Closing `{inst.runtime_name}` (flatten positions + return funds; async). "
-                            f"Re-run `{rerun}` to redeploy once it's closed.")}
-            log("\n  " + out["note"]); return out
+            return _emit(a, log, {"strategy": pkg.id, "instance": inst.name, "status": "closing",
+                                  "note": (f"Closing `{inst.runtime_name}` (flatten positions + return funds; "
+                                           f"async). Re-run `{rerun}` to redeploy once it's closed.")})
 
         # nothing live to close (arm not deployed, or a runtime-less trap that `create` itself clears) →
         # straight to redeploy.

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -130,10 +130,32 @@ def delete_state(pkg):
     """Remove the ephemeral deploy state — called once a deploy is fully live, or on close. Also sweeps
     any rendered `<inst>.deploy.runtime.yaml` build artifacts: they carry a baked-in wallet, and a stale
     one left on disk is exactly what a lost-state manual redeploy wrongly picks up (the reuse trap)."""
-    _safe_unlink(_state_path(pkg))
-    for inst in pkg.instances:
+    for inst in pkg.instances:  # sweep the rendered build artifacts for THESE instances either way
         if inst.runtime_path:
             _safe_unlink(inst.runtime_path.with_name(f"{inst.name}.deploy.runtime.yaml"))
+    # A SCOPED op (`--instance`, so pkg was narrowed below its true arity) must NOT unlink the whole file —
+    # that discards the SIBLINGS' entries (a mid-deploy sibling's strategyId/wallet included), contradicting
+    # `_scope_pkg`'s "siblings untouched". Drop only this arm's entry (+ the per-arm `_upgrade` marker);
+    # remove the file only when nothing remains. A full deploy (unscoped) clears the whole file as before.
+    scoped = getattr(pkg, "full_instance_count", len(pkg.instances)) > len(pkg.instances)
+    p = _state_path(pkg)
+    if not scoped:
+        _safe_unlink(p)
+        return
+    if not p.is_file():
+        return
+    try:
+        st = json.loads(p.read_text())
+    except (json.JSONDecodeError, OSError):
+        _safe_unlink(p)
+        return
+    for inst in pkg.instances:
+        st.get("instances", {}).pop(inst.name, None)
+    st.pop("_upgrade", None)
+    if st.get("instances"):
+        p.write_text(json.dumps(st, indent=2) + "\n")
+    else:
+        _safe_unlink(p)
 
 
 def inst_state(st, name):
@@ -374,24 +396,35 @@ def _scope_pkg(pkg, instance_name):
     pkg.instances = kept
 
 
+def _scope_flag(a):
+    """` --instance <arm>` when the current op is scoped, else "". Threaded into every resume hint so an
+    agent following one mid-single-arm-op re-runs SCOPED — an unscoped `create` on a multi-arm package
+    refuses on live siblings and can close a runtime-less sibling WITHOUT consent."""
+    return f" --instance {a.instance}" if getattr(a, "instance", None) else ""
+
+
 def _arm_wallet(pkg, inst, mcp):
-    """This arm's wallet address, or None. Prefers its live runtime; if the runtime is GONE (crashed, or
-    the funded-but-never-registered trap) the strategy can still be OPEN, so fall back to the unique ACTIVE
-    strategy carrying the name `create` gave this arm (`_wallet_name`) — the same key `_recover_wallet`
-    matches on, held fixed by the backend while the strategy is active. NEVER guesses: anything but a
-    unique name match stays None, so a sibling's wallet can't bind. Without the fallback a runtime-less-
-    but-open arm reads as 'not deployed', and a single-arm op would fund a fresh wallet NEXT TO the
-    orphaned open one (double funding, un-consented flatten). Shared by cmd_create's live-guard and
-    cmd_upgrade's PHASE A so the two resolve the arm identically and can't drift."""
+    """This arm's ``(wallet, kind)``. ``kind`` is None on a clean resolve; otherwise a REFUSAL kind the
+    caller must NOT treat as "safe to fund fresh":
+      None         — resolved: ``wallet`` is the arm's address (its live runtime, or the unique ACTIVE
+                     strategy carrying the name ``create`` gave it).
+      "none"       — verified ABSENT: the read succeeded and no ACTIVE <id> wallet matches → fund fresh is safe.
+      "unreadable" — the ``strategy_list`` read FAILED → we don't know; refuse (a money path can't fund blind).
+      "unnamed"/"ambiguous" — a wallet exists but no UNIQUE name match (a name-rejection fallback, or a prior
+                     double-fund left two) → one may be a funded LIVE arm; refuse, never fund next to it.
+    Prefers the live runtime; falls back to the arm's stable strategyName via ``_recover_wallet`` (shared
+    tri-state, so this and ``create``'s guard resolve identically and can't drift). The fail-CLOSED read +
+    tri-state is what stops an unreadable/ambiguous backend from disarming BOTH the consent gate and the
+    double-fund guard at once."""
     rt = _cli.find_runtime(inst.runtime_name)
     wallet = _cli.runtime_wallet(rt) if rt else None
     if wallet:
-        return wallet
-    want = _wallet_name(pkg, inst)
-    cands = [s for s in _cli.strategies_for(mcp, skill_name=pkg.id, statuses=["ACTIVE"])
-             if _cli.strategy_name(s) == want]
-    addrs = {str(_cli.strategy_wallet(s)).lower() for s in cands if _cli.strategy_wallet(s)}
-    return _cli.strategy_wallet(cands[0]) if len(addrs) == 1 else None
+        return wallet, None
+    active = _cli.strategies_for_or_none(mcp, skill_name=pkg.id, statuses=["ACTIVE"])
+    if active is None:
+        return None, "unreadable"
+    w, kind, _why = _recover_wallet(pkg, inst, active)
+    return w, kind
 
 
 def cmd_create(pkg, a, log):
@@ -473,12 +506,21 @@ def cmd_create(pkg, a, log):
     runtimes = _cli.list_runtimes()
     existing_open = [s for s in _cli.strategies_for(mcp, skill_name=pkg.id) if _cli.strategy_open(s)]
     if getattr(a, "instance", None):
-        # single-arm: the live-guard + close-existing must consider ONLY this arm's strategy, never its
-        # siblings — else a one-arm redeploy refuses/closes a healthy sibling. `_arm_wallet` also resolves
-        # a runtime-LESS open arm by name, so the funded-but-stuck trap is closed here too rather than
-        # double-funded; a genuinely absent arm resolves to None → no match → fresh wallet.
-        w = _arm_wallet(pkg, pkg.instances[0], mcp)
-        existing_open = [s for s in existing_open if _cli.wallet_match(_cli.strategy_wallet(s), w)]
+        # single-arm: consider ONLY this arm's strategy, never siblings — and do it fail-CLOSED. An
+        # unreadable strategy_list must REFUSE, not disarm the live-guard + close-existing by reading []
+        # (the double-fund trap). `_arm_wallet`'s tri-state resolves a runtime-less open arm by name too;
+        # a verified-absent arm returns ("none") → no match → fresh wallet.
+        _rows = _cli.strategies_for_or_none(mcp, skill_name=pkg.id)
+        if _rows is None:
+            raise SystemExit(f"error: couldn't read strategy_list for {pkg.id} — refusing to fund a fresh "
+                             f"{a.instance} wallet blind. Re-run once the backend is readable.")
+        existing_open = [s for s in _rows if _cli.strategy_open(s)]
+        w, wkind = _arm_wallet(pkg, pkg.instances[0], mcp)
+        if wkind in ("unreadable", "unnamed", "ambiguous"):
+            raise SystemExit(f"[E_STATE_AMBIGUOUS] {pkg.id}-{a.instance}: can't safely resolve the arm's "
+                             f"wallet ({wkind}) — refusing to fund a fresh wallet blind. Triage read-only: "
+                             f"python3 {Path(__file__).with_name('status.py').name} {pkg.id}")
+        existing_open = [s for s in existing_open if w and _cli.wallet_match(_cli.strategy_wallet(s), w)]
 
     def _has_running_runtime(s):
         rt = _cli.find_runtime_by_wallet(_cli.strategy_wallet(s))
@@ -486,6 +528,12 @@ def cmd_create(pkg, a, log):
 
     live = [s for s in existing_open if _has_running_runtime(s)]
     if live:
+        # If we got here mid-upgrade (a stale `_upgrade` marker steered us into redeploy while the arm is
+        # actually live), CLEAR the marker before refusing — else the next `upgrade` skips PHASE A, lands
+        # back here, and refuses "use upgrade" forever (the circular-refusal loop). Cleared, the next
+        # `upgrade` re-checks liveness from PHASE A.
+        if st.get("_upgrade"):
+            st.pop("_upgrade", None); save_state(pkg, st)
         _inst_flag = f" --instance {a.instance}" if getattr(a, "instance", None) else ""
         raise SystemExit(
             f"error: {pkg.id} is already deployed AND running ({len(live)} live wallet(s)) — `create` will not "
@@ -508,7 +556,7 @@ def cmd_create(pkg, a, log):
         return report(pkg, st, "closing-existing", note=(
             f"Found {len(existing_open)} existing {pkg.id} strateg(y/ies) with NO running runtime — closing "
             f"them (recovering funds) so this deploys on a FRESH wallet, never reusing the runtime-less one. "
-            f"strategy_close is async; re-run `python3 {Path(__file__).name} create {pkg.id} --budget "
+            f"strategy_close is async; re-run `python3 {Path(__file__).name} create {pkg.id}{_scope_flag(a)} --budget "
             f"{budget_arg(a.budget)}` once they're CLOSED and the funds are back."), as_json=a.json)
 
     need = [i for i in pkg.instances if not inst_state(st, i.name).get("strategyId")]
@@ -584,10 +632,10 @@ def cmd_create(pkg, a, log):
             else:
                 pending.append(f"{inst.name}={status or '…'}")
         if not pending:
-            return report(pkg, st, "wallets-ready", note="Next: deploy.py runtime " + pkg.id, as_json=a.json)
+            return report(pkg, st, "wallets-ready", note="Next: deploy.py runtime " + pkg.id + _scope_flag(a), as_json=a.json)
         if time.time() >= deadline:
             return report(pkg, st, "creating",
-                          note="Wallets still funding. Re-run `deploy.py create " + pkg.id + "` to resume.",
+                          note="Wallets still funding. Re-run `deploy.py create " + pkg.id + _scope_flag(a) + "` to resume.",
                           as_json=a.json)
         log(f"  waiting on {', '.join(pending)}…")
         time.sleep(POLL_EVERY)
@@ -611,7 +659,7 @@ def _recover_wallet(pkg, inst, active):
     binding a runtime to the wrong/old wallet — the exact reuse trap (agent hand-registers onto a
     stale wallet). Names are matched via the shared `_wallet_name` sanitizer so recovery can't drift
     from what `create` actually named the wallet."""
-    if len(pkg.instances) > 1:  # multi-instance: match by the sanitized name create assigned each wallet
+    if getattr(pkg, "full_instance_count", len(pkg.instances)) > 1:  # multi-instance: match by the sanitized name create assigned each wallet
         want = _wallet_name(pkg, inst)
         cands = [s for s in active if _cli.strategy_name(s) == want]
         if not cands and active:
@@ -736,7 +784,7 @@ def cmd_runtime(pkg, a, log):
     failed = [i.name for i in pkg.instances if inst_state(st, i.name).get("error")]
     overall = "failed" if failed else "registered"
     note = ("Some instances failed to register — see errors above." if failed else
-            "Registered — now confirm it's actually live: run `deploy.py verify " + pkg.id + "`. "
+            "Registered — now confirm it's actually live: run `deploy.py verify " + pkg.id + _scope_flag(a) + "`. "
             "That gate checks every instance is runtime-running + scanner-active + DSL-wired + funded; "
             "the strategy is NOT live until it passes. (verify does not wait for the first scan tick.)")
     return report(pkg, st, overall, note=note, as_json=a.json)
@@ -935,7 +983,7 @@ def cmd_verify(pkg, a, log):
                     print(f"  - {r['instance']}: scanner={r['scanner']}, dsl={r['dsl']}, "
                           f"budget={r['budget']}" + (f"  → {r['reason']}" if r["reason"] else ""))
                 if not live:
-                    print(f"\nNOT live — fix the flagged component(s) and re-run `deploy.py verify {pkg.id}`. "
+                    print(f"\nNOT live — fix the flagged component(s) and re-run `deploy.py verify {pkg.id}{_scope_flag(a)}`. "
                           "A strategy is live only when every instance is runtime-running + scanner-active "
                           "+ DSL-wired + funded.")
             if live:
@@ -990,30 +1038,47 @@ def cmd_upgrade(pkg, a, log):
     # Skipped on --dry-run: the preview must be side-effect + network free, so it routes straight to the
     # create dry-run without probing the backend for a live arm.
     if not a.dry_run and up.get("phase") != "redeploy":
-        # Resolve the arm's wallet via the shared resolver — its live runtime, or (runtime gone) the
-        # unique ACTIVE strategy carrying the arm's name. Without the fallback a runtime-less-but-open arm
-        # reads as "not deployed", so upgrade would skip consent + old-wallet cleanup and DOUBLE-FUND a
-        # fresh wallet next to the orphaned open one. Same resolver cmd_create's live-guard uses.
-        arm_wallet = _arm_wallet(pkg, inst, mcp)
-        open_mine = ([s for s in _cli.strategies_for(mcp, skill_name=pkg.id)
-                      if _cli.strategy_open(s)
-                      and _cli.wallet_match(_cli.strategy_wallet(s), arm_wallet)]
-                     if arm_wallet else [])
+        blocked = lambda why: _emit(a, log, {  # noqa: E731 — one refusal shape, reused
+            "strategy": pkg.id, "instance": inst.name, "status": "blocked",
+            "note": f"[E_STATE_AMBIGUOUS] {why} Refusing so upgrade can't skip consent or fund a second "
+                    f"wallet. Triage read-only first, then resolve WITH THE USER:\n"
+                    f"      python3 {Path(__file__).with_name('status.py').name} {pkg.id}"})
 
         if up.get("phase") == "closing":
-            # a close was triggered on a prior call — strategy_close is async, so wait for the flatten
-            # to finish (the arm's open strategy disappears) before minting the fresh wallet.
-            if open_mine:
+            # A close was triggered on a prior call. strategy_close is async — poll the strategyIds we
+            # CLOSED, directly. (Name-matching here would false-report `closed`: `close_one` deletes the
+            # runtime, and a CLOSING strategy has already left ACTIVE, so the name fallback returns nothing
+            # while the flatten is still in flight.) Read fail-CLOSED: on a failed read, keep waiting.
+            ids = set(up.get("closing_ids") or [])
+            rows = _cli.strategies_for_or_none(mcp, skill_name=pkg.id)
+            if rows is None:
+                return _emit(a, log, {"strategy": pkg.id, "instance": inst.name, "status": "closing",
+                                      "note": f"couldn't read strategy_list — re-run `{rerun}` to keep polling the close."})
+            if [s for s in rows if _cli.strategy_open(s) and _cli.strategy_id_of(s) in ids]:
                 return _emit(a, log, {"strategy": pkg.id, "instance": inst.name, "status": "closing",
                                       "note": f"old {inst.runtime_name} still flattening — re-run `{rerun}` to continue."})
-            up["phase"] = "redeploy"; st["_upgrade"] = up; save_state(pkg, st)
+            up["phase"] = "redeploy"; up.pop("closing_ids", None); st["_upgrade"] = up; save_state(pkg, st)
             return _emit(a, log, {"strategy": pkg.id, "instance": inst.name, "status": "closed",
                                   "note": f"old arm closed, funds returning to main. Re-run `{rerun}` to redeploy on "
                                           f"a FRESH wallet. (If create reports `underfunded`, the funds are still "
                                           f"returning — wait a moment and re-run.)"})
 
+        # START. Resolve the arm's wallet via the shared tri-state resolver, and REFUSE on anything but a
+        # clean resolve or a verified-absent `none` — an unreadable/ambiguous backend must not disarm the
+        # consent gate + double-fund guard (fund a fresh wallet next to an unread live one).
+        arm_wallet, arm_kind = _arm_wallet(pkg, inst, mcp)
+        if arm_kind in ("unreadable", "unnamed", "ambiguous"):
+            return blocked(f"can't safely resolve `{inst.runtime_name}`'s wallet ({arm_kind}).")
+
+        open_mine = []
+        if arm_wallet:
+            rows = _cli.strategies_for_or_none(mcp, wallet=arm_wallet)  # fail-CLOSED — never fund on a blind read
+            if rows is None:
+                return blocked(f"couldn't read strategy_list to confirm `{inst.runtime_name}`'s open book.")
+            open_mine = [s for s in rows if _cli.strategy_open(s)]
+
         if open_mine:
-            # START: the arm is LIVE. Closing it MARKET-EXITS its positions — never do that silently.
+            # The arm is LIVE. Closing it MARKET-EXITS its positions — never do that silently.
             if not a.yes:
                 return _emit(a, log, {
                     "strategy": pkg.id, "instance": inst.name, "status": "needs-consent", "wallet": arm_wallet,
@@ -1023,31 +1088,31 @@ def cmd_upgrade(pkg, a, log):
                              f"arm on a FRESH wallet. The old wallet is retired, and a custom ratchet/stop ladder on "
                              f"the old positions does NOT carry over — re-apply it after if wanted. Confirm with the "
                              f"user, then re-run with --yes:\n      {rerun} --yes")})
-            # consent given → close THIS arm via the tested close primitive (same in-process call cmd_create
-            # uses for the runtime-less trap), then hand off to redeploy on a fresh wallet.
+            # consent given → close THIS arm via the tested close primitive, remembering its strategyIds so
+            # the closing-wait can poll them directly, then hand off to redeploy on a fresh wallet.
             import close as _close  # noqa: E402 — sibling module, lazy import
             runtimes = _cli.list_runtimes()
             recs = [_close.close_one(pkg.id, s, runtimes, False, log) for s in open_mine]
             bad = [r for r in recs if r.get("status") == "failed"]
             if bad:
                 # A failed close (runtime still listed after two delete attempts → it may re-enter
-                # positions) must SURFACE, not be swallowed. State stays put, so the next run re-enters this
-                # branch and re-attempts; advancing to `closing` would poll a strategy nothing is closing,
-                # forever, with the real error never shown.
+                # positions) must SURFACE, not be swallowed. State stays put, so the next run re-attempts;
+                # advancing to `closing` would poll a strategy nothing is closing, forever.
                 return _emit(a, log, {
                     "strategy": pkg.id, "instance": inst.name, "status": "failed",
                     "note": "close FAILED, nothing redeployed: "
                             + "; ".join(str(r.get("error") or "?") for r in bad)
                             + f"\n      Resolve it, then re-run `{rerun} --yes`."})
             st["instances"][inst.name] = {"status": "pending"}  # forget the old id → create makes a FRESH wallet
-            st["_upgrade"] = {"phase": "closing"}
+            st["_upgrade"] = {"phase": "closing",
+                              "closing_ids": [_cli.strategy_id_of(s) for s in open_mine if _cli.strategy_id_of(s)]}
             save_state(pkg, st)
             return _emit(a, log, {"strategy": pkg.id, "instance": inst.name, "status": "closing",
                                   "note": (f"Closing `{inst.runtime_name}` (flatten positions + return funds; "
                                            f"async). Re-run `{rerun}` to redeploy once it's closed.")})
 
-        # nothing live to close (arm not deployed, or a runtime-less trap that `create` itself clears) →
-        # straight to redeploy.
+        # arm_kind == "none" (verified absent) — genuinely not deployed, or a runtime-less trap `create`
+        # itself clears → straight to redeploy.
         up["phase"] = "redeploy"; st["_upgrade"] = up
         save_state(pkg, st)
 
@@ -1060,7 +1125,20 @@ def cmd_upgrade(pkg, a, log):
         return cmd_runtime(pkg, a, log)
     # registered → a fast single check (max_wait=0); verify deletes state on `live`, clearing _upgrade too.
     av = argparse.Namespace(**{**vars(a), "max_wait": 0})
-    return cmd_verify(pkg, av, log)
+    out = cmd_verify(pkg, av, log)
+    if out.get("status") != "live" and st.get("_upgrade"):
+        # Registered but NOT live mid-upgrade (e.g. the edited scanner is broken — exactly when the user
+        # re-edits and re-runs). Verify-only would loop forever and the re-edit would never re-render
+        # (cmd_runtime idempotent-skips the same wallet). Drop the runtime + reset to `active` so the next
+        # run re-registers the CURRENT on-disk edit instead of re-judging the stale deployment.
+        _cli.run_cli(["openclaw", "senpi", "runtime", "delete", inst.runtime_name], timeout=60)
+        s["status"] = "active"
+        save_state(pkg, st)
+        return _emit(a, log, {"strategy": pkg.id, "instance": inst.name, "status": "not-live",
+                              "note": f"redeploy registered but not live yet (scanner unconfirmed). Re-run "
+                                      f"`{rerun}` — it re-registers the current edit (fix the scanner on disk "
+                                      f"first if it's broken)."})
+    return out
 
 
 # ---------- cli ----------
@@ -1159,9 +1237,10 @@ def main(argv):
     else:  # status
         out = report(pkg, load_state(pkg), "status", as_json=a.json)
 
-    # `needs-consent` exits non-zero: the upgrade is BLOCKED on the operator confirming the flatten, not
-    # complete. `closing`/`closed`/`creating`/`wallets-ready` are in-progress (re-run) and exit 0.
-    sys.exit(2 if out.get("status") in ("failed", "underfunded", "not-live", "needs-consent") else 0)
+    # `needs-consent` (blocked on operator confirming the flatten) and `blocked` (unreadable/ambiguous
+    # backend — refused rather than fund blind) exit non-zero: not complete, action required.
+    # `closing`/`closed`/`creating`/`wallets-ready` are in-progress (re-run) and exit 0.
+    sys.exit(2 if out.get("status") in ("failed", "underfunded", "not-live", "needs-consent", "blocked") else 0)
 
 
 if __name__ == "__main__":

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -949,8 +949,21 @@ def cmd_upgrade(pkg, a, log):
     # Skipped on --dry-run: the preview must be side-effect + network free, so it routes straight to the
     # create dry-run without probing the backend for a live arm.
     if not a.dry_run and up.get("phase") != "redeploy":
+        # Resolve the arm's wallet. Prefer its live runtime; but if the runtime is GONE (crashed, or the
+        # funded-but-never-registered trap) the strategy can still be OPEN — so fall back to the arm's
+        # stable strategyName (== `_wallet_name(<id>-<instance>)`) among ACTIVE strategies. The backend
+        # keeps that name fixed while the strategy is active (confirmed), so this reliably re-finds the
+        # wallet — the same key `_recover_wallet` uses for lost-state recovery. Without the fallback a
+        # runtime-less-but-open arm looks "not deployed", so upgrade would skip consent + old-wallet
+        # cleanup and DOUBLE-FUND a fresh wallet next to the orphaned open one.
         arm_rt = _cli.find_runtime(inst.runtime_name)
         arm_wallet = _cli.runtime_wallet(arm_rt) if arm_rt else None
+        if not arm_wallet:
+            want = _wallet_name(pkg, inst)
+            cands = [s for s in _cli.strategies_for(mcp, skill_name=pkg.id, statuses=["ACTIVE"])
+                     if _cli.strategy_name(s) == want]
+            addrs = {str(_cli.strategy_wallet(s)).lower() for s in cands if _cli.strategy_wallet(s)}
+            arm_wallet = _cli.strategy_wallet(cands[0]) if len(addrs) == 1 else None  # unique match only
         open_mine = ([s for s in _cli.strategies_for(mcp, skill_name=pkg.id)
                       if _cli.strategy_open(s)
                       and _cli.wallet_match(_cli.strategy_wallet(s), arm_wallet)]

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -614,5 +614,111 @@ class AvailableUsd(unittest.TestCase):
         self.assertEqual(deploy.available_usd(_StubMCP(_portfolio())), 0.0)
 
 
+class ScopePkgSingleArm(unittest.TestCase):
+    """--instance scoping for a single-arm (re)deploy/upgrade: narrow to one sleeve, fund it fully,
+    leave siblings untouched, and reject an unknown name with a helpful list."""
+
+    def _pkg(self):
+        return types.SimpleNamespace(
+            id="cub",
+            instances=[_inst("long", 0.45), _inst("short", 0.45), _inst("preipo", 0.10)],
+        )
+
+    def test_narrows_to_the_named_arm(self):
+        pkg = self._pkg()
+        deploy._scope_pkg(pkg, "preipo")
+        self.assertEqual([i.name for i in pkg.instances], ["preipo"])
+
+    def test_scoped_arm_funds_fully_not_scaled_by_its_share(self):
+        # a 0.10-share sleeve deployed alone must take the WHOLE --budget, else $15 → ~$1.50 → floored.
+        pkg = self._pkg()
+        deploy._scope_pkg(pkg, "preipo")
+        self.assertEqual(pkg.instances[0].funding_share, 1.0)
+
+    def test_unknown_instance_raises_with_the_valid_names(self):
+        pkg = self._pkg()
+        with self.assertRaises(SystemExit) as ctx:
+            deploy._scope_pkg(pkg, "nope")
+        msg = str(ctx.exception)
+        self.assertIn("no instance 'nope'", msg)
+        self.assertIn("long", msg)  # lists what IS valid so the agent can self-correct
+        self.assertIn("preipo", msg)
+
+
+class UpgradeGates(unittest.TestCase):
+    """`upgrade` refuses the two ways it must before touching MCP: a multi-arm package with no --instance
+    (which arm?), and a missing --budget (the fresh wallet needs funding)."""
+
+    def _pkg(self, names):
+        return types.SimpleNamespace(id="cub", dir=Path("/nonexistent"),
+                                     version="1", instances=[_inst(n, 1.0) for n in names])
+
+    def _args(self, **kw):
+        base = dict(budget=None, dry_run=False, yes=False, instance=None, json=False,
+                    max_wait=0, decision_model=None, ref=None, package="cub")
+        base.update(kw)
+        return types.SimpleNamespace(**base)
+
+    def test_multiarm_without_instance_refuses(self):
+        with self.assertRaises(SystemExit) as e:
+            deploy.cmd_upgrade(self._pkg(["long", "short"]), self._args(budget=25), lambda m: None)
+        self.assertIn("ONE arm", str(e.exception))
+        self.assertIn("long", str(e.exception))  # names the valid arms
+
+    def test_budget_required_when_not_dry_run(self):
+        with self.assertRaises(SystemExit) as e:
+            deploy.cmd_upgrade(self._pkg(["preipo"]), self._args(budget=None), lambda m: None)
+        self.assertIn("--budget", str(e.exception))
+
+
+class UpgradeDispatch(unittest.TestCase):
+    """PHASE B advances ONE tested step per call, chosen by the arm's deploy-state status:
+    pending→create, active→runtime, registered→verify. Money-path calls are stubbed — this asserts the
+    routing, not the steps themselves (those have their own tests + live integration)."""
+
+    _PATCH = ("load_state", "save_state", "MCPClient", "cmd_create", "cmd_runtime", "cmd_verify")
+
+    def setUp(self):
+        self._saved = {k: getattr(deploy, k) for k in self._PATCH}
+        self.calls = []
+        deploy.MCPClient = lambda *a, **k: object()
+        deploy.save_state = lambda pkg, st: None
+        deploy.cmd_create = lambda pkg, a, log: (self.calls.append("create"), {"status": "wallets-ready"})[1]
+        deploy.cmd_runtime = lambda pkg, a, log: (self.calls.append("runtime"), {"status": "registered"})[1]
+        deploy.cmd_verify = lambda pkg, a, log: (self.calls.append("verify"), {"status": "live"})[1]
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(deploy, k, v)
+
+    def _pkg(self):
+        return types.SimpleNamespace(id="cub", dir=Path("/x"), version="1",
+                                     instances=[_inst("preipo", 1.0)])
+
+    def _args(self):
+        return types.SimpleNamespace(budget=25, dry_run=False, yes=True, instance="preipo",
+                                     json=False, max_wait=0, decision_model=None, ref=None, package="cub")
+
+    def _state(self, inst_status, **inst_extra):
+        arm = {"status": inst_status}
+        arm.update(inst_extra)
+        return {"id": "cub", "_upgrade": {"phase": "redeploy"}, "instances": {"preipo": arm}}
+
+    def test_redeploy_pending_routes_to_create(self):
+        deploy.load_state = lambda pkg: self._state("pending")
+        deploy.cmd_upgrade(self._pkg(), self._args(), lambda m: None)
+        self.assertEqual(self.calls, ["create"])
+
+    def test_redeploy_active_routes_to_runtime(self):
+        deploy.load_state = lambda pkg: self._state("active", strategyId="0xsid", wallet="0xw")
+        deploy.cmd_upgrade(self._pkg(), self._args(), lambda m: None)
+        self.assertEqual(self.calls, ["runtime"])
+
+    def test_redeploy_registered_routes_to_verify(self):
+        deploy.load_state = lambda pkg: self._state("registered", strategyId="0xsid", wallet="0xw")
+        deploy.cmd_upgrade(self._pkg(), self._args(), lambda m: None)
+        self.assertEqual(self.calls, ["verify"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -720,5 +720,96 @@ class UpgradeDispatch(unittest.TestCase):
         self.assertEqual(self.calls, ["verify"])
 
 
+class UpgradeConsentPhase(unittest.TestCase):
+    """PHASE A: detect a live arm — via its runtime, OR (if the runtime is gone) via the arm's stable
+    strategyName among ACTIVE strategies — and gate the flatten on --yes. The name fallback is the
+    regression guard for the runtime-gone-but-open double-funding bug."""
+
+    _PATCH = ("_cli", "MCPClient", "load_state", "save_state", "_wallet_name", "cmd_create")
+
+    def setUp(self):
+        self._saved = {k: getattr(deploy, k) for k in self._PATCH}
+        self._closed = []
+        self._created = []
+        deploy.MCPClient = lambda *a, **k: object()
+        deploy.load_state = lambda pkg: {"id": pkg.id, "instances": {}}
+        deploy.save_state = lambda pkg, st: None
+        deploy._wallet_name = lambda pkg, inst: f"{pkg.id}-{inst.name}"
+        deploy.cmd_create = lambda pkg, a, log: (self._created.append("create"), {"status": "wallets-ready"})[1]
+        close_mod = types.ModuleType("close")
+        close_mod.close_one = lambda label, s, rts, dry, log: self._closed.append(s)
+        sys.modules["close"] = close_mod
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            setattr(deploy, k, v)
+        sys.modules.pop("close", None)
+
+    def _pkg(self):
+        return types.SimpleNamespace(
+            id="cub", dir=Path("/x"), version="1",
+            instances=[types.SimpleNamespace(name="preipo", funding_share=1.0, runtime_name="cub-preipo")])
+
+    def _args(self, yes=False):
+        return types.SimpleNamespace(budget=25, dry_run=False, yes=yes, instance="preipo",
+                                     json=False, max_wait=0, decision_model=None, ref=None, package="cub")
+
+    def _cli(self, runtime=None, strategies=()):
+        s = types.SimpleNamespace()
+        s.find_runtime = lambda name: runtime
+        s.runtime_wallet = lambda rt: (rt or {}).get("wallet")
+        s.list_runtimes = lambda: []
+        s.strategy_open = lambda x: x.get("status", "ACTIVE") not in ("CLOSED", "FAILED", "TERMINATED")
+        s.strategy_wallet = lambda x: x.get("wallet")
+        s.strategy_name = lambda x: x.get("name")
+        s.wallet_match = lambda a, b: bool(a) and bool(b) and str(a).lower() == str(b).lower()
+
+        def strategies_for(mcp, skill_name=None, statuses=None, **kw):
+            rows = list(strategies)
+            if statuses:
+                rows = [x for x in rows if x.get("status", "ACTIVE") in statuses]
+            return rows
+        s.strategies_for = strategies_for
+        return s
+
+    def test_live_arm_without_yes_needs_consent(self):
+        deploy._cli = self._cli(runtime={"wallet": "0xAAA"},
+                                strategies=[{"wallet": "0xAAA", "name": "cub-preipo", "status": "ACTIVE"}])
+        out = deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
+        self.assertEqual(out["status"], "needs-consent")
+        self.assertEqual(self._closed, [])            # nothing flattened without consent
+        self.assertEqual(self._created, [])           # and it did NOT fall through to create
+
+    def test_live_arm_with_yes_closes_that_arm(self):
+        deploy._cli = self._cli(runtime={"wallet": "0xAAA"},
+                                strategies=[{"wallet": "0xAAA", "name": "cub-preipo", "status": "ACTIVE"}])
+        out = deploy.cmd_upgrade(self._pkg(), self._args(yes=True), lambda m: None)
+        self.assertEqual(out["status"], "closing")
+        self.assertEqual(len(self._closed), 1)
+
+    def test_runtime_gone_but_strategy_open_still_gated(self):
+        # THE FIX: no runtime, but an ACTIVE strategy carries the arm's name → resolve the wallet by name
+        # and STILL gate consent, instead of treating the arm as undeployed and double-funding.
+        deploy._cli = self._cli(runtime=None,
+                                strategies=[{"wallet": "0xBBB", "name": "cub-preipo", "status": "ACTIVE"}])
+        out = deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
+        self.assertEqual(out["status"], "needs-consent")
+        self.assertEqual(self._created, [])           # must NOT have jumped to create
+
+    def test_runtime_gone_sibling_active_not_mismatched(self):
+        # no runtime for preipo, and the only ACTIVE strategy is a SIBLING (different name) → no match →
+        # treat as not-deployed and redeploy; must never bind preipo to a sibling's wallet.
+        deploy._cli = self._cli(runtime=None,
+                                strategies=[{"wallet": "0xLONG", "name": "cub-long", "status": "ACTIVE"}])
+        deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
+        self.assertEqual(self._closed, [])
+        self.assertEqual(self._created, ["create"])   # genuinely undeployed arm → PHASE B
+
+    def test_truly_undeployed_proceeds_to_create(self):
+        deploy._cli = self._cli(runtime=None, strategies=[])
+        deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
+        self.assertEqual(self._created, ["create"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -788,7 +788,7 @@ class UpgradeConsentPhase(unittest.TestCase):
         return types.SimpleNamespace(budget=25, dry_run=False, yes=yes, instance="preipo",
                                      json=json, max_wait=0, decision_model=None, ref=None, package="cub")
 
-    def _cli(self, runtime=None, strategies=()):
+    def _cli(self, runtime=None, strategies=(), read_ok=True):
         s = types.SimpleNamespace()
         s.find_runtime = lambda name: runtime
         s.runtime_wallet = lambda rt: (rt or {}).get("wallet")
@@ -796,14 +796,19 @@ class UpgradeConsentPhase(unittest.TestCase):
         s.strategy_open = lambda x: x.get("status", "ACTIVE") not in ("CLOSED", "FAILED", "TERMINATED")
         s.strategy_wallet = lambda x: x.get("wallet")
         s.strategy_name = lambda x: x.get("name")
+        s.strategy_id_of = lambda x: x.get("id")
         s.wallet_match = lambda a, b: bool(a) and bool(b) and str(a).lower() == str(b).lower()
 
-        def strategies_for(mcp, skill_name=None, statuses=None, **kw):
-            rows = list(strategies)
+        def _filter(rows, statuses, wallet):
+            out = list(rows)
             if statuses:
-                rows = [x for x in rows if x.get("status", "ACTIVE") in statuses]
-            return rows
-        s.strategies_for = strategies_for
+                out = [x for x in out if x.get("status", "ACTIVE") in statuses]
+            if wallet is not None:
+                out = [x for x in out if str(x.get("wallet") or "").lower() == str(wallet).lower()]
+            return out
+        s.strategies_for = lambda mcp, skill_name=None, statuses=None, wallet=None, **kw: _filter(strategies, statuses, wallet)
+        s.strategies_for_or_none = (
+            lambda mcp, skill_name=None, statuses=None, wallet=None, **kw: (_filter(strategies, statuses, wallet) if read_ok else None))
         return s
 
     def test_live_arm_without_yes_needs_consent(self):
@@ -822,28 +827,58 @@ class UpgradeConsentPhase(unittest.TestCase):
         self.assertEqual(len(self._closed), 1)
 
     def test_runtime_gone_but_strategy_open_still_gated(self):
-        # THE FIX (regression guard): no runtime, but an ACTIVE strategy carries the arm's REAL name
-        # (cub-preipo, only correct once arity survives scoping) → resolve the wallet by name and STILL
-        # gate consent, instead of treating the arm as undeployed and double-funding.
+        # regression guard: no runtime, but an ACTIVE strategy carries the arm's REAL name (cub-preipo,
+        # only correct once arity survives scoping) → resolve by name and STILL gate consent, instead of
+        # treating the arm as undeployed and double-funding.
         deploy._cli = self._cli(runtime=None,
                                 strategies=[{"wallet": "0xBBB", "name": "cub-preipo", "status": "ACTIVE"}])
         out = deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
         self.assertEqual(out["status"], "needs-consent")
         self.assertEqual(self._created, [])           # must NOT have jumped to create
 
-    def test_runtime_gone_sibling_active_not_mismatched(self):
-        # no runtime for preipo, and the only ACTIVE strategy is a SIBLING (cub-long) → no name match →
-        # treat as not-deployed and redeploy; must never bind preipo to a sibling's wallet.
+    def test_unreadable_backend_refuses_not_funds(self):
+        # strategy_list read FAILS (→ None) → must NOT read as "arm absent" and fund fresh. Refuse.
+        deploy._cli = self._cli(runtime=None, strategies=[], read_ok=False)
+        out = deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
+        self.assertEqual(out["status"], "blocked")
+        self.assertEqual(self._created, [])
+        self.assertEqual(self._closed, [])
+
+    def test_ambiguous_two_same_name_refuses(self):
+        # a prior double-fund left TWO ACTIVE strategies with the arm's name on different wallets → can't
+        # uniquely resolve → refuse, never fund a third next to them.
+        deploy._cli = self._cli(runtime=None, strategies=[
+            {"wallet": "0xB1", "name": "cub-preipo", "status": "ACTIVE"},
+            {"wallet": "0xB2", "name": "cub-preipo", "status": "ACTIVE"}])
+        out = deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
+        self.assertEqual(out["status"], "blocked")
+        self.assertEqual(self._created, [])
+
+    def test_runtime_gone_only_sibling_active_refuses(self):
+        # no runtime for preipo, and the only ACTIVE strategy is a SIBLING (cub-long): ambiguous — could be
+        # a name-rejection fallback wallet for preipo itself → refuse, never bind to the sibling or fund blind.
         deploy._cli = self._cli(runtime=None,
                                 strategies=[{"wallet": "0xLONG", "name": "cub-long", "status": "ACTIVE"}])
-        deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
+        out = deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
+        self.assertEqual(out["status"], "blocked")
         self.assertEqual(self._closed, [])
-        self.assertEqual(self._created, ["create"])   # genuinely undeployed arm → PHASE B
+        self.assertEqual(self._created, [])
 
     def test_truly_undeployed_proceeds_to_create(self):
+        # verified-absent (read OK, NO active cub strategies at all) → clean "none" → redeploy (create).
         deploy._cli = self._cli(runtime=None, strategies=[])
         deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
         self.assertEqual(self._created, ["create"])
+
+    def test_closing_wait_polls_ids_directly(self):
+        # phase=closing: still-open strategy with a closing id → keep waiting; gone → advance to `closed`.
+        pkg = self._pkg()
+        deploy.load_state = lambda p: {"id": "cub", "instances": {},
+                                       "_upgrade": {"phase": "closing", "closing_ids": ["sid1"]}}
+        deploy._cli = self._cli(strategies=[{"wallet": "0xAAA", "name": "cub-preipo", "id": "sid1", "status": "ACTIVE"}])
+        self.assertEqual(deploy.cmd_upgrade(pkg, self._args(yes=True), lambda m: None)["status"], "closing")
+        deploy._cli = self._cli(strategies=[{"wallet": "0xAAA", "name": "cub-preipo", "id": "sid1", "status": "CLOSED"}])
+        self.assertEqual(deploy.cmd_upgrade(pkg, self._args(yes=True), lambda m: None)["status"], "closed")
 
     def test_failed_close_surfaces_and_does_not_advance(self):
         # close_one can report failed (runtime still listed after delete → may re-enter). It must SURFACE

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -901,5 +901,22 @@ class UpgradeConsentPhase(unittest.TestCase):
         self.assertIn("needs-consent", buf.getvalue())
 
 
+class ExitCodeContract(unittest.TestCase):
+    """0 = done/info, 2 = refused/failed, 3 = resumable-re-run. `closed`/`closing` MUST be 3, not 0 — a
+    `$?`/`&&` caller that reads `closed` (old arm gone, nothing deployed) as success strands the user."""
+
+    def test_done_and_informational_exit_zero(self):
+        for s in ("live", "wallets-ready", "registered", "creating", "closing-existing", "planned", "status", None):
+            self.assertEqual(deploy._exit_code(s), 0, s)
+
+    def test_refused_or_failed_exit_two(self):
+        for s in ("failed", "underfunded", "not-live", "needs-consent", "blocked"):
+            self.assertEqual(deploy._exit_code(s), 2, s)
+
+    def test_upgrade_inflight_exit_three_not_zero(self):
+        for s in ("closing", "closed"):
+            self.assertEqual(deploy._exit_code(s), 3, s)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/senpi-strategy-ops/tests/test_deploy_gates.py
+++ b/senpi-strategy-ops/tests/test_deploy_gates.py
@@ -5,6 +5,8 @@ No MCP, no openclaw, no network — every input is a plain dict/stub. Run:
     python3 senpi-strategy-ops/tests/test_deploy_gates.py
 """
 # Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import contextlib
+import io
 import re
 import sys
 import types
@@ -720,24 +722,52 @@ class UpgradeDispatch(unittest.TestCase):
         self.assertEqual(self.calls, ["verify"])
 
 
-class UpgradeConsentPhase(unittest.TestCase):
-    """PHASE A: detect a live arm — via its runtime, OR (if the runtime is gone) via the arm's stable
-    strategyName among ACTIVE strategies — and gate the flatten on --yes. The name fallback is the
-    regression guard for the runtime-gone-but-open double-funding bug."""
+class UpgradeArity(unittest.TestCase):
+    """`_scope_pkg` narrows pkg.instances to 1, but `_wallet_name` keys off arity — so the scoped arm's
+    name must be derived from the TRUE pre-scope arity, else a multi-arm arm's wallet collapses to the
+    bare `<id>` and every by-name lookup (upgrade fallback + scoped create's naming) misses."""
 
-    _PATCH = ("_cli", "MCPClient", "load_state", "save_state", "_wallet_name", "cmd_create")
+    def _multi(self):
+        arm = lambda n: types.SimpleNamespace(name=n, funding_share=1 / 3, runtime_name=f"cub-{n}")
+        return types.SimpleNamespace(id="cub", dir=Path("/x"), version="1",
+                                     instances=[arm("long"), arm("short"), arm("preipo")])
+
+    def test_scoped_multiarm_keeps_full_name(self):
+        pkg = self._multi()
+        deploy._scope_pkg(pkg, "preipo")
+        self.assertEqual(deploy._wallet_name(pkg, pkg.instances[0]), "cub-preipo")  # NOT the bare "cub"
+
+    def test_true_single_arm_is_bare_id(self):
+        pkg = types.SimpleNamespace(id="solo", dir=Path("/x"), version="1",
+                                    instances=[types.SimpleNamespace(name="main", funding_share=1.0)])
+        self.assertEqual(deploy._wallet_name(pkg, pkg.instances[0]), "solo")       # unscoped 1-arm unchanged
+
+
+class UpgradeConsentPhase(unittest.TestCase):
+    """PHASE A: detect a live arm — via its runtime, OR (runtime gone) via the arm's stable strategyName
+    among ACTIVE strategies — gate the flatten on --yes, surface a failed close, and emit under --json.
+
+    The fixture is a REAL 3-arm package narrowed by `_scope_pkg` (exactly what main() hands cmd_upgrade),
+    and `_wallet_name` is deliberately NOT stubbed — the name it derives after scoping IS the mechanism
+    under test. Stubbing it (as the first cut did) hid the arity bug that made the fallback search 'cub'."""
+
+    _PATCH = ("_cli", "MCPClient", "load_state", "save_state", "cmd_create")
 
     def setUp(self):
         self._saved = {k: getattr(deploy, k) for k in self._PATCH}
         self._closed = []
         self._created = []
+        self._close_result = {"status": "closed"}
         deploy.MCPClient = lambda *a, **k: object()
         deploy.load_state = lambda pkg: {"id": pkg.id, "instances": {}}
         deploy.save_state = lambda pkg, st: None
-        deploy._wallet_name = lambda pkg, inst: f"{pkg.id}-{inst.name}"
         deploy.cmd_create = lambda pkg, a, log: (self._created.append("create"), {"status": "wallets-ready"})[1]
         close_mod = types.ModuleType("close")
-        close_mod.close_one = lambda label, s, rts, dry, log: self._closed.append(s)
+
+        def close_one(label, s, rts, dry, log):
+            self._closed.append(s)
+            return self._close_result
+        close_mod.close_one = close_one
         sys.modules["close"] = close_mod
 
     def tearDown(self):
@@ -746,13 +776,17 @@ class UpgradeConsentPhase(unittest.TestCase):
         sys.modules.pop("close", None)
 
     def _pkg(self):
-        return types.SimpleNamespace(
-            id="cub", dir=Path("/x"), version="1",
-            instances=[types.SimpleNamespace(name="preipo", funding_share=1.0, runtime_name="cub-preipo")])
+        """A real 3-arm package narrowed to `preipo` by `_scope_pkg` — what main() hands cmd_upgrade for
+        `--instance preipo`. Multi-arm on purpose: scoping a 1-arm fixture would hide the arity trap."""
+        arm = lambda n: types.SimpleNamespace(name=n, funding_share=1 / 3, runtime_name=f"cub-{n}")
+        pkg = types.SimpleNamespace(id="cub", dir=Path("/x"), version="1",
+                                    instances=[arm("long"), arm("short"), arm("preipo")])
+        deploy._scope_pkg(pkg, "preipo")
+        return pkg
 
-    def _args(self, yes=False):
+    def _args(self, yes=False, json=False):
         return types.SimpleNamespace(budget=25, dry_run=False, yes=yes, instance="preipo",
-                                     json=False, max_wait=0, decision_model=None, ref=None, package="cub")
+                                     json=json, max_wait=0, decision_model=None, ref=None, package="cub")
 
     def _cli(self, runtime=None, strategies=()):
         s = types.SimpleNamespace()
@@ -788,8 +822,9 @@ class UpgradeConsentPhase(unittest.TestCase):
         self.assertEqual(len(self._closed), 1)
 
     def test_runtime_gone_but_strategy_open_still_gated(self):
-        # THE FIX: no runtime, but an ACTIVE strategy carries the arm's name → resolve the wallet by name
-        # and STILL gate consent, instead of treating the arm as undeployed and double-funding.
+        # THE FIX (regression guard): no runtime, but an ACTIVE strategy carries the arm's REAL name
+        # (cub-preipo, only correct once arity survives scoping) → resolve the wallet by name and STILL
+        # gate consent, instead of treating the arm as undeployed and double-funding.
         deploy._cli = self._cli(runtime=None,
                                 strategies=[{"wallet": "0xBBB", "name": "cub-preipo", "status": "ACTIVE"}])
         out = deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
@@ -797,7 +832,7 @@ class UpgradeConsentPhase(unittest.TestCase):
         self.assertEqual(self._created, [])           # must NOT have jumped to create
 
     def test_runtime_gone_sibling_active_not_mismatched(self):
-        # no runtime for preipo, and the only ACTIVE strategy is a SIBLING (different name) → no match →
+        # no runtime for preipo, and the only ACTIVE strategy is a SIBLING (cub-long) → no name match →
         # treat as not-deployed and redeploy; must never bind preipo to a sibling's wallet.
         deploy._cli = self._cli(runtime=None,
                                 strategies=[{"wallet": "0xLONG", "name": "cub-long", "status": "ACTIVE"}])
@@ -809,6 +844,26 @@ class UpgradeConsentPhase(unittest.TestCase):
         deploy._cli = self._cli(runtime=None, strategies=[])
         deploy.cmd_upgrade(self._pkg(), self._args(yes=False), lambda m: None)
         self.assertEqual(self._created, ["create"])
+
+    def test_failed_close_surfaces_and_does_not_advance(self):
+        # close_one can report failed (runtime still listed after delete → may re-enter). It must SURFACE
+        # as `failed`, not get swallowed and advance to a `closing` poll nothing will ever clear.
+        self._close_result = {"status": "failed", "error": "runtime still listed"}
+        deploy._cli = self._cli(runtime={"wallet": "0xAAA"},
+                                strategies=[{"wallet": "0xAAA", "name": "cub-preipo", "status": "ACTIVE"}])
+        out = deploy.cmd_upgrade(self._pkg(), self._args(yes=True), lambda m: None)
+        self.assertEqual(out["status"], "failed")
+        self.assertIn("runtime still listed", out["note"])
+
+    def test_json_emits_consent_to_stdout(self):
+        # under --json, `log` is a no-op; the PHASE-A verdict must still reach stdout as JSON, else the
+        # agent (which runs --json) gets exit code 2 and an empty stdout — losing the consent text.
+        deploy._cli = self._cli(runtime={"wallet": "0xAAA"},
+                                strategies=[{"wallet": "0xAAA", "name": "cub-preipo", "status": "ACTIVE"}])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            deploy.cmd_upgrade(self._pkg(), self._args(yes=False, json=True), lambda m: None)
+        self.assertIn("needs-consent", buf.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Re-scoring / re-scanning / re-tuning a **live** strategy had no supported path — agents hand-sequenced close+recreate and hit the `./scanners` wrong-directory trap (a funded wallet that never trades), raw `strategy_create_custom_strategy` (naked wallet), and retry-loops on a nonexistent "update" verb. ~80 users hit the `./scanners` break over 4.5 weeks.

## Solution

One resumable, consent-gated verb: **`deploy.py upgrade <id> [--instance <arm>] --budget <usd>`**. It drives the tested `close → create → runtime → verify` path per arm — validates before closing, refuses to flatten without `--yes`, redeploys on a fresh full-budget wallet, siblings untouched. Applies an edit **authored in `senpi-strategy-author`** (ops applies, author edits — routing wired both ways). **Stopgap** for the runtime engine's in-place reload; same command surface when that lands.

## Money-path hardening (all reads that gate money fail **closed**)

- `strategies_for_or_none` — a failed `strategy_list` **refuses** (`blocked`, exit 2) rather than reading `[]` → funding a second wallet.
- Tri-state `_arm_wallet` (reuses `_recover_wallet`'s taxonomy) — refuses on `unreadable`/`unnamed`/`ambiguous`; arity twin fixed at `_recover_wallet` too.
- Circular-refusal loop broken; closing-wait polls the captured `strategyId`s; registered-stall re-renders the edit; scoped `delete_state` spares siblings; resume hints carry `--instance`.
- **Exit codes:** `0` done · `2` refused/failed · **`3` resumable** (`closing`/`closed` — so a `$?`/`&&` caller can't misread the "nothing deployed yet" state as done).

## Review

Three rounds addressed — @shnoodles (arity: the fix was a no-op on multi-arm; my test had stubbed the broken function), @danielmbirochi (8 fail-open money-path findings), @0xsarvesh (exit-3 for in-flight states + budget-continuity doc). **160 tests green**, incl. a real 3-arm fixture through `_scope_pkg` and RED→GREEN regressions.

## Coordination (not code blockers)

- **#526 merge order:** #526 rewrites `deploy.py` and deletes the machinery `upgrade` is built on; if it lands first it must absorb the `upgrade` surface (hand-off checklist posted). If #528 lands first, #526 rebases.
- **Naming:** `upgrade` (destructive close→redeploy) vs the engine's `update` (in-place). Proposal: keep `upgrade` as the stable surface, point it at the engine when it ships (SKILL already promises this).
- **Version reconcile with #512** (both bump strategy-ops SKILL): whoever merges second takes max+1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
