### PR TITLE
fix(condor,piranha): unreachable entry gates blocked 100% of signals

### DIFF
--- a/senpi-strategy-discover/catalog.json
+++ b/senpi-strategy-discover/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-08-12",
+  "_updated": "2026-08-13",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the machine-COMPUTED minimum total budget at which the design functions (min_budget.py) — the smallest budget where every wallet funds and its smallest slot clears the $12 bumped notional; 'wallet_count' + 'min_budget_binding_wallet' explain it. It is NOT authored — deleting an authored min_budget is a no-op; use min_budget_floor to RAISE it. Positions scale with budget above the min. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -849,10 +849,10 @@
       "id": "condor",
       "name": "Condor — One Amazing Trade per Day",
       "emoji": "🦅",
-      "tagline": "Scans the top 50 Hyperliquid crypto assets by volume and fires at most one position at a time — only when 4h, 1h and 15m momentum all align, smart money is >=70% leaning the same way, and the move isn't a runaway counter-trend. Sizes margin to conviction (50/70/80%) at 10x, then rides a wide DSL.",
+      "tagline": "Scans the top 50 Hyperliquid crypto assets by volume and fires at most one position at a time — only when 4h, 1h and 15m momentum all align, the smart-money leaderboard is leaning the same way on a market it is actually concentrated in, and the move isn't a runaway counter-trend. Sizes margin to conviction (50/70/80%) at 10x, then rides a wide DSL.",
       "belief_plain": "Watches every liquid coin on Hyperliquid and waits, doing nothing until ONE setup is near-perfect: the trend, the momentum and the best traders all pointing the same direction at once. Then it takes a single, well-sized swing and trails a stop instead of guessing the top.",
-      "version": "1.0.0",
-      "thesis": "The biggest swings happen when 4h + 1h + 15m momentum are perfectly unified AND the smart-money leaderboard is heavily lopsided (>=70%) in that same direction — a runaway trend's continuation, not a reversal. One amazing trade a day beats a scattergun: scan broadly, fire rarely, size to conviction, and never fight a trend already up >10% on the 4h.",
+      "version": "1.1.0",
+      "thesis": "The biggest swings happen when 4h + 1h + 15m momentum are perfectly unified AND the smart-money leaderboard is leaning that same way on a market it has meaningful skin in — a runaway trend's continuation, not a reversal. One amazing trade a day beats a scattergun: scan broadly, fire rarely, size to conviction, and never fight a trend already up >10% on the 4h.",
       "tags": [
         "momentum",
         "trend-continuation",
@@ -1526,7 +1526,7 @@
       "emoji": "🐟",
       "tagline": "Rides forced flow on crypto majors (BTC/ETH/SOL/HYPE): when open interest is unwinding fast (positions being force-closed) AND price is moving violently AND the 5-minute candle is still pushing the same way, it takes ONE position in the direction of the flow, sized 1-5x, and lets a wide DSL ratchet ride the squeeze with a 24h outer bound.",
       "belief_plain": "A liquidation cascade is the cleanest momentum in crypto — it's forced flow, not opinion. When lots of positions are being force-closed at once, price gets shoved hard in one direction and the move feeds on itself until the leverage is flushed. Piranha reads the order flow underneath price (open-interest velocity + order-book depth) to confirm the move is forced, then rides it: OI down + price up = shorts squeezed, go long; OI down + price down = longs liquidated, go short.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "thesis": "Most agents react to price; the edge is reading the forced flow beneath it. Open interest dropping fast means positions are closing under duress, and when that coincides with a violent move and a thinning book on the side price is running into, there is little resistance left and the cascade continues. That signature is short-horizon and self-resolving, so the right move is one conviction entry in the flow direction, a wide ratchet that lets a squeeze extend, and a 24h hard timeout because if the cascade hasn't paid in a day it's over.",
       "tags": [
         "btc",

--- a/senpi-strategy-ops/tests/test_entry_gate_reachability.py
+++ b/senpi-strategy-ops/tests/test_entry_gate_reachability.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Entry-gate reachability: a hard gate must be satisfiable by real upstream data.
+
+Two silent no-trade bugs found live on M176334 (2026-08-13), where condor ($4,000)
+and piranha ($1,500) each sat ACTIVE and fully funded for 15 days, ~7,000 scanner
+ticks apiece, and never emitted a single signal. Both scanners were healthy — they
+logged `WAITING` every tick and exited clean, which is indistinguishable from a
+selective strategy correctly standing aside, so no error-keyed health check fires.
+
+  condor  — gated `pct_of_top_traders_gain >= 70` under the name "SM consensus".
+            That field is a share of TOTAL top-trader gain spread across every
+            market in the leaderboard response (it sums to ~100 board-wide;
+            observed max 25.6 across 271 markets), NOT a per-market "% of traders
+            leaning this way". No market can reach 70, so the gate blocked 100%
+            of signals. Directional agreement lives in `is_dominant_direction`.
+
+  piranha — read OI velocity from a NESTED `oi_change_pct: {"1h": …}` shape, but
+            `market_get_asset_data` returns FLAT keys (`oi_change_pct_1h`), so the
+            primary source never resolved; and scan.py refreshed the OI cache
+            BEFORE reading the previous value out of it, so the self-computed
+            fallback delta was always exactly 0.00%. Gate 1 (OI unwinding
+            >= 3%/1h) could therefore never pass by either route.
+
+7 of the 11 tests below fail against the pre-fix code. The remaining 4 are
+deliberate controls — a non-dominant market, a quiet tape, the nested oi_velocity
+shape, and the fallback given a genuine previous OI — which must keep passing, so
+that "make it trade again" cannot be satisfied by simply removing the gates.
+
+Run:
+    python3 senpi-strategy-ops/tests/test_entry_gate_reachability.py
+"""
+# Copyright 2026 Senpi (https://senpi.ai) — Apache-2.0
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+STRATEGIES = ROOT / "strategies"
+
+
+def _load(path, name):
+    """Import a scanner module the way the runtime does — with its own directory
+    on sys.path, so the sibling `import scoring` resolves."""
+    path = Path(path)
+    sys.path.insert(0, str(path.parent))
+    try:
+        for stale in ("scoring",):           # sibling modules differ per strategy
+            sys.modules.pop(stale, None)
+        spec = importlib.util.spec_from_file_location(name, path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        sys.path.pop(0)
+
+
+class _Ctx:
+    """Minimal ctx: only `senpi_mcp.call_tool` is exercised by fetch_sm_map."""
+
+    def __init__(self, responses):
+        self._responses = responses
+        outer = self
+
+        class _MCP:
+            def call_tool(self, name, args):        # noqa: ARG002
+                return outer._responses[name]
+
+        self.senpi_mcp = _MCP()
+        self.state = None
+
+
+# ── the REAL leaderboard_get_markets shape (verified against prod 2026-08-13) ──
+# `pct_of_top_traders_gain` is an ATTRIBUTION SHARE across the whole board — the
+# live snapshot summed to 125.2 over 271 markets, max 25.63, median 0.01. Any
+# fixture that puts 70+ on a single market is not reproducible in production and
+# is what let condor's unreachable gate survive review.
+LEADERBOARD_ROWS = [
+    # token   dir      gain%  dominant traders   4h      1h     c15m
+    ("HYPE",  "short", 25.63, True,    212,     -1.01,  -0.81,  6.69),
+    ("ETH",   "short",  8.20, True,    114,      0.26,  -0.02,  7.85),
+    ("CRCL",  "long",   5.68, True,     86,      6.71,   2.32, -0.23),
+    ("BTC",   "long",   5.52, True,    112,     -0.12,   0.05, -6.84),
+    ("LIT",   "short",  5.47, True,     63,     -3.33,  -1.60,  0.94),
+    ("SOL",   "long",   3.60, True,     69,      0.55,   0.14,  2.14),
+    ("XMR",   "short",  1.21, True,     53,     -1.36,  -0.20, -0.31),
+    ("DOGE",  "long",   0.01, True,      8,      2.10,   0.90,  1.50),
+]
+
+
+def _leaderboard():
+    return {"data": {"markets": {"markets": [
+        {"token": t, "dex": "", "direction": d, "pct_of_top_traders_gain": g,
+         "is_dominant_direction": dom, "trader_count": n,
+         "token_price_change_pct_4h": p4, "token_price_change_pct_1h": p1,
+         "contribution_pct_change_15m": c15, "contribution_pct_change_1h": c15}
+        for t, d, g, dom, n, p4, p1, c15 in LEADERBOARD_ROWS
+    ]}}}
+
+
+class CondorGateReachable(unittest.TestCase):
+    """condor's smart-money gate must be satisfiable by real leaderboard data."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.scan = _load(STRATEGIES / "condor/main/scanners/scan.py", "condor_scan")
+        cls.scoring = sys.modules["scoring"] if "scoring" in sys.modules else None
+        cls.sm_map = cls.scan.fetch_sm_map(_Ctx({"leaderboard_get_markets": _leaderboard()}), {})
+
+    def test_gain_share_is_carried_on_its_own_scale(self):
+        """The field is a gain SHARE — mapping it to a 0-100 'consensus' is the bug."""
+        hype = self.sm_map["HYPE"]
+        self.assertIn("gain_share_pct", hype,
+                      "condor must carry pct_of_top_traders_gain as gain_share_pct, "
+                      "not as a 0-100 'consensus_pct'")
+        self.assertAlmostEqual(hype["gain_share_pct"], 25.63, places=2)
+        self.assertTrue(hype["is_dominant"],
+                        "is_dominant_direction must be carried — it is the only field "
+                        "that actually expresses directional agreement")
+
+    def test_board_wide_gain_share_cannot_reach_a_consensus_threshold(self):
+        """Guards the root cause: no single market can carry 70% of board gain."""
+        shares = [m["gain_share_pct"] for m in self.sm_map.values()]
+        self.assertLess(max(shares), 70.0,
+                        "fixture must reflect production: gain share is distributed "
+                        "across the board and never approaches 70")
+
+    def test_at_least_one_candidate_survives_the_full_gate_chain(self):
+        """The whole point: a live-shaped board must produce a scorable setup."""
+        scoring = self.scan.scoring
+        btc = self.sm_map.get("BTC")
+        btc_macro = {"direction": btc["direction"], "p4h": btc["p4h"]} if btc else None
+        hits = []
+        for coin, sm in self.sm_map.items():
+            asset_info = {"coin": coin, "oi_usd": 5_000_000, "volume_24h": 1e8,
+                          "price": 1.0, "funding": 0.0}
+            sig = scoring.evaluate_trend_continuation(asset_info, sm, btc_macro, 17)
+            if sig:
+                hits.append(sig)
+        self.assertGreaterEqual(
+            len(hits), 1,
+            "condor produced ZERO candidates from a production-shaped leaderboard — "
+            "an entry gate is unreachable, so the strategy can never trade")
+        self.assertTrue(any(h["score"] >= scoring.MIN_SCORE for h in hits),
+                        f"no candidate cleared MIN_SCORE={scoring.MIN_SCORE}")
+
+    def test_non_dominant_direction_is_rejected(self):
+        """The replacement gate must still filter — not just pass everything."""
+        scoring = self.scan.scoring
+        sm = dict(self.sm_map["HYPE"])
+        sm["is_dominant"] = False
+        asset_info = {"coin": "HYPE", "oi_usd": 5_000_000, "volume_24h": 1e8,
+                      "price": 1.0, "funding": 0.0}
+        self.assertIsNone(
+            scoring.evaluate_trend_continuation(asset_info, sm, None, 17),
+            "a market where smart money is NOT directionally dominant must be skipped")
+
+    def test_legacy_consensus_input_cannot_re_brick_the_strategy(self):
+        """A stale runtime.yaml still carrying minSmConsensusPct: 70 must be ignored."""
+        scoring = self.scan.scoring
+        asset_info = {"coin": "HYPE", "oi_usd": 5_000_000, "volume_24h": 1e8,
+                      "price": 1.0, "funding": 0.0}
+        sig = scoring.evaluate_trend_continuation(
+            asset_info, self.sm_map["HYPE"], None, 17, {"minSmConsensusPct": 70})
+        self.assertIsNotNone(
+            sig, "the legacy minSmConsensusPct input must NOT be honoured — it was set "
+                 "on the wrong scale and would block every signal again")
+
+
+class PiranhaOiGateReachable(unittest.TestCase):
+    """piranha's OI-unwind gate must resolve from the shape production sends."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.scan = _load(STRATEGIES / "piranha/main/scanners/scan.py", "piranha_scan")
+        cls.scoring = cls.scan.scoring
+
+    @staticmethod
+    def _payload(oi_1h, move_1h_pct, move_5m_pct, nested=False):
+        """market_get_asset_data as prod returns it: oi_velocity with FLAT keys."""
+        base = 1000.0
+        c1h = [{"c": str(base)}, {"c": str(base)},
+               {"c": str(base / (1 + move_1h_pct / 100))}, {"c": str(base)}]
+        c5m = [{"c": str(base)}, {"c": str(base)},
+               {"c": str(base / (1 + move_5m_pct / 100))}, {"c": str(base)}]
+        oiv = ({"oi_change_pct": {"1h": oi_1h}} if nested else
+               {"current_oi": 2.5e9, "oi_change_pct_5m": -0.1, "oi_change_pct_15m": -0.5,
+                "oi_change_pct_1h": oi_1h, "oi_change_pct_4h": -2.0,
+                "oi_trend": "DECLINING", "oi_acceleration": "INCREASING"})
+        return {"data": {"candles": {"1h": c1h, "5m": c5m},
+                         "asset_context": {"openInterest": "39456.03", "markPx": str(base)},
+                         "oi_velocity": oiv,
+                         "l2_book": {"levels": [[{"px": "999", "sz": "10"}],
+                                                [{"px": "1001", "sz": "10"}]]}}}
+
+    def test_flat_oi_velocity_shape_resolves(self):
+        """prod sends oi_change_pct_1h; the nested-only reader silently returned None."""
+        for oi in (1.28, -3.5, -7.0):
+            val, src = self.scoring.oi_velocity_1h(self._payload(oi, -2.5, -0.4), None)
+            self.assertIsNotNone(
+                val, "oi_velocity_1h returned None for the FLAT oi_velocity shape that "
+                     "market_get_asset_data actually sends — gate 1 can never pass")
+            self.assertAlmostEqual(val, oi, places=4)
+            self.assertEqual(src, "oi_velocity")
+
+    def test_nested_oi_velocity_shape_still_resolves(self):
+        """Back-compat: don't break whichever payloads do use the nested shape."""
+        val, src = self.scoring.oi_velocity_1h(self._payload(-7.0, -2.5, -0.4, nested=True), None)
+        self.assertAlmostEqual(val, -7.0, places=4)
+        self.assertEqual(src, "oi_velocity")
+
+    def test_forced_flow_signature_produces_a_thesis(self):
+        thesis = self.scoring.build_thesis(
+            "BTC", self._payload(-7.0, -2.5, -0.4), None, ("SHORT", 60.0), {})
+        self.assertIsNotNone(
+            thesis, "a textbook forced-flow signature (OI -7%/1h, price -2.5%/1h, 5m "
+                    "still falling) produced no thesis — the OI gate is unreachable")
+        self.assertEqual(thesis["direction"], "SHORT")
+        self.assertGreaterEqual(thesis["score"], 5, "below the runtime.yaml minScore floor")
+
+    def test_quiet_market_is_still_rejected(self):
+        """The gate must still gate — a calm tape is not forced flow."""
+        self.assertIsNone(
+            self.scoring.build_thesis("BTC", self._payload(1.28, -0.2, -0.05), None,
+                                      ("SHORT", 60.0), {}),
+            "a quiet market must not be read as a liquidation cascade")
+
+    def test_self_compute_fallback_uses_the_previous_tick(self):
+        """Regression on the cache-ordering bug: prev_oi must differ from current OI.
+
+        scan.py wrote the current OI into oi_cache and then read it straight back
+        as `prev_oi`, so this delta was always exactly 0.00% and never cleared the
+        -3% gate. Here prev_oi is a genuine earlier value.
+        """
+        payload = self._payload(-7.0, -2.5, -0.4)
+        del payload["data"]["oi_velocity"]           # force the fallback path
+        val, src = self.scoring.oi_velocity_1h(payload, 42000.0)
+        self.assertEqual(src, "computed")
+        self.assertLess(val, -3.0,
+                        "fallback delta must be a real change vs the previous tick")
+
+    def test_scan_reads_prev_oi_before_refreshing_the_cache(self):
+        """Source-level guard: the CALL SITE must precede the cache write.
+
+        Matching `_prev_oi(oi_cache` naively also hits the `def _prev_oi(...)`
+        definition further up the file, which would make this pass spuriously —
+        so skip any occurrence that is a definition.
+        """
+        src = (STRATEGIES / "piranha/main/scanners/scan.py").read_text()
+        call_sites = [i for i in range(len(src))
+                      if src.startswith("_prev_oi(oi_cache", i)
+                      and not src[:i].rstrip().endswith("def")]
+        write_at = src.find("oi_cache[cu] = {")
+        self.assertTrue(call_sites, "expected a _prev_oi(oi_cache, …) call site")
+        self.assertNotEqual(write_at, -1, "expected an oi_cache[cu] = {…} refresh")
+        self.assertLess(min(call_sites), write_at,
+                        "scan.py refreshes the OI cache BEFORE reading the previous "
+                        "value out of it — the computed delta will always be 0.00%")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/strategies/catalog.json
+++ b/strategies/catalog.json
@@ -1,6 +1,6 @@
 {
   "_version": "2.1",
-  "_updated": "2026-08-12",
+  "_updated": "2026-08-13",
   "_generated": true,
   "_instructions": "GENERATED from each strategy package's strategy.yaml — do not hand-edit; run senpi-trading-runtime/scripts/gen_catalog.py. Agents read this via senpi-strategy-discover (scripts/discover.py). DECLARED fields (archetype, sub_style, asset_classes, asset_scope, risk_level, tier, belief_plain, direction) are author-set in strategy.yaml `catalog:`; DERIVED fields (assets, leverage_max, funding_split, instance_count, cadence_seconds, time_horizon, max_slots) are computed from instances/params. Labels/glosses come from senpi-strategy-discover/references/glossary.yaml. 'min_budget' is the machine-COMPUTED minimum total budget at which the design functions (min_budget.py) — the smallest budget where every wallet funds and its smallest slot clears the $12 bumped notional; 'wallet_count' + 'min_budget_binding_wallet' explain it. It is NOT authored — deleting an authored min_budget is a no-op; use min_budget_floor to RAISE it. Positions scale with budget above the min. A strategy is a deployable package; install via senpi-strategy-ops.",
   "skills": [
@@ -849,10 +849,10 @@
       "id": "condor",
       "name": "Condor — One Amazing Trade per Day",
       "emoji": "🦅",
-      "tagline": "Scans the top 50 Hyperliquid crypto assets by volume and fires at most one position at a time — only when 4h, 1h and 15m momentum all align, smart money is >=70% leaning the same way, and the move isn't a runaway counter-trend. Sizes margin to conviction (50/70/80%) at 10x, then rides a wide DSL.",
+      "tagline": "Scans the top 50 Hyperliquid crypto assets by volume and fires at most one position at a time — only when 4h, 1h and 15m momentum all align, the smart-money leaderboard is leaning the same way on a market it is actually concentrated in, and the move isn't a runaway counter-trend. Sizes margin to conviction (50/70/80%) at 10x, then rides a wide DSL.",
       "belief_plain": "Watches every liquid coin on Hyperliquid and waits, doing nothing until ONE setup is near-perfect: the trend, the momentum and the best traders all pointing the same direction at once. Then it takes a single, well-sized swing and trails a stop instead of guessing the top.",
-      "version": "1.0.0",
-      "thesis": "The biggest swings happen when 4h + 1h + 15m momentum are perfectly unified AND the smart-money leaderboard is heavily lopsided (>=70%) in that same direction — a runaway trend's continuation, not a reversal. One amazing trade a day beats a scattergun: scan broadly, fire rarely, size to conviction, and never fight a trend already up >10% on the 4h.",
+      "version": "1.1.0",
+      "thesis": "The biggest swings happen when 4h + 1h + 15m momentum are perfectly unified AND the smart-money leaderboard is leaning that same way on a market it has meaningful skin in — a runaway trend's continuation, not a reversal. One amazing trade a day beats a scattergun: scan broadly, fire rarely, size to conviction, and never fight a trend already up >10% on the 4h.",
       "tags": [
         "momentum",
         "trend-continuation",
@@ -1526,7 +1526,7 @@
       "emoji": "🐟",
       "tagline": "Rides forced flow on crypto majors (BTC/ETH/SOL/HYPE): when open interest is unwinding fast (positions being force-closed) AND price is moving violently AND the 5-minute candle is still pushing the same way, it takes ONE position in the direction of the flow, sized 1-5x, and lets a wide DSL ratchet ride the squeeze with a 24h outer bound.",
       "belief_plain": "A liquidation cascade is the cleanest momentum in crypto — it's forced flow, not opinion. When lots of positions are being force-closed at once, price gets shoved hard in one direction and the move feeds on itself until the leverage is flushed. Piranha reads the order flow underneath price (open-interest velocity + order-book depth) to confirm the move is forced, then rides it: OI down + price up = shorts squeezed, go long; OI down + price down = longs liquidated, go short.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "thesis": "Most agents react to price; the edge is reading the forced flow beneath it. Open interest dropping fast means positions are closing under duress, and when that coincides with a violent move and a thinning book on the side price is running into, there is little resistance left and the cascade continues. That signature is short-horizon and self-resolving, so the right move is one conviction entry in the flow direction, a wide ratchet that lets a squeeze extend, and a 24h hard timeout because if the cascade hasn't paid in a day it's over.",
       "tags": [
         "btc",

--- a/strategies/condor/main/runtime.yaml
+++ b/strategies/condor/main/runtime.yaml
@@ -38,13 +38,22 @@ scanners:
       minScore: 12                         # v2 MIN_SCORE (v3.4 calibration)
       marginPct: 50                        # PERCENT of withdrawable (0,100] — runtime sizes (marginPct/100)*withdrawable
       maxPositions: 1                      # "one amazing trade per day"
-      minSmConsensusPct: 70                # SM consensus hard gate
+      # SM gates. `minSmConsensusPct: 70` used to live here and gated
+      # `pct_of_top_traders_gain` — a share of TOTAL top-trader gain spread across the
+      # whole leaderboard (sums to ~100 board-wide), never a per-market "% of traders".
+      # No market could reach 70, so it blocked 100% of signals. Directional agreement
+      # now comes from `is_dominant_direction`; the gain share is a separate
+      # concentration filter on its own scale. Thresholds derived from one live
+      # snapshot — NOT backtested, tune before relying on them.
+      requireDominantDirection: true       # is_dominant_direction must be true
+      minSmGainSharePct: 5.0               # concentration hard gate (~median of deep markets)
       minTraderCount: 50                   # trader-depth hard gate
       min4hMagnitude: 1.0                  # 3TF alignment floors
       min1hMagnitude: 0.3
       min15mVelocity: 0.1
       macroGateThresholdPct: 10.0          # MACRO_TREND_GATE (no counter-trend >10%)
-      stronglyTiltedPct: 80                # SM consensus scoring tier
+      stronglyTiltedPct: 15                # SM concentration scoring tier (+4)
+      convergentPct: 8                     # SM concentration scoring tier (+3)
       recentSignalTtlSeconds: 240          # v2 RECENT_SIGNAL_TTL_SEC race-window dedup
       # leverageTiers: per-score [min_score, leverage, marginPct(PERCENT)]; omit -> scoring defaults
       leverageTiers: [[15, 10, 80], [13, 10, 70], [11, 10, 50]]
@@ -56,7 +65,7 @@ scanners:
       priceChange4hPct: { type: number, required: false }
       priceChange1hPct: { type: number, required: false }
       contribChange15m: { type: number, required: false }
-      smConsensusPct: { type: number, required: false }
+      smGainSharePct: { type: number, required: false }
       smTraders: { type: number, required: false }
       oiUsd: { type: number, required: false }
       funding: { type: number, required: false }

--- a/strategies/condor/main/scanners/scan.py
+++ b/strategies/condor/main/scanners/scan.py
@@ -101,8 +101,17 @@ def fetch_universe(ctx, inputs):
 
 
 def fetch_sm_map(ctx, inputs):
-    """Hyperfeed SM leaderboard: per-coin direction, consensus, 4h/1h price,
-    15m velocity. Ported verbatim from v2 fetch_sm_map (XYZ banned by name)."""
+    """Hyperfeed SM leaderboard: per-coin direction, gain share, dominance, 4h/1h
+    price, 15m velocity. Ported from v2 fetch_sm_map (XYZ banned by name).
+
+    NOTE on `gain_share_pct`: this is `pct_of_top_traders_gain`, a share of the
+    TOTAL top-trader gain attributed to this market — it is NOT a "% of traders
+    leaning this way". It is distributed across every market in the response
+    (observed: sums to ~125 across 271 markets, max ~26, median ~0.01), so a
+    threshold on the 0-100 "consensus" scale can never be met. The v2 port named
+    this `consensus_pct` and gated it at >=70, which silently blocked every
+    signal. Directional agreement is carried separately by `is_dominant`
+    (`is_dominant_direction`), which is the field that actually expresses it."""
     limit = int(inputs.get("smLimit", 100))
     raw = _read(ctx, "leaderboard_get_markets", {"limit": limit})
     if not raw:
@@ -128,7 +137,8 @@ def fetch_sm_map(ctx, inputs):
             continue
         sm_map[token] = {
             "direction": str(m.get("direction", "")).upper(),
-            "consensus_pct": scoring._f(m.get("pct_of_top_traders_gain", 0)),
+            "gain_share_pct": scoring._f(m.get("pct_of_top_traders_gain", 0)),
+            "is_dominant": bool(m.get("is_dominant_direction", False)),
             "traders": int(m.get("trader_count", 0) or 0),
             "p4h": scoring._f(m.get("token_price_change_pct_4h", 0)),
             "p1h": scoring._f(m.get("token_price_change_pct_1h",
@@ -277,7 +287,7 @@ def scan(inputs, ctx):
             "priceChange4hPct": best["p4h"],
             "priceChange1hPct": best["p1h"],
             "contribChange15m": best["c15m"],
-            "smConsensusPct": best["sm_consensus"],
+            "smGainSharePct": best["sm_gain_share"],
             "smTraders": best["sm_traders"],
             "oiUsd": best["oi_usd"],
             "funding": best["funding"],

--- a/strategies/condor/main/scanners/scoring.py
+++ b/strategies/condor/main/scanners/scoring.py
@@ -40,8 +40,25 @@ MIN_15M_VELOCITY = 0.1            # v2: v3.4 calibration (was 0.2 in v3.2)
 MACRO_GATE_THRESHOLD_PCT = 10.0
 
 # SM gates
-MIN_SM_CONSENSUS_PCT = 70.0       # v2: v3.4 calibration (65 in v3.0/v3.1, 75 in v3.2)
-STRONGLY_TILTED_PCT = 80.0
+#
+# The v2 port gated `pct_of_top_traders_gain >= 70` under the name
+# MIN_SM_CONSENSUS_PCT, believing it was a "% of top traders leaning this way".
+# It is not: it is a share of TOTAL top-trader gain spread across every market
+# in the leaderboard response, so it sums to ~100 board-wide and no single
+# market can reach 70. That gate was unreachable and blocked 100% of signals.
+#
+# Directional agreement now comes from `is_dominant_direction` (the field that
+# actually carries it). The gain share is kept as a separate CONCENTRATION
+# filter, on its own real scale.
+#
+# CALIBRATION NOTE: the thresholds below are derived from a single live
+# leaderboard snapshot (2026-08-13, 271 markets; among the 12 with >=50 traders
+# the gain share ran max 25.6 / median 5.2 / min 1.2). They restore signal flow
+# but are NOT backtested — the strategy owner should tune them.
+REQUIRE_DOMINANT_DIRECTION = True  # `is_dominant_direction` must be true
+MIN_SM_GAIN_SHARE_PCT = 5.0        # concentration floor (~median of deep markets)
+STRONGLY_TILTED_PCT = 15.0         # top-tier concentration  (+4)
+CONVERGENT_PCT = 8.0               # mid-tier concentration   (+3)
 
 # Score floor
 MIN_SCORE = 12                    # v2: v3.4 calibration
@@ -76,29 +93,41 @@ def evaluate_trend_continuation(asset_info, sm, btc_macro, hour, inputs=None):
     """Score an asset for trend-continuation apex setup.
 
     `asset_info` = {coin, oi_usd, volume_24h, price, funding}
-    `sm`         = {direction, consensus_pct, traders, p4h, p1h, c15m, c1h}
+    `sm`         = {direction, gain_share_pct, is_dominant, traders, p4h, p1h,
+                    c15m, c1h}
     `btc_macro`  = {direction, p4h} or None
     `hour`       = current UTC hour (caller owns the clock — keeps this pure)
 
-    Returns scored signal dict or None if any hard gate fails. Scoring
-    tables, gate thresholds, and bonus magnitudes are VERBATIM from v2."""
+    Returns scored signal dict or None if any hard gate fails. Scoring tables and
+    bonus magnitudes are VERBATIM from v2; the smart-money gate is not — see the
+    MIN_SM_GAIN_SHARE_PCT block above for why the v2 threshold was unreachable.
+
+    The legacy `minSmConsensusPct` input is deliberately IGNORED: it was set to 70
+    on the wrong scale, and honouring a stale runtime.yaml carrying it would
+    re-brick the strategy. Use `minSmGainSharePct` instead."""
     inputs = inputs or {}
     min_score = float(inputs.get("minScore", MIN_SCORE))
-    min_consensus = float(inputs.get("minSmConsensusPct", MIN_SM_CONSENSUS_PCT))
+    min_gain_share = float(inputs.get("minSmGainSharePct", MIN_SM_GAIN_SHARE_PCT))
+    require_dominant = bool(inputs.get("requireDominantDirection",
+                                       REQUIRE_DOMINANT_DIRECTION))
     min_traders = int(inputs.get("minTraderCount", MIN_TRADER_COUNT))
     min_4h = float(inputs.get("min4hMagnitude", MIN_4H_MAGNITUDE))
     min_1h = float(inputs.get("min1hMagnitude", MIN_1H_MAGNITUDE))
     min_15m = float(inputs.get("min15mVelocity", MIN_15M_VELOCITY))
     macro_gate = float(inputs.get("macroGateThresholdPct", MACRO_GATE_THRESHOLD_PCT))
     strongly_tilted = float(inputs.get("stronglyTiltedPct", STRONGLY_TILTED_PCT))
+    convergent = float(inputs.get("convergentPct", CONVERGENT_PCT))
 
     coin = asset_info["coin"]
     sm_dir = sm["direction"]
     if sm_dir not in ("LONG", "SHORT"):
         return None
 
-    # HARD GATE: SM consensus
-    if sm["consensus_pct"] < min_consensus:
+    # HARD GATE: smart money agrees on the direction
+    if require_dominant and not sm.get("is_dominant", False):
+        return None
+    # HARD GATE: this market carries a meaningful share of top-trader gain
+    if sm.get("gain_share_pct", 0.0) < min_gain_share:
         return None
     # HARD GATE: trader depth
     if sm["traders"] < min_traders:
@@ -167,16 +196,20 @@ def evaluate_trend_continuation(asset_info, sm, btc_macro, hour, inputs=None):
     score += 3
     reasons.append(f"3TF_ALIGNED_{sm_dir}")
 
-    # SM consensus tier
-    if sm["consensus_pct"] >= strongly_tilted:
+    # SM concentration tier. Tier boundaries rescaled onto the gain-share scale
+    # (v2 used 80/75 on the unreachable 0-100 "consensus" scale, so every scored
+    # candidate would have landed in the base +2 bucket). Tier magnitudes (+4/+3/+2)
+    # are unchanged, so the maximum score is still 19.
+    gain_share = sm.get("gain_share_pct", 0.0)
+    if gain_share >= strongly_tilted:
         score += 4
-        reasons.append(f"SM_STRONGLY_TILTED {sm['consensus_pct']:.0f}%")
-    elif sm["consensus_pct"] >= 75:        # v2-quirk: literal 75 (not min_consensus). Preserved.
+        reasons.append(f"SM_STRONGLY_TILTED {gain_share:.1f}%")
+    elif gain_share >= convergent:
         score += 3
-        reasons.append(f"SM_CONVERGENT {sm['consensus_pct']:.0f}%")
+        reasons.append(f"SM_CONVERGENT {gain_share:.1f}%")
     else:
         score += 2
-        reasons.append(f"SM_ALIGNED {sm['consensus_pct']:.0f}%")
+        reasons.append(f"SM_ALIGNED {gain_share:.1f}%")
 
     # Trader depth
     if sm["traders"] >= 100:
@@ -211,7 +244,7 @@ def evaluate_trend_continuation(asset_info, sm, btc_macro, hour, inputs=None):
         "p4h": p4h,
         "p1h": p1h,
         "c15m": c15m,
-        "sm_consensus": sm["consensus_pct"],
+        "sm_gain_share": gain_share,
         "sm_traders": sm["traders"],
         "oi_usd": asset_info["oi_usd"],
         "funding": asset_info.get("funding", 0),

--- a/strategies/condor/strategy.yaml
+++ b/strategies/condor/strategy.yaml
@@ -6,14 +6,14 @@
 schema_version: 1
 
 id: condor
-version: "1.0.0"
+version: "1.1.0"
 
 catalog:
   name: "Condor — One Amazing Trade per Day"
   emoji: "🦅"
-  tagline: "Scans the top 50 Hyperliquid crypto assets by volume and fires at most one position at a time — only when 4h, 1h and 15m momentum all align, smart money is >=70% leaning the same way, and the move isn't a runaway counter-trend. Sizes margin to conviction (50/70/80%) at 10x, then rides a wide DSL."
+  tagline: "Scans the top 50 Hyperliquid crypto assets by volume and fires at most one position at a time — only when 4h, 1h and 15m momentum all align, the smart-money leaderboard is leaning the same way on a market it is actually concentrated in, and the move isn't a runaway counter-trend. Sizes margin to conviction (50/70/80%) at 10x, then rides a wide DSL."
   belief_plain: "Watches every liquid coin on Hyperliquid and waits, doing nothing until ONE setup is near-perfect: the trend, the momentum and the best traders all pointing the same direction at once. Then it takes a single, well-sized swing and trails a stop instead of guessing the top."
-  thesis: "The biggest swings happen when 4h + 1h + 15m momentum are perfectly unified AND the smart-money leaderboard is heavily lopsided (>=70%) in that same direction — a runaway trend's continuation, not a reversal. One amazing trade a day beats a scattergun: scan broadly, fire rarely, size to conviction, and never fight a trend already up >10% on the 4h."
+  thesis: "The biggest swings happen when 4h + 1h + 15m momentum are perfectly unified AND the smart-money leaderboard is leaning that same way on a market it has meaningful skin in — a runaway trend's continuation, not a reversal. One amazing trade a day beats a scattergun: scan broadly, fire rarely, size to conviction, and never fight a trend already up >10% on the 4h."
   group: momentum
   archetype: breakout_momentum
   sub_style: trend_continuation

--- a/strategies/piranha/main/scanners/scan.py
+++ b/strategies/piranha/main/scanners/scan.py
@@ -264,12 +264,16 @@ def scan(inputs, ctx):
         md = _asset_data(ctx, coin)
         if not md:
             continue
+        # Read the PREVIOUS tick's OI *before* refreshing the cache. Reading it after
+        # the write handed build_thesis prev_oi == cur_oi, so the self-computed delta
+        # was always exactly 0.00% and GATE 1 (oi_pct <= -oiDropMinPct) could never pass.
+        prev_oi = _prev_oi(oi_cache, coin)
         # refresh OI cache for the self-compute fallback (verbatim: record on every pass)
         cur_oi = scoring.current_oi(md)
         if cur_oi > 0:
             oi_cache[cu] = {"oi": cur_oi, "ts": now}
         sm = _get_sm_direction(ctx, cu)
-        th = scoring.build_thesis(coin, md, _prev_oi(oi_cache, coin), sm, inputs)
+        th = scoring.build_thesis(coin, md, prev_oi, sm, inputs)
         if th and th["score"] >= min_score:
             candidates.append(th)
 

--- a/strategies/piranha/main/scanners/scoring.py
+++ b/strategies/piranha/main/scanners/scoring.py
@@ -73,7 +73,13 @@ def oi_velocity_1h(asset_data, prev_oi):
     caller. None if neither is available. Verbatim from v2 except the prev-OI is
     passed in (caller owns the cache) instead of read from a file here.
 
-    Returns (None, "unavailable") when OI velocity cannot be resolved."""
+    Returns (None, "unavailable") when OI velocity cannot be resolved.
+
+    Live `market_get_asset_data` returns oi_velocity with FLAT keys
+    (`oi_change_pct_1h`, `oi_change_pct_5m`, …). The original port only read a
+    NESTED `oi_change_pct: {"1h": …}` shape, so the primary source never
+    resolved and every tick fell through to the self-computed path. Both shapes
+    are accepted now; the flat one is what production actually sends."""
     data = asset_data.get("data", {}) if isinstance(asset_data, dict) else {}
     ctx = data.get("asset_context", {}) or {}
     cur_oi = _f(ctx, "openInterest")
@@ -83,6 +89,12 @@ def oi_velocity_1h(asset_data, prev_oi):
         if isinstance(ch, dict) and ch.get("1h") is not None:
             try:
                 return float(ch["1h"]), "oi_velocity"
+            except (TypeError, ValueError):
+                pass
+        flat = oiv.get("oi_change_pct_1h")
+        if flat is not None:
+            try:
+                return float(flat), "oi_velocity"
             except (TypeError, ValueError):
                 pass
     if cur_oi > 0 and prev_oi and float(prev_oi) > 0:

--- a/strategies/piranha/strategy.yaml
+++ b/strategies/piranha/strategy.yaml
@@ -8,7 +8,7 @@
 schema_version: 1
 
 id: piranha
-version: "1.0.1"
+version: "1.0.2"
 catalog:
   name: "Piranha — Liquidation-Cascade / Forced-Flow Hunter"
   emoji: "🐟"


### PR DESCRIPTION
## What

condor and piranha were **structurally unable to ever open a position**. Both are fixed here, with regression tests.

Found while investigating a live account (M176334) where **condor ($4,000) and piranha ($1,500) sat `ACTIVE` and fully funded for 15 days — ~7,000 scanner ticks each, zero signals, zero fills.**

Nothing alerted, because nothing was broken in the usual sense: both scanners spawned, ticked on cadence, exited clean, and logged

```
[condor.scan]  WAITING — no apex setup >= MIN_SCORE=12 (scanned 50)
[piranha.scan] WAITING — no forced-flow / liquidation-unwind signature (min score 5); scanned=4 held=[]
```

which is indistinguishable from a selective strategy correctly standing aside.

## condor — the smart-money gate can never be satisfied

`fetch_sm_map` mapped `pct_of_top_traders_gain` onto a field named `consensus_pct`, and `evaluate_trend_continuation` gated it at `>= 70` as if it were a per-market *"% of top traders leaning this way"*.

It isn't. It's a share of **total** top-trader gain, distributed across the whole leaderboard. From a live `leaderboard_get_markets` snapshot (2026-08-13, 271 markets):

| | value |
|---|---:|
| max | **25.63** |
| p90 | 0.92 |
| median | 0.01 |
| **sum across all markets** | **125.2** |
| markets ≥ 70 | **0** |

A market clearing 70 would have to account for 70% of all top-trader gain board-wide. The live gate funnel:

```
valid direction     271
SM consensus >= 70    0   <-- every signal died here
traders >= 50         0
3TF alignment         0
macro gate            0
```

Drop that single gate and the rest of the chain works: **271 → 12 → 4**.

There is no per-market consensus percentage anywhere in the payload — the closest field is the boolean `is_dominant_direction`. The gate was written against a field shape that does not exist. Condor's own catalog copy advertised *"smart money is >=70% leaning the same way"*, so this was intent, not a typo.

**Fix:** directional agreement comes from `is_dominant_direction`. The gain share is kept as a separate *concentration* filter on its own scale, and the `+4/+3/+2` scoring tiers are rescaled onto that scale — they were pinned at 80/75, so even a passing candidate would always have landed in the base `+2` bucket. Tier magnitudes are unchanged, so the maximum score is still 19.

The legacy `minSmConsensusPct` input is **deliberately ignored**: it was set on the wrong scale, and honouring a stale `runtime.yaml` that still carries `70` would silently re-brick the strategy.

## piranha — gate 1 can't resolve by either route

Gate 1 requires OI unwinding ≥3% over 1h (`if oi_pct > -3.0: return None`). There are two ways to get `oi_pct`, and **both were broken**:

1. **Primary source — key-shape mismatch.** `oi_velocity_1h` did `oiv.get("oi_change_pct")` and required a nested dict with a `"1h"` key. Live `market_get_asset_data` returns **flat** keys:
   ```
   "oi_velocity": { "oi_change_pct_5m": …, "oi_change_pct_1h": 1.2772…, "oi_change_pct_4h": … }
   ```
   so it resolved to `None` and the real value was never read. (The tool docs describe it as "`oi_change_pct` (5m/15m/1h/4h)", which reads like a nested object — likely where this came from.) Both shapes are accepted now.

2. **Fallback — cache overwritten before it's read.** `scan.py` wrote the current OI into `oi_cache[cu]`, then passed `_prev_oi(oi_cache, coin)` — reading back the value it had just written. `prev_oi == cur_oi`, so the computed delta was **exactly +0.000000%** every tick. The read now happens before the refresh.

`minScore: 5` was never even consulted. (`scanned=4` is by design — the universe is `[BTC, ETH, SOL, HYPE]`.)

## Verification

Against live data, on this branch:

- **condor** emits `HYPE SHORT score=13` (≥ `MIN_SCORE` 12) — `['4H_TREND_LIGHT -1.0%', '1H_CONFIRMS -0.81%', '15M_SPIKE +6.69', '3TF_ALIGNED_SHORT', 'SM_STRONGLY_TILTED 25.6%', 'DEEP_CONSENSUS (212t)', 'PEAK_SESSION_17UTC']`
- **piranha** produces a `SHORT` thesis `score=6` (≥ `minScore` 5) on a forced-flow signature, and still returns `None` on a quiet tape.

New: `senpi-strategy-ops/tests/test_entry_gate_reachability.py` — **11 tests, 7 of which fail against `origin/main`** (verified in a throwaway worktree). The other 4 are deliberate controls — non-dominant market, quiet tape, nested `oi_velocity` shape, fallback given a genuine previous OI — so "make it trade again" can't be satisfied by deleting the gates.

Full suite: **217 passed** (206 before + 11), plus `validate_strategy`, `validate_universe`, vendor parity and the min_budget golden. `catalog.json` regenerated to both locations via `gen_catalog.py`.

Versions: condor `1.0.0 → 1.1.0` (gate semantics changed), piranha `1.0.1 → 1.0.2` (pure defect fix, no tunables touched). Condor's tagline/thesis updated — they advertised the `>=70%` threshold that never existed.

## ⚠️ Needs an owner decision

Condor's new thresholds — `minSmGainSharePct: 5.0`, tiers `15`/`8` — are **derived from a single live snapshot and are not backtested**. They restore signal flow and are deliberately conservative (5.0 ≈ the median gain share among markets with ≥50 traders; it yields 3–4 candidates per tick, and condor takes only the single highest-scoring one at `maxPositions: 1`). **Someone who owns this strategy should tune them.** Everything is exposed as `runtime.yaml` inputs.

## Follow-ups not in this PR

- **Two more packages show the identical zero-signal shape** on the same account: `albatross` (6,680 ticks / 0 signals — already `catalog.status: blocked`) and `kestrel` (766 ticks / 0 signals). Same class suspected, **not verified**. Worth a fleet-wide sweep for other hard gates written against a misread field.
- `senpi-strategy-ops/tests/test_dex_awareness.py` fixtures use `pct_of_top_traders_gain: 71.0` / `63.0` — values that can't occur in production, and part of why this gate looked plausible. Harmless for what that test asserts (dex handling), but worth rebasing onto the real scale.
- **A `WAITING` tick that never varies is undetectable today.** Consider having the scaffold log the best score seen (`best=9 vs min=12`) and/or the per-gate rejection counts, so "structurally unreachable" is distinguishable from "selective" without reading the recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
