### PR TITLE
trader-research: clamp sub-1 leverage in mirror min-budget (fixes the ~$182K 'min to run')

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Every analytical skill follows the **hidden-engine pattern**: a vendored, stdlib
 | [`senpi-portfolio`](senpi-portfolio/) | 1.13.3 | All-wallet portfolio, positions, DSL protection, per-strategy mandate reads |
 | [`senpi-market-pulse`](senpi-market-pulse/) | 1.2.0 | Daily cross-asset market read (crypto, equities, commodities, macro, funding regime) |
 | [`senpi-smart-money`](senpi-smart-money/) | 1.2.0 | Where the most-profitable wallets are positioned vs. the crowd |
-| [`senpi-trader-research`](senpi-trader-research/) | 1.3.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |
+| [`senpi-trader-research`](senpi-trader-research/) | 1.4.0 | Rank + vet Hyperliquid traders before copying them (mirror-aware: copyability, min-budget, live book) |
 | [`senpi-improve-trades`](senpi-improve-trades/) | 1.1.1 | Retrospective review + health checks off the **telemetry event log**: exit quality, missed signals, leaks, crashes, "if I'd held" counterfactual |
 | [`senpi-account-status`](senpi-account-status/) | 1.1.1 | Points, loyalty tier, fees, Arena standing, referrals |
 | **Run a strategy** | | |

--- a/senpi-trader-research/SKILL.md
+++ b/senpi-trader-research/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: Apache-2.0
 metadata:
   author: Senpi
-  version: "1.3.0"
+  version: "1.4.0"
   platform: senpi
   exchange: hyperliquid
 ---

--- a/senpi-trader-research/scripts/research.py
+++ b/senpi-trader-research/scripts/research.py
@@ -308,8 +308,12 @@ def _min_mirror_budget(account_value, positions, mult=1.0):
         if adv is not None and adv > NEAR_ENTRY_BAND_PCT:   # ran in the OG's favor → slippage-skipped → costs no margin
             continue
         lev = p.get("leverage")
-        lev = lev if (isinstance(lev, (int, float)) and lev > 0) else 1.0   # missing leverage → assume 1x (full notional as margin)
-        margins.append(MIN_NOTIONAL_USD / lev)
+        # A perp opens at >= 1x, so the margin for a $12-floor position is <= $12. A sub-1 (or missing / garbage)
+        # leverage is a BAD READ — e.g. an XYZ isolated-margin field carrying a fraction — which once inflated a
+        # whale's min-budget to ~$182K (12 / 0.0002 ≈ $60K per position). Clamp to 1x AND cap each position's
+        # margin at the notional floor, so a mirror position's margin can never exceed $12 no matter the read.
+        lev = lev if (isinstance(lev, (int, float)) and lev >= 1.0) else 1.0
+        margins.append(min(MIN_NOTIONAL_USD, MIN_NOTIONAL_USD / lev))
     if not margins:
         return None
     mult = mult or 1.0

--- a/senpi-trader-research/tests/test_research.py
+++ b/senpi-trader-research/tests/test_research.py
@@ -54,6 +54,23 @@ def test_min_mirror_budget():
     assert research._min_mirror_budget(1000.0, None) is None
 
 
+def test_min_mirror_budget_clamps_sub_1_leverage_bad_read():
+    """A perp opens at >= 1x, so a mirror position's margin can never exceed the $12 notional floor. A sub-1
+    leverage read (an XYZ isolated-margin field carrying a fraction) must NOT inflate the budget — it once
+    produced a ~$182K "minimum" for a whale's 3-position book (12 / 0.0002 ≈ $60K each). Clamp to 1x + cap."""
+    whale = [{"notional": 838000, "direction": "short", "moved_from_entry_pct": 4.4, "leverage": 0.0002},
+             {"notional": 500000, "direction": "short", "moved_from_entry_pct": 3.0, "leverage": 0.0002},
+             {"notional": 300000, "direction": "short", "moved_from_entry_pct": 2.0, "leverage": 0.0002}]
+    b = research._min_mirror_budget(None, whale)
+    assert b["positions"] == 3
+    assert b["min_budget_usd"] == 36.0             # 3 × $12 floor — NOT ~$182K
+    assert b["opens_nothing_below_usd"] == 12.0    # cheapest openable margin, capped at the notional floor
+    # 0 / negative leverage is a bad read too → the 1x floor, never a divide-by-zero or a huge margin
+    assert research._min_mirror_budget(
+        None, [{"notional": 100, "direction": "long", "moved_from_entry_pct": 0.0, "leverage": 0}]
+    )["min_budget_usd"] == 12.0
+
+
 def test_min_mirror_budget_wired():
     # the key is always set (a dict when computable, else None) — never silently absent
     assert "min_mirror_budget" in research.run(_client(), "vet", addr="0xpro")["trader"]


### PR DESCRIPTION
## The bug

The copy-trade shortlist showed a whale trader with **"Min to run ~$182K"** for a 3-position book — absurd for a mirror, and enough to scare a user off an otherwise-copyable trader.

## Root cause

`_min_mirror_budget` estimates the budget to open the openable book as `Σ (MIN_NOTIONAL_USD / leverage)` — the margin to open each position at the ~$12 notional floor. A perp always opens at **≥ 1×**, so a mirror position's margin can never exceed the $12 floor. But the leverage guard only rejected `lev <= 0`, so a **sub-1 leverage read** slipped through:

```
12 / 0.0002 ≈ $60,000 per position  →  ~$182K for three
```

The `~0.0002` is a bad read — almost certainly the XYZ **isolated-margin** leverage field carrying a fraction rather than the leverage.

## Fix

Clamp leverage to **≥ 1×**, and cap each position's margin at `MIN_NOTIONAL_USD`, so a mirror position's margin is `≤ $12` no matter what the field reads:

```python
lev = lev if (isinstance(lev, (int, float)) and lev >= 1.0) else 1.0
margins.append(min(MIN_NOTIONAL_USD, MIN_NOTIONAL_USD / lev))
```

**Regression test:** 3 whale shorts at `lev 0.0002` → `min_budget_usd == $36` (3 × the floor), not $182K; `0` / negative leverage → the 1× floor too. Existing `lev ≥ 1` cases unchanged. **28 pass.**

trader-research `1.3.0 → 1.4.0`.

> **Follow-up (needs live data):** the underlying leverage *extraction* for XYZ isolated positions likely reads a fraction — worth confirming against a raw `discovery_get_trader_state` for an XYZ whale and fixing at source, since it also skews the displayed per-position leverage. This PR fixes the concrete harm (the min-budget) with a bound that's correct regardless of the read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
