### PR TITLE
fix(portfolio): resolve runtime state dir from install path, not $HOME

### DIFF
--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.11.0"
+  version: "1.12.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -50,8 +50,36 @@ CLOSED_HISTORY_PULL = 50    # closed positions to pull for the realized-PnL tota
 
 # The runtime registers every deployed strategy in installed_runtimes.json in the state dir.
 STATE_DIR_ENV = "SENPI_STATE_DIR"
-DEFAULT_STATE_DIR = os.path.expanduser("~/.openclaw/senpi-state")
 REGISTRY_FILENAME = "installed_runtimes.json"
+
+
+def _resolve_state_dir():
+    """Locate the OpenClaw runtime state dir holding installed_runtimes.json — robustly, WITHOUT relying
+    on $HOME. On agent hosts $HOME is /root while OpenClaw lives under /data, so `~/.openclaw/senpi-state`
+    resolves to a directory that does not exist and liveness reads 'registry unreadable' for every strategy
+    (falsely — the runtimes are up). The skill installs at `<root>/.openclaw/skills/<skill>/scripts/` and the
+    state dir is a sibling: `<root>/.openclaw/senpi-state`. Order: (1) $SENPI_STATE_DIR; (2) derive from THIS
+    file's install path — the enclosing `.openclaw` dir → its `senpi-state` (or any ancestor that actually
+    holds the registry); (3) common host locations; (4) ~/.openclaw/senpi-state as last resort. Mirrors
+    senpi-improve-trades/scripts/review.py so the two can't drift."""
+    env = os.environ.get(STATE_DIR_ENV)
+    if env:
+        return env
+    d = os.path.abspath(__file__)
+    for _ in range(8):
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+        if os.path.basename(d) == ".openclaw":
+            return os.path.join(d, "senpi-state")
+        if os.path.isfile(os.path.join(d, "senpi-state", REGISTRY_FILENAME)):
+            return os.path.join(d, "senpi-state")
+    for base in ("~/.openclaw/senpi-state", "/data/.openclaw/senpi-state", "/root/.openclaw/senpi-state"):
+        p = os.path.expanduser(base)
+        if os.path.isdir(p):
+            return p
+    return os.path.expanduser("~/.openclaw/senpi-state")
 # Telemetry liveness (health check): `openclaw senpi status -r <runtime_id> --json` says whether a
 # REGISTERED runtime is actually WORKING (healthy vs degraded), not just present in the registry. Same
 # fail-open + fixture pattern as senpi-improve-trades' event-log read. Offline test hook: a JSON file at
@@ -231,7 +259,7 @@ def load_runtime_registry(meta):
     meta.warnings note is added ONLY for a real parse error, not for a simply-absent registry file.
     Also returns a wallet_lower → runtime_id map (the `senpi status --runtime <id>` address, for the
     telemetry liveness read). Returns (profiles_map, id_map, registered_wallets, source)."""
-    state_dir = os.environ.get(STATE_DIR_ENV) or DEFAULT_STATE_DIR
+    state_dir = _resolve_state_dir()
     path = os.path.join(state_dir, REGISTRY_FILENAME)
     if not os.path.isfile(path):          # absent registry is normal, not an error
         return {}, {}, set(), None

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -936,6 +936,32 @@ def test_within_ttl_cached_state_is_reused():
     assert s["account_value"] == 9999.0, "within-TTL cache was re-fetched (fast path lost)"
 
 
+def test_state_dir_resolves_from_install_path_not_home():
+    """Liveness must find installed_runtimes.json on an agent host where $HOME=/root but OpenClaw lives
+    under /data. The resolver derives the state dir from the skill's install path (the `.openclaw` sibling),
+    never from ~/. Regression for the 'registry unreadable → runtime health unverified' misread."""
+    saved_home = os.environ.get("HOME")
+    saved_env = os.environ.pop(portfolio.STATE_DIR_ENV, None)
+    saved_file = portfolio.__file__
+    try:
+        root = tempfile.mkdtemp()
+        inst = os.path.join(root, ".openclaw", "skills", "senpi-portfolio", "scripts")
+        state = os.path.join(root, ".openclaw", "senpi-state")
+        os.makedirs(inst)
+        os.makedirs(state)
+        with open(os.path.join(state, portfolio.REGISTRY_FILENAME), "w") as fh:
+            fh.write("{}")
+        portfolio.__file__ = os.path.join(inst, "portfolio.py")
+        os.environ["HOME"] = "/root"            # the exact mismatch that caused the misread
+        assert portfolio._resolve_state_dir() == state, "resolver fell back to $HOME, not the install-path sibling"
+    finally:
+        portfolio.__file__ = saved_file
+        if saved_home is not None:
+            os.environ["HOME"] = saved_home
+        if saved_env is not None:
+            os.environ[portfolio.STATE_DIR_ENV] = saved_env
+
+
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     for fn in fns:


### PR DESCRIPTION
## Problem

Portfolio's runtime-liveness check reported **"⚠️ Could not verify runtime health for any strategy (registry unreadable)"** on agent hosts — falsely. The strategies were live; the skill just couldn't find the registry.

**Root cause:** it resolved the OpenClaw state dir as `$SENPI_STATE_DIR or ~/.openclaw/senpi-state`. On agent hosts `$HOME=/root`, but the runtime registry lives at `/data/.openclaw/senpi-state/installed_runtimes.json`. Path mismatch → no `installed_runtimes.json` → no runtime IDs to probe → every strategy reported "health unverified." Users were told *"can't confirm your DSL ratchets are managing your winners"* when the ratchets were running fine.

## Fix

Replace the naive `~`-only default with a robust `_resolve_state_dir()` — **ported verbatim from `senpi-improve-trades/scripts/review.py`**, which already solved this:

1. `$SENPI_STATE_DIR` if set
2. **derive from the skill's own install path** — walk up to the enclosing `.openclaw` dir → its `senpi-state` sibling (this is what fixes the `$HOME=/root` case: `<root>/.openclaw/skills/senpi-portfolio/scripts/` → `<root>/.openclaw/senpi-state`)
3. common host locations (`/data/.openclaw/...`, `/root/.openclaw/...`)
4. `~/.openclaw/senpi-state` as last resort

A comment points at review.py so the two impls can't drift.

## Fleet audit

Grepped every script that reads `installed_runtimes.json`: **only portfolio had the naive resolver.** `review.py` was already correct; `senpi-strategy-author/validate_strategy.py` only mentions the file in a comment.

## Verification

- Proved the resolver finds a `/data`-style layout with `$HOME=/root` (the exact mismatch).
- **+1 regression test** (`test_state_dir_resolves_from_install_path_not_home`); **42/42 passing**.
- Version `1.11.0 → 1.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
