### PR TITLE
fee-honest realized PnL: net-of-fees in improve-trades + portfolio (was reporting gross as booked)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
       # pytest collects every test regardless of a __main__ runner — bare `python3 <file>` exits 0
       # without running anything on a runner-less file (test_default_catalog.py), a silent green.
       - name: full suites (ops + discover + trading-runtime)
-        run: python3 -m pytest senpi-strategy-ops/tests senpi-strategy-discover/tests senpi-trading-runtime/tests senpi-trader-research/tests senpi-market-pulse/tests -q
+        run: python3 -m pytest senpi-strategy-ops/tests senpi-strategy-discover/tests senpi-trading-runtime/tests senpi-trader-research/tests senpi-market-pulse/tests senpi-improve-trades/tests senpi-portfolio/tests -q

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | Skill | Ver | Role |
 |---|---|---|
 | **Analyze** | | |
-| [`senpi-portfolio`](senpi-portfolio/) | 1.13.3 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
+| [`senpi-portfolio`](senpi-portfolio/) | 1.14.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
 | [`senpi-market-pulse`](senpi-market-pulse/) | 1.2.0 | Daily cross-asset market read (crypto, equities, commodities, macro, funding regime) |
 | [`senpi-smart-money`](senpi-smart-money/) | 1.2.0 | Where the most-profitable wallets are positioned vs. the crowd |
 | [`senpi-trader-research`](senpi-trader-research/) | 1.3.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |
-| [`senpi-improve-trades`](senpi-improve-trades/) | 1.1.1 | Retrospective review + health checks off the **telemetry event log**: exit quality, missed signals, leaks, crashes, "if I'd held" counterfactual |
+| [`senpi-improve-trades`](senpi-improve-trades/) | 1.9.0 | Retrospective review + health checks off the **telemetry event log**: exit quality, missed signals, leaks, crashes, "if I'd held" counterfactual |
 | [`senpi-account-status`](senpi-account-status/) | 1.1.1 | Points, loyalty tier, fees, Arena standing, referrals |
 | **Run a strategy** | | |
 | [`senpi-strategy-discover`](senpi-strategy-discover/) | 2.17.0 | Conversational picker — rank the catalog against your worldview |

--- a/senpi-improve-trades/SKILL.md
+++ b/senpi-improve-trades/SKILL.md
@@ -17,7 +17,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.8.0"
+  version: "1.9.0"
   platform: senpi
   exchange: hyperliquid
 ---
@@ -38,12 +38,16 @@ more" questions; use `senpi-portfolio` for live state.
 
 ## HARD RULES (never violate — obey these even if you skim the rest)
 
-1. **Lead with TOTAL PnL** (`pnl_summary.total` = realized + unrealized), never realized alone. Realized-only
-   is half the ledger — it calls a book riding open winners a "loser" and penalizes hold-strategies. **If
-   `pnl_summary.unrealized_partial` is true (or `unrealized_coverage.read < .current_strategies`), TOTAL is a
-   FLOOR, not a complete number** — some current wallets couldn't be read. Say **"at least $X (N of M wallets
-   readable)"**, never present it as the finished total. (`total: null` = the open book was *entirely*
-   unreadable → UNKNOWN, not 0 and not a floor.)
+1. **Lead with NET TOTAL PnL** (`pnl_summary.net_total` = net_realized + unrealized), never realized alone and
+   never a GROSS number. `gross_*` excludes trading fees — the biggest killer of returns — so a gross headline
+   can read ~5× rosier than the wallet on a churny book. **When `pnl_summary.fees_status` is `undetermined`
+   (the fills ledger couldn't be read), `fees` and every `net_*` are `null`:** the figure you have is GROSS and
+   fees are UNKNOWN (**not 0**) — say **"about $X gross; fees couldn't be read, so net is lower by an unknown
+   amount,"** never present a gross number as net/booked. Realized-only is half the ledger — it calls a book
+   riding open winners a "loser" and penalizes hold-strategies. **If `pnl_summary.unrealized_partial` is true
+   (or `unrealized_coverage.read < .current_strategies`), the total is a FLOOR** — some current wallets couldn't
+   be read; say **"at least $X (N of M wallets readable)"**. (`net_total`/`gross_total` `null` = the open book
+   was *entirely* unreadable → UNKNOWN, not 0 and not a floor.)
 2. **The hold-to-now counterfactual is CONTEXT, never a verdict.** `held_higher` / a positive
    `if_all_reclosed_now_total` just means the asset kept running THIS window (hindsight; it ignores the risk
    the exit avoided). NEVER say "you exited too early / N% premature / left $X on the table," and NEVER let it
@@ -194,7 +198,7 @@ could I make more" — run the steps **in order** and narrate between:
 
 1. `review.py timing` → narrate the timing teardown (the NEUTRAL exit counts `exits_ahead` / `exits_held_higher`
    + realized so far) — but this is NOT your headline: TOTAL PnL (realized + unrealized) lands with the
-   `strategies` step (`pnl_summary.total`). `exit_reason` is still `UNKNOWN` here (telemetry hasn't run) —
+   `strategies` step (`pnl_summary.net_total`). `exit_reason` is still `UNKNOWN` here (telemetry hasn't run) —
    narrate the *timing*, not the mechanism yet, and never call `held_higher` "premature / left on the table."
 2. `review.py strategies` → narrate the **per-strategy read** (each CURRENT strategy vs its OWN mandate,
    realized PnL as evidence; `closed_strategies[]` is history — no verdict).
@@ -262,7 +266,7 @@ These are non-negotiable. Each fixes a real failure from live agent responses to
 
 ### 1. TOTAL PnL leads; `if_held` is NEUTRAL context, symmetric, never the verdict
 
-**Lead with `pnl_summary.total`** (realized closed + unrealized open) — NOT `realized_pnl_total` alone.
+**Lead with `pnl_summary.net_total`** (realized closed + unrealized open) — NOT `gross_realized_pnl_total` alone.
 Realized-only is half the ledger: it calls a book riding open winners a "loser" and penalizes hold-strategies.
 **Degraded-read honesty (same principle as `undetermined ≠ all-clear`):** if `pnl_summary.unrealized_partial`
 is true (some current wallets read, some didn't), `total` is a **FLOOR** — headline it as *"at least $X (N of M
@@ -322,7 +326,7 @@ never from whether a live position has *armed* it:
 
 **Never invent a forward number.** No "+$1,400–2,200/week," no "deploy 25% = +$800–1,200," no guaranteed-gain
 figure of any kind. The only dollar figures you may state are:
-- **realized PnL** (`realized_pnl`, `realized_pnl_total`) — what actually happened, and
+- **realized PnL** — GROSS (`gross_realized_pnl`, `gross_realized_pnl_total`) and NET of fees (`net_realized_pnl`, `net_realized_pnl_total`) — what actually happened, and
 - the engine's **counterfactuals** (`if_held_delta_usd`, `if_all_reclosed_now_total`) — clearly labeled as
   *"if held to now"* context.
 
@@ -463,11 +467,11 @@ run on a just-deployed book):
 
 ## What the engine gives you
 
-The engine prints one JSON dict. **Lead with `pnl_summary.total`** (realized+unrealized); the PROCESS counts are in `timing_summary`; per-strategy verdicts in `strategies[]` (CURRENT book only); the telemetry streams (`dsl_close_reason_mix` / `blocked_summary` / `leaks` / `execution_quality`) are real only when `telemetry_availability.streams_computed` is true; `trades[]` is a curated outlier sample (counts from the aggregates, never `len(trades)`). **Full field-by-field catalog + the `exit_reason.terminal` enum: [`references/output-shape.md`](references/output-shape.md).**
+The engine prints one JSON dict. **Lead with `pnl_summary.net_total`** (realized+unrealized); the PROCESS counts are in `timing_summary`; per-strategy verdicts in `strategies[]` (CURRENT book only); the telemetry streams (`dsl_close_reason_mix` / `blocked_summary` / `leaks` / `execution_quality`) are real only when `telemetry_availability.streams_computed` is true; `trades[]` is a curated outlier sample (counts from the aggregates, never `len(trades)`). **Full field-by-field catalog + the `exit_reason.terminal` enum: [`references/output-shape.md`](references/output-shape.md).**
 
 ## The output contract — what you produce
 
-1. **Total-PnL + timing teardown** — **led by TOTAL PnL** (`pnl_summary.total` = realized + unrealized), then
+1. **Total-PnL + timing teardown** — **led by TOTAL PnL** (`pnl_summary.net_total` = realized + unrealized), then
    the NEUTRAL aggregate (`timing_summary`: `exits_ahead` / `exits_held_higher`), each exit attributed via
    `exit_reason` (which tier / hard stop fired). Process-framed, NEVER "premature / left on the table."
    Discuss individual reversals only after the aggregate, and only as evidence. Trades whose
@@ -504,10 +508,14 @@ Never pick for the user, and never act unprompted.
 
 Don't re-implement these — call them and weave their output into the four-part contract above.
 
-## The one pending upgrade — authoritative fee $
+## Authoritative fee $ — wired (net PnL)
 
-`execution_quality` reports the maker-vs-taker **rate** today, not fee dollars. The authoritative fee **$**
-lives in the ledger — `order.filled` / `position.closed` carry `senpi.order.id`, which joins to
-`execution_get_closed_position_details({closedOrderId})` → realized PnL + **fees** + funding. That per-order
-join is the future upgrade; it's intentionally **not** called per-trade (rate-limit risk), so until it's
-wired, quote the maker ratio as a fee-tier signal, never a fee dollar total.
+Fee **dollars** are now sourced from the HL **fills ledger** (`userFills.fee`, already builder-fee-inclusive)
+and attributed per round-trip (matched OPEN-side fee + CLOSE fee), so every PnL surface carries
+`gross_realized_pnl` / `fees` / `net_realized_pnl` (and `gross_total` / `net_total` on `pnl_summary`,
+`gross_realized_pnl_total` / `fees_total` / `net_realized_pnl_total` on `timing_summary`). **Lead with net;
+`gross_*` is pre-fee.** When the fills read fails for a wallet, that record's `fees` / `net_*` are `null` and
+`fees_status` is `undetermined` — the figure is GROSS and fees are UNKNOWN, never 0 (HARD RULE 1).
+
+`execution_quality` still reports the maker-vs-taker **rate** — a separate execution-quality signal ("am I
+paying taker fees I could avoid?"), not the fee-dollar total above.

--- a/senpi-improve-trades/references/output-shape.md
+++ b/senpi-improve-trades/references/output-shape.md
@@ -14,8 +14,10 @@ trades[]      per CLOSED trade (from strategies of ALL statuses — a churned bo
   exit_reason: { terminal, tier_index/tier_reached, high_water_roe, source },   # which DSL lever fired
   source: "telemetry" | "reconstructed"   # telemetry = exit_reason came from the event log; else discovery+ratchet
 
-pnl_summary      TOTAL LEDGER — LEAD WITH THIS (realized closed + unrealized open):
-  realized, unrealized (None = UNKNOWN read, not 0), total (None when unrealized UNKNOWN),
+pnl_summary      TOTAL LEDGER — LEAD WITH NET (net_realized closed + unrealized open); gross_* is pre-fee:
+  gross_realized, fees (None = UNDETERMINED, fills read failed — NOT 0), net_realized (gross − fees; None when fees undetermined),
+  fees_status ("ok" | "undetermined"), unrealized (None = UNKNOWN read, not 0),
+  gross_total, net_total (None when unrealized OR fees UNKNOWN),   # LEAD with net_total, not gross_total
   realized_by_book{ current, closed },      # quote this split — never re-derive a closed-book figure
   unrealized_coverage{ read, current_strategies },
   unrealized_partial   # true → some wallets UNKNOWN; unrealized/total are a FLOOR ("at least $X, N of M") — HARD RULE 1
@@ -27,7 +29,8 @@ telemetry_availability   the 'undetermined ≠ all-clear' signal — READ IT FIR
 
 timing_summary   PROCESS-framed COUNTS (never $/week; NEUTRAL, never a grade):
   trade_count, exits_ahead, exits_held_higher, exits_flat, exits_unknown,
-  realized_pnl_total, if_all_reclosed_now_total (CONTEXT, symmetric — see guardrail 1), by_asset_class{}
+  gross_realized_pnl_total, fees_total (None = UNDETERMINED, NOT 0), net_realized_pnl_total (LEAD with this), fees_status,
+  if_all_reclosed_now_total (CONTEXT, symmetric — see guardrail 1), by_asset_class{}   # by_asset_class carries gross/fees/net per class
 
 dsl_close_reason_mix   "shaken out too early / how are my exits firing" (from trades[] exit_reason):
   overall        { by_terminal{}, trade_count, premature_exits }
@@ -60,16 +63,19 @@ strategies[]  the CURRENT book ONLY (status ACTIVE | PAUSED) — each judged vs 
     skill_name,               # the package attribution stamp — same pairing, survives a dead registry
     # group/skill_name are the ONLY proof two rows are one strategy: sleeves are named apart and carry
     # different mandates. Two ACTIVE rows sharing either one are sleeves — never merge or close one.
-    wallet, status, mandate, dsl, closed_trade_count, realized_pnl,
+    wallet, status, mandate, dsl, closed_trade_count,
+    gross_realized_pnl,       # HL closedPnl — GROSS (pre-fee)
+    fees, net_realized_pnl, fees_status,   # fees from the fills ledger (None = UNDETERMINED, NOT 0); net = gross − fees
     unrealized_pnl,           # current open positions' unrealized — None = UNKNOWN read (never a fake 0)
-    total_pnl,                # realized + unrealized (None when unrealized UNKNOWN) — JUDGE ON THIS, not realized
+    gross_total_pnl,          # gross_realized + unrealized (None when unrealized UNKNOWN)
+    net_total_pnl,            # net_realized + unrealized (None when either UNKNOWN) — JUDGE ON THIS, not gross
     open_position_count,
     open_positions[]{ asset, direction, unrealized_pnl, return_on_equity_pct, entry_px, position_value, leverage },
     on_mandate_note }         # open_positions = the 'are winners running' evidence (guardrail 1)
   # THIS is the verdict + improvement surface. Nothing here is closed.
 
 closed_strategies[]  HISTORY ONLY (CLOSED / INACTIVE / … — churned or retired redeployments):
-  { label, wallet_short, status, trade_count, realized_pnl }
+  { label, wallet_short, status, trade_count, gross_realized_pnl, fees, net_realized_pnl, fees_status }
   # deliberately NO mandate / dsl / verdict / on_mandate_note. Their trades are already in trades[]
   # (part of the timing review, attributed by label). NEVER give these a "consolidate/kill/fix" verdict,
   # NEVER flag their absent mandate as a bug, NEVER count them as live "wallets to consolidate."

--- a/senpi-improve-trades/references/output-shape.md
+++ b/senpi-improve-trades/references/output-shape.md
@@ -16,7 +16,7 @@ trades[]      per CLOSED trade (from strategies of ALL statuses — a churned bo
 
 pnl_summary      TOTAL LEDGER — LEAD WITH NET (net_realized closed + unrealized open); gross_* is pre-fee:
   gross_realized, fees (None = UNDETERMINED, fills read failed — NOT 0), net_realized (gross − fees; None when fees undetermined),
-  fees_status ("ok" | "undetermined"), unrealized (None = UNKNOWN read, not 0),
+  fees_status ("ok" | "undetermined"), fees_coverage {resolved, total} (partial → "net for R of T"), unrealized (None = UNKNOWN read, not 0),
   gross_total, net_total (None when unrealized OR fees UNKNOWN),   # LEAD with net_total, not gross_total
   realized_by_book{ current, closed },      # quote this split — never re-derive a closed-book figure
   unrealized_coverage{ read, current_strategies },
@@ -29,7 +29,7 @@ telemetry_availability   the 'undetermined ≠ all-clear' signal — READ IT FIR
 
 timing_summary   PROCESS-framed COUNTS (never $/week; NEUTRAL, never a grade):
   trade_count, exits_ahead, exits_held_higher, exits_flat, exits_unknown,
-  gross_realized_pnl_total, fees_total (None = UNDETERMINED, NOT 0), net_realized_pnl_total (LEAD with this), fees_status,
+  gross_realized_pnl_total, fees_total (None = UNDETERMINED, NOT 0), net_realized_pnl_total (LEAD with this), fees_status, fees_coverage {resolved, total},
   if_all_reclosed_now_total (CONTEXT, symmetric — see guardrail 1), by_asset_class{}   # by_asset_class carries gross/fees/net per class
 
 dsl_close_reason_mix   "shaken out too early / how are my exits firing" (from trades[] exit_reason):
@@ -65,7 +65,7 @@ strategies[]  the CURRENT book ONLY (status ACTIVE | PAUSED) — each judged vs 
     # different mandates. Two ACTIVE rows sharing either one are sleeves — never merge or close one.
     wallet, status, mandate, dsl, closed_trade_count,
     gross_realized_pnl,       # HL closedPnl — GROSS (pre-fee)
-    fees, net_realized_pnl, fees_status,   # fees from the fills ledger (None = UNDETERMINED, NOT 0); net = gross − fees
+    fees, net_realized_pnl, fees_status, fees_coverage {resolved, total},   # fees from the fills ledger (None = UNDETERMINED, NOT 0); net = gross − fees; coverage = trades whose fee resolved
     unrealized_pnl,           # current open positions' unrealized — None = UNKNOWN read (never a fake 0)
     gross_total_pnl,          # gross_realized + unrealized (None when unrealized UNKNOWN)
     net_total_pnl,            # net_realized + unrealized (None when either UNKNOWN) — JUDGE ON THIS, not gross
@@ -75,7 +75,7 @@ strategies[]  the CURRENT book ONLY (status ACTIVE | PAUSED) — each judged vs 
   # THIS is the verdict + improvement surface. Nothing here is closed.
 
 closed_strategies[]  HISTORY ONLY (CLOSED / INACTIVE / … — churned or retired redeployments):
-  { label, wallet_short, status, trade_count, gross_realized_pnl, fees, net_realized_pnl, fees_status }
+  { label, wallet_short, status, trade_count, gross_realized_pnl, fees, net_realized_pnl, fees_status, fees_coverage }
   # deliberately NO mandate / dsl / verdict / on_mandate_note. Their trades are already in trades[]
   # (part of the timing review, attributed by label). NEVER give these a "consolidate/kill/fix" verdict,
   # NEVER flag their absent mandate as a bug, NEVER count them as live "wallets to consolidate."

--- a/senpi-improve-trades/scripts/review.py
+++ b/senpi-improve-trades/scripts/review.py
@@ -46,7 +46,9 @@ CLOSED_HISTORY_PULL = 100    # closed positions to pull per wallet before the wi
 WINDOW_DEFAULT_DAYS = 7      # the default review window
 TOP_MOVERS_CAP = 12          # cap the book-vs-market movers surfaced
 HL_INFO_URL = "https://api.hyperliquid.xyz/info"   # public, no-auth — durable closed-trade recovery
-HL_FILLS_CAP = 2000          # userFills returns the most recent N fills; ample for any review window
+HL_FILLS_CAP = 2000          # userFills / userFillsByTime page size — the most recent (or per-page) N fills
+FILL_LOOKBACK_MS = 90 * 24 * 3600 * 1000   # page fills from since−90d so a closed trade's OPEN leg is captured
+FILL_PAGE_CAP = 25           # userFillsByTime page backstop (×~2000) — never hit in practice; stops a runaway
 
 # The runtime registers every deployed strategy in installed_runtimes.json in the state dir — the
 # UNIVERSAL source of a strategy's mandate (the runtime.yaml `description`) + its DSL ladder. Reused
@@ -778,6 +780,44 @@ def _hl_info(payload, meta, client=None, timeout=12):
         return None
 
 
+def _fetch_window_fills(client, wallet, since_ms, until_ms, meta):
+    """The authoritative fee source — HL fills covering the review window. `userFills` returns only the most
+    recent ~2000 fills with NO paging, so on a long / high-turnover window an older trade's fills fall off the
+    slice and its fee silently reads UNKNOWN (blanking net for the whole wallet). When a window is set we page
+    `userFillsByTime` from since−lookback .. until, so COVERAGE MATCHES the window being reported (the lookback
+    captures the OPEN leg of a position that closed inside the window). Ascending pages, deduped on the boundary
+    overlap. Fails OPEN → None (a failed read) — distinct from [] (genuinely no fills). No window → the recent
+    `userFills` slice (the standalone / test path)."""
+    if since_ms is None or until_ms is None:
+        return _hl_info({"type": "userFills", "user": wallet}, meta, client)
+    cursor, end = max(0, int(since_ms) - FILL_LOOKBACK_MS), int(until_ms)
+    out, seen = [], set()
+    for _ in range(FILL_PAGE_CAP):
+        page = _hl_info({"type": "userFillsByTime", "user": wallet,
+                         "startTime": cursor, "endTime": end}, meta, client)
+        if page is None:
+            return out if out else None          # earlier pages are still usable; nothing yet → propagate failure
+        if not isinstance(page, list):
+            break
+        fresh, last_t = 0, cursor
+        for f in page:
+            if not isinstance(f, dict):
+                continue
+            key = (f.get("tid"), f.get("oid"), f.get("time"), f.get("dir"), f.get("sz"), f.get("px"))
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(f)
+            fresh += 1
+            ft = _num(f.get("time"))
+            if ft is not None and int(ft) > last_t:
+                last_t = int(ft)
+        if len(page) < HL_FILLS_CAP or fresh == 0 or last_t <= cursor:
+            break                                # last (short) page, or no forward progress → done
+        cursor = last_t                          # advance; the dedup set absorbs the boundary overlap
+    return out
+
+
 def _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap):
     """Rebuild round-trip CLOSED trades from raw HL fills — the durable, close-independent source. HL gives
     per-fill `dir` ('Open/Close Long/Short'), px, sz, closedPnl, fee, time, oid. Walk fills per coin
@@ -801,7 +841,7 @@ def _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap):
         if d.startswith("Open"):
             # carry the OPEN-side fee + original size so a later Close can pro-rate the matched share.
             lots[coin].append({"px": px, "sz": sz, "orig_sz": sz, "time": t,
-                               "fee": abs(_num(f.get("fee")) or 0.0)})
+                               "fee": _num(f.get("fee")) or 0.0})    # SIGNED — a maker rebate is a NEGATIVE fee
         elif d.startswith("Close"):
             side = "long" if "Long" in d else ("short" if "Short" in d else None)
             remaining, entry_notional, matched, open_time = sz, 0.0, 0.0, t
@@ -831,9 +871,10 @@ def _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap):
                 "open_time": open_time,
                 "close_time": t,
                 "closed_order_id": f.get("oid"),
-                # round-trip trading fee = matched OPEN-side fees + this CLOSE fill's fee. HL `fee` ALREADY
-                # includes the builder fee, so this is the whole cost — never add a builder fee on top.
-                "fee": round(open_fee + abs(_num(f.get("fee")) or 0.0), 4),
+                # round-trip trading fee = matched OPEN-side fees + this CLOSE fill's fee. HL `fee` is SIGNED
+                # (a maker rebate is NEGATIVE — the wallet was paid) and ALREADY includes the builder fee, so
+                # sum it as-is: never abs() it (that turns rebates into costs) and never add a builder fee.
+                "fee": round(open_fee + (_num(f.get("fee")) or 0.0), 4),
                 "source": "onchain_fills",
             })
     out = []
@@ -899,10 +940,10 @@ def fetch_closed_trades(client, wallet, since_ms, until_ms, cap, meta):
             "source": "discovery",
         })
     # FEES: the fills ledger is the ONLY authoritative fee source — discovery_get_trader_history carries no
-    # fee, so the realized_pnl above is GROSS. Pull userFills ONCE and use it both to attribute a round-trip
+    # fee, so the realized_pnl above is GROSS. Pull the window fills ONCE (userFillsByTime, paged) and use them to attribute a round-trip
     # `fee` to each discovery trade and (when discovery is empty) to reconstruct the closed book. `_hl_info`
     # fails OPEN → None (distinct from an empty list): None ⇒ fee UNDETERMINED for these trades, never a fake $0.
-    fills = _hl_info({"type": "userFills", "user": wallet}, meta, client)
+    fills = _fetch_window_fills(client, wallet, since_ms, until_ms, meta)
     recon = _reconstruct_closed_from_fills(fills, since_ms, until_ms, None) if isinstance(fills, list) else []
     fee_by_oid = {}
     for r in recon:
@@ -1438,6 +1479,8 @@ def _timing_summary(trades):
         "fees_total": fees_total,              # window trading fees (builder-fee-incl); None = UNDETERMINED
         "net_realized_pnl_total": net_realized_total,   # gross − fees; None when fees undetermined — LEAD with this
         "fees_status": ("ok" if fees_total is not None else "undetermined"),
+        "fees_coverage": {"resolved": sum(1 for f in _fees if isinstance(f, (int, float)) and not isinstance(f, bool)),
+                          "total": trade_count},
         "if_all_reclosed_now_total": if_all,   # counterfactual aggregate — CONTEXT, NEVER a projection/target
         "by_asset_class": by_class,
     }
@@ -1726,6 +1769,7 @@ def _strategy_reads(trades, strategies, open_book=None):
             "gross_total_pnl": gross_total,         # gross_realized + unrealized; None when unrealized UNKNOWN
             "net_total_pnl": net_total,             # net_realized + unrealized; None when either UNKNOWN
             "fees_status": fees_status,             # ok | undetermined — never render gross as net when undetermined
+            "fees_coverage": {"resolved": agg.get("fees_known", 0), "total": cnt},  # net knowable for resolved/total trades
             "open_position_count": len(open_positions),
             "open_positions": open_positions,    # asset/direction/unrealized_pnl/return_on_equity_pct/entry/lev
             "on_mandate_note": note,
@@ -1759,6 +1803,7 @@ def _closed_strategy_rollup(trades, strategies):
             "fees": _fees,                          # None = UNDETERMINED (fills read failed for some trade)
             "net_realized_pnl": (round(agg["pnl"] - _fees, 2) if _fees is not None else None),
             "fees_status": ("ok" if _fees is not None else "undetermined"),
+            "fees_coverage": {"resolved": agg.get("fees_known", 0), "total": cnt},
         })
     return out
 
@@ -1798,7 +1843,15 @@ def _fees_total_of(trades):
     return None
 
 
-def _pnl_summary(realized_total, strat_reads, fees_total=None):
+def _fees_coverage_of(trades):
+    """How many trades' fees resolved vs total — lets a partial read say 'net is at least $X (R of T resolved)'
+    instead of dropping the whole book to gross when a single fee is unknown."""
+    resolved = sum(1 for t in trades
+                   if isinstance(t.get("fee"), (int, float)) and not isinstance(t.get("fee"), bool))
+    return {"resolved": resolved, "total": len(trades)}
+
+
+def _pnl_summary(realized_total, strat_reads, fees_total=None, fees_coverage=None):
     """The TOTAL-ledger headline the narrator LEADS with — realized (closed trades) + unrealized (current
     open positions) + total — PLUS the current-vs-closed realized split (so the narrator QUOTES it and never
     re-derives a wrong closed-book figure). `realized_total` is ALL closed trades; current-book realized = the
@@ -1826,6 +1879,7 @@ def _pnl_summary(realized_total, strat_reads, fees_total=None):
         "fees": fees,                             # window trading fees (builder-fee-incl); None = UNDETERMINED
         "net_realized": net_realized,             # gross_realized − fees; None when fees undetermined
         "fees_status": fees_status,               # ok | undetermined
+        "fees_coverage": fees_coverage or {"resolved": 0, "total": 0},   # net knowable for resolved/total trades
         "realized_by_book": {"current": current_realized, "closed": closed_realized},
         "unrealized": unrealized,                 # None → no current open book readable (UNKNOWN, not 0)
         "unrealized_coverage": {"read": len(known), "current_strategies": len(strat_reads)},
@@ -2022,7 +2076,7 @@ def step_strategies(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_m
     strat_reads = _strategy_reads(trades, strategies, open_book)
     closed_reads = _closed_strategy_rollup(trades, strategies)
     realized_total = round(sum(_num(t.get("realized_pnl")) or 0.0 for t in trades), 2)
-    pnl_summary = _pnl_summary(realized_total, strat_reads, _fees_total_of(trades))
+    pnl_summary = _pnl_summary(realized_total, strat_reads, _fees_total_of(trades), _fees_coverage_of(trades))
     dsl_mix = _dsl_close_reason_mix(trades)   # from whatever exit_reason is in state (UNKNOWN until telemetry)
     current_count = sum(1 for s in strategies if _is_current(s.get("status")))
     closed_count = len(strategies) - current_count
@@ -2147,7 +2201,7 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
     strat_reads = _strategy_reads(trades, strategies, open_book)   # CURRENT book — now with unrealized/total/open
     closed_reads = _closed_strategy_rollup(trades, strategies) # HISTORY: closed/inactive, rollup only
     pnl_summary = _pnl_summary(timing["gross_realized_pnl_total"], strat_reads,   # realized + unrealized, net of fees
-                               timing.get("fees_total"))
+                               timing.get("fees_total"), timing.get("fees_coverage"))
 
     current_count = sum(1 for s in strategies if _is_current(s.get("status")))
     closed_count = len(strategies) - current_count

--- a/senpi-improve-trades/scripts/review.py
+++ b/senpi-improve-trades/scripts/review.py
@@ -799,10 +799,13 @@ def _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap):
         if not coin or sz <= 0:
             continue
         if d.startswith("Open"):
-            lots[coin].append({"px": px, "sz": sz, "time": t})
+            # carry the OPEN-side fee + original size so a later Close can pro-rate the matched share.
+            lots[coin].append({"px": px, "sz": sz, "orig_sz": sz, "time": t,
+                               "fee": abs(_num(f.get("fee")) or 0.0)})
         elif d.startswith("Close"):
             side = "long" if "Long" in d else ("short" if "Short" in d else None)
             remaining, entry_notional, matched, open_time = sz, 0.0, 0.0, t
+            open_fee = 0.0                               # matched share of the OPEN-side fees
             q = lots[coin]
             while remaining > 1e-9 and q:                # FIFO-match the closed size against open lots
                 lot = q[0]
@@ -810,6 +813,8 @@ def _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap):
                 entry_notional += take * (lot["px"] or 0.0)
                 matched += take
                 open_time = lot["time"] or open_time
+                if lot.get("orig_sz"):                   # pro-rate the open fee by the fraction of the lot taken
+                    open_fee += (lot.get("fee") or 0.0) * (take / lot["orig_sz"])
                 lot["sz"] -= take
                 remaining -= take
                 if lot["sz"] <= 1e-9:
@@ -821,12 +826,14 @@ def _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap):
                 "leverage": None,                        # not carried on HL fills
                 "entry_px": (entry_notional / matched) if matched > 0 else None,
                 "exit_px": px,
-                "realized_pnl": round(_num(f.get("closedPnl")) or 0.0, 2),   # HL's own realized — authoritative
+                "realized_pnl": round(_num(f.get("closedPnl")) or 0.0, 2),   # HL's own realized — GROSS (pre-fee)
                 "margin_used": None,
                 "open_time": open_time,
                 "close_time": t,
                 "closed_order_id": f.get("oid"),
-                "fee": _num(f.get("fee")),
+                # round-trip trading fee = matched OPEN-side fees + this CLOSE fill's fee. HL `fee` ALREADY
+                # includes the builder fee, so this is the whole cost — never add a builder fee on top.
+                "fee": round(open_fee + abs(_num(f.get("fee")) or 0.0), 4),
                 "source": "onchain_fills",
             })
     out = []
@@ -891,18 +898,31 @@ def fetch_closed_trades(client, wallet, since_ms, until_ms, cap, meta):
             "closed_order_id": _field(p, "closedOrderId", "closed_order_id"),
             "source": "discovery",
         })
+    # FEES: the fills ledger is the ONLY authoritative fee source — discovery_get_trader_history carries no
+    # fee, so the realized_pnl above is GROSS. Pull userFills ONCE and use it both to attribute a round-trip
+    # `fee` to each discovery trade and (when discovery is empty) to reconstruct the closed book. `_hl_info`
+    # fails OPEN → None (distinct from an empty list): None ⇒ fee UNDETERMINED for these trades, never a fake $0.
+    fills = _hl_info({"type": "userFills", "user": wallet}, meta, client)
+    recon = _reconstruct_closed_from_fills(fills, since_ms, until_ms, None) if isinstance(fills, list) else []
+    fee_by_oid = {}
+    for r in recon:
+        oid = r.get("closed_order_id")
+        if oid is not None:
+            fee_by_oid[oid] = round((fee_by_oid.get(oid) or 0.0) + (_num(r.get("fee")) or 0.0), 4)
+
     if trades:
+        for t in trades:                        # stamp the fills-derived round-trip fee onto each discovery row
+            t["fee"] = fee_by_oid.get(t.get("closed_order_id")) if isinstance(fills, list) else None
         trades.sort(key=lambda t: _num(t.get("close_time")) or 0, reverse=True)
         return trades[:cap] if cap else trades
 
-    # DISCOVERY EMPTY → recover on-chain. This is the closed-strategy trap: the trades exist, just not in
-    # Senpi's index. Empty HL fills too ⇒ genuinely no trades (a brand-new book) → [].
-    fills = _hl_info({"type": "userFills", "user": wallet}, meta, client)
-    recon = _reconstruct_closed_from_fills(fills, since_ms, until_ms, cap)
+    # DISCOVERY EMPTY → the reconstructed on-chain book IS the trade list (each row already carries its `fee`).
+    # The closed-strategy trap: strategy_close clears Senpi's index but HL keeps the fills by wallet ADDRESS.
+    # Empty HL fills too ⇒ genuinely no trades (a brand-new book) → [].
     if recon:
         meta.setdefault("onchain_recovered_wallets", []).append(wallet)
         meta["closed_trade_source"] = "onchain_fills"
-    return recon
+    return recon[:cap] if cap else recon
 
 
 # ──────────────────────────────────────────────────────────────── current price (market_get_asset_data)
@@ -1376,7 +1396,12 @@ def _timing_summary(trades):
     held_higher = sum(1 for t in trades if t.get("exit_vs_hold") == "held_higher")
     flat = sum(1 for t in trades if t.get("exit_vs_hold") == "flat")
     unknown = sum(1 for t in trades if t.get("exit_vs_hold") == "unknown")
-    realized_total = round(sum(_num(t.get("realized_pnl")) or 0.0 for t in trades), 2)
+    realized_total = round(sum(_num(t.get("realized_pnl")) or 0.0 for t in trades), 2)   # GROSS — pre-fee
+    _fees = [t.get("fee") for t in trades]
+    _all_known = all(isinstance(f, (int, float)) and not isinstance(f, bool) for f in _fees)   # True for []
+    fees_total = (round(sum(f for f in _fees if isinstance(f, (int, float)) and not isinstance(f, bool)), 2)
+                  if _all_known else None)
+    net_realized_total = round(realized_total - fees_total, 2) if fees_total is not None else None
     if_deltas = [_num(t.get("if_held_delta_usd")) for t in trades]
     if_deltas = [d for d in if_deltas if d is not None]
     if_all = round(sum(if_deltas), 2) if if_deltas else None
@@ -1385,13 +1410,23 @@ def _timing_summary(trades):
     for t in trades:
         cls = "equity/index" if t.get("dex") == "xyz" else "crypto"
         b = by_class.setdefault(cls, {"trade_count": 0, "exits_ahead": 0, "exits_held_higher": 0,
-                                      "realized_pnl_total": 0.0})
+                                      "gross_realized_pnl_total": 0.0, "_fees": 0.0, "_fees_known": 0})
         b["trade_count"] += 1
         if t.get("exit_vs_hold") == "exit_ahead":
             b["exits_ahead"] += 1
         elif t.get("exit_vs_hold") == "held_higher":
             b["exits_held_higher"] += 1
-        b["realized_pnl_total"] = round(b["realized_pnl_total"] + (_num(t.get("realized_pnl")) or 0.0), 2)
+        b["gross_realized_pnl_total"] = round(b["gross_realized_pnl_total"] + (_num(t.get("realized_pnl")) or 0.0), 2)
+        fee = t.get("fee")
+        if isinstance(fee, (int, float)) and not isinstance(fee, bool):
+            b["_fees"] = round(b["_fees"] + fee, 2)
+            b["_fees_known"] += 1
+    for b in by_class.values():                # finalize each class's net (UNDETERMINED if any fee missing)
+        known = b.pop("_fees_known") == b["trade_count"]
+        f = b.pop("_fees")
+        b["fees_total"] = round(f, 2) if known else None
+        b["net_realized_pnl_total"] = round(b["gross_realized_pnl_total"] - f, 2) if known else None
+        b["fees_status"] = "ok" if known else "undetermined"
 
     return {
         "trade_count": trade_count,
@@ -1399,7 +1434,10 @@ def _timing_summary(trades):
         "exits_held_higher": held_higher,      # holding to now would be higher — NEUTRAL, NOT 'premature'
         "exits_flat": flat,
         "exits_unknown": unknown,              # price missing → couldn't compare (honest sourcing)
-        "realized_pnl_total": realized_total,
+        "gross_realized_pnl_total": realized_total,     # GROSS — before trading fees
+        "fees_total": fees_total,              # window trading fees (builder-fee-incl); None = UNDETERMINED
+        "net_realized_pnl_total": net_realized_total,   # gross − fees; None when fees undetermined — LEAD with this
+        "fees_status": ("ok" if fees_total is not None else "undetermined"),
         "if_all_reclosed_now_total": if_all,   # counterfactual aggregate — CONTEXT, NEVER a projection/target
         "by_asset_class": by_class,
     }
@@ -1608,14 +1646,21 @@ def book_vs_market(client, trades, strategies, meta, want_market):
 
 # ──────────────────────────────────────────────────────────────── per-strategy read (judged vs mandate)
 def _pnl_by_wallet(trades):
-    """wallet_lower → {count, pnl} rollup of closed trades. Shared by the current-book read and the
-    historical closed-strategy rollup so both attribute trades by the SAME wallet key."""
+    """wallet_lower → {count, pnl (GROSS realized), fees, fees_known} rollup of closed trades. Shared by the
+    current-book read and the historical closed-strategy rollup so both attribute trades by the SAME wallet
+    key. `fees` sums each trade's authoritative fills-ledger fee (builder-fee-inclusive); `fees_known` counts
+    the trades whose fee resolved — when it is < count the fee source was UNDETERMINED for some trade, so the
+    wallet's net PnL must stay UNKNOWN rather than subtract a partial (understated) fee total."""
     by_wallet = {}
     for t in trades:
         w = str(t.get("strategy_wallet") or "").lower()
-        b = by_wallet.setdefault(w, {"count": 0, "pnl": 0.0})
+        b = by_wallet.setdefault(w, {"count": 0, "pnl": 0.0, "fees": 0.0, "fees_known": 0})
         b["count"] += 1
         b["pnl"] = round(b["pnl"] + (_num(t.get("realized_pnl")) or 0.0), 2)
+        fee = t.get("fee")
+        if isinstance(fee, (int, float)) and not isinstance(fee, bool):
+            b["fees"] = round(b["fees"] + fee, 4)
+            b["fees_known"] += 1
     return by_wallet
 
 
@@ -1638,9 +1683,17 @@ def _strategy_reads(trades, strategies, open_book=None):
         ob = open_book.get(w) or {}
         unrealized = ob.get("unrealized_pnl")       # None → open book unreadable (UNKNOWN, never a fake 0)
         open_positions = ob.get("positions") or []
-        realized = agg["pnl"]
-        total = (round(realized + unrealized, 2)
-                 if isinstance(unrealized, (int, float)) and not isinstance(unrealized, bool) else None)
+        gross_realized = agg["pnl"]                  # HL closedPnl sum — GROSS, before trading fees
+        _uok = isinstance(unrealized, (int, float)) and not isinstance(unrealized, bool)
+        # NET is available only when EVERY closed trade's fee resolved. If the fills read was UNDETERMINED for
+        # even one, subtracting a partial fee understates the cost — so fees/net stay UNKNOWN (never gross-as-net).
+        cnt = agg.get("count", 0)
+        fees_ok = (cnt == 0) or (agg.get("fees_known", 0) == cnt)
+        fees = round(agg.get("fees", 0.0), 2) if fees_ok else None
+        net_realized = round(gross_realized - fees, 2) if fees is not None else None
+        gross_total = round(gross_realized + unrealized, 2) if _uok else None
+        net_total = round(net_realized + unrealized, 2) if (net_realized is not None and _uok) else None
+        fees_status = "ok" if fees is not None else "undetermined"
         mandate = s.get("mandate")
         if mandate is None:
             note = ("mandate unavailable on this CURRENT strategy — look it up / check the runtime "
@@ -1666,9 +1719,13 @@ def _strategy_reads(trades, strategies, open_book=None):
             "mandate": mandate,
             "dsl": s.get("dsl"),                 # the levers a fix routes to
             "closed_trade_count": agg["count"],
-            "realized_pnl": realized,
-            "unrealized_pnl": unrealized,        # current open positions' unrealized — None = UNKNOWN read
-            "total_pnl": total,                  # realized + unrealized; None when unrealized UNKNOWN
+            "gross_realized_pnl": gross_realized,   # HL closedPnl sum — GROSS, before trading fees
+            "fees": fees,                           # window trading fees (builder-fee-incl); None = UNDETERMINED
+            "net_realized_pnl": net_realized,       # gross_realized − fees; None when fees undetermined
+            "unrealized_pnl": unrealized,           # current open positions' unrealized — None = UNKNOWN read
+            "gross_total_pnl": gross_total,         # gross_realized + unrealized; None when unrealized UNKNOWN
+            "net_total_pnl": net_total,             # net_realized + unrealized; None when either UNKNOWN
+            "fees_status": fees_status,             # ok | undetermined — never render gross as net when undetermined
             "open_position_count": len(open_positions),
             "open_positions": open_positions,    # asset/direction/unrealized_pnl/return_on_equity_pct/entry/lev
             "on_mandate_note": note,
@@ -1690,12 +1747,18 @@ def _closed_strategy_rollup(trades, strategies):
         w = str(s.get("wallet") or "").lower()
         agg = by_wallet.get(w, {"count": 0, "pnl": 0.0})
         wallet = s.get("wallet")
+        cnt = agg.get("count", 0)
+        _fok = (cnt == 0) or (agg.get("fees_known", 0) == cnt)
+        _fees = round(agg.get("fees", 0.0), 2) if _fok else None
         out.append({
             "label": s.get("label"),
             "wallet_short": (str(wallet)[:10] if wallet else None),
             "status": s.get("status"),
             "trade_count": agg["count"],
-            "realized_pnl": agg["pnl"],
+            "gross_realized_pnl": agg["pnl"],       # GROSS (pre-fee)
+            "fees": _fees,                          # None = UNDETERMINED (fills read failed for some trade)
+            "net_realized_pnl": (round(agg["pnl"] - _fees, 2) if _fees is not None else None),
+            "fees_status": ("ok" if _fees is not None else "undetermined"),
         })
     return out
 
@@ -1726,36 +1789,54 @@ def _telemetry_source(source_counts, telemetry_warned):
 
 
 # ──────────────────────────────────────────────── total-ledger PnL + the 'undetermined ≠ all-clear' signal
-def _pnl_summary(realized_total, strat_reads):
+def _fees_total_of(trades):
+    """Sum of every trade's authoritative round-trip fee — or None if ANY trade's fee is UNDETERMINED, so the
+    net headline stays UNKNOWN rather than subtract a partial (understated) fee. None for [] → 0.0 (no trades)."""
+    fees = [t.get("fee") for t in trades]
+    if all(isinstance(f, (int, float)) and not isinstance(f, bool) for f in fees):   # all() is True for []
+        return round(sum(f for f in fees if isinstance(f, (int, float)) and not isinstance(f, bool)), 2)
+    return None
+
+
+def _pnl_summary(realized_total, strat_reads, fees_total=None):
     """The TOTAL-ledger headline the narrator LEADS with — realized (closed trades) + unrealized (current
     open positions) + total — PLUS the current-vs-closed realized split (so the narrator QUOTES it and never
     re-derives a wrong closed-book figure). `realized_total` is ALL closed trades; current-book realized = the
     current strategies' realized sum; closed-book = the remainder (reconciles by construction). `unrealized`
     sums only the current strategies whose open book was READABLE → None when none were, so `total` stays an
     honest UNKNOWN rather than collapsing to a realized-only headline."""
-    realized = round(_num(realized_total) or 0.0, 2)
-    current_realized = round(sum(_num(s.get("realized_pnl")) or 0.0 for s in strat_reads), 2)
-    closed_realized = round(realized - current_realized, 2)
+    gross_realized = round(_num(realized_total) or 0.0, 2)
+    current_realized = round(sum(_num(s.get("gross_realized_pnl")) or 0.0 for s in strat_reads), 2)
+    closed_realized = round(gross_realized - current_realized, 2)
     known = [u for u in (s.get("unrealized_pnl") for s in strat_reads)
              if isinstance(u, (int, float)) and not isinstance(u, bool)]
     unrealized = round(sum(known), 2) if known else None
-    total = round(realized + unrealized, 2) if unrealized is not None else None
+    gross_total = round(gross_realized + unrealized, 2) if unrealized is not None else None
+    fees = round(fees_total, 2) if isinstance(fees_total, (int, float)) and not isinstance(fees_total, bool) else None
+    net_realized = round(gross_realized - fees, 2) if fees is not None else None
+    net_total = round(net_realized + unrealized, 2) if (net_realized is not None and unrealized is not None) else None
+    fees_status = "ok" if fees is not None else "undetermined"
     # PARTIAL coverage: some current wallets were readable, some were NOT — so `unrealized` (and therefore
     # `total`) sums only the readable ones: a FLOOR, not a complete number. Flag it so the narrator says
     # "at least $X (N of M wallets readable)" and never presents a partial sum as the finished total. (0
     # readable is the all-UNKNOWN case: unrealized/total = None above, not a floor.)
     partial = unrealized is not None and len(known) < len(strat_reads)
     return {
-        "realized": realized,
+        "gross_realized": gross_realized,         # GROSS closed-trade PnL — before trading fees
+        "fees": fees,                             # window trading fees (builder-fee-incl); None = UNDETERMINED
+        "net_realized": net_realized,             # gross_realized − fees; None when fees undetermined
+        "fees_status": fees_status,               # ok | undetermined
         "realized_by_book": {"current": current_realized, "closed": closed_realized},
         "unrealized": unrealized,                 # None → no current open book readable (UNKNOWN, not 0)
         "unrealized_coverage": {"read": len(known), "current_strategies": len(strat_reads)},
         "unrealized_partial": partial,            # True → unrealized/total are a FLOOR (some wallets UNKNOWN)
-        "total": total,                           # realized + unrealized; None when UNKNOWN; a FLOOR when partial
-        "note": ("TOTAL = realized (closed trades) + unrealized (current open positions). LEAD with TOTAL, "
-                 "not realized alone. unrealized None = the open book couldn't be read (UNKNOWN, not 0). "
-                 "unrealized_partial True = only some current wallets read, so unrealized/total are a FLOOR "
-                 "('at least $X, N of M wallets readable') — never present them as complete."),
+        "gross_total": gross_total,               # gross_realized + unrealized; None UNKNOWN; FLOOR when partial
+        "net_total": net_total,                   # net_realized + unrealized — the honest headline; None UNKNOWN
+        "note": ("LEAD with NET total (net_realized + unrealized), NOT gross. gross_* excludes trading fees. "
+                 "fees None / fees_status 'undetermined' = the fills ledger couldn't be read, so the number is "
+                 "GROSS and fees are UNKNOWN (NOT 0) — never present a gross number as net/booked. unrealized "
+                 "None = open book unreadable (UNKNOWN, not 0). unrealized_partial True = only some current "
+                 "wallets read, so unrealized/total are a FLOOR ('at least $X, N of M wallets readable')."),
     }
 
 
@@ -1941,7 +2022,7 @@ def step_strategies(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_m
     strat_reads = _strategy_reads(trades, strategies, open_book)
     closed_reads = _closed_strategy_rollup(trades, strategies)
     realized_total = round(sum(_num(t.get("realized_pnl")) or 0.0 for t in trades), 2)
-    pnl_summary = _pnl_summary(realized_total, strat_reads)
+    pnl_summary = _pnl_summary(realized_total, strat_reads, _fees_total_of(trades))
     dsl_mix = _dsl_close_reason_mix(trades)   # from whatever exit_reason is in state (UNKNOWN until telemetry)
     current_count = sum(1 for s in strategies if _is_current(s.get("status")))
     closed_count = len(strategies) - current_count
@@ -2065,7 +2146,8 @@ def run(client, window_days=WINDOW_DEFAULT_DAYS, last_n=None, want_market=True, 
     bvm = book_vs_market(client, trades, strategies, meta, want_market)
     strat_reads = _strategy_reads(trades, strategies, open_book)   # CURRENT book — now with unrealized/total/open
     closed_reads = _closed_strategy_rollup(trades, strategies) # HISTORY: closed/inactive, rollup only
-    pnl_summary = _pnl_summary(timing["realized_pnl_total"], strat_reads)   # realized + unrealized = TOTAL ledger
+    pnl_summary = _pnl_summary(timing["gross_realized_pnl_total"], strat_reads,   # realized + unrealized, net of fees
+                               timing.get("fees_total"))
 
     current_count = sum(1 for s in strategies if _is_current(s.get("status")))
     closed_count = len(strategies) - current_count

--- a/senpi-improve-trades/tests/test_review.py
+++ b/senpi-improve-trades/tests/test_review.py
@@ -370,7 +370,7 @@ def test_closed_strategies_rollup_shape():
     assert cs["trade_count"] == 2                       # BTC + DOGE on the closed wallet
     assert cs["gross_realized_pnl"] == 220.0                  # 200 + 20
     assert set(cs.keys()) == {"label", "wallet_short", "status", "trade_count",
-                              "gross_realized_pnl", "fees", "net_realized_pnl", "fees_status"}
+                              "gross_realized_pnl", "fees", "net_realized_pnl", "fees_status", "fees_coverage"}
     # explicitly NO verdict/mandate leakage onto a closed strategy
     for banned in ("mandate", "dsl", "on_mandate_note", "verdict"):
         assert banned not in cs
@@ -917,6 +917,49 @@ def test_fees_undetermined_when_fills_read_fails():
     assert r["gross_realized_pnl"] == 40.0                          # gross still known
     assert r["fees"] is None and r["net_realized_pnl"] is None and r["fees_status"] == "undetermined"
     assert r["net_total_pnl"] is None and r["gross_total_pnl"] == 45.0   # net UNKNOWN; gross total = 40 + 5
+
+
+def test_reconstruct_fees_are_signed_maker_rebates_reduce_cost():
+    """HL `fee` is SIGNED — a maker rebate is NEGATIVE (the wallet was paid). The round-trip fee sums it
+    as-is; abs() would flip a rebate into a cost and understate net by 2x (Ignas' review of #538)."""
+    base = 1784000000000
+    fills = [
+        {"coin": "SOL", "dir": "Open Long",  "sz": "1", "px": "100", "closedPnl": "0",  "fee": "-0.5", "time": base + 1, "oid": 1},  # maker rebate
+        {"coin": "SOL", "dir": "Close Long", "sz": "1", "px": "110", "closedPnl": "10", "fee": "0.2",  "time": base + 2, "oid": 2},  # taker cost
+    ]
+    tr = review._reconstruct_closed_from_fills(fills, None, None, None)
+    assert len(tr) == 1 and tr[0]["fee"] == -0.3        # −0.5 rebate + 0.2 cost — SIGNED, not abs()
+    tr[0]["strategy_wallet"] = "0xw"
+    agg = review._pnl_by_wallet(tr)["0xw"]
+    assert agg["fees"] == -0.3 and round(agg["pnl"] - agg["fees"], 2) == 10.3   # the rebate ADDS to net
+
+
+def test_fees_coverage_reports_resolved_over_total():
+    """When some trades' fees resolve and one doesn't, the record carries fees_coverage {resolved, total}
+    so a consumer can say 'net for R of T' instead of only a flat undetermined (Ignas' review of #538)."""
+    w = "0xcov00000000000000000000000000000000cov0"
+    trades = [
+        {"asset": "A", "realized_pnl": 10.0, "fee": 0.1,  "strategy_wallet": w},
+        {"asset": "B", "realized_pnl": 5.0,  "fee": None, "strategy_wallet": w},   # one unresolved
+    ]
+    strategies = [{"wallet": w, "status": "ACTIVE", "label": "x", "mandate": None}]
+    r = review._strategy_reads(trades, strategies, {w.lower(): {"unrealized_pnl": 0.0, "positions": []}})[0]
+    assert r["fees_status"] == "undetermined" and r["net_realized_pnl"] is None
+    assert r["fees_coverage"] == {"resolved": 1, "total": 2}
+
+
+def test_fetch_window_fills_pages_userfillsbytime_when_windowed():
+    """A windowed review pages `userFillsByTime` (so coverage matches the window, not the recent-2000 cap);
+    no window → the recent `userFills` slice. Both are served by the fixture under their own hl:: keys."""
+    w = "0xwin00000000000000000000000000000000win0"
+    byt = [{"coin": "X", "dir": "Open Long", "sz": "1", "px": "1", "closedPnl": "0", "fee": "0.1", "time": 5, "oid": 1}]
+    recent = [{"coin": "Y", "dir": "Open Long", "sz": "1", "px": "1", "closedPnl": "0", "fee": "0.2", "time": 5, "oid": 2}]
+    client = review._FixtureClient({
+        f"hl::userFillsByTime::{w.lower()}": byt,
+        f"hl::userFills::{w.lower()}": recent,
+    })
+    assert review._fetch_window_fills(client, w, 100, 200, {}) == byt        # windowed → userFillsByTime
+    assert review._fetch_window_fills(client, w, None, None, {}) == recent   # no window → userFills
 
 
 # ────────────────────────────── scope + fast-fail (the "telemetry unavailable" live-run fix) ──

--- a/senpi-improve-trades/tests/test_review.py
+++ b/senpi-improve-trades/tests/test_review.py
@@ -105,7 +105,7 @@ def test_timing_summary_counts_beat_vs_worse():
     assert ts["exits_ahead"] == 1
     assert ts["exits_held_higher"] == 2
     assert ts["exits_flat"] == 0
-    assert ts["realized_pnl_total"] == 340.0
+    assert ts["gross_realized_pnl_total"] == 340.0
     assert ts["if_all_reclosed_now_total"] == 290.0
 
 
@@ -165,7 +165,7 @@ def test_strategy_read_carries_mandate_and_dsl_lever():
     assert strat["dsl"]["hard_stop_roe_pct"] == -15.0      # the hard-stop lever
     assert strat["dsl"]["arm_at_roe_pct"] == 10            # the arm-at lever
     assert strat["closed_trade_count"] == 3
-    assert strat["realized_pnl"] == 340.0
+    assert strat["gross_realized_pnl"] == 340.0
 
 
 def test_open_book_unrealized_and_total_pnl():
@@ -174,15 +174,15 @@ def test_open_book_unrealized_and_total_pnl():
     the current/closed realized split. A book riding an open winner is NOT judged on realized alone."""
     res = _result()
     strat = {s["label"]: s for s in res["strategies"]}["kodiak"]
-    assert strat["realized_pnl"] == 340.0
+    assert strat["gross_realized_pnl"] == 340.0
     assert strat["unrealized_pnl"] == 120.0
-    assert strat["total_pnl"] == 460.0
+    assert strat["gross_total_pnl"] == 460.0
     assert strat["open_position_count"] == 1
     op = strat["open_positions"][0]
     assert op["asset"] == "SOL" and op["direction"] == "long"
     assert op["unrealized_pnl"] == 120.0 and op["return_on_equity_pct"] == 10.0
     ps = res["pnl_summary"]
-    assert ps["realized"] == 340.0 and ps["unrealized"] == 120.0 and ps["total"] == 460.0
+    assert ps["gross_realized"] == 340.0 and ps["unrealized"] == 120.0 and ps["gross_total"] == 460.0
     assert ps["realized_by_book"] == {"current": 340.0, "closed": 0.0}
 
 
@@ -202,9 +202,9 @@ def test_open_book_unreadable_is_unknown_not_zero():
         else:
             os.environ["SENPI_STATE_DIR"] = old
     strat = {s["label"]: s for s in res["strategies"]}["kodiak"]
-    assert strat["unrealized_pnl"] is None and strat["total_pnl"] is None   # UNKNOWN, not 0
-    assert res["pnl_summary"]["unrealized"] is None and res["pnl_summary"]["total"] is None
-    assert res["pnl_summary"]["realized"] == 340.0                          # realized still known
+    assert strat["unrealized_pnl"] is None and strat["gross_total_pnl"] is None   # UNKNOWN, not 0
+    assert res["pnl_summary"]["unrealized"] is None and res["pnl_summary"]["gross_total"] is None
+    assert res["pnl_summary"]["gross_realized"] == 340.0                          # realized still known
 
 
 def test_pnl_summary_partial_coverage_is_flagged_floor_not_complete():
@@ -219,7 +219,7 @@ def test_pnl_summary_partial_coverage_is_flagged_floor_not_complete():
     ]
     ps = review._pnl_summary(150.0, strat_reads)
     assert ps["unrealized"] == 500.0                         # only the readable wallet — a FLOOR
-    assert ps["total"] == 650.0                              # 150 realized + 500 known unrealized (floor)
+    assert ps["gross_total"] == 650.0                              # 150 realized + 500 known unrealized (floor)
     assert ps["unrealized_partial"] is True                 # <-- flagged, not silent
     assert ps["unrealized_coverage"] == {"read": 1, "current_strategies": 2}
 
@@ -229,7 +229,7 @@ def test_pnl_summary_full_coverage_is_not_partial():
     strat_reads = [{"realized_pnl": 100.0, "unrealized_pnl": 500.0},
                    {"realized_pnl": 50.0, "unrealized_pnl": -20.0}]
     ps = review._pnl_summary(150.0, strat_reads)
-    assert ps["unrealized"] == 480.0 and ps["total"] == 630.0
+    assert ps["unrealized"] == 480.0 and ps["gross_total"] == 630.0
     assert ps["unrealized_partial"] is False
 
 
@@ -238,7 +238,7 @@ def test_pnl_summary_all_unreadable_is_none_not_partial():
     strat_reads = [{"realized_pnl": 100.0, "unrealized_pnl": None},
                    {"realized_pnl": 50.0, "unrealized_pnl": None}]
     ps = review._pnl_summary(150.0, strat_reads)
-    assert ps["unrealized"] is None and ps["total"] is None
+    assert ps["unrealized"] is None and ps["gross_total"] is None
     assert ps["unrealized_partial"] is False                # None ≠ floor
 
 
@@ -306,7 +306,7 @@ def test_fails_open_when_market_source_missing():
     assert all(t["if_held_delta_usd"] is None for t in res["trades"])
     assert res["timing_summary"]["exits_unknown"] == 3
     assert res["book_vs_market"]["top_movers"] == []
-    assert res["timing_summary"]["realized_pnl_total"] == 340.0   # realized PnL is source-independent
+    assert res["timing_summary"]["gross_realized_pnl_total"] == 340.0   # realized PnL is source-independent
 
 
 def test_fails_open_on_empty_everything():
@@ -368,8 +368,9 @@ def test_closed_strategies_rollup_shape():
     cs = res["closed_strategies"][0]
     assert cs["label"] == "kodiak" and cs["status"] == "CLOSED"
     assert cs["trade_count"] == 2                       # BTC + DOGE on the closed wallet
-    assert cs["realized_pnl"] == 220.0                  # 200 + 20
-    assert set(cs.keys()) == {"label", "wallet_short", "status", "trade_count", "realized_pnl"}
+    assert cs["gross_realized_pnl"] == 220.0                  # 200 + 20
+    assert set(cs.keys()) == {"label", "wallet_short", "status", "trade_count",
+                              "gross_realized_pnl", "fees", "net_realized_pnl", "fees_status"}
     # explicitly NO verdict/mandate leakage onto a closed strategy
     for banned in ("mandate", "dsl", "on_mandate_note", "verdict"):
         assert banned not in cs
@@ -663,7 +664,7 @@ def test_step_strategies_slice_reads_state():
     assert set(out) == {"strategies", "closed_strategies", "pnl_summary", "dsl_close_reason_mix", "meta"}
     strat = {s["label"]: s for s in out["strategies"]}["kodiak"]
     assert strat["dsl"]["hard_stop_roe_pct"] == -15.0    # mandate/DSL from the registry
-    assert strat["realized_pnl"] == 340.0
+    assert strat["gross_realized_pnl"] == 340.0
     assert out["meta"]["current_strategy_count"] == 1
     assert out["strategies"] == _result()["strategies"]  # == all's per-strategy read
 
@@ -757,7 +758,7 @@ def test_steps_self_heal_when_state_absent():
         return s, te
     s, te = _with_env(_solo, events=True)
     assert {x["label"] for x in s["strategies"]} == {"kodiak"}
-    assert s["strategies"][0]["realized_pnl"] == 340.0
+    assert s["strategies"][0]["gross_realized_pnl"] == 340.0
     # telemetry self-healed the fetch, then enriched
     assert {t["asset"]: t["exit_reason"]["terminal"] for t in te["trades"]}["SOL"] == "tier_breach"
 
@@ -821,7 +822,11 @@ def test_reconstruct_closed_from_fills_fifo_direction_pnl():
     assert by[("HYPE", 120.0)]["entry_px"] == 100.0 and by[("HYPE", 120.0)]["direction"] == "long"
     assert by[("HYPE", 130.0)]["entry_px"] == 110.0
     assert by[("SOL", 190.0)]["direction"] == "short" and by[("SOL", 190.0)]["entry_px"] == 200.0
-    assert round(sum(t["realized_pnl"] for t in tr), 2) == 160.0    # HL closedPnl — authoritative
+    assert round(sum(t["realized_pnl"] for t in tr), 2) == 160.0    # HL closedPnl — GROSS, authoritative
+    # round-trip fee = matched OPEN-side fee (pro-rated) + this CLOSE fill's fee (HL fee is builder-inclusive)
+    assert by[("HYPE", 120.0)]["fee"] == 0.22 and by[("HYPE", 130.0)]["fee"] == 0.11
+    assert by[("SOL", 190.0)]["fee"] == 0.39
+    assert round(sum(t["fee"] for t in tr), 2) == 0.72              # total trading fees over the window
     assert all(t["source"] == "onchain_fills" for t in tr)
     assert tr[0]["asset"] == "SOL"                                  # newest close first
     assert [t["asset"] for t in review._reconstruct_closed_from_fills(fills, base + 5000, None, None)] == ["SOL"]
@@ -861,6 +866,57 @@ def test_no_trades_when_both_sources_empty():
     meta = {}
     assert review.fetch_closed_trades(client, w, None, None, None, meta) == []
     assert "closed_trade_source" not in meta
+
+
+# ── fee-honest PnL: discovery is GROSS; fees come from the fills ledger; net stays UNKNOWN when unread ──
+def test_discovery_trades_get_fees_from_fills_and_net():
+    """discovery owns the trade list but carries NO fee (its realized_pnl is GROSS). fetch_closed_trades
+    stamps each row's round-trip fee from the fills ledger (matched by close order id), so net = gross − fees."""
+    w = "0xfeed00000000000000000000000000000000feed"
+    disco = {"closedPositions": [
+        {"coin": "HYPE", "szi": "2",   "entryPx": "100", "exitPx": "120", "realizedPnl": "40",
+         "closeTime": 1784000003000, "openTime": 1784000001000, "closedOrderId": 3},
+        {"coin": "SOL",  "szi": "-10", "entryPx": "200", "exitPx": "190", "realizedPnl": "100",
+         "closeTime": 1784000009000, "openTime": 1784000001500, "closedOrderId": 6},
+    ]}
+    fills = [
+        {"coin": "HYPE", "dir": "Open Long",   "sz": "2",  "px": "100", "closedPnl": "0",   "fee": "0.10", "time": 1784000001000, "oid": 1},
+        {"coin": "HYPE", "dir": "Close Long",  "sz": "2",  "px": "120", "closedPnl": "40",  "fee": "0.12", "time": 1784000003000, "oid": 3},
+        {"coin": "SOL",  "dir": "Open Short",  "sz": "10", "px": "200", "closedPnl": "0",   "fee": "0.20", "time": 1784000001500, "oid": 5},
+        {"coin": "SOL",  "dir": "Close Short", "sz": "10", "px": "190", "closedPnl": "100", "fee": "0.19", "time": 1784000009000, "oid": 6},
+    ]
+    client = review._FixtureClient({
+        f"discovery_get_trader_history::{w.lower()}": disco,
+        f"hl::userFills::{w.lower()}": fills,
+    })
+    trades = review.fetch_closed_trades(client, w, None, None, None, {})
+    assert len(trades) == 2
+    by = {t["asset"]: t for t in trades}
+    assert by["HYPE"]["fee"] == 0.22 and by["SOL"]["fee"] == 0.39   # open + close, matched by oid
+    for t in trades:
+        t["strategy_wallet"] = w
+    agg = review._pnl_by_wallet(trades)[w.lower()]
+    assert agg["pnl"] == 140.0 and round(agg["fees"], 2) == 0.61 and agg["fees_known"] == 2
+
+
+def test_fees_undetermined_when_fills_read_fails():
+    """discovery has closed trades but the fills ledger is UNREADABLE → each fee is None, and the record marks
+    fees/net UNDETERMINED (never a fake $0 net that would read to the user as booked profit)."""
+    w = "0xnofills0000000000000000000000000000nofil"
+    disco = {"closedPositions": [
+        {"coin": "HYPE", "szi": "2", "entryPx": "100", "exitPx": "120", "realizedPnl": "40",
+         "closeTime": 1784000003000, "closedOrderId": 3},
+    ]}
+    client = review._FixtureClient({f"discovery_get_trader_history::{w.lower()}": disco})   # NO userFills → read fails
+    trades = review.fetch_closed_trades(client, w, None, None, None, {})
+    assert len(trades) == 1 and trades[0]["fee"] is None
+    for t in trades:
+        t["strategy_wallet"] = w
+    strategies = [{"wallet": w, "status": "ACTIVE", "label": "x", "mandate": None}]
+    r = review._strategy_reads(trades, strategies, {w.lower(): {"unrealized_pnl": 5.0, "positions": []}})[0]
+    assert r["gross_realized_pnl"] == 40.0                          # gross still known
+    assert r["fees"] is None and r["net_realized_pnl"] is None and r["fees_status"] == "undetermined"
+    assert r["net_total_pnl"] is None and r["gross_total_pnl"] == 45.0   # net UNKNOWN; gross total = 40 + 5
 
 
 # ────────────────────────────── scope + fast-fail (the "telemetry unavailable" live-run fix) ──
@@ -954,7 +1010,7 @@ def _big_result(n_trades=146, n_missed=40):
                 "exit_reason": {"terminal": "SL_TRIGGERED", "tier_reached": 2, "high_water_roe": 41.0}}
     return {"trades": [mk(i) for i in range(n_trades)],
             "timing_summary": {"trade_count": n_trades, "exits_ahead": 124},
-            "pnl_summary": {"total": 468.44, "realized": -239.44},
+            "pnl_summary": {"gross_total": 468.44, "net_total": 467.5, "gross_realized": -239.44},
             "missed_signals": [{"asset": f"M{i}", "reason_code": "no_slots"} for i in range(n_missed)],
             "meta": {"trade_count": n_trades}}
 
@@ -967,7 +1023,7 @@ def test_stdout_slim_samples_trades_and_keeps_aggregates():
     assert len(slim["trades"]) == review.STDOUT_TRADES_SAMPLE                  # sampled, not all 146
     assert slim["trades_sample"]["total"] == 146                              # true count preserved
     assert slim["timing_summary"]["exits_ahead"] == 124                       # aggregate untouched
-    assert slim["pnl_summary"]["total"] == 468.44
+    assert slim["pnl_summary"]["gross_total"] == 468.44
     assert len(slim["missed_signals"]) == review.STDOUT_MISSED_SAMPLE
     keys = set(slim["trades"][0].keys())                                      # per-trade fields trimmed
     assert "realized_pnl" in keys and "exit_reason" in keys

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.13.3"
+  version: "1.14.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -71,8 +71,8 @@ dump when the user asked about their **strategies** — is a failure. The user w
 >   scanner-managed wallet can be reconciled as foreign and DSL-flattened within minutes (order "succeeds,"
 >   position gone; a raw read of the wrong sub-wallet then shows it "phantom").
 > - **"What happened to my [asset] / my closed trades"** → read the authoritative CLOSED record
->   (`closed.recent[]` / `closed.realized_pnl` here, or hand to `senpi-improve-trades` for why-it-closed).
->   Never narrate a closed-position story from memory.
+>   (`closed.recent[]` / `closed.net_realized_pnl` — after fees — here, or hand to `senpi-improve-trades`
+>   for why-it-closed). Never narrate a closed-position story from memory.
 
 ## The wallet model (get this exactly right)
 
@@ -323,11 +323,18 @@ directly.)
   *fighting* a rally? Read net exposure, concentration, idle drag. See `references/analysis-framework.md`.
 - **Use leveraged return, not raw price %.** Cite `return_on_equity_pct` (uPnL / margin), the number
   that actually reflects the position — a 1% price move at 10x is a 10% return on margin.
-- **Report realized PnL + closed trades, not only open ones.** Each strategy carries a `closed` block —
-  `realized_pnl` (total booked PnL over the recent history pull) and `recent[]` (last few closed
-  trades: asset, direction, realized pnl, closed time). A strategy flat right now may have *already
-  booked* real gains; report both realized and unrealized. If `closed.realized_pnl` is `null`, the
-  history read failed (see `meta.warnings`) — say realized PnL is unavailable, don't imply zero.
+- **Report NET realized PnL + closed trades, not only open ones — and never gross-as-booked.** Each
+  strategy carries a `closed` block with four PnL fields: `gross_realized_pnl` (price-PnL over the recent
+  history pull, **BEFORE fees**), `fees` (the window's builder-inclusive trading fees actually paid),
+  `net_realized_pnl` (`gross − fees` — the **real booked** number), and `fees_status`. **Lead with
+  `net_realized_pnl`** — that is what the user actually pocketed; gross alone overstates their profit.
+  `recent[]` carries the last few closed trades (asset, direction, per-trade gross `realized_pnl`, closed
+  time). A strategy flat right now may have *already booked* real gains; report both net realized and
+  unrealized. **Honesty gate on `fees_status`:** when it is `"undetermined"` the fills read failed/was
+  empty, so `fees` and `net_realized_pnl` are `null` — report the `gross_realized_pnl` figure explicitly
+  as **gross/before-fees with fees UNKNOWN (not zero)**, and never present it as booked or net. If
+  `gross_realized_pnl` is also `null`, the history read itself failed (see `meta.warnings`) — say realized
+  PnL is unavailable, don't imply zero.
 - **Surface the protection posture per strategy — then the live tiers.** Each strategy carries
   `protected` (`true` / `false` / `null`): `true` only when the deployed `runtime.yaml`'s `exit:` block
   is one the **ENGINE actually read** (`dsl_preset` or `engine: dsl`) — a `skill_name` attribution stamp
@@ -538,7 +545,10 @@ Returns `{totals, embedded_wallet, strategies, strategy_groups, exposure, signal
     `wallet_short`, `account_value`, `idle_withdrawable`, `deployed`, `upnl`, `positions[]` (each with a
     live `dsl` tier object), `closed`.
   - `totals` — summed across every instance: `account_value`, `idle_withdrawable`, `deployed`, `upnl`,
-    and `realized_pnl` (when available). **Report the strategy's figures from here, not per-wallet.**
+    and the closed-PnL set `gross_realized_pnl` / `fees` / `net_realized_pnl` / `fees_status`. Fees/net
+    are `null` with `fees_status: "undetermined"` if **any** sleeve's fees are undetermined (a partial fee
+    sum is never reported as complete). **Report the strategy's figures from here, not per-wallet — and
+    lead with `net_realized_pnl`.**
   - `protected` (`true` / `false` / `null`) — `true` **only if ALL instances are protected**; `null` if
     ANY instance is `null` — an unread instance is never laundered into a `false`.
   - `flat_instances` — names of instances with **no open positions**. For a multi-wallet strategy these
@@ -575,11 +585,17 @@ Returns `{totals, embedded_wallet, strategies, strategy_groups, exposure, signal
     stamp alone no longer counts. `null` = the runtime read did not answer — say "could not verify on
     this host," never "protected" or "not protected." Config-level posture, not a live per-position
     check — see the tri-state rule above.
-  - `closed` — `{realized_pnl, trade_count, recent[]}` from a read-guarded `discovery_get_trader_history`
-    on the strategy wallet: `realized_pnl` (total booked PnL over the recent pull), `trade_count`, and
-    `recent[]` (last few closed trades: `asset`, `direction`, `realized_pnl`, `entry_px`, `exit_px`,
-    `closed_time`). On a read failure `realized_pnl` is `null` and a `meta.warnings` entry is added —
-    treat as "realized PnL unavailable," never as zero.
+  - `closed` — `{gross_realized_pnl, fees, net_realized_pnl, fees_status, trade_count, recent[]}`.
+    `gross_realized_pnl` (price-PnL over the recent pull, **BEFORE fees**) comes from a read-guarded
+    `discovery_get_trader_history` on the strategy wallet; `fees` (window trading fees, builder-inclusive)
+    is summed from the HL `userFills` ledger; `net_realized_pnl` = `gross − fees` is the **real booked
+    figure — lead with it**. `fees_status` is `"ok"` when fees were determined and `"undetermined"` when
+    the fills read failed or was empty **while the wallet has closed trades** — then `fees` and
+    `net_realized_pnl` are `null` and you must call the number **gross with fees UNKNOWN (not $0)**. A
+    wallet with genuinely **no** closed trades reports `fees: 0.0`, `net_realized_pnl` = gross, `"ok"`.
+    `recent[]` = the last few closed trades (`asset`, `direction`, per-trade gross `realized_pnl`,
+    `entry_px`, `exit_px`, `closed_time`). If `gross_realized_pnl` is `null` the history read failed (a
+    `meta.warnings` entry is added) — treat realized PnL as "unavailable," never as zero.
   - `positions[]` (asset, dex, direction, leverage, notional, margin, `upnl`, `return_on_equity_pct`,
     `liq_px`, `market_24h_pct`, `vs_market`, and **`dsl`** — the live per-position ratchet tier).
     - **`dsl`** — this position's live DSL/ratchet state. **`armed: true`** → `tier_index`,
@@ -637,9 +653,11 @@ See "A strategy is ALL its wallets."
       **OTHER sleeve waiting for its signal** (for a multi-wallet strategy) or the whole strategy
       waiting for its setup (for a single-wallet one) — say that, never "dead money." Flag any position
       fighting the tape *for a directional-momentum mandate* / near `liq_px` / oversized.
-   4. **PnL — realized + unrealized, summed across the strategy.** The group's `totals.realized_pnl`
-      and `totals.upnl` (+ a couple of `closed.recent[]` trades from its instances). A flat sleeve may
-      have already banked real gains on the other sleeve.
+   4. **PnL — NET realized + unrealized, summed across the strategy.** Lead with `totals.net_realized_pnl`
+      (gross − fees — what was actually booked), not `totals.gross_realized_pnl`, alongside `totals.upnl`
+      (+ a couple of `closed.recent[]` trades from its instances). If `totals.fees_status` is
+      `"undetermined"`, net/fees are `null` — quote gross as **before-fees, fees unknown (not $0)**. A flat
+      sleeve may have already banked real gains on the other sleeve.
    5. **DSL protection — ladder + live tiers.** State the group's `protected` posture (⟹ **all**
       instances ship a DSL exit), then **how its DSL works** from `group.dsl` / `profile.dsl` (hard stop
       at `hard_stop_roe_pct`, ratchet arms at `arm_at_roe_pct`, the tier ladder), then **each open
@@ -683,9 +701,13 @@ Show strategy wallet addresses in short form (`0x35d1...acb1`) unless asked for 
   token (it needs a USER-scoped token); don't report an empty portfolio as "$0."
 - **A strategy's clearinghouse read failed** → it's in `meta.warnings`; that wallet's positions may be
   incomplete. Say so rather than implying it's flat.
-- **A strategy's closed-history read failed** → `closed.realized_pnl` is `null` + a `meta.warnings`
+- **A strategy's closed-history read failed** → `closed.gross_realized_pnl` is `null` + a `meta.warnings`
   entry (`trader_history … failed/returned no data`). Report realized PnL as **unavailable** for that
   strategy — never as `$0`.
+- **A strategy's fee read failed / was empty** → `closed.fees_status` is `"undetermined"`, with
+  `closed.fees` and `closed.net_realized_pnl` `null` + a `meta.warnings` entry (`userFills … undetermined`).
+  Only `gross_realized_pnl` is known: report it as **gross / before fees, with fees UNKNOWN (not zero)** —
+  never present gross as booked or net. Fees are $0 **only** when the wallet has no closed trades at all.
 - **`totals.reconciles == false`** → the per-wallet sum and the portfolio aggregate disagree; surface
   it and trust the per-wallet (live) figures.
 - **Never** report `total_withdrawable` as embedded idle, never skip a wallet, never skip the CTAs.

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -944,9 +944,9 @@ def _hl_info(payload, meta, client=None, timeout=12):
 def _window_fees(client, wallet, rows, meta):
     """Total builder-inclusive trading fee for the closed-trade window, summed from the HL `userFills`
     ledger — the SEPARATE cost that discovery's gross `realizedPnl` excludes (net = gross − fees). The
-    window is the span the reported closed trades occupy: every fill with `time` at or before the LATEST
-    reported close, so BOTH the opening and closing legs of each closed trade are captured (with the
-    default CLOSED_HISTORY_PULL page this is the whole book — the exact total fee for the exact gross).
+    window is the span the reported closed trades occupy — every fill between the EARLIEST reported open and
+    the LATEST reported close — so fees are symmetric with the gross those rows produce. (An unbounded-below
+    sum would add fees for trades NOT in the gross total and overstate the cost on a long-history wallet.)
 
     Returns (fees, status):
       (sum, "ok")            fills read and summed — a per-fill `fee` ALREADY includes the builder fee, so
@@ -955,9 +955,23 @@ def _window_fees(client, wallet, rows, meta):
                              trades — fees are UNKNOWN and MUST NOT be reported as $0 (that would overstate
                              the user's booked profit, the exact bug this guards).
     FAIL-OPEN: any fee-source error degrades to `undetermined`, it never raises into the portfolio read."""
-    closes = [t for t in (_ms(_field(p, "closeTime", "closed_time", "closeTimeMs"))
-                          for p in rows if isinstance(p, dict)) if t is not None]
-    until_ms = max(closes) if closes else None      # bound above by the latest reported close; no lower bound
+    opens, closes = [], []
+    for p in rows:
+        if not isinstance(p, dict):
+            continue
+        for k in ("openTime", "open_time"):
+            ov = _ms(p.get(k)) if p.get(k) is not None else None
+            if ov is not None:
+                opens.append(ov)
+        for k in ("closeTime", "closed_time", "closeTimeMs"):
+            cv = _ms(p.get(k)) if p.get(k) is not None else None
+            if cv is not None:
+                closes.append(cv)
+    until_ms = max(closes) if closes else None      # bound ABOVE by the latest reported close
+    # bound BELOW by the earliest reported OPEN — captures both legs of every reported round-trip, so fees are
+    # symmetric with the gross those rows produce. If opens are unavailable, leave it UNBOUNDED rather than clip
+    # at the earliest close: undercounting fees overstates net (the exact bug), so prefer to over-attribute.
+    since_ms = min(opens) if opens else None
     try:
         fills = _hl_info({"type": "userFills", "user": wallet}, meta, client)
     except Exception as e:  # noqa
@@ -973,8 +987,10 @@ def _window_fees(client, wallet, rows, meta):
         if not isinstance(fl, dict):
             continue
         t = _ms(fl.get("time"))
-        if until_ms is not None and t is not None and t > until_ms:
-            continue                                # a fill after the last reported close — not this window
+        if t is not None and until_ms is not None and t > until_ms:
+            continue                                # a fill AFTER the latest reported close — not this window
+        if t is not None and since_ms is not None and t < since_ms:
+            continue                                # a fill BEFORE the earliest reported open — not this window
         total += _num(fl.get("fee")) or 0.0
     return round(total, 2), "ok"
 

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -38,6 +38,12 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 MARKET_ENRICH_CAP = 24      # cap the per-asset market pull
 CLOSED_HISTORY_CAP = 5      # recent closed trades to surface per strategy (realized PnL is over the full pull)
 CLOSED_HISTORY_PULL = 50    # closed positions to pull for the realized-PnL total (API default page)
+# Fees come from the Hyperliquid fills ledger, NOT from discovery: HL `realizedPnl`/`closedPnl` is
+# price-PnL EXCLUDING fees, so the discovery total is GROSS. The per-fill `fee` (which ALREADY includes
+# the builder fee — never add a builder fee on top, that double-counts) is the separate cost; net =
+# gross − fees. `userFills` is public + no-auth and keyed by wallet ADDRESS, the same transport the
+# sibling senpi-improve-trades review engine uses.
+HL_INFO_URL = "https://api.hyperliquid.xyz/info"
 
 # WHAT A STRATEGY DOES = its `profile`, and the load-bearing field is `profile.description`, taken from
 # the descriptor the RUNTIME renders for each runtime it has. This is UNIVERSAL: it works for a user's
@@ -157,6 +163,17 @@ def _field(d, *names, default=None):
             if n in d and d[n] is not None:
                 return d[n]
     return default
+
+
+def _ms(ts):
+    """Normalize a Unix timestamp to MILLISECONDS. trader-history close times come in seconds OR ms and HL
+    fill `time` is ms; anything below ~1e12 (≈ 2001 in ms) is seconds → scale ×1000. Without this a
+    seconds-valued closeTime and a ms-valued fill time land in different eras and every fee falls outside
+    the window (a fee-window that reads $0 on a book that paid fees)."""
+    n = _num(ts)
+    if n is None:
+        return None
+    return n * 1000.0 if n < 1e12 else n
 
 
 # ── VENDORED, byte-identical in senpi-portfolio/scripts/portfolio.py and
@@ -904,13 +921,79 @@ def fetch_strategies(client, meta):
     return strategies
 
 
+def _hl_info(payload, meta, client=None, timeout=12):
+    """POST the Hyperliquid Info API (public, no auth) — the same transport the sibling senpi-improve-trades
+    review engine uses. HL keys fills by wallet ADDRESS (durable across a `strategy_close`). Offline/fixture
+    aware for tests (`_FixtureClient` serves a recorded `hl::<type>::<wallet>` entry). Fails OPEN → None."""
+    if client is not None and hasattr(client, "_r"):          # _FixtureClient — serve recorded HL response
+        u = str(payload.get("user", "")).lower()
+        return client._r.get(f"hl::{payload.get('type')}::{u}") or client._r.get(f"hl::{payload.get('type')}")
+    try:
+        p = subprocess.run(
+            ["curl", "-s", "-m", str(timeout), "-X", "POST", HL_INFO_URL,
+             "-H", "Content-Type: application/json", "-d", json.dumps(payload)],
+            capture_output=True, text=True, timeout=timeout + 3)
+        if p.returncode != 0 or not (p.stdout or "").strip():
+            return None
+        return json.loads(p.stdout)
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"hl_info {payload.get('type')} failed: {e}")
+        return None
+
+
+def _window_fees(client, wallet, rows, meta):
+    """Total builder-inclusive trading fee for the closed-trade window, summed from the HL `userFills`
+    ledger — the SEPARATE cost that discovery's gross `realizedPnl` excludes (net = gross − fees). The
+    window is the span the reported closed trades occupy: every fill with `time` at or before the LATEST
+    reported close, so BOTH the opening and closing legs of each closed trade are captured (with the
+    default CLOSED_HISTORY_PULL page this is the whole book — the exact total fee for the exact gross).
+
+    Returns (fees, status):
+      (sum, "ok")            fills read and summed — a per-fill `fee` ALREADY includes the builder fee, so
+                             it is NEVER added again.
+      (None, "undetermined") the `userFills` read FAILED or came back EMPTY while the wallet HAS closed
+                             trades — fees are UNKNOWN and MUST NOT be reported as $0 (that would overstate
+                             the user's booked profit, the exact bug this guards).
+    FAIL-OPEN: any fee-source error degrades to `undetermined`, it never raises into the portfolio read."""
+    closes = [t for t in (_ms(_field(p, "closeTime", "closed_time", "closeTimeMs"))
+                          for p in rows if isinstance(p, dict)) if t is not None]
+    until_ms = max(closes) if closes else None      # bound above by the latest reported close; no lower bound
+    try:
+        fills = _hl_info({"type": "userFills", "user": wallet}, meta, client)
+    except Exception as e:  # noqa
+        meta.setdefault("warnings", []).append(f"userFills {wallet[:8]} failed: {e}")
+        return None, "undetermined"
+    # A FAILED (None) or EMPTY fills read while the wallet has closed trades ⇒ fees UNKNOWN, never $0.
+    if not isinstance(fills, list) or not fills:
+        meta.setdefault("warnings", []).append(
+            f"userFills {wallet[:8]} empty/unavailable — fees undetermined (NOT $0)")
+        return None, "undetermined"
+    total = 0.0
+    for fl in fills:
+        if not isinstance(fl, dict):
+            continue
+        t = _ms(fl.get("time"))
+        if until_ms is not None and t is not None and t > until_ms:
+            continue                                # a fill after the last reported close — not this window
+        total += _num(fl.get("fee")) or 0.0
+    return round(total, 2), "ok"
+
+
 def fetch_closed(client, wallet, meta):
-    """Read-guarded closed-position ledger for a strategy wallet: total realized PnL + a short list of
-    recent closed trades. Extraction matches the real `discovery_get_trader_history` shape
-    (senpi://guides/trader-closed-positions): a `closedPositions[]` of records with `coin`, signed `szi`
-    (>0 closed long / <0 closed short), string `realizedPnl`, Unix-ms `closeTime`, `entryPx`/`exitPx`.
+    """Read-guarded closed-position ledger for a strategy wallet: GROSS realized PnL, the trading fees, the
+    NET (gross − fees), and a short list of recent closed trades. Extraction matches the real
+    `discovery_get_trader_history` shape (senpi://guides/trader-closed-positions): a `closedPositions[]` of
+    records with `coin`, signed `szi` (>0 closed long / <0 closed short), string `realizedPnl` (price-PnL
+    EXCLUDING fees → GROSS), Unix-ms `closeTime`, `entryPx`/`exitPx`. Fees are sourced SEPARATELY from the
+    HL `userFills` ledger (see `_window_fees`).
+
+    Emits: `gross_realized_pnl`, `fees`, `net_realized_pnl`, `fees_status` ("ok" | "undetermined"),
+    `trade_count`, `recent[]`. Degrades HONESTLY — a wallet WITH closed trades whose fills read
+    fails/empty reports `fees`/`net_realized_pnl` = null + `fees_status` "undetermined" (NEVER a fake $0).
     Fails OPEN — any read/parse error → empty closed block + a meta.warning, never crashes."""
-    empty = {"realized_pnl": None, "trade_count": 0, "recent": []}
+    # trader-history itself unread ⇒ GROSS is unknown, so net + fees are unknowable too → undetermined.
+    empty = {"gross_realized_pnl": None, "fees": None, "net_realized_pnl": None,
+             "fees_status": "undetermined", "trade_count": 0, "recent": []}
     try:
         h = _ok(client.mcp_call("discovery_get_trader_history", trader_address=wallet,
                                 sort_by="CLOSED_TIME", sort_direction="DESC",
@@ -930,19 +1013,28 @@ def fetch_closed(client, wallet, meta):
     for p in rows:
         if not isinstance(p, dict):
             continue
-        pnl = _f(p, "realizedPnl", "realized_pnl", default=0.0)   # often a string → _f coerces
+        pnl = _f(p, "realizedPnl", "realized_pnl", default=0.0)   # GROSS price-PnL; often a string → _f coerces
         realized_total += pnl
         if len(recent) < CLOSED_HISTORY_CAP:
             szi = _f(p, "szi", "size", default=0.0)
             recent.append({
                 "asset": _field(p, "coin", "coinDisplayName", "asset"),
                 "direction": "long" if szi >= 0 else "short",   # closed-side sign (szi>0 closed a long)
-                "realized_pnl": round(pnl, 2),
+                "realized_pnl": round(pnl, 2),                   # per-trade GROSS (kept as-is)
                 "entry_px": _field(p, "entryPx", "entry_px"),
                 "exit_px": _field(p, "exitPx", "exit_px"),
                 "closed_time": _field(p, "closeTime", "closed_time", "closeTimeMs"),
             })
-    return {"realized_pnl": round(realized_total, 2), "trade_count": len(rows), "recent": recent}
+    gross = round(realized_total, 2)
+    if not rows:
+        # A SUCCESSFUL read of an empty book: genuinely no closed trades ⇒ fees really ARE $0 (net = gross).
+        # This is the ONLY branch that may report $0 fees — distinct from a failed/empty fills read above.
+        return {"gross_realized_pnl": gross, "fees": 0.0, "net_realized_pnl": gross,
+                "fees_status": "ok", "trade_count": 0, "recent": recent}
+    fees, fees_status = _window_fees(client, wallet, rows, meta)
+    net = round(gross - fees, 2) if fees is not None else None
+    return {"gross_realized_pnl": gross, "fees": fees, "net_realized_pnl": net,
+            "fees_status": fees_status, "trade_count": len(rows), "recent": recent}
 
 
 # ──────────────────────────────────────────────────────────────── live per-position DSL / ratchet tier
@@ -1249,14 +1341,34 @@ def group_strategies(strategies, meta):
             vals = [_num(i.get(field)) for i in instances]
             vals = [v for v in vals if v is not None]
             return round(sum(vals), 2) if vals else None
-        realized_vals = [_num((s.get("closed") or {}).get("realized_pnl")) for s in insts]
-        realized_vals = [v for v in realized_vals if v is not None]
+        # Closed-PnL roll-up across the strategy's wallets. GROSS (from discovery) sums independently of
+        # fees. FEES/NET are known for the STRATEGY only if EVERY instance's fees were determined — one
+        # `undetermined` sleeve makes the strategy total fees/net undetermined too (a partial fee sum must
+        # never be reported as the complete cost). Never launder an unknown fee into $0.
+        closed_recs = [(s.get("closed") or {}) for s in insts]
+        gross_vals = [_num(c.get("gross_realized_pnl")) for c in closed_recs]
+        gross_vals = [v for v in gross_vals if v is not None]
+        gross_total = round(sum(gross_vals), 2) if gross_vals else None
+        fee_statuses = [c.get("fees_status") for c in closed_recs if c.get("fees_status") is not None]
+        fees_known = bool(fee_statuses) and all(st == "ok" for st in fee_statuses)
+        if fees_known:
+            fee_vals = [v for v in (_num(c.get("fees")) for c in closed_recs) if v is not None]
+            fees_total = round(sum(fee_vals), 2) if fee_vals else None
+            net_total = (round(gross_total - fees_total, 2)
+                         if (gross_total is not None and fees_total is not None) else None)
+            fees_status_total = "ok"
+        else:
+            fees_total = net_total = None
+            fees_status_total = "undetermined" if fee_statuses else None
         totals = {
             "account_value": _sum("account_value"),
             "idle_withdrawable": _sum("idle_withdrawable"),
             "deployed": _sum("deployed"),
             "upnl": _sum("upnl"),
-            "realized_pnl": round(sum(realized_vals), 2) if realized_vals else None,
+            "gross_realized_pnl": gross_total,
+            "fees": fees_total,
+            "net_realized_pnl": net_total,
+            "fees_status": fees_status_total,
         }
 
         # flat instances = an instance with NO open positions. For a multi-wallet strategy this is its

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -1270,6 +1270,133 @@ def test_within_ttl_cached_state_is_reused():
     assert s["account_value"] == 9999.0, "within-TTL cache was re-fetched (fast path lost)"
 
 
+# ─────────────────────────────── fee-aware closed PnL (gross vs net, builder-inclusive) ───────────────
+FEE_WALLET = "0xFEE0000000000000000000000000000000feefe"
+NOFILLS_WALLET = "0xNOFILL000000000000000000000000000nofill"
+EMPTY_CLOSED_WALLET = "0xEMPTYCLOSED0000000000000000000000empty"
+
+
+def _closed_fixture(wallet, closed_positions, fills=None):
+    """A `_FixtureClient` serving `discovery_get_trader_history` (keyed by trader_address) and, when
+    provided, the HL `userFills` ledger (keyed `hl::userFills::<wallet>` — the same key `_hl_info` reads).
+    Omit `fills` entirely to model an UNAVAILABLE fills read (the fixture returns None)."""
+    rec = {f"discovery_get_trader_history::{wallet.lower()}": {"closedPositions": closed_positions}}
+    if fills is not None:
+        rec[f"hl::userFills::{wallet.lower()}"] = fills
+    return portfolio._FixtureClient(rec)
+
+
+def test_closed_net_realized_is_gross_minus_fees_from_the_fills_ledger():
+    """A wallet WITH fills: `net_realized_pnl == gross_realized_pnl - fees`, `fees_status == "ok"`, and the
+    fee is the builder-INCLUSIVE `fee` summed straight off `userFills` (never gross reported as booked)."""
+    closed = [
+        {"coin": "ETH", "szi": 1, "realizedPnl": "100", "closeTime": 2000, "entryPx": "1", "exitPx": "2"},
+        {"coin": "BTC", "szi": -1, "realizedPnl": "50", "closeTime": 3000, "entryPx": "2", "exitPx": "1"},
+    ]
+    fills = [
+        {"coin": "ETH", "time": 1000, "fee": "1.25", "closedPnl": "0"},     # ETH open leg
+        {"coin": "ETH", "time": 2000, "fee": "1.25", "closedPnl": "100"},   # ETH close leg
+        {"coin": "BTC", "time": 1500, "fee": "1.00", "closedPnl": "0"},     # BTC open leg
+        {"coin": "BTC", "time": 3000, "fee": "1.50", "closedPnl": "50"},    # BTC close leg
+        {"coin": "ETH", "time": 9000, "fee": "99.0", "closedPnl": "0"},     # AFTER last close — excluded
+    ]
+    meta = {}
+    out = portfolio.fetch_closed(_closed_fixture(FEE_WALLET, closed, fills), FEE_WALLET, meta)
+    assert out["gross_realized_pnl"] == 150.0             # discovery's realizedPnl is GROSS (pre-fee)
+    assert out["fees"] == 5.0                             # 1.25+1.25+1.00+1.50 — the 99.0 fill is out-of-window
+    assert out["net_realized_pnl"] == 145.0
+    assert out["net_realized_pnl"] == round(out["gross_realized_pnl"] - out["fees"], 2)
+    assert out["fees_status"] == "ok"
+    assert out["trade_count"] == 2
+    assert "realized_pnl" not in out                      # the gross-as-booked key is GONE (renamed)
+
+
+def test_closed_fees_undetermined_when_fills_empty_never_a_fake_zero():
+    """DEGRADATION: closed trades EXIST but the `userFills` read comes back an EMPTY list → fees/net are
+    null and `fees_status` is "undetermined" (NOT $0 — reporting $0 fees would overstate the user's booked
+    profit, the exact bug). A loud warning is emitted; gross is still known. `_hl_info` is forced to return
+    a genuine `[]` here (the fixture's `or`-fallback would otherwise collapse `[]` to the None path)."""
+    closed = [{"coin": "ETH", "szi": 1, "realizedPnl": "80", "closeTime": 3000, "entryPx": "1", "exitPx": "2"}]
+    client = _closed_fixture(NOFILLS_WALLET, closed, fills=None)
+    meta = {}
+    saved = portfolio._hl_info
+    portfolio._hl_info = lambda payload, m, c=None, timeout=12: []      # empty-list read reaching _window_fees
+    try:
+        out = portfolio.fetch_closed(client, NOFILLS_WALLET, meta)
+    finally:
+        portfolio._hl_info = saved
+    assert out["gross_realized_pnl"] == 80.0
+    assert out["fees"] is None                            # NOT 0.0
+    assert out["net_realized_pnl"] is None                # NOT 80.0
+    assert out["fees_status"] == "undetermined"
+    assert out["trade_count"] == 1
+    assert any("undetermined" in w for w in meta.get("warnings", [])), "a silent $0, not a loud warning"
+
+
+def test_closed_fees_undetermined_when_fills_read_unavailable():
+    """DEGRADATION (read failure, not empty list): the `userFills` source is UNAVAILABLE (fixture returns
+    None) while the wallet has closed trades → same honest degradation, never $0."""
+    closed = [{"coin": "BTC", "szi": -1, "realizedPnl": "40", "closeTime": 5000, "entryPx": "2", "exitPx": "1"}]
+    meta = {}
+    out = portfolio.fetch_closed(_closed_fixture(NOFILLS_WALLET, closed, fills=None), NOFILLS_WALLET, meta)
+    assert out["gross_realized_pnl"] == 40.0
+    assert out["fees"] is None and out["net_realized_pnl"] is None
+    assert out["fees_status"] == "undetermined"
+
+
+def test_closed_no_trades_is_genuinely_zero_fees_not_undetermined():
+    """The ONLY legitimate $0-fees branch: a SUCCESSFUL read of an empty book (zero closed trades). Fees
+    are really $0, net == gross == 0.0, `fees_status == "ok"` — and the fills ledger is never even read."""
+    meta = {}
+    out = portfolio.fetch_closed(_closed_fixture(EMPTY_CLOSED_WALLET, []), EMPTY_CLOSED_WALLET, meta)
+    assert out["trade_count"] == 0
+    assert out["gross_realized_pnl"] == 0.0
+    assert out["fees"] == 0.0                             # genuine zero — distinct from undetermined
+    assert out["net_realized_pnl"] == 0.0
+    assert out["fees_status"] == "ok"
+
+
+def _closed_rec(gross, fees, status):
+    net = round(gross - fees, 2) if (gross is not None and fees is not None) else None
+    return {"gross_realized_pnl": gross, "fees": fees, "net_realized_pnl": net,
+            "fees_status": status, "trade_count": 1, "recent": []}
+
+
+def test_group_totals_sum_net_and_fees_when_every_sleeve_is_ok():
+    """A multi-wallet strategy whose every sleeve read fees cleanly: group `totals` sum gross + fees and
+    net == gross − fees, `fees_status == "ok"`."""
+    rows = [
+        {"name": "tigris-long", "wallet": "0xL", "profile": {"group": "tigris"},
+         "closed": _closed_rec(100.0, 5.0, "ok")},
+        {"name": "tigris-short", "wallet": "0xS", "profile": {"group": "tigris"},
+         "closed": _closed_rec(40.0, 3.0, "ok")},
+    ]
+    groups = portfolio.group_strategies(rows, {})
+    t = groups[0]["totals"]
+    assert t["gross_realized_pnl"] == 140.0
+    assert t["fees"] == 8.0
+    assert t["net_realized_pnl"] == 132.0
+    assert t["fees_status"] == "ok"
+    assert "realized_pnl" not in t                        # renamed at the totals level too
+
+
+def test_group_totals_are_undetermined_if_any_sleeve_is_undetermined():
+    """Honesty roll-up: one sleeve's fees are undetermined → the STRATEGY's fees/net are undetermined too
+    (a partial fee sum is never laundered into a complete cost). Gross still sums from what was readable."""
+    rows = [
+        {"name": "tigris-long", "wallet": "0xL", "profile": {"group": "tigris"},
+         "closed": _closed_rec(100.0, 5.0, "ok")},
+        {"name": "tigris-short", "wallet": "0xS", "profile": {"group": "tigris"},
+         "closed": _closed_rec(40.0, None, "undetermined")},
+    ]
+    groups = portfolio.group_strategies(rows, {})
+    t = groups[0]["totals"]
+    assert t["gross_realized_pnl"] == 140.0               # gross is fee-independent — still summed
+    assert t["fees"] is None                              # NOT 5.0 (a partial sum)
+    assert t["net_realized_pnl"] is None
+    assert t["fees_status"] == "undetermined"
+
+
 if __name__ == "__main__":
     # Direct-script mode bypasses pytest's setup_module/teardown_module hooks entirely, so this run
     # must bracket the same guarantee by hand.

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -1290,20 +1290,21 @@ def test_closed_net_realized_is_gross_minus_fees_from_the_fills_ledger():
     """A wallet WITH fills: `net_realized_pnl == gross_realized_pnl - fees`, `fees_status == "ok"`, and the
     fee is the builder-INCLUSIVE `fee` summed straight off `userFills` (never gross reported as booked)."""
     closed = [
-        {"coin": "ETH", "szi": 1, "realizedPnl": "100", "closeTime": 2000, "entryPx": "1", "exitPx": "2"},
-        {"coin": "BTC", "szi": -1, "realizedPnl": "50", "closeTime": 3000, "entryPx": "2", "exitPx": "1"},
+        {"coin": "ETH", "szi": 1, "realizedPnl": "100", "openTime": 1000, "closeTime": 2000, "entryPx": "1", "exitPx": "2"},
+        {"coin": "BTC", "szi": -1, "realizedPnl": "50", "openTime": 1500, "closeTime": 3000, "entryPx": "2", "exitPx": "1"},
     ]
     fills = [
+        {"coin": "ETH", "time": 500,  "fee": "88.0", "closedPnl": "0"},     # BEFORE earliest open — a prior trade, EXCLUDED
         {"coin": "ETH", "time": 1000, "fee": "1.25", "closedPnl": "0"},     # ETH open leg
         {"coin": "ETH", "time": 2000, "fee": "1.25", "closedPnl": "100"},   # ETH close leg
         {"coin": "BTC", "time": 1500, "fee": "1.00", "closedPnl": "0"},     # BTC open leg
         {"coin": "BTC", "time": 3000, "fee": "1.50", "closedPnl": "50"},    # BTC close leg
-        {"coin": "ETH", "time": 9000, "fee": "99.0", "closedPnl": "0"},     # AFTER last close — excluded
+        {"coin": "ETH", "time": 9000, "fee": "99.0", "closedPnl": "0"},     # AFTER last close — EXCLUDED
     ]
     meta = {}
     out = portfolio.fetch_closed(_closed_fixture(FEE_WALLET, closed, fills), FEE_WALLET, meta)
     assert out["gross_realized_pnl"] == 150.0             # discovery's realizedPnl is GROSS (pre-fee)
-    assert out["fees"] == 5.0                             # 1.25+1.25+1.00+1.50 — the 99.0 fill is out-of-window
+    assert out["fees"] == 5.0                             # 1.25+1.25+1.00+1.50 — the 88.0 (pre-open) + 99.0 (post-close) are out-of-window
     assert out["net_realized_pnl"] == 145.0
     assert out["net_realized_pnl"] == round(out["gross_realized_pnl"] - out["fees"], 2)
     assert out["fees_status"] == "ok"


### PR DESCRIPTION
## The bug

`senpi-improve-trades/scripts/review.py` and `senpi-portfolio/scripts/portfolio.py` both reported realized PnL sourced straight from `discovery_get_trader_history` — which is **GROSS** (HL `closedPnl` is price-PnL, fees are a separate field). Both narrated it to the user as **"TOTAL PnL" / "total booked PnL / real gains booked."**

On a churny book that reads **~5× rosier than the wallet**. Found live on a funded account where the agent praised a strategy at "+$19, doing its job well" that was **+$2 net lifetime** — fees had eaten essentially all of it — while the user stared at a truthful (worse) wallet balance. It is **not a prompting slip**: the schema had nowhere to put fees, and the only fee-aware path (a separate subcommand) could time out, leaving its "fees UNDETERMINED" caveat orphaned from the numbers it invalidated.

Reported by @shnoodles; portfolio.py surfaced by a fleet sweep of the same idiom.

## The fix — both skills, identical schema

- **Fees come from the HL fills ledger** (`userFills.fee`, **already builder-fee-inclusive** — never add builder fee on top). improve-trades attributes a round-trip fee per trade (matched open + close, pro-rated); portfolio sums the window.
- Every PnL surface now carries **`gross_realized_pnl` / `fees` / `net_realized_pnl` / `fees_status`**, plus `gross_total` / `net_total` on the headlines.
- **Degradation is first-class:** a failed/empty fills read → `fees`/`net_*` = `null`, `fees_status: "undetermined"` — **never a fake $0**. The only $0-fees branch is a genuinely-no-closed-trades wallet.
- **SKILL narration now LEADS with net**; `gross_*` is labeled pre-fee; the old "authoritative fee $ is a pending upgrade" note is now "wired."
- Bonus: fees are now decoupled from the flaky telemetry event-log read (they come from the durable fills ledger, not the subcommand that timed out).

## Sweep result

The same idiom was audited across the repo. **Only these two** compute the *user's own* realized PnL as net — everything else is an external trader's copy-ranking stat, a cohort threshold, or a clearly-labeled platform passthrough (not this bug). **Out of repo:** `strategies-of-the-week` and `funnel-report` were named as suspects but live elsewhere — flagged for a **separate audit**.

## Tests & versions

- improve-trades **1.8.0 → 1.9.0**: 73 pass, incl. fee-attribution (discovery rows get the fills-ledger fee, net = gross − fees) + undetermined-degradation (no fills read → `null`, not $0).
- portfolio **1.13.3 → 1.14.0**: 72 pass (+6, incl. group-total goes undetermined if any sleeve is).
- Both skills **added to CI** (`.github/workflows/tests.yml`) — they weren't run before. README version table synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
