### PR TITLE
portfolio: recognize copy-trade / mirror strategies (stop misdiagnosing them as unprotected)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
       # pytest collects every test regardless of a __main__ runner — bare `python3 <file>` exits 0
       # without running anything on a runner-less file (test_default_catalog.py), a silent green.
       - name: full suites (ops + discover + trading-runtime)
-        run: python3 -m pytest senpi-strategy-ops/tests senpi-strategy-discover/tests senpi-trading-runtime/tests senpi-trader-research/tests senpi-market-pulse/tests -q
+        run: python3 -m pytest senpi-strategy-ops/tests senpi-strategy-discover/tests senpi-trading-runtime/tests senpi-trader-research/tests senpi-market-pulse/tests senpi-portfolio/tests -q

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | Skill | Ver | Role |
 |---|---|---|
 | **Analyze** | | |
-| [`senpi-portfolio`](senpi-portfolio/) | 1.13.3 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
+| [`senpi-portfolio`](senpi-portfolio/) | 1.14.0 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
 | [`senpi-market-pulse`](senpi-market-pulse/) | 1.2.0 | Daily cross-asset market read (crypto, equities, commodities, macro, funding regime) |
 | [`senpi-smart-money`](senpi-smart-money/) | 1.2.0 | Where the most-profitable wallets are positioned vs. the crowd |
 | [`senpi-trader-research`](senpi-trader-research/) | 1.3.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |

--- a/senpi-portfolio/SKILL.md
+++ b/senpi-portfolio/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.13.3"
+  version: "1.14.0"
   platform: senpi
   exchange: hyperliquid
   requires:
@@ -156,6 +156,13 @@ live multi-wallet strategy is not.
 
 ### "ACTIVE" ≠ running — a strategy with no runtime registered is NOT alive, and NOT protected
 
+> **First, is it a copy-trade?** If `strategy_kind: "mirror"` (a.k.a. `runtime_health: "mirror"`), everything in
+> this section does **NOT** apply — a mirror / copy-trade strategy has **no runtime by design**. Its
+> `runtime_registered` / `not_running` / `running_blind` / `protected` are **`null` (N/A), never `false`** — do
+> NOT report it as "not running / unprotected," do NOT tell the user to add a DSL, set a stop via
+> `edit_position`, or redeploy via `senpi-strategy-ops`, and never call it "redundant." See **Copy-trade /
+> mirror strategies** below. Everything here is about **CUSTOM** strategies (`strategy_kind: "custom"`).
+
 `status: ACTIVE` only means the strategy *record* exists and is funded — it does **not** mean a runtime is
 actually running it. The engine checks the runtime registry and flags any strategy that is **ACTIVE +
 funded but has NO runtime registered** via `strategy_groups[].not_running` (and per-instance `not_running`
@@ -192,6 +199,9 @@ strategy and per group. Narrate it honestly — a registered runtime is not auto
   host"** — never "protected," "not protected," "running," or "not running." **`null` is not `false`.**
   `meta.warnings` names the failed command; quote it, never invent a cause. This is the honest bar:
   **only `live` means "confirmed working."**
+- **`mirror`** — a **copy-trade** strategy: no runtime BY DESIGN (see **Copy-trade / mirror strategies** below).
+  Never `live` / `degraded` / `not_running` / `unverified` — those don't apply to it. Judge it on `mirror_of` +
+  `mirror_multiplier` + `stop_loss_pct` / `take_profit_pct`, never on a runtime it was never meant to have.
 
 **Minimum runtime — `openclaw senpi runtime list --json`.** The engine asks the runtime for its own
 inventory through that command (it never reads the runtime's private state files). It is a **newer
@@ -214,6 +224,34 @@ it as the required next step (and its verdict, if you can run it), then close.py
 **"where am I leaking / did a stop fail / any halts / exit quality"**, hand to `senpi-improve-trades` (it
 reads the runtime event log for protection gaps, risk halts, failed orders, and exit quality). Reference the
 right tool to *confirm* — never re-derive its analysis here.
+
+### Copy-trade / mirror strategies (`strategy_kind: "mirror"`)
+
+A **mirror** (copy-trade) strategy — created via **`senpi-trade`** (`strategy_create`) — **copies a specific
+trader** instead of running a scanner. It has **no runtime, no `runtime.yaml`, and no DSL by design** — that is
+NOT a defect, and it is NOT "unprotected." Recognise it by `strategy_kind: "mirror"` (equivalently
+`runtime_health: "mirror"`); it carries `mirror_of` (the copied trader, masked), `mirror_multiplier` (how hard
+it sizes vs the OG), and `stop_loss_pct` / `take_profit_pct` (its **strategy-level** risk caps). Its `name` is
+**"copy of `mirror_of`"** — never call it "unnamed."
+
+**How a mirror is protected — two ways, neither a DSL:**
+1. It **follows the copied trader's exits** — when the OG closes or trims, the mirror does too. Its positions,
+   direction, and leverage are the OG's, scaled by `mirror_multiplier` (so a `20x` position is the *trader's*
+   20x, mirrored — inherited, not a config you tune per-position).
+2. Optional **strategy-level `stop_loss_pct` / `take_profit_pct`** — a hard cap the user placed on the copy.
+
+**Judging one, and the ONLY correct remedies.** A mirror's risk = the copied trader's risk × `mirror_multiplier`.
+High leverage or a lopsided book is worth *surfacing* ("this copies `mirror_of` at 20x — a sharp adverse move
+liquidates fast; it has [no] strategy-level stop"), but the fix is **never** a DSL or a per-position stop. To
+add/tighten a downside cap, take profit, or size down → set `stopLossPercentage` / `takeProfitPercentage` or
+lower `mirrorMultiplier` **via `senpi-trade`** (it wraps `strategy_update`). To stop copying → unsubscribe /
+close the mirror **via `senpi-trade`**.
+
+> **NEVER, for a mirror:** add a DSL / ratchet; set a stop via `edit_position` on its positions; "redeploy it
+> via `senpi-strategy-ops`"; call it "running unprotected / not running"; or call it "redundant with strategy X,
+> close it." Those are **custom-strategy** remedies — applied to a mirror they break the copy-trade the user
+> deliberately set up. A mirror is an intentional copy of a trader, judged on the trader + the multiplier + its
+> strategy-level SL/TP.
 
 ## Judge each strategy against its OWN mandate — not a momentum benchmark
 

--- a/senpi-portfolio/scripts/portfolio.py
+++ b/senpi-portfolio/scripts/portfolio.py
@@ -704,6 +704,14 @@ def fetch_strategies(client, meta):
         registry_prof = _profile_from_descriptor(desc)
         catalog_facets = _catalog_facets(catalog.get(skill_name) if skill_name else None)
         profile = _merge_profile(registry_prof, catalog_facets)
+        # MIRROR / copy-trade strategies (`strategy_create`, via senpi-trade) run WITHOUT a runtime — they
+        # follow the copied trader's positions AND exits, and carry their OWN risk config (multiplier +
+        # strategy-level SL/TP). The runtime questions below (registered / not_running / running_blind /
+        # DSL-protected) do NOT apply to them; answering them False would misread an intentional copy-trade
+        # as a broken, unprotected custom strategy — the senpi-trade → portfolio blind spot this fixes.
+        strategy_type = str(_field(s, "strategyType", "strategy_type", default="") or "")
+        is_mirror = strategy_type.upper() == "MIRROR"
+        short_trader = _first_written(s, "shortTraderAddress", "short_trader_address")
         # Registered per the runtime itself. None ⇒ we could not ask — never False, which reads as
         # "we checked and there is nothing", a claim no failed read has earned. PRESENCE-based, not
         # descriptor-based: a registered runtime whose YAML the engine couldn't render is still RUNNING.
@@ -732,7 +740,12 @@ def fetch_strategies(client, meta):
             protected = False
         else:
             protected = bool(desc and desc.get("hasExit"))
+        if is_mirror:
+            # N/A, not False — a mirror has no runtime; False here reads as "we checked, and it's broken/naked".
+            runtime_registered = not_running = running_blind = protected = None
         name, name_source = _strategy_name_and_source(s)
+        if is_mirror and name_source != "strategyName" and short_trader:
+            name, name_source = f"copy of {short_trader}", "shortTraderAddress"   # a mirror has no name of its own
         strategies.append({
             "name": name,
             # WHICH field named it: "strategyName" = its own name; "tradingStrategyName"/"name" = the
@@ -753,6 +766,14 @@ def fetch_strategies(client, meta):
             "runtime_registered": runtime_registered,   # True | False | None (null — could not ask)
             "not_running": not_running,                  # ACTIVE + funded skill strategy, no runtime → dead
             "running_blind": running_blind,              # up, but with NO entry scanners — cannot enter
+            # COPY-TRADE / MIRROR: `strategy_kind` "mirror" (else "custom"). A mirror follows `mirror_of`'s
+            # book + exits and carries its OWN risk levers (multiplier + strategy-level SL/TP) — NOT a DSL
+            # runtime. For a mirror the runtime flags above are null (N/A); judge it on these fields instead.
+            "strategy_kind": "mirror" if is_mirror else "custom",
+            "mirror_of": short_trader if is_mirror else None,          # the copied OG (masked) — its name + risk anchor
+            "mirror_multiplier": _f(s, "mirrorMultiplier", "mirror_multiplier", default=None) if is_mirror else None,
+            "stop_loss_pct": _f(s, "stopLossPercentage", "stop_loss_percentage", default=None) if is_mirror else None,
+            "take_profit_pct": _f(s, "takeProfitPercentage", "take_profit_percentage", default=None) if is_mirror else None,
             # The strategy's declared job — `profile.description` from the descriptor the RUNTIME
             # rendered for it, plus optional catalog facets. The yardstick to judge it against.
             "profile": profile,
@@ -844,7 +865,10 @@ def fetch_strategies(client, meta):
     #   unknown     — NOT PROVEN LIVE (telemetry unavailable, or the runtime won't vouch for it yet)
     # Fail-open + short-circuited by _telemetry_dead; sequential (few per user).
     for s in strategies:
-        if s.get("runtime_registered") is None:
+        if s.get("strategy_kind") == "mirror":
+            s["runtime_health"] = "mirror"         # copy-trade: no runtime BY DESIGN — the runtime flags are N/A,
+            #                                        not "broken"; judge it on mirror_of + multiplier + SL/TP
+        elif s.get("runtime_registered") is None:
             s["runtime_health"] = "unverified"     # the read failed — nothing below was ever asked
         elif s.get("not_running"):
             s["runtime_health"] = "not_running"

--- a/senpi-portfolio/tests/test_portfolio.py
+++ b/senpi-portfolio/tests/test_portfolio.py
@@ -280,7 +280,45 @@ def test_active_funded_strategy_absent_from_the_list_is_not_running():
     assert ghost["protected"] is False
     assert ghost["runtime_health"] == "not_running"
     assert out["meta"].get("not_running") == ["gibbon"]
+    assert ghost.get("strategy_kind") == "custom"        # a real custom strategy is still classified normally
     assert any("not running" in w.lower() for w in out["meta"]["warnings"])
+
+
+def test_mirror_copy_trade_is_not_flagged_not_running_or_unprotected():
+    """A copy-trade / MIRROR strategy (strategy_create, via senpi-trade) has NO runtime BY DESIGN. It must NOT
+    be misread as an unprotected, not-running custom strategy: its runtime flags are null (N/A, never False),
+    runtime_health is 'mirror', it is named by the copied trader, and it never lands in meta.not_running — even
+    though it is ACTIVE + funded + absent from the runtime list (the exact shape that trips `not_running`)."""
+    W = "0xB67D00000000000000000000000000000000B67D"
+    fixture = {
+        "user_get_me": {"wallets": [
+            {"walletType": "embedded", "walletAddress": "0xembed00000000000000000000000000000000ed"}]},
+        "account_get_portfolio": {"total_balance_usd": 500, "total_withdrawable": 500,
+                                  "total_usdc_in_hyperliquid": 0, "token_balances": []},
+        "strategy_list": {"strategies": [{
+            "strategyName": None, "strategyType": "MIRROR",
+            "shortTraderAddress": "0x35d1...acb1",
+            "traderAddress": "0x35d1000000000000000000000000000000acb1",
+            "mirrorMultiplier": 1.0, "stopLossPercentage": None, "takeProfitPercentage": None,
+            "strategyMetadata": {"skillName": "senpi-trade", "skillVersion": "1.0.0"},
+            "strategyWalletAddress": W, "status": "ACTIVE", "totalFunded": 500}]},
+        f"strategy_get_clearinghouse_state::{W.lower()}": {
+            "main": {"marginSummary": {"accountValue": "500"}, "withdrawable": "50",
+                     "assetPositions": [{"position": {
+                         "coin": "BTC", "szi": "-0.1", "leverage": {"type": "cross", "value": 20},
+                         "entryPx": "60000", "positionValue": "6000", "unrealizedPnl": "5"}}]},
+            "xyz": {"marginSummary": {"accountValue": "500"}, "withdrawable": "50", "assetPositions": []}},
+    }
+    out = run_engine(mcp_fixture=fixture)                 # default runtime list — the mirror wallet is NOT in it
+    m = by_wallet(out, W)
+    assert m["strategy_kind"] == "mirror"
+    assert m["runtime_health"] == "mirror"
+    # the runtime questions are N/A for a mirror — null, never False (False reads as "checked, and it's broken")
+    assert m["runtime_registered"] is None and m["not_running"] is None
+    assert m["running_blind"] is None and m["protected"] is None
+    assert m["mirror_of"] == "0x35d1...acb1" and m["mirror_multiplier"] == 1.0
+    assert m["name"] == "copy of 0x35d1...acb1"           # named by the copied trader, never "unnamed"/"strategy"
+    assert out["meta"].get("not_running") is None         # a mirror is NEVER an unprotected/not-running warning
 
 
 def test_running_blind_is_surfaced():


### PR DESCRIPTION
## The bug

A user's **copy-trade / mirror** strategy (created via `senpi-trade` → `strategy_create`) was read by `senpi-portfolio` as an **unprotected, not-running custom strategy**, and the agent advised the user to add a per-position stop-loss (which breaks the mirror) or **close it as "redundant"** — destroying an intentional copy-trade.

Root cause: a mirror runs **without a runtime by design** (it follows the copied trader's book + exits and carries its own risk config). `portfolio.py` never read `strategyType`, so a mirror fell through the **CUSTOM-strategy** runtime classifier → `not_running: true`, `protected: false`, name `"unnamed"`, and the "⛔ NOT RUNNING / UNPROTECTED — redeploy it" narration fired on it.

## The fix

**Engine (`portfolio.py`):** read `strategyType`. For a `MIRROR`:
- `runtime_registered` / `not_running` / `running_blind` / `protected` → **`null` (N/A, not `false`)** — a mirror has no runtime to check, and `false` reads as "we checked, it's broken."
- `runtime_health: "mirror"`; name it **`"copy of <shortTraderAddress>"`** (never "unnamed").
- Emit `strategy_kind`, `mirror_of`, `mirror_multiplier`, `stop_loss_pct`, `take_profit_pct`.
- Mirrors never land in the `meta.not_running` / "unprotected" warning.

**SKILL:** a mirror carve-out atop the "ACTIVE ≠ running" section, a `runtime_health: "mirror"` case, and a **"Copy-trade / mirror strategies"** playbook. Judge a mirror on trader + multiplier + strategy-level SL/TP. The **only** correct remedies: set/tighten `stopLossPercentage` / `takeProfitPercentage` or lower `mirrorMultiplier` **via `senpi-trade`**, or unsubscribe. **Never** a DSL, an `edit_position` stop, a `senpi-strategy-ops` redeploy, or "redundant, close it."

## Tests

`test_mirror_copy_trade_is_not_flagged_not_running_or_unprotected` — a MIRROR that is ACTIVE + funded + absent from the runtime list (the exact shape that trips `not_running`) is classified `mirror`, all runtime flags `null`, named by the copied trader, and never in `meta.not_running`. A `strategy_kind: "custom"` assertion proves custom strategies are unaffected. **67 pass.** Added `senpi-portfolio` to CI.

portfolio `1.13.3 → 1.14.0`.

> **Note:** the in-flight fee PR #538 also touches `senpi-portfolio` and bumps it to `1.14.0`; whichever merges second will need a version bump + a trivial rebase (disjoint code — this touches `fetch_strategies`/classification, #538 touches `fetch_closed`/fees).

**Separate, still open:** the same agent also flagged a healthy runtime strategy (`starling`) as "degraded." That's a *different* mechanism (a real runtime, not a mirror) and I couldn't reproduce it — my token can't read that account, and the health logic is already careful (reads the overall verdict, not per-scanner errors). Needs the raw `runtime_health` + `senpi status` verdict to fix precisely; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
