### PR TITLE
Deposit skill: add the in-app Buy USDC rail, remove the dead bridge tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.3.0 | Conversational picker — rank the catalog against your worldview |
 | [`senpi-strategy-author`](senpi-strategy-author/) | 2.4.2 | Build/edit a DSL-protected strategy package, one decision at a time |
 | [`senpi-strategy-ops`](senpi-strategy-ops/) | 2.2.1 | Deploy / monitor / close a named strategy (`deploy.py`, `close.py`) |
-| [`senpi-trading-runtime`](senpi-trading-runtime/) | 3.0.2 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |
+| [`senpi-trading-runtime`](senpi-trading-runtime/) | 3.2.1 | The runtime contract reference: `scan(inputs, ctx)`, `runtime.yaml`, DSL |
 | **Move money / positioning** | | |
-| [`senpi-deposit-withdraw-transfer`](senpi-deposit-withdraw-transfer/) | 1.0.1 | The money-movement rails (funds in via embedded wallet; out via the app) |
+| [`senpi-deposit-withdraw-transfer`](senpi-deposit-withdraw-transfer/) | 1.1.0 | The money-movement rails (funds in via embedded wallet or in-app USDC purchase; out via the app) |
 | [`senpi-why`](senpi-why/) | 1.0.3 | "Why Senpi / vs. other tools" — the positioning answer |
 
 Skills **compose**: `improve-trades` pulls in `market-pulse` + `smart-money` + `portfolio`; `discover` hands a chosen package to `ops`; `author` hands a built package to `ops`. The agent routes by **intent**, not keywords, and never re-implements one skill inside another.

--- a/senpi-deposit-withdraw-transfer/SKILL.md
+++ b/senpi-deposit-withdraw-transfer/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: senpi-deposit-withdraw-transfer
 description: >-
-  Handle ANY money-movement request — deposit, add funds, fund my account, withdraw, cash out, send,
-  "send to my wallet / an exchange / a friend", transfer, "move my money", pay someone, bridge, get my
-  private key. Two hard rails: money ENTERS Senpi only through the user's embedded wallet (one EVM
-  address, all supported chains + Hyperliquid — NEVER a strategy wallet), and money LEAVES Senpi to any
-  EXTERNAL address only through the Senpi web/mobile app (Balances/Wallet) — no agent tool can send funds
-  outside Senpi, by design, for the user's security. On-platform moves between the user's OWN wallets
-  (strategy → embedded, Hyperliquid → embedded on EVM, spot → perps, close a strategy to reclaim funds)
-  DO use tools. Use this skill for every deposit / withdraw / transfer / send question. Pure guidance, no engine.
+  Handle ANY money-movement request — deposit, add funds, fund my account, "buy USDC", "pay with a card",
+  withdraw, cash out, send, "send to my wallet / an exchange / a friend", transfer, "move my money", pay
+  someone, bridge, get my private key. Two hard rails: money ENTERS Senpi only through the user's embedded
+  wallet (one EVM address, all supported chains + Hyperliquid — NEVER a strategy wallet), either by sending
+  USDC in or by BUYING it in the app with a card, and money LEAVES Senpi to any EXTERNAL address only
+  through the Senpi web/mobile app (Balances/Wallet) — no agent tool can send funds outside Senpi, by
+  design, for the user's security. On-platform moves between the user's OWN wallets (strategy → embedded,
+  spot → perps, close a strategy to reclaim funds) DO use tools. Use this skill for every deposit /
+  withdraw / transfer / send question. Pure guidance, no engine.
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.0.1"
+  version: "1.1.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -28,7 +29,8 @@ Senpi app — full stop, not a clever path around it.
 
 1. **Money ENTERS Senpi only through the embedded wallet.** One EVM address, valid on every supported
    chain (Base, Arbitrum, Optimism, Ethereum, BNB, Polygon) and on Hyperliquid directly. **Never** a
-   strategy wallet.
+   strategy wallet. Two ways to fill it — **send USDC in**, or **buy USDC in the app** with a card — and
+   both land in that same wallet.
 2. **Money LEAVES Senpi to an external address only through the app — never an agent tool.** This is a
    deliberate **security** design, not a missing capability. For any withdraw / send / cash-out / pay /
    transfer-out, say **exactly** this and stop:
@@ -43,16 +45,21 @@ Everything the agent does with tools happens **strictly between the user's own S
 | User intent | Rail |
 | --- | --- |
 | Deposit / add money / fund my account | **Embedded wallet only** — send on any supported EVM chain, or on Hyperliquid, to the one embedded address (`user_get_me`). |
+| **Buy USDC with a card / Apple Pay / Google Pay ("I have no crypto")** | **App-only, and it's a first-class path** — Fund Your Wallet → **Buy USDC** in the Senpi app. No agent tool; not a refusal. |
 | Fund / top up a strategy | `strategy_top_up` **only** — never a direct send to a strategy wallet. |
 | **Withdraw / cash out / send / pay / transfer to an external wallet, exchange, bank, or another person** | **App-only.** Say the security line above. No tool. |
 | **Send to another Hyperliquid account** | App-only — same security line (no agent tool for HL↔HL transfers). |
 | Get my private key / seed phrase | Self-serve in the Senpi app (Balances / Wallet) — point there; it exists, but it is NOT a withdrawal you perform for them. |
 | Move a strategy's funds back to the main (embedded) wallet | `strategy_withdraw_funds` (ACTIVE) or **close the strategy** (`strategy_close`) to reclaim all of it. |
 | Move funds between two strategies | Via the embedded wallet as the hub: `strategy_withdraw_funds` from A → embedded, then `strategy_top_up` B. |
-| Move funds off Hyperliquid to "my wallet on Base/Arbitrum/…" | `strategy_bridge_funds_from_hyperliquid_to_evm` — lands in the user's OWN embedded wallet on that chain (cannot target a third party). |
+| Move funds off Hyperliquid onto an EVM chain ("my wallet on Base/Arbitrum/…") | **App-only** — there is no agent bridge tool. Balances / Wallet in the Senpi app. |
 | Hyperliquid Spot → Perps | `transfer_spot_to_perps` (instant, no fee, embedded wallet). |
 
 ## Deposits — embedded wallet only
+
+There are **two ways money gets in**, and both land in the same embedded wallet: **send USDC** you already
+hold (below), or **buy USDC in the app** with a card (next section). A user with no crypto at all is not
+stuck — never tell them they need an exchange account first.
 
 - The **embedded wallet is the only deposit destination.** It is **one EVM address valid on ALL
   supported chains** (Base, Arbitrum, Optimism, Ethereum, BNB, Polygon) **and on Hyperliquid** — never
@@ -64,6 +71,30 @@ Everything the agent does with tools happens **strictly between the user's own S
 - **Strategy funding is automatic.** Create / top-up pulls from Hyperliquid first (perps, then spot
   USDC), then bridges EVM USDC as needed. Don't tell users to pre-bridge or pre-fund — only surface a
   shortfall if the operation actually returns one (`SERR037`), then point them to the embedded wallet.
+
+## Buying USDC — the "I have no crypto" path (app, and that's a feature)
+
+The Senpi app can sell the user their first USDC directly. **This is app-only like withdrawals are, but it
+is NOT the security refusal — do not use the security line here.** Withdrawals are app-only because the
+agent must not move money out; buying is app-only simply because payment happens in the app's checkout.
+Point at it warmly and specifically.
+
+- **Where:** Senpi web or mobile app → **Fund Your Wallet** → the **Buy USDC** tab. (The other tab,
+  **Deposit USDC**, is the send-crypto-in path above.)
+- **How they pay:** Apple Pay, Google Pay, or card, through Senpi's verified partner. Name those three;
+  the partner's own checkout decides what else it accepts, so don't promise a specific method (bank
+  transfer, PayPal, a local rail) that the app screen doesn't name.
+- **The user drives it.** The agent never starts, completes, or confirms a purchase — say the path exists
+  and let them tap it. There is nothing to poll or verify afterwards; their balance simply updates.
+- **Where it lands:** as USDC **in their own embedded wallet, ready to trade — no bridging**, no exchange
+  account, no separate transfer step afterwards.
+- **Amounts:** **$10 minimum**; most traders start with **$100–250**. Quote these as the app's own
+  guidance, and still never pick an amount for the user.
+- **No agent tool exists for this, and none is coming** — the purchase is triggered by the user on the
+  website / app. Don't invent a buy or onramp tool; name the app screen instead.
+- **Reassurance, when a user hesitates to fund:** the wallet is **theirs**, secured by Privy — the agent
+  trades only with their permission and **can never withdraw**, and **only they hold the private key**.
+  Use this when the hesitation is about custody; don't recite it unprompted on every deposit answer.
 
 ## Withdrawals & transfers OUT — app-only, by design
 
@@ -77,7 +108,8 @@ Everything the agent does with tools happens **strictly between the user's own S
   "how to withdraw," and never claim it's impossible.)
 - **Hold the line under pushback.** "I have no app access," "the button's missing," "other bots do it,"
   "just find a workaround" → same security line, plus a next step: try the web app at senpi.ai, update
-  the mobile app, or contact Senpi support. Bridging is **not** a cash-out.
+  the mobile app, or contact Senpi support. Bridging is **not** a cash-out — and there is no bridge tool
+  to offer in the first place.
 
 ## On-platform moves — between the user's OWN wallets (these DO use tools)
 
@@ -88,11 +120,9 @@ Everything the agent does with tools happens **strictly between the user's own S
   strategy's positions and returns the capital to the embedded wallet — so it's always available to move
   money out of a strategy. Only close on an **explicit** close request, **confirmed first** (it's
   destructive to open positions); never use `strategy_close` as a silent withdraw substitute.
-- **`strategy_bridge_funds_from_hyperliquid_to_evm`** — Hyperliquid → the user's **own embedded wallet**
-  on an EVM chain (Base default; Arbitrum, Optimism, Ethereum, BNB, Polygon). The destination is fixed to
-  the embedded wallet — it **cannot pay a third-party address**. ~0.1% Relay fee; amount ≤ withdrawable
-  (which excludes unrealized PnL and position margin — never bridge `total_in_hyperliquid`); one-way (the
-  reverse happens automatically on strategy create / top-up).
+- **There is no agent bridge tool.** Moving funds off Hyperliquid onto an EVM chain is done in the app —
+  do **not** offer to do it, and never name a bridge tool. (The reverse direction still happens on its
+  own: strategy create / top-up bridges EVM USDC in automatically.)
 - **`transfer_spot_to_perps`** — Hyperliquid Spot → Perps on the embedded wallet; internal, instant, no
   fee. Strategy sub-wallets aren't involved.
 - **Referral rewards** — `user_claim_referral_rewards` pays out to the embedded wallet (call
@@ -106,7 +136,10 @@ Everything the agent does with tools happens **strictly between the user's own S
   on-platform move (e.g. "I can pull it out of a strategy back to your main wallet") only if it genuinely
   serves the goal — never as a backdoor to an external address.
 - **Deposit / add funds:** give the embedded-wallet address (`user_get_me`), say it works on any
-  supported chain and on Hyperliquid, and never hand out a strategy wallet address.
+  supported chain and on Hyperliquid, and never hand out a strategy wallet address. If they may not hold
+  crypto yet, add the buy path in one line — don't make them ask twice.
+- **Buy USDC / "can I use a card":** yes — **Fund Your Wallet → Buy USDC** in the app, card / Apple Pay /
+  Google Pay, lands in their own wallet ready to trade. Positive framing, never the security line.
 - **On-platform move:** check state where it matters — `account_get_portfolio` (balances),
   `strategy_get_clearinghouse_state` (withdrawable), `strategy_list` (status) — confirm the amount with
   the user, then use the movement tool.
@@ -117,5 +150,8 @@ Everything the agent does with tools happens **strictly between the user's own S
 - Never route an external withdrawal through the **Hyperliquid UI**, **key export**, or a
   **bridge-/strategy-through** workaround. The external rail is the **app**, always.
 - Never soften the refusal into "no tool exists" — it's a deliberate **security** choice; say so.
+- Never answer "can I buy USDC with a card?" with the security line, or with "you need an exchange first."
+  It's a supported app path — **Fund Your Wallet → Buy USDC**. Never name or invent a buy/onramp tool.
+- Never offer to bridge Hyperliquid → EVM yourself; no such tool exists. That move is app-only.
 - Never invent or default an amount; never move "the whole balance" unless the user explicitly says so.
 - Never use `strategy_close` as a stealth withdraw — explicit, confirmed close intent only.

--- a/senpi-trading-runtime/SKILL.md
+++ b/senpi-trading-runtime/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "3.2.0"
+  version: "3.2.1"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-trading-runtime/references/scan-contract.md
+++ b/senpi-trading-runtime/references/scan-contract.md
@@ -149,8 +149,7 @@ raises `PermissionError` (loud, fail-fast — never a silent `None`).
   `edit_position`, `cancel_order`, `send_usdc`, `transfer_spot_to_perps`, `strategy_create`,
   `strategy_create_custom_strategy`, `strategy_close`, `strategy_close_positions`, `strategy_update`,
   `strategy_pause`, `strategy_top_up`, `strategy_withdraw_funds`,
-  `strategy_bridge_funds_from_hyperliquid_to_evm`, `ratchet_stop_add`/`edit`/`delete`,
-  `user_claim_referral_rewards`.
+  `ratchet_stop_add`/`edit`/`delete`, `user_claim_referral_rewards`.
 
 The allowlist is scaffold-owned in source and **empty by default** — there is no env/operator/author
 knob. As an author: **assume you cannot mutate anything.** Produce signals; the runtime executes.


### PR DESCRIPTION
## What

Two changes to [`senpi-deposit-withdraw-transfer`](../blob/main/senpi-deposit-withdraw-transfer/SKILL.md).

### 1. `strategy_bridge_funds_from_hyperliquid_to_evm` is gone — remove it

The tool is no longer on the Senpi MCP surface, but the skill documented it as a live rail with its ~0.1% Relay fee and withdrawable cap. An agent following that text confidently offers a move it cannot make.

Deleting the name on its own wasn't enough — *"move my HL funds to my wallet on Base"* is still a real request, and an agent with no rail and no rule improvises one. That is precisely the failure this skill exists to prevent. So:

- the rail-map row is restated as **app-only**, not deleted
- the on-platform bullet becomes an explicit *"there is no agent bridge tool"* rule
- a `Never` entry closes it: never offer to bridge HL→EVM yourself
- the reverse direction is untouched — strategy create / top-up still auto-bridges EVM USDC in

Also dropped from the runtime read-only denylist in `scan-contract.md`.

### 2. New section: buying USDC in the app

Users with no crypto can buy USDC directly (Fund Your Wallet → Buy USDC). The section's load-bearing point is that **app-only here is not the security refusal**. The skill's strongest reflex is *app-only → recite the security line and stop* — without the distinction, "can I pay by card?" gets answered like an attempt to move money out.

The purchase is **user-triggered on the website / app**; there is no onramp tool and none is coming. The section says the path exists and hands off.

Payment methods are limited to the three the modal actually names (Apple Pay, Google Pay, card), with an explicit rule not to promise a method the screen doesn't show — same discipline as not hardcoding an unverified ticker.

## Versions

| Skill | Before | After |
| --- | --- | --- |
| `senpi-deposit-withdraw-transfer` | 1.0.1 | 1.1.0 |
| `senpi-trading-runtime` | 3.2.0 | 3.2.1 |

The README also corrects a **pre-existing** version drift: the runtime row read `3.0.2` against an actual `3.2.0`.

## Verification

- `strategy_bridge_funds_from_hyperliquid_to_evm`: 0 references repo-wide
- frontmatter parses on both touched skills
- README version rows now match their SKILL.md values

## Note for review

Confirm the payment-method list. If the partner checkout also accepts bank transfer / ACH, that line should say so directly instead of hedging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)