### PR TITLE
Multi-wallet deploy: fund legs sequentially, and stop closing our own funded sleeves

### DIFF
--- a/senpi-strategy-ops/SKILL.md
+++ b/senpi-strategy-ops/SKILL.md
@@ -25,7 +25,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "2.16.0"
+  version: "2.16.1"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -120,14 +120,17 @@ strategyName=<id>-<instance>)` — **every wallet is named for its role in the s
 WhaleHunter deploy with two sub-wallets creates `whalehunter-long` and `whalehunter-short`), **never
 left as a bare `0x…` address**, so the user can tell a strategy's wallets apart in the app, balances,
 and notifications. Naming is best-effort: if the backend rejects a name (conflict/format), that wallet
-is still created (unnamed) rather than failing the deploy. It records the `strategyId`, and polls
-`strategy_list` to **ACTIVE** — **bounded** (~150s). If it prints
-**`creating`** (wallets still funding), just **re-run the same `create` command** — it resumes and
-**never re-creates** a wallet. It prints **`wallets-ready`** when done. **`create` never reuses an existing
-wallet — every deploy gets a FRESH one.** If an existing `<id>` strategy is found: a **runtime-less** one
-(funded but never got a runtime — the reuse trap an agent keeps landing back on) is **closed to recover its
-funds**, then a new wallet is created (prints **`closing-existing`**; re-run `create` once it's closed and
-funds are back); a **live, running** one is left untouched — `create` **refuses** so it can't silently
+is still created (unnamed) rather than failing the deploy. It records the `strategyId`, then polls
+`strategy_list` to **ACTIVE before submitting the next instance** — **one wallet funds at a time**,
+all **bounded** by one shared `--max-wait` (~150s). Two funding jobs on one embedded wallet race, and
+the loser reads a balance the winner already claimed, funds **$0.00** and parks in `PENDING_FUNDING`.
+If it prints **`creating`** (a wallet still funding), just **re-run the same `create` command** — it
+resumes, **adopting the wallets it already created** and never re-creating or closing them. It prints
+**`wallets-ready`** when done. If an existing `<id>` strategy is found **that this deploy did not
+create**: a **runtime-less** one (funded but never got a runtime — the reuse trap an agent keeps landing
+back on) is **closed to recover its funds**, then a new wallet is created (prints **`closing-existing`**;
+re-run `create` once it's closed and funds are back); a **live, running** one is left untouched —
+`create` **refuses** so it can't silently
 flatten a real book (to apply an edit to it, use **`deploy.py upgrade`** — see *Upgrade*; `close.py <id>`
 only to tear it down). The **`--budget` is a hard target**: create funds
 exactly what you ask (split by `funding_share`, $10/wallet floor); if your live balance can't cover it,
@@ -185,8 +188,9 @@ scheduled/supervised scanner passes, so it does **not** wait for the first scan 
 > user (the note gives the exact `--budget ≤ X` ceiling it can fund), then **re-run `create`**;
 > **`[E_FUNDS_BELOW_FLOOR]`** = no budget is valid, so help the user **deposit** and re-run — **never**
 > suggest a lower budget below the floor. Do not switch tools. If
-> `create` reports **`closing-existing`**, it's closing a runtime-less `<id>` wallet to recover funds so it
-> can deploy fresh — re-run `create` once it's closed. If it **refuses** "already deployed AND running", a
+> `create` reports **`closing-existing`**, it's closing a runtime-less `<id>` wallet **this deploy never
+> created** to recover funds so it can deploy fresh — re-run `create` once it's closed. A wallet this
+> deploy DID create is adopted on a re-run, never closed. If it **refuses** "already deployed AND running", a
 > live `<id>` strategy exists — to apply an edit use **`deploy.py upgrade <id> [--instance <arm>] --budget
 > <usd>`** (closes + redeploys fresh, consent-gated; see *Upgrade*), not a bare `close`+`create`. If **`runtime`** lost its
 > deploy state and can't safely resolve the fresh wallet, it refuses **split by cause** — and in **both**

--- a/senpi-strategy-ops/references/lifecycle.md
+++ b/senpi-strategy-ops/references/lifecycle.md
@@ -51,8 +51,13 @@ just means re-run that step.
    - Per instance: `strategy_create_custom_strategy(skillName=<id>, skillVersion=<version>, initialBudget=…,
      strategyName=<id>-<instance>)` — names the wallet for its role (e.g. `whalehunter-short`), never a bare
      address; best-effort (falls back to unnamed if the name is rejected). Record `strategyId` **immediately**,
-     poll `strategy_list` to **ACTIVE** (bounded by `--max-wait`).
-     Not all ACTIVE → **`creating`** (re-run to resume); all ACTIVE → **`wallets-ready`**.
+     poll `strategy_list` to **ACTIVE before the next instance is submitted** — one wallet funds at a
+     time, all bounded by ONE shared `--max-wait`. `strategy_create_custom_strategy` returns at
+     `CREATE_WALLET` and funds asynchronously, so concurrent legs draw on the same embedded wallet: the
+     loser reads a balance the winner already claimed, funds $0 and parks in `PENDING_FUNDING`.
+     Not all ACTIVE → **`creating`** (re-run to resume — it ADOPTS the wallets it already created; only
+     an open runtime-less strategy this deploy never created is closed); all ACTIVE →
+     **`wallets-ready`**.
 2. **`runtime <id>`** — per instance: render the instance's `runtime.yaml` (substitute `${wallet_env}` + the
    decision-model env iff a `decision_mode: llm` action) **beside the source** (so `path: ./scanners`
    resolves) → `openclaw senpi runtime create … --runtime-id <id>-<instance>`. **Self-healing:** an existing

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -11,8 +11,10 @@ in order and re-runs a step until it reports done.
 Step 1 `create`  — creating wallets & funding them: per instance strategy_create_custom_strategy (records
                    strategyId IMMEDIATELY), then poll strategy_list until ACTIVE before submitting the
                    NEXT instance — one wallet funds at a time — all BOUNDED by one --max-wait budget.
-                   Not all ACTIVE yet → exits `creating`; re-run `create` to RESUME (never re-creates).
-                   Refuses if it finds skillName==<id> strategies not in the state file (close first).
+                   Not all ACTIVE yet → exits `creating`; re-run `create` to RESUME — it ADOPTS the
+                   wallets it already created, never re-creating or closing them. REFUSES on a
+                   skillName==<id> strategy whose runtime is running; CLOSES one that is runtime-less
+                   AND absent from the state file (an orphan).
 Step 2 `runtime` — setting up the autonomous trading strategy: render each runtime.yaml with its wallet →
                    openclaw senpi runtime create. Fast, self-healing. AFTER THIS, DEPLOY IS DONE — the
                    strategy trades autonomously (scans on its own interval). Do NOT wait for the first tick.
@@ -161,6 +163,26 @@ def delete_state(pkg):
 
 def inst_state(st, name):
     return st["instances"].setdefault(name, {"status": "pending"})
+
+
+def recorded_strategy_ids(pkg, st):
+    """Every strategyId this package's state file knows about. Read it BEFORE `create`'s reconcile
+    drops the non-ACTIVE ones — the close sweep asks "did THIS deploy create it", not "is it still
+    healthy", and a leg stuck in PENDING_FUNDING is both ours and not-ACTIVE."""
+    return {sid for sid in (inst_state(st, i.name).get("strategyId") for i in pkg.instances) if sid}
+
+
+def orphan_strategies(existing_open, recorded_ids):
+    """The open <id> strategies the close sweep may touch: the ones this deploy never created.
+
+    A RECORDED wallet is not the runtime-less trap — it is this deploy mid-flight, and closing it is
+    how a multi-leg package destroys a fully-funded sleeve to recover from its sibling. Each leg costs
+    a flat ~$1 to fund and the fee is NOT returned on close, so create → close → recreate is pure loss
+    that lands back in the same state; M415566 burned 38 wallets and $39 that way, until the
+    accumulated fees made the user's own budget unaffordable. An id we cannot read is treated as an
+    orphan (`None not in recorded_ids`), which keeps the pre-existing protection: an unidentifiable
+    open wallet still blocks a fresh fund beside it."""
+    return [s for s in existing_open if _cli.strategy_id_of(s) not in recorded_ids]
 
 
 def _num(*vals):
@@ -523,6 +545,8 @@ def cmd_create(pkg, a, log):
     except Exception as e:  # noqa
         log(f"  (universe preflight skipped: {e})")
 
+    recorded_ids = recorded_strategy_ids(pkg, st)  # BEFORE the reconcile below discards any of them
+
     # Reconcile recorded strategies against the backend — drop any that aren't ACTIVE so we never
     # reuse a CLOSED wallet or get stuck on a FAILED one. Self-heals stale state; no manual editing.
     for inst in pkg.instances:
@@ -537,14 +561,16 @@ def cmd_create(pkg, a, log):
             st["instances"][inst.name] = {"status": "pending"}
     save_state(pkg, st)
 
-    # NEVER reuse an existing strategy's wallet. Re-using a funded, runtime-less wallet is the trap an
-    # agent keeps falling into (creates <id>, never deploys the runtime, keeps landing back on the same
-    # dead wallet); creating a second alongside it double-funds. So every `create` deploys on a FRESH
-    # wallet, resolving any existing OPEN <id> strategy first:
+    # Resolve every existing OPEN <id> strategy before funding anything:
     #   • RUNNING runtime → a live, working deploy: REFUSE to silently flatten it; redeploy is explicit
     #     (close.py first). Protects a real book from an accidental `create`.
-    #   • no running runtime → the funded-but-stuck trap: CLOSE it (recovers its funds), then this deploy
-    #     creates a fresh wallet. strategy_close is async, so hand off and re-run `create` once it's closed.
+    #   • no running runtime, NOT recorded here → an ORPHAN (an abandoned run, a raw-MCP create, a
+    #     deleted state file): the funded-but-stuck trap an agent keeps falling into — creates <id>,
+    #     never deploys the runtime, keeps landing back on the same dead wallet, and creating a second
+    #     alongside it double-funds. CLOSE it (recovers its funds), then this deploy creates a FRESH
+    #     wallet. strategy_close is async, so hand off and re-run `create` once it's closed.
+    #   • no running runtime, RECORDED here → not a trap: this deploy's own wallet, mid-flight. It is
+    #     adopted, never closed. See the orphan filter below for why that distinction is load-bearing.
     runtimes = _cli.list_runtimes()
     existing_open = [s for s in _cli.strategies_for(mcp, skill_name=pkg.id) if _cli.strategy_open(s)]
     if getattr(a, "instance", None):
@@ -586,20 +612,21 @@ def cmd_create(pkg, a, log):
             f"To tear it down instead:  python3 {Path(__file__).with_name('close.py')} {pkg.id}\n"
             f"Or just re-check it:  python3 {Path(__file__).name} verify {pkg.id}")
 
-    if existing_open:  # open but NOT running → the runtime-less trap: close (recover funds) → fresh wallet
+    # ORPHANS ONLY (see `orphan_strategies` for why closing our own wallet is the expensive mistake).
+    # Recorded wallets fall through instead — an ACTIVE one is adopted by the poll below (→
+    # `wallets-ready`, next step `runtime`), and one the reconcile above just discarded is recreated
+    # on a fresh wallet.
+    orphans = orphan_strategies(existing_open, recorded_ids)
+    if orphans:
         import close as _close  # noqa: E402 — sibling module, lazy import
-        for s in existing_open:
+        for s in orphans:
             _close.close_one(pkg.id, s, runtimes, False, log)
-        for inst in pkg.instances:  # forget the old ids so the re-run makes NEW wallets, never resumes them
-            prev = inst_state(st, inst.name)
-            st["instances"][inst.name] = ({"status": "pending", "requested": prev["requested"]}
-                                          if prev.get("requested") else {"status": "pending"})
-        save_state(pkg, st)
         return report(pkg, st, "closing-existing", note=(
-            f"Found {len(existing_open)} existing {pkg.id} strateg(y/ies) with NO running runtime — closing "
-            f"them (recovering funds) so this deploys on a FRESH wallet, never reusing the runtime-less one. "
-            f"strategy_close is async; re-run `python3 {Path(__file__).name} create {pkg.id}{_scope_flag(a)} --budget "
-            f"{budget_arg(a.budget)}` once they're CLOSED and the funds are back."), as_json=a.json)
+            f"Found {len(orphans)} existing {pkg.id} strateg(y/ies) with NO running runtime that this deploy "
+            f"never created — closing them (recovering funds) so this deploys on a FRESH wallet, never reusing "
+            f"the runtime-less one. strategy_close is async; re-run `python3 {Path(__file__).name} create "
+            f"{pkg.id}{_scope_flag(a)} --budget {budget_arg(a.budget)}` once they're CLOSED and the funds are "
+            f"back."), as_json=a.json)
 
     need = [i for i in pkg.instances if not inst_state(st, i.name).get("strategyId")]
 

--- a/senpi-strategy-ops/scripts/deploy.py
+++ b/senpi-strategy-ops/scripts/deploy.py
@@ -9,7 +9,8 @@ in order and re-runs a step until it reports done.
   python3 deploy.py status   <id> [--json]
 
 Step 1 `create`  — creating wallets & funding them: per instance strategy_create_custom_strategy (records
-                   strategyId IMMEDIATELY), then poll strategy_list until ACTIVE, BOUNDED by --max-wait.
+                   strategyId IMMEDIATELY), then poll strategy_list until ACTIVE before submitting the
+                   NEXT instance — one wallet funds at a time — all BOUNDED by one --max-wait budget.
                    Not all ACTIVE yet → exits `creating`; re-run `create` to RESUME (never re-creates).
                    Refuses if it finds skillName==<id> strategies not in the state file (close first).
 Step 2 `runtime` — setting up the autonomous trading strategy: render each runtime.yaml with its wallet →
@@ -321,6 +322,47 @@ def underfunded_note(shortfall):
             f"across these {shortfall['wallets']} wallet(s) at the {usd(MIN_WALLET)}/wallet floor).")
 
 
+def is_name_rejection(err):
+    """True when the backend is refusing the wallet NAME, not the deploy — so retrying unnamed works.
+
+    SERR083 belongs here despite its generic text ("Custom strategy creation failed unexpectedly.
+    Retry with the same payload."): a strategy stuck in PENDING_FUNDING keeps holding its
+    strategyName, and every create reusing that name 500s until the record expires ~15 min later.
+    Retrying the SAME payload — what the error itself advises — can never clear it; dropping the
+    name clears it instantly. Observed on a real deploy, two calls 3.6s apart, same $693 budget:
+        {initialBudget: 693, strategyName: "vanguard-long"}  → SERR083
+        {initialBudget: 693}                                 → success
+    It also failed at $100 with the name, ruling out any funding cause.
+    """
+    s = str(err)
+    return any(c in s for c in ("SERR055", "SERR056", "SERR058", "SERR083")) or "name" in s.lower()
+
+
+def await_funded(mcp, pkg, st, insts, deadline, log=lambda m: None):
+    """Poll `insts` until each is ACTIVE with a wallet, or `deadline` passes.
+
+    Returns the still-pending ["name=STATUS", …] list — empty means every leg settled.
+    """
+    while True:
+        pending = []
+        for inst in insts:
+            s = inst_state(st, inst.name)
+            if s.get("status") in ("active", "registered", "live"):
+                continue
+            m = _cli.strategies_for(mcp, strategy_id=s["strategyId"], timeout=POLL_HTTP_TIMEOUT)
+            status = str(_cli.strategy_status(m[0]) if m else "").upper()
+            addr = _cli.strategy_wallet(m[0]) if m else None
+            if status == "ACTIVE" and addr:
+                s.update(wallet=addr, status="active")
+                save_state(pkg, st)
+            else:
+                pending.append(f"{inst.name}={status or '…'}")
+        if not pending or time.time() >= deadline:
+            return pending
+        log(f"  waiting on {', '.join(pending)}…")
+        time.sleep(POLL_EVERY)
+
+
 def report(pkg, st, overall, note=None, as_json=False):
     insts = [{"instance": i, **st["instances"].get(i, {"status": "pending"})}
              for i in [x for x in st["instances"]]]
@@ -568,6 +610,10 @@ def cmd_create(pkg, a, log):
     if shortfall:
         return report(pkg, st, "underfunded", note=underfunded_note(shortfall), as_json=a.json)
 
+    # ONE SHARED poll budget across every leg — a per-leg budget would let an N-wallet package
+    # run for N × max_wait and blow past the tool timeout.
+    deadline = time.time() + a.max_wait
+
     # create any instance that has no strategyId yet — record the id IMMEDIATELY (before polling),
     # so an interrupted run resumes instead of re-creating.
     for inst in pkg.instances:
@@ -593,7 +639,7 @@ def cmd_create(pkg, a, log):
             res = _create(sname)
         except MCPError as e:
             # Naming is best-effort — a name conflict/format rejection must never block the deploy.
-            if any(c in str(e) for c in ("SERR055", "SERR056", "SERR058")) or "name" in str(e).lower():
+            if is_name_rejection(e):
                 log(f"  [{inst.name}] name {sname!r} rejected ({e}); creating without a custom name")
                 try:
                     res = _create()
@@ -615,30 +661,24 @@ def cmd_create(pkg, a, log):
         s.update(strategyId=sid, status="creating", error=None)
         save_state(pkg, st)  # ← persist before any polling
 
-    # poll to ACTIVE, bounded by --max-wait (resume on re-run)
-    deadline = time.time() + a.max_wait
-    while True:
-        pending = []
-        for inst in pkg.instances:
-            s = inst_state(st, inst.name)
-            if s.get("status") in ("active", "registered", "live"):
-                continue
-            m = _cli.strategies_for(mcp, strategy_id=s["strategyId"], timeout=POLL_HTTP_TIMEOUT)
-            status = str(_cli.strategy_status(m[0]) if m else "").upper()
-            addr = _cli.strategy_wallet(m[0]) if m else None
-            if status == "ACTIVE" and addr:
-                s.update(wallet=addr, status="active")
-                save_state(pkg, st)
-            else:
-                pending.append(f"{inst.name}={status or '…'}")
-        if not pending:
-            return report(pkg, st, "wallets-ready", note="Next: deploy.py runtime " + pkg.id + _scope_flag(a), as_json=a.json)
-        if time.time() >= deadline:
+        # Fund ONE WALLET AT A TIME. `create` returns at CREATE_WALLET and funding settles
+        # asynchronously afterwards, so submitting the next leg straight away puts two funding
+        # jobs on the SAME embedded wallet concurrently — one reads a balance the other has
+        # already claimed, funds $0, and sticks in PENDING_FUNDING. Waiting here is what makes
+        # the balance check in plan_funding actually mean something.
+        if await_funded(mcp, pkg, st, [inst], deadline, log):
+            # Not settled inside the budget — do NOT submit the next leg, that is the race.
+            # State is saved, so a re-run picks up exactly here.
             return report(pkg, st, "creating",
-                          note="Wallets still funding. Re-run `deploy.py create " + pkg.id + _scope_flag(a) + "` to resume.",
-                          as_json=a.json)
-        log(f"  waiting on {', '.join(pending)}…")
-        time.sleep(POLL_EVERY)
+                          note=("Wallet still funding. Re-run `deploy.py create " + pkg.id + _scope_flag(a) +
+                                "` to resume — wallets are funded one at a time."), as_json=a.json)
+
+    # everything submitted; wait out any leg that was already in flight from a previous run
+    if await_funded(mcp, pkg, st, pkg.instances, deadline, log):
+        return report(pkg, st, "creating",
+                      note="Wallets still funding. Re-run `deploy.py create " + pkg.id + _scope_flag(a) + "` to resume.",
+                      as_json=a.json)
+    return report(pkg, st, "wallets-ready", note="Next: deploy.py runtime " + pkg.id + _scope_flag(a), as_json=a.json)
 
 
 # ---------- step 2: deploy runtimes ----------

--- a/senpi-strategy-ops/tests/test_create_e2e.py
+++ b/senpi-strategy-ops/tests/test_create_e2e.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""End-to-end `cmd_create` against a faked BACKEND — the M415566 incident, replayed.
+
+Everything below the network boundary is real: package state, reconcile, the close sweep, the
+create loop, `await_funded`, `report`. Only `MCPClient` / `_cli` / `close` are stubbed, so these
+assert what the DEPLOY DID (which calls it made, in what order) rather than what a helper returned.
+That distinction is the point — the bug this file guards was never inside a function, it was a
+filter missing at the call site, so a unit test of the helper would have passed on broken code.
+
+No MCP, no openclaw, no network, no sleeping. Run:
+    python3 senpi-strategy-ops/tests/test_create_e2e.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import argparse
+import sys
+import types
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import _cli as real_cli  # noqa: E402 — pure readers (dig) stay REAL, so payload shape is tested too
+import deploy  # noqa: E402
+
+
+class Backend:
+    """The two-leg backend, with the funding outcome per leg scripted by the test.
+
+    `stall` names the instances whose wallet never leaves FUND_WALLET — the losing side of the
+    concurrent-funding race (`total_funded = 0`, parked in PENDING_FUNDING). Everything else goes
+    ACTIVE on its next read, which is what a wallet funded with no sibling competing does.
+    """
+
+    def __init__(self, stall=(), settle_after=1):
+        self.stall = set(stall)
+        self.settle_after = settle_after   # reads a wallet needs before it reports ACTIVE
+        self.rows = {}          # strategyId -> row
+        self.creates = []       # ordered log of (budget, name) submitted
+        self.closed = []        # ordered log of strategyIds handed to close_one
+        self.runtimes = []      # wallets with a RUNNING runtime
+        self.reads = {}         # strategyId -> how many times it has been polled
+        self._n = 0
+
+    # --- the money call ---------------------------------------------------
+    def create(self, initialBudget, strategyName=None, **kw):
+        self._n += 1
+        sid = f"S-{self._n}"
+        # Which leg is this? The wallet name carries it (`elephant-trend`), which is exactly how
+        # `_wallet_name` builds it and how `_recover_wallet` reads it back.
+        leg = (strategyName or "").rsplit("-", 1)[-1]
+        self.creates.append({"budget": initialBudget, "name": strategyName, "id": sid})
+        self.rows[sid] = {"id": sid, "strategyName": strategyName, "skillName": kw.get("skillName"),
+                          "status": "FUND_WALLET", "strategyWalletAddress": "",
+                          "totalFunded": 0, "_leg": leg}
+        return {"strategyId": sid}
+
+    def settle(self, sid):
+        """One read tick: a non-stalled wallet becomes ACTIVE and funded once it has been polled
+        `settle_after` times — real funding takes 8-20s, so a wallet is not ACTIVE on first read."""
+        row = self.rows[sid]
+        self.reads[sid] = self.reads.get(sid, 0) + 1
+        if (row["_leg"] in self.stall or row["status"] != "FUND_WALLET"
+                or self.reads[sid] < self.settle_after):
+            return row
+        row["status"] = "ACTIVE"
+        row["strategyWalletAddress"] = "0xw" + sid[-1]
+        row["totalFunded"] = self.creates[int(sid[-1]) - 1]["budget"]
+        return row
+
+    def adopt(self, sid, wallet="0xORPHAN"):
+        """Plant a wallet as if a PREVIOUS, unrecorded run had created it."""
+        self.rows[sid] = {"id": sid, "strategyName": "elephant-trend", "skillName": "elephant",
+                          "status": "ACTIVE", "strategyWalletAddress": wallet, "totalFunded": 100,
+                          "_leg": "trend"}
+
+
+class FakeMCP:
+    def __init__(self, backend, available=1000.0):
+        self.backend, self.available = backend, available
+
+    def mcp_call(self, tool, timeout=None, **kw):
+        if tool == "account_get_portfolio":
+            return {"data": {"portfolio": {"total_in_hyperliquid": self.available,
+                                           "spot_balances": [], "token_balances": []}}}
+        if tool == "strategy_create_custom_strategy":
+            return self.backend.create(**kw)
+        raise AssertionError(f"unexpected MCP call: {tool}")
+
+
+class FakeCli:
+    """Only the surface `cmd_create` touches. Reads SETTLE a wallet, mirroring a real poll."""
+
+    # The payload readers stay REAL — `available_usd` walks the portfolio shape with these, so
+    # faking them would stop this test from exercising the balance read at all.
+    dig = staticmethod(real_cli.dig)
+
+    def __init__(self, backend):
+        self.b = backend
+
+    def strategies_for(self, mcp, skill_name=None, strategy_id=None, wallet=None,
+                       timeout=15, statuses=None):
+        if strategy_id:
+            return [self.b.settle(strategy_id)] if strategy_id in self.b.rows else []
+        rows = [self.b.settle(s) for s in list(self.b.rows)]
+        if skill_name:
+            rows = [r for r in rows if r.get("skillName") == skill_name]
+        if statuses:
+            rows = [r for r in rows if r["status"] in statuses]
+        return rows
+
+    strategies_for_or_none = strategies_for
+
+    def list_runtimes(self):
+        return list(self.b.runtimes)
+
+    def find_runtime_by_wallet(self, wallet):
+        return {"wallet": wallet} if wallet in self.b.runtimes else None
+
+    @staticmethod
+    def runtime_running(rt):
+        return bool(rt)
+
+    @staticmethod
+    def strategy_id_of(s):
+        return s.get("strategyId") or s.get("id")
+
+    @staticmethod
+    def strategy_status(s):
+        return s["status"]
+
+    @staticmethod
+    def strategy_wallet(s):
+        return s["strategyWalletAddress"] or None
+
+    @staticmethod
+    def strategy_name(s):
+        return s.get("strategyName")
+
+    @staticmethod
+    def strategy_open(s):
+        return s["status"] not in ("CLOSED", "FAILED", "INACTIVE", "TERMINATED", "CLOSING_DONE")
+
+
+def _inst(name, share):
+    return types.SimpleNamespace(name=name, funding_share=share, runtime_name=f"elephant-{name}")
+
+
+class CreateE2E(unittest.TestCase):
+    """`elephant`: trend 0.6 / fade 0.4 — the package from the incident."""
+
+    def setUp(self):
+        self.pkg = types.SimpleNamespace(id="elephant", version="1.0.0", dir=Path("/nonexistent"),
+                                         instances=[_inst("trend", 0.6), _inst("fade", 0.4)])
+        self.state = {"instances": {}}
+        self._orig = (deploy._cli, deploy.MCPClient, deploy.load_state, deploy.save_state,
+                      deploy.strategy_min, deploy.POLL_EVERY, sys.modules.get("close"))
+        deploy.load_state = lambda pkg: self.state
+        deploy.save_state = lambda pkg, st: None
+        deploy.strategy_min = lambda pkg: {"min_budget": 20.0, "wallet_count": 2,
+                                           "binding_wallet": "trend"}
+        deploy.POLL_EVERY = 0
+
+    def tearDown(self):
+        (deploy._cli, deploy.MCPClient, deploy.load_state, deploy.save_state,
+         deploy.strategy_min, deploy.POLL_EVERY, _close) = self._orig
+        if _close is None:
+            sys.modules.pop("close", None)
+        else:
+            sys.modules["close"] = _close
+
+    def run_create(self, backend, max_wait=60):
+        deploy._cli = FakeCli(backend)
+        deploy.MCPClient = lambda: FakeMCP(backend)
+        fake_close = types.ModuleType("close")
+        fake_close.close_one = lambda pkg_id, s, runtimes, force, log: (
+            backend.closed.append(FakeCli.strategy_id_of(s)) or {"status": "closed"})
+        sys.modules["close"] = fake_close
+        a = argparse.Namespace(budget=100.0, max_wait=max_wait, json=False,
+                               dry_run=False, instance=None)
+        return deploy.cmd_create(self.pkg, a, lambda m: None)
+
+    # --- commit 1: one wallet at a time -----------------------------------
+
+    def test_second_leg_is_not_submitted_until_the_first_is_active(self):
+        b = Backend(stall=["trend"])          # the incident: the LARGER leg loses the race
+        out = self.run_create(b, max_wait=0)  # budget lapses immediately
+        self.assertEqual(out["status"], "creating")
+        # THE assertion. Pre-fix, both legs were submitted back-to-back before any polling — which
+        # is what put two funding jobs on one embedded wallet ~1s apart.
+        self.assertEqual(len(b.creates), 1, f"submitted {len(b.creates)} legs, expected 1")
+        self.assertEqual(b.creates[0]["name"], "elephant-trend")
+
+    def test_both_legs_fund_when_neither_stalls(self):
+        b = Backend()
+        out = self.run_create(b)
+        self.assertEqual(out["status"], "wallets-ready")
+        self.assertEqual([c["name"] for c in b.creates], ["elephant-trend", "elephant-fade"])
+        self.assertEqual([c["budget"] for c in b.creates], [60.0, 40.0])  # 0.6 / 0.4 split
+
+    # --- commit 2: a re-run adopts, it does not close ---------------------
+
+    def test_rerun_adopts_its_own_funded_wallet_instead_of_closing_it(self):
+        """The $39. Leg 1 funded, leg 2 never got submitted, the budget lapsed — now re-run."""
+        b = Backend(settle_after=2)         # leg 1 is still funding when the budget lapses
+        first = self.run_create(b, max_wait=0)
+        self.assertEqual(first["status"], "creating")
+        funded = b.creates[0]["id"]
+
+        second = self.run_create(b)           # same state, same backend — the agent's re-run
+        self.assertEqual(b.closed, [], f"re-run CLOSED {b.closed} — that is the fee burn")
+        self.assertEqual(second["status"], "wallets-ready")
+        self.assertIn(funded, [c["id"] for c in b.creates])   # adopted, not replaced
+        self.assertEqual(len(b.creates), 2, "a third wallet was created — the leg was not adopted")
+
+    def test_an_unrecorded_wallet_is_still_closed(self):
+        """The orphan protection this must not weaken."""
+        b = Backend()
+        b.adopt("S-orphan")
+        out = self.run_create(b)
+        self.assertEqual(out["status"], "closing-existing")
+        self.assertEqual(b.closed, ["S-orphan"])
+        self.assertEqual(b.creates, [], "funded a wallet while an orphan was still open")
+
+    def test_a_live_running_strategy_still_refuses(self):
+        b = Backend()
+        b.adopt("S-live", wallet="0xLIVE")
+        b.runtimes.append("0xLIVE")
+        with self.assertRaises(SystemExit) as cm:
+            self.run_create(b)
+        self.assertIn("already deployed AND running", str(cm.exception))
+        self.assertEqual(b.closed, [], "closed a LIVE strategy")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/senpi-strategy-ops/tests/test_orphan_close.py
+++ b/senpi-strategy-ops/tests/test_orphan_close.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Hermetic tests for the close sweep's orphan filter — `create` must never close its OWN wallet.
+
+The close sweep exists to clear the runtime-less trap (a funded wallet from an abandoned run that a
+re-run would otherwise land on forever). It must not fire on a wallet this deploy created and is
+still working on: closing a funded sleeve to recover from its sibling's failure is what turns one
+failed multi-leg deploy into an unbounded create → close → recreate churn at ~$1/wallet.
+
+No MCP, no openclaw, no network. Run:
+    python3 senpi-strategy-ops/tests/test_orphan_close.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import types
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import deploy  # noqa: E402
+
+
+def _row(sid, status="ACTIVE"):
+    return {"id": sid, "status": status, "strategyWalletAddress": "0x" + sid}
+
+
+def _pkg(*names):
+    return types.SimpleNamespace(id="elephant", version="1.0.0",
+                                 instances=[types.SimpleNamespace(name=n) for n in names])
+
+
+class RecordedStrategyIds(unittest.TestCase):
+    def test_collects_every_recorded_leg(self):
+        st = {"instances": {"trend": {"strategyId": "S-trend"}, "fade": {"strategyId": "S-fade"}}}
+        self.assertEqual(deploy.recorded_strategy_ids(_pkg("trend", "fade"), st), {"S-trend", "S-fade"})
+
+    def test_a_leg_with_no_id_yet_contributes_nothing(self):
+        st = {"instances": {"trend": {"strategyId": "S-trend"}, "fade": {"status": "pending"}}}
+        self.assertEqual(deploy.recorded_strategy_ids(_pkg("trend", "fade"), st), {"S-trend"})
+
+    def test_absent_instances_do_not_raise(self):
+        self.assertEqual(deploy.recorded_strategy_ids(_pkg("trend", "fade"), {"instances": {}}), set())
+
+
+class OrphanStrategies(unittest.TestCase):
+    """The regression this filter exists for: M415566's 38 churned wallets."""
+
+    def test_our_own_wallets_are_never_orphans(self):
+        # The incident shape: `fade` funded and went ACTIVE, `trend` stalled in PENDING_FUNDING.
+        # Neither has a runtime yet. Both are OURS, so the sweep must touch neither — closing the
+        # funded `fade` to recover from `trend` is the $1/cycle burn.
+        rows = [_row("S-fade", "ACTIVE"), _row("S-trend", "PENDING_FUNDING")]
+        self.assertEqual(deploy.orphan_strategies(rows, {"S-fade", "S-trend"}), [])
+
+    def test_a_wallet_we_never_recorded_is_an_orphan(self):
+        rows = [_row("S-fade"), _row("S-stale")]
+        self.assertEqual(deploy.orphan_strategies(rows, {"S-fade"}), [_row("S-stale")])
+
+    def test_no_recorded_ids_means_every_open_wallet_is_an_orphan(self):
+        # A fresh deploy with a deleted/empty state file keeps the original protection in full.
+        rows = [_row("S-a"), _row("S-b")]
+        self.assertEqual(deploy.orphan_strategies(rows, set()), rows)
+
+    def test_an_unreadable_id_stays_an_orphan(self):
+        # Fail-CLOSED: a wallet we cannot identify must still block funding a fresh one beside it.
+        rows = [{"status": "ACTIVE", "strategyWalletAddress": "0xabc"}]
+        self.assertEqual(deploy.orphan_strategies(rows, {"S-fade"}), rows)
+
+    def test_nothing_open_closes_nothing(self):
+        self.assertEqual(deploy.orphan_strategies([], {"S-fade"}), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/senpi-strategy-ops/tests/test_sequential_funding.py
+++ b/senpi-strategy-ops/tests/test_sequential_funding.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Hermetic tests for one-wallet-at-a-time funding + the SERR083 name-collision fallback.
+
+No MCP, no openclaw, no network, no sleeping. Run:
+    python3 senpi-strategy-ops/tests/test_sequential_funding.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import sys
+import time
+import types
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import deploy  # noqa: E402
+
+
+class IsNameRejection(unittest.TestCase):
+    """SERR083 must route to the unnamed retry — that is the whole unblock."""
+
+    def test_serr083_is_a_name_rejection(self):
+        # Real payload: "tool failed: SERR083: Custom strategy creation failed unexpectedly.
+        # Retry with the same payload." — generic text, no "name" anywhere in it.
+        err = deploy.MCPError("tool failed: SERR083: Custom strategy creation failed "
+                              "unexpectedly. Retry with the same payload.")
+        self.assertTrue(deploy.is_name_rejection(err))
+
+    def test_existing_name_codes_still_route(self):
+        for code in ("SERR055", "SERR056", "SERR058"):
+            self.assertTrue(deploy.is_name_rejection(deploy.MCPError(f"tool failed: {code}: nope")))
+
+    def test_word_name_still_routes(self):
+        self.assertTrue(deploy.is_name_rejection(deploy.MCPError("strategyName is invalid")))
+
+    def test_unrelated_errors_do_not_route(self):
+        # These must stay hard failures — retrying them unnamed would mask a real problem.
+        for msg in ("tool failed: SERR037: Insufficient USDC balance",
+                    "tool failed: SERR045: not in a state to be topped up",
+                    "HTTP 503"):
+            self.assertFalse(deploy.is_name_rejection(deploy.MCPError(msg)), msg)
+
+
+class _Inst:
+    def __init__(self, name):
+        self.name = name
+
+
+class _StubCli:
+    """Stands in for _cli: each strategy reports NOT-ACTIVE once, then ACTIVE."""
+
+    def __init__(self):
+        self.polls = {}
+
+    def strategies_for(self, mcp, strategy_id=None, timeout=None):
+        n = self.polls.get(strategy_id, 0) + 1
+        self.polls[strategy_id] = n
+        return [{"id": strategy_id, "status": "ACTIVE" if n >= 2 else "FUND_WALLET",
+                 "strategyWalletAddress": "0xabc" if n >= 2 else ""}]
+
+    @staticmethod
+    def strategy_status(row):
+        return row["status"]
+
+    @staticmethod
+    def strategy_wallet(row):
+        return row["strategyWalletAddress"] or None
+
+
+class AwaitFunded(unittest.TestCase):
+    def setUp(self):
+        self.pkg = types.SimpleNamespace(id="vanguard", version="2.1.0",
+                                         instances=[_Inst("long"), _Inst("short")])
+        self.st = {"instances": {"long": {"strategyId": "S-long", "status": "creating"},
+                                 "short": {"strategyId": "S-short", "status": "creating"}}}
+        self._orig = (deploy._cli, deploy.save_state, deploy.POLL_EVERY)
+        self.cli = _StubCli()
+        deploy._cli = self.cli
+        deploy.save_state = lambda pkg, st: None
+        deploy.POLL_EVERY = 0  # no real sleeping
+
+    def tearDown(self):
+        (deploy._cli, deploy.save_state, deploy.POLL_EVERY) = self._orig
+
+    def test_polls_until_active_and_records_wallet(self):
+        pending = deploy.await_funded(None, self.pkg, self.st, [self.pkg.instances[0]],
+                                      deadline=time.time() + 60)
+        self.assertEqual(pending, [])
+        self.assertEqual(self.st["instances"]["long"]["status"], "active")
+        self.assertEqual(self.st["instances"]["long"]["wallet"], "0xabc")
+
+    def test_scoped_to_the_given_leg_only(self):
+        # Waiting on `long` must not poll — or settle — `short`.
+        deploy.await_funded(None, self.pkg, self.st, [self.pkg.instances[0]],
+                            deadline=time.time() + 60)
+        self.assertNotIn("S-short", self.cli.polls)
+        self.assertEqual(self.st["instances"]["short"]["status"], "creating")
+
+    def test_expired_deadline_returns_pending_instead_of_looping(self):
+        pending = deploy.await_funded(None, self.pkg, self.st, self.pkg.instances,
+                                      deadline=time.time() - 1)
+        self.assertEqual(sorted(pending), ["long=FUND_WALLET", "short=FUND_WALLET"])
+
+    def test_already_active_leg_is_not_repolled(self):
+        self.st["instances"]["long"]["status"] = "active"
+        deploy.await_funded(None, self.pkg, self.st, [self.pkg.instances[0]],
+                            deadline=time.time() + 60)
+        self.assertEqual(self.cli.polls, {})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Unblocks `elephant` / `cougar` / any multi-leg package. **Supersedes #525** (rebased onto current `main` as commit 1) and adds the fix that stops the money burning.

Reported: [Slack thread](https://senpiai.slack.com/archives/C06MA8GUHRS/p1786013450373869) · incidents M409759 (08-04), M409650 (08-05, ×2), M415566 (08-09→10).

Independent of the deploy-verb convergence (#526) — both commits are deleted for free when that lands. This is what unblocks users in the meantime.

## 1. Fund one wallet at a time (@danielmbirochi's #525, rebased)

`strategy_create_custom_strategy` returns at `CREATE_WALLET` and funds **asynchronously**, so submitting every leg back-to-back put two funding jobs on the same embedded wallet ~1s apart. One wins; the other reads a balance already claimed, funds **$0.00**, and parks in `PENDING_FUNDING` — which then holds its `strategyName` for ~15 min, so every retry returns `SERR083` ("retry with the same payload", advice that can never work).

Each leg now polls to ACTIVE before the next is submitted, under **one shared** `--max-wait` (a per-leg budget would let an N-wallet package run N × max_wait past the tool timeout). `SERR083` joins the name-rejection set and retries unnamed.

Waiting is also what makes the existing `plan_funding` balance check mean anything: by the time leg 2 is submitted, leg 1's debit has actually landed.

Rebase note: one conflict, `main`'s `_scope_flag(a)` additions to the resume hints vs #525's restructure of the same block. Kept #525's structure with the scope flags threaded through all three notes.

## 2. `create` adopts the wallets it made — only orphans are closed

The close sweep took every open `skillName==<id>` strategy with no running runtime, and was **never filtered against the state file's own recorded ids**. So a re-run closed the wallets this same deploy had just funded.

This — not the race — is what burned the money in M415566, and it needs no race at all, only a package that takes two calls to finish: leg 1 goes ACTIVE, leg 2 is still settling when the shared `--max-wait` lapses, the run exits `creating` telling the agent to re-run, and the re-run closes both. Funding costs a flat ~$1 that close does not return, so each cycle is pure loss landing back in the same state. **38 wallets and $39 over 2.75h**, until the accumulated fees made the user's own $288 budget unaffordable (`E_FUNDS_SHORT` on attempt 24).

The sweep now closes **orphans only** — an open, runtime-less strategy the state file has never recorded (abandoned run, raw-MCP create, deleted state file).

| situation | before | after |
|---|---|---|
| our wallet, ACTIVE, no runtime yet | closed + recreated | adopted → `wallets-ready`, next `runtime` |
| our leg still settling | closed | left alone; recreated only if reconcile discarded it |
| unrecorded runtime-less wallet | closed | closed (unchanged) |
| unreadable `strategyId` | closed | closed — `None not in recorded_ids` keeps it fail-closed |
| running runtime | refuses | refuses (unchanged — the `live` guard reads unfiltered `existing_open`) |

`recorded_strategy_ids` is read *before* reconcile, since reconcile drops non-ACTIVE ids and a leg stuck in `PENDING_FUNDING` is both ours and not-ACTIVE. The branch's state-reset loop is dropped: it wiped every instance's recorded id, which is wrong once we only close wallets that were never in state.

The file header already promised these semantics — *"Refuses if it finds skillName==\<id\> strategies not in the state file"* — the state-file half was never implemented. Header updated to describe what the code now does.

## 3. `senpi-strategy-ops` 2.16.0 -> 2.16.1, docs follow the code

Patch bump so deployed agents pick up the fix — patch rather than minor because this fixes a defect and adds no capability (no new subcommand, flag, or output status).

`SKILL.md` carried a rule commit 2 makes false: *"`create` never reuses an existing wallet — every deploy gets a FRESH one."* It now reuses exactly one class of wallet — its own — which is the point. Left standing, an agent reading it would treat an adopted `wallets-ready` as a bug and reach for `close.py`.

`SKILL.md` and `references/lifecycle.md` now both state the sequencing (one wallet at a time under one shared `--max-wait`, and why) and the adoption rule (a re-run adopts what it created; only a runtime-less strategy this deploy never created is closed). The `closing-existing` triage line says whose wallet it is closing.

## Testing

`senpi-strategy-ops` pytest **176 passed**. New `test_orphan_close.py` (8 cases) reconstructs M415566's shape directly — `fade` ACTIVE, `trend` `PENDING_FUNDING`, neither with a runtime, both recorded → sweep touches neither — plus the fail-closed cases (empty state, unreadable id) proving the orphan protection survived. `test_sequential_funding.py` comes from #525 unchanged.

(`python3 -m pytest` from the repo root dies during collection on `strategies/chimp/tests/test_package_shape.py`'s module-level `sys.exit`. Reproduces on unmodified `main` — pre-existing, unrelated.)

## Still not fixed — backend

Both commits are client-side mitigations. Any other concurrent caller (app UI, direct MCP, a second agent session) can still trigger the race, and #526's verb has the same limitation — it serializes its own legs, not everyone's. The durable fix is server-side per-source-wallet serialization, or reserving the balance synchronously at create and settling async. Per @vigneshwaran in the thread, `feat/topup-idempotency` does not touch the launch funding path.

Also unaddressed here: `SERR121` reporting a balance that isn't real, `PENDING_FUNDING` being unclosable for ~15 min, and `SERR045`'s "completes on its own" wording (it expires to `FAILED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJHsbsoc7zNiQzJBtm25Ke

